### PR TITLE
[ty] Avoid MRO cycle when collecting NamedTuple fields

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -46,6 +46,27 @@ while 1:
     y = (y, *y)
 ```
 
+## Generic `NamedTuple` with recursive fields
+
+This is a regression test for <https://github.com/astral-sh/ty/issues/3872>. Computing the
+`NamedTuple` fields while building the class's MRO must not try to determine whether the same class
+is a `TypedDict`.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from typing import NamedTuple
+
+class Node[KT, VT](NamedTuple):
+    children: tuple[Node[KT, VT], ...] | tuple[Leaf[VT], ...]
+
+class Leaf[VT](NamedTuple):
+    values: tuple[VT, ...]
+```
+
 ## Literal reduction during cycle recovery
 
 This is a regression test for <https://github.com/astral-sh/ty/issues/3851>. Constructing a union

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2006,7 +2006,17 @@ impl<'db> StaticClassLiteral<'db> {
 
         let use_def = use_def_map(db, class_body_scope);
 
-        let typed_dict_params = self.typed_dict_params(db);
+        // `own_fields(..., NamedTuple)` is called while constructing the class's MRO because the
+        // field types determine the synthesized tuple base. `typed_dict_params` also queries the
+        // class's MRO, so only read the `total` default when collecting `TypedDict` fields.
+        let typed_dict_fields_are_required_by_default =
+            if field_policy == CodeGeneratorKind::TypedDict {
+                self.typed_dict_params(db)
+                    .expect("TypedDictParams should be available for CodeGeneratorKind::TypedDict")
+                    .contains(TypedDictParams::TOTAL)
+            } else {
+                false
+            };
         let dataclass_kw_only_default = matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
             .then(|| self.has_dataclass_param(db, field_policy, DataclassFlags::KW_ONLY));
         let mut kw_only_sentinel_field_seen = false;
@@ -2064,10 +2074,14 @@ impl<'db> StaticClassLiteral<'db> {
             }
 
             if let Some(attr_ty) = attr.place.ignore_possibly_undefined() {
-                let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
-                let mut default_ty = place_from_bindings(db, bindings)
-                    .place
-                    .ignore_possibly_undefined();
+                let mut default_ty = if field_policy == CodeGeneratorKind::TypedDict {
+                    None
+                } else {
+                    let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
+                    place_from_bindings(db, bindings)
+                        .place
+                        .ignore_possibly_undefined()
+                };
 
                 default_ty =
                     default_ty.map(|ty| ty.apply_optional_specialization(db, specialization));
@@ -2103,9 +2117,7 @@ impl<'db> StaticClassLiteral<'db> {
                             false
                         } else {
                             // No explicit qualifier - use class default (`total` parameter)
-                            typed_dict_params
-                                .expect("TypedDictParams should be available for CodeGeneratorKind::TypedDict")
-                                .contains(TypedDictParams::TOTAL)
+                            typed_dict_fields_are_required_by_default
                         };
 
                         FieldKind::TypedDict {
@@ -2122,7 +2134,9 @@ impl<'db> StaticClassLiteral<'db> {
                 };
 
                 // Check if this is a KW_ONLY sentinel and mark subsequent fields as keyword-only
-                if field.is_kw_only_sentinel(db) {
+                if matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
+                    && field.is_kw_only_sentinel(db)
+                {
                     kw_only_sentinel_field_seen = true;
                 }
 


### PR DESCRIPTION
## Summary

When we build the MRO for a class-syntax `NamedTuple`, we synthesize its tuple base from the class's own field types. `own_fields` previously queried `typed_dict_params` unconditionally, even though only `TypedDict` field generation uses those parameters. That query checks whether the class is a `TypedDict` by walking its MRO, re-entering the MRO construction already in progress.

This evaluates policy-specific field metadata only for the field kind that consumes it: the `TypedDict` `total` default is read only for `TypedDict` fields, binding defaults are inferred only for `NamedTuple` and dataclass fields, and `KW_ONLY` sentinels are checked only for dataclasses. In particular, gating the `typed_dict_params` lookup removes the `MRO -> own_fields -> MRO` dependency without changing field generation. The recursive generic `NamedTuple` from the issue is covered under Python 3.14.

The full ty semantic test suite, package Clippy, and repository hooks pass.

Closes https://github.com/astral-sh/ty/issues/3872.
