### PR TITLE
[ty] Fix identity narrowing for NewTypes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -578,8 +578,7 @@ A = NewType("A", EllipsisType)
 static_assert(is_singleton(A))
 static_assert(is_single_valued(A))
 reveal_type(type(A(...)) is EllipsisType)  # revealed: Literal[True]
-# TODO: This should be `Literal[True]` also.
-reveal_type(A(...) is ...)  # revealed: bool
+reveal_type(A(...) is ...)  # revealed: Literal[True]
 
 B = NewType("B", int)
 static_assert(not is_singleton(B))

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -1,4 +1,6 @@
-# Identity tests
+# Identity comparisons
+
+## Basic comparisons
 
 ```py
 from typing_extensions import TypeAliasType
@@ -39,4 +41,21 @@ def _(a1: TypeAliasType, a2: TypeAliasType):
 
 reveal_type(list[int] is list[int])  # revealed: bool
 reveal_type(list[int] is not list[int])  # revealed: bool
+```
+
+## Recursive type aliases
+
+Projecting a recursive alias for an identity comparison must stop when it encounters the alias
+again.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type Recursive = Recursive | int
+
+def f(value: Recursive) -> None:
+    reveal_type(value is 1)  # revealed: bool
 ```

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -53,6 +53,7 @@ from ty_extensions import Unknown
 
 def f(value: Unknown) -> None:
     if value is None:
+        reveal_type(value)  # revealed: Unknown & None
         reveal_type(value is not None)  # revealed: Literal[False]
 ```
 
@@ -80,20 +81,4 @@ type Alias[X] = X
 
 def aliased(left: Alias[T], right: T) -> None:
     reveal_type(left is right)  # revealed: Literal[True]
-```
-
-## Recursive type aliases
-
-Checking identity for a recursive alias must terminate instead of repeatedly expanding the alias.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-type Recursive = Recursive | int
-
-def f(value: Recursive) -> None:
-    reveal_type(value is 1)  # revealed: bool
 ```

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -75,7 +75,6 @@ T = TypeVar("T", None, EllipsisType)
 
 def f(left: T, right: T) -> None:
     reveal_type(left is right)  # revealed: Literal[True]
-    reveal_type(left is not right)  # revealed: Literal[False]
 
 type Alias[X] = X
 

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -43,11 +43,11 @@ reveal_type(list[int] is list[int])  # revealed: bool
 reveal_type(list[int] is not list[int])  # revealed: bool
 ```
 
-## Same constrained `TypeVar`
+## Identity comparisons for the same constrained `TypeVar`
 
-Every occurrence of the same constrained `TypeVar` has the same specialization, including when an
-occurrence appears through a type alias. If every constraint is a singleton, two values with that
-`TypeVar` must therefore be the same object.
+All occurrences of the same constrained `TypeVar` use the same constraint. Here, each constraint
+contains only one object, so two values with that `TypeVar` must be identical. This remains true
+when one occurrence appears through a type alias.
 
 ```toml
 [environment]
@@ -68,13 +68,11 @@ type Alias[X] = X
 
 def aliased(left: Alias[T], right: T) -> None:
     reveal_type(left is right)  # revealed: Literal[True]
-    reveal_type(left is not right)  # revealed: Literal[False]
 ```
 
 ## Recursive type aliases
 
-Projecting a recursive alias for an identity comparison must stop when it encounters the alias
-again.
+Checking identity for a recursive alias must terminate instead of repeatedly expanding the alias.
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -43,6 +43,22 @@ reveal_type(list[int] is list[int])  # revealed: bool
 reveal_type(list[int] is not list[int])  # revealed: bool
 ```
 
+## Same constrained `TypeVar`
+
+Every occurrence of the same constrained `TypeVar` has the same specialization. If every
+constraint is a singleton, two values with that `TypeVar` must therefore be the same object.
+
+```py
+from types import EllipsisType
+from typing import TypeVar
+
+T = TypeVar("T", None, EllipsisType)
+
+def f(left: T, right: T) -> None:
+    reveal_type(left is right)  # revealed: Literal[True]
+    reveal_type(left is not right)  # revealed: Literal[False]
+```
+
 ## Recursive type aliases
 
 Projecting a recursive alias for an identity comparison must stop when it encounters the alias

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -45,8 +45,14 @@ reveal_type(list[int] is not list[int])  # revealed: bool
 
 ## Same constrained `TypeVar`
 
-Every occurrence of the same constrained `TypeVar` has the same specialization. If every
-constraint is a singleton, two values with that `TypeVar` must therefore be the same object.
+Every occurrence of the same constrained `TypeVar` has the same specialization, including when an
+occurrence appears through a type alias. If every constraint is a singleton, two values with that
+`TypeVar` must therefore be the same object.
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
 from types import EllipsisType
@@ -55,6 +61,12 @@ from typing import TypeVar
 T = TypeVar("T", None, EllipsisType)
 
 def f(left: T, right: T) -> None:
+    reveal_type(left is right)  # revealed: Literal[True]
+    reveal_type(left is not right)  # revealed: Literal[False]
+
+type Alias[X] = X
+
+def aliased(left: Alias[T], right: T) -> None:
     reveal_type(left is right)  # revealed: Literal[True]
     reveal_type(left is not right)  # revealed: Literal[False]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -43,6 +43,19 @@ reveal_type(list[int] is list[int])  # revealed: bool
 reveal_type(list[int] is not list[int])  # revealed: bool
 ```
 
+## Repeated identity comparisons after narrowing `Unknown`
+
+Once `value is None` has succeeded, the value can only be the `None` singleton even when its
+original type is `Unknown`.
+
+```py
+from ty_extensions import Unknown
+
+def f(value: Unknown) -> None:
+    if value is None:
+        reveal_type(value is not None)  # revealed: Literal[False]
+```
+
 ## Identity comparisons for the same constrained `TypeVar`
 
 All occurrences of the same constrained `TypeVar` use the same constraint. Here, each constraint

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -92,8 +92,8 @@ def _(x: int):
 
 ### Identity comparisons
 
-The type `~None` excludes the `None` object. A `NewType` based on `NoneType` is still a subtype of
-`NoneType`, so it cannot be passed where `~None` is expected.
+The type `~None` excludes the `None` object, so its identity comparisons with `None` have definite
+results.
 
 ```py
 def _(o: object):

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -92,22 +92,17 @@ def _(x: int):
 
 ### Identity comparisons
 
-An intersection type does not record how a negative facet arose. The same `~None` type can come from
-an annotation that accepts a `NewType` of `NoneType`, which still evaluates to the `None` singleton
-at runtime. Identity inference therefore cannot rely on the negative facet alone, even when it came
-from an identity guard in this example.
+A `~None` constraint excludes the `None` singleton at runtime. A `NewType` of `NoneType` does not
+invalidate this constraint because it is a subtype of `NoneType` and cannot inhabit `~None`.
 
 ```py
-class A: ...
-
 def _(o: object):
-    a = A()
     n = None
 
     if o is not None:
-        reveal_type(o)  # revealed:  ~None
-        reveal_type(o is n)  # revealed: bool
-        reveal_type(o is not n)  # revealed: bool
+        reveal_type(o)  # revealed: ~None
+        reveal_type(o is n)  # revealed: Literal[False]
+        reveal_type(o is not n)  # revealed: Literal[True]
 ```
 
 ## Diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -105,6 +105,22 @@ def _(o: object):
         reveal_type(o is not n)  # revealed: Literal[True]
 ```
 
+A user-defined single-member enum is also a singleton nominal instance. Excluding the enum makes an
+identity check against its only member always false, so the branch below is unreachable and must not
+emit an attribute error.
+
+```py
+from enum import Enum
+from ty_extensions import Not
+
+class E(Enum):
+    ONLY = 1
+
+def f(value: Not[E]) -> None:
+    if value is E.ONLY:
+        value.missing
+```
+
 ## Diagnostics
 
 ### Unsupported operators for positive contributions

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -92,8 +92,8 @@ def _(x: int):
 
 ### Identity comparisons
 
-A `~None` constraint excludes the `None` singleton at runtime. A `NewType` of `NoneType` does not
-invalidate this constraint because it is a subtype of `NoneType` and cannot inhabit `~None`.
+The type `~None` excludes the `None` object. A `NewType` based on `NoneType` is still a subtype of
+`NoneType`, so it cannot be passed where `~None` is expected.
 
 ```py
 def _(o: object):
@@ -105,9 +105,8 @@ def _(o: object):
         reveal_type(o is not n)  # revealed: Literal[True]
 ```
 
-A user-defined single-member enum is also a singleton nominal instance. Excluding the enum makes an
-identity check against its only member always false, so the branch below is unreachable and must not
-emit an attribute error.
+A single-member enum contains only one object. A value excluded from `E` cannot be `E.ONLY`, so the
+branch below is unreachable and must not emit an attribute error.
 
 ```py
 from enum import Enum
@@ -121,8 +120,8 @@ def f(value: Not[E]) -> None:
         value.missing
 ```
 
-Excluding an entire class also rules out identity with any instance of that class, even when the
-class has multiple possible instances. The branch below is therefore unreachable.
+After `not isinstance(value, B)`, `value` cannot be identical to a `B` instance. This remains true
+when `value` has also been narrowed to `A`, so the inner branch is unreachable.
 
 ```py
 class A: ...

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -117,7 +117,8 @@ class E(Enum):
 
 def f(value: Not[E]) -> None:
     if value is E.ONLY:
-        value.missing
+        reveal_type(value)  # revealed: Never
+        value.does_not_exist  # no error (unreachable branch)
 ```
 
 After `not isinstance(value, B)`, `value` cannot be identical to a `B` instance. This remains true
@@ -130,7 +131,8 @@ class B: ...
 def f(value: object, other_b: B) -> None:
     if isinstance(value, A) and not isinstance(value, B):
         if value is other_b:
-            value.missing
+            reveal_type(value)  # revealed: Never
+            value.does_not_exist  # no error (unreachable branch)
 ```
 
 ## Diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -121,6 +121,19 @@ def f(value: Not[E]) -> None:
         value.missing
 ```
 
+Excluding an entire class also rules out identity with any instance of that class, even when the
+class has multiple possible instances. The branch below is therefore unreachable.
+
+```py
+class A: ...
+class B: ...
+
+def f(value: object, other_b: B) -> None:
+    if isinstance(value, A) and not isinstance(value, B):
+        if value is other_b:
+            value.missing
+```
+
 ## Diagnostics
 
 ### Unsupported operators for positive contributions

--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -92,6 +92,11 @@ def _(x: int):
 
 ### Identity comparisons
 
+An intersection type does not record how a negative facet arose. The same `~None` type can come from
+an annotation that accepts a `NewType` of `NoneType`, which still evaluates to the `None` singleton
+at runtime. Identity inference therefore cannot rely on the negative facet alone, even when it came
+from an identity guard in this example.
+
 ```py
 class A: ...
 
@@ -101,8 +106,8 @@ def _(o: object):
 
     if o is not None:
         reveal_type(o)  # revealed:  ~None
-        reveal_type(o is n)  # revealed: Literal[False]
-        reveal_type(o is not n)  # revealed: Literal[True]
+        reveal_type(o is n)  # revealed: bool
+        reveal_type(o is not n)  # revealed: bool
 ```
 
 ## Diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -308,6 +308,32 @@ def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> None:
         reveal_type(left)  # revealed: ConstrainedT@constrained_typevars
 ```
 
+When every constraint is a `NewType` of the same singleton type, every specialization represents the
+same runtime object. An `is not` branch must therefore exclude other `NewType`s of that singleton,
+both directly and when narrowing a tuple.
+
+```py
+from types import EllipsisType
+from typing import NewType, TypeVar
+from typing_extensions import assert_never
+
+SingletonA = NewType("SingletonA", EllipsisType)
+SingletonB = NewType("SingletonB", EllipsisType)
+SingletonC = NewType("SingletonC", EllipsisType)
+
+SingletonT = TypeVar("SingletonT", SingletonA, SingletonB)
+
+def direct(value: SingletonC | int, other: SingletonT) -> None:
+    if value is not other:
+        if value is other:
+            assert_never(value)
+
+def tuple_parent(value: tuple[SingletonC] | tuple[int], other: SingletonT) -> None:
+    if value[0] is not other:
+        if value[0] is other:
+            assert_never(value)
+```
+
 ### Preserving a `NewType` in the true branch
 
 If an object is identical to a value with a `NewType`, the true branch preserves the `NewType`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -196,7 +196,7 @@ Distinct `NewType`s can describe the same runtime object even though they are st
 An identity comparison between them must not be considered always false or narrow either operand:
 
 ```py
-from typing import NewType, final
+from typing import NewType, TypeVar, final
 from ty_extensions import Intersection, Not, is_disjoint_from, static_assert
 
 class Foo: ...
@@ -212,6 +212,28 @@ def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
     if foo1 is foo2:
         reveal_type(foo1)  # revealed: FooNewType1
         reveal_type(foo2)  # revealed: FooNewType2
+
+BoundedT = TypeVar("BoundedT", bound=FooNewType1)
+BoundedU = TypeVar("BoundedU", bound=FooNewType2)
+
+def bounded_typevars(left: BoundedT, right: BoundedU) -> None:
+    reveal_type(left is right)  # revealed: bool
+    reveal_type(left is not right)  # revealed: bool
+    if left is right:
+        reveal_type(left)  # revealed: BoundedT@bounded_typevars
+        reveal_type(right)  # revealed: BoundedU@bounded_typevars
+
+FooNewType3 = NewType("FooNewType3", Foo)
+FooNewType4 = NewType("FooNewType4", Foo)
+ConstrainedT = TypeVar("ConstrainedT", FooNewType1, FooNewType2)
+ConstrainedU = TypeVar("ConstrainedU", FooNewType3, FooNewType4)
+
+def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> None:
+    reveal_type(left is right)  # revealed: bool
+    reveal_type(left is not right)  # revealed: bool
+    if left is right:
+        reveal_type(left)  # revealed: ConstrainedT@constrained_typevars
+        reveal_type(right)  # revealed: ConstrainedU@constrained_typevars
 
 def unions(left: FooNewType1 | str, right: FooNewType2 | bytes) -> None:
     reveal_type(left is right)  # revealed: bool

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -313,8 +313,9 @@ def literals(
 
 ### `is not` with singleton `NewType`s
 
-Distinct `NewType`s of the same singleton type contain the same runtime object. In the true branch
-below, `value` can therefore only be the `int` alternative.
+Distinct `NewType`s of the same singleton type contain the same runtime object. These checks
+therefore remove the `NewType` alternative from the true branch, including when a check on a tuple
+element narrows the tuple union.
 
 ```py
 from types import EllipsisType
@@ -328,6 +329,12 @@ def singleton_is_not(value: SingletonA | int, other: SingletonB) -> None:
         reveal_type(value)  # revealed: int
     else:
         reveal_type(value)  # revealed: SingletonA
+
+def tuple_parent_is_not(value: tuple[SingletonA] | tuple[int], other: SingletonB) -> None:
+    if value[0] is not other:
+        reveal_type(value)  # revealed: tuple[int]
+    else:
+        reveal_type(value)  # revealed: tuple[SingletonA]
 ```
 
 ### Static exclusions

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -190,6 +190,24 @@ def narrow_generic_alias[T: (Generic[int], Specialized)](klass: type[T]) -> None
         reveal_type(Generic[int])  # revealed: <class 'Generic[int]'>
 ```
 
