### PR TITLE
[ty] Model EnumType-created methods

### DIFF
--- a/PR_26431_ECOSYSTEM_SUMMARY.md
+++ b/PR_26431_ECOSYSTEM_SUMMARY.md
@@ -1,0 +1,76 @@
+# [PR #26431](https://github.com/astral-sh/ruff/pull/26431) ecosystem summary
+
+The report contains nine added diagnostics and two changed diagnostics, all in Home Assistant. The nine additions are false positives caused by synthesizing the narrower `Flag.__or__(Self) -> Self` contract for `IntFlag` subclasses: mixed `IntFlag | int` expressions fall through to `int` even though the runtime operation returns the `IntFlag` subclass. The two message-only changes improve the precision of pure flag unions by retaining every participating enum member instead of only the leftmost member.
+
+## Mixed `IntFlag` and `int` operations produce false positives
+
+**Report entries:**
+
+- [homeassistant/components/freebox/alarm_control_panel.py:74](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/freebox/alarm_control_panel.py#L74)
+- [homeassistant/components/group/cover.py:340](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/group/cover.py#L340)
+- [homeassistant/components/mqtt/vacuum.py:257](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/mqtt/vacuum.py#L257)
+- [homeassistant/components/aprilaire/climate.py:115](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/aprilaire/climate.py#L115)
+- [homeassistant/components/devialet/media_player.py:127](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/devialet/media_player.py#L127)
+- [homeassistant/components/zwave_js/cover.py:99](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/zwave_js/cover.py#L99)
+- [homeassistant/components/zwave_js/cover.py:112](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/zwave_js/cover.py#L112)
+- [homeassistant/components/zwave_js/cover.py:267](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/zwave_js/cover.py#L267)
+- [homeassistant/components/zwave_js/cover.py:280](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/zwave_js/cover.py#L280)
+
+On the merge base, enum member lookup retains the `IntFlag.__or__(int) -> Self` signature for these expressions. On the PR, class-creation synthesis exposes the `Flag` signature instead, so any branch containing an integer fallback such as `0` is inferred as `int`. This causes the assignment and return errors; the errors at Z-Wave lines 112 and 280 are cascades because the preceding invalid assignments no longer narrow the optional attributes.
+
+```python
+# Merge base: no diagnostics
+# PR: error[invalid-return-type] Return type does not match returned value: expected `Feature`, found `int`
+# PR: error[invalid-assignment] Object of type `int` is not assignable to attribute `features` of type `Feature | None`
+# PR: error[unsupported-operator] Operator `|=` is not supported between objects of type `None` and `Literal[Feature.B]`
+from enum import IntFlag
+
+class Feature(IntFlag):
+    A = 1
+    B = 2
+
+def supported_features(condition: bool) -> Feature:
+    features = Feature.A | (Feature.B if condition else 0)
+    return features
+
+class Entity:
+    features: Feature | None
+
+    def update(self, condition: bool) -> None:
+        self.features = (self.features or 0) | Feature.A | Feature.B
+        if condition:
+            self.features |= Feature.B
+```
+
+## Pure flag unions retain all enum members
+
+**Report entries:**
+
+- [homeassistant/components/hunterdouglas_powerview/cover.py:368](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/hunterdouglas_powerview/cover.py#L368)
+- [homeassistant/components/velux/cover.py:242](https://github.com/home-assistant/core/blob/9d34e83f71af0e8f7466ca18fa316ca1281c9ba3/homeassistant/components/velux/cover.py#L242)
+
+Both revisions diagnose the optional left operand. The PR improves the right operand from only the first enum literal to the union of every flag member in the expression, which explains the longer but more accurate messages in both entries.
+
+```python
+# Merge base: error[unsupported-operator] Operator `|=` is not supported between objects of type `None` and `Literal[Feature.A]`
+# PR: error[unsupported-operator] Operator `|=` is not supported between objects of type `None` and `Literal[Feature.A, Feature.B]`
+from enum import IntFlag
+
+class Feature(IntFlag):
+    A = 1
+    B = 2
+
+def update(features: Feature | None) -> None:
+    features |= Feature.A | Feature.B
+```
+
+## Reproduction
+
+- Detailed report: [ecosystem-analyzer report](https://32d753d8.ty-ecosystem-ext.pages.dev/diff)
+- Actions run: [run 28294734198](https://github.com/astral-sh/ruff/actions/runs/28294734198)
+- Ruff comparison: [`0da3f45792522418655b5081ef78fd34ba9bf48f`](https://github.com/astral-sh/ruff/commit/0da3f45792522418655b5081ef78fd34ba9bf48f) to [`ab0765f2e469bf1a84eff480062e0012b3485393`](https://github.com/astral-sh/ruff/commit/ab0765f2e469bf1a84eff480062e0012b3485393)
+- `ecosystem-analyzer`: [`e2c5b76149b147fae104a7d8fa0997a9eb7f7754`](https://github.com/astral-sh/ecosystem-analyzer/commit/e2c5b76149b147fae104a7d8fa0997a9eb7f7754)
+- `mypy-primer`: [`ff3d9531335dad605d43fcc208c9c159bb09fa81`](https://github.com/hauntsaninja/mypy_primer/commit/ff3d9531335dad605d43fcc208c9c159bb09fa81)
+- Project Python: `core: 3.11`
+- Dependency cutoff: `2026-06-27T16:17:05Z`
+- Comparison method: Set up `core` at revision `9d34e83f71af0e8f7466ca18fa316ca1281c9ba3` with the pinned `mypy-primer` helper and dependency cutoff, then ran copied binaries from both Ruff revisions with `ty check homeassistant --python .venv --output-format concise` and the PR's `.github/ty-ecosystem.toml`.

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -55,6 +55,65 @@ reveal_type(Number.ONE.__str__)  # revealed: bound method Number.__str__() -> st
 reveal_type(ReprNumber.ONE.__str__)  # revealed: bound method ReprNumber.__repr__() -> str
 ```
 
+## Python 3.8 enum data type selection
+
+Before Python 3.9, `EnumType` used a different rule to select a data type from a base's MRO:
+
+```toml
+[environment]
+python-version = "3.8"
+```
+
+```py
+from enum import Enum
+from typing import Literal
+
+class Root:
+    def __new__(cls, value: int): ...
+
+class Middle(Root): ...
+
+class Leaf(Middle):
+    def __str__(self) -> Literal["leaf"]:
+        return "leaf"
+
+class Number(Leaf, Enum):
+    ONE = 1
+
+reveal_type(Number.ONE.__str__)  # revealed: bound method Number.__str__() -> Literal["leaf"]
+```
+
+## Python 3.7 enum data type selection
+
+Python 3.7 selected the class that defined `__new__` instead:
+
+```toml
+[environment]
+python-version = "3.7"
+```
+
+```py
+from enum import Enum
+from typing import Literal
+
+class Root:
+    def __new__(cls, value: int): ...
+
+    def __str__(self) -> str:
+        return "root"
+
+class Middle(Root):
+    def __str__(self) -> Literal["middle"]:
+        return "middle"
+
+class Leaf(Middle): ...
+
+class Number(Leaf, Enum):
+    ONE = 1
+
+reveal_type(Number.ONE.__str__)  # revealed: bound method Number.__str__() -> Literal["middle"]
+```
+
 ## Flag operators installed during class creation
 
 Starting in Python 3.11, `EnumType` replaces inherited bitwise operators on every `Flag` subclass. A

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -22,11 +22,11 @@ reveal_type(Color(1))  # revealed: Color
 reveal_type(Color.RED in Color)  # revealed: bool
 ```
 
-## Methods managed during class creation
+## Methods replaced during enum class creation
 
-`EnumType` can replace inherited methods when it creates an enum class. It preserves ordinary mixin
-implementations, uses the data type's string methods for `ReprEnum`, and installs `Flag`'s operators
-on `Flag` subclasses:
+`EnumType` chooses some methods after the class body has been evaluated. An ordinary mixin method is
+preserved. For an enum that also inherits from a value type such as `int`, `EnumType` normally uses
+the `Enum` representation methods, while `ReprEnum` keeps the value type's representation:
 
 ```toml
 [environment]
@@ -34,7 +34,7 @@ python-version = "3.13"
 ```
 
 ```py
-from enum import Enum, Flag, IntFlag, ReprEnum
+from enum import Enum, ReprEnum
 from typing import Literal
 
 class StringMixin:
@@ -50,19 +50,31 @@ class Number(int, Enum):
 class ReprNumber(int, ReprEnum):
     ONE = 1
 
+reveal_type(Mixed.MEMBER.__str__)  # revealed: bound method Mixed.__str__() -> Literal["mixin"]
+reveal_type(Number.ONE.__str__)  # revealed: bound method Number.__str__() -> str
+reveal_type(ReprNumber.ONE.__str__)  # revealed: bound method ReprNumber.__repr__() -> str
+```
+
+## Flag operators installed during class creation
+
+Starting in Python 3.11, `EnumType` replaces inherited bitwise operators on every `Flag` subclass. A
+plain `Flag` only accepts another member of the same class. A flag with a separate value type also
+accepts values of that type:
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from enum import Flag, IntFlag, ReprEnum
+from typing import Literal
+
 class ReprFlag(int, ReprEnum, Flag):
     READ = 1
     WRITE = 2
 
-class FlagValue(int):
-    pass
-
-class CustomFlag(FlagValue, ReprEnum, Flag):
-    READ = 1
-
-class IntPermission(IntFlag):
-    READ = 1
-    WRITE = 2
+reveal_type(ReprFlag.READ.__str__)  # revealed: bound method Literal[ReprFlag.READ].__repr__() -> str
 
 class OrMixin:
     def __or__(self, other: object) -> Literal["mixin"]:
@@ -72,31 +84,30 @@ class Permission(OrMixin, Flag):
     READ = 1
     WRITE = 2
 
-reveal_type(Mixed.MEMBER.__str__)  # revealed: bound method Mixed.__str__() -> Literal["mixin"]
-reveal_type(Number.ONE.__str__)  # revealed: bound method Number.__str__() -> str
-reveal_type(ReprNumber.ONE.__str__)  # revealed: bound method ReprNumber.__repr__() -> str
-reveal_type(ReprFlag.READ.__str__)  # revealed: bound method Literal[ReprFlag.READ].__repr__() -> str
-# revealed: bound method Literal[Permission.READ].__or__(other: Literal[Permission.READ]) -> Literal[Permission.READ]
-reveal_type(Permission.READ.__or__)
 reveal_type(Permission.READ | Permission.WRITE)  # revealed: Literal[Permission.READ, Permission.WRITE]
 Permission.READ | 0  # error: [unsupported-operator]
 
-def repr_flag_features(condition: bool) -> ReprFlag:
+def repr_flag_or_int(condition: bool) -> ReprFlag:
     return ReprFlag.READ | (ReprFlag.WRITE if condition else 0)
 
-def custom_flag_features(value: FlagValue) -> CustomFlag:
+class FlagValue(int):
+    pass
+
+class CustomFlag(FlagValue, ReprEnum, Flag):
+    READ = 1
+
+def custom_flag_or_value(value: FlagValue) -> CustomFlag:
     return CustomFlag.READ | value
 
-def int_flag_features(condition: bool) -> IntPermission:
+class IntPermission(IntFlag):
+    READ = 1
+    WRITE = 2
+
+def int_flag_or_int(condition: bool) -> IntPermission:
     return IntPermission.READ | (IntPermission.WRITE if condition else 0)
 
-class Entity:
-    features: IntPermission | None
-
-    def update(self, condition: bool) -> None:
-        self.features = (self.features or 0) | IntPermission.READ | IntPermission.WRITE
-        if condition:
-            self.features |= IntPermission.WRITE
+def int_fallback_before_flags(value: IntPermission | None) -> IntPermission:
+    return (value or 0) | IntPermission.READ | IntPermission.WRITE
 ```
 
 For standard-library enum classes, we preserve literal `.value` types when we can model how the data

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -22,6 +22,52 @@ reveal_type(Color(1))  # revealed: Color
 reveal_type(Color.RED in Color)  # revealed: bool
 ```
 
+## Methods managed during class creation
+
+`EnumType` can replace inherited methods when it creates an enum class. It preserves ordinary mixin
+implementations, uses the data type's string methods for `ReprEnum`, and installs `Flag`'s operators
+on `Flag` subclasses:
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from enum import Enum, Flag, ReprEnum
+from typing import Literal
+
+class StringMixin:
+    def __str__(self) -> Literal["mixin"]:
+        return "mixin"
+
+class Mixed(StringMixin, Enum):
+    MEMBER = 1
+
+class Number(int, Enum):
+    ONE = 1
+
+class ReprNumber(int, ReprEnum):
+    ONE = 1
+
+class ReprFlag(int, ReprEnum, Flag):
+    READ = 1
+
+class OrMixin:
+    def __or__(self, other: object) -> Literal["mixin"]:
+        return "mixin"
+
+class Permission(OrMixin, Flag):
+    READ = 1
+
+reveal_type(Mixed.MEMBER.__str__)  # revealed: bound method Mixed.__str__() -> Literal["mixin"]
+reveal_type(Number.ONE.__str__)  # revealed: bound method Number.__str__() -> str
+reveal_type(ReprNumber.ONE.__str__)  # revealed: bound method ReprNumber.__repr__() -> str
+reveal_type(ReprFlag.READ.__str__)  # revealed: bound method Literal[ReprFlag.READ].__repr__() -> str
+# revealed: bound method Literal[Permission.READ].__or__(other: Literal[Permission.READ]) -> Literal[Permission.READ]
+reveal_type(Permission.READ.__or__)
+```
+
 For standard-library enum classes, we preserve literal `.value` types when we can model how the data
 type constructs each value. The inherited `_value_` annotation remains the fallback when we cannot,
 or when accessing `.value` on the enum class as a whole:

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -34,7 +34,7 @@ python-version = "3.13"
 ```
 
 ```py
-from enum import Enum, ReprEnum
+from enum import Enum, EnumType, ReprEnum
 from typing import Literal
 
 class StringMixin:
@@ -53,6 +53,29 @@ class ReprNumber(int, ReprEnum):
 reveal_type(Mixed.MEMBER.__str__)  # revealed: bound method Mixed.__str__() -> Literal["mixin"]
 reveal_type(Number.ONE.__str__)  # revealed: bound method Number.__str__() -> str
 reveal_type(ReprNumber.ONE.__str__)  # revealed: bound method ReprNumber.__repr__() -> str
+
+class Scalar(int):
+    def __str__(self) -> Literal["scalar"]:
+        return "scalar"
+
+class IgnoreStrAssignments(EnumType):
+    def __setattr__(cls, name: str, value: object) -> None:
+        if name != "__str__":
+            super().__setattr__(name, value)
+
+class AssignmentHookNumber(Scalar, Enum, metaclass=IgnoreStrAssignments):
+    ONE = 1
+
+reveal_type(AssignmentHookNumber.ONE.__str__())  # revealed: Literal["scalar"]
+
+class RestoreStrAfterCreation(EnumType):
+    def __init__(cls, *args, **kwargs):
+        type.__setattr__(cls, "__str__", Scalar.__str__)
+
+class InitializationHookNumber(Scalar, Enum, metaclass=RestoreStrAfterCreation):
+    ONE = 1
+
+reveal_type(InitializationHookNumber.ONE.__str__())  # revealed: Literal["scalar"]
 ```
 
 ## Python 3.8 enum data type selection
@@ -98,7 +121,6 @@ from typing import Literal
 
 class Root:
     def __new__(cls, value: int): ...
-
     def __str__(self) -> str:
         return "root"
 

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -34,7 +34,7 @@ python-version = "3.13"
 ```
 
 ```py
-from enum import Enum, Flag, ReprEnum
+from enum import Enum, Flag, IntFlag, ReprEnum
 from typing import Literal
 
 class StringMixin:
@@ -52,6 +52,17 @@ class ReprNumber(int, ReprEnum):
 
 class ReprFlag(int, ReprEnum, Flag):
     READ = 1
+    WRITE = 2
+
+class FlagValue(int):
+    pass
+
+class CustomFlag(FlagValue, ReprEnum, Flag):
+    READ = 1
+
+class IntPermission(IntFlag):
+    READ = 1
+    WRITE = 2
 
 class OrMixin:
     def __or__(self, other: object) -> Literal["mixin"]:
@@ -59,6 +70,7 @@ class OrMixin:
 
 class Permission(OrMixin, Flag):
     READ = 1
+    WRITE = 2
 
 reveal_type(Mixed.MEMBER.__str__)  # revealed: bound method Mixed.__str__() -> Literal["mixin"]
 reveal_type(Number.ONE.__str__)  # revealed: bound method Number.__str__() -> str
@@ -66,6 +78,25 @@ reveal_type(ReprNumber.ONE.__str__)  # revealed: bound method ReprNumber.__repr_
 reveal_type(ReprFlag.READ.__str__)  # revealed: bound method Literal[ReprFlag.READ].__repr__() -> str
 # revealed: bound method Literal[Permission.READ].__or__(other: Literal[Permission.READ]) -> Literal[Permission.READ]
 reveal_type(Permission.READ.__or__)
+reveal_type(Permission.READ | Permission.WRITE)  # revealed: Literal[Permission.READ, Permission.WRITE]
+Permission.READ | 0  # error: [unsupported-operator]
+
+def repr_flag_features(condition: bool) -> ReprFlag:
+    return ReprFlag.READ | (ReprFlag.WRITE if condition else 0)
+
+def custom_flag_features(value: FlagValue) -> CustomFlag:
+    return CustomFlag.READ | value
+
+def int_flag_features(condition: bool) -> IntPermission:
+    return IntPermission.READ | (IntPermission.WRITE if condition else 0)
+
+class Entity:
+    features: IntPermission | None
+
+    def update(self, condition: bool) -> None:
+        self.features = (self.features or 0) | IntPermission.READ | IntPermission.WRITE
+        if condition:
+            self.features |= IntPermission.WRITE
 ```
 
 For standard-library enum classes, we preserve literal `.value` types when we can model how the data

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -86,7 +86,11 @@ class Permission(OrMixin, Flag):
 
 reveal_type(Permission.READ | Permission.WRITE)  # revealed: Literal[Permission.READ, Permission.WRITE]
 Permission.READ | 0  # error: [unsupported-operator]
-reveal_type(0 | ReprFlag.READ)  # revealed: Literal[ReprFlag.READ]
+reveal_type(ReprFlag.READ | 2)  # revealed: ReprFlag
+reveal_type(2 | ReprFlag.READ)  # revealed: ReprFlag
+
+def flag_with_data_operand_is_not_a_known_member() -> Literal[ReprFlag.READ]:
+    return ReprFlag.READ | 2  # error: [invalid-return-type]
 
 def repr_flag_or_int(condition: bool) -> ReprFlag:
     return ReprFlag.READ | (ReprFlag.WRITE if condition else 0)

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -86,6 +86,7 @@ class Permission(OrMixin, Flag):
 
 reveal_type(Permission.READ | Permission.WRITE)  # revealed: Literal[Permission.READ, Permission.WRITE]
 Permission.READ | 0  # error: [unsupported-operator]
+reveal_type(0 | ReprFlag.READ)  # revealed: Literal[ReprFlag.READ]
 
 def repr_flag_or_int(condition: bool) -> ReprFlag:
     return ReprFlag.READ | (ReprFlag.WRITE if condition else 0)
@@ -98,6 +99,9 @@ class CustomFlag(FlagValue, ReprEnum, Flag):
 
 def custom_flag_or_value(value: FlagValue) -> CustomFlag:
     return CustomFlag.READ | value
+
+def value_or_custom_flag(value: FlagValue) -> CustomFlag:
+    return value | CustomFlag.READ
 
 class IntPermission(IntFlag):
     READ = 1

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1273,7 +1273,10 @@ impl<'db> StaticClassLiteral<'db> {
         member
     }
 
-    /// Returns the type of a member synthesized during class creation.
+    /// Returns the type of a member synthesized for this class.
+    ///
+    /// This includes methods installed by `EnumType`, `functools.total_ordering`, dataclass-like
+    /// transforms, and `NamedTuple` construction.
     pub(crate) fn own_synthesized_member(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -36,7 +36,10 @@ use crate::{
         context::InferContext,
         definition_expression_type, determine_upper_bound,
         diagnostic::INVALID_DATACLASS_OVERRIDE,
-        enums::{enum_metadata, is_enum_class_by_inheritance, try_unwrap_nonmember_value},
+        enums::{
+            enum_class_creation_synthesized_member, enum_metadata, is_enum_class_by_inheritance,
+            try_unwrap_nonmember_value,
+        },
         function::{
             DataclassTransformerParams, KnownFunction, is_implicit_classmethod,
             is_implicit_staticmethod,
@@ -1270,8 +1273,7 @@ impl<'db> StaticClassLiteral<'db> {
         member
     }
 
-    /// Returns the type of a synthesized dataclass member like `__init__` or `__lt__`, or
-    /// a synthesized `__new__` method for a `NamedTuple`.
+    /// Returns the type of a member synthesized during class creation.
     pub(crate) fn own_synthesized_member(
         self,
         db: &'db dyn Db,
@@ -1279,6 +1281,10 @@ impl<'db> StaticClassLiteral<'db> {
         inherited_generic_context: Option<GenericContext<'db>>,
         name: &str,
     ) -> Option<Type<'db>> {
+        if let Some(member) = enum_class_creation_synthesized_member(db, self, name) {
+            return Some(member);
+        }
+
         // Handle `@functools.total_ordering`: synthesize comparison methods
         // for classes that have `@total_ordering` and define at least one
         // ordering method. The decorator requires at least one of __lt__,

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1416,6 +1416,7 @@ fn enum_data_type_class<'db>(
     class: StaticClassLiteral<'db>,
 ) -> Option<ClassType<'db>> {
     let object = KnownClass::Object.to_class_literal(db).to_class_type(db)?;
+    let python_version = Program::get(db).python_version(db);
     let mut selected = None;
 
     for explicit_base in class.explicit_bases(db) {
@@ -1441,7 +1442,7 @@ fn enum_data_type_class<'db>(
             }
 
             let defines_new = !base.own_class_member(db, None, "__new__").is_undefined();
-            let is_dataclass = Program::get(db).python_version(db) >= PythonVersion::PY311
+            let is_dataclass = python_version >= PythonVersion::PY311
                 && !base
                     .own_class_member(db, None, "__dataclass_fields__")
                     .is_undefined();
@@ -1452,7 +1453,11 @@ fn enum_data_type_class<'db>(
                 break;
             }
 
-            candidate.get_or_insert(base);
+            if python_version == PythonVersion::PY38 {
+                candidate = Some(base);
+            } else if python_version >= PythonVersion::PY39 {
+                candidate.get_or_insert(base);
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1,19 +1,20 @@
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast::name::Name;
+use ruff_python_ast::{PythonVersion, name::Name};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use crate::FxOrderSet;
 use crate::{
-    Db, FxIndexMap,
+    Db, FxIndexMap, Program,
     place::{
-        DefinedPlace, Place, PlaceAndQualifiers, place_from_bindings, place_from_declarations,
+        DefinedPlace, Place, PlaceAndQualifiers, known_module_symbol, place_from_bindings,
+        place_from_declarations,
     },
     reachability::DeclarationsIteratorExtension,
     types::{
-        ClassBase, ClassLiteral, DynamicType, EnumLiteralType, IntersectionType, KnownClass,
-        LiteralValueTypeKind, MemberLookupPolicy, NegativeIntersectionElements, StaticClassLiteral,
-        Type, UnionType, binding_type,
+        ClassBase, ClassLiteral, ClassType, DynamicType, EnumLiteralType, IntersectionType,
+        KnownClass, LiteralValueTypeKind, MemberLookupPolicy, NegativeIntersectionElements,
+        StaticClassLiteral, Type, UnionType, binding_type,
         function::FunctionType,
         set_theoretic::{
             RecursivelyDefined,
@@ -21,6 +22,7 @@ use crate::{
         },
     },
 };
+use ty_module_resolver::KnownModule;
 use ty_python_core::{definition::DefinitionKind, place_table, scope::ScopeId, use_def_map};
 
 /// A resolved enum method, retaining both whether it is analyzable and who defines it.
@@ -1018,7 +1020,7 @@ pub(crate) fn enum_metadata<'db>(
     let new = resolve_enum_method(user_defined_new, || {
         inherited_known_enum_method(db, class, "__new__")
     });
-    let metaclass_may_transform_values = enum_metaclass_may_transform_values(db, class);
+    let metaclass_may_transform_values = enum_metaclass_may_transform_class(db, class);
     let user_defined_generate_next_value =
         custom_enum_method(db, scope_id, "_generate_next_value_")
             .or_else(|| inherited_user_defined_enum_method(db, class, "_generate_next_value_"));
@@ -1244,13 +1246,13 @@ pub(crate) fn enum_metadata<'db>(
     })
 }
 
-/// Returns whether an enum's metaclass has a custom value-transforming method before the stdlib
-/// `EnumType`/`EnumMeta` implementation.
+/// Returns whether an enum's metaclass can customize the namespace or completed class before the
+/// stdlib `EnumType`/`EnumMeta` implementation.
 ///
 /// `__prepare__` can return a namespace that rewrites assignments, and `__new__` can rewrite the
 /// completed class dictionary. Either method can therefore change member values before the stdlib
 /// enum constructor validates and forwards them to `__new__`/`__init__`.
-fn enum_metaclass_may_transform_values<'db>(
+fn enum_metaclass_may_transform_class<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
 ) -> bool {
@@ -1269,6 +1271,185 @@ fn enum_metaclass_may_transform_values<'db>(
                 .into_iter()
                 .any(|name| custom_enum_method(db, base.body_scope(db), name).is_some())
         })
+}
+
+/// Returns a member that `EnumType` adds to `class` during class creation.
+///
+/// The caller must first establish that `class` does not define `name` itself. `EnumType` preserves
+/// explicit definitions, but can replace an inherited data-type or `object` implementation with the
+/// corresponding enum implementation. Mixin implementations are preserved.
+pub(crate) fn enum_class_creation_synthesized_member<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+    name: &str,
+) -> Option<Type<'db>> {
+    let is_flag_operator = matches!(
+        name,
+        "__or__" | "__and__" | "__xor__" | "__ror__" | "__rand__" | "__rxor__" | "__invert__"
+    );
+    let is_enum_representation_method = matches!(
+        name,
+        "__repr__" | "__str__" | "__format__" | "__reduce_ex__"
+    );
+    if !is_flag_operator && !is_enum_representation_method {
+        return None;
+    }
+
+    if !is_enum_class_by_inheritance(db, class) || enum_metaclass_may_transform_class(db, class) {
+        return None;
+    }
+
+    if is_flag_operator
+        && Program::get(db).python_version(db) >= PythonVersion::PY311
+        && class_type_mro_contains(db, class.identity_specialization(db), KnownClass::Flag)
+    {
+        return class_member_type(
+            db,
+            KnownClass::Flag.to_class_literal(db).to_class_type(db)?,
+            name,
+        );
+    }
+
+    if !is_enum_representation_method {
+        return None;
+    }
+
+    let data_type = enum_data_type_class(db, class)?;
+    let first_enum = class.explicit_bases(db).last()?.to_class_type(db)?;
+    if !class_type_mro_contains(db, first_enum, KnownClass::Enum) {
+        return None;
+    }
+
+    if matches!(name, "__str__" | "__format__") && has_repr_enum_base(db, class) {
+        let data_type_method = if name == "__str__"
+            && class_member_type(db, data_type, name)
+                == class_member_type(
+                    db,
+                    KnownClass::Object.to_class_literal(db).to_class_type(db)?,
+                    name,
+                ) {
+            "__repr__"
+        } else {
+            name
+        };
+        return class_member_type(db, data_type, data_type_method);
+    }
+
+    let inherited_method = class
+        .iter_mro(db, None)
+        .skip(1)
+        .filter_map(ClassBase::into_class)
+        .find_map(|base| {
+            (!base.own_class_member(db, None, name).is_undefined())
+                .then(|| class_member_type(db, base, name))
+                .flatten()
+        })?;
+    let data_type_method = class_member_type(db, data_type, name)?;
+    let object_method = class_member_type(
+        db,
+        KnownClass::Object.to_class_literal(db).to_class_type(db)?,
+        name,
+    )?;
+
+    if inherited_method != data_type_method && inherited_method != object_method {
+        return None;
+    }
+
+    class_member_type(db, first_enum, name)
+}
+
+fn class_type_mro_contains<'db>(db: &'db dyn Db, class: ClassType<'db>, known: KnownClass) -> bool {
+    class
+        .iter_mro(db)
+        .filter_map(ClassBase::into_class)
+        .any(|base| base.known(db) == Some(known))
+}
+
+fn enum_data_type_class<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> Option<ClassType<'db>> {
+    let object = KnownClass::Object.to_class_literal(db).to_class_type(db)?;
+    let mut selected = None;
+
+    for explicit_base in class.explicit_bases(db) {
+        let explicit_base = explicit_base.to_class_type(db)?;
+        let mut candidate = None;
+
+        for base in explicit_base.iter_mro(db) {
+            let base = base.into_class()?;
+            if base == object {
+                continue;
+            }
+
+            if class_type_is_enum(db, base) {
+                let base = base.class_literal(db).as_static()?;
+                let data_type = enum_data_type_class(db, base)?;
+                if data_type != object {
+                    if !select_enum_data_type(&mut selected, data_type) {
+                        return None;
+                    }
+                    break;
+                }
+                continue;
+            }
+
+            let defines_new = !base.own_class_member(db, None, "__new__").is_undefined();
+            let is_dataclass = Program::get(db).python_version(db) >= PythonVersion::PY311
+                && !base
+                    .own_class_member(db, None, "__dataclass_fields__")
+                    .is_undefined();
+            if defines_new || is_dataclass {
+                if !select_enum_data_type(&mut selected, candidate.unwrap_or(base)) {
+                    return None;
+                }
+                break;
+            }
+
+            candidate.get_or_insert(base);
+        }
+    }
+
+    Some(selected.unwrap_or(object))
+}
+
+fn select_enum_data_type<'db>(
+    selected: &mut Option<ClassType<'db>>,
+    candidate: ClassType<'db>,
+) -> bool {
+    if selected.is_some_and(|selected| selected != candidate) {
+        false
+    } else {
+        *selected = Some(candidate);
+        true
+    }
+}
+
+fn class_type_is_enum<'db>(db: &'db dyn Db, class: ClassType<'db>) -> bool {
+    class_type_mro_contains(db, class, KnownClass::Enum)
+}
+
+fn class_member_type<'db>(db: &'db dyn Db, class: ClassType<'db>, name: &str) -> Option<Type<'db>> {
+    class
+        .class_member(db, name, MemberLookupPolicy::default())
+        .place
+        .ignore_possibly_undefined()
+}
+
+fn has_repr_enum_base<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> bool {
+    let Some(repr_enum) = known_module_symbol(db, KnownModule::Enum, "ReprEnum")
+        .place
+        .ignore_possibly_undefined()
+        .and_then(|ty| ty.to_class_type(db))
+    else {
+        return false;
+    };
+
+    class
+        .explicit_bases(db)
+        .iter()
+        .filter_map(|base| base.to_class_type(db))
+        .any(|base| base == repr_enum)
 }
 
 /// Iterates over parent enum classes in the MRO, skipping known enum

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1305,7 +1305,7 @@ pub(crate) fn enum_class_creation_synthesized_member<'db>(
         && class_type_mro_contains(db, class.identity_specialization(db), KnownClass::Flag)
     {
         let data_type = enum_data_type_class(db, class)?;
-        return flag_operator_member_type(db, data_type, name);
+        return flag_operator_member_type(db, class, data_type, name);
     }
 
     if !is_enum_representation_method {
@@ -1358,6 +1358,7 @@ pub(crate) fn enum_class_creation_synthesized_member<'db>(
 
 fn flag_operator_member_type<'db>(
     db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
     data_type: ClassType<'db>,
     name: &str,
 ) -> Option<Type<'db>> {
@@ -1368,6 +1369,7 @@ fn flag_operator_member_type<'db>(
     }
 
     let data_type = Type::instance(db, data_type);
+    let enum_instance = Type::instance(db, class.identity_specialization(db));
     Some(
         member
             .try_upcast_to_callable(db)?
@@ -1378,13 +1380,18 @@ fn flag_operator_member_type<'db>(
                     callable.signatures(db).iter().flat_map(|signature| {
                         let data_type_signature =
                             if let [receiver, operand] = signature.parameters().as_slice() {
-                                Some(signature.clone().with_parameters(Parameters::new(
-                                    db,
-                                    [
-                                        receiver.clone(),
-                                        operand.clone().with_annotated_type(data_type),
-                                    ],
-                                )))
+                                Some(
+                                    signature
+                                        .clone()
+                                        .with_parameters(Parameters::new(
+                                            db,
+                                            [
+                                                receiver.clone(),
+                                                operand.clone().with_annotated_type(data_type),
+                                            ],
+                                        ))
+                                        .with_return_type(enum_instance),
+                                )
                             } else {
                                 None
                             };

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -12,14 +12,15 @@ use crate::{
     },
     reachability::DeclarationsIteratorExtension,
     types::{
-        ClassBase, ClassLiteral, ClassType, DynamicType, EnumLiteralType, IntersectionType,
-        KnownClass, LiteralValueTypeKind, MemberLookupPolicy, NegativeIntersectionElements,
-        StaticClassLiteral, Type, UnionType, binding_type,
+        CallableType, ClassBase, ClassLiteral, ClassType, DynamicType, EnumLiteralType,
+        IntersectionType, KnownClass, LiteralValueTypeKind, MemberLookupPolicy,
+        NegativeIntersectionElements, StaticClassLiteral, Type, UnionType, binding_type,
         function::FunctionType,
         set_theoretic::{
             RecursivelyDefined,
             builder::{IntersectionBuilder, UnionBuilder},
         },
+        signatures::{CallableSignature, Parameters},
     },
 };
 use ty_module_resolver::KnownModule;
@@ -1303,11 +1304,8 @@ pub(crate) fn enum_class_creation_synthesized_member<'db>(
         && Program::get(db).python_version(db) >= PythonVersion::PY311
         && class_type_mro_contains(db, class.identity_specialization(db), KnownClass::Flag)
     {
-        return class_member_type(
-            db,
-            KnownClass::Flag.to_class_literal(db).to_class_type(db)?,
-            name,
-        );
+        let data_type = enum_data_type_class(db, class)?;
+        return flag_operator_member_type(db, data_type, name);
     }
 
     if !is_enum_representation_method {
@@ -1356,6 +1354,47 @@ pub(crate) fn enum_class_creation_synthesized_member<'db>(
     }
 
     class_member_type(db, first_enum, name)
+}
+
+fn flag_operator_member_type<'db>(
+    db: &'db dyn Db,
+    data_type: ClassType<'db>,
+    name: &str,
+) -> Option<Type<'db>> {
+    let flag = KnownClass::Flag.to_class_literal(db).to_class_type(db)?;
+    let member = class_member_type(db, flag, name)?;
+    if name == "__invert__" || data_type.known(db) == Some(KnownClass::Object) {
+        return Some(member);
+    }
+
+    let data_type = Type::instance(db, data_type);
+    Some(
+        member
+            .try_upcast_to_callable(db)?
+            .map(|callable| {
+                // Keep the `Self` overload so that combining two known members preserves both
+                // literals, and add the enum's data type as the operand accepted at runtime.
+                let signatures = CallableSignature::from_overloads(
+                    callable.signatures(db).iter().flat_map(|signature| {
+                        let data_type_signature =
+                            if let [receiver, operand] = signature.parameters().as_slice() {
+                                Some(signature.clone().with_parameters(Parameters::new(
+                                    db,
+                                    [
+                                        receiver.clone(),
+                                        operand.clone().with_annotated_type(data_type),
+                                    ],
+                                )))
+                            } else {
+                                None
+                            };
+                        std::iter::once(signature.clone()).chain(data_type_signature)
+                    }),
+                );
+                CallableType::new(db, signatures, callable.kind(db), callable.provenance(db))
+            })
+            .into_type(db),
+    )
 }
 
 fn class_type_mro_contains<'db>(db: &'db dyn Db, class: ClassType<'db>, known: KnownClass) -> bool {

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1247,12 +1247,12 @@ pub(crate) fn enum_metadata<'db>(
     })
 }
 
-/// Returns whether an enum's metaclass can customize the namespace or completed class before the
+/// Returns whether an enum's metaclass can customize the namespace or completed class around the
 /// stdlib `EnumType`/`EnumMeta` implementation.
 ///
 /// `__prepare__` can return a namespace that rewrites assignments, and `__new__` can rewrite the
-/// completed class dictionary. Either method can therefore change member values before the stdlib
-/// enum constructor validates and forwards them to `__new__`/`__init__`.
+/// completed class dictionary. `__setattr__` can intercept methods that `EnumType` installs on the
+/// completed class, and `__init__` can rewrite the class after `EnumType.__new__` returns.
 fn enum_metaclass_may_transform_class<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
@@ -1268,7 +1268,7 @@ fn enum_metaclass_may_transform_class<'db>(
         .filter_map(|base| base.class_literal(db).as_static())
         .take_while(|base| base.known(db) != Some(KnownClass::EnumType))
         .any(|base| {
-            ["__prepare__", "__new__"]
+            ["__prepare__", "__new__", "__setattr__", "__init__"]
                 .into_iter()
                 .any(|name| custom_enum_method(db, base.body_scope(db), name).is_some())
         })

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1279,6 +1279,14 @@ fn enum_metaclass_may_transform_class<'db>(
 /// The caller must first establish that `class` does not define `name` itself. `EnumType` preserves
 /// explicit definitions, but can replace an inherited data-type or `object` implementation with the
 /// corresponding enum implementation. Mixin implementations are preserved.
+///
+/// ```python
+/// class Number(int, Enum):
+///     ONE = 1
+///
+/// # EnumType replaces the inherited int implementation with Enum.__str__.
+/// Number.ONE.__str__()
+/// ```
 pub(crate) fn enum_class_creation_synthesized_member<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
@@ -1356,6 +1364,11 @@ pub(crate) fn enum_class_creation_synthesized_member<'db>(
     class_member_type(db, first_enum, name)
 }
 
+/// Returns the effective `Flag` operator installed by `EnumType`.
+///
+/// The stdlib declaration accepts another instance of `Self`, but a scalar-backed flag also accepts
+/// its selected data type at runtime. We retain the `Self` overload for enum-literal precision and
+/// add an overload for that data type. Unary `__invert__` needs no additional overload.
 fn flag_operator_member_type<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
@@ -1411,6 +1424,12 @@ fn class_type_mro_contains<'db>(db: &'db dyn Db, class: ClassType<'db>, known: K
         .any(|base| base.known(db) == Some(known))
 }
 
+/// Returns the data type that `EnumType` records as the class's `_member_type_`.
+///
+/// Each explicit base contributes the closest class before the `__new__` implementation (or
+/// dataclass marker) that makes it a data type. Enum bases contribute their recursively selected
+/// data type. If different bases imply different data types, this returns `None` so synthesized
+/// methods do not claim a runtime contract for a class that Python would reject.
 fn enum_data_type_class<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
@@ -1429,16 +1448,16 @@ fn enum_data_type_class<'db>(
                 continue;
             }
 
-            if class_type_is_enum(db, base) {
+            if class_type_mro_contains(db, base, KnownClass::Enum) {
                 let base = base.class_literal(db).as_static()?;
                 let data_type = enum_data_type_class(db, base)?;
-                if data_type != object {
-                    if !select_enum_data_type(&mut selected, data_type) {
-                        return None;
-                    }
-                    break;
+                if data_type == object {
+                    continue;
                 }
-                continue;
+                if !select_enum_data_type(&mut selected, data_type) {
+                    return None;
+                }
+                break;
             }
 
             let defines_new = !base.own_class_member(db, None, "__new__").is_undefined();
@@ -1464,6 +1483,10 @@ fn enum_data_type_class<'db>(
     Some(selected.unwrap_or(object))
 }
 
+/// Merges one explicit base's data type into the selected type.
+///
+/// Returns `false` when another base selected a different data type; `EnumType` rejects that
+/// ambiguity rather than choosing one by MRO order.
 fn select_enum_data_type<'db>(
     selected: &mut Option<ClassType<'db>>,
     candidate: ClassType<'db>,
@@ -1474,10 +1497,6 @@ fn select_enum_data_type<'db>(
         *selected = Some(candidate);
         true
     }
-}
-
-fn class_type_is_enum<'db>(db: &'db dyn Db, class: ClassType<'db>) -> bool {
-    class_type_mro_contains(db, class, KnownClass::Enum)
 }
 
 fn class_member_type<'db>(db: &'db dyn Db, class: ClassType<'db>, name: &str) -> Option<Type<'db>> {


### PR DESCRIPTION
## Summary

This PR is stacked on #26434, which models reflected-operator precedence using the operands' runtime classes.

`EnumType` can replace inherited methods while creating an enum class, but our member lookup previously exposed the unchanged static MRO. That forces semantic consumers to carry their own lists of methods that enum class creation might rewrite, and those lists cannot distinguish preserved mixin implementations from methods actually replaced by `EnumType`.

This PR moves that behavior into enum member lookup. Methods added or replaced during class creation are exposed as synthesized own members, so all semantic consumers see the effective runtime contract.

The model preserves ordinary mixin implementations, handles the representation methods managed by `EnumType`, selects the data-type methods used by `ReprEnum`, and installs `Flag` operators starting in Python 3.11. Flag operators retain their precise `Self` overload and also accept the enum's resolved data type, matching the runtime `_member_type_` behavior for `IntFlag` and custom scalar-backed flags.

The reflected flag cases use the runtime-class dispatch supplied by #26434. This preserves the flag result for expressions such as `0 | IntFlagMember` and for custom scalar-backed flags, even though an enum literal is not a subtype of a specific scalar literal.

Runtime data-type selection remains separate from conservative enum value inference, allowing user-defined scalar mixins to retain opaque values while still exposing the correct effective methods. This provides the enum semantics consumed by #26430 without coupling inherited-method checking to enum-specific names.

The mdtests distinguish methods that remain unchanged from methods actually replaced during class creation. They cover ordinary mixins, `ReprEnum`, plain `Flag`, `IntFlag`, custom scalar-backed flags, reflected operators, and the integer-fallback expression seen in the ecosystem. Each assertion of changed behavior fails on `main`; the cases that pass there are deliberate guards against replacing too much. The full `ty_python_semantic` suite, workspace Clippy, and repository hooks pass.
