### PR TITLE
[ty] Improve mechanism for distinguishing between `typing.TypedDict` and `typing_extensions.TypedDict`

### DIFF
--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -386,6 +386,10 @@ impl KnownModule {
         matches!(self, Self::Typing)
     }
 
+    pub const fn is_typing_extensions(self) -> bool {
+        matches!(self, Self::TypingExtensions)
+    }
+
     pub const fn is_ty_extensions(self) -> bool {
         matches!(self, Self::TyExtensions)
     }

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_`TypedDict`_base_(6f76171c88fc8760).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/unsupported_base_dyn…_-_Unsupported_base_for…_-_`TypedDict`_base_(6f76171c88fc8760).snap
@@ -25,7 +25,7 @@ error[invalid-base]: Invalid base for class created via `type()`
  --> src/mdtest_snippet.py:3:16
   |
 3 | X = type("X", (TypedDict,), {})  # error: [invalid-base]
-  |                ^^^^^^^^^ Has type `<special-form 'typing.TypedDict'>`
+  |                ^^^^^^^^^ Has type `<special-form 'typing_extensions.TypedDict'>`
   |
 info: Classes created via `type()` cannot be TypedDicts
 info: Consider using `TypedDict("X", {})` instead

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -122,6 +122,7 @@ pub enum KnownClass {
     Mapping,
     // typing_extensions
     ExtensionsTypeVar, // must be distinct from typing.TypeVar, backports new features
+    ExtensionTypedDictFallback,
     Sentinel,
     // Collections
     ChainMap,
@@ -277,6 +278,7 @@ impl KnownClass {
             | Self::Specialization
             | Self::ProtocolMeta
             | Self::FunctoolsPartial
+            | Self::ExtensionTypedDictFallback
             | Self::TypedDictFallback => Some(Truthiness::Ambiguous),
 
             Self::Tuple => None,
@@ -380,6 +382,7 @@ impl KnownClass {
             | KnownClass::GenericContext
             | KnownClass::Specialization
             | KnownClass::TypedDictFallback
+            | KnownClass::ExtensionTypedDictFallback
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
@@ -484,6 +487,7 @@ impl KnownClass {
             | KnownClass::GenericContext
             | KnownClass::Specialization
             | KnownClass::TypedDictFallback
+            | KnownClass::ExtensionTypedDictFallback
             | KnownClass::BuiltinFunctionType
             | KnownClass::ProtocolMeta
             | KnownClass::Template
@@ -582,6 +586,7 @@ impl KnownClass {
             | KnownClass::Field
             | KnownClass::KwOnly
             | KnownClass::TypedDictFallback
+            | KnownClass::ExtensionTypedDictFallback
             | KnownClass::NamedTupleLike
             | KnownClass::NamedTupleFallback
             | KnownClass::ConstraintSet
@@ -701,6 +706,7 @@ impl KnownClass {
             | Self::GenericContext
             | Self::Specialization
             | Self::TypedDictFallback
+            | Self::ExtensionTypedDictFallback
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
             | Self::Template
@@ -814,7 +820,9 @@ impl KnownClass {
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
             | KnownClass::Specialization => false,
-            KnownClass::NamedTupleFallback | KnownClass::TypedDictFallback => true,
+            KnownClass::NamedTupleFallback
+            | KnownClass::TypedDictFallback
+            | KnownClass::ExtensionTypedDictFallback => true,
         }
     }
 
@@ -926,6 +934,7 @@ impl KnownClass {
             Self::GenericContext => "GenericContext",
             Self::Specialization => "Specialization",
             Self::TypedDictFallback => "TypedDictFallback",
+            Self::ExtensionTypedDictFallback => "_TypedDict",
             Self::Template => "Template",
             Self::Path => "Path",
             Self::FunctoolsPartial => "partial",
@@ -1261,6 +1270,7 @@ impl KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::Deprecated
+            | Self::ExtensionTypedDictFallback
             | Self::NewType => KnownModule::TypingExtensions,
             Self::Sentinel => {
                 if Program::get(db).python_version(db) >= PythonVersion::PY315 {
@@ -1399,6 +1409,7 @@ impl KnownClass {
             | Self::GenericContext
             | Self::Specialization
             | Self::TypedDictFallback
+            | Self::ExtensionTypedDictFallback
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
             | Self::Template
@@ -1509,6 +1520,7 @@ impl KnownClass {
             | Self::GenericContext
             | Self::Specialization
             | Self::TypedDictFallback
+            | Self::ExtensionTypedDictFallback
             | Self::BuiltinFunctionType
             | Self::ProtocolMeta
             | Self::Template
@@ -1622,6 +1634,7 @@ impl KnownClass {
             "Path" => &[Self::Path],
             "partial" => &[Self::FunctoolsPartial],
             "_ProtocolMeta" => &[Self::ProtocolMeta],
+            "_TypedDict" => &[Self::ExtensionTypedDictFallback],
             _ => return None,
         };
 
@@ -1698,6 +1711,7 @@ impl KnownClass {
             | Self::KwOnly
             | Self::NamedTupleFallback
             | Self::TypedDictFallback
+            | Self::ExtensionTypedDictFallback
             | Self::TypeVar
             | Self::ExtensionsTypeVar
             | Self::ParamSpec

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -1006,29 +1006,15 @@ pub(super) fn typed_dict_fallback_class_member<'db>(
     lookup_policy: MemberLookupPolicy,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
-    let fallback_member = KnownClass::TypedDictFallback
+    let fallback = match module {
+        TypedDictModule::Typing => KnownClass::TypedDictFallback,
+        TypedDictModule::TypingExtensions => KnownClass::ExtensionTypedDictFallback,
+    };
+
+    fallback
         .to_class_literal(db)
         .find_name_in_mro_with_policy(db, name, lookup_policy)
-        .expect("Will return Some() when called on class literal");
-    if !fallback_member.is_undefined() || module != TypedDictModule::TypingExtensions {
-        return fallback_member;
-    }
-
-    let Some(fallback) = known_module_symbol(db, KnownModule::TypingExtensions, "_TypedDict")
-        .place
-        .ignore_possibly_undefined()
-        .filter(|ty| ty.as_class_literal().is_some())
-    else {
-        return fallback_member;
-    };
-    let member = fallback
-        .find_name_in_mro_with_policy(db, name, lookup_policy)
-        .expect("Will return Some() when called on class literal");
-    if member.is_undefined() {
-        fallback_member
-    } else {
-        member
-    }
+        .expect("Will return Some() when called on class literal")
 }
 
 pub(super) fn typed_dict_class_member<'db>(

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -139,8 +139,6 @@ pub enum TypedDictModule {
     Typing,
     /// `typing_extensions.TypedDict`.
     TypingExtensions,
-    /// `TypedDict` may resolve to the symbol from either module.
-    Either,
 }
 
 impl TypedDictModule {
@@ -159,18 +157,19 @@ impl TypedDictModule {
                     else {
                         return None;
                     };
-                    Some(module.union(*element_module))
+                    // `typing_extensions.TypedDict` always offers strictly more functionality than `typing.TypedDict`.
+                    // If any element is from `typing`, we therefore infer that the type is a `typing.TypedDict`,
+                    // since an operation on a union is only valid if the operation is valid on all elements in the
+                    // union.
+                    Some(match (module, element_module) {
+                        (TypedDictModule::TypingExtensions, TypedDictModule::TypingExtensions) => {
+                            TypedDictModule::TypingExtensions
+                        }
+                        _ => TypedDictModule::Typing,
+                    })
                 })
             }
             _ => None,
-        }
-    }
-
-    const fn union(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Typing, Self::Typing) => Self::Typing,
-            (Self::TypingExtensions, Self::TypingExtensions) => Self::TypingExtensions,
-            _ => Self::Either,
         }
     }
 }
@@ -271,10 +270,14 @@ impl SpecialFormType {
         file: File,
         symbol_name: &str,
     ) -> Option<Self> {
-        let candidate = Self::from_name(symbol_name)?;
-        candidate
-            .check_module(file_to_module(db, file)?.known(db)?)
-            .then_some(candidate)
+        Self::candidates_from_name(symbol_name)
+            .iter()
+            .find(|candidate| {
+                file_to_module(db, file)
+                    .and_then(|module| module.known(db))
+                    .is_some_and(|known_module| candidate.check_module(known_module))
+            })
+            .copied()
     }
 
     /// Given the special form we resolved (`self`) and the module the user actually
@@ -283,8 +286,7 @@ impl SpecialFormType {
     ///
     /// This exists because typeshed defines some special forms as re-exports from other modules.
     /// Following the alias chain to the definition site would otherwise erase distinctions such as
-    /// `typing.Callable` versus `collections.abc.Callable`, or `typing.TypedDict` versus
-    /// `typing_extensions.TypedDict`.
+    /// `typing.Callable` versus `collections.abc.Callable`.
     ///
     /// Called at module-attribute resolution — the one boundary where the import-path
     /// module is still observable.
@@ -293,18 +295,12 @@ impl SpecialFormType {
             (Self::TypingCallable, "Callable", KnownModule::CollectionsAbcInternal) => {
                 Self::CollectionsAbcCallable
             }
-            (Self::TypedDict(_), "TypedDict", KnownModule::Typing) => {
-                Self::TypedDict(TypedDictModule::Typing)
-            }
-            (Self::TypedDict(_), "TypedDict", KnownModule::TypingExtensions) => {
-                Self::TypedDict(TypedDictModule::TypingExtensions)
-            }
             _ => self,
         }
     }
 
     /// Parse a `SpecialFormType` from its runtime symbol name.
-    fn from_name(name: &str) -> Option<Self> {
+    fn candidates_from_name(name: &str) -> &'static [Self] {
         /// An enum that maps 1:1 with `SpecialFormType`, but which holds no associated data
         /// (and therefore can have `EnumString` derived on it).
         /// This is much more robust than having a manual `from_string` method that matches
@@ -430,69 +426,91 @@ impl SpecialFormType {
 
         SpecialFormTypeBuilder::try_from(name)
             .ok()
-            .map(|form| match form {
-                SpecialFormTypeBuilder::AlwaysFalsy => Self::AlwaysFalsy,
-                SpecialFormTypeBuilder::AlwaysTruthy => Self::AlwaysTruthy,
-                SpecialFormTypeBuilder::Annotated => Self::Annotated,
-                SpecialFormTypeBuilder::Callable => Self::TypingCallable,
-                SpecialFormTypeBuilder::CallableTypeOf => Self::CallableTypeOf,
-                SpecialFormTypeBuilder::RegularCallableTypeOf => Self::RegularCallableTypeOf,
-                SpecialFormTypeBuilder::Concatenate => Self::Concatenate,
-                SpecialFormTypeBuilder::Intersection => Self::Intersection,
-                SpecialFormTypeBuilder::Literal => Self::Literal,
-                SpecialFormTypeBuilder::LiteralString => Self::LiteralString,
-                SpecialFormTypeBuilder::Never => Self::Never,
-                SpecialFormTypeBuilder::NoReturn => Self::NoReturn,
-                SpecialFormTypeBuilder::Not => Self::Not,
-                SpecialFormTypeBuilder::Optional => Self::Optional,
-                SpecialFormTypeBuilder::Protocol => Self::Protocol,
-                SpecialFormTypeBuilder::Type => Self::Type,
-                SpecialFormTypeBuilder::TypeForm => Self::TypeForm,
-                SpecialFormTypeBuilder::TypeAlias => Self::TypeAlias,
-                SpecialFormTypeBuilder::TypeGuard => Self::TypeGuard,
-                SpecialFormTypeBuilder::TypeIs => Self::TypeIs,
-                SpecialFormTypeBuilder::TypingSelf => Self::TypingSelf,
-                SpecialFormTypeBuilder::Union => Self::Union,
-                SpecialFormTypeBuilder::Unknown => Self::Unknown,
-                SpecialFormTypeBuilder::Divergent => Self::Divergent,
-                SpecialFormTypeBuilder::Todo => Self::Todo,
-                SpecialFormTypeBuilder::Generic => Self::Generic,
-                SpecialFormTypeBuilder::NamedTuple => Self::NamedTuple,
-                SpecialFormTypeBuilder::Any => Self::Any,
-                SpecialFormTypeBuilder::Bottom => Self::Bottom,
-                SpecialFormTypeBuilder::Top => Self::Top,
-                SpecialFormTypeBuilder::Unpack => Self::Unpack,
-                SpecialFormTypeBuilder::Tuple => Self::Tuple,
-                SpecialFormTypeBuilder::TypedDict => Self::TypedDict(TypedDictModule::Typing),
-                SpecialFormTypeBuilder::TypeOf => Self::TypeOf,
-                SpecialFormTypeBuilder::List => Self::LegacyStdlibAlias(LegacyStdlibAlias::List),
-                SpecialFormTypeBuilder::Dict => Self::LegacyStdlibAlias(LegacyStdlibAlias::Dict),
-                SpecialFormTypeBuilder::Set => Self::LegacyStdlibAlias(LegacyStdlibAlias::Set),
-                SpecialFormTypeBuilder::FrozenSet => {
-                    Self::LegacyStdlibAlias(LegacyStdlibAlias::FrozenSet)
+            .map(|form| -> &'static [Self] {
+                match form {
+                    SpecialFormTypeBuilder::AlwaysFalsy => &[Self::AlwaysFalsy],
+                    SpecialFormTypeBuilder::AlwaysTruthy => &[Self::AlwaysTruthy],
+                    SpecialFormTypeBuilder::Annotated => &[Self::Annotated],
+                    SpecialFormTypeBuilder::Callable => &[Self::TypingCallable],
+                    SpecialFormTypeBuilder::CallableTypeOf => &[Self::CallableTypeOf],
+                    SpecialFormTypeBuilder::RegularCallableTypeOf => &[Self::RegularCallableTypeOf],
+                    SpecialFormTypeBuilder::Concatenate => &[Self::Concatenate],
+                    SpecialFormTypeBuilder::Intersection => &[Self::Intersection],
+                    SpecialFormTypeBuilder::Literal => &[Self::Literal],
+                    SpecialFormTypeBuilder::LiteralString => &[Self::LiteralString],
+                    SpecialFormTypeBuilder::Never => &[Self::Never],
+                    SpecialFormTypeBuilder::NoReturn => &[Self::NoReturn],
+                    SpecialFormTypeBuilder::Not => &[Self::Not],
+                    SpecialFormTypeBuilder::Optional => &[Self::Optional],
+                    SpecialFormTypeBuilder::Protocol => &[Self::Protocol],
+                    SpecialFormTypeBuilder::Type => &[Self::Type],
+                    SpecialFormTypeBuilder::TypeForm => &[Self::TypeForm],
+                    SpecialFormTypeBuilder::TypeAlias => &[Self::TypeAlias],
+                    SpecialFormTypeBuilder::TypeGuard => &[Self::TypeGuard],
+                    SpecialFormTypeBuilder::TypeIs => &[Self::TypeIs],
+                    SpecialFormTypeBuilder::TypingSelf => &[Self::TypingSelf],
+                    SpecialFormTypeBuilder::Union => &[Self::Union],
+                    SpecialFormTypeBuilder::Unknown => &[Self::Unknown],
+                    SpecialFormTypeBuilder::Divergent => &[Self::Divergent],
+                    SpecialFormTypeBuilder::Todo => &[Self::Todo],
+                    SpecialFormTypeBuilder::Generic => &[Self::Generic],
+                    SpecialFormTypeBuilder::NamedTuple => &[Self::NamedTuple],
+                    SpecialFormTypeBuilder::Any => &[Self::Any],
+                    SpecialFormTypeBuilder::Bottom => &[Self::Bottom],
+                    SpecialFormTypeBuilder::Top => &[Self::Top],
+                    SpecialFormTypeBuilder::Unpack => &[Self::Unpack],
+                    SpecialFormTypeBuilder::Tuple => &[Self::Tuple],
+                    SpecialFormTypeBuilder::TypedDict => &[
+                        Self::TypedDict(TypedDictModule::Typing),
+                        Self::TypedDict(TypedDictModule::TypingExtensions),
+                    ],
+                    SpecialFormTypeBuilder::TypeOf => &[Self::TypeOf],
+                    SpecialFormTypeBuilder::List => {
+                        &[Self::LegacyStdlibAlias(LegacyStdlibAlias::List)]
+                    }
+                    SpecialFormTypeBuilder::Dict => {
+                        &[Self::LegacyStdlibAlias(LegacyStdlibAlias::Dict)]
+                    }
+                    SpecialFormTypeBuilder::Set => {
+                        &[Self::LegacyStdlibAlias(LegacyStdlibAlias::Set)]
+                    }
+                    SpecialFormTypeBuilder::FrozenSet => {
+                        &[Self::LegacyStdlibAlias(LegacyStdlibAlias::FrozenSet)]
+                    }
+                    SpecialFormTypeBuilder::ChainMap => {
+                        &[Self::LegacyStdlibAlias(LegacyStdlibAlias::ChainMap)]
+                    }
+                    SpecialFormTypeBuilder::Counter => {
+                        &[Self::LegacyStdlibAlias(LegacyStdlibAlias::Counter)]
+                    }
+                    SpecialFormTypeBuilder::DefaultDict => {
+                        &[Self::LegacyStdlibAlias(LegacyStdlibAlias::DefaultDict)]
+                    }
+                    SpecialFormTypeBuilder::Deque => {
+                        &[Self::LegacyStdlibAlias(LegacyStdlibAlias::Deque)]
+                    }
+                    SpecialFormTypeBuilder::OrderedDict => {
+                        &[Self::LegacyStdlibAlias(LegacyStdlibAlias::OrderedDict)]
+                    }
+                    SpecialFormTypeBuilder::Final => &[Self::TypeQualifier(TypeQualifier::Final)],
+                    SpecialFormTypeBuilder::ClassVar => {
+                        &[Self::TypeQualifier(TypeQualifier::ClassVar)]
+                    }
+                    SpecialFormTypeBuilder::ReadOnly => {
+                        &[Self::TypeQualifier(TypeQualifier::ReadOnly)]
+                    }
+                    SpecialFormTypeBuilder::Required => {
+                        &[Self::TypeQualifier(TypeQualifier::Required)]
+                    }
+                    SpecialFormTypeBuilder::NotRequired => {
+                        &[Self::TypeQualifier(TypeQualifier::NotRequired)]
+                    }
+                    SpecialFormTypeBuilder::InitVar => {
+                        &[Self::TypeQualifier(TypeQualifier::InitVar)]
+                    }
                 }
-                SpecialFormTypeBuilder::ChainMap => {
-                    Self::LegacyStdlibAlias(LegacyStdlibAlias::ChainMap)
-                }
-                SpecialFormTypeBuilder::Counter => {
-                    Self::LegacyStdlibAlias(LegacyStdlibAlias::Counter)
-                }
-                SpecialFormTypeBuilder::DefaultDict => {
-                    Self::LegacyStdlibAlias(LegacyStdlibAlias::DefaultDict)
-                }
-                SpecialFormTypeBuilder::Deque => Self::LegacyStdlibAlias(LegacyStdlibAlias::Deque),
-                SpecialFormTypeBuilder::OrderedDict => {
-                    Self::LegacyStdlibAlias(LegacyStdlibAlias::OrderedDict)
-                }
-                SpecialFormTypeBuilder::Final => Self::TypeQualifier(TypeQualifier::Final),
-                SpecialFormTypeBuilder::ClassVar => Self::TypeQualifier(TypeQualifier::ClassVar),
-                SpecialFormTypeBuilder::ReadOnly => Self::TypeQualifier(TypeQualifier::ReadOnly),
-                SpecialFormTypeBuilder::Required => Self::TypeQualifier(TypeQualifier::Required),
-                SpecialFormTypeBuilder::NotRequired => {
-                    Self::TypeQualifier(TypeQualifier::NotRequired)
-                }
-                SpecialFormTypeBuilder::InitVar => Self::TypeQualifier(TypeQualifier::InitVar),
             })
+            .unwrap_or_default()
     }
 
     /// Return `true` if `module` is a module from which this `SpecialFormType` variant can validly originate.
@@ -509,6 +527,7 @@ impl SpecialFormType {
             | Self::Tuple
             | Self::Type
             | Self::Generic
+            | Self::TypedDict(TypedDictModule::Typing)
             | Self::TypingCallable => module.is_typing(),
 
             Self::Annotated
@@ -519,7 +538,6 @@ impl SpecialFormType {
             | Self::Unpack
             | Self::TypeAlias
             | Self::TypeGuard
-            | Self::TypedDict(_)
             | Self::TypeIs
             | Self::TypeForm
             | Self::TypingSelf
@@ -546,6 +564,8 @@ impl SpecialFormType {
                 module,
                 KnownModule::CollectionsAbc | KnownModule::CollectionsAbcInternal
             ),
+
+            Self::TypedDict(TypedDictModule::TypingExtensions) => module.is_typing_extensions(),
         }
     }
 
@@ -736,13 +756,17 @@ impl SpecialFormType {
             | SpecialFormType::Unpack
             | SpecialFormType::TypeAlias
             | SpecialFormType::TypeGuard
-            | SpecialFormType::TypedDict(_)
             | SpecialFormType::TypeIs
             | SpecialFormType::Protocol
             | SpecialFormType::Generic
             | SpecialFormType::NamedTuple
             | SpecialFormType::LegacyStdlibAlias(_) => {
                 &[KnownModule::Typing, KnownModule::TypingExtensions]
+            }
+
+            SpecialFormType::TypedDict(TypedDictModule::Typing) => &[KnownModule::Typing],
+            SpecialFormType::TypedDict(TypedDictModule::TypingExtensions) => {
+                &[KnownModule::TypingExtensions]
             }
 
             SpecialFormType::TypeQualifier(qualifier) => qualifier.definition_modules(),


### PR DESCRIPTION
## Summary

- `typing.TypedDict` and `typing_extensions.TypedDict` are (accurately) represented as two distinct symbols in the latest version of our vendored typeshed stubs, so we can get rid of the use of `rewrap_from_module` (which feels like a _bit_ of a hack, best avoided where possible) and instead register them as distinct special forms in the way we usually would. The only snag here is that the two special forms have the same name, so `SpecialFormType::from_name()` has to be refactored to return `&'static [Self]` instead of `Option<Self>`, and is renamed to `SpecialFormType::candidates_from_name` (the name "TypedDict" has two candidates: `typing.TypedDict` and `typing_extensions.TypedDict`).
- Add `typing_extensions._TypedDict` as a `KnownClass`. This significantly simplifies `typed_dict_fallback_class_member` in `typed_dict.rs`.
- Get rid of `TypedDictModule::Either`. We always treated it exactly the same as `TypedDictModule::Typing`.

This is a followup to https://github.com/astral-sh/ruff/pull/25843