+## `is not` with a constrained `TypeVar`
+
+An `is not` check excludes the current specialization of a constrained `TypeVar`. A subsequent
+identity check against the same value is therefore unreachable.
+
+```py
+from types import EllipsisType
+from typing import TypeVar
+from typing_extensions import assert_never
+
+T = TypeVar("T", None, EllipsisType)
+
+def f(value: int | None | EllipsisType, other: T) -> None:
+    if value is not other:
+        if value is other:
+            assert_never(value)
+```
+
 ## `is` with `NewType`s
 
 ### Distinct `NewType`s with the same base

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -208,6 +208,28 @@ def f(value: int | None | EllipsisType, other: T) -> None:
             assert_never(value)
 ```
 
+## Tuple narrowing with a constrained `TypeVar`
+
+When every constraint of a `TypeVar` is a singleton, an identity check on a tuple element can
+exclude tuple alternatives that cannot contain its current specialization. The complementary
+`is not` branch must retain both singleton alternatives because either one can differ from the
+current specialization.
+
+```py
+from types import EllipsisType
+from typing import TypeVar
+
+T = TypeVar("T", None, EllipsisType)
+
+def takes_singleton_tuple(value: tuple[None] | tuple[EllipsisType]) -> None: ...
+
+def f(value: tuple[int] | tuple[None] | tuple[EllipsisType], other: T) -> None:
+    if value[0] is other:
+        takes_singleton_tuple(value)
+    if value[0] is not other:
+        reveal_type(value)  # revealed: tuple[int] | tuple[None] | tuple[EllipsisType]
+```
+
 ## `is` with `NewType`s
 
 ### Distinct `NewType`s with the same base

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -197,7 +197,7 @@ An identity comparison between them must not be considered always false or narro
 
 ```py
 from typing import NewType, final
-from ty_extensions import Intersection, is_disjoint_from, static_assert
+from ty_extensions import Intersection, Not, is_disjoint_from, static_assert
 
 class Foo: ...
 class FooSub(Foo): ...
@@ -224,6 +224,17 @@ def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) ->
     if left is right:
         reveal_type(left)  # revealed: FooNewType1 & FooSub
         reveal_type(right)  # revealed: FooNewType2 & FooSub
+
+FooSubNewType = NewType("FooSubNewType", FooSub)
+
+def negative_intersection(left: Intersection[FooNewType1, Not[FooSub]], right: FooSubNewType) -> None:
+    reveal_type(left is right)  # revealed: Literal[False]
+    reveal_type(right is left)  # revealed: Literal[False]
+    reveal_type(left is not right)  # revealed: Literal[True]
+    reveal_type(right is not left)  # revealed: Literal[True]
+    if left is right:
+        reveal_type(left)  # revealed: Never
+        reveal_type(right)  # revealed: Never
 
 UserId = NewType("UserId", int)
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -311,7 +311,7 @@ def literals(
         reveal_type(some_bytes)  # revealed: Literal[b"some_bytes"]
 ```
 
-### Negative-only types
+### Static exclusions
 
 A static exclusion does not necessarily exclude an object's runtime type. In the example below,
 `BoolNewType` is statically disjoint from `Literal[True]`, so it inhabits `Not[Literal[True]]`.
@@ -330,24 +330,29 @@ def excludes_true(value: Not[Literal[True]]) -> None:
 excludes_true(BoolNewType(True))
 ```
 
+The same applies when an intersection has positive elements. `IntNewType(1)` is accepted as
+`Intersection[int, Not[Literal[1]]]`, but still returns the `1` object unchanged.
+
+```py
+from typing import Literal, NewType
+from ty_extensions import Intersection, Not
+
+IntNewType = NewType("IntNewType", int)
+
+def excludes_one(value: Intersection[int, Not[Literal[1]]]) -> None:
+    reveal_type(value is 1)  # revealed: bool
+    if value is 1:
+        reveal_type(value)  # revealed: int & ~Literal[1]
+
+excludes_one(IntNewType(1))
+```
+
 ### Comparisons that are always false
 
-These comparisons are still always false when a positive type excludes the other operand and when
-the two runtime types are distinct final classes.
+An identity comparison is still always false when the two runtime types are distinct final classes.
 
 ```py
 from typing import NewType, final
-from ty_extensions import Intersection, Not
-
-class Foo: ...
-class FooSub(Foo): ...
-
-FooNewType = NewType("FooNewType", Foo)
-FooSubNewType = NewType("FooSubNewType", FooSub)
-
-def excluded_subtype(left: Intersection[FooNewType, Not[FooSub]], right: FooSubNewType) -> None:
-    reveal_type(left is right)  # revealed: Literal[False]
-    reveal_type(left is not right)  # revealed: Literal[True]
 
 @final
 class A: ...

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -190,42 +190,24 @@ def narrow_generic_alias[T: (Generic[int], Specialized)](klass: type[T]) -> None
         reveal_type(Generic[int])  # revealed: <class 'Generic[int]'>
 ```
 
-## `is not` with a constrained `TypeVar`
+## Narrowing with a constrained `TypeVar`
 
-An `is not` check excludes the object selected by a constrained `TypeVar`. A subsequent identity
-check against the same value is therefore unreachable.
+The `is` check below can discard `int` because it cannot be `None` or `...`. The `is not` check
+cannot discard either remaining type: depending on the current constraint, either value could differ
+from `other`.
 
 ```py
 from types import EllipsisType
 from typing import TypeVar
-from typing_extensions import assert_never
 
 T = TypeVar("T", None, EllipsisType)
 
+def takes_singleton(value: None | EllipsisType) -> None: ...
 def f(value: int | None | EllipsisType, other: T) -> None:
+    if value is other:
+        takes_singleton(value)
     if value is not other:
-        if value is other:
-            assert_never(value)
-```
-
-## Tuple narrowing with a constrained `TypeVar`
-
-The `is` check below can discard `tuple[int]` because its element cannot be `None` or `...`. The
-`is not` check cannot discard either remaining tuple: depending on the current constraint, either
-one could differ from `other`.
-
-```py
-from types import EllipsisType
-from typing import TypeVar
-
-T = TypeVar("T", None, EllipsisType)
-
-def takes_singleton_tuple(value: tuple[None] | tuple[EllipsisType]) -> None: ...
-def f(value: tuple[int] | tuple[None] | tuple[EllipsisType], other: T) -> None:
-    if value[0] is other:
-        takes_singleton_tuple(value)
-    if value[0] is not other:
-        reveal_type(value)  # revealed: tuple[int] | tuple[None] | tuple[EllipsisType]
+        reveal_type(value)  # revealed: int | (None & ~T@f) | (EllipsisType & ~T@f)
 ```
 
 ## `is` with `NewType`s
@@ -233,8 +215,8 @@ def f(value: tuple[int] | tuple[None] | tuple[EllipsisType], other: T) -> None:
 ### Distinct `NewType`s with the same base
 
 Calling a `NewType` returns its argument unchanged. Values with distinct `NewType`s over `Foo` can
-therefore be the same object even though their types are distinct. The examples below cover direct
-comparisons and narrowing through unions, intersections, and tuple elements.
+therefore be the same object even though their types are disjoint. The examples below cover direct
+comparisons and narrowing through unions and intersections.
 
 ```py
 from typing import NewType
@@ -245,8 +227,6 @@ class FooSub(Foo): ...
 
 FooNewType1 = NewType("FooNewType1", Foo)
 FooNewType2 = NewType("FooNewType2", Foo)
-IntNewType1 = NewType("IntNewType1", int)
-IntNewType2 = NewType("IntNewType2", int)
 
 def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
     reveal_type(foo1 is foo2)  # revealed: bool
@@ -261,10 +241,6 @@ def union(value: FooNewType1 | None, other: FooNewType2) -> None:
 def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) -> None:
     if left is right:
         reveal_type(right)  # revealed: FooNewType2 & FooSub
-
-def tuple_element(value: tuple[IntNewType1] | tuple[str], other: IntNewType2) -> None:
-    if value[0] is other:
-        reveal_type(value)  # revealed: tuple[IntNewType1]
 ```
 
 ### `NewType`s in `TypeVar` bounds and constraints
@@ -286,23 +262,29 @@ FooNewType4 = NewType("FooNewType4", Foo)
 BoundedT = TypeVar("BoundedT", bound=FooNewType1)
 BoundedU = TypeVar("BoundedU", bound=FooNewType2)
 
-def bounded_typevars(left: BoundedT, right: BoundedU) -> None:
+def bounded_typevars(left: BoundedT, right: BoundedU) -> tuple[BoundedU, BoundedU]:
     reveal_type(left is right)  # revealed: bool
     if left is right:
+        # TODO: This should narrow to `BoundedT & BoundedU` and avoid the false positive below.
         reveal_type(left)  # revealed: BoundedT@bounded_typevars
+        return (left, left)  # error: [invalid-return-type]
+    return (right, right)
 
 ConstrainedT = TypeVar("ConstrainedT", FooNewType1, FooNewType2)
 ConstrainedU = TypeVar("ConstrainedU", FooNewType3, FooNewType4)
 
-def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> None:
+def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> tuple[ConstrainedU, ConstrainedU]:
     reveal_type(left is right)  # revealed: bool
     if left is right:
+        # TODO: This should narrow to `ConstrainedT & ConstrainedU` and avoid the false positive.
         reveal_type(left)  # revealed: ConstrainedT@constrained_typevars
+        return (left, left)  # error: [invalid-return-type]
+    return (right, right)
 ```
 
 Every constraint below is a `NewType` based on `EllipsisType`, so `other` always refers to the same
 `...` object as a `SingletonC` value. After an `is not` check, repeating the opposite check must be
-unreachable, both directly and when narrowing a tuple.
+unreachable.
 
 ```py
 from types import EllipsisType
@@ -319,27 +301,21 @@ def direct(value: SingletonC | int, other: SingletonT) -> None:
     if value is not other:
         if value is other:
             assert_never(value)
-
-def tuple_element(value: tuple[SingletonC] | tuple[int], other: SingletonT) -> None:
-    if value[0] is not other:
-        if value[0] is other:
-            assert_never(value)
 ```
 
-### Preserving a `NewType` in the true branch
+### Narrowing an object to a `NewType` in the true branch
 
-If an object is identical to a value with a `NewType`, the true branch preserves the `NewType`
-rather than replacing it with its underlying type. The call below should not emit an error.
+If an object is identical to a value with a `NewType`, the true branch narrows the object to that
+`NewType` rather than its underlying type.
 
 ```py
 from typing import NewType
 
 UserId = NewType("UserId", int)
 
-def takes_user_id(value: UserId) -> None: ...
 def preserve_newtype(x: object, user_id: UserId) -> None:
     if x is user_id:
-        takes_user_id(x)
+        reveal_type(x)  # revealed: UserId
 ```
 
 ### Comparing `NewType`s with literals
@@ -348,26 +324,24 @@ Calls to `NewType` return their arguments unchanged. Comparisons with `bool` and
 therefore succeed, so the true branches below remain reachable.
 
 ```py
-from typing import NewType
+from typing import Literal, NewType
 
 BoolNewType = NewType("BoolNewType", bool)
 IntNewType = NewType("IntNewType", int)
 
-def literals() -> None:
-    true = True
-    forty_two = 42
-
-    if BoolNewType(true) is true:
+def literals(true: Literal[True], b: BoolNewType, forty_two: Literal[42], i: IntNewType) -> None:
+    if b is true:
         reveal_type(true)  # revealed: Literal[True]
-    if IntNewType(forty_two) is forty_two:
+        reveal_type(b)  # revealed: BoolNewType
+    if i is forty_two:
         reveal_type(forty_two)  # revealed: Literal[42]
+        reveal_type(i)  # revealed: IntNewType
 ```
 
 ### `is not` with singleton `NewType`s
 
 Both `NewType`s below are based on `EllipsisType`, which contains only the `...` object. The
-`is not` branch therefore removes the `NewType` alternative. The same rule applies when the check
-narrows a tuple.
+`is not` branch therefore removes the `NewType` alternative.
 
 ```py
 from types import EllipsisType
@@ -379,40 +353,35 @@ SingletonB = NewType("SingletonB", EllipsisType)
 def singleton_is_not(value: SingletonA | int, other: SingletonB) -> None:
     if value is not other:
         reveal_type(value)  # revealed: int
-
-def tuple_is_not(value: tuple[SingletonA] | tuple[int], other: SingletonB) -> None:
-    if value[0] is not other:
-        reveal_type(value)  # revealed: tuple[int]
 ```
 
 ### Static exclusions
 
-The type `Not[Literal[True]]` excludes the literal type but accepts the distinct `BoolNewType`.
-However, `BoolNewType(True)` returns `True` unchanged, so `value is True` can be either true or
-false.
+The type `~Literal[True]` excludes the literal type but accepts the distinct `BoolNewType`. However,
+`BoolNewType(True)` returns `True` unchanged, so `value is True` can be either true or false.
 
 ```py
+from __future__ import annotations
+
 from typing import Literal, NewType
-from ty_extensions import Not
 
 BoolNewType = NewType("BoolNewType", bool)
 
-def excludes_true(value: Not[Literal[True]]) -> None:
+def excludes_true(value: ~Literal[True]) -> None:
     reveal_type(value is True)  # revealed: bool
 
 excludes_true(BoolNewType(True))
 ```
 
-Similarly, `Intersection[int, Not[Literal[1]]]` accepts `IntNewType(1)`, which returns the `1`
-object unchanged, so the comparison remains possible.
+Similarly, `int & ~Literal[1]` accepts `IntNewType(1)`, which returns the `1` object unchanged, so
+the comparison remains possible.
 
 ```py
 from typing import Literal, NewType
-from ty_extensions import Intersection, Not
 
 IntNewType = NewType("IntNewType", int)
 
-def excludes_one(value: Intersection[int, Not[Literal[1]]]) -> None:
+def excludes_one(value: int & ~Literal[1]) -> None:
     reveal_type(value is 1)  # revealed: bool
 
 excludes_one(IntNewType(1))

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -250,14 +250,16 @@ IntNewType2 = NewType("IntNewType2", int)
 
 def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
     reveal_type(foo1 is foo2)  # revealed: bool
+    if foo1 is foo2:
+        reveal_type(foo1)  # revealed: FooNewType1
+        reveal_type(foo2)  # revealed: FooNewType2
 
-def unions(left: FooNewType1 | str, right: FooNewType2 | bytes) -> None:
-    if left is right:
-        reveal_type(left)  # revealed: (str & FooNewType2) | FooNewType1
+def union(value: FooNewType1 | None, other: FooNewType2) -> None:
+    if value is other:
+        reveal_type(value)  # revealed: FooNewType1
 
 def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) -> None:
     if left is right:
-        reveal_type(left)  # revealed: FooNewType1 & FooSub
         reveal_type(right)  # revealed: FooNewType2 & FooSub
 
 def tuple_element(value: tuple[IntNewType1] | tuple[str], other: IntNewType2) -> None:
@@ -267,8 +269,9 @@ def tuple_element(value: tuple[IntNewType1] | tuple[str], other: IntNewType2) ->
 
 ### `NewType`s in `TypeVar` bounds and constraints
 
