### PR TITLE
Run OS-sensitive macOS tests on pull requests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,7 +8,6 @@ self-hosted-runner:
     - depot-ubuntu-latest-8
     - depot-ubuntu-22.04-16
     - depot-ubuntu-22.04-32
-    - depot-macos-15
     - depot-windows-2022-16
     - depot-ubuntu-22.04-arm-4
     - github-windows-2025-x86_64-8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -463,10 +463,8 @@ jobs:
       - name: "Run OS-sensitive tests"
         if: ${{ runner.os == 'macOS' && github.event_name == 'pull_request' }}
         run: |
-          # Run CLI and real-filesystem/process integration tests. Only the server
-          # end-to-end tests are OS-sensitive.
+          # Run CLI and real-filesystem/process integration tests.
           cargo nextest run --all-features --profile ci \
-            -E 'not (package(ruff_server) | package(ty_server)) | binary(e2e)' \
             --package ruff \
             --package ruff_db \
             --package ruff_server \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -423,7 +423,7 @@ jobs:
       matrix:
         platform:
           - ${{ github.repository == 'astral-sh/ruff' && 'depot-windows-2022-16' || 'windows-latest' }}
-          - ${{ github.repository == 'astral-sh/ruff' && 'depot-macos-15' || 'macos-latest' }}
+          - macos-latest
     name: "cargo test (${{ matrix.platform }})"
     runs-on: ${{ matrix.platform }}
     needs: determine_changes
@@ -452,10 +452,29 @@ jobs:
         with:
           version: "0.11.24"
           enable-cache: "true"
+      # The full test suite takes a long time on GitHub-hosted macOS runners. Depot
+      # runners are faster, but we only have limited capacity. Run only OS-sensitive
+      # tests for pull requests; pushes to main still run the complete suite.
       - name: "Run tests"
+        if: ${{ runner.os != 'macOS' || github.event_name != 'pull_request' }}
         run: |
           cargo nextest run --all-features --profile ci
           cargo test --all-features --doc
+      - name: "Run OS-sensitive tests"
+        if: ${{ runner.os == 'macOS' && github.event_name == 'pull_request' }}
+        run: |
+          # Run CLI and real-filesystem/process integration tests. Only the server
+          # end-to-end tests are OS-sensitive.
+          cargo nextest run --all-features --profile ci \
+            -E 'not (package(ruff_server) | package(ty_server)) | binary(e2e)' \
+            --package ruff \
+            --package ruff_db \
+            --package ruff_server \
+            --package ruff_workspace \
+            --package ty \
+            --package ty_module_resolver \
+            --package ty_server \
+            --package ty_site_packages
 
   cargo-test-wasm:
     name: "cargo test (wasm)"


### PR DESCRIPTION
## Summary

Run only OS-sensitive test suites on GitHub-hosted macOS runners for pull requests, while retaining full macOS coverage on main. This avoids slow full-suite runs without relying on limited Depot macOS capacity.

## Test Plan

Testing: Ran the reduced nextest suite and repository hooks.
