### PR TITLE
[ty] Respect return-context inference when filtering overloads

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -2108,6 +2108,21 @@ reveal_type(x)  # revealed: int | str
 f([{"y": 1}], int_or_str())
 ```
 
+An expected return type can specialize a generic overload and provide context for its arguments.
+Overload filtering should preserve that context:
+
+```py
+from typing import Any, overload
+
+@overload
+def f[T](value: T) -> T: ...
+@overload
+def f(value: Any) -> Any: ...
+def f(value: Any) -> Any: ...
+
+values: list[int] = reveal_type(f([]))  # revealed: list[int]
+```
+
 Non-matching overloads do not produce diagnostics:
 
 ```py

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3568,13 +3568,16 @@ impl<'db> CallableBinding<'db> {
                         matched_argument.iter().map(move |matched_parameter| {
                             // TODO: For an unannotated `self` / `cls` parameter, the type should be
                             // `typing.Self` / `type[typing.Self]`
-                            let parameter_type = overload.signature.parameters()
+                            let raw_parameter_type = overload.signature.parameters()
                                 [matched_parameter.index]
-                                .annotated_type()
+                                .annotated_type();
+                            let parameter_type = raw_parameter_type
                                 .apply_optional_specialization(db, overload.specialization);
                             OverloadFilterSlot {
                                 parameter: parameter_type,
-                                argument: argument_types.get_for_declared_type(parameter_type),
+                                // Argument types are cached by the raw parameter type, even when
+                                // they were inferred using a return-context specialization.
+                                argument: argument_types.get_for_declared_type(raw_parameter_type),
                                 variadic_argument: matched_parameter.argument_type,
                             }
                         })


### PR DESCRIPTION
## Summary

```py
from typing import Any, overload

@overload
def f[T](value: T) -> T: ...
@overload
def f(value: Any) -> Any: ...
def f(value: Any) -> Any: ...

values: list[int] = reveal_type(f([]))  # Before: Unknown, now: list[int]
```

The expected `list[int]` return type specializes `T` and provides `list[int]` as context for `[]`. Previously, overload filtering lost that context, treated the argument as `list[Unknown]`, and considered the call ambiguous. It now preserves the contextual type and selects the generic overload.

closes https://github.com/astral-sh/ty/issues/3874

## Test plan

- Regression test
- Verified that it fixes the linked bug