### PR TITLE
[ty] Detect conflicting inherited methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -690,6 +690,24 @@ class Right(ReceiverBase):
     def selected(cls) -> str: ...
 
 class FinalReceiver(Left, Right): ...  # error: [invalid-method-override]
+
+class InstanceMethod:
+    def kind(self, value: int) -> int: ...
+
+class StaticMethod:
+    @staticmethod
+    def kind(value: int) -> int: ...
+
+class ClassMethod:
+    @classmethod
+    def kind(cls, value: int) -> int: ...
+
+class InstanceStaticConflict(InstanceMethod, StaticMethod): ...  # error: [invalid-method-override]
+class StaticInstanceConflict(StaticMethod, InstanceMethod): ...  # error: [invalid-method-override]
+class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid-method-override]
+class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # error: [invalid-method-override]
+class StaticClassConflict(StaticMethod, ClassMethod): ...  # error: [invalid-method-override]
+class ClassStaticConflict(ClassMethod, StaticMethod): ...  # error: [invalid-method-override]
 ```
 
 ```snapshot

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -665,6 +665,7 @@ class GenericReturn(Generic[T]):
     def method(self) -> T: ...
 
 class GenericConflict(ReturnsStr, GenericReturn[int]): ...  # error: [invalid-method-override]
+class GenericPseudoBaseConflict(Generic[T], ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
 
 class IteratesStr:
     def __iter__(self) -> Iterator[str]: ...

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -643,7 +643,7 @@ effective source-defined method contract exposed by every direct branch.
 `multiple_inheritance.pyi`:
 
 ```pyi
-from typing import Generic, TypeVar, overload
+from typing import Generic, Iterator, TypeVar, overload
 
 T = TypeVar("T")
 
@@ -665,6 +665,14 @@ class GenericReturn(Generic[T]):
     def method(self) -> T: ...
 
 class GenericConflict(ReturnsStr, GenericReturn[int]): ...  # error: [invalid-method-override]
+
+class IteratesStr:
+    def __iter__(self) -> Iterator[str]: ...
+
+class IteratesInt:
+    def __iter__(self) -> Iterator[int]: ...
+
+class IteratorConflict(IteratesStr, IteratesInt): ...  # error: [invalid-method-override]
 
 class ReceiverBase:
     @overload

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -714,6 +714,13 @@ class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid
 class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # snapshot: invalid-method-override
 class StaticClassConflict(StaticMethod, ClassMethod): ...  # error: [invalid-method-override]
 class ClassStaticConflict(ClassMethod, StaticMethod): ...  # error: [invalid-method-override]
+class Empty: ...
+
+class InvalidStr:
+    def __str__(self) -> int: ...  # error: [invalid-method-override]
+
+# The implicit `object` tail of `Empty` is not a competing explicit branch contract.
+class DoesNotRepeatObjectConflict(Empty, InvalidStr): ...
 ```
 
 ```snapshot

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -661,6 +661,12 @@ class CompatibleReturns(ReturnsBool, ReturnsInt): ...
 class IntermediateReturnsStr(ReturnsStr): ...
 class IndirectConflict(IntermediateReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
 
+class UnreachableShadow(ReturnsStr):
+    if False:
+        method = 0
+
+class UnreachableShadowConflict(ReturnsInt, UnreachableShadow): ...  # error: [invalid-method-override]
+
 class GenericReturn(Generic[T]):
     def method(self) -> T: ...
 
@@ -732,20 +738,20 @@ info: This violates the Liskov Substitution Principle
 
 
 error[invalid-method-override]: Base classes for class `ClassInstanceConflict` define method `kind` incompatibly
-  --> src/multiple_inheritance.pyi:58:9
+  --> src/multiple_inheritance.pyi:64:9
    |
-58 |     def kind(cls, value: int) -> int: ...
+64 |     def kind(cls, value: int) -> int: ...
    |         ---- `ClassMethod.kind` defined here
-59 |
-60 | class InstanceStaticConflict(InstanceMethod, StaticMethod): ...  # error: [invalid-method-override]
-61 | class StaticInstanceConflict(StaticMethod, InstanceMethod): ...  # error: [invalid-method-override]
-62 | class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid-method-override]
-63 | class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # snapshot: invalid-method-override
+65 |
+66 | class InstanceStaticConflict(InstanceMethod, StaticMethod): ...  # error: [invalid-method-override]
+67 | class StaticInstanceConflict(StaticMethod, InstanceMethod): ...  # error: [invalid-method-override]
+68 | class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid-method-override]
+69 | class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # snapshot: invalid-method-override
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClassMethod.kind` is incompatible with `InstanceMethod.kind`
    |
-  ::: src/multiple_inheritance.pyi:50:9
+  ::: src/multiple_inheritance.pyi:56:9
    |
-50 |     def kind(self, value: int) -> int: ...
+56 |     def kind(self, value: int) -> int: ...
    |         ---- `InstanceMethod.kind` defined here
    |
 info: `ClassMethod.kind` is a classmethod but `InstanceMethod.kind` is an instance method

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -643,7 +643,7 @@ effective source-defined method contract exposed by every direct branch.
 `multiple_inheritance.pyi`:
 
 ```pyi
-from typing import Generic, Iterator, TypeVar, overload
+from typing import Any, Generic, Iterator, TypeVar, overload
 
 T = TypeVar("T")
 
@@ -721,6 +721,22 @@ class InvalidStr:
 
 # The implicit `object` tail of `Empty` is not a competing explicit branch contract.
 class DoesNotRepeatObjectConflict(Empty, InvalidStr): ...
+
+class Meta(type):
+    @property
+    def class_method(cls) -> Any: ...
+
+class MetaIntBase(metaclass=Meta):
+    @classmethod
+    def class_method(cls) -> int: ...
+
+class MetaStrBase:
+    @classmethod
+    def class_method(cls) -> str: ...
+
+# The metaclass descriptor affects class-object lookup, but it does not replace the method exposed
+# by instances of `MetaIntBase`.
+class MetaclassDescriptorConflict(MetaIntBase, MetaStrBase): ...  # error: [invalid-method-override]
 ```
 
 ```snapshot

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -635,6 +635,75 @@ class ProtocolWithClassVarImpl(ProtocolBase):
     instance_attr = 0
 ```
 
+## Inherited method conflicts in multiple inheritance
+
+At an explicit nominal multiple-inheritance join, the method selected by the MRO must satisfy the
+effective source-defined method contract exposed by every direct branch.
+
+`multiple_inheritance.pyi`:
+
+```pyi
+from typing import Generic, TypeVar, overload
+
+T = TypeVar("T")
+
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class ReturnsBool:
+    def method(self) -> bool: ...
+
+class IncompatibleReturns(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
+class CompatibleReturns(ReturnsBool, ReturnsInt): ...
+class IntermediateReturnsStr(ReturnsStr): ...
+class IndirectConflict(IntermediateReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+
+class GenericReturn(Generic[T]):
+    def method(self) -> T: ...
+
+class GenericConflict(ReturnsStr, GenericReturn[int]): ...  # error: [invalid-method-override]
+
+class ReceiverBase:
+    @overload
+    @classmethod
+    def selected(cls: type[FinalReceiver]) -> int: ...
+    @overload
+    @classmethod
+    def selected(cls) -> str: ...
+
+class Left(ReceiverBase): ...
+
+class Right(ReceiverBase):
+    @classmethod
+    def selected(cls) -> str: ...
+
+class FinalReceiver(Left, Right): ...  # error: [invalid-method-override]
+```
+
+```snapshot
+error[invalid-method-override]: Base classes for class `IncompatibleReturns` define method `method` incompatibly
+  --> src/multiple_inheritance.pyi:6:9
+   |
+ 6 |     def method(self) -> str: ...
+   |         ------ `ReturnsStr.method` defined here
+ 7 |
+ 8 | class ReturnsInt:
+ 9 |     def method(self) -> int: ...
+   |         ------ `ReturnsInt.method` defined here
+10 |
+11 | class ReturnsBool:
+12 |     def method(self) -> bool: ...
+13 |
+14 | class IncompatibleReturns(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ReturnsStr.method` is incompatible with `ReturnsInt.method`
+   |
+info: incompatible return types: `str` is not assignable to `int`
+info: This violates the Liskov Substitution Principle
+```
+
 ## The entire class hierarchy is checked
 
 If a child class's method definition is Liskov-compatible with the method definition on its parent

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -637,16 +637,16 @@ class ProtocolWithClassVarImpl(ProtocolBase):
 
 ## Inherited method conflicts in multiple inheritance
 
-At an explicit nominal multiple-inheritance join, the method selected by the MRO must satisfy the
-effective source-defined method contract exposed by every direct branch.
+When a class directly inherits from two or more statically known classes, the method selected by
+Python's MRO must be compatible with the effective method inherited through each base.
 
-`multiple_inheritance.pyi`:
+### Basic conflicts
+
+`IncompatibleReturns.method` comes from `ReturnsStr`, but its `str` return type does not satisfy the
+contract inherited from `ReturnsInt`. Returning `bool` is compatible because `bool` is a subtype of
+`int`.
 
 ```pyi
-from typing import Any, Generic, Iterator, TypeVar, overload
-
-T = TypeVar("T")
-
 class ReturnsStr:
     def method(self) -> str: ...
 
@@ -658,20 +658,94 @@ class ReturnsBool:
 
 class IncompatibleReturns(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
 class CompatibleReturns(ReturnsBool, ReturnsInt): ...
-class IntermediateReturnsStr(ReturnsStr): ...
-class IndirectConflict(IntermediateReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+```
+
+```snapshot
+error[invalid-method-override]: Base classes for class `IncompatibleReturns` define method `method` incompatibly
+  --> src/mdtest_snippet.pyi:2:9
+   |
+ 2 |     def method(self) -> str: ...
+   |         ------ `ReturnsStr.method` defined here
+ 3 |
+ 4 | class ReturnsInt:
+ 5 |     def method(self) -> int: ...
+   |         ------ `ReturnsInt.method` defined here
+ 6 |
+ 7 | class ReturnsBool:
+ 8 |     def method(self) -> bool: ...
+ 9 |
+10 | class IncompatibleReturns(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ReturnsStr.method` is incompatible with `ReturnsInt.method`
+   |
+info: incompatible return types: `str` is not assignable to `int`
+info: This violates the Liskov Substitution Principle
+```
+
+### Methods inherited by a direct base
+
+A direct base does not need to define the method itself. Its effective method can come from an
+ancestor.
+
+```pyi
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class Intermediate(ReturnsStr): ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class Child(Intermediate, ReturnsInt): ...  # error: [invalid-method-override]
+```
+
+### Unreachable definitions do not shadow inherited methods
+
+An assignment in an unreachable branch does not replace the method inherited from `ReturnsStr`.
+
+```pyi
+class ReturnsStr:
+    def method(self) -> str: ...
 
 class UnreachableShadow(ReturnsStr):
     if False:
         method = 0
 
-class UnreachableShadowConflict(ReturnsInt, UnreachableShadow): ...  # error: [invalid-method-override]
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class Child(ReturnsInt, UnreachableShadow): ...  # error: [invalid-method-override]
+```
+
+### Generic bases
+
+Methods inherited from a specialized generic base use the specialization selected by the subclass.
+The legacy `Generic[T]` base does not participate in method selection, but it must not prevent us
+from checking the other bases.
+
+```pyi
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
 
 class GenericReturn(Generic[T]):
     def method(self) -> T: ...
 
-class GenericConflict(ReturnsStr, GenericReturn[int]): ...  # error: [invalid-method-override]
-class GenericPseudoBaseConflict(Generic[T], ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+class SpecializedConflict(ReturnsStr, GenericReturn[int]): ...  # error: [invalid-method-override]
+class GenericBaseConflict(Generic[T], ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+```
+
+### Special methods
+
+Ordinary special methods participate in the same compatibility check as named methods.
+
+```pyi
+from typing import Iterator
 
 class IteratesStr:
     def __iter__(self) -> Iterator[str]: ...
@@ -679,12 +753,21 @@ class IteratesStr:
 class IteratesInt:
     def __iter__(self) -> Iterator[int]: ...
 
-class IteratorConflict(IteratesStr, IteratesInt): ...  # error: [invalid-method-override]
+class Child(IteratesStr, IteratesInt): ...  # error: [invalid-method-override]
+```
+
+### Classmethods use the final class as their receiver
+
+A classmethod overload can depend on the concrete class through which the method is accessed. The
+inherited contracts are therefore bound to `Final` rather than to the classes that define them.
+
+```pyi
+from typing import overload
 
 class ReceiverBase:
     @overload
     @classmethod
-    def selected(cls: type[FinalReceiver]) -> int: ...
+    def selected(cls: type[Final]) -> int: ...
     @overload
     @classmethod
     def selected(cls) -> str: ...
@@ -695,8 +778,16 @@ class Right(ReceiverBase):
     @classmethod
     def selected(cls) -> str: ...
 
-class FinalReceiver(Left, Right): ...  # error: [invalid-method-override]
+class Final(Left, Right): ...  # error: [invalid-method-override]
+```
 
+### Method kinds
+
+Instance methods, classmethods, and staticmethods are bound differently when accessed, even when
+their callable signatures are otherwise identical. All three pairings are checked in both base
+orders because changing the order changes the method selected by the MRO.
+
+```pyi
 class InstanceMethod:
     def kind(self, value: int) -> int: ...
 
@@ -714,71 +805,67 @@ class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid
 class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # snapshot: invalid-method-override
 class StaticClassConflict(StaticMethod, ClassMethod): ...  # error: [invalid-method-override]
 class ClassStaticConflict(ClassMethod, StaticMethod): ...  # error: [invalid-method-override]
+```
+
+```snapshot
+error[invalid-method-override]: Base classes for class `ClassInstanceConflict` define method `kind` incompatibly
+  --> src/mdtest_snippet.pyi:10:9
+   |
+10 |     def kind(cls, value: int) -> int: ...
+   |         ---- `ClassMethod.kind` defined here
+11 |
+12 | class InstanceStaticConflict(InstanceMethod, StaticMethod): ...  # error: [invalid-method-override]
+13 | class StaticInstanceConflict(StaticMethod, InstanceMethod): ...  # error: [invalid-method-override]
+14 | class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid-method-override]
+15 | class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # snapshot: invalid-method-override
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClassMethod.kind` is incompatible with `InstanceMethod.kind`
+   |
+  ::: src/mdtest_snippet.pyi:2:9
+   |
+ 2 |     def kind(self, value: int) -> int: ...
+   |         ---- `InstanceMethod.kind` defined here
+   |
+info: `ClassMethod.kind` is a classmethod but `InstanceMethod.kind` is an instance method
+info: This violates the Liskov Substitution Principle
+```
+
+### The implicit `object` base is not a competing contract
+
+Every class eventually inherits from `object`, but that shared tail of the MRO is not a separate
+method contract from an otherwise empty base. `InvalidStr` receives the ordinary override error;
+`Child` should not receive a second error.
+
+```pyi
 class Empty: ...
 
 class InvalidStr:
     def __str__(self) -> int: ...  # error: [invalid-method-override]
 
-# The implicit `object` tail of `Empty` is not a competing explicit branch contract.
-class DoesNotRepeatObjectConflict(Empty, InvalidStr): ...
+class Child(Empty, InvalidStr): ...
+```
+
+### Metaclass descriptors do not replace classmethod contracts
+
+Looking up a classmethod by name on a class object can invoke a same-named descriptor on its
+metaclass. The inherited contract comes from the source-defined classmethod, not that metaclass
+descriptor.
+
+```pyi
+from typing import Any
 
 class Meta(type):
     @property
     def class_method(cls) -> Any: ...
 
-class MetaIntBase(metaclass=Meta):
+class ReturnsInt(metaclass=Meta):
     @classmethod
     def class_method(cls) -> int: ...
 
-class MetaStrBase:
+class ReturnsStr:
     @classmethod
     def class_method(cls) -> str: ...
 
-# The metaclass descriptor affects class-object lookup, but it does not replace the method exposed
-# by instances of `MetaIntBase`.
-class MetaclassDescriptorConflict(MetaIntBase, MetaStrBase): ...  # error: [invalid-method-override]
-```
-
-```snapshot
-error[invalid-method-override]: Base classes for class `IncompatibleReturns` define method `method` incompatibly
-  --> src/multiple_inheritance.pyi:6:9
-   |
- 6 |     def method(self) -> str: ...
-   |         ------ `ReturnsStr.method` defined here
- 7 |
- 8 | class ReturnsInt:
- 9 |     def method(self) -> int: ...
-   |         ------ `ReturnsInt.method` defined here
-10 |
-11 | class ReturnsBool:
-12 |     def method(self) -> bool: ...
-13 |
-14 | class IncompatibleReturns(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ReturnsStr.method` is incompatible with `ReturnsInt.method`
-   |
-info: incompatible return types: `str` is not assignable to `int`
-info: This violates the Liskov Substitution Principle
-
-
-error[invalid-method-override]: Base classes for class `ClassInstanceConflict` define method `kind` incompatibly
-  --> src/multiple_inheritance.pyi:64:9
-   |
-64 |     def kind(cls, value: int) -> int: ...
-   |         ---- `ClassMethod.kind` defined here
-65 |
-66 | class InstanceStaticConflict(InstanceMethod, StaticMethod): ...  # error: [invalid-method-override]
-67 | class StaticInstanceConflict(StaticMethod, InstanceMethod): ...  # error: [invalid-method-override]
-68 | class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid-method-override]
-69 | class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # snapshot: invalid-method-override
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClassMethod.kind` is incompatible with `InstanceMethod.kind`
-   |
-  ::: src/multiple_inheritance.pyi:56:9
-   |
-56 |     def kind(self, value: int) -> int: ...
-   |         ---- `InstanceMethod.kind` defined here
-   |
-info: `ClassMethod.kind` is a classmethod but `InstanceMethod.kind` is an instance method
-info: This violates the Liskov Substitution Principle
+class Child(ReturnsInt, ReturnsStr): ...  # error: [invalid-method-override]
 ```
 
 ## The entire class hierarchy is checked

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -681,6 +681,24 @@ info: incompatible return types: `str` is not assignable to `int`
 info: This violates the Liskov Substitution Principle
 ```
 
+### Functions assigned in a class body
+
+A function installed through a class-body assignment is bound as a method and contributes the same
+kind of inherited contract as a class-body function definition. Both base orders are checked.
+
+```pyi
+def returns_str(self) -> str: ...
+
+class Assigned:
+    method = returns_str
+
+class Defined:
+    def method(self) -> int: ...
+
+class AssignedFirst(Assigned, Defined): ...  # error: [invalid-method-override]
+class AssignedSecond(Defined, Assigned): ...  # error: [invalid-method-override]
+```
+
 ### Methods inherited by a direct base
 
 A direct base does not need to define the method itself. Its effective method can come from an

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -705,7 +705,7 @@ class ClassMethod:
 class InstanceStaticConflict(InstanceMethod, StaticMethod): ...  # error: [invalid-method-override]
 class StaticInstanceConflict(StaticMethod, InstanceMethod): ...  # error: [invalid-method-override]
 class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid-method-override]
-class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # error: [invalid-method-override]
+class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # snapshot: invalid-method-override
 class StaticClassConflict(StaticMethod, ClassMethod): ...  # error: [invalid-method-override]
 class ClassStaticConflict(ClassMethod, StaticMethod): ...  # error: [invalid-method-override]
 ```
@@ -728,6 +728,27 @@ error[invalid-method-override]: Base classes for class `IncompatibleReturns` def
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ReturnsStr.method` is incompatible with `ReturnsInt.method`
    |
 info: incompatible return types: `str` is not assignable to `int`
+info: This violates the Liskov Substitution Principle
+
+
+error[invalid-method-override]: Base classes for class `ClassInstanceConflict` define method `kind` incompatibly
+  --> src/multiple_inheritance.pyi:58:9
+   |
+58 |     def kind(cls, value: int) -> int: ...
+   |         ---- `ClassMethod.kind` defined here
+59 |
+60 | class InstanceStaticConflict(InstanceMethod, StaticMethod): ...  # error: [invalid-method-override]
+61 | class StaticInstanceConflict(StaticMethod, InstanceMethod): ...  # error: [invalid-method-override]
+62 | class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid-method-override]
+63 | class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # snapshot: invalid-method-override
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClassMethod.kind` is incompatible with `InstanceMethod.kind`
+   |
+  ::: src/multiple_inheritance.pyi:50:9
+   |
+50 |     def kind(self, value: int) -> int: ...
+   |         ---- `InstanceMethod.kind` defined here
+   |
+info: `ClassMethod.kind` is a classmethod but `InstanceMethod.kind` is an instance method
 info: This violates the Liskov Substitution Principle
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -699,6 +699,34 @@ class AssignedFirst(Assigned, Defined): ...  # error: [invalid-method-override]
 class AssignedSecond(Defined, Assigned): ...  # error: [invalid-method-override]
 ```
 
+### Enum mixins
+
+Ordinary mixin methods continue to contribute inherited contracts when the resulting class is an
+enum.
+
+```pyi
+from enum import Enum
+from typing import Literal
+
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class MixedEnum(ReturnsStr, ReturnsInt, Enum):  # error: [invalid-method-override]
+    MEMBER = 1
+
+class FirstString:
+    def __str__(self) -> Literal["first"]: ...
+
+class SecondString:
+    def __str__(self) -> Literal["second"]: ...
+
+class StringConflict(FirstString, SecondString, Enum):  # error: [invalid-method-override]
+    MEMBER = 1
+```
+
 ### Methods inherited by a direct base
 
 A direct base does not need to define the method itself. Its effective method can come from an

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3911,6 +3911,46 @@ pub(super) fn report_invalid_method_override<'db>(
     }
 }
 
+pub(super) fn report_incompatible_base_method<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+    member: &str,
+    selected: (ClassType<'db>, Definition<'db>),
+    contract: (ClassType<'db>, Definition<'db>),
+    error_context: impl FnOnce() -> ErrorContextTree<'db>,
+) {
+    let db = context.db();
+    let Some(builder) = context.report_lint(&INVALID_METHOD_OVERRIDE, class.header_range(db))
+    else {
+        return;
+    };
+
+    let (selected_owner, selected_definition) = selected;
+    let (contract_owner, contract_definition) = contract;
+    let selected_name = selected_owner.name(db);
+    let contract_name = contract_owner.name(db);
+    let mut diagnostic = builder.into_diagnostic(format_args!(
+        "Base classes for class `{}` define method `{member}` incompatibly",
+        class.name(db)
+    ));
+    diagnostic.set_primary_message(format_args!(
+        "`{selected_name}.{member}` is incompatible with `{contract_name}.{member}`"
+    ));
+    error_context().attach_to(db, &mut diagnostic);
+    diagnostic.info("This violates the Liskov Substitution Principle");
+
+    for (definition, owner_name) in [
+        (selected_definition, selected_name),
+        (contract_definition, contract_name),
+    ] {
+        let module = parsed_module(db, definition.file(db)).load(db);
+        diagnostic.annotate(
+            Annotation::secondary(Span::from(definition.focus_range(db, &module)))
+                .message(format_args!("`{owner_name}.{member}` defined here")),
+        );
+    }
+}
+
 pub(super) fn report_overridden_final_method<'db>(
     context: &InferContext<'db, '_>,
     member: &str,

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3911,6 +3911,11 @@ pub(super) fn report_invalid_method_override<'db>(
     }
 }
 
