### PR TITLE
Inline `fits_element` in formatter

### DIFF
--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -1153,6 +1153,9 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
     }
 
     /// Tests if the passed element fits on the current line or not.
+    // LLVM considers this function too large to inline on its own, but it is called for every
+    // element visited by the fitting loop.
+    #[inline(always)]
     fn fits_element(&mut self, element: &'a FormatElement) -> PrintResult<Fits> {
         #[allow(clippy::enum_glob_use)]
         use Tag::*;


### PR DESCRIPTION
## Summary

The formatter's fitting loop calls `FitsMeasurer::fits_element` for every visited format element. LLVM does not inline this dispatcher heuristically because of its size, so each visit currently pays for an out-of-line function call.

This change marks `fits_element` as `#[inline(always)]`, keeping the dispatcher in the hot fitting loop. On the non-microbenchmark `formatter[large/dataset.py]`, CodSpeed CPU simulation improves from 8.42 ms to 7.98 ms, a 5.5% speedup ([comparison](https://app.codspeed.io/astral-sh/ruff/runs/compare/6a3fe180822c3b6c2491f461..6a3fe29b822c3b6c2491f48c)). The other measured formatter workloads improve by 1.0-4.5%, with no formatter output or memory changes.
