### PR TITLE
[`ruff`] Fix non-triggering example for `if-key-in-dict-del` (`RUF051`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/if_key_in_dict_del.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/if_key_in_dict_del.rs
@@ -17,6 +17,7 @@ type Dict = ExprName;
 /// ## Example
 ///
 /// ```python
+/// dictionary = {}
 /// if key in dictionary:
 ///     del dictionary[key]
 /// ```
@@ -24,6 +25,7 @@ type Dict = ExprName;
 /// Use instead:
 ///
 /// ```python
+/// dictionary = {}
 /// dictionary.pop(key, None)
 /// ```
 ///


### PR DESCRIPTION
## Summary

The `if-key-in-dict-del` (`RUF051`) rule docstring's `## Example` does not actually trigger the rule.

RUF051 only fires when the dictionary is *known to be of type `dict`* (`typing::is_known_to_be_of_type_dict`). The example used a bare, unbound `dictionary`, whose type can't be inferred — so the snippet presented as triggering is in fact clean:

```console
$ printf 'if key in dictionary:\n    del dictionary[key]\n' | ruff check --select RUF051 -
All checks passed!
```

## Change

Bind `dictionary = {}` in both code blocks so the example triggers (and the "Use instead" stays parallel). Docstring-only; no behavior change.

```python
# Example (now triggers)
dictionary = {}
if key in dictionary:
    del dictionary[key]

# Use instead
dictionary = {}
dictionary.pop(key, None)
```

This matches the convention already used by the sibling dict-type-gated rule `if-else-block-instead-of-dict-get` (`SIM401`), whose docstring example likewise binds `foo = {}`.

## Test plan

- Verified the old example is clean and the new one triggers:
  ```console
  $ printf 'dictionary = {}\nif key in dictionary:\n    del dictionary[key]\n' | ruff check --select RUF051 -
  RUF051 [*] Use `pop` instead of `key in dict` followed by `del dict[key]`
  ```
- `cargo dev generate-docs` regenerates `docs/rules/if-key-in-dict-del.md` cleanly.
- `scripts/check_docs_formatted.py` → `All docs are formatted correctly.`