+/// Reports incompatible effective source-method contracts from two direct base branches.
+///
+/// `selected` is the method chosen by the MRO and `contract` is the method exposed by the competing
+/// branch. Both source definitions are annotated, and descriptor-kind differences are explained
+/// separately from callable-signature incompatibilities.
 pub(super) fn report_incompatible_base_method<'db>(
     context: &InferContext<'db, '_>,
     class: StaticClassLiteral<'db>,

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3915,8 +3915,8 @@ pub(super) fn report_incompatible_base_method<'db>(
     context: &InferContext<'db, '_>,
     class: StaticClassLiteral<'db>,
     member: &str,
-    selected: (ClassType<'db>, Definition<'db>),
-    contract: (ClassType<'db>, Definition<'db>),
+    selected: (ClassType<'db>, Definition<'db>, MethodDecorator),
+    contract: (ClassType<'db>, Definition<'db>, MethodDecorator),
     error_context: impl FnOnce() -> ErrorContextTree<'db>,
 ) {
     let db = context.db();
@@ -3925,8 +3925,8 @@ pub(super) fn report_incompatible_base_method<'db>(
         return;
     };
 
-    let (selected_owner, selected_definition) = selected;
-    let (contract_owner, contract_definition) = contract;
+    let (selected_owner, selected_definition, selected_decorator) = selected;
+    let (contract_owner, contract_definition, contract_decorator) = contract;
     let selected_name = selected_owner.name(db);
     let contract_name = contract_owner.name(db);
     let mut diagnostic = builder.into_diagnostic(format_args!(
@@ -3936,6 +3936,13 @@ pub(super) fn report_incompatible_base_method<'db>(
     diagnostic.set_primary_message(format_args!(
         "`{selected_name}.{member}` is incompatible with `{contract_name}.{member}`"
     ));
+    if selected_decorator != contract_decorator {
+        diagnostic.info(format_args!(
+            "`{selected_name}.{member}` is {} but `{contract_name}.{member}` is {}",
+            selected_decorator.description(),
+            contract_decorator.description(),
+        ));
+    }
     error_context().attach_to(db, &mut diagnostic);
     diagnostic.info("This violates the Liskov Substitution Principle");
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -239,6 +239,9 @@ fn effective_source_method_contract<'db>(
             ClassBase::Any | ClassBase::Dynamic(_) | ClassBase::Divergent(_) => return None,
             ClassBase::Protocol | ClassBase::Generic | ClassBase::TypedDict(_) => continue,
         };
+        if owner.is_object(db) {
+            return None;
+        }
         if owner.own_class_member(db, None, name).is_undefined() {
             continue;
         }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -19,9 +19,8 @@ use crate::{
     place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin},
     reachability::ReachabilityConstraintsExtension,
     types::{
-        CallableType, ClassBase, ClassLiteral, ClassType, IntersectionType, KnownClass,
-        MemberLookupPolicy, Parameter, Parameters, Signature, StaticClassLiteral, Type,
-        TypeContext, TypeQualifiers,
+        CallableType, ClassBase, ClassLiteral, ClassType, IntersectionType, KnownClass, Parameter,
+        Parameters, Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
         call::CallArguments,
         class::{CodeGeneratorKind, FieldKind, MethodDecorator},
         constraints::ConstraintSetBuilder,
@@ -261,21 +260,9 @@ fn effective_source_method_contract<'db>(
         let Type::FunctionLiteral(function) = own_ty else {
             return None;
         };
-        let (lookup_ty, receiver) = if function.is_classmethod(db) {
-            (Type::from(class), receiver.to_meta_type(db))
-        } else {
-            (Type::instance(db, class), receiver)
-        };
-
-        let ty = lookup_ty
-            .member_lookup_with_policy_and_receiver(
-                db,
-                name.clone(),
-                MemberLookupPolicy::default(),
-                Some(receiver),
-            )
-            .place
-            .ignore_possibly_undefined()?
+        let ty = Type::FunctionLiteral(function)
+            .try_call_dunder_get(db, Some(receiver), receiver.to_meta_type(db))?
+            .0
             .try_upcast_to_callable(db)?
             .into_type(db);
         return Some(SourceMethodContract {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -194,6 +194,9 @@ fn source_method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> Fx
         };
         let scope = owner_literal.body_scope(db);
         let table = place_table(db, scope);
+        let use_def = use_def_map(db, scope);
+        let predicates = use_def.predicates();
+        let reachability_constraints = use_def.reachability_constraints();
         for symbol in table.symbols().filter(|symbol| symbol.is_local()) {
             let name = symbol.name();
             if is_mangled_private(name.as_str())
@@ -202,13 +205,31 @@ fn source_method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> Fx
             {
                 continue;
             }
-            if owner.own_class_member(db, None, name).is_undefined() {
+            let Some(symbol_id) = table.symbol_id(name) else {
+                continue;
+            };
+            let has_reachable_definition =
+                use_def
+                    .end_of_scope_symbol_bindings(symbol_id)
+                    .any(|binding| {
+                        binding.binding.definition().is_some()
+                            && !reachability_constraints
+                                .evaluate(db, predicates, binding.reachability_constraint)
+                                .is_always_false()
+                    })
+                    || use_def
+                        .end_of_scope_symbol_declarations(symbol_id)
+                        .any(|declaration| {
+                            declaration.declaration.definition().is_some()
+                                && !reachability_constraints
+                                    .evaluate(db, predicates, declaration.reachability_constraint)
+                                    .is_always_false()
+                        });
+            if !has_reachable_definition {
                 continue;
             }
             seen.insert(name.clone());
-            if let Some(symbol_id) = table.symbol_id(name)
-                && is_function_definition(db, scope, symbol_id)
-            {
+            if is_function_definition(db, scope, symbol_id) {
                 methods.insert(name.clone());
             }
         }
@@ -1806,7 +1827,10 @@ fn check_enum_member_against_constructor_method<'db>(
 mod tests {
     use super::*;
     use crate::{db::tests::setup_db, place::global_symbol};
-    use ruff_db::{files::system_path_to_file, system::DbWithWritableSystem as _};
+    use ruff_db::{
+        files::system_path_to_file, system::DbWithWritableSystem as _,
+        testing::assert_function_query_was_not_run,
+    };
 
     #[test]
     fn empty_branch_has_no_inherited_method_candidates() {
@@ -1821,5 +1845,50 @@ mod tests {
             .unwrap();
 
         assert!(source_method_names_in_mro(&db, class).is_empty());
+    }
+
+    #[test]
+    fn inherited_method_candidate_discovery_does_not_infer_fields() {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/test.py",
+            r#"
+            class Base:
+                field = 1
+
+                def method(self) -> None:
+                    pass
+            "#,
+        )
+        .unwrap();
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        db.clear_salsa_events();
+        let candidates = {
+            let class = global_symbol(&db, file, "Base")
+                .place
+                .expect_type()
+                .to_class_type(&db)
+                .unwrap();
+            source_method_names_in_mro(&db, class)
+        };
+        let events = db.take_salsa_events();
+        assert_eq!(
+            candidates,
+            FxHashSet::from_iter([Name::new_static("method")])
+        );
+
+        let class = global_symbol(&db, file, "Base")
+            .place
+            .expect_type()
+            .to_class_type(&db)
+            .unwrap();
+        let (class_literal, _) = class.static_class_literal(&db).unwrap();
+        let scope = class_literal.body_scope(&db);
+        let field_symbol = place_table(&db, scope).symbol_id("field").unwrap();
+        let field_definition = use_def_map(&db, scope)
+            .end_of_scope_symbol_bindings(field_symbol)
+            .find_map(|binding| binding.binding.definition())
+            .unwrap();
+        assert_function_query_was_not_run(&db, infer_definition_types, field_definition, &events);
     }
 }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -172,8 +172,8 @@ fn check_inherited_method_conflicts<'db>(
                 context,
                 class,
                 &name,
-                (selected.owner, selected.definition),
-                (contract.owner, contract.definition),
+                (selected.owner, selected.definition, selected.decorator),
+                (contract.owner, contract.definition, contract.decorator),
                 || selected.ty.assignability_error_context(db, contract.ty),
             );
             continue 'members;

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -23,7 +23,7 @@ use crate::{
         MemberLookupPolicy, Parameter, Parameters, Signature, StaticClassLiteral, Type,
         TypeContext, TypeQualifiers,
         call::CallArguments,
-        class::{CodeGeneratorKind, FieldKind},
+        class::{CodeGeneratorKind, FieldKind, MethodDecorator},
         constraints::ConstraintSetBuilder,
         context::InferContext,
         diagnostic::{
@@ -162,7 +162,8 @@ fn check_inherited_method_conflicts<'db>(
                 continue;
             };
             if selected.owner.class_literal(db) == contract.owner.class_literal(db)
-                || selected.ty.is_assignable_to(db, contract.ty)
+                || (selected.decorator == contract.decorator
+                    && selected.ty.is_assignable_to(db, contract.ty))
             {
                 continue;
             }
@@ -217,6 +218,7 @@ fn source_method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> Fx
 struct SourceMethodContract<'db> {
     owner: ClassType<'db>,
     definition: Definition<'db>,
+    decorator: MethodDecorator,
     ty: Type<'db>,
 }
 
@@ -272,6 +274,7 @@ fn effective_source_method_contract<'db>(
         return Some(SourceMethodContract {
             owner,
             definition: symbol_definition(db, scope, symbol)?,
+            decorator: MethodDecorator::try_from_fn_type(db, function)?,
             ty,
         });
     }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -118,13 +118,13 @@ fn check_inherited_method_conflicts<'db>(
 
     let mut direct_bases = Vec::new();
     for base in class.explicit_bases(db) {
-        let Some(base) = base.to_class_type(db) else {
-            return;
-        };
-        if base.static_class_literal(db).is_none() {
-            return;
+        match ClassBase::try_from_explicit_base(db, *base, Some(class.into())) {
+            Some(ClassBase::Class(base)) if base.static_class_literal(db).is_some() => {
+                direct_bases.push(base);
+            }
+            Some(ClassBase::Generic | ClassBase::Protocol) => {}
+            _ => return,
         }
-        direct_bases.push(base);
     }
     if direct_bases.len() < 2 || class.try_mro(db, None).is_err() {
         return;

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -100,7 +100,18 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     }
 }
 
-/// Checks source-defined method conflicts introduced by explicit nominal multiple inheritance.
+/// Checks source-defined method conflicts when a class directly inherits from multiple statically
+/// known classes.
+///
+/// For a class such as:
+///
+/// ```python
+/// class Child(Left, Right): ...
+/// ```
+///
+/// Python's MRO selects one effective method, which must satisfy the effective source-method
+/// contract inherited through every direct base. Candidate names only need to come from bases after
+/// the first: a method inherited solely through the first base cannot conflict here.
 fn check_inherited_method_conflicts<'db>(
     context: &InferContext<'db, '_>,
     class: StaticClassLiteral<'db>,
@@ -180,7 +191,12 @@ fn check_inherited_method_conflicts<'db>(
     }
 }
 
-/// Returns effective source-defined method names without resolving their types.
+/// Returns effective source-defined method names without resolving member types.
+///
+/// A reachable local definition shadows the same name earlier in the MRO even when that definition
+/// is not a function. Unreachable definitions do not shadow, and the shared `object` tail is not a
+/// separate branch contract. The reachability-only scan keeps unrelated field types out of Salsa's
+/// retained query graph.
 fn source_method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> FxHashSet<Name> {
     let mut seen = FxHashSet::default();
     let mut methods = FxHashSet::default();
@@ -238,7 +254,7 @@ fn source_method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> Fx
     methods
 }
 
-#[derive(Debug, Clone, Copy)]
+/// An effective source method together with its diagnostic origin and descriptor kind.
 struct SourceMethodContract<'db> {
     owner: ClassType<'db>,
     definition: Definition<'db>,
@@ -246,7 +262,12 @@ struct SourceMethodContract<'db> {
     ty: Type<'db>,
 }
 