-Bounds and constraints containing `NewType`s require the same runtime handling. Comparing the
-distinct `TypeVar`s below is not always false, and a true branch keeps the original `TypeVar`.
+`NewType`s inside `TypeVar` bounds and constraints can likewise refer to the same runtime object.
+Comparing the distinct `TypeVar`s below is not always false, and a true branch keeps the original
+`TypeVar`.
 
 ```py
 from typing import NewType, TypeVar
@@ -285,7 +288,6 @@ BoundedU = TypeVar("BoundedU", bound=FooNewType2)
 
 def bounded_typevars(left: BoundedT, right: BoundedU) -> None:
     reveal_type(left is right)  # revealed: bool
-    reveal_type(left is not right)  # revealed: bool
     if left is right:
         reveal_type(left)  # revealed: BoundedT@bounded_typevars
 
@@ -318,7 +320,7 @@ def direct(value: SingletonC | int, other: SingletonT) -> None:
         if value is other:
             assert_never(value)
 
-def tuple_parent(value: tuple[SingletonC] | tuple[int], other: SingletonT) -> None:
+def tuple_element(value: tuple[SingletonC] | tuple[int], other: SingletonT) -> None:
     if value[0] is not other:
         if value[0] is other:
             assert_never(value)
@@ -351,38 +353,21 @@ from typing import NewType
 BoolNewType = NewType("BoolNewType", bool)
 IntNewType = NewType("IntNewType", int)
 
-def literals(bool_newtype: BoolNewType, int_newtype: IntNewType) -> None:
+def literals() -> None:
     true = True
     forty_two = 42
 
-    if bool_newtype is true:
+    if BoolNewType(true) is true:
         reveal_type(true)  # revealed: Literal[True]
-    if int_newtype is forty_two:
+    if IntNewType(forty_two) is forty_two:
         reveal_type(forty_two)  # revealed: Literal[42]
-```
-
-### `NewType` based on `NoneType`
-
-A `NewType` of `NoneType` is statically distinct from `NoneType`, but its only possible runtime
-value is still the `None` singleton. It is therefore not assignable to `Not[None]`.
-
-```py
-from types import NoneType
-from typing import NewType
-from ty_extensions import Not, is_assignable_to, static_assert
-
-NoneNewType = NewType("NoneNewType", NoneType)
-
-value = NoneNewType(None)
-reveal_type(value is None)  # revealed: Literal[True]
-static_assert(not is_assignable_to(NoneNewType, Not[None]))
 ```
 
 ### `is not` with singleton `NewType`s
 
 Both `NewType`s below are based on `EllipsisType`, which contains only the `...` object. The
-`is not` branch therefore removes the `NewType` alternative, while the `else` branch keeps it. The
-same rule applies when the check narrows a tuple.
+`is not` branch therefore removes the `NewType` alternative. The same rule applies when the check
+narrows a tuple.
 
 ```py
 from types import EllipsisType
@@ -394,21 +379,17 @@ SingletonB = NewType("SingletonB", EllipsisType)
 def singleton_is_not(value: SingletonA | int, other: SingletonB) -> None:
     if value is not other:
         reveal_type(value)  # revealed: int
-    else:
-        reveal_type(value)  # revealed: SingletonA
 
-def tuple_parent_is_not(value: tuple[SingletonA] | tuple[int], other: SingletonB) -> None:
+def tuple_is_not(value: tuple[SingletonA] | tuple[int], other: SingletonB) -> None:
     if value[0] is not other:
         reveal_type(value)  # revealed: tuple[int]
-    else:
-        reveal_type(value)  # revealed: tuple[SingletonA]
 ```
 
 ### Static exclusions
 
 The type `Not[Literal[True]]` excludes the literal type but accepts the distinct `BoolNewType`.
-However, `BoolNewType(True)` returns `True` unchanged, so the identity comparison must remain
-ambiguous.
+However, `BoolNewType(True)` returns `True` unchanged, so `value is True` can be either true or
+false.
 
 ```py
 from typing import Literal, NewType
@@ -423,8 +404,7 @@ excludes_true(BoolNewType(True))
 ```
 
 Similarly, `Intersection[int, Not[Literal[1]]]` accepts `IntNewType(1)`, which returns the `1`
-object unchanged. The comparison remains possible, and the true branch keeps the original
-constraint.
+object unchanged, so the comparison remains possible.
 
 ```py
 from typing import Literal, NewType
@@ -434,8 +414,6 @@ IntNewType = NewType("IntNewType", int)
 
 def excludes_one(value: Intersection[int, Not[Literal[1]]]) -> None:
     reveal_type(value is 1)  # revealed: bool
-    if value is 1:
-        reveal_type(value)  # revealed: int & ~Literal[1]
 
 excludes_one(IntNewType(1))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -192,12 +192,16 @@ def narrow_generic_alias[T: (Generic[int], Specialized)](klass: type[T]) -> None
 
 ## `is` with `NewType`s
 
-Distinct `NewType`s can describe the same runtime object even though they are statically disjoint.
-An identity comparison between them must not be considered always false or narrow either operand:
+### Distinct `NewType`s with the same base
+
+Calling a `NewType` returns its argument unchanged, so values with statically disjoint `NewType`s
+can still be the same object at runtime. An identity comparison between distinct `NewType`s with
+the same base is therefore not always false. In the true branch, we preserve both nominal types,
+including when they appear in unions or intersections.
 
 ```py
-from typing import NewType, TypeVar, final
-from ty_extensions import Intersection, Not, is_disjoint_from, static_assert
+from typing import NewType
+from ty_extensions import Intersection
 
 class Foo: ...
 class FooSub(Foo): ...
@@ -205,38 +209,13 @@ class FooSub(Foo): ...
 FooNewType1 = NewType("FooNewType1", Foo)
 FooNewType2 = NewType("FooNewType2", Foo)
 
-static_assert(is_disjoint_from(FooNewType1, FooNewType2))
-
 def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
     reveal_type(foo1 is foo2)  # revealed: bool
     if foo1 is foo2:
         reveal_type(foo1)  # revealed: FooNewType1
         reveal_type(foo2)  # revealed: FooNewType2
 
-BoundedT = TypeVar("BoundedT", bound=FooNewType1)
-BoundedU = TypeVar("BoundedU", bound=FooNewType2)
-
-def bounded_typevars(left: BoundedT, right: BoundedU) -> None:
-    reveal_type(left is right)  # revealed: bool
-    reveal_type(left is not right)  # revealed: bool
-    if left is right:
-        reveal_type(left)  # revealed: BoundedT@bounded_typevars
-        reveal_type(right)  # revealed: BoundedU@bounded_typevars
-
-FooNewType3 = NewType("FooNewType3", Foo)
-FooNewType4 = NewType("FooNewType4", Foo)
-ConstrainedT = TypeVar("ConstrainedT", FooNewType1, FooNewType2)
-ConstrainedU = TypeVar("ConstrainedU", FooNewType3, FooNewType4)
-
-def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> None:
-    reveal_type(left is right)  # revealed: bool
-    reveal_type(left is not right)  # revealed: bool
-    if left is right:
-        reveal_type(left)  # revealed: ConstrainedT@constrained_typevars
-        reveal_type(right)  # revealed: ConstrainedU@constrained_typevars
-
 def unions(left: FooNewType1 | str, right: FooNewType2 | bytes) -> None:
-    reveal_type(left is right)  # revealed: bool
     if left is right:
         reveal_type(left)  # revealed: (str & FooNewType2) | FooNewType1
         reveal_type(right)  # revealed: (bytes & FooNewType1) | FooNewType2
@@ -246,25 +225,65 @@ def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) ->
     if left is right:
         reveal_type(left)  # revealed: FooNewType1 & FooSub
         reveal_type(right)  # revealed: FooNewType2 & FooSub
+```
 
-FooSubNewType = NewType("FooSubNewType", FooSub)
+### `NewType`s in `TypeVar` bounds and constraints
 
-def negative_intersection(left: Intersection[FooNewType1, Not[FooSub]], right: FooSubNewType) -> None:
-    reveal_type(left is right)  # revealed: Literal[False]
-    reveal_type(right is left)  # revealed: Literal[False]
-    reveal_type(left is not right)  # revealed: Literal[True]
-    reveal_type(right is not left)  # revealed: Literal[True]
+The same runtime behavior applies when the operands are `TypeVar`s whose bounds or constraints are
+distinct `NewType`s with the same base. The result is not statically known, and a true branch
+preserves the `TypeVar`.
+
+```py
+from typing import NewType, TypeVar
+
+class Foo: ...
+
+FooNewType1 = NewType("FooNewType1", Foo)
+FooNewType2 = NewType("FooNewType2", Foo)
+FooNewType3 = NewType("FooNewType3", Foo)
+FooNewType4 = NewType("FooNewType4", Foo)
+
+BoundedT = TypeVar("BoundedT", bound=FooNewType1)
+BoundedU = TypeVar("BoundedU", bound=FooNewType2)
+
+def bounded_typevars(left: BoundedT, right: BoundedU) -> None:
+    reveal_type(left is right)  # revealed: bool
+    reveal_type(left is not right)  # revealed: bool
     if left is right:
-        reveal_type(left)  # revealed: Never
-        reveal_type(right)  # revealed: Never
+        reveal_type(left)  # revealed: BoundedT@bounded_typevars
+
+ConstrainedT = TypeVar("ConstrainedT", FooNewType1, FooNewType2)
+ConstrainedU = TypeVar("ConstrainedU", FooNewType3, FooNewType4)
+
+def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> None:
+    reveal_type(left is right)  # revealed: bool
+    if left is right:
+        reveal_type(left)  # revealed: ConstrainedT@constrained_typevars
+```
+
+### Preserving a `NewType` in the true branch
+
+If an object is identical to a value with a `NewType`, the true branch preserves the `NewType`
+rather than replacing it with its underlying type. The call below should not emit an error.
+
+```py
+from typing import NewType
 
 UserId = NewType("UserId", int)
 
 def takes_user_id(value: UserId) -> None: ...
-def preserve_newtype_constraint(x: object, user_id: UserId) -> None:
+def preserve_newtype(x: object, user_id: UserId) -> None:
     if x is user_id:
-        reveal_type(x)  # revealed: UserId
         takes_user_id(x)
+```
+
+### `NewType`s of builtin literal types
+
+`NewType`s of `bool`, `int`, `str`, and `bytes` also return their arguments unchanged. An identity
+comparison with the original literal can therefore succeed, so the true branch remains reachable.
+
+```py
+from typing import NewType
 
 BoolNewType = NewType("BoolNewType", bool)
 IntNewType = NewType("IntNewType", int)
