### PR TITLE
fix(add-noqa): preserve trailing content after noqa directives

### DIFF
--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -2232,6 +2232,40 @@ def unused(x):  # noqa: ANN001, ARG001, D103
 }
 
 #[test]
+fn add_noqa_existing_noqa_with_trailing_content() -> Result<()> {
+    let fixture = CliTest::new()?;
+
+    fixture.write_file(
+        "noqa.py",
+        r#"
+import math  # noqa: RUF100 with a trailing reason
+import sys  # noqa: RUF100 # fmt:skip
+"#,
+    )?;
+
+    assert_cmd_snapshot!(fixture
+        .check_command()
+        .arg("--add-noqa")
+        .arg("--select=F401,RUF100,I002")
+        .arg("noqa.py"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Added 2 noqa directives.
+    ");
+
+    let content = fs::read_to_string(fixture.root().join("noqa.py"))?;
+    insta::assert_snapshot!(content, @r"
+    import math  # noqa: F401, RUF100 with a trailing reason
+    import sys  # noqa: F401, RUF100 # fmt:skip
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn add_noqa_existing_file_level_noqa() -> Result<()> {
     let fixture = CliTest::new()?;
     fixture.write_file(

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -984,6 +984,13 @@ struct NoqaEdit<'a> {
     line_ending: LineEnding,
     reason: Option<&'a str>,
     blank_line: bool,
+    /// Whether the [`NoqaEdit::write`] should append the line ending.
+    ///
+    /// This is `false` when the edit only replaces an existing `noqa`
+    /// directive (but not the rest of the line), so that any trailing content
+    /// on the line (e.g. a trailing reason or a `# fmt: skip` comment) is
+    /// preserved verbatim.
+    emit_line_ending: bool,
 }
 
 impl NoqaEdit<'_> {
@@ -1017,7 +1024,9 @@ impl NoqaEdit<'_> {
         if let Some(reason) = self.reason {
             write!(writer, " {reason}").unwrap();
         }
-        write!(writer, "{}", self.line_ending.as_str()).unwrap();
+        if self.emit_line_ending {
+            write!(writer, "{}", self.line_ending.as_str()).unwrap();
+        }
     }
 }
 
@@ -1040,6 +1049,7 @@ fn generate_noqa_edit<'a>(
     let edit_range;
     let codes;
     let blank_line;
+    let emit_line_ending;
 
     // Add codes.
     match directive {
@@ -1048,6 +1058,10 @@ fn generate_noqa_edit<'a>(
             blank_line = trimmed_line.trim_whitespace_start().is_empty();
             edit_range = TextRange::new(TextSize::of(trimmed_line), line_range.len()) + offset;
             codes = None;
+            // The edit extends to the end of the line (including the line
+            // ending), so the line ending has to be emitted as part of the
+            // edit.
+            emit_line_ending = true;
         }
         Some(Directive::Codes(existing_codes)) => {
             // find trimmed line without the noqa
@@ -1055,8 +1069,18 @@ fn generate_noqa_edit<'a>(
                 .slice(TextRange::new(line_range.start(), existing_codes.start()))
                 .trim_end();
             blank_line = false;
-            edit_range = TextRange::new(TextSize::of(trimmed_line), line_range.len()) + offset;
+            // Only replace from the end of the trimmed code line up to the end
+            // of the existing `noqa` directive, leaving any trailing content
+            // (e.g. a trailing reason or a `# fmt: skip` comment) untouched.
+            edit_range = TextRange::new(
+                TextSize::of(trimmed_line),
+                existing_codes.end() - line_range.start(),
+            ) + line_range.start();
             codes = Some(existing_codes);
+            // The edit only covers the `noqa` directive, not the rest of the
+            // line, so the line ending must not be emitted (it is preserved
+            // together with any trailing content).
+            emit_line_ending = false;
         }
         Some(Directive::All(_)) => return None,
     }
@@ -1068,6 +1092,7 @@ fn generate_noqa_edit<'a>(
         line_ending,
         reason,
         blank_line,
+        emit_line_ending,
     })
 }
 


### PR DESCRIPTION
## Summary

When running `--add-noqa` on a line with an existing `noqa` directive that has trailing content (e.g. a trailing reason or a `# fmt:skip` comment), the edit was extending to the end of the line and overwriting that trailing content.

## Reproduction

```python
import math  # noqa: RUF100 with a trailing reason
import sys  # noqa: RUF100 # fmt:skip
```

**Before (broken):**
```python
import math  # noqa: F401, RUF100
import sys  # noqa: F401, RUF100
```

Both the trailing reason and `# fmt:skip` are deleted.

**After (fixed):**
```python
import math  # noqa: F401, RUF100 with a trailing reason
import sys  # noqa: F401, RUF100 # fmt:skip
```

Trailing content is preserved.

## Root Cause

In `generate_noqa_edit` (`crates/ruff_linter/src/noqa.rs`), the `Directive::Codes` branch computed `edit_range` as `TextRange::new(TextSize::of(trimmed_line), line_range.len())`, which extends from the end of the trimmed code to the **end of the full line**. This range includes any trailing content after the noqa directive.

## Fix

1. Limit the edit range for `Directive::Codes` to only cover up to `existing_codes.end()` — the end of the noqa directive itself — leaving trailing content untouched.
2. Add an `emit_line_ending: bool` flag to `NoqaEdit` so the line ending is only emitted when the edit actually covers the end of the line (the `None` / blank-line case).

## Test Plan

Added `add_noqa_existing_noqa_with_trailing_content` test verifying both scenarios (trailing reason and `# fmt:skip`). All 14 existing `add_noqa` tests continue to pass.

```
test lint::add_noqa ... ok
test lint::add_noqa_existing_noqa ... ok
test lint::add_noqa_existing_noqa_with_trailing_content ... ok   ← new
... (14 passed, 0 failed)
```

Closes #26287