-/// Returns the selected source-defined method bound to `receiver`.
+/// Returns the selected source-defined method bound directly to `receiver`.
+///
+/// Direct function-descriptor binding preserves receiver-sensitive overload selection without
+/// repeating class-object lookup, where a custom metaclass descriptor could replace the discovered
+/// method. The contract is unavailable when the effective member is not a source function or the
+/// MRO reaches a dynamic boundary or the shared `object` tail.
 fn effective_source_method_contract<'db>(
     db: &'db dyn Db,
     class: ClassType<'db>,
@@ -262,7 +283,8 @@ fn effective_source_method_contract<'db>(
         if owner.is_object(db) {
             return None;
         }
-        if owner.own_class_member(db, None, name).is_undefined() {
+        let member = owner.own_class_member(db, None, name);
+        if member.is_undefined() {
             continue;
         }
 
@@ -273,11 +295,7 @@ fn effective_source_method_contract<'db>(
             return None;
         }
 
-        let own_ty = owner
-            .own_class_member(db, None, name)
-            .inner
-            .place
-            .raw_type()?;
+        let own_ty = member.inner.place.raw_type()?;
         let Type::FunctionLiteral(function) = own_ty else {
             return None;
         };
@@ -1820,75 +1838,5 @@ fn check_enum_member_against_constructor_method<'db>(
                 Type::FunctionLiteral(function).display(db),
             ));
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{db::tests::setup_db, place::global_symbol};
-    use ruff_db::{
-        files::system_path_to_file, system::DbWithWritableSystem as _,
-        testing::assert_function_query_was_not_run,
-    };
-
-    #[test]
-    fn empty_branch_has_no_inherited_method_candidates() {
-        let mut db = setup_db();
-        db.write_dedented("/src/test.py", "class Empty: pass")
-            .unwrap();
-        let file = system_path_to_file(&db, "/src/test.py").unwrap();
-        let class = global_symbol(&db, file, "Empty")
-            .place
-            .expect_type()
-            .to_class_type(&db)
-            .unwrap();
-
-        assert!(source_method_names_in_mro(&db, class).is_empty());
-    }
-
-    #[test]
-    fn inherited_method_candidate_discovery_does_not_infer_fields() {
-        let mut db = setup_db();
-        db.write_dedented(
-            "/src/test.py",
-            r#"
-            class Base:
-                field = 1
-
-                def method(self) -> None:
-                    pass
-            "#,
-        )
-        .unwrap();
-        let file = system_path_to_file(&db, "/src/test.py").unwrap();
-        db.clear_salsa_events();
-        let candidates = {
-            let class = global_symbol(&db, file, "Base")
-                .place
-                .expect_type()
-                .to_class_type(&db)
-                .unwrap();
-            source_method_names_in_mro(&db, class)
-        };
-        let events = db.take_salsa_events();
-        assert_eq!(
-            candidates,
-            FxHashSet::from_iter([Name::new_static("method")])
-        );
-
-        let class = global_symbol(&db, file, "Base")
-            .place
-            .expect_type()
-            .to_class_type(&db)
-            .unwrap();
-        let (class_literal, _) = class.static_class_literal(&db).unwrap();
-        let scope = class_literal.body_scope(&db);
-        let field_symbol = place_table(&db, scope).symbol_id("field").unwrap();
-        let field_definition = use_def_map(&db, scope)
-            .end_of_scope_symbol_bindings(field_symbol)
-            .find_map(|binding| binding.binding.definition())
-            .unwrap();
-        assert_function_query_was_not_run(&db, infer_definition_types, field_definition, &events);
     }
 }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -186,6 +186,9 @@ fn source_method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> Fx
     let mut methods = FxHashSet::default();
 
     for owner in class.iter_mro(db).filter_map(ClassBase::into_class) {
+        if owner.is_object(db) {
+            break;
+        }
         let Some((owner_literal, _)) = owner.static_class_literal(db) else {
             continue;
         };
@@ -1799,5 +1802,27 @@ fn check_enum_member_against_constructor_method<'db>(
                 Type::FunctionLiteral(function).display(db),
             ));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{db::tests::setup_db, place::global_symbol};