@@ -282,7 +301,6 @@ def literals(
     some_string = "some_string"
     some_bytes = b"some_bytes"
 
-    reveal_type(bool_newtype is true)  # revealed: bool
     if bool_newtype is true:
         reveal_type(true)  # revealed: Literal[True]
     if int_newtype is forty_two:
@@ -291,6 +309,27 @@ def literals(
         reveal_type(some_string)  # revealed: Literal["some_string"]
     if bytes_newtype is some_bytes:
         reveal_type(some_bytes)  # revealed: Literal[b"some_bytes"]
+```
+
+### Comparisons that are always false
+
+These comparisons are still always false when the declared types rule out a shared object. This is
+true when one operand excludes the other's base class and when the two bases are distinct final
+classes.
+
+```py
+from typing import NewType, final
+from ty_extensions import Intersection, Not
+
+class Foo: ...
+class FooSub(Foo): ...
+
+FooNewType = NewType("FooNewType", Foo)
+FooSubNewType = NewType("FooSubNewType", FooSub)
+
+def excluded_subtype(left: Intersection[FooNewType, Not[FooSub]], right: FooSubNewType) -> None:
+    reveal_type(left is right)  # revealed: Literal[False]
+    reveal_type(left is not right)  # revealed: Literal[True]
 
 @final
 class A: ...
@@ -303,9 +342,6 @@ BNewType = NewType("BNewType", B)
 
 def disjoint_bases(a: ANewType, b: BNewType) -> None:
     reveal_type(a is b)  # revealed: Literal[False]
-    if a is b:
-        reveal_type(a)  # revealed: Never
-        reveal_type(b)  # revealed: Never
 ```
 
 ## `is` where the other operand is a call expression

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -311,6 +311,25 @@ def literals(
         reveal_type(some_bytes)  # revealed: Literal[b"some_bytes"]
 ```
 
+### `is not` with singleton `NewType`s
+
+Distinct `NewType`s of the same singleton type contain the same runtime object. In the true branch
+below, `value` can therefore only be the `int` alternative.
+
+```py
+from types import EllipsisType
+from typing import NewType
+
+SingletonA = NewType("SingletonA", EllipsisType)
+SingletonB = NewType("SingletonB", EllipsisType)
+
+def singleton_is_not(value: SingletonA | int, other: SingletonB) -> None:
+    if value is not other:
+        reveal_type(value)  # revealed: int
+    else:
+        reveal_type(value)  # revealed: SingletonA
+```
+
 ### Static exclusions
 
 A static exclusion does not necessarily exclude an object's runtime type. In the example below,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -195,8 +195,8 @@ def narrow_generic_alias[T: (Generic[int], Specialized)](klass: type[T]) -> None
 ### Distinct `NewType`s with the same base
 
 Calling a `NewType` returns its argument unchanged, so values with statically disjoint `NewType`s
-can still be the same object at runtime. An identity comparison between distinct `NewType`s with
-the same base is therefore not always false. In the true branch, we preserve both nominal types,
+can still be the same object at runtime. An identity comparison between distinct `NewType`s with the
+same base is therefore not always false. In the true branch, we preserve both nominal types,
 including when they appear in unions or intersections.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -311,11 +311,29 @@ def literals(
         reveal_type(some_bytes)  # revealed: Literal[b"some_bytes"]
 ```
 
+### Negative-only types
+
+A static exclusion does not necessarily exclude an object's runtime type. In the example below,
+`BoolNewType` is statically disjoint from `Literal[True]`, so it inhabits `Not[Literal[True]]`.
+However, calling the `NewType` returns `True` unchanged. The identity comparison must therefore
+remain ambiguous.
+
+```py
+from typing import Literal, NewType
+from ty_extensions import Not
+
+BoolNewType = NewType("BoolNewType", bool)
+
+def excludes_true(value: Not[Literal[True]]) -> None:
+    reveal_type(value is True)  # revealed: bool
+
+excludes_true(BoolNewType(True))
+```
+
 ### Comparisons that are always false
 
-These comparisons are still always false when the declared types rule out a shared object. This is
-true when one operand excludes the other's base class and when the two bases are distinct final
-classes.
+These comparisons are still always false when a positive type excludes the other operand and when
+the two runtime types are distinct final classes.
 
 ```py
 from typing import NewType, final

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -237,7 +237,9 @@ def f(value: tuple[int] | tuple[None] | tuple[EllipsisType], other: T) -> None:
 Calling a `NewType` returns its argument unchanged, so values with statically disjoint `NewType`s
 can still be the same object at runtime. An identity comparison between distinct `NewType`s with the
 same base is therefore not always false. In the true branch, we preserve both nominal types,
-including when they appear in unions or intersections.
+including when they appear in unions or intersections. A positive check on a tuple element can
+also remove tuple alternatives whose element is runtime-disjoint, even when the compared value is
+not a singleton.
 
 ```py
 from typing import NewType
@@ -248,6 +250,8 @@ class FooSub(Foo): ...
 
 FooNewType1 = NewType("FooNewType1", Foo)
 FooNewType2 = NewType("FooNewType2", Foo)
+IntNewType1 = NewType("IntNewType1", int)
+IntNewType2 = NewType("IntNewType2", int)
 
 def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
     reveal_type(foo1 is foo2)  # revealed: bool
@@ -265,6 +269,10 @@ def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) ->
     if left is right:
         reveal_type(left)  # revealed: FooNewType1 & FooSub
         reveal_type(right)  # revealed: FooNewType2 & FooSub
+
+def tuple_element(value: tuple[IntNewType1] | tuple[str], other: IntNewType2) -> None:
+    if value[0] is other:
+        reveal_type(value)  # revealed: tuple[IntNewType1]
 ```
 
 ### `NewType`s in `TypeVar` bounds and constraints

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -222,7 +222,6 @@ from typing import TypeVar
 T = TypeVar("T", None, EllipsisType)
 
 def takes_singleton_tuple(value: tuple[None] | tuple[EllipsisType]) -> None: ...
-
 def f(value: tuple[int] | tuple[None] | tuple[EllipsisType], other: T) -> None:
     if value[0] is other:
         takes_singleton_tuple(value)
@@ -237,9 +236,9 @@ def f(value: tuple[int] | tuple[None] | tuple[EllipsisType], other: T) -> None:
 Calling a `NewType` returns its argument unchanged, so values with statically disjoint `NewType`s
 can still be the same object at runtime. An identity comparison between distinct `NewType`s with the
 same base is therefore not always false. In the true branch, we preserve both nominal types,
-including when they appear in unions or intersections. A positive check on a tuple element can
-also remove tuple alternatives whose element is runtime-disjoint, even when the compared value is
-not a singleton.
+including when they appear in unions or intersections. A positive check on a tuple element can also
+remove tuple alternatives whose element is runtime-disjoint, even when the compared value is not a
+singleton.
 
 ```py
 from typing import NewType

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -192,8 +192,8 @@ def narrow_generic_alias[T: (Generic[int], Specialized)](klass: type[T]) -> None
 
 ## `is not` with a constrained `TypeVar`
 
-An `is not` check excludes the current specialization of a constrained `TypeVar`. A subsequent
-identity check against the same value is therefore unreachable.
+An `is not` check excludes the object selected by a constrained `TypeVar`. A subsequent identity
+check against the same value is therefore unreachable.
 
 ```py
 from types import EllipsisType
@@ -210,10 +210,9 @@ def f(value: int | None | EllipsisType, other: T) -> None:
 
 ## Tuple narrowing with a constrained `TypeVar`
 
-When every constraint of a `TypeVar` is a singleton, an identity check on a tuple element can
-exclude tuple alternatives that cannot contain its current specialization. The complementary
-`is not` branch must retain both singleton alternatives because either one can differ from the
-current specialization.
+The `is` check below can discard `tuple[int]` because its element cannot be `None` or `...`. The
+`is not` check cannot discard either remaining tuple: depending on the current constraint, either
+one could differ from `other`.
 
 ```py
 from types import EllipsisType
@@ -233,12 +232,9 @@ def f(value: tuple[int] | tuple[None] | tuple[EllipsisType], other: T) -> None:
 
 ### Distinct `NewType`s with the same base
 
-Calling a `NewType` returns its argument unchanged, so values with statically disjoint `NewType`s
-can still be the same object at runtime. An identity comparison between distinct `NewType`s with the
-same base is therefore not always false. In the true branch, we preserve both nominal types,
-including when they appear in unions or intersections. A positive check on a tuple element can also
-remove tuple alternatives whose element is runtime-disjoint, even when the compared value is not a
-singleton.
+Calling a `NewType` returns its argument unchanged. Values with distinct `NewType`s over `Foo` can
+therefore be the same object even though their types are distinct. The examples below cover direct
+comparisons and narrowing through unions, intersections, and tuple elements.
 
 ```py
 from typing import NewType
@@ -254,17 +250,12 @@ IntNewType2 = NewType("IntNewType2", int)
 
 def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
     reveal_type(foo1 is foo2)  # revealed: bool
-    if foo1 is foo2:
-        reveal_type(foo1)  # revealed: FooNewType1
-        reveal_type(foo2)  # revealed: FooNewType2
 
 def unions(left: FooNewType1 | str, right: FooNewType2 | bytes) -> None:
     if left is right:
         reveal_type(left)  # revealed: (str & FooNewType2) | FooNewType1
-        reveal_type(right)  # revealed: (bytes & FooNewType1) | FooNewType2
 
 def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) -> None:
-    reveal_type(left is right)  # revealed: bool
     if left is right:
         reveal_type(left)  # revealed: FooNewType1 & FooSub
         reveal_type(right)  # revealed: FooNewType2 & FooSub
@@ -276,9 +267,8 @@ def tuple_element(value: tuple[IntNewType1] | tuple[str], other: IntNewType2) ->
 
 ### `NewType`s in `TypeVar` bounds and constraints
 
-The same runtime behavior applies when the operands are `TypeVar`s whose bounds or constraints are
-distinct `NewType`s with the same base. The result is not statically known, and a true branch
-preserves the `TypeVar`.
+Bounds and constraints containing `NewType`s require the same runtime handling. Comparing the
+distinct `TypeVar`s below is not always false, and a true branch keeps the original `TypeVar`.
 
 ```py
 from typing import NewType, TypeVar
@@ -308,9 +298,9 @@ def constrained_typevars(left: ConstrainedT, right: ConstrainedU) -> None:
         reveal_type(left)  # revealed: ConstrainedT@constrained_typevars
 ```
 
-When every constraint is a `NewType` of the same singleton type, every specialization represents the
-same runtime object. An `is not` branch must therefore exclude other `NewType`s of that singleton,
-both directly and when narrowing a tuple.
+Every constraint below is a `NewType` based on `EllipsisType`, so `other` always refers to the same
+`...` object as a `SingletonC` value. After an `is not` check, repeating the opposite check must be
+unreachable, both directly and when narrowing a tuple.
 
 ```py
 from types import EllipsisType
@@ -350,41 +340,28 @@ def preserve_newtype(x: object, user_id: UserId) -> None:
         takes_user_id(x)
 ```
 
-### `NewType`s of builtin literal types
+### Comparing `NewType`s with literals
 
-`NewType`s of `bool`, `int`, `str`, and `bytes` also return their arguments unchanged. An identity
-comparison with the original literal can therefore succeed, so the true branch remains reachable.
+Calls to `NewType` return their arguments unchanged. Comparisons with `bool` and `int` literals can
+therefore succeed, so the true branches below remain reachable.
 
 ```py
 from typing import NewType
 
 BoolNewType = NewType("BoolNewType", bool)
 IntNewType = NewType("IntNewType", int)
-StrNewType = NewType("StrNewType", str)
-BytesNewType = NewType("BytesNewType", bytes)
 
-def literals(
-    bool_newtype: BoolNewType,
-    int_newtype: IntNewType,
-    str_newtype: StrNewType,
-    bytes_newtype: BytesNewType,
-) -> None:
+def literals(bool_newtype: BoolNewType, int_newtype: IntNewType) -> None:
     true = True
     forty_two = 42
-    some_string = "some_string"
-    some_bytes = b"some_bytes"
 
     if bool_newtype is true:
         reveal_type(true)  # revealed: Literal[True]
     if int_newtype is forty_two:
         reveal_type(forty_two)  # revealed: Literal[42]
-    if str_newtype is some_string:
-        reveal_type(some_string)  # revealed: Literal["some_string"]
-    if bytes_newtype is some_bytes:
-        reveal_type(some_bytes)  # revealed: Literal[b"some_bytes"]
 ```
 
-### `NewType` of a singleton class
+### `NewType` based on `NoneType`
 
 A `NewType` of `NoneType` is statically distinct from `NoneType`, but its only possible runtime
 value is still the `None` singleton. It is therefore not assignable to `Not[None]`.
@@ -403,9 +380,9 @@ static_assert(not is_assignable_to(NoneNewType, Not[None]))
 
 ### `is not` with singleton `NewType`s
 
-Distinct `NewType`s of the same singleton type contain the same runtime object. These checks
-therefore remove the `NewType` alternative from the true branch, including when a check on a tuple
-element narrows the tuple union.
+Both `NewType`s below are based on `EllipsisType`, which contains only the `...` object. The
+`is not` branch therefore removes the `NewType` alternative, while the `else` branch keeps it. The
+same rule applies when the check narrows a tuple.
 
 ```py
 from types import EllipsisType
@@ -429,10 +406,9 @@ def tuple_parent_is_not(value: tuple[SingletonA] | tuple[int], other: SingletonB
 
 ### Static exclusions
 
-A static exclusion does not necessarily exclude an object's runtime type. In the example below,
-`BoolNewType` is statically disjoint from `Literal[True]`, so it inhabits `Not[Literal[True]]`.
-However, calling the `NewType` returns `True` unchanged. The identity comparison must therefore
-remain ambiguous.
+The type `Not[Literal[True]]` excludes the literal type but accepts the distinct `BoolNewType`.
+However, `BoolNewType(True)` returns `True` unchanged, so the identity comparison must remain
+ambiguous.
 
 ```py
 from typing import Literal, NewType
@@ -446,8 +422,9 @@ def excludes_true(value: Not[Literal[True]]) -> None:
 excludes_true(BoolNewType(True))
 ```
 
-The same applies when an intersection has positive elements. `IntNewType(1)` is accepted as
-`Intersection[int, Not[Literal[1]]]`, but still returns the `1` object unchanged.
+Similarly, `Intersection[int, Not[Literal[1]]]` accepts `IntNewType(1)`, which returns the `1`
+object unchanged. The comparison remains possible, and the true branch keeps the original
+constraint.
 
 ```py
 from typing import Literal, NewType

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -216,14 +216,22 @@ def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
 def unions(left: FooNewType1 | str, right: FooNewType2 | bytes) -> None:
     reveal_type(left is right)  # revealed: bool
     if left is right:
-        reveal_type(left)  # revealed: FooNewType1 | (str & Foo)
-        reveal_type(right)  # revealed: FooNewType2 | (bytes & Foo)
+        reveal_type(left)  # revealed: (str & FooNewType2) | FooNewType1
+        reveal_type(right)  # revealed: (bytes & FooNewType1) | FooNewType2
 
 def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) -> None:
     reveal_type(left is right)  # revealed: bool
     if left is right:
         reveal_type(left)  # revealed: FooNewType1 & FooSub
         reveal_type(right)  # revealed: FooNewType2 & FooSub
+
+UserId = NewType("UserId", int)
+
+def takes_user_id(value: UserId) -> None: ...
+def preserve_newtype_constraint(x: object, user_id: UserId) -> None:
+    if x is user_id:
+        reveal_type(x)  # revealed: UserId
+        takes_user_id(x)
 
 BoolNewType = NewType("BoolNewType", bool)
 IntNewType = NewType("IntNewType", int)

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -359,6 +359,23 @@ def literals(
         reveal_type(some_bytes)  # revealed: Literal[b"some_bytes"]
 ```
 
+### `NewType` of a singleton class
+
+A `NewType` of `NoneType` is statically distinct from `NoneType`, but its only possible runtime
+value is still the `None` singleton. It is therefore not assignable to `Not[None]`.
+
+```py
+from types import NoneType
+from typing import NewType
+from ty_extensions import Not, is_assignable_to, static_assert
+
+NoneNewType = NewType("NoneNewType", NoneType)
+
+value = NoneNewType(None)
+reveal_type(value is None)  # revealed: Literal[True]
+static_assert(not is_assignable_to(NoneNewType, Not[None]))
+```
+
 ### `is not` with singleton `NewType`s
 
 Distinct `NewType`s of the same singleton type contain the same runtime object. These checks

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -190,6 +190,83 @@ def narrow_generic_alias[T: (Generic[int], Specialized)](klass: type[T]) -> None
         reveal_type(Generic[int])  # revealed: <class 'Generic[int]'>
 ```
 
+## `is` with `NewType`s
+
+Distinct `NewType`s can describe the same runtime object even though they are statically disjoint.
+An identity comparison between them must not be considered always false or narrow either operand:
+
+```py
+from typing import NewType, final
+from ty_extensions import Intersection, is_disjoint_from, static_assert
+
+class Foo: ...
+class FooSub(Foo): ...
+
+FooNewType1 = NewType("FooNewType1", Foo)
+FooNewType2 = NewType("FooNewType2", Foo)
+
+static_assert(is_disjoint_from(FooNewType1, FooNewType2))
+
+def same_base(foo1: FooNewType1, foo2: FooNewType2) -> None:
+    reveal_type(foo1 is foo2)  # revealed: bool
+    if foo1 is foo2:
+        reveal_type(foo1)  # revealed: FooNewType1
+        reveal_type(foo2)  # revealed: FooNewType2
+
+def unions(left: FooNewType1 | str, right: FooNewType2 | bytes) -> None:
+    reveal_type(left is right)  # revealed: bool
+    if left is right:
+        reveal_type(left)  # revealed: FooNewType1 | (str & Foo)
+        reveal_type(right)  # revealed: FooNewType2 | (bytes & Foo)
+
+def intersection(left: Intersection[FooNewType1, FooSub], right: FooNewType2) -> None:
+    reveal_type(left is right)  # revealed: bool
+    if left is right:
+        reveal_type(left)  # revealed: FooNewType1 & FooSub
+        reveal_type(right)  # revealed: FooNewType2 & FooSub
+
+BoolNewType = NewType("BoolNewType", bool)
+IntNewType = NewType("IntNewType", int)
+StrNewType = NewType("StrNewType", str)
+BytesNewType = NewType("BytesNewType", bytes)
+
+def literals(
+    bool_newtype: BoolNewType,
+    int_newtype: IntNewType,
+    str_newtype: StrNewType,
+    bytes_newtype: BytesNewType,
+) -> None:
+    true = True
+    forty_two = 42
+    some_string = "some_string"
+    some_bytes = b"some_bytes"
+
+    reveal_type(bool_newtype is true)  # revealed: bool
+    if bool_newtype is true:
+        reveal_type(true)  # revealed: Literal[True]
+    if int_newtype is forty_two:
+        reveal_type(forty_two)  # revealed: Literal[42]
+    if str_newtype is some_string:
+        reveal_type(some_string)  # revealed: Literal["some_string"]
+    if bytes_newtype is some_bytes:
+        reveal_type(some_bytes)  # revealed: Literal[b"some_bytes"]
+
+@final
+class A: ...
+
+@final
+class B: ...
+
+ANewType = NewType("ANewType", A)
+BNewType = NewType("BNewType", B)
+
+def disjoint_bases(a: ANewType, b: BNewType) -> None:
+    reveal_type(a is b)  # revealed: Literal[False]
+    if a is b:
+        reveal_type(a)  # revealed: Never
+        reveal_type(b)  # revealed: Never
+```
+
 ## `is` where the other operand is a call expression
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -31,10 +31,8 @@ o: Not[()]
 p: Not[(int,)]
 
 def static_truthiness(not_one: Not[Literal[1]]) -> None:
-    # All possible runtime objects created by the literal syntax `1` are members of
-    # `Literal[1]`, so `not_one` cannot be the same object as `1`.
-    reveal_type(not_one is not 1)  # revealed: Literal[True]
-    reveal_type(not_one is 1)  # revealed: Literal[False]
+    reveal_type(not_one is not 1)  # revealed: bool
+    reveal_type(not_one is 1)  # revealed: bool
 
     # But these are both `bool`, rather than `Literal[True]` or `Literal[False]`
     # as there are many runtime objects that inhabit the type `~Literal[1]`

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -31,11 +31,10 @@ o: Not[()]
 p: Not[(int,)]
 
 def static_truthiness(not_one: Not[Literal[1]]) -> None:
-    # TODO: `bool` is not incorrect, but these would ideally be `Literal[True]` and `Literal[False]`
-    # respectively, since all possible runtime objects that are created by the literal syntax `1`
-    # are members of the type `Literal[1]`
-    reveal_type(not_one is not 1)  # revealed: bool
-    reveal_type(not_one is 1)  # revealed: bool
+    # All possible runtime objects created by the literal syntax `1` are members of
+    # `Literal[1]`, so `not_one` cannot be the same object as `1`.
+    reveal_type(not_one is not 1)  # revealed: Literal[True]
+    reveal_type(not_one is 1)  # revealed: Literal[False]
 
     # But these are both `bool`, rather than `Literal[True]` or `Literal[False]`
     # as there are many runtime objects that inhabit the type `~Literal[1]`

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -31,6 +31,8 @@ o: Not[()]
 p: Not[(int,)]
 
 def static_truthiness(not_one: Not[Literal[1]]) -> None:
+    # A `NewType` over `int` is distinct from `Literal[1]` but can refer to the same runtime object,
+    # so neither identity comparison has a definite result.
     reveal_type(not_one is not 1)  # revealed: bool
     reveal_type(not_one is 1)  # revealed: bool
 

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -116,38 +116,6 @@ pub(crate) struct UnsupportedComparisonError<'db> {
     pub(crate) right_ty: Type<'db>,
 }
 
-/// Return the truthiness of `left is right` when it is known for every represented runtime value.
-///
-/// Projecting the complete types before the comparison dispatch below accounts for `NewType`'s
-/// runtime behavior. Distinct `NewType`s are statically disjoint, but their constructors can return
-/// the same object unchanged:
-///
-/// ```python
-/// from typing import NewType
-///
-/// UserId = NewType("UserId", int)
-/// OrderId = NewType("OrderId", int)
-///
-/// def same_object(user_id: UserId, order_id: OrderId) -> None:
-///     reveal_type(user_id is order_id)  # bool
-/// ```
-fn identity_comparison_truthiness<'db>(
-    db: &'db dyn Db,
-    left: Type<'db>,
-    right: Type<'db>,
-) -> Truthiness {
-    let left = left.identity_comparison_type(db);
-    let right = right.identity_comparison_type(db);
-
-    if left.is_disjoint_from(db, right) {
-        Truthiness::AlwaysFalse
-    } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
-        Truthiness::AlwaysTrue
-    } else {
-        Truthiness::Ambiguous
-    }
-}
-
 /// Infers the type of a binary comparison (e.g. 'left == right'). See
 /// `TypeInferenceBuilder::infer_compare_expression` for the higher level logic dealing with
 /// multi-comparison expressions.
