### PR TITLE
[`flake8-bandit`] Fix misleading docstring for `mako-templates` (`S702`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/mako_templates.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/mako_templates.rs
@@ -11,21 +11,21 @@ use crate::checkers::ast::Checker;
 /// ## Why is this bad?
 /// Mako templates allow HTML and JavaScript rendering by default, and are
 /// inherently open to XSS attacks. Ensure variables in all templates are
-/// properly sanitized via the `n`, `h` or `x` flags (depending on context).
-/// For example, to HTML escape the variable `data`, use `${ data |h }`.
+/// properly escaped via the `h` (HTML) or `x` (XML) filters, depending on
+/// context. For example, to HTML escape the variable `data`, use `${ data |h }`.
 ///
 /// ## Example
 /// ```python
 /// from mako.template import Template
 ///
-/// Template("hello")
+/// Template("${ data }")  # Unescaped: vulnerable to XSS.
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// from mako.template import Template
 ///
-/// Template("hello |h")
+/// Template("${ data |h }")  # HTML-escaped with the `h` filter.
 /// ```
 ///
 /// ## References


### PR DESCRIPTION
## Summary

The `mako-templates` (`S702`) rule docstring is misleading in two ways.

**1. The "Use instead" example demonstrates nothing.**

```python
# Example (flagged)
Template("hello")

# Use instead (current)
Template("hello |h")
```

`Template("hello |h")` escapes nothing: mako's `|h` filter applies to a
**variable expression** (`${ data |h }`), so `"hello |h"` is just a literal
string. It also contradicts the rule's own prose just above it:

> For example, to HTML escape the variable `data`, use `${ data |h }`.

**2. The rationale lists `n` as a sanitizing filter.**

The "Why is this bad?" text said variables should be *"sanitized via the `n`,
`h` or `x` flags"*. Mako's `n` filter **disables** default filtering, so it
cannot sanitize — listing it alongside the escaping filters is misleading.

## Change

Docstring-only; no behavior change.

- Rework both examples to show the escaping contrast on a variable, with inline
  comments matching the convention in sibling bandit rules (e.g.
  `unsafe_markup_use`'s `# XSS` / `# Safe`):

  ```python
  # Example (bad)
  Template("${ data }")      # Unescaped: vulnerable to XSS.

  # Use instead
  Template("${ data |h }")   # HTML-escaped with the `h` filter.
  ```

- Drop `n` from the list of sanitizing filters in the rationale; keep the
  accurate `h` (HTML) and `x` (XML) escaping filters.

## Test plan

- `cargo dev generate-docs` regenerates `docs/rules/mako-templates.md` cleanly.
- `scripts/check_docs_formatted.py` passes — both snippets are already
  `ruff format`-clean and parse without error.