+    use ruff_db::{files::system_path_to_file, system::DbWithWritableSystem as _};
+
+    #[test]
+    fn empty_branch_has_no_inherited_method_candidates() {
+        let mut db = setup_db();
+        db.write_dedented("/src/test.py", "class Empty: pass")
+            .unwrap();
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        let class = global_symbol(&db, file, "Empty")
+            .place
+            .expect_type()
+            .to_class_type(&db)
+            .unwrap();
+
+        assert!(source_method_names_in_mro(&db, class).is_empty());
     }
 }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -9,7 +9,7 @@ use ruff_db::{
     files::FileRange,
     parsed::ParsedModuleRef,
 };
-use ruff_python_ast::{helpers::is_dunder, name::Name};
+use ruff_python_ast::name::Name;
 use ruff_python_stdlib::identifiers::is_mangled_private;
 use rustc_hash::FxHashSet;
 
@@ -194,7 +194,7 @@ fn source_method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> Fx
         for symbol in table.symbols().filter(|symbol| symbol.is_local()) {
             let name = symbol.name();
             if is_mangled_private(name.as_str())
-                || is_dunder(name.as_str())
+                || is_constructor_like_method(name.as_str())
                 || !seen.insert(name.clone())
             {
                 continue;

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -9,7 +9,7 @@ use ruff_db::{
     files::FileRange,
     parsed::ParsedModuleRef,
 };
-use ruff_python_ast::name::Name;
+use ruff_python_ast::{helpers::is_dunder, name::Name};
 use ruff_python_stdlib::identifiers::is_mangled_private;
 use rustc_hash::FxHashSet;
 
@@ -19,8 +19,9 @@ use crate::{
     place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin},
     reachability::ReachabilityConstraintsExtension,
     types::{
-        CallableType, ClassBase, ClassLiteral, ClassType, IntersectionType, KnownClass, Parameter,
-        Parameters, Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
+        CallableType, ClassBase, ClassLiteral, ClassType, IntersectionType, KnownClass,
+        MemberLookupPolicy, Parameter, Parameters, Signature, StaticClassLiteral, Type,
+        TypeContext, TypeQualifiers,
         call::CallArguments,
         class::{CodeGeneratorKind, FieldKind},
         constraints::ConstraintSetBuilder,
@@ -29,10 +30,11 @@ use crate::{
             INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_OVERRIDE, INVALID_DATACLASS,
             INVALID_EXPLICIT_OVERRIDE, INVALID_METHOD_OVERRIDE, INVALID_NAMED_TUPLE,
             INVALID_NAMED_TUPLE_OVERRIDE, MISSING_OVERRIDE_DECORATOR, OVERRIDE_OF_FINAL_METHOD,
-            OVERRIDE_OF_FINAL_VARIABLE, report_invalid_method_override,
-            report_overridden_final_method, report_overridden_final_variable,
+            OVERRIDE_OF_FINAL_VARIABLE, report_incompatible_base_method,
+            report_invalid_method_override, report_overridden_final_method,
+            report_overridden_final_variable,
         },
-        enums::{EnumMetadata, enum_metadata},
+        enums::{EnumMetadata, enum_metadata, is_enum_class_by_inheritance},
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
         infer::infer_definition_types,
         list_members::{Member, MemberWithDefinition, all_end_of_scope_members},
@@ -75,6 +77,10 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     }
 
     let class_specialized = class.identity_specialization(db);
+    if configuration.check_method_liskov_violations() {
+        check_inherited_method_conflicts(context, class, class_specialized);
+    }
+
     let scope = class.body_scope(db);
     let own_class_members: FxHashSet<_> = all_end_of_scope_members(db, scope).collect();
     let enum_info = enum_metadata(db, class.into());
@@ -93,6 +99,181 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
             &member,
         );
     }