@@ -181,8 +149,24 @@ pub(super) fn infer_binary_type_comparison<'db>(
             ast::CmpOp::NotIn => {
                 membership_test_comparison(MembershipTestCompareOperator::NotIn, range)
             }
-            // Identity results are returned by `identity_comparison_truthiness` below.
-            ast::CmpOp::Is | ast::CmpOp::IsNot => Ok(KnownClass::Bool.to_instance(db)),
+            ast::CmpOp::Is => {
+                if left.is_disjoint_from(db, right) {
+                    Ok(Type::bool_literal(false))
+                } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
+                    Ok(Type::bool_literal(true))
+                } else {
+                    Ok(KnownClass::Bool.to_instance(db))
+                }
+            }
+            ast::CmpOp::IsNot => {
+                if left.is_disjoint_from(db, right) {
+                    Ok(Type::bool_literal(true))
+                } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
+                    Ok(Type::bool_literal(false))
+                } else {
+                    Ok(KnownClass::Bool.to_instance(db))
+                }
+            }
         }
     };
 
@@ -194,15 +178,29 @@ pub(super) fn infer_binary_type_comparison<'db>(
         (Type::TypeVar(left), Type::TypeVar(right)) if left.is_same_typevar_as(db, right)
     );
     if !same_typevar && matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot) {
-        let truthiness = identity_comparison_truthiness(db, left, right);
-        return Ok(Type::from_truthiness(
-            db,
-            if op == ast::CmpOp::Is {
-                truthiness
-            } else {
-                truthiness.negate()
-            },
-        ));
+        // `NewType` is an identity function at runtime, so distinct NewTypes can still contain the
+        // same object:
+        //
+        // UserId = NewType("UserId", int)
+        // OrderId = NewType("OrderId", int)
+        // user_id is order_id  # possibly true
+        //
+        // Project both operands before using the ordinary comparison logic. Keeping the usual
+        // recursive dispatch preserves facts carried by unions and intersections after projection.
+        let left_identity = left.identity_comparison_type(db);
+        let right_identity = right.identity_comparison_type(db);
+        if left_identity != left || right_identity != right {
+            return visitor.visit((left, op, right), || {
+                infer_binary_type_comparison(
+                    context,
+                    left_identity,
+                    op,
+                    right_identity,
+                    range,
+                    visitor,
+                )
+            });
+        }
     }
 
     let soundness_policy =

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -193,22 +193,16 @@ pub(super) fn infer_binary_type_comparison<'db>(
         ),
         (Type::TypeVar(left), Type::TypeVar(right)) if left.is_same_typevar_as(db, right)
     );
-    if !same_typevar {
-        match op {
-            ast::CmpOp::Is => {
-                return Ok(Type::from_truthiness(
-                    db,
-                    identity_comparison_truthiness(db, left, right),
-                ));
-            }
-            ast::CmpOp::IsNot => {
-                return Ok(Type::from_truthiness(
-                    db,
-                    identity_comparison_truthiness(db, left, right).negate(),
-                ));
-            }
-            _ => {}
-        }
+    if !same_typevar && matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot) {
+        let truthiness = identity_comparison_truthiness(db, left, right);
+        return Ok(Type::from_truthiness(
+            db,
+            if op == ast::CmpOp::Is {
+                truthiness
+            } else {
+                truthiness.negate()
+            },
+        ));
     }
 
     let soundness_policy =

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -116,6 +116,39 @@ pub(crate) struct UnsupportedComparisonError<'db> {
     pub(crate) right_ty: Type<'db>,
 }
 
+/// Return the truthiness of `left is right` when it is known for every represented runtime value.
+///
+/// Checking the complete types before the comparison dispatch below is important for intersections.
+/// Otherwise, decomposing an intersection into its positive elements can lose an exclusion that
+/// proves two values cannot be identical:
+///
+/// ```python
+/// from typing import NewType
+/// from ty_extensions import Intersection, Not
+///
+/// class A: ...
+/// class ASub(A): ...
+///
+/// N = NewType("N", A)
+/// NSub = NewType("NSub", ASub)
+///
+/// def f(x: Intersection[N, Not[ASub]], y: NSub) -> None:
+///     reveal_type(x is y)  # Literal[False]
+/// ```
+fn identity_comparison_truthiness<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+) -> Truthiness {
+    if left.is_disjoint_from_for_identity(db, right) {
+        Truthiness::AlwaysFalse
+    } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
+        Truthiness::AlwaysTrue
+    } else {
+        Truthiness::Ambiguous
+    }
+}
+
 /// Infers the type of a binary comparison (e.g. 'left == right'). See
 /// `TypeInferenceBuilder::infer_compare_expression` for the higher level logic dealing with
 /// multi-comparison expressions.
@@ -132,41 +165,6 @@ pub(super) fn infer_binary_type_comparison<'db>(
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
     let db = context.db();
 
-    // Check identity disjointness before the general comparison code below decomposes an
-    // intersection into its positive elements. Otherwise, we would lose the exclusion in this
-    // example:
-    //
-    // ```python
-    // from typing import NewType
-    // from ty_extensions import Intersection, Not
-    //
-    // class A: ...
-    // class ASub(A): ...
-    //
-    // N = NewType("N", A)
-    // NSub = NewType("NSub", ASub)
-    //
-    // def f(x: Intersection[N, Not[ASub]], y: NSub) -> None:
-    //     reveal_type(x is y)  # Literal[False]
-    // ```
-    //
-    // `y` is always an `ASub`, while `x` explicitly excludes `ASub`.
-    if matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot) {
-        let left_resolved = left.resolve_type_alias(db);
-        let right_resolved = right.resolve_type_alias(db);
-        if (left_resolved.is_intersection() || right_resolved.is_intersection())
-            && (left.identity_comparison_type(db) != left_resolved
-                || right.identity_comparison_type(db) != right_resolved)
-            && left.is_disjoint_from_for_identity(db, right)
-        {
-            return Ok(Type::bool_literal(op == ast::CmpOp::IsNot));
-        }
-    }
-
-    // Note: identity (is, is not) for equal builtin types is unreliable and not part of the
-    // language spec.
-    // - `[ast::CompOp::Is]`: return `false` if unequal, `bool` if equal
-    // - `[ast::CompOp::IsNot]`: return `true` if unequal, `bool` if equal
     let try_dunder = |policy: MemberLookupPolicy| {
         let rich_comparison = |op| infer_rich_comparison(db, left, right, op, policy);
         let membership_test_comparison = |op, range: TextRange| {
@@ -184,24 +182,8 @@ pub(super) fn infer_binary_type_comparison<'db>(
             ast::CmpOp::NotIn => {
                 membership_test_comparison(MembershipTestCompareOperator::NotIn, range)
             }
-            ast::CmpOp::Is => {
-                if left.is_disjoint_from_for_identity(db, right) {
-                    Ok(Type::bool_literal(false))
-                } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
-                    Ok(Type::bool_literal(true))
-                } else {
-                    Ok(KnownClass::Bool.to_instance(db))
-                }
-            }
-            ast::CmpOp::IsNot => {
-                if left.is_disjoint_from_for_identity(db, right) {
-                    Ok(Type::bool_literal(true))
-                } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
-                    Ok(Type::bool_literal(false))
-                } else {
-                    Ok(KnownClass::Bool.to_instance(db))
-                }
-            }
+            // Definite identity results are returned by `identity_comparison_truthiness` below.
+            ast::CmpOp::Is | ast::CmpOp::IsNot => Ok(KnownClass::Bool.to_instance(db)),
         }
     };
 
