### PR TITLE
chore: pin pre-commit hook refs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ exclude: |
 repos:
   # Priority 0: Read-only hooks; hooks that modify disjoint file types.
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-merge-conflict
         priority: 0
@@ -33,13 +33,13 @@ repos:
         priority: 0
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.25
+    rev: 4b2e70d08cb2ccd26d1fba73588de41c7a5d50b7 # frozen: v0.25
     hooks:
       - id: validate-pyproject
         priority: 0
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.47.2
+    rev: 37bb98842b0d8c4ffebdb75301a13db0267cef89 # frozen: v1.47.2
     hooks:
       - id: typos
         priority: 0
@@ -54,7 +54,7 @@ repos:
         priority: 0
   # Prettier
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.4
+    rev: 06507ab9500d4a9919b5ebd76d9d5b7074f15c1f # frozen: v3.8.4
     hooks:
       - id: prettier
         types: [yaml]
@@ -63,19 +63,19 @@ repos:
   # zizmor detects security vulnerabilities in GitHub Actions workflows.
   # Additional configuration for the tool is found in `.github/zizmor.yml`
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.25.2
+    rev: 9257c6050c0261b8c57e712f632dc4a8010109a9 # frozen: v1.25.2
     hooks:
       - id: zizmor
         priority: 0
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.3
+    rev: 5030dca3047414c338091455ac41803200ec1f0f # frozen: 0.37.3
     hooks:
       - id: check-github-workflows
         priority: 0
 
   - repo: https://github.com/executablebooks/mdformat
-    rev: 1.0.0
+    rev: 82912cdaea4fb830f751504486a7879c70526547 # frozen: 1.0.0
     hooks:
       - id: mdformat
         language: python # means renovate will also update `additional_dependencies`
@@ -91,7 +91,7 @@ repos:
         priority: 0
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.19
+    rev: 745be0411e3c150e246d527e531e5a221b8c3462 # frozen: v0.15.19
     hooks:
       - id: ruff-format
         exclude: crates/ty_python_semantic/resources/corpus/
@@ -105,7 +105,7 @@ repos:
 
   # Priority 1: Second-pass fixers (e.g., markdownlint-fix runs after mdformat).
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    rev: e72a3ca1632f0b11a07d171449fe447a7ff6795e # frozen: v0.48.0
     hooks:
       - id: markdownlint-fix
         exclude: |
@@ -118,7 +118,7 @@ repos:
 
   # Priority 2: ruffen-docs runs after markdownlint-fix (both modify markdown).
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.19
+    rev: 745be0411e3c150e246d527e531e5a221b8c3462 # frozen: v0.15.19
     hooks:
       - id: ruff-format
         name: mdtest format
@@ -130,7 +130,7 @@ repos:
   # `actionlint` hook, for verifying correct syntax in GitHub Actions workflows.
   # Some additional configuration for `actionlint` can be found in `.github/actionlint.yaml`.
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.12
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca # frozen: v1.7.12
     hooks:
       - id: actionlint
         stages:


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Pin pre-commit hook refs to the exact commits currently resolved by their tags. The version tag is kept in a `# frozen: ...` comment so Renovate can still update these normally.

This was generated via `prek auto-update --freeze --cooldown-days 14`.

Towards #26386 .

## Changed refs