+}
+
+/// Checks source-defined method conflicts introduced by explicit nominal multiple inheritance.
+fn check_inherited_method_conflicts<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+    class_specialized: ClassType<'db>,
+) {
+    let db = context.db();
+    if matches!(
+        CodeGeneratorKind::from_class(db, class.into()),
+        Some(CodeGeneratorKind::NamedTuple | CodeGeneratorKind::TypedDict)
+    ) || is_enum_class_by_inheritance(db, class)
+    {
+        return;
+    }
+
+    let mut direct_bases = Vec::new();
+    for base in class.explicit_bases(db) {
+        let Some(base) = base.to_class_type(db) else {
+            return;
+        };
+        if base.static_class_literal(db).is_none() {
+            return;
+        }
+        direct_bases.push(base);
+    }
+    if direct_bases.len() < 2 || class.try_mro(db, None).is_err() {
+        return;
+    }
+
+    let constraints = ConstraintSetBuilder::new();
+    if direct_bases.iter().enumerate().any(|(index, left)| {
+        direct_bases[index + 1..]
+            .iter()
+            .any(|right| !left.could_coexist_in_mro_with(db, *right, &constraints))
+    }) {
+        return;
+    }
+
+    let receiver = Type::instance(db, class_specialized);
+    let mut candidates = FxHashSet::default();
+    for base in direct_bases.iter().copied().skip(1) {
+        candidates.extend(source_method_names_in_mro(db, base));
+    }
+    let mut candidates: Vec<_> = candidates.into_iter().collect();
+    candidates.sort_unstable();
+
+    'members: for name in candidates {
+        let Some(selected) =
+            effective_source_method_contract(db, class_specialized, receiver, &name)
+        else {
+            continue;
+        };
+        if selected.owner.class_literal(db) == ClassLiteral::Static(class) {
+            continue;
+        }
+
+        for base in direct_bases.iter().copied() {
+            let Some(contract) = effective_source_method_contract(db, base, receiver, &name) else {
+                continue;
+            };
+            if selected.owner.class_literal(db) == contract.owner.class_literal(db)
+                || selected.ty.is_assignable_to(db, contract.ty)
+            {
+                continue;
+            }
+
+            report_incompatible_base_method(
+                context,
+                class,
+                &name,
+                (selected.owner, selected.definition),
+                (contract.owner, contract.definition),
+                || selected.ty.assignability_error_context(db, contract.ty),
+            );
+            continue 'members;
+        }
+    }
+}
+
+/// Returns effective source-defined method names without resolving their types.
+fn source_method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> FxHashSet<Name> {
+    let mut seen = FxHashSet::default();
+    let mut methods = FxHashSet::default();
+
+    for owner in class.iter_mro(db).filter_map(ClassBase::into_class) {
+        let Some((owner_literal, _)) = owner.static_class_literal(db) else {
+            continue;
+        };
+        let scope = owner_literal.body_scope(db);
+        let table = place_table(db, scope);
+        for symbol in table.symbols().filter(|symbol| symbol.is_local()) {
+            let name = symbol.name();
+            if is_mangled_private(name.as_str())
+                || is_dunder(name.as_str())
+                || !seen.insert(name.clone())
+            {
+                continue;
+            }
+            if let Some(symbol_id) = table.symbol_id(name)
+                && is_function_definition(db, scope, symbol_id)
+            {
+                methods.insert(name.clone());
+            }
+        }
+    }
+
+    methods
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SourceMethodContract<'db> {
+    owner: ClassType<'db>,
+    definition: Definition<'db>,
+    ty: Type<'db>,
+}
+
+/// Returns the selected source-defined method bound to `receiver`.
+fn effective_source_method_contract<'db>(
+    db: &'db dyn Db,
+    class: ClassType<'db>,
+    receiver: Type<'db>,
+    name: &Name,
+) -> Option<SourceMethodContract<'db>> {
+    for base in class.iter_mro(db) {
+        let owner = match base {
+            ClassBase::Class(owner) => owner,
+            ClassBase::Any | ClassBase::Dynamic(_) | ClassBase::Divergent(_) => return None,
+            ClassBase::Protocol | ClassBase::Generic | ClassBase::TypedDict(_) => continue,
+        };
+        if owner.own_class_member(db, None, name).is_undefined() {
+            continue;
+        }
+
+        let (owner_literal, _) = owner.static_class_literal(db)?;
+        let scope = owner_literal.body_scope(db);
+        let symbol = place_table(db, scope).symbol_id(name)?;
+        if !is_function_definition(db, scope, symbol) {
+            return None;
+        }
+
+        let own_ty = owner
+            .own_class_member(db, None, name)
+            .inner
+            .place
+            .raw_type()?;
+        let Type::FunctionLiteral(function) = own_ty else {
+            return None;
+        };
+        let (lookup_ty, receiver) = if function.is_classmethod(db) {
+            (Type::from(class), receiver.to_meta_type(db))
+        } else {
+            (Type::instance(db, class), receiver)
+        };
+
+        let ty = lookup_ty
+            .member_lookup_with_policy_and_receiver(
+                db,
+                name.clone(),
+                MemberLookupPolicy::default(),
+                Some(receiver),
+            )
+            .place
+            .ignore_possibly_undefined()?
+            .try_upcast_to_callable(db)?
+            .into_type(db);
+        return Some(SourceMethodContract {
+            owner,
+            definition: symbol_definition(db, scope, symbol)?,
+            ty,
+        });
+    }
+
+    None
 }
 
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -245,7 +245,7 @@ fn source_method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> Fx
                 continue;
             }
             seen.insert(name.clone());