@@ -210,6 +192,8 @@ pub(super) fn infer_binary_type_comparison<'db>(
     let comparison_truthiness = match op {
         ast::CmpOp::Eq => equality_truthiness(db, left, right, soundness_policy),
         ast::CmpOp::NotEq => inequality_truthiness(db, left, right, soundness_policy),
+        ast::CmpOp::Is => identity_comparison_truthiness(db, left, right),
+        ast::CmpOp::IsNot => identity_comparison_truthiness(db, left, right).negate(),
         _ => Truthiness::Ambiguous,
     };
     if comparison_truthiness != Truthiness::Ambiguous {

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -132,6 +132,21 @@ pub(super) fn infer_binary_type_comparison<'db>(
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
     let db = context.db();
 
+    if matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot) {
+        let left_resolved = left.resolve_type_alias(db);
+        let right_resolved = right.resolve_type_alias(db);
+        let has_intersection = matches!(left_resolved, Type::Intersection(_))
+            || matches!(right_resolved, Type::Intersection(_));
+        let identity_projection_changes_type = left.identity_comparison_type(db) != left_resolved
+            || right.identity_comparison_type(db) != right_resolved;
+        if has_intersection
+            && identity_projection_changes_type
+            && left.is_disjoint_from_for_identity(db, right)
+        {
+            return Ok(Type::bool_literal(op == ast::CmpOp::IsNot));
+        }
+    }
+
     // Note: identity (is, is not) for equal builtin types is unreliable and not part of the
     // language spec.
     // - `[ast::CompOp::Is]`: return `false` if unequal, `bool` if equal

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -135,12 +135,9 @@ pub(super) fn infer_binary_type_comparison<'db>(
     if matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot) {
         let left_resolved = left.resolve_type_alias(db);
         let right_resolved = right.resolve_type_alias(db);
-        let has_intersection = matches!(left_resolved, Type::Intersection(_))
-            || matches!(right_resolved, Type::Intersection(_));
-        let identity_projection_changes_type = left.identity_comparison_type(db) != left_resolved
-            || right.identity_comparison_type(db) != right_resolved;
-        if has_intersection
-            && identity_projection_changes_type
+        if (left_resolved.is_intersection() || right_resolved.is_intersection())
+            && (left.identity_comparison_type(db) != left_resolved
+                || right.identity_comparison_type(db) != right_resolved)
             && left.is_disjoint_from_for_identity(db, right)
         {
             return Ok(Type::bool_literal(op == ast::CmpOp::IsNot));

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -170,14 +170,15 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
     };
 
-    let same_typevar = matches!(
-        (
-            left.resolve_type_alias(db),
-            right.resolve_type_alias(db)
-        ),
-        (Type::TypeVar(left), Type::TypeVar(right)) if left.is_same_typevar_as(db, right)
-    );
-    if !same_typevar && matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot) {
+    if matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot)
+        && !matches!(
+            (
+                left.resolve_type_alias(db),
+                right.resolve_type_alias(db)
+            ),
+            (Type::TypeVar(left), Type::TypeVar(right)) if left.is_same_typevar_as(db, right)
+        )
+    {
         // `NewType` is an identity function at runtime, so distinct NewTypes can still contain the
         // same object:
         //
@@ -190,7 +191,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
         let left_identity = left.identity_comparison_type(db);
         let right_identity = right.identity_comparison_type(db);
         if left_identity != left || right_identity != right {
-            return visitor.visit((left, op, right), || {
+            return visitor.visit(db, (left, op, right), || {
                 infer_binary_type_comparison(
                     context,
                     left_identity,

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -154,7 +154,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 membership_test_comparison(MembershipTestCompareOperator::NotIn, range)
             }
             ast::CmpOp::Is => {
-                if left.is_disjoint_from(db, right) {
+                if left.is_disjoint_from_for_identity(db, right) {
                     Ok(Type::bool_literal(false))
                 } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
                     Ok(Type::bool_literal(true))
@@ -163,7 +163,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 }
             }
             ast::CmpOp::IsNot => {
-                if left.is_disjoint_from(db, right) {
+                if left.is_disjoint_from_for_identity(db, right) {
                     Ok(Type::bool_literal(true))
                 } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
                     Ok(Type::bool_literal(false))

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -118,29 +118,28 @@ pub(crate) struct UnsupportedComparisonError<'db> {
 
 /// Return the truthiness of `left is right` when it is known for every represented runtime value.
 ///
-/// Checking the complete types before the comparison dispatch below is important for intersections.
-/// Otherwise, decomposing an intersection into its positive elements can lose an exclusion that
-/// proves two values cannot be identical:
+/// Projecting the complete types before the comparison dispatch below accounts for `NewType`'s
+/// runtime behavior. Distinct `NewType`s are statically disjoint, but their constructors can return
+/// the same object unchanged:
 ///
 /// ```python
 /// from typing import NewType
-/// from ty_extensions import Intersection, Not
 ///
-/// class A: ...
-/// class ASub(A): ...
+/// UserId = NewType("UserId", int)
+/// OrderId = NewType("OrderId", int)
 ///
-/// N = NewType("N", A)
-/// NSub = NewType("NSub", ASub)
-///
-/// def f(x: Intersection[N, Not[ASub]], y: NSub) -> None:
-///     reveal_type(x is y)  # Literal[False]
+/// def same_object(user_id: UserId, order_id: OrderId) -> None:
+///     reveal_type(user_id is order_id)  # bool
 /// ```
 fn identity_comparison_truthiness<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
     right: Type<'db>,
 ) -> Truthiness {
-    if left.is_disjoint_from_for_identity(db, right) {
+    let left = left.identity_comparison_type(db);
+    let right = right.identity_comparison_type(db);
+
+    if left.is_disjoint_from(db, right) {
         Truthiness::AlwaysFalse
     } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
         Truthiness::AlwaysTrue
@@ -182,18 +181,32 @@ pub(super) fn infer_binary_type_comparison<'db>(
             ast::CmpOp::NotIn => {
                 membership_test_comparison(MembershipTestCompareOperator::NotIn, range)
             }
-            // Definite identity results are returned by `identity_comparison_truthiness` below.
+            // Identity results are returned by `identity_comparison_truthiness` below.
             ast::CmpOp::Is | ast::CmpOp::IsNot => Ok(KnownClass::Bool.to_instance(db)),
         }
     };
+
+    match op {
+        ast::CmpOp::Is => {
+            return Ok(Type::from_truthiness(
+                db,
+                identity_comparison_truthiness(db, left, right),
+            ));
+        }
+        ast::CmpOp::IsNot => {
+            return Ok(Type::from_truthiness(
+                db,
+                identity_comparison_truthiness(db, left, right).negate(),
+            ));
+        }
+        _ => {}
+    }
 
     let soundness_policy =
         ComparisonSoundnessPolicy::from_analysis_settings(db.analysis_settings(context.file()));
     let comparison_truthiness = match op {
         ast::CmpOp::Eq => equality_truthiness(db, left, right, soundness_policy),
         ast::CmpOp::NotEq => inequality_truthiness(db, left, right, soundness_policy),
-        ast::CmpOp::Is => identity_comparison_truthiness(db, left, right),
-        ast::CmpOp::IsNot => identity_comparison_truthiness(db, left, right).negate(),
         _ => Truthiness::Ambiguous,
     };
     if comparison_truthiness != Truthiness::Ambiguous {

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -132,6 +132,10 @@ pub(super) fn infer_binary_type_comparison<'db>(
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
     let db = context.db();
 
+    // Identity comparisons between equal builtin types are unreliable and not guaranteed by the
+    // language specification:
+    // - `is` returns `false` if the types are disjoint and `bool` if they overlap.
+    // - `is not` returns `true` if the types are disjoint and `bool` if they overlap.
     let try_dunder = |policy: MemberLookupPolicy| {
         let rich_comparison = |op| infer_rich_comparison(db, left, right, op, policy);
         let membership_test_comparison = |op, range: TextRange| {
@@ -170,6 +174,9 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
     };
 
+    // Keep two occurrences of the same `TypeVar` symbolic. Replacing them with their bounds or
+    // constraints would lose their shared specialization: a `TypeVar` constrained to `None` and
+    // `EllipsisType` chooses the same singleton for both operands, not independent alternatives.
     if matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot)
         && !matches!(
             (
@@ -186,8 +193,9 @@ pub(super) fn infer_binary_type_comparison<'db>(
         // OrderId = NewType("OrderId", int)
         // user_id is order_id  # possibly true
         //
-        // Project both operands before using the ordinary comparison logic. Keeping the usual
-        // recursive dispatch preserves facts carried by unions and intersections after projection.
+        // Widen both operands to the types of their possible runtime objects before using the
+        // ordinary comparison logic. Keeping the usual recursive dispatch preserves facts carried
+        // by unions and intersections after widening.
         let left_identity = left.identity_comparison_type(db);
         let right_identity = right.identity_comparison_type(db);
         if left_identity != left || right_identity != right {

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -132,6 +132,25 @@ pub(super) fn infer_binary_type_comparison<'db>(
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
     let db = context.db();
 
+    // Check identity disjointness before the general comparison code below decomposes an
+    // intersection into its positive elements. Otherwise, we would lose the exclusion in this
+    // example:
+    //
+    // ```python
+    // from typing import NewType
+    // from ty_extensions import Intersection, Not
+    //
+    // class A: ...
+    // class ASub(A): ...
+    //
+    // N = NewType("N", A)
+    // NSub = NewType("NSub", ASub)
+    //
+    // def f(x: Intersection[N, Not[ASub]], y: NSub) -> None:
+    //     reveal_type(x is y)  # Literal[False]
+    // ```
+    //
+    // `y` is always an `ASub`, while `x` explicitly excludes `ASub`.
     if matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot) {
         let left_resolved = left.resolve_type_alias(db);
         let right_resolved = right.resolve_type_alias(db);

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -13,10 +13,74 @@ use crate::types::equality::{
 use crate::types::tuple::TupleSpec;
 use crate::types::{
     DynamicType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
-    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext,
+    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext, TypeTransformer,
     TypeVarBoundOrConstraints, UnionBuilder,
 };
 use ty_python_core::Truthiness;
+
+impl<'db> Type<'db> {
+    /// Upcast `self` to a type that conservatively describes its possible runtime objects in an
+    /// identity comparison.
+    ///
+    /// A `NewType` wrapper is an identity function at runtime, so it contributes its concrete base
+    /// type here while remaining distinct for ordinary type relations and intersections.
+    ///
+    /// Negative intersection elements are generally omitted. A static exclusion does not imply a
+    /// runtime exclusion: `NewType("N", bool)(True)` can inhabit `~Literal[True]`, but evaluates
+    /// to the `True` singleton at runtime. However, excluding an entire nominal instance type is
+    /// stable under `NewType` erasure, so constraints such as `~None` and `~SomeClass` are
+    /// preserved.
+    pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
+        struct IdentityComparisonUpcasting;
+
+        fn upcast<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            visitor: &TypeTransformer<'db, IdentityComparisonUpcasting>,
+        ) -> Type<'db> {
+            match ty {
+                Type::TypeAlias(alias) => {
+                    visitor.visit_type(db, ty, || upcast(db, alias.value_type(db), visitor))
+                }
+                Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
+                Type::TypeVar(typevar) => visitor.visit_type(db, ty, || {
+                    match typevar.typevar(db).bound_or_constraints(db) {
+                        Some(bound_or_constraints) => {
+                            upcast(db, bound_or_constraints.as_type(db), visitor)
+                        }
+                        None => ty,
+                    }
+                }),
+                Type::Union(union) => union.map(db, |element| upcast(db, *element, visitor)),
+                Type::Intersection(intersection) => {
+                    let mut builder = IntersectionBuilder::new(db);
+                    for element in intersection.positive(db) {
+                        builder = builder.add_positive(upcast(db, *element, visitor));
+                    }
+                    for element in intersection.negative(db) {
+                        if element.resolve_type_alias(db).is_nominal_instance() {
+                            builder = builder.add_negative(*element);
+                        }
+                    }
+                    builder.build()
+                }
+                _ => ty,
+            }
+        }
+
+        upcast(
+            db,
+            self,
+            &TypeTransformer::<IdentityComparisonUpcasting>::default(),
+        )
+    }
+
+    /// Return `true` if `self` and `other` cannot describe the same runtime object.
+    pub(crate) fn is_disjoint_from_for_identity(self, db: &'db dyn Db, other: Type<'db>) -> bool {
+        self.identity_comparison_type(db)
+            .is_disjoint_from(db, other.identity_comparison_type(db))
+    }
+}
 
 /// Whether the intersection type is on the left or right side of the comparison.
 #[derive(Debug, Clone, Copy)]

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -186,20 +186,26 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
     };
 
-    match op {
-        ast::CmpOp::Is => {
-            return Ok(Type::from_truthiness(
-                db,
-                identity_comparison_truthiness(db, left, right),
-            ));
+    let same_typevar = matches!(
+        (left, right),
+        (Type::TypeVar(left), Type::TypeVar(right)) if left.is_same_typevar_as(db, right)
+    );
+    if !same_typevar {
+        match op {
+            ast::CmpOp::Is => {
+                return Ok(Type::from_truthiness(
+                    db,
+                    identity_comparison_truthiness(db, left, right),
+                ));
+            }
+            ast::CmpOp::IsNot => {
+                return Ok(Type::from_truthiness(
+                    db,
+                    identity_comparison_truthiness(db, left, right).negate(),
+                ));
+            }
+            _ => {}
         }
-        ast::CmpOp::IsNot => {
-            return Ok(Type::from_truthiness(
-                db,
-                identity_comparison_truthiness(db, left, right).negate(),
-            ));
-        }
-        _ => {}
     }
 
     let soundness_policy =

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -187,7 +187,10 @@ pub(super) fn infer_binary_type_comparison<'db>(
     };
 
     let same_typevar = matches!(
-        (left, right),
+        (
+            left.resolve_type_alias(db),
+            right.resolve_type_alias(db)
+        ),
         (Type::TypeVar(left), Type::TypeVar(right)) if left.is_same_typevar_as(db, right)
     );
     if !same_typevar {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3060,9 +3060,14 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         match op {
             ast::CmpOp::IsNot => {
-                let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db);
-                if rhs_identity_ty.is_singleton(self.db) {
-                    Some(rhs_identity_ty.negate(self.db))
+                // Keep a constrained `TypeVar` symbolic so that another occurrence refers to the
+                // same specialization. Other types use their runtime identity representation.
+                let rhs_constraint = match rhs_ty.resolve_type_alias(self.db) {
+                    Type::TypeVar(_) if rhs_ty.is_singleton(self.db) => rhs_ty,
+                    _ => rhs_ty.identity_comparison_type(self.db),
+                };
+                if rhs_constraint.is_singleton(self.db) {
+                    Some(rhs_constraint.negate(self.db))
                 } else {
                     // Non-singletons cannot be safely narrowed using `is not`
                     None
@@ -3074,15 +3079,32 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 // LHS as well so that applying the constraint does not erase that possibility.
                 let mut builder = UnionBuilder::new(self.db).add(rhs_ty);
                 let add_runtime_overlap = |builder: UnionBuilder<'db>, element: Type<'db>| {
+                    let overlaps_only_at_runtime = |rhs_element| {
+                        element.is_disjoint_from(self.db, rhs_element)
+                            && !element.is_disjoint_from_for_identity(self.db, rhs_element)
+                    };
                     let has_runtime_only_overlap = match rhs_ty.resolve_type_alias(self.db) {
-                        Type::Union(union) => union.elements(self.db).iter().any(|rhs_element| {
-                            element.is_disjoint_from(self.db, *rhs_element)
-                                && !element.is_disjoint_from_for_identity(self.db, *rhs_element)
-                        }),
-                        rhs_ty => {
-                            element.is_disjoint_from(self.db, rhs_ty)
-                                && !element.is_disjoint_from_for_identity(self.db, rhs_ty)
+                        Type::Union(union) => union
+                            .elements(self.db)
+                            .iter()
+                            .copied()
+                            .any(overlaps_only_at_runtime),
+                        Type::TypeVar(typevar) => {
+                            match typevar.typevar(self.db).bound_or_constraints(self.db) {
+                                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                                    overlaps_only_at_runtime(bound)
+                                }
+                                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                                    constraints
+                                        .elements(self.db)
+                                        .iter()
+                                        .copied()
+                                        .any(overlaps_only_at_runtime)
+                                }
+                                None => overlaps_only_at_runtime(rhs_ty),
+                            }
                         }
+                        rhs_ty => overlaps_only_at_runtime(rhs_ty),
                     };
                     if !has_runtime_only_overlap {
                         builder

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3060,18 +3060,19 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         match op {
             ast::CmpOp::IsNot => {
-                // Keep a constrained `TypeVar` symbolic so that another occurrence refers to the
-                // same specialization. Other types use their runtime identity representation.
-                let rhs_constraint = match rhs_ty.resolve_type_alias(self.db) {
-                    Type::TypeVar(_) if rhs_ty.is_singleton(self.db) => rhs_ty,
-                    _ => rhs_ty.identity_comparison_type(self.db),
-                };
-                if rhs_constraint.is_singleton(self.db) {
-                    Some(rhs_constraint.negate(self.db))
+                let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db);
+                // Prefer a singleton runtime representation when all constraints collapse to the
+                // same object. Otherwise, keep a singleton-constrained `TypeVar` symbolic so that
+                // another occurrence refers to the same specialization.
+                let rhs_constraint = if rhs_identity_ty.is_singleton(self.db) {
+                    rhs_identity_ty
                 } else {
-                    // Non-singletons cannot be safely narrowed using `is not`
-                    None
-                }
+                    match rhs_ty.resolve_type_alias(self.db) {
+                        Type::TypeVar(_) if rhs_ty.is_singleton(self.db) => rhs_ty,
+                        _ => return None,
+                    }
+                };
+                Some(rhs_constraint.negate(self.db))
             }
             ast::CmpOp::Is => {
                 // Preserve the nominal RHS constraint for ordinary overlaps. If a `NewType`
@@ -3277,13 +3278,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .as_int_literal()
             && let Ok(index) = i32::try_from(index)
             && let rhs_ty = inference.expression_type(&comparators[0])
-            && let rhs_is_correlated_singleton =
-                (matches!(rhs_ty.resolve_type_alias(self.db), Type::TypeVar(_))
-                    && rhs_ty.is_singleton(self.db))
             && let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db)
-            && (is_positive_check
-                || rhs_is_correlated_singleton
-                || rhs_identity_ty.is_singleton(self.db))
+            && let rhs_identity_is_singleton = rhs_identity_ty.is_singleton(self.db)
+            && let rhs_is_correlated_singleton = (!rhs_identity_is_singleton
+                && matches!(rhs_ty.resolve_type_alias(self.db), Type::TypeVar(_))
+                && rhs_ty.is_singleton(self.db))
+            && (is_positive_check || rhs_is_correlated_singleton || rhs_identity_is_singleton)
         {
             let filtered = union.filter(self.db, |elem| {
                 elem.tuple_instance_spec(self.db)

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3066,11 +3066,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 // another occurrence refers to the same specialization.
                 let rhs_constraint = if rhs_identity_ty.is_singleton(self.db) {
                     rhs_identity_ty
+                } else if matches!(rhs_ty.resolve_type_alias(self.db), Type::TypeVar(_))
+                    && rhs_ty.is_singleton(self.db)
+                {
+                    rhs_ty
                 } else {
-                    match rhs_ty.resolve_type_alias(self.db) {
-                        Type::TypeVar(_) if rhs_ty.is_singleton(self.db) => rhs_ty,
-                        _ => return None,
-                    }
+                    return None;
                 };
                 Some(rhs_constraint.negate(self.db))
             }
@@ -3079,12 +3080,14 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 // creates additional runtime-only overlap, retain the corresponding part of the
                 // LHS as well so that applying the constraint does not erase that possibility.
                 let mut builder = UnionBuilder::new(self.db).add(rhs_ty);
+                let rhs_resolved = rhs_ty.resolve_type_alias(self.db);
+                let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db);
                 let add_runtime_overlap = |builder: UnionBuilder<'db>, element: Type<'db>| {
                     let overlaps_only_at_runtime = |rhs_element| {
                         element.is_disjoint_from(self.db, rhs_element)
                             && !element.is_disjoint_from_for_identity(self.db, rhs_element)
                     };
-                    let has_runtime_only_overlap = match rhs_ty.resolve_type_alias(self.db) {
+                    let has_runtime_only_overlap = match rhs_resolved {
                         Type::Union(union) => union
                             .elements(self.db)
                             .iter()
@@ -3110,11 +3113,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     if !has_runtime_only_overlap {
                         builder
                     } else {
-                        let runtime_overlap = IntersectionType::from_two_elements(
-                            self.db,
-                            element,
-                            rhs_ty.identity_comparison_type(self.db),
-                        );
+                        let runtime_overlap =
+                            IntersectionType::from_two_elements(self.db, element, rhs_identity_ty);
                         builder.add(if runtime_overlap.is_never() {
                             element
                         } else {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3067,7 +3067,18 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     None
                 }
             }
-            ast::CmpOp::Is => Some(rhs_ty),
+            ast::CmpOp::Is => {
+                let rhs_constraint = rhs_ty.identity_comparison_type(self.db);
+                if lhs_ty.is_disjoint_from(self.db, rhs_constraint)
+                    && !lhs_ty.is_disjoint_from_for_identity(self.db, rhs_ty)
+                {
+                    // A static intersection cannot represent overlap that exists only because a
+                    // `NewType` wrapper is transparent at runtime.
+                    None
+                } else {
+                    Some(rhs_constraint)
+                }
+            }
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
             ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty),
             _ => None,
@@ -3219,7 +3230,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     .is_none_or(|el_ty| {
                         if is_positive_check {
                             // `is X` context: keep tuples where element could be X
-                            !el_ty.is_disjoint_from(self.db, rhs_ty)
+                            !el_ty.is_disjoint_from_for_identity(self.db, rhs_ty)
                         } else {
                             // `is not X` context: keep tuples where element is not always X
                             !el_ty.is_subtype_of(self.db, rhs_ty)

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3061,9 +3061,24 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         match op {
             ast::CmpOp::IsNot => {
                 let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db);
-                // Prefer a singleton runtime representation when all constraints collapse to the
-                // same object. Otherwise, keep a singleton-constrained `TypeVar` symbolic so that
-                // another occurrence refers to the same specialization.
+                // An `is not` check can narrow the LHS only when the RHS identifies a single
+                // runtime object. There are two ways this can happen:
+                //
+                // 1. The RHS's runtime identity type is itself a singleton. This includes ordinary
+                //    singleton types, such as `None`, and distinct `NewType`s that all wrap the
+                //    same singleton object. Narrow against the runtime identity type so that every
+                //    static type representing that object is excluded.
+                //
+                // 2. The RHS is a constrained `TypeVar` whose constraints are all singletons. For
+                //    example, `T = TypeVar("T", None, EllipsisType)` can be specialized to either
+                //    `None` or `EllipsisType` across different calls. Within one specialization,
+                //    however, every occurrence of `T` resolves to the same constraint, so all
+                //    values of type `T` are either `None` or all are `...`. Keep `T` symbolic so
+                //    that excluding it preserves its relationship with subsequent occurrences of
+                //    the same specialization.
+                //
+                // In every other case, the RHS might identify multiple objects even within a
+                // single specialization, so excluding its entire type would be unsound.
                 let rhs_constraint = if rhs_identity_ty.is_singleton(self.db) {
                     rhs_identity_ty
                 } else if matches!(rhs_ty.resolve_type_alias(self.db), Type::TypeVar(_))

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3254,7 +3254,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .as_int_literal()
             && let Ok(index) = i32::try_from(index)
             && let rhs_ty = inference.expression_type(&comparators[0])
-            && rhs_ty.is_singleton(self.db)
+            && let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db)
+            && rhs_identity_ty.is_singleton(self.db)
         {
             let is_positive_check = is_positive == (ops[0] == ast::CmpOp::Is);
             let filtered = union.filter(self.db, |elem| {
@@ -3266,7 +3267,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                             !el_ty.is_disjoint_from_for_identity(self.db, rhs_ty)
                         } else {
                             // `is not X` context: keep tuples where element is not always X
-                            !el_ty.is_subtype_of(self.db, rhs_ty)
+                            !el_ty
+                                .identity_comparison_type(self.db)
+                                .is_subtype_of(self.db, rhs_identity_ty)
                         }
                     })
             });

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3068,16 +3068,48 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             }
             ast::CmpOp::Is => {
-                let rhs_constraint = rhs_ty.identity_comparison_type(self.db);
-                if lhs_ty.is_disjoint_from(self.db, rhs_constraint)
-                    && !lhs_ty.is_disjoint_from_for_identity(self.db, rhs_ty)
-                {
-                    // A static intersection cannot represent overlap that exists only because a
-                    // `NewType` wrapper is transparent at runtime.
-                    None
+                // Preserve the nominal RHS constraint for ordinary overlaps. If a `NewType`
+                // creates additional runtime-only overlap, retain the corresponding part of the
+                // LHS as well so that applying the constraint does not erase that possibility.
+                let mut builder = UnionBuilder::new(self.db).add(rhs_ty);
+                let add_runtime_overlap = |builder: UnionBuilder<'db>, element: Type<'db>| {
+                    let has_runtime_only_overlap = match rhs_ty.resolve_type_alias(self.db) {
+                        Type::Union(union) => union.elements(self.db).iter().any(|rhs_element| {
+                            element.is_disjoint_from(self.db, *rhs_element)
+                                && !element.is_disjoint_from_for_identity(self.db, *rhs_element)
+                        }),
+                        rhs_ty => {
+                            element.is_disjoint_from(self.db, rhs_ty)
+                                && !element.is_disjoint_from_for_identity(self.db, rhs_ty)
+                        }
+                    };
+                    if !has_runtime_only_overlap {
+                        builder
+                    } else {
+                        let runtime_overlap = IntersectionType::from_two_elements(
+                            self.db,
+                            element,
+                            rhs_ty.identity_comparison_type(self.db),
+                        );
+                        builder.add(if runtime_overlap.is_never() {
+                            element
+                        } else {
+                            runtime_overlap
+                        })
+                    }
+                };
+
+                if let Type::Union(union) = lhs_ty.resolve_type_alias(self.db) {
+                    builder = union
+                        .elements(self.db)
+                        .iter()
+                        .copied()
+                        .fold(builder, add_runtime_overlap);
                 } else {
-                    Some(rhs_constraint)
+                    builder = add_runtime_overlap(builder, lhs_ty);
                 }
+
+                Some(builder.build())
             }
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
             ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty),

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3277,10 +3277,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .as_int_literal()
             && let Ok(index) = i32::try_from(index)
             && let rhs_ty = inference.expression_type(&comparators[0])
-            && let rhs_is_correlated_singleton = (matches!(
-                rhs_ty.resolve_type_alias(self.db),
-                Type::TypeVar(_)
-            ) && rhs_ty.is_singleton(self.db))
+            && let rhs_is_correlated_singleton =
+                (matches!(rhs_ty.resolve_type_alias(self.db), Type::TypeVar(_))
+                    && rhs_ty.is_singleton(self.db))
             && let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db)
             && (is_positive_check
                 || rhs_is_correlated_singleton

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3266,6 +3266,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         //         if t[0] is not None:
         //             reveal_type(t)  # tuple[int, int]
         if matches!(&**ops, [ast::CmpOp::Is | ast::CmpOp::IsNot])
+            && let is_positive_check = is_positive == (ops[0] == ast::CmpOp::Is)
             && let ast::Expr::Subscript(subscript) = left.expression_value()
             && let Type::Union(union) = inference
                 .expression_type(&*subscript.value)
@@ -3276,14 +3277,15 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .as_int_literal()
             && let Ok(index) = i32::try_from(index)
             && let rhs_ty = inference.expression_type(&comparators[0])
-            && let rhs_is_correlated_singleton = matches!(
+            && let rhs_is_correlated_singleton = (matches!(
                 rhs_ty.resolve_type_alias(self.db),
                 Type::TypeVar(_)
-            ) && rhs_ty.is_singleton(self.db)
+            ) && rhs_ty.is_singleton(self.db))
             && let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db)
-            && (rhs_is_correlated_singleton || rhs_identity_ty.is_singleton(self.db))
+            && (is_positive_check
+                || rhs_is_correlated_singleton
+                || rhs_identity_ty.is_singleton(self.db))
         {
-            let is_positive_check = is_positive == (ops[0] == ast::CmpOp::Is);
             let filtered = union.filter(self.db, |elem| {
                 elem.tuple_instance_spec(self.db)
                     .and_then(|spec| spec.py_index(self.db, index).ok())

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3276,8 +3276,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .as_int_literal()
             && let Ok(index) = i32::try_from(index)
             && let rhs_ty = inference.expression_type(&comparators[0])
+            && let rhs_is_correlated_singleton = matches!(
+                rhs_ty.resolve_type_alias(self.db),
+                Type::TypeVar(_)
+            ) && rhs_ty.is_singleton(self.db)
             && let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db)
-            && rhs_identity_ty.is_singleton(self.db)
+            && (rhs_is_correlated_singleton || rhs_identity_ty.is_singleton(self.db))
         {
             let is_positive_check = is_positive == (ops[0] == ast::CmpOp::Is);
             let filtered = union.filter(self.db, |elem| {
@@ -3287,6 +3291,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         if is_positive_check {
                             // `is X` context: keep tuples where element could be X
                             !el_ty.is_disjoint_from_for_identity(self.db, rhs_ty)
+                        } else if rhs_is_correlated_singleton {
+                            // Preserve the shared specialization instead of excluding every
+                            // constraint in the projected union.
+                            !el_ty.is_subtype_of(self.db, rhs_ty)
                         } else {
                             // `is not X` context: keep tuples where element is not always X
                             !el_ty

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3111,16 +3111,16 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         rhs_ty => overlaps_only_at_runtime(rhs_ty),
                     };
                     if !has_runtime_only_overlap {
-                        builder
-                    } else {
-                        let runtime_overlap =
-                            IntersectionType::from_two_elements(self.db, element, rhs_identity_ty);
-                        builder.add(if runtime_overlap.is_never() {
-                            element
-                        } else {
-                            runtime_overlap
-                        })
+                        return builder;
                     }
+
+                    let runtime_overlap =
+                        IntersectionType::from_two_elements(self.db, element, rhs_identity_ty);
+                    builder.add(if runtime_overlap.is_never() {
+                        element
+                    } else {
+                        runtime_overlap
+                    })
                 };
 
                 if let Type::Union(union) = lhs_ty.resolve_type_alias(self.db) {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3060,8 +3060,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         match op {
             ast::CmpOp::IsNot => {
-                if rhs_ty.is_singleton(self.db) {
-                    Some(rhs_ty.negate(self.db))
+                let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db);
+                if rhs_identity_ty.is_singleton(self.db) {
+                    Some(rhs_identity_ty.negate(self.db))
                 } else {
                     // Non-singletons cannot be safely narrowed using `is not`
                     None

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -691,6 +691,28 @@ impl<'db> Type<'db> {
             .is_always_satisfied(db)
     }
 
+    /// Return the type that describes the possible runtime objects represented by `self` in an
+    /// identity comparison.
+    ///
+    /// A `NewType` wrapper is an identity function at runtime, so it contributes its concrete base
+    /// type here while remaining distinct for ordinary type relations and intersections.
+    pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
+        match self.resolve_type_alias(db) {
+            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
+            Type::Union(union) => union.map(db, |element| element.identity_comparison_type(db)),
+            Type::Intersection(intersection) => {
+                intersection.map_positive(db, |element| element.identity_comparison_type(db))
+            }
+            ty => ty,
+        }
+    }
+
+    /// Return `true` if `self` and `other` cannot describe the same runtime object.
+    pub(crate) fn is_disjoint_from_for_identity(self, db: &'db dyn Db, other: Type<'db>) -> bool {
+        self.identity_comparison_type(db)
+            .is_disjoint_from(db, other.identity_comparison_type(db))
+    }
+
     pub(crate) fn when_disjoint_from<'c>(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -17,10 +17,9 @@ use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
 use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
-    IntersectionBuilder, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
-    LiteralValueTypeKind, MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType,
-    SubclassOfInner, SubclassOfType, TypeTransformer, TypeVarBoundOrConstraints, UnionType,
-    UpcastPolicy,
+    IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
+    MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SubclassOfInner,
+    SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
 };
 use crate::{
     Db,
@@ -690,68 +689,6 @@ impl<'db> Type<'db> {
         let constraints = ConstraintSetBuilder::new();
         self.when_disjoint_from(db, other, &constraints, InferableTypeVars::None)
             .is_always_satisfied(db)
-    }
-
-    /// Widen `self` to a type that conservatively describes its possible runtime objects in an
-    /// identity comparison.
-    ///
-    /// A `NewType` wrapper is an identity function at runtime, so it contributes its concrete base
-    /// type here while remaining distinct for ordinary type relations and intersections.
-    ///
-    /// Negative intersection elements are generally omitted. A static exclusion does not imply a
-    /// runtime exclusion: `NewType("N", bool)(True)` can inhabit `~Literal[True]`, but evaluates
-    /// to the `True` singleton at runtime. However, excluding an entire nominal instance type is
-    /// stable under `NewType` erasure, so constraints such as `~None` and `~SomeClass` are
-    /// preserved.
-    pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
-        struct IdentityComparisonWidening;
-
-        fn widen<'db>(
-            db: &'db dyn Db,
-            ty: Type<'db>,
-            visitor: &TypeTransformer<'db, IdentityComparisonWidening>,
-        ) -> Type<'db> {
-            match ty {
-                Type::TypeAlias(alias) => {
-                    visitor.visit_type(db, ty, || widen(db, alias.value_type(db), visitor))
-                }
-                Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
-                Type::TypeVar(typevar) => visitor.visit_type(db, ty, || {
-                    match typevar.typevar(db).bound_or_constraints(db) {
-                        Some(bound_or_constraints) => {
-                            widen(db, bound_or_constraints.as_type(db), visitor)
-                        }
-                        None => ty,
-                    }
-                }),
-                Type::Union(union) => union.map(db, |element| widen(db, *element, visitor)),
-                Type::Intersection(intersection) => {
-                    let mut builder = IntersectionBuilder::new(db);
-                    for element in intersection.positive(db) {
-                        builder = builder.add_positive(widen(db, *element, visitor));
-                    }
-                    for element in intersection.negative(db) {
-                        if element.resolve_type_alias(db).is_nominal_instance() {
-                            builder = builder.add_negative(*element);
-                        }
-                    }
-                    builder.build()
-                }
-                _ => ty,
-            }
-        }
-
-        widen(
-            db,
-            self,
-            &TypeTransformer::<IdentityComparisonWidening>::default(),
-        )
-    }
-
-    /// Return `true` if `self` and `other` cannot describe the same runtime object.
-    pub(crate) fn is_disjoint_from_for_identity(self, db: &'db dyn Db, other: Type<'db>) -> bool {
-        self.identity_comparison_type(db)
-            .is_disjoint_from(db, other.identity_comparison_type(db))
     }
 
     pub(crate) fn when_disjoint_from<'c>(

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -691,11 +691,15 @@ impl<'db> Type<'db> {
             .is_always_satisfied(db)
     }
 
-    /// Return the type that describes the possible runtime objects represented by `self` in an
-    /// identity comparison.
+    /// Return a type that conservatively describes the possible runtime objects represented by
+    /// `self` in an identity comparison.
     ///
     /// A `NewType` wrapper is an identity function at runtime, so it contributes its concrete base
     /// type here while remaining distinct for ordinary type relations and intersections.
+    ///
+    /// Negative-only intersections are widened to `object`. A static exclusion alone does not
+    /// imply a runtime exclusion: `NewType("N", bool)(True)` can inhabit `Not[Literal[True]]`, but
+    /// evaluates to the `True` singleton at runtime.
     pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
         match self.resolve_type_alias(db) {
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
@@ -709,9 +713,12 @@ impl<'db> Type<'db> {
                 None => Type::TypeVar(typevar),
             },
             Type::Union(union) => union.map(db, |element| element.identity_comparison_type(db)),
-            Type::Intersection(intersection) => {
-                intersection.map_positive(db, |element| element.identity_comparison_type(db))
+            Type::Intersection(intersection) if intersection.positive(db).is_empty() => {
+                Type::object()
             }
+            Type::Intersection(intersection) => intersection.map_positive(db, |element| {
+                element.identity_comparison_type(db)
+            }),
             ty => ty,
         }
     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -17,9 +17,10 @@ use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
 use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
-    IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
-    MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SubclassOfInner,
-    SubclassOfType, TypeTransformer, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
+    IntersectionBuilder, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
+    LiteralValueTypeKind, MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType,
+    SubclassOfInner, SubclassOfType, TypeTransformer, TypeVarBoundOrConstraints, UnionType,
+    UpcastPolicy,
 };
 use crate::{
     Db,
@@ -697,9 +698,10 @@ impl<'db> Type<'db> {
     /// A `NewType` wrapper is an identity function at runtime, so it contributes its concrete base
     /// type here while remaining distinct for ordinary type relations and intersections.
     ///
-    /// Negative intersection elements are omitted. A static exclusion does not imply a runtime
-    /// exclusion: `NewType("N", bool)(True)` can inhabit `Not[Literal[True]]`, but evaluates to
-    /// the `True` singleton at runtime.
+    /// Negative intersection elements are generally omitted. A static exclusion does not imply a
+    /// runtime exclusion: `NewType("N", bool)(True)` can inhabit `Not[Literal[True]]`, but evaluates
+    /// to the `True` singleton at runtime. However, excluding an entire known singleton class is
+    /// stable under `NewType` erasure, so constraints such as `Not[None]` are preserved.
     pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
         struct IdentityComparisonProjection;
 
@@ -725,13 +727,23 @@ impl<'db> Type<'db> {
                     }
                 }),
                 Type::Union(union) => union.map(db, |element| project(db, *element, visitor)),
-                Type::Intersection(intersection) => IntersectionType::from_elements(
-                    db,
-                    intersection
-                        .positive(db)
-                        .iter()
-                        .map(|element| project(db, *element, visitor)),
-                ),
+                Type::Intersection(intersection) => {
+                    let mut builder = IntersectionBuilder::new(db);
+                    for element in intersection.positive(db) {
+                        builder = builder.add_positive(project(db, *element, visitor));
+                    }
+                    for element in intersection.negative(db) {
+                        let is_known_singleton_class = element
+                            .resolve_type_alias(db)
+                            .as_nominal_instance()
+                            .and_then(|instance| instance.known_class(db))
+                            .is_some_and(KnownClass::is_singleton);
+                        if is_known_singleton_class {
+                            builder = builder.add_negative(*element);
+                        }
+                    }
+                    builder.build()
+                }
                 _ => ty,
             }
         }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -699,6 +699,15 @@ impl<'db> Type<'db> {
     pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
         match self.resolve_type_alias(db) {
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
+            Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db) {
+                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                    bound.identity_comparison_type(db)
+                }
+                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                    constraints.as_type(db).identity_comparison_type(db)
+                }
+                None => Type::TypeVar(typevar),
+            },
             Type::Union(union) => union.map(db, |element| element.identity_comparison_type(db)),
             Type::Intersection(intersection) => {
                 intersection.map_positive(db, |element| element.identity_comparison_type(db))

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -697,9 +697,9 @@ impl<'db> Type<'db> {
     /// A `NewType` wrapper is an identity function at runtime, so it contributes its concrete base
     /// type here while remaining distinct for ordinary type relations and intersections.
     ///
-    /// Negative-only intersections are widened to `object`. A static exclusion alone does not
-    /// imply a runtime exclusion: `NewType("N", bool)(True)` can inhabit `Not[Literal[True]]`, but
-    /// evaluates to the `True` singleton at runtime.
+    /// Negative intersection elements are omitted. A static exclusion does not imply a runtime
+    /// exclusion: `NewType("N", bool)(True)` can inhabit `Not[Literal[True]]`, but evaluates to
+    /// the `True` singleton at runtime.
     pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
         struct IdentityComparisonProjection;
 
@@ -725,12 +725,13 @@ impl<'db> Type<'db> {
                     }
                 }),
                 Type::Union(union) => union.map(db, |element| project(db, *element, visitor)),
-                Type::Intersection(intersection) if intersection.positive(db).is_empty() => {
-                    Type::object()
-                }
-                Type::Intersection(intersection) => {
-                    intersection.map_positive(db, |element| project(db, *element, visitor))
-                }
+                Type::Intersection(intersection) => IntersectionType::from_elements(
+                    db,
+                    intersection
+                        .positive(db)
+                        .iter()
+                        .map(|element| project(db, *element, visitor)),
+                ),
                 _ => ty,
             }
         }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -692,43 +692,43 @@ impl<'db> Type<'db> {
             .is_always_satisfied(db)
     }
 
-    /// Return a type that conservatively describes the possible runtime objects represented by
-    /// `self` in an identity comparison.
+    /// Widen `self` to a type that conservatively describes its possible runtime objects in an
+    /// identity comparison.
     ///
     /// A `NewType` wrapper is an identity function at runtime, so it contributes its concrete base
     /// type here while remaining distinct for ordinary type relations and intersections.
     ///
     /// Negative intersection elements are generally omitted. A static exclusion does not imply a
-    /// runtime exclusion: `NewType("N", bool)(True)` can inhabit `Not[Literal[True]]`, but evaluates
+    /// runtime exclusion: `NewType("N", bool)(True)` can inhabit `~Literal[True]`, but evaluates
     /// to the `True` singleton at runtime. However, excluding an entire nominal instance type is
-    /// stable under `NewType` erasure, so constraints such as `Not[None]` and `Not[SomeClass]` are
+    /// stable under `NewType` erasure, so constraints such as `~None` and `~SomeClass` are
     /// preserved.
     pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
-        struct IdentityComparisonProjection;
+        struct IdentityComparisonWidening;
 
-        fn project<'db>(
+        fn widen<'db>(
             db: &'db dyn Db,
             ty: Type<'db>,
-            visitor: &TypeTransformer<'db, IdentityComparisonProjection>,
+            visitor: &TypeTransformer<'db, IdentityComparisonWidening>,
         ) -> Type<'db> {
             match ty {
                 Type::TypeAlias(alias) => {
-                    visitor.visit_type(db, ty, || project(db, alias.value_type(db), visitor))
+                    visitor.visit_type(db, ty, || widen(db, alias.value_type(db), visitor))
                 }
                 Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
                 Type::TypeVar(typevar) => visitor.visit_type(db, ty, || {
                     match typevar.typevar(db).bound_or_constraints(db) {
                         Some(bound_or_constraints) => {
-                            project(db, bound_or_constraints.as_type(db), visitor)
+                            widen(db, bound_or_constraints.as_type(db), visitor)
                         }
                         None => ty,
                     }
                 }),
-                Type::Union(union) => union.map(db, |element| project(db, *element, visitor)),
+                Type::Union(union) => union.map(db, |element| widen(db, *element, visitor)),
                 Type::Intersection(intersection) => {
                     let mut builder = IntersectionBuilder::new(db);
                     for element in intersection.positive(db) {
-                        builder = builder.add_positive(project(db, *element, visitor));
+                        builder = builder.add_positive(widen(db, *element, visitor));
                     }
                     for element in intersection.negative(db) {
                         if element.resolve_type_alias(db).is_nominal_instance() {
@@ -741,10 +741,10 @@ impl<'db> Type<'db> {
             }
         }
 
-        project(
+        widen(
             db,
             self,
-            &TypeTransformer::<IdentityComparisonProjection>::default(),
+            &TypeTransformer::<IdentityComparisonWidening>::default(),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -700,8 +700,8 @@ impl<'db> Type<'db> {
     ///
     /// Negative intersection elements are generally omitted. A static exclusion does not imply a
     /// runtime exclusion: `NewType("N", bool)(True)` can inhabit `Not[Literal[True]]`, but evaluates
-    /// to the `True` singleton at runtime. However, excluding an entire known singleton class is
-    /// stable under `NewType` erasure, so constraints such as `Not[None]` are preserved.
+    /// to the `True` singleton at runtime. However, excluding an entire singleton nominal instance
+    /// is stable under `NewType` erasure, so constraints such as `Not[None]` are preserved.
     pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
         struct IdentityComparisonProjection;
 
@@ -733,12 +733,11 @@ impl<'db> Type<'db> {
                         builder = builder.add_positive(project(db, *element, visitor));
                     }
                     for element in intersection.negative(db) {
-                        let is_known_singleton_class = element
+                        if element
                             .resolve_type_alias(db)
                             .as_nominal_instance()
-                            .and_then(|instance| instance.known_class(db))
-                            .is_some_and(KnownClass::is_singleton);
-                        if is_known_singleton_class {
+                            .is_some_and(|instance| instance.is_singleton(db))
+                        {
                             builder = builder.add_negative(*element);
                         }
                     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -19,7 +19,7 @@ use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
     MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SubclassOfInner,
-    SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
+    SubclassOfType, TypeTransformer, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
 };
 use crate::{
     Db,
@@ -701,26 +701,45 @@ impl<'db> Type<'db> {
     /// imply a runtime exclusion: `NewType("N", bool)(True)` can inhabit `Not[Literal[True]]`, but
     /// evaluates to the `True` singleton at runtime.
     pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
-        match self.resolve_type_alias(db) {
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
-            Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db) {
-                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                    bound.identity_comparison_type(db)
+        struct IdentityComparisonProjection;
+
+        fn project<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            visitor: &TypeTransformer<'db, IdentityComparisonProjection>,
+        ) -> Type<'db> {
+            match ty {
+                Type::TypeAlias(alias) => {
+                    visitor.visit_type(db, ty, || project(db, alias.value_type(db), visitor))
                 }
-                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                    constraints.as_type(db).identity_comparison_type(db)
+                Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
+                Type::TypeVar(typevar) => visitor.visit_type(db, ty, || {
+                    match typevar.typevar(db).bound_or_constraints(db) {
+                        Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                            project(db, bound, visitor)
+                        }
+                        Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                            project(db, constraints.as_type(db), visitor)
+                        }
+                        None => ty,
+                    }
+                }),
+                Type::Union(union) => union.map(db, |element| project(db, *element, visitor)),
+                Type::Intersection(intersection) if intersection.positive(db).is_empty() => {
+                    Type::object()
                 }
-                None => Type::TypeVar(typevar),
-            },
-            Type::Union(union) => union.map(db, |element| element.identity_comparison_type(db)),
-            Type::Intersection(intersection) if intersection.positive(db).is_empty() => {
-                Type::object()
+                Type::Intersection(intersection) => {
+                    intersection.map_positive(db, |element| project(db, *element, visitor))
+                }
+                _ => ty,
             }
-            Type::Intersection(intersection) => intersection.map_positive(db, |element| {
-                element.identity_comparison_type(db)
-            }),
-            ty => ty,
         }
+
+        project(
+            db,
+            self,
+            &TypeTransformer::<IdentityComparisonProjection>::default(),
+        )
     }
 
     /// Return `true` if `self` and `other` cannot describe the same runtime object.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -718,11 +718,8 @@ impl<'db> Type<'db> {
                 Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
                 Type::TypeVar(typevar) => visitor.visit_type(db, ty, || {
                     match typevar.typevar(db).bound_or_constraints(db) {
-                        Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            project(db, bound, visitor)
-                        }
-                        Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                            project(db, constraints.as_type(db), visitor)
+                        Some(bound_or_constraints) => {
+                            project(db, bound_or_constraints.as_type(db), visitor)
                         }
                         None => ty,
                     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -700,8 +700,9 @@ impl<'db> Type<'db> {
     ///
     /// Negative intersection elements are generally omitted. A static exclusion does not imply a
     /// runtime exclusion: `NewType("N", bool)(True)` can inhabit `Not[Literal[True]]`, but evaluates
-    /// to the `True` singleton at runtime. However, excluding an entire singleton nominal instance
-    /// is stable under `NewType` erasure, so constraints such as `Not[None]` are preserved.
+    /// to the `True` singleton at runtime. However, excluding an entire nominal instance type is
+    /// stable under `NewType` erasure, so constraints such as `Not[None]` and `Not[SomeClass]` are
+    /// preserved.
     pub(crate) fn identity_comparison_type(self, db: &'db dyn Db) -> Type<'db> {
         struct IdentityComparisonProjection;
 
@@ -733,11 +734,7 @@ impl<'db> Type<'db> {
                         builder = builder.add_positive(project(db, *element, visitor));
                     }
                     for element in intersection.negative(db) {
-                        if element
-                            .resolve_type_alias(db)
-                            .as_nominal_instance()
-                            .is_some_and(|instance| instance.is_singleton(db))
-                        {
+                        if element.resolve_type_alias(db).is_nominal_instance() {
                             builder = builder.add_negative(*element);
                         }
                     }


### PR DESCRIPTION
## Summary

`NewType` is nominal for static typing, but its constructor returns the input object unchanged at runtime. Prior to this change, we used ordinary type disjointness to evaluate and narrow `is` comparisons, so two distinct NewTypes with the same concrete base could be treated as unable to share an object and valid branches narrowed to `Never`:

```python
from typing import NewType

class Foo: ...

FooNewType1 = NewType("FooNewType1", Foo)
FooNewType2 = NewType("FooNewType2", Foo)

foo = Foo()
foo1 = FooNewType1(foo)
foo2 = FooNewType2(foo)

reveal_type(foo1 is foo2)  # main: Literal[False]; this PR: bool
if foo1 is foo2:  # True at runtime
    reveal_type(foo1)  # main: Never; this PR: FooNewType1
    reveal_type(foo2)  # main: Never; this PR: FooNewType2
```

This PR projects NewTypes to their runtime representations before evaluating identity.

Closes https://github.com/astral-sh/ty/issues/3552.
