### PR TITLE
Fix ruff:ignore RUF100 self-suppression parity with noqa

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_8.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_8.py
@@ -1,0 +1,2 @@
+value = 1  # noqa: RUF100
+value = 1  # ruff:ignore[RUF100]

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -668,6 +668,19 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn ruf100_8_ruff_ignore_self_suppression() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("ruff/RUF100_8.py"),
+            &settings::LinterSettings {
+                preview: PreviewMode::Enabled,
+                ..settings::LinterSettings::for_rules(vec![Rule::UnusedNOQA, Rule::UnusedVariable])
+            },
+        )?;
+        assert_diagnostics!(diagnostics);
+        Ok(())
+    }
+
     #[test_case(Path::new("ruff/RUF102.py"))]
     #[test_case(Path::new("ruff/RUF102_1.py"))]
     fn invalid_rule_code_external_rules(path: &Path) -> Result<()> {

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_8_ruff_ignore_self_suppression.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_8_ruff_ignore_self_suppression.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -385,7 +385,16 @@ impl Suppressions {
                 }
             }
 
-            if group.any_unused() {
+            if group.any_unused()
+                && !group
+                    .suppression
+                    .comments
+                    .first()
+                    .codes_as_str(locator.contents())
+                    .any(|code| {
+                        get_redirect_target(code).unwrap_or(code) == Rule::UnusedNOQA.noqa_code()
+                    })
+            {
                 let mut codes = group.disabled_codes.clone();
                 codes.extend(group.unused_codes.clone());
                 Suppressions::report_suppression_codes(


### PR DESCRIPTION
﻿## Summary
- Treat ruff:ignore comments that include RUF100 as self-suppressing, matching existing noqa behavior
- Fixes discrepancy #2 from issue #26282 where ruff:ignore[RUF100] still reported an unused-suppression diagnostic

## Test plan
- [x] Added RUF100_8 fixture and snapshot test (preview mode)