-            if is_function_definition(db, scope, symbol_id) {
+            if source_method_function(db, owner, name).is_some() {
                 methods.insert(name.clone());
             }
         }
@@ -291,14 +291,7 @@ fn effective_source_method_contract<'db>(
         let (owner_literal, _) = owner.static_class_literal(db)?;
         let scope = owner_literal.body_scope(db);
         let symbol = place_table(db, scope).symbol_id(name)?;
-        if !is_function_definition(db, scope, symbol) {
-            return None;
-        }
-
-        let own_ty = member.inner.place.raw_type()?;
-        let Type::FunctionLiteral(function) = own_ty else {
-            return None;
-        };
+        let function = source_method_function(db, owner, name)?;
         let ty = Type::FunctionLiteral(function)
             .try_call_dunder_get(db, Some(receiver), receiver.to_meta_type(db))?
             .0
@@ -313,6 +306,26 @@ fn effective_source_method_contract<'db>(
     }
 
     None
+}
+
+/// Returns the function stored in a source-defined class member.
+///
+/// This includes functions installed by assignment, such as `method = helper`, because Python
+/// binds those function objects as methods in the same way as a class-body function definition.
+fn source_method_function<'db>(
+    db: &'db dyn Db,
+    owner: ClassType<'db>,
+    name: &Name,
+) -> Option<FunctionType<'db>> {
+    let Type::FunctionLiteral(function) = owner
+        .own_class_member(db, None, name)
+        .inner
+        .place
+        .raw_type()?
+    else {
+        return None;
+    };
+    Some(function)
 }
 
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -199,10 +199,14 @@ fn source_method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> Fx
             let name = symbol.name();
             if is_mangled_private(name.as_str())
                 || is_constructor_like_method(name.as_str())
