### PR TITLE
[ty] Avoid cloning Salsa field values

### DIFF
--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -242,6 +242,7 @@ pub struct PatternPredicate<'db> {
     pub guard: Option<Expression<'db>>,
 
     /// A reference to the pattern of the previous match case
+    #[returns(as_deref)]
     pub previous_predicate: Option<Box<PatternPredicate<'db>>>,
 }
 

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -232,7 +232,7 @@ enum DescriptorReceiverKind {
     Instance,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, get_size2::GetSize, salsa::Update)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, get_size2::GetSize, salsa::Update)]
 pub struct ResolvedSuperOwner<'db> {
     /// The resolved second `super()` argument, used when binding descriptors after
     /// attribute lookup. If `receiver` is [`DescriptorReceiverKind::Instance`], this
@@ -286,7 +286,7 @@ impl<'db> ResolvedSuperOwner<'db> {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, get_size2::GetSize, salsa::Update)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, get_size2::GetSize, salsa::Update)]
 pub enum SuperOwnerKind<'db> {
     Dynamic(DynamicType<'db>),
     Divergent(DivergentType),
@@ -304,7 +304,7 @@ impl<'db> SuperOwnerKind<'db> {
             SuperOwnerKind::Dynamic(dynamic) => {
                 Some(SuperOwnerKind::Dynamic(dynamic.recursive_type_normalized()))
             }
-            SuperOwnerKind::Divergent(_) => Some(self.clone()),
+            SuperOwnerKind::Divergent(_) => Some(*self),
             SuperOwnerKind::Resolved(resolved_owner) => Some(SuperOwnerKind::Resolved(
                 resolved_owner.recursive_type_normalized_impl(db, div, nested)?,
             )),

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -446,6 +446,7 @@ impl<'db> KnownInstanceType<'db> {
 /// Contains information about a sentinel object created with `typing_extensions.Sentinel`.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct SentinelInstance<'db> {
+    #[returns(ref)]
     pub name: Name,
     pub definition: Definition<'db>,
 }


### PR DESCRIPTION
## Summary

Avoid cloning non-Copy Salsa field values when callers only need borrowed access. Keep bound-super access by value by making its owner payload `Copy`.

## Test Plan

Testing: Ran the ty_python_semantic test suite and repository hooks.