| Repo | Previous ref | Release | Frozen commit |
|---|---:|---:|---|
| [`pre-commit/pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks) | [`v6.0.0`](https://github.com/pre-commit/pre-commit-hooks/tree/v6.0.0) | [release](https://github.com/pre-commit/pre-commit-hooks/releases/tag/v6.0.0) | [`3e8a870`](https://github.com/pre-commit/pre-commit-hooks/commit/3e8a8703264a2f4a69428a0aa4dcb512790b2c8c) |
| [`abravalheri/validate-pyproject`](https://github.com/abravalheri/validate-pyproject) | [`v0.25`](https://github.com/abravalheri/validate-pyproject/tree/v0.25) | [release](https://github.com/abravalheri/validate-pyproject/releases/tag/v0.25) | [`4b2e70d`](https://github.com/abravalheri/validate-pyproject/commit/4b2e70d08cb2ccd26d1fba73588de41c7a5d50b7) |
| [`crate-ci/typos`](https://github.com/crate-ci/typos) | [`v1.47.2`](https://github.com/crate-ci/typos/tree/v1.47.2) | [release](https://github.com/crate-ci/typos/releases/tag/v1.47.2) | [`37bb988`](https://github.com/crate-ci/typos/commit/37bb98842b0d8c4ffebdb75301a13db0267cef89) |
| [`rbubley/mirrors-prettier`](https://github.com/rbubley/mirrors-prettier) | [`v3.8.4`](https://github.com/rbubley/mirrors-prettier/tree/v3.8.4) | n/a | [`06507ab`](https://github.com/rbubley/mirrors-prettier/commit/06507ab9500d4a9919b5ebd76d9d5b7074f15c1f) |
| [`zizmorcore/zizmor-pre-commit`](https://github.com/zizmorcore/zizmor-pre-commit) | [`v1.25.2`](https://github.com/zizmorcore/zizmor-pre-commit/tree/v1.25.2) | [release](https://github.com/zizmorcore/zizmor-pre-commit/releases/tag/v1.25.2) | [`9257c60`](https://github.com/zizmorcore/zizmor-pre-commit/commit/9257c6050c0261b8c57e712f632dc4a8010109a9) |
| [`python-jsonschema/check-jsonschema`](https://github.com/python-jsonschema/check-jsonschema) | [`0.37.3`](https://github.com/python-jsonschema/check-jsonschema/tree/0.37.3) | [release](https://github.com/python-jsonschema/check-jsonschema/releases/tag/0.37.3) | [`5030dca`](https://github.com/python-jsonschema/check-jsonschema/commit/5030dca3047414c338091455ac41803200ec1f0f) |
| [`executablebooks/mdformat`](https://github.com/executablebooks/mdformat) | [`1.0.0`](https://github.com/executablebooks/mdformat/tree/1.0.0) | n/a | [`82912cd`](https://github.com/executablebooks/mdformat/commit/82912cdaea4fb830f751504486a7879c70526547) |
| [`astral-sh/ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit) | [`v0.15.19`](https://github.com/astral-sh/ruff-pre-commit/tree/v0.15.19) | [release](https://github.com/astral-sh/ruff-pre-commit/releases/tag/v0.15.19) | [`745be04`](https://github.com/astral-sh/ruff-pre-commit/commit/745be0411e3c150e246d527e531e5a221b8c3462) |
| [`igorshubovych/markdownlint-cli`](https://github.com/igorshubovych/markdownlint-cli) | [`v0.48.0`](https://github.com/igorshubovych/markdownlint-cli/tree/v0.48.0) | [release](https://github.com/igorshubovych/markdownlint-cli/releases/tag/v0.48.0) | [`e72a3ca`](https://github.com/igorshubovych/markdownlint-cli/commit/e72a3ca1632f0b11a07d171449fe447a7ff6795e) |
| [`astral-sh/ruff-pre-commit`](https://github.com/astral-sh/ruff-pre-commit) | [`v0.15.19`](https://github.com/astral-sh/ruff-pre-commit/tree/v0.15.19) | [release](https://github.com/astral-sh/ruff-pre-commit/releases/tag/v0.15.19) | [`745be04`](https://github.com/astral-sh/ruff-pre-commit/commit/745be0411e3c150e246d527e531e5a221b8c3462) |
| [`rhysd/actionlint`](https://github.com/rhysd/actionlint) | [`v1.7.12`](https://github.com/rhysd/actionlint/tree/v1.7.12) | [release](https://github.com/rhysd/actionlint/releases/tag/v1.7.12) | [`914e7df`](https://github.com/rhysd/actionlint/commit/914e7df21a07ef503a81201c76d2b11c789d3fca) |

## Test Plan

```bash
uvx prek auto-update --freeze --cooldown-days 14
git diff --exit-code -- .pre-commit-config.yaml
uvx prek run --all-files
```