-                || !seen.insert(name.clone())
+                || seen.contains(name)
             {
                 continue;
             }
+            if owner.own_class_member(db, None, name).is_undefined() {
+                continue;
+            }
+            seen.insert(name.clone());
             if let Some(symbol_id) = table.symbol_id(name)
                 && is_function_definition(db, scope, symbol_id)
             {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -9,12 +9,12 @@ use ruff_db::{
     files::FileRange,
     parsed::ParsedModuleRef,
 };
-use ruff_python_ast::name::Name;
+use ruff_python_ast::{PythonVersion, name::Name};
 use ruff_python_stdlib::identifiers::is_mangled_private;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    Db,
+    Db, Program,
     lint::LintId,
     place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin},
     reachability::ReachabilityConstraintsExtension,
@@ -121,8 +121,7 @@ fn check_inherited_method_conflicts<'db>(
     if matches!(
         CodeGeneratorKind::from_class(db, class.into()),
         Some(CodeGeneratorKind::NamedTuple | CodeGeneratorKind::TypedDict)
-    ) || is_enum_class_by_inheritance(db, class)
-    {
+    ) {
         return;
     }
 
@@ -178,6 +177,15 @@ fn check_inherited_method_conflicts<'db>(
                 continue;
             }
 
+            if enum_class_creation_manages_conflict(
+                db,
+                class,
+                &name,
+                selected.owner,
+                contract.owner,
+            ) {
+                continue;
+            }
             report_incompatible_base_method(
                 context,
                 class,
@@ -326,6 +334,40 @@ fn source_method_function<'db>(
         return None;
     };
     Some(function)
