### PR TITLE
[ty] Update `__slots__` string when renaming an attribute

### DIFF
--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -704,14 +704,32 @@ impl<'a> LocalReferencesFinder<'a> {
         })
     }
 
-    /// Returns whether any of the rename target's definitions belongs to
-    /// `class` (i.e. the class scope is an ancestor of the definition's scope).
+    /// Returns whether any of the rename target's definitions is an instance attribute of `class`.
+    ///
+    /// The target must name an actual instance attribute of `class`, either a member access like
+    /// `self.value = ...` or a bare class-body annotation like `value: int`, and its nearest
+    /// enclosing class must be `class` itself. A parameter or local that merely shares the name, or
+    /// an attribute of a nested class, is not treated as the slot.
     fn target_belongs_to_class(&self, class: &'a ast::StmtClassDef) -> bool {
+        use ty_python_core::definition::DefinitionKind;
+        use ty_python_core::scope::{FileScopeId, NodeWithScopeKind};
+
         let db = self.model.db();
         let file = self.model.file();
         let class_range = class.range();
         let module = ruff_db::parsed::parsed_module(db, file).load(db);
         let index = ty_python_core::semantic_index(db, file);
+
+        // The nearest class scope lexically enclosing `scope`, if any. `ancestor_scopes` skips
+        // class scopes for name resolution, so we walk the lexical parents directly to stop at the
+        // innermost enclosing class rather than an outer one.
+        let nearest_enclosing_class_scope = |mut scope: FileScopeId| loop {
+            let node = index.scope(scope);
+            if node.kind() == ScopeKind::Class {
+                return Some(scope);
+            }
+            scope = node.parent()?;
+        };
 
         self.target_definitions.iter().any(|resolved| {
             let Some(definition) = resolved.definition() else {
@@ -720,14 +738,28 @@ impl<'a> LocalReferencesFinder<'a> {
             if definition.file(db) != file {
                 return false;
             }
-            index
-                .ancestor_scopes(definition.file_scope(db))
-                .any(|(_, scope)| match scope.node() {
-                    ty_python_core::scope::NodeWithScopeKind::Class(node) => {
-                        node.node(&module).range() == class_range
-                    }
-                    _ => false,
-                })
+
+            // The target's nearest enclosing class must be the one declaring the `__slots__`, so an
+            // attribute of a nested class doesn't rename an outer class's slot.
+            let Some(owning_class_scope) = nearest_enclosing_class_scope(definition.file_scope(db))
+            else {
+                return false;
+            };
+            match index.scope(owning_class_scope).node() {
+                NodeWithScopeKind::Class(node) if node.node(&module).range() == class_range => {}
+                _ => return false,
+            }
+
+            // Accept only a member access (`self.value = ...`) or a bare class-body annotation
+            // (`value: int`), so a parameter or local sharing the name is not treated as the slot.
+            let is_bare_class_annotation = definition.file_scope(db) == owning_class_scope
+                && definition.place(db).is_symbol()
+                && matches!(
+                    definition.kind(db),
+                    DefinitionKind::AnnotatedAssignment(assignment)
+                        if assignment.value(&module).is_none()
+                );
+            definition.place(db).is_member() || is_bare_class_annotation
         })
     }
 

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -219,21 +219,26 @@ fn is_ascii_identifier_continue(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
-/// Returns whether `node` is an assignment whose (sole) target is the name
-/// `__slots__`, e.g. `__slots__ = (...)` or `__slots__: tuple = (...)`.
-fn is_slots_assignment(node: AnyNodeRef<'_>) -> bool {
+/// Returns whether `node` assigns `value` to the sole target `__slots__`, e.g.
+/// `__slots__ = (...)` or `__slots__: tuple = (...)`.
+fn is_slots_assignment(node: AnyNodeRef<'_>, value: AnyNodeRef<'_>) -> bool {
     match node {
         AnyNodeRef::StmtAssign(assign) => {
-            matches!(
-                assign.targets.as_slice(),
-                [ast::Expr::Name(name)] if name.id.as_str() == "__slots__"
-            )
+            assign.value.range() == value.range()
+                && matches!(
+                    assign.targets.as_slice(),
+                    [ast::Expr::Name(name)] if name.id.as_str() == "__slots__"
+                )
         }
         AnyNodeRef::StmtAnnAssign(assign) => {
-            matches!(
-                assign.target.as_ref(),
-                ast::Expr::Name(name) if name.id.as_str() == "__slots__"
-            )
+            assign
+                .value
+                .as_deref()
+                .is_some_and(|assigned| assigned.range() == value.range())
+                && matches!(
+                    assign.target.as_ref(),
+                    ast::Expr::Name(name) if name.id.as_str() == "__slots__"
+                )
         }
         _ => false,
     }
@@ -665,7 +670,8 @@ impl<'a> LocalReferencesFinder<'a> {
             AnyNodeRef::ExprStringLiteral(_) => {}
             _ => return None,
         }
-        match ancestors.next()? {
+        let container = *ancestors.next()?;
+        match container {
             AnyNodeRef::ExprTuple(_) | AnyNodeRef::ExprList(_) | AnyNodeRef::ExprSet(_) => {}
             // For a dict, both keys and values have the `ExprDict` as their
             // direct parent, so `is_dict_key` checks that this string is one of
@@ -680,7 +686,7 @@ impl<'a> LocalReferencesFinder<'a> {
 
         // The container must be the value of an assignment to `__slots__`.
         let assignment = ancestors.next()?;
-        if !is_slots_assignment(*assignment) {
+        if !is_slots_assignment(*assignment, container) {
             return None;
         }
 

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -219,6 +219,26 @@ fn is_ascii_identifier_continue(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
+/// Returns whether `node` is an assignment whose (sole) target is the name
+/// `__slots__`, e.g. `__slots__ = (...)` or `__slots__: tuple = (...)`.
+fn is_slots_assignment(node: AnyNodeRef<'_>) -> bool {
+    match node {
+        AnyNodeRef::StmtAssign(assign) => {
+            matches!(
+                assign.targets.as_slice(),
+                [ast::Expr::Name(name)] if name.id.as_str() == "__slots__"
+            )
+        }
+        AnyNodeRef::StmtAnnAssign(assign) => {
+            matches!(
+                assign.target.as_ref(),
+                ast::Expr::Name(name) if name.id.as_str() == "__slots__"
+            )
+        }
+        _ => false,
+    }
+}
+
 /// Find all references to a local symbol within the current file.
 /// The behavior depends on the provided mode.
 fn references_for_file(
@@ -446,6 +466,11 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
                 self.check_declaration_identifier(&param_var.name);
             }
             AnyNodeRef::ExprStringLiteral(string_expr) => {
+                // A string literal listed in a class's `__slots__` names an
+                // instance attribute, so renaming that attribute should rename
+                // the matching slot string too.
+                self.check_slots_string_literal(string_expr);
+
                 // Highlight the sub-AST of a string annotation
                 if let Some((sub_ast, sub_model)) = self.model.enter_string_annotation(string_expr)
                 {
@@ -581,6 +606,129 @@ impl<'a> LocalReferencesFinder<'a> {
             kind.to_reference_kind(),
         );
         self.references.push(target);
+    }
+
+    /// Checks a string literal that may be an entry in a class's `__slots__`.
+    ///
+    /// `__slots__` entries are plain strings, but they name instance
+    /// attributes of the enclosing class. When the rename target is one of
+    /// those attributes, the matching slot string should be renamed as well.
+    /// We only do this when the attribute belongs to the same class that
+    /// declares the `__slots__`, so unrelated classes that happen to use the
+    /// same slot name are left untouched.
+    fn check_slots_string_literal(&mut self, string_expr: &'a ast::ExprStringLiteral) {
+        // Quick text-based check first. We only handle single-part string
+        // literals; implicitly concatenated strings ("a" "b") can't name a
+        // single attribute, so they never match an identifier here.
+        if string_expr.value.is_implicit_concatenated() {
+            return;
+        }
+        let [part] = string_expr.value.as_slice() else {
+            return;
+        };
+        if part.value.as_ref() != self.target_text {
+            return;
+        }
+
+        // The literal must sit directly inside a tuple/list/set container, or
+        // be a key in a dict, that is the value of a `__slots__` assignment in
+        // a class body.
+        let Some(class) = self.enclosing_slots_class() else {
+            return;
+        };
+
+        // Only rename the slot if the target attribute belongs to this class.
+        if !self.target_belongs_to_class(class) {
+            return;
+        }
+
+        // Rename the inner content of the string, leaving the quotes intact.
+        let content_range = ast::StringLikePart::String(part).content_range();
+        let target = ReferenceTarget::new(self.model.file(), content_range, ReferenceKind::Other);
+        self.references.push(target);
+    }
+
+    /// Returns the class definition whose `__slots__` assignment contains the
+    /// string literal currently being visited, if the ancestor chain matches
+    /// one of the supported `__slots__` shapes.
+    ///
+    /// Supported shapes (v1):
+    /// - `__slots__ = ("a", "b")` / `["a", "b"]` / `{"a", "b"}`
+    /// - `__slots__ = {"a": ..., "b": ...}` (dict keys only)
+    fn enclosing_slots_class(&self) -> Option<&'a ast::StmtClassDef> {
+        // `self.ancestors` ends with the string literal itself. Walk outward.
+        let mut ancestors = self.ancestors.iter().rev();
+
+        // The string is either a direct element of a tuple/list/set, or a key
+        // of a dict. Skip the immediate container node.
+        match ancestors.next()? {
+            AnyNodeRef::ExprStringLiteral(_) => {}
+            _ => return None,
+        }
+        match ancestors.next()? {
+            AnyNodeRef::ExprTuple(_) | AnyNodeRef::ExprList(_) | AnyNodeRef::ExprSet(_) => {}
+            // For a dict, both keys and values have the `ExprDict` as their
+            // direct parent, so `is_dict_key` checks that this string is one of
+            // the keys before we treat it as a slot name.
+            AnyNodeRef::ExprDict(dict) => {
+                if !self.is_dict_key(dict) {
+                    return None;
+                }
+            }
+            _ => return None,
+        }
+
+        // The container must be the value of an assignment to `__slots__`.
+        let assignment = ancestors.next()?;
+        if !is_slots_assignment(*assignment) {
+            return None;
+        }
+
+        // That assignment must live directly in a class body.
+        match ancestors.next()? {
+            AnyNodeRef::StmtClassDef(class) => Some(class),
+            _ => None,
+        }
+    }
+
+    /// Returns whether the string literal currently being visited is a *key*
+    /// of `dict`, as opposed to one of its values.
+    fn is_dict_key(&self, dict: &'a ast::ExprDict) -> bool {
+        let Some(AnyNodeRef::ExprStringLiteral(string_expr)) = self.ancestors.last() else {
+            return false;
+        };
+        dict.items.iter().any(|item| {
+            item.key
+                .as_ref()
+                .is_some_and(|key| key.range() == string_expr.range())
+        })
+    }
+
+    /// Returns whether any of the rename target's definitions belongs to
+    /// `class` (i.e. the class scope is an ancestor of the definition's scope).
+    fn target_belongs_to_class(&self, class: &'a ast::StmtClassDef) -> bool {
+        let db = self.model.db();
+        let file = self.model.file();
+        let class_range = class.range();
+        let module = ruff_db::parsed::parsed_module(db, file).load(db);
+        let index = ty_python_core::semantic_index(db, file);
+
+        self.target_definitions.iter().any(|resolved| {
+            let Some(definition) = resolved.definition() else {
+                return false;
+            };
+            if definition.file(db) != file {
+                return false;
+            }
+            index
+                .ancestor_scopes(definition.file_scope(db))
+                .any(|(_, scope)| match scope.node() {
+                    ty_python_core::scope::NodeWithScopeKind::Class(node) => {
+                        node.node(&module).range() == class_range
+                    }
+                    _ => false,
+                })
+        })
     }
 
     fn is_declaration(&self, covering_node: &CoveringNode<'_>) -> bool {

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -713,9 +713,10 @@ impl<'a> LocalReferencesFinder<'a> {
     /// Returns whether any of the rename target's definitions is an instance attribute of `class`.
     ///
     /// The target must name an actual instance attribute of `class`, either a member access like
-    /// `self.value = ...` or a bare class-body annotation like `value: int`, and its nearest
-    /// enclosing class must be `class` itself. A parameter or local that merely shares the name, or
-    /// an attribute of a nested class, is not treated as the slot.
+    /// `self.value = ...` or a class-body declaration like `value: int` (optionally using `...` as
+    /// the value in a stub), and its nearest enclosing class must be `class` itself. A parameter or
+    /// local that merely shares the name, or an attribute of a nested class, is not treated as the
+    /// slot.
     fn target_belongs_to_class(&self, class: &'a ast::StmtClassDef) -> bool {
         use ty_python_core::definition::DefinitionKind;
         use ty_python_core::scope::{FileScopeId, NodeWithScopeKind};
@@ -756,16 +757,19 @@ impl<'a> LocalReferencesFinder<'a> {
                 _ => return false,
             }
 
-            // Accept only a member access (`self.value = ...`) or a bare class-body annotation
-            // (`value: int`), so a parameter or local sharing the name is not treated as the slot.
-            let is_bare_class_annotation = definition.file_scope(db) == owning_class_scope
+            // Accept only a member access (`self.value = ...`) or a class-body attribute declaration
+            // (`value: int` or `value: int = ...` in a stub), so a parameter or local sharing the
+            // name is not treated as the slot.
+            let is_class_attribute_declaration = definition.file_scope(db) == owning_class_scope
                 && definition.place(db).is_symbol()
                 && matches!(
                     definition.kind(db),
                     DefinitionKind::AnnotatedAssignment(assignment)
-                        if assignment.value(&module).is_none()
+                        if assignment.value(&module).is_none_or(|value| {
+                            file.is_stub(db) && value.is_ellipsis_literal_expr()
+                        })
                 );
-            definition.place(db).is_member() || is_bare_class_annotation
+            definition.place(db).is_member() || is_class_attribute_declaration
         })
     }
 

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -22,8 +22,8 @@ use ruff_python_ast::{
 };
 use ruff_text_size::Ranged;
 use ty_project::parallel::{ParallelIteratorExt, minimum_parallel_job_len};
-use ty_python_core::definition::{Definition, DefinitionState};
-use ty_python_core::scope::ScopeKind;
+use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
+use ty_python_core::scope::{FileScopeId, NodeWithScopeKind, ScopeKind};
 use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticModel};
 
 /// Salsa snapshots coordinate clone and drop through shared state. For cached files that don't
@@ -718,9 +718,6 @@ impl<'a> LocalReferencesFinder<'a> {
     /// local that merely shares the name, or an attribute of a nested class, is not treated as the
     /// slot.
     fn target_belongs_to_class(&self, class: &'a ast::StmtClassDef) -> bool {
-        use ty_python_core::definition::DefinitionKind;
-        use ty_python_core::scope::{FileScopeId, NodeWithScopeKind};
-
         let db = self.model.db();
         let file = self.model.file();
         let class_range = class.range();

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -2905,6 +2905,28 @@ class C:
     }
 
     #[test]
+    fn rename_attribute_ignores_slots_annotation_container() {
+        let test = cursor_test(
+            r#"
+class C:
+    __slots__: ("value",) = ("other",)
+
+    def __init__(self):
+        self.va<CURSOR>lue = 1
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @"
+        info[rename]: Rename symbol (found 1 locations)
+         --> main.py:6:14
+          |
+        6 |         self.value = 1
+          |              ^^^^^
+          |
+        ");
+    }
+
+    #[test]
     fn rename_parameter_does_not_touch_slots() {
         // The parameter `value` is a local symbol, not the instance attribute, so renaming it must
         // leave the `__slots__` string untouched even though it shares the name.

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -2705,4 +2705,180 @@ DC(f=1)
           |
         "#);
     }
+
+    #[test]
+    fn rename_attribute_updates_slots_tuple() {
+        let test = cursor_test(
+            r#"
+class C:
+    __slots__ = ("value", "other")
+
+    def __init__(self):
+        self.va<CURSOR>lue = 1
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @r#"
+        info[rename]: Rename symbol (found 2 locations)
+         --> main.py:3:19
+          |
+        3 |     __slots__ = ("value", "other")
+          |                   ^^^^^
+        4 |
+        5 |     def __init__(self):
+        6 |         self.value = 1
+          |              -----
+          |
+        "#);
+    }
+
+    #[test]
+    fn rename_attribute_updates_slots_list() {
+        let test = cursor_test(
+            r#"
+class C:
+    __slots__ = ["value", "other"]
+
+    def __init__(self):
+        self.va<CURSOR>lue = 1
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @r#"
+        info[rename]: Rename symbol (found 2 locations)
+         --> main.py:3:19
+          |
+        3 |     __slots__ = ["value", "other"]
+          |                   ^^^^^
+        4 |
+        5 |     def __init__(self):
+        6 |         self.value = 1
+          |              -----
+          |
+        "#);
+    }
+
+    #[test]
+    fn rename_attribute_updates_slots_set() {
+        let test = cursor_test(
+            r#"
+class C:
+    __slots__ = {"value", "other"}
+
+    def __init__(self):
+        self.va<CURSOR>lue = 1
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @r#"
+        info[rename]: Rename symbol (found 2 locations)
+         --> main.py:3:19
+          |
+        3 |     __slots__ = {"value", "other"}
+          |                   ^^^^^
+        4 |
+        5 |     def __init__(self):
+        6 |         self.value = 1
+          |              -----
+          |
+        "#);
+    }
+
+    #[test]
+    fn rename_attribute_updates_slots_dict_key() {
+        let test = cursor_test(
+            r#"
+class C:
+    __slots__ = {"value": "doc", "other": "doc"}
+
+    def __init__(self):
+        self.va<CURSOR>lue = 1
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @r#"
+        info[rename]: Rename symbol (found 2 locations)
+         --> main.py:3:19
+          |
+        3 |     __slots__ = {"value": "doc", "other": "doc"}
+          |                   ^^^^^
+        4 |
+        5 |     def __init__(self):
+        6 |         self.value = 1
+          |              -----
+          |
+        "#);
+    }
+
+    #[test]
+    fn rename_cannot_start_from_slot_string() {
+        // Renaming is driven from the attribute; the `__slots__` string itself
+        // is not a renameable symbol, so starting a rename on it is rejected.
+        let test = cursor_test(
+            r#"
+class C:
+    __slots__ = ("va<CURSOR>lue",)
+
+    def __init__(self):
+        self.value = 1
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @"Cannot rename");
+    }
+
+    #[test]
+    fn rename_attribute_does_not_touch_other_class_slots() {
+        let test = cursor_test(
+            r#"
+class C:
+    __slots__ = ("value",)
+
+    def __init__(self):
+        self.va<CURSOR>lue = 1
+
+class D:
+    __slots__ = ("value",)
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @r#"
+        info[rename]: Rename symbol (found 2 locations)
+         --> main.py:3:19
+          |
+        3 |     __slots__ = ("value",)
+          |                   ^^^^^
+        4 |
+        5 |     def __init__(self):
+        6 |         self.value = 1
+          |              -----
+          |
+        "#);
+    }
+
+    #[test]
+    fn rename_attribute_does_not_touch_slots_dict_value() {
+        let test = cursor_test(
+            r#"
+class C:
+    __slots__ = {"value": "value"}
+
+    def __init__(self):
+        self.va<CURSOR>lue = 1
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @r#"
+        info[rename]: Rename symbol (found 2 locations)
+         --> main.py:3:19
+          |
+        3 |     __slots__ = {"value": "value"}
+          |                   ^^^^^
+        4 |
+        5 |     def __init__(self):
+        6 |         self.value = 1
+          |              -----
+          |
+        "#);
+    }
 }

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -2881,4 +2881,77 @@ class C:
           |
         "#);
     }
+
+    #[test]
+    fn rename_class_body_annotation_updates_slots() {
+        let test = cursor_test(
+            r#"
+class C:
+    __slots__ = ("value",)
+    va<CURSOR>lue: int
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @r#"
+        info[rename]: Rename symbol (found 2 locations)
+         --> main.py:3:19
+          |
+        3 |     __slots__ = ("value",)
+          |                   ^^^^^
+        4 |     value: int
+          |     -----
+          |
+        "#);
+    }
+
+    #[test]
+    fn rename_parameter_does_not_touch_slots() {
+        // The parameter `value` is a local symbol, not the instance attribute, so renaming it must
+        // leave the `__slots__` string untouched even though it shares the name.
+        let test = cursor_test(
+            r#"
+class C:
+    __slots__ = ("value",)
+
+    def __init__(self, va<CURSOR>lue):
+        self.value = value
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @r#"
+        info[rename]: Rename symbol (found 2 locations)
+         --> main.py:5:24
+          |
+        5 |     def __init__(self, value):
+          |                        ^^^^^
+        6 |         self.value = value
+          |                      -----
+          |
+        "#);
+    }
+
+    #[test]
+    fn rename_nested_class_attribute_does_not_touch_outer_slots() {
+        // The instance attribute belongs to `Inner`, whose nearest enclosing class has no matching
+        // slot, so renaming it must not touch `Outer.__slots__`.
+        let test = cursor_test(
+            r#"
+class Outer:
+    __slots__ = ("value",)
+
+    class Inner:
+        def __init__(self):
+            self.va<CURSOR>lue = 1
+"#,
+        );
+
+        assert_snapshot!(test.rename("amount"), @r#"
+        info[rename]: Rename symbol (found 1 locations)
+         --> main.py:7:18
+          |
+        7 |             self.value = 1
+          |                  ^^^^^
+          |
+        "#);
+    }
 }

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -2927,6 +2927,31 @@ class C:
     }
 
     #[test]
+    fn rename_stub_ellipsis_valued_attribute_updates_slots() {
+        let test = CursorTest::builder()
+            .source(
+                "main.pyi",
+                r#"
+class C:
+    __slots__ = ("value",)
+    va<CURSOR>lue: int = ...
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.rename("amount"), @r#"
+        info[rename]: Rename symbol (found 2 locations)
+         --> main.pyi:3:19
+          |
+        3 |     __slots__ = ("value",)
+          |                   ^^^^^
+        4 |     value: int = ...
+          |     -----
+          |
+        "#);
+    }
+
+    #[test]
     fn rename_parameter_does_not_touch_slots() {
         // The parameter `value` is a local symbol, not the instance attribute, so renaming it must
         // leave the `__slots__` string untouched even though it shares the name.


### PR DESCRIPTION
Fixes astral-sh/ty#3674.

When you rename an instance attribute, ty now also renames the matching string in the class's `__slots__`. Pylance does this and the issue asks for the same behavior.

## How it works

The references visitor already walks every node looking for matches. I added a check on string literals: when it hits one, it looks at whether the string is sitting in a `__slots__` assignment inside a class body, and whether the attribute being renamed actually belongs to that class. If both hold, it emits an edit for the inner content of the string (the quotes stay put).

The same-class check walks the ancestor scopes of the rename target's definitions and looks for the class that owns the `__slots__`. So if two unrelated classes both have a `"value"` slot, renaming `self.value` on one of them leaves the other one alone.

## Scope

This is intentionally a first cut, matching what was discussed on the issue:

- same class only (no subclass/superclass propagation)
- `__slots__` written as a tuple, list, set, or dict literal; for a dict, only the keys are renamed (values are left as-is, which is what was requested)
- single-part string literals only (implicitly concatenated strings like `"a" "b"` are skipped)

Renaming is still driven from the attribute itself. Starting a rename on the `__slots__` string directly isn't supported, since a string literal isn't a renameable symbol on its own.

## Tests

Added rename tests in `ty_ide` covering tuple/list/set/dict-key slots, the same-class isolation case, that dict values are not touched, and that starting from the slot string is rejected. `cargo test -p ty_ide`, `cargo clippy -p ty_ide`, and `cargo fmt` all pass.