### PR TITLE
[ty] Add blanket ignore comment rule

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -174,8 +174,8 @@ Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.55">0.0.55</a
 
 Checks for `ty: ignore` comments that don't specify which rules to ignore.
 
-When [`unused-ignore-comment`](#unused-ignore-comment) is enabled, unused blanket comments are reported
-by that rule instead.
+Unused blanket comments aren't reported by this rule because they don't suppress
+any diagnostics. Enable [`unused-ignore-comment`](#unused-ignore-comment) to report them separately.
 
 **Why is this bad?**
 

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -163,7 +163,7 @@ def _(x: int):
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
-Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.55">0.0.55</a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.57">0.0.57</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22blanket-ignore-comment%22" target="_blank">Related issues</a> ·
 <a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L61" target="_blank">View source</a>
 </small>

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -159,6 +159,45 @@ def _(x: int):
         assert_type(x, int)
 ```
 
+## `blanket-ignore-comment`
+
+<small>
+Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.55">0.0.55</a> ·
+<a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22blanket-ignore-comment%22" target="_blank">Related issues</a> ·
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L61" target="_blank">View source</a>
+</small>
+
+
+**What it does**
+
+
+Checks for `ty: ignore` comments that don't specify which rules to ignore.
+
+When [`unused-ignore-comment`](#unused-ignore-comment) is enabled, unused blanket comments are reported
+by that rule instead.
+
+**Why is this bad?**
+
+
+A blanket `ty: ignore` comment suppresses every type-checking diagnostic on the
+applicable line or file. Specifying rule codes documents which diagnostics are
+expected and prevents the comment from hiding unrelated errors.
+
+**Examples**
+
+
+```py
+# error
+value = unknown  # ty: ignore
+```
+
+Use instead:
+
+```py
+value = unknown  # ty: ignore[unresolved-reference]
+```
+
 ## `call-abstract-method`
 
 <small>

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -179,7 +179,7 @@ Checks for `ty: ignore` comments that don't specify which rules to ignore.
 
 A blanket `ty: ignore` comment suppresses every type-checking diagnostic on the
 applicable line or file. Specifying rule codes documents which diagnostics are
-expected and prevents the comment from hiding unrelated errors.
+expected and prevents the comment from silencing unrelated errors.
 
 **Examples**
 

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -174,9 +174,6 @@ Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.55">0.0.55</a
 
 Checks for `ty: ignore` comments that don't specify which rules to ignore.
 
-Blanket comments are reported whether or not they suppress a diagnostic. If
-[`unused-ignore-comment`](#unused-ignore-comment) is also enabled, unused blanket comments emit both diagnostics.
-
 **Why is this bad?**
 
 

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -174,8 +174,8 @@ Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.55">0.0.55</a
 
 Checks for `ty: ignore` comments that don't specify which rules to ignore.
 
-Unused blanket comments aren't reported by this rule because they don't suppress
-any diagnostics. Enable [`unused-ignore-comment`](#unused-ignore-comment) to report them separately.
+Blanket comments are reported whether or not they suppress a diagnostic. If
+[`unused-ignore-comment`](#unused-ignore-comment) is also enabled, unused blanket comments emit both diagnostics.
 
 **Why is this bad?**
 

--- a/crates/ty_python_semantic/resources/lint_docs/blanket-ignore-comment.md
+++ b/crates/ty_python_semantic/resources/lint_docs/blanket-ignore-comment.md
@@ -6,7 +6,7 @@ Checks for `ty: ignore` comments that don't specify which rules to ignore.
 
 A blanket `ty: ignore` comment suppresses every type-checking diagnostic on the
 applicable line or file. Specifying rule codes documents which diagnostics are
-expected and prevents the comment from hiding unrelated errors.
+expected and prevents the comment from silencing unrelated errors.
 
 ## Examples
 

--- a/crates/ty_python_semantic/resources/lint_docs/blanket-ignore-comment.md
+++ b/crates/ty_python_semantic/resources/lint_docs/blanket-ignore-comment.md
@@ -1,0 +1,25 @@
+## What it does
+
+Checks for `ty: ignore` comments that don't specify which rules to ignore.
+
+When `unused-ignore-comment` is enabled, unused blanket comments are reported
+by that rule instead.
+
+## Why is this bad?
+
+A blanket `ty: ignore` comment suppresses every type-checking diagnostic on the
+applicable line or file. Specifying rule codes documents which diagnostics are
+expected and prevents the comment from hiding unrelated errors.
+
+## Examples
+
+```py
+# error
+value = unknown  # ty: ignore
+```
+
+Use instead:
+
+```py
+value = unknown  # ty: ignore[unresolved-reference]
+```

--- a/crates/ty_python_semantic/resources/lint_docs/blanket-ignore-comment.md
+++ b/crates/ty_python_semantic/resources/lint_docs/blanket-ignore-comment.md
@@ -2,9 +2,6 @@
 
 Checks for `ty: ignore` comments that don't specify which rules to ignore.
 
-Blanket comments are reported whether or not they suppress a diagnostic. If
-`unused-ignore-comment` is also enabled, unused blanket comments emit both diagnostics.
-
 ## Why is this bad?
 
 A blanket `ty: ignore` comment suppresses every type-checking diagnostic on the

--- a/crates/ty_python_semantic/resources/lint_docs/blanket-ignore-comment.md
+++ b/crates/ty_python_semantic/resources/lint_docs/blanket-ignore-comment.md
@@ -2,8 +2,8 @@
 
 Checks for `ty: ignore` comments that don't specify which rules to ignore.
 
-Unused blanket comments aren't reported by this rule because they don't suppress
-any diagnostics. Enable `unused-ignore-comment` to report them separately.
+Blanket comments are reported whether or not they suppress a diagnostic. If
+`unused-ignore-comment` is also enabled, unused blanket comments emit both diagnostics.
 
 ## Why is this bad?
 

--- a/crates/ty_python_semantic/resources/lint_docs/blanket-ignore-comment.md
+++ b/crates/ty_python_semantic/resources/lint_docs/blanket-ignore-comment.md
@@ -2,8 +2,8 @@
 
 Checks for `ty: ignore` comments that don't specify which rules to ignore.
 
-When `unused-ignore-comment` is enabled, unused blanket comments are reported
-by that rule instead.
+Unused blanket comments aren't reported by this rule because they don't suppress
+any diagnostics. Enable `unused-ignore-comment` to report them separately.
 
 ## Why is this bad?
 

--- a/crates/ty_python_semantic/resources/mdtest/public_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/public_types.md
@@ -299,7 +299,7 @@ this:
 
 ```py
 try:
-    import optional_dependency  # ty: ignore
+    import optional_dependency  # ty: ignore[unresolved-import]
 except ImportError:
     optional_dependency = None
 

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -16,7 +16,7 @@ a = unresolved  # ty: ignore
 
 b = unresolved  # ty: ignore[unresolved-reference]
 
-# `blanket-ignore-comment` covers only `# ty: ignore`; we can also add `blanket-type-ignore-comment`,
+# `blanket-ignore-comment` covers only `ty: ignore`; we can also add `blanket-type-ignore-comment`,
 # parallel to `unused-ignore-comment` and `unused-type-ignore-comment`. In the meantime, blanket
 # `type: ignore` can also be caught by Ruff's PGH003 rule.
 c = unresolved  # type: ignore

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -22,7 +22,8 @@ c = unresolved  # type: ignore
 
 ## Unused ignore comments
 
-When `unused-ignore-comment` is also enabled, unused blanket comments trigger both rules.
+When `unused-ignore-comment` is enabled, an unused `ty: ignore` comment without rule codes triggers
+both rules.
 
 ```py
 # error: [unused-ignore-comment] "Unused `ty: ignore` without a code"

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -1,7 +1,7 @@
 # Blanket `ty: ignore` comments
 
 The optional `blanket-ignore-comment` rule requires `ty: ignore` comments to include specific rule
-codes, regardless of whether they suppress a diagnostic.
+codes.
 
 ```toml
 [rules]
@@ -22,7 +22,7 @@ c = unresolved  # type: ignore
 
 ## Unused ignore comments
 
-If `unused-ignore-comment` is also enabled, unused blanket comments emit both diagnostics.
+When `unused-ignore-comment` is also enabled, unused blanket comments trigger both rules.
 
 ```py
 # error: [unused-ignore-comment] "Unused `ty: ignore` without a code"

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -29,7 +29,10 @@ e = 1  # ty: ignore
 
 ## Unused blanket ignores
 
-Unused blanket comments aren't reported by this rule, even when `unused-ignore-comment` is disabled:
+Unused blanket comments aren't reported by this rule, even when `unused-ignore-comment` is disabled.
+They are harmless because they don't suppress any diagnostics. Leaving all unused suppressions to
+`unused-ignore-comment` also keeps their treatment consistent and avoids overlapping diagnostics
+when that rule is enabled:
 
 ```toml
 [rules]
@@ -43,12 +46,16 @@ a = 1  # ty: ignore
 
 ## Suppression diagnostics
 
-Suppression-related diagnostics also count as using a blanket ignore.
+Suppression-related diagnostics are checked before `blanket-ignore-comment`. A blanket ignore that
+suppresses an `ignore-comment-unknown-rule` or `invalid-ignore-comment` diagnostic therefore counts
+as used:
 
 ```py
+# The nested ignore contains an unknown rule.
 # error: [blanket-ignore-comment]
 a = 1  # ty: ignore # ty: ignore[not-a-rule]
 
+# The nested ignore is invalid.
 # error: [blanket-ignore-comment]
 b = 1  # ty: ignore # ty: ignore[*]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -1,8 +1,8 @@
 # Blanket `ty: ignore` comments
 
 The optional `blanket-ignore-comment` rule requires `ty: ignore` comments to include specific rule
-codes. Unused blanket comments aren't reported because they don't suppress any diagnostics; use
-`unused-ignore-comment` to report them separately.
+codes, regardless of whether they suppress a diagnostic. If `unused-ignore-comment` is also enabled,
+unused blanket comments emit both diagnostics.
 
 ```toml
 [rules]
@@ -23,35 +23,13 @@ c = unresolved  # type: ignore
 
 ## Unused ignore comments
 
-### Empty ignore comments
-
 ```py
 # error: [unused-ignore-comment] "Unused `ty: ignore` without a code"
 d = 1  # ty: ignore[]
-```
 
-### Blanket ignore comments
-
-```py
+# error: [blanket-ignore-comment]
 # error: [unused-ignore-comment] "Unused blanket `ty: ignore` directive"
 e = 1  # ty: ignore
-```
-
-### When `unused-ignore-comment` is disabled
-
-Unused blanket comments aren't reported by this rule, even when `unused-ignore-comment` is disabled.
-They are harmless because they don't suppress any diagnostics. Leaving all unused suppressions to
-`unused-ignore-comment` also keeps their treatment consistent and avoids overlapping diagnostics
-when that rule is enabled:
-
-```toml
-[rules]
-blanket-ignore-comment = "error"
-unused-ignore-comment = "ignore"
-```
-
-```py
-a = 1  # ty: ignore
 ```
 
 ## Suppression diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -1,0 +1,75 @@
+# Blanket `ty: ignore` comments
+
+The optional `blanket-ignore-comment` rule requires `ty: ignore` comments to include specific rule
+codes. When `unused-ignore-comment` is enabled, unused blanket comments are reported by that rule
+instead.
+
+```toml
+[rules]
+blanket-ignore-comment = "error"
+```
+
+## Line-level ignores
+
+```py
+# error: [blanket-ignore-comment]
+a = unresolved  # ty: ignore
+
+b = unresolved  # ty: ignore[unresolved-reference]
+
+# Blanket `type: ignore` comments are covered by Ruff's PGH003 rule.
+c = unresolved  # type: ignore
+
+# error: [unused-ignore-comment] "Unused `ty: ignore` without a code"
+d = 1  # ty: ignore[]
+
+# error: [unused-ignore-comment] "Unused blanket `ty: ignore` directive"
+e = 1  # ty: ignore
+```
+
+## Disabled unused-ignore rule
+
+When `unused-ignore-comment` is disabled, unused blanket comments are reported by
+`blanket-ignore-comment`:
+
+```toml
+[rules]
+blanket-ignore-comment = "error"
+unused-ignore-comment = "ignore"
+```
+
+```py
+# error: [blanket-ignore-comment]
+a = 1  # ty: ignore
+```
+
+## Suppression diagnostics
+
+Suppression-related diagnostics also count as using a blanket ignore.
+
+```py
+# error: [blanket-ignore-comment]
+a = 1  # ty: ignore # ty: ignore[not-a-rule]
+
+# error: [blanket-ignore-comment]
+b = 1  # ty: ignore # ty: ignore[*]
+```
+
+## File-level ignores
+
+The rule also detects file-level blanket ignores:
+
+```py
+# error: [blanket-ignore-comment]
+# ty: ignore
+
+a = unresolved
+```
+
+## Suppressing the rule
+
+A blanket ignore can be suppressed by a code-specific ignore:
+
+```py
+a = unresolved  # ty: ignore # ty: ignore[blanket-ignore-comment]
+```

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -1,8 +1,7 @@
 # Blanket `ty: ignore` comments
 
 The optional `blanket-ignore-comment` rule requires `ty: ignore` comments to include specific rule
-codes, regardless of whether they suppress a diagnostic. If `unused-ignore-comment` is also enabled,
-unused blanket comments emit both diagnostics.
+codes, regardless of whether they suppress a diagnostic.
 
 ```toml
 [rules]
@@ -22,6 +21,8 @@ c = unresolved  # type: ignore
 ```
 
 ## Unused ignore comments
+
+If `unused-ignore-comment` is also enabled, unused blanket comments emit both diagnostics.
 
 ```py
 # error: [unused-ignore-comment] "Unused `ty: ignore` without a code"

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -19,15 +19,25 @@ b = unresolved  # ty: ignore[unresolved-reference]
 
 # Blanket `type: ignore` comments are covered by Ruff's PGH003 rule.
 c = unresolved  # type: ignore
+```
 
+## Unused ignore comments
+
+### Empty ignore comments
+
+```py
 # error: [unused-ignore-comment] "Unused `ty: ignore` without a code"
 d = 1  # ty: ignore[]
+```
 
+### Blanket ignore comments
+
+```py
 # error: [unused-ignore-comment] "Unused blanket `ty: ignore` directive"
 e = 1  # ty: ignore
 ```
 
-## Unused blanket ignores
+### When `unused-ignore-comment` is disabled
 
 Unused blanket comments aren't reported by this rule, even when `unused-ignore-comment` is disabled.
 They are harmless because they don't suppress any diagnostics. Leaving all unused suppressions to

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -16,7 +16,9 @@ a = unresolved  # ty: ignore
 
 b = unresolved  # ty: ignore[unresolved-reference]
 
-# Blanket `type: ignore` comments are covered by Ruff's PGH003 rule.
+# `blanket-ignore-comment` covers only `# ty: ignore`; we can also add `blanket-type-ignore-comment`,
+# parallel to `unused-ignore-comment` and `unused-type-ignore-comment`. In the meantime, blanket
+# `type: ignore` can also be caught by Ruff's PGH003 rule.
 c = unresolved  # type: ignore
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -1,8 +1,8 @@
 # Blanket `ty: ignore` comments
 
 The optional `blanket-ignore-comment` rule requires `ty: ignore` comments to include specific rule
-codes. When `unused-ignore-comment` is enabled, unused blanket comments are reported by that rule
-instead.
+codes. Unused blanket comments aren't reported because they don't suppress any diagnostics; use
+`unused-ignore-comment` to report them separately.
 
 ```toml
 [rules]
@@ -27,10 +27,9 @@ d = 1  # ty: ignore[]
 e = 1  # ty: ignore
 ```
 
-## Disabled unused-ignore rule
+## Unused blanket ignores
 
-When `unused-ignore-comment` is disabled, unused blanket comments are reported by
-`blanket-ignore-comment`:
+Unused blanket comments aren't reported by this rule, even when `unused-ignore-comment` is disabled:
 
 ```toml
 [rules]
@@ -39,7 +38,6 @@ unused-ignore-comment = "ignore"
 ```
 
 ```py
-# error: [blanket-ignore-comment]
 a = 1  # ty: ignore
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
@@ -1,6 +1,13 @@
 # Suppressing errors with `ty: ignore`
 
-Type check errors can be suppressed by a `ty: ignore` comment on the same line as the violation.
+Type check errors can be suppressed by a `ty: ignore` comment on the same line as the violation. The
+optional `blanket-ignore-comment` rule is tested separately so that these examples can exercise bare
+ignore comments.
+
+```toml
+[rules]
+blanket-ignore-comment = "ignore"
+```
 
 ## Simple `ty: ignore`
 

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -4,7 +4,8 @@
 )]
 use crate::lint::{LintRegistry, LintRegistryBuilder};
 use crate::suppression::{
-    IGNORE_COMMENT_UNKNOWN_RULE, INVALID_IGNORE_COMMENT, UNUSED_TYPE_IGNORE_COMMENT,
+    BLANKET_IGNORE_COMMENT, IGNORE_COMMENT_UNKNOWN_RULE, INVALID_IGNORE_COMMENT,
+    UNUSED_TYPE_IGNORE_COMMENT,
 };
 use crate::types::check_types;
 pub use db::Db;
@@ -85,6 +86,7 @@ pub fn register_lints(registry: &mut LintRegistryBuilder) {
     registry.register_lint(&UNUSED_TYPE_IGNORE_COMMENT);
     registry.register_lint(&IGNORE_COMMENT_UNKNOWN_RULE);
     registry.register_lint(&INVALID_IGNORE_COMMENT);
+    registry.register_lint(&BLANKET_IGNORE_COMMENT);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -58,6 +58,15 @@ declare_lint! {
     }
 }
 
+declare_lint! {
+    #[doc = include_str!("../resources/lint_docs/blanket-ignore-comment.md")]
+    pub(crate) static BLANKET_IGNORE_COMMENT = {
+        summary: "detects blanket `ty: ignore` comments",
+        status: LintStatus::stable("0.0.55"),
+        default_level: Level::Ignore,
+    }
+}
+
 pub fn is_unused_ignore_comment_lint(name: LintName) -> bool {
     name == UNUSED_IGNORE_COMMENT.name() || name == UNUSED_TYPE_IGNORE_COMMENT.name()
 }
@@ -127,9 +136,43 @@ pub(crate) fn check_suppressions(
 
     check_unknown_rule(&mut context);
     check_invalid_suppression(&mut context);
+    check_blanket_suppressions(&mut context);
     check_unused_suppressions(&mut context);
 
     context.diagnostics.into_inner().into_diagnostics()
+}
+
+fn check_blanket_suppressions(context: &mut CheckSuppressionsContext) {
+    if context.is_lint_disabled(&BLANKET_IGNORE_COMMENT) {
+        return;
+    }
+
+    let unused_ignore_enabled = !context.is_lint_disabled(&UNUSED_IGNORE_COMMENT);
+
+    for suppression in context.suppressions.iter().filter(|suppression| {
+        suppression.kind == SuppressionKind::Ty && suppression.target == SuppressionTarget::All
+    }) {
+        if unused_ignore_enabled && !context.is_suppression_used(suppression.id()) {
+            continue;
+        }
+
+        // A blanket suppression cannot suppress its own diagnostic, but a code-specific
+        // suppression can.
+        if let Some(code_suppression) = context
+            .suppressions
+            .lint_suppressions(suppression.range, LintId::of(&BLANKET_IGNORE_COMMENT))
+            .find(|candidate| candidate.target.is_lint())
+        {
+            context
+                .diagnostics
+                .borrow_mut()
+                .mark_used(code_suppression.id());
+        } else if let Some(diag) =
+            context.report_unchecked(&BLANKET_IGNORE_COMMENT, suppression.range)
+        {
+            diag.into_diagnostic("Use specific rule codes in `ty: ignore`");
+        }
+    }
 }
 
 /// Checks for `ty: ignore` and `type: ignore[ty:<code>]` comments that reference unknown rules.

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -147,12 +147,10 @@ fn check_blanket_suppressions(context: &mut CheckSuppressionsContext) {
         return;
     }
 
-    let unused_ignore_enabled = !context.is_lint_disabled(&UNUSED_IGNORE_COMMENT);
-
     for suppression in context.suppressions.iter().filter(|suppression| {
         suppression.kind == SuppressionKind::Ty && suppression.target == SuppressionTarget::All
     }) {
-        if unused_ignore_enabled && !context.is_suppression_used(suppression.id()) {
+        if !context.is_suppression_used(suppression.id()) {
             continue;
         }
 

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -148,12 +148,10 @@ fn check_blanket_suppressions(context: &mut CheckSuppressionsContext) {
     }
 
     for suppression in context.suppressions.iter().filter(|suppression| {
-        suppression.kind == SuppressionKind::Ty && suppression.target == SuppressionTarget::All
+        suppression.kind == SuppressionKind::Ty
+            && suppression.target == SuppressionTarget::All
+            && context.is_suppression_used(suppression.id())
     }) {
-        if !context.is_suppression_used(suppression.id()) {
-            continue;
-        }
-
         // A blanket suppression cannot suppress its own diagnostic, but a code-specific
         // suppression can.
         if let Some(code_suppression) = context

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -148,9 +148,7 @@ fn check_blanket_suppressions(context: &mut CheckSuppressionsContext) {
     }
 
     for suppression in context.suppressions.iter().filter(|suppression| {
-        suppression.kind == SuppressionKind::Ty
-            && suppression.target == SuppressionTarget::All
-            && context.is_suppression_used(suppression.id())
+        suppression.kind == SuppressionKind::Ty && suppression.target == SuppressionTarget::All
     }) {
         // A blanket suppression cannot suppress its own diagnostic, but a code-specific
         // suppression can.

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -62,7 +62,7 @@ declare_lint! {
     #[doc = include_str!("../resources/lint_docs/blanket-ignore-comment.md")]
     pub(crate) static BLANKET_IGNORE_COMMENT = {
         summary: "detects blanket `ty: ignore` comments",
-        status: LintStatus::stable("0.0.55"),
+        status: LintStatus::stable("0.0.57"),
         default_level: Level::Ignore,
     }
 }

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -362,7 +362,7 @@
         },
         "blanket-ignore-comment": {
           "title": "detects blanket `ty: ignore` comments",
-          "description": "## What it does\n\nChecks for `ty: ignore` comments that don't specify which rules to ignore.\n\nUnused blanket comments aren't reported by this rule because they don't suppress\nany diagnostics. Enable `unused-ignore-comment` to report them separately.\n\n## Why is this bad?\n\nA blanket `ty: ignore` comment suppresses every type-checking diagnostic on the\napplicable line or file. Specifying rule codes documents which diagnostics are\nexpected and prevents the comment from hiding unrelated errors.\n\n## Examples\n\n```py\n# error\nvalue = unknown  # ty: ignore\n```\n\nUse instead:\n\n```py\nvalue = unknown  # ty: ignore[unresolved-reference]\n```",
+          "description": "## What it does\n\nChecks for `ty: ignore` comments that don't specify which rules to ignore.\n\nBlanket comments are reported whether or not they suppress a diagnostic. If\n`unused-ignore-comment` is also enabled, unused blanket comments emit both diagnostics.\n\n## Why is this bad?\n\nA blanket `ty: ignore` comment suppresses every type-checking diagnostic on the\napplicable line or file. Specifying rule codes documents which diagnostics are\nexpected and prevents the comment from hiding unrelated errors.\n\n## Examples\n\n```py\n# error\nvalue = unknown  # ty: ignore\n```\n\nUse instead:\n\n```py\nvalue = unknown  # ty: ignore[unresolved-reference]\n```",
           "default": "ignore",
           "oneOf": [
             {

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -360,6 +360,16 @@
             }
           ]
         },
+        "blanket-ignore-comment": {
+          "title": "detects blanket `ty: ignore` comments",
+          "description": "## What it does\n\nChecks for `ty: ignore` comments that don't specify which rules to ignore.\n\nWhen `unused-ignore-comment` is enabled, unused blanket comments are reported\nby that rule instead.\n\n## Why is this bad?\n\nA blanket `ty: ignore` comment suppresses every type-checking diagnostic on the\napplicable line or file. Specifying rule codes documents which diagnostics are\nexpected and prevents the comment from hiding unrelated errors.\n\n## Examples\n\n```py\n# error\nvalue = unknown  # ty: ignore\n```\n\nUse instead:\n\n```py\nvalue = unknown  # ty: ignore[unresolved-reference]\n```",
+          "default": "ignore",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "call-abstract-method": {
           "title": "detects calls to abstract methods with trivial bodies on class objects",
           "description": "## What it does\n\nChecks for calls to abstract `@classmethod`s or `@staticmethod`s\nwith \"trivial bodies\" when accessed on the class object itself.\n\n\"Trivial bodies\" are bodies that solely consist of `...`, `pass`,\na docstring, and/or `raise NotImplementedError`.\n\n## Why is this bad?\n\nAn abstract method with a trivial body has no concrete implementation\nto execute, so calling such a method directly on the class will probably\nnot have the desired effect.\n\nIt is also unsound to call these methods directly on the class. Unlike\nother methods, ty permits abstract methods with trivial bodies to have\nnon-`None` return types even though they always return `None` at runtime.\nThis is because it is expected that these methods will always be\noverridden rather than being called directly. As a result of this\nexception to the normal rule, ty may infer an incorrect type if one of\nthese methods is called directly, which may then mean that type errors\nelsewhere in your code go undetected by ty.\n\nCalling abstract classmethods or staticmethods via `type[X]` is allowed,\nsince the actual runtime type could be a concrete subclass with an implementation.\n\n## Example\n\n```python\nfrom abc import ABC, abstractmethod\n\n\nclass Foo(ABC):\n    @classmethod\n    @abstractmethod\n    def method(cls) -> int: ...\n\n\n# cannot call abstract classmethod\nFoo.method()  # error\n```",

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -362,7 +362,7 @@
         },
         "blanket-ignore-comment": {
           "title": "detects blanket `ty: ignore` comments",
-          "description": "## What it does\n\nChecks for `ty: ignore` comments that don't specify which rules to ignore.\n\nWhen `unused-ignore-comment` is enabled, unused blanket comments are reported\nby that rule instead.\n\n## Why is this bad?\n\nA blanket `ty: ignore` comment suppresses every type-checking diagnostic on the\napplicable line or file. Specifying rule codes documents which diagnostics are\nexpected and prevents the comment from hiding unrelated errors.\n\n## Examples\n\n```py\n# error\nvalue = unknown  # ty: ignore\n```\n\nUse instead:\n\n```py\nvalue = unknown  # ty: ignore[unresolved-reference]\n```",
+          "description": "## What it does\n\nChecks for `ty: ignore` comments that don't specify which rules to ignore.\n\nUnused blanket comments aren't reported by this rule because they don't suppress\nany diagnostics. Enable `unused-ignore-comment` to report them separately.\n\n## Why is this bad?\n\nA blanket `ty: ignore` comment suppresses every type-checking diagnostic on the\napplicable line or file. Specifying rule codes documents which diagnostics are\nexpected and prevents the comment from hiding unrelated errors.\n\n## Examples\n\n```py\n# error\nvalue = unknown  # ty: ignore\n```\n\nUse instead:\n\n```py\nvalue = unknown  # ty: ignore[unresolved-reference]\n```",
           "default": "ignore",
           "oneOf": [
             {

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -362,7 +362,7 @@
         },
         "blanket-ignore-comment": {
           "title": "detects blanket `ty: ignore` comments",
-          "description": "## What it does\n\nChecks for `ty: ignore` comments that don't specify which rules to ignore.\n\nBlanket comments are reported whether or not they suppress a diagnostic. If\n`unused-ignore-comment` is also enabled, unused blanket comments emit both diagnostics.\n\n## Why is this bad?\n\nA blanket `ty: ignore` comment suppresses every type-checking diagnostic on the\napplicable line or file. Specifying rule codes documents which diagnostics are\nexpected and prevents the comment from hiding unrelated errors.\n\n## Examples\n\n```py\n# error\nvalue = unknown  # ty: ignore\n```\n\nUse instead:\n\n```py\nvalue = unknown  # ty: ignore[unresolved-reference]\n```",
+          "description": "## What it does\n\nChecks for `ty: ignore` comments that don't specify which rules to ignore.\n\n## Why is this bad?\n\nA blanket `ty: ignore` comment suppresses every type-checking diagnostic on the\napplicable line or file. Specifying rule codes documents which diagnostics are\nexpected and prevents the comment from hiding unrelated errors.\n\n## Examples\n\n```py\n# error\nvalue = unknown  # ty: ignore\n```\n\nUse instead:\n\n```py\nvalue = unknown  # ty: ignore[unresolved-reference]\n```",
           "default": "ignore",
           "oneOf": [
             {

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -362,7 +362,7 @@
         },
         "blanket-ignore-comment": {
           "title": "detects blanket `ty: ignore` comments",
-          "description": "## What it does\n\nChecks for `ty: ignore` comments that don't specify which rules to ignore.\n\n## Why is this bad?\n\nA blanket `ty: ignore` comment suppresses every type-checking diagnostic on the\napplicable line or file. Specifying rule codes documents which diagnostics are\nexpected and prevents the comment from hiding unrelated errors.\n\n## Examples\n\n```py\n# error\nvalue = unknown  # ty: ignore\n```\n\nUse instead:\n\n```py\nvalue = unknown  # ty: ignore[unresolved-reference]\n```",
+          "description": "## What it does\n\nChecks for `ty: ignore` comments that don't specify which rules to ignore.\n\n## Why is this bad?\n\nA blanket `ty: ignore` comment suppresses every type-checking diagnostic on the\napplicable line or file. Specifying rule codes documents which diagnostics are\nexpected and prevents the comment from silencing unrelated errors.\n\n## Examples\n\n```py\n# error\nvalue = unknown  # ty: ignore\n```\n\nUse instead:\n\n```py\nvalue = unknown  # ty: ignore[unresolved-reference]\n```",
           "default": "ignore",
           "oneOf": [
             {


### PR DESCRIPTION
## Summary

Adds an opt-in `blanket-ignore-comment` rule that requires rule codes on `ty: ignore` comments.

Closes astral-sh/ty#3324.

## Test Plan

Testing: Added mdtest coverage and ran the ty semantic test suite, Clippy, and repository hooks.