+}
+
+/// Returns `true` when this source-level conflict involves a method replaced by `EnumType` during
+/// class creation.
+///
+/// Restricting this to a known enum implementation still allows two ordinary mixins to contribute
+/// conflicting contracts for the same method name.
+fn enum_class_creation_manages_conflict<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+    name: &Name,
+    selected_owner: ClassType<'db>,
+    contract_owner: ClassType<'db>,
+) -> bool {
+    if !is_enum_class_by_inheritance(db, class) {
+        return false;
+    }
+
+    if matches!(
+        name.as_str(),
+        "__repr__" | "__str__" | "__format__" | "__reduce_ex__"
+    ) {
+        return selected_owner.is_known(db, KnownClass::Enum)
+            || contract_owner.is_known(db, KnownClass::Enum);
+    }
+
+    Program::get(db).python_version(db) >= PythonVersion::PY311
+        && Type::ClassLiteral(class.into()).is_subtype_of(db, KnownClass::Flag.to_subclass_of(db))
+        && matches!(
+            name.as_str(),
+            "__or__" | "__and__" | "__xor__" | "__ror__" | "__rand__" | "__rxor__" | "__invert__"
+        )
+        && (selected_owner.is_known(db, KnownClass::Flag)
+            || contract_owner.is_known(db, KnownClass::Flag))
 }
 
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.


### PR DESCRIPTION
## Summary

Multiple inheritance can make the method selected from one base silently replace an incompatible contract from another base. We previously ran Liskov checks only for methods defined directly on the subclass, so we accepted conflicts inherited entirely from its bases:

```python
class ReturnsStr:
    def method(self) -> str: ...

class ReturnsInt:
    def method(self) -> int: ...

class Child(ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
```

Implementing this in-full (performantly) turns out to be pretty hard. So this PR defers some cases as TODOs.

Specifically, when a class directly inherits from two or more statically known classes, this PR checks that the method selected by the MRO is compatible with the effective method inherited through each base:

```python
from collections.abc import Iterator
from typing import Generic, TypeVar

T = TypeVar("T")

class GenericReturn(Generic[T]):
    def method(self) -> T: ...

class GenericConflict(ReturnsStr, GenericReturn[int]): ...  # error
class GenericPseudoBase(Generic[T], ReturnsStr, ReturnsInt): ...  # error

class IteratesStr:
    def __iter__(self) -> Iterator[str]: ...

class IteratesInt:
    def __iter__(self) -> Iterator[int]: ...

class IteratorConflict(IteratesStr, IteratesInt): ...  # error
```

Method kinds are also respected even when descriptor binding produces otherwise-identical callable signatures:

```python
class InstanceMethod:
    def method(self, value: int) -> int: ...

class ClassMethod:
    @classmethod
    def method(cls, value: int) -> int: ...

class MethodKindConflict(ClassMethod, InstanceMethod): ...  # error
```

## Deferred work

We don't catch every "stricter" violation. For example, we intentionally do not diagnose this gradual conflict:

```python
from typing import Any

class AcceptsInt:
    def method(self, value: int) -> None: ...

class AcceptsAny(AcceptsInt):
    def method(self, value: Any) -> None: ...

class AcceptsStr:
    def method(self, value: str) -> None: ...

class Child(AcceptsStr, AcceptsAny): ...  # not checked against AcceptsInt.method
```

We also do not re-evaluate otherwise-empty single-base descendants for conflicts that appear only after receiver rebinding -- here's a complex case that Codex came up with:

```python
from typing import overload

class ReceiverBase:
    @overload
    @classmethod
    def selected(cls: type["Final"]) -> int: ...
    @overload
    @classmethod
    def selected(cls) -> str: ...

class Left(ReceiverBase): ...

class Right(ReceiverBase):
    @classmethod
    def selected(cls) -> str: ...

class Intermediate(Left, Right): ...  # compatible for Intermediate
class Final(Intermediate): ...         # conflict appears for Final
```

We also defer... dynamic `type(...)` bases, methods synthesized during `dataclass`, `NamedTuple`, `TypedDict`, or `Enum` creation, properties and custom descriptors, callable or non-callable fields, and mutable-attribute invariance.

## Comparison with mypy and Pyright

Codex generated this table to compare mypy 2.1.0 and Pyright 1.1.410 with our implementation:

| Behavior | This PR | mypy | Pyright |
| --- | --- | --- | --- |
| Basic incompatible source methods at a join | Reports | Reports | Reports |
| Specialized generic branch or `Generic[T]` pseudo-base | Reports | Reports | Reports |
| Ordinary inherited dunder conflict such as `__iter__` | Reports | Reports | Does not report the tested case |
| Instance/class/static method-kind mismatch | Reports | Does not report the inherited join | Reports |
| Stricter ancestor hidden behind an effective `Any` override | Does not report | Reports | Does not report |
| Conflict appearing only on an empty single-base descendant | Does not report | Does not report | Does not report |
| Receiver-sensitive conflict exposed by adding an empty second base | Does not report | Reports the tested `Self` case | Does not report |

This is therefore not intended as exact mypy or Pyright parity. It covers their common static source-method case, includes a few cases supported by only one of them, and keeps the expensive or inconsistently modeled cases as explicit follow-ups.

Closes https://github.com/astral-sh/ty/issues/3751.
