### PR TITLE
[ty] Automatically update import statements and references when a module is renamed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4920,6 +4920,7 @@ dependencies = [
  "jod-thread",
  "libc",
  "lsp-server",
+ "percent-encoding",
  "regex",
  "ruff_db",
  "ruff_diagnostics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4932,6 +4932,7 @@ dependencies = [
  "jod-thread",
  "libc",
  "lsp-server",
+ "percent-encoding",
  "regex",
  "ruff_db",
  "ruff_diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ parking_lot = { version = "0.12.4" }
 path-absolutize = { version = "4.0.0" }
 path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
+percent-encoding = { version = "2.3.1" }
 pep440_rs = { version = "0.7.1" }
 pretty_assertions = "1.3.0"
 proc-macro2 = { version = "1.0.79" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ parking_lot = { version = "0.12.4" }
 path-absolutize = { version = "4.0.0" }
 path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
+percent-encoding = { version = "2.3.1" }
 pep440_rs = { version = "0.7.1" }
 pretty_assertions = "1.3.0"
 proc-macro2 = { version = "1.0.79" }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -483,7 +483,7 @@ impl Project {
     }
 
     /// Returns the open files in the project.
-    fn open_files(self, db: &dyn Db) -> &FxHashSet<File> {
+    pub fn open_files(self, db: &dyn Db) -> &FxHashSet<File> {
         self.open_fileset(db)
     }
 

--- a/crates/ty_server/Cargo.toml
+++ b/crates/ty_server/Cargo.toml
@@ -35,6 +35,7 @@ crossbeam = { workspace = true }
 jod-thread = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
+percent-encoding = { workspace = true }
 rustc-hash = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true }

--- a/crates/ty_server/Cargo.toml
+++ b/crates/ty_server/Cargo.toml
@@ -36,6 +36,7 @@ crossbeam = { workspace = true }
 jod-thread = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
+percent-encoding = { workspace = true }
 rustc-hash = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true }

--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -421,6 +421,12 @@ pub(crate) fn server_capabilities(
                 server_diagnostic_options(true),
             ))
         };
+    let rename_filter = |glob: &str, kind| {
+        types::FileOperationFilter::new(
+            Some("file".to_string()),
+            types::FileOperationPattern::new(glob.to_string(), Some(kind), None),
+        )
+    };
 
     ServerCapabilities {
         position_encoding: Some(position_encoding.into()),
@@ -514,6 +520,13 @@ pub(crate) fn server_capabilities(
                 // https://github.com/microsoft/language-server-protocol/issues/1720#issuecomment-1514732305
                 supported: Some(true),
                 change_notifications: Some(true.into()),
+            }),
+            file_operations: Some(types::FileOperationOptions {
+                will_rename: Some(types::FileOperationRegistrationOptions::new(vec![
+                    rename_filter("**/*.{py,pyi}", types::FileOperationPatternKind::File),
+                    rename_filter("**", types::FileOperationPatternKind::Folder),
+                ])),
+                ..types::FileOperationOptions::default()
             }),
             ..Default::default()
         }),

--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -440,6 +440,12 @@ pub(crate) fn server_capabilities(
                 server_diagnostic_options(true),
             ))
         };
+    let rename_filter = |glob: &str, kind| {
+        types::FileOperationFilter::new(
+            Some("file".to_string()),
+            types::FileOperationPattern::new(glob.to_string(), Some(kind), None),
+        )
+    };
 
     ServerCapabilities {
         position_encoding: Some(position_encoding.into()),
@@ -533,6 +539,13 @@ pub(crate) fn server_capabilities(
                 // https://github.com/microsoft/language-server-protocol/issues/1720#issuecomment-1514732305
                 supported: Some(true),
                 change_notifications: Some(true.into()),
+            }),
+            file_operations: Some(types::FileOperationOptions {
+                will_rename: Some(types::FileOperationRegistrationOptions::new(vec![
+                    rename_filter("**/*.{py,pyi}", types::FileOperationPatternKind::File),
+                    rename_filter("**", types::FileOperationPatternKind::Folder),
+                ])),
+                ..types::FileOperationOptions::default()
             }),
             ..Default::default()
         }),

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -113,6 +113,9 @@ pub(super) fn request(req: server::Request) -> Task {
         >(
             req, BackgroundSchedule::Worker
         ),
+        requests::WillRenameFilesHandler::METHOD => background_request_task::<
+            requests::WillRenameFilesHandler,
+        >(req, BackgroundSchedule::Worker),
         requests::PrepareTypeHierarchyRequestHandler::METHOD => background_document_request_task::<
             requests::PrepareTypeHierarchyRequestHandler,
         >(

--- a/crates/ty_server/src/server/api/requests.rs
+++ b/crates/ty_server/src/server/api/requests.rs
@@ -39,6 +39,7 @@ mod shutdown;
 mod signature_help;
 mod type_hierarchy_subtypes;
 mod type_hierarchy_supertypes;
+mod will_rename_files;
 mod workspace_diagnostic;
 mod workspace_symbols;
 
@@ -69,5 +70,6 @@ pub(super) use shutdown::ShutdownHandler;
 pub(super) use signature_help::SignatureHelpRequestHandler;
 pub(super) use type_hierarchy_subtypes::TypeHierarchySubtypesRequestHandler;
 pub(super) use type_hierarchy_supertypes::TypeHierarchySupertypesRequestHandler;
+pub(super) use will_rename_files::WillRenameFilesHandler;
 pub(super) use workspace_diagnostic::WorkspaceDiagnosticRequestHandler;
 pub(super) use workspace_symbols::WorkspaceSymbolRequestHandler;

--- a/crates/ty_server/src/server/api/requests/will_rename_files.rs
+++ b/crates/ty_server/src/server/api/requests/will_rename_files.rs
@@ -1,0 +1,411 @@
+//! LSP exposure for best-effort Python file and regular-package renames.
+//!
+//! Each supported entry is analyzed in the workspace that owns both paths. A renamed folder may
+//! not contain another workspace. Candidates include indexed and open files plus every physical
+//! Python source moved with a folder. Unsupported entries and failed workspace groups or LSP
+//! documents are omitted without suppressing independent edits. The server sends one warning when
+//! it omits a request entry or cannot project an edit.
+
+use std::collections::{BTreeMap, HashMap};
+
+use lsp_types::{
+    FileRename, RenameFilesParams, TextEdit, Uri, WillRenameFilesRequest, WorkspaceEdit,
+};
+use percent_encoding::percent_decode_str;
+use ruff_db::Db as _;
+use ruff_db::files::{File, system_path_to_file};
+use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use ty_ide::{PathRename, will_rename_paths};
+use ty_project::{Db as _, ProjectDatabase};
+
+use crate::document::FileRangeExt;
+use crate::server::api::traits::{
+    BackgroundRequestHandler, RequestHandler, RetriableRequestHandler,
+};
+use crate::session::SessionSnapshot;
+use crate::session::client::Client;
+
+/// Handles `workspace/willRenameFiles` for supported Python modules and packages.
+pub(crate) struct WillRenameFilesHandler;
+
+impl RequestHandler for WillRenameFilesHandler {
+    type RequestType = WillRenameFilesRequest;
+}
+
+impl BackgroundRequestHandler for WillRenameFilesHandler {
+    fn run(
+        snapshot: &SessionSnapshot,
+        client: &Client,
+        params: RenameFilesParams,
+    ) -> crate::server::Result<Option<WorkspaceEdit>> {
+        let result = workspace_edit(snapshot, params);
+        if result.known_omissions {
+            client.show_warning_message(INCOMPLETE_RENAME_WARNING);
+        }
+        Ok(result.edit)
+    }
+}
+
+impl RetriableRequestHandler for WillRenameFilesHandler {
+    const RETRY_ON_CANCELLATION: bool = true;
+}
+
+const INCOMPLETE_RENAME_WARNING: &str = "ty could not safely update all affected Python code. Some imports, references, or exports may remain unchanged after this file operation.";
+
+fn workspace_edit(snapshot: &SessionSnapshot, params: RenameFilesParams) -> WorkspaceEditResult {
+    let mut omissions = Omissions::default();
+    let Some(system) = snapshot.projects().first().map(ProjectDatabase::system) else {
+        if params
+            .files
+            .iter()
+            .any(|rename| !uri_is_non_python_file(&rename.old_uri))
+        {
+            omissions.record("no project is available");
+        }
+        return WorkspaceEditResult {
+            edit: None,
+            known_omissions: omissions.any,
+        };
+    };
+    let mut groups: BTreeMap<usize, Vec<PendingRename>> = BTreeMap::new();
+
+    for rename in params.files {
+        match prepare_rename(snapshot, system, rename) {
+            Ok(Some(prepared)) => groups
+                .entry(prepared.project)
+                .or_default()
+                .push(prepared.pending),
+            Ok(None) => {}
+            Err(omission) => omission.record(&mut omissions),
+        }
+    }
+
+    let mut changes = HashMap::new();
+    for (owner, group) in groups {
+        let db = &snapshot.projects()[owner];
+        let mut moved_files = Vec::new();
+        let mut renames = Vec::new();
+        for pending in group {
+            let mut files = Vec::with_capacity(pending.moved.len());
+            let mut valid = true;
+            for path in pending.moved {
+                if snapshot.enclosing_project_index(&path) != Some(owner) {
+                    omissions.path("a moved source belongs to another workspace", &path);
+                    valid = false;
+                    break;
+                }
+                let Ok(file) = system_path_to_file(db, &path) else {
+                    omissions.path("a moved source cannot be registered", &path);
+                    valid = false;
+                    break;
+                };
+                files.push(file);
+            }
+            if valid {
+                moved_files.extend(files);
+                renames.push(pending.rename);
+            }
+        }
+        if renames.is_empty() {
+            continue;
+        }
+        let in_scope = |file: File| {
+            file.path(db)
+                .as_system_path()
+                .is_none_or(|path| snapshot.enclosing_project_index(path) == Some(owner))
+        };
+        if snapshot.language_services_disabled(owner) {
+            omissions.path(
+                "language services are disabled for the workspace",
+                snapshot.workspace_root(owner),
+            );
+            continue;
+        }
+        let project = db.project();
+        let result = will_rename_paths(
+            db,
+            &renames,
+            project
+                .files(db)
+                .into_iter()
+                .chain(project.open_files(db).iter().copied())
+                .chain(moved_files),
+            in_scope,
+        );
+        project_lsp_edits(
+            db,
+            snapshot.position_encoding(),
+            result,
+            &mut changes,
+            &mut omissions,
+        );
+    }
+    normalize_lsp_edits(&mut changes, &mut omissions);
+    WorkspaceEditResult {
+        edit: (!changes.is_empty()).then(|| WorkspaceEdit::new(Some(changes), None, None)),
+        known_omissions: omissions.any,
+    }
+}
+
+struct WorkspaceEditResult {
+    edit: Option<WorkspaceEdit>,
+    known_omissions: bool,
+}
+
+fn prepare_rename(
+    snapshot: &SessionSnapshot,
+    system: &dyn System,
+    rename: FileRename,
+) -> Result<Option<PreparedRename>, RenameOmission> {
+    let old_path = match file_uri_to_path(&rename.old_uri) {
+        Some(path) => path,
+        None if uri_is_non_python_file(&rename.old_uri) => return Ok(None),
+        None => return Err(RenameOmission::NonLocalUri(rename.old_uri)),
+    };
+
+    let directory = system.is_directory(&old_path);
+    if !directory && !matches!(old_path.extension(), Some("py" | "pyi")) {
+        return Ok(None);
+    }
+
+    let new_path =
+        file_uri_to_path(&rename.new_uri).ok_or(RenameOmission::NonLocalUri(rename.new_uri))?;
+
+    let project = snapshot
+        .enclosing_project_index(&old_path)
+        .ok_or_else(|| RenameOmission::OutsideWorkspace(old_path.clone()))?;
+    if snapshot.enclosing_project_index(&new_path) != Some(project) {
+        return Err(RenameOmission::CrossesWorkspaceOwnership { old_path, new_path });
+    }
+    if directory && snapshot.contains_other_workspace(project, &old_path) {
+        return Err(RenameOmission::ContainsAnotherWorkspace(old_path));
+    }
+
+    let moved = if directory {
+        let files = python_files_in_directory(system, &old_path)
+            .ok_or_else(|| RenameOmission::UnreadableDirectory(old_path.clone()))?;
+        if files.is_empty() {
+            return Ok(None);
+        }
+        files
+    } else {
+        if new_path.extension() != old_path.extension() {
+            return Err(RenameOmission::ChangedPythonExtension { old_path, new_path });
+        }
+        vec![old_path.clone()]
+    };
+
+    let rename = if directory {
+        PathRename::directory(old_path, new_path)
+    } else {
+        PathRename::file(old_path, new_path)
+    };
+
+    Ok(Some(PreparedRename {
+        project,
+        pending: PendingRename { rename, moved },
+    }))
+}
+
+struct PreparedRename {
+    project: usize,
+    pending: PendingRename,
+}
+
+enum RenameOmission {
+    NonLocalUri(Uri),
+    UnreadableDirectory(SystemPathBuf),
+    ChangedPythonExtension {
+        old_path: SystemPathBuf,
+        new_path: SystemPathBuf,
+    },
+    OutsideWorkspace(SystemPathBuf),
+    CrossesWorkspaceOwnership {
+        old_path: SystemPathBuf,
+        new_path: SystemPathBuf,
+    },
+    ContainsAnotherWorkspace(SystemPathBuf),
+}
+
+impl RenameOmission {
+    fn record(self, omissions: &mut Omissions) {
+        match self {
+            Self::NonLocalUri(uri) => {
+                omissions.uri("a rename URI is not a local file path", uri);
+            }
+            Self::UnreadableDirectory(path) => {
+                omissions.path("a renamed directory cannot be read completely", path);
+            }
+            Self::ChangedPythonExtension { old_path, new_path } => omissions.rename(
+                "a Python file rename changes its extension",
+                old_path,
+                new_path,
+            ),
+            Self::OutsideWorkspace(path) => {
+                omissions.path("a renamed source is outside every workspace", path);
+            }
+            Self::CrossesWorkspaceOwnership { old_path, new_path } => {
+                omissions.rename("a rename crosses workspace ownership", old_path, new_path);
+            }
+            Self::ContainsAnotherWorkspace(path) => {
+                omissions.path("a renamed directory contains another workspace", path);
+            }
+        }
+    }
+}
+
+struct PendingRename {
+    rename: PathRename,
+    moved: Vec<SystemPathBuf>,
+}
+
+fn project_lsp_edits(
+    db: &ProjectDatabase,
+    encoding: crate::PositionEncoding,
+    edits: Vec<ty_ide::FileRenameEdit>,
+    changes: &mut HashMap<Uri, Vec<TextEdit>>,
+    omissions: &mut Omissions,
+) {
+    let mut by_file: HashMap<File, Vec<_>> = HashMap::new();
+    for edit in edits {
+        by_file.entry(edit.range.file()).or_default().push(edit);
+    }
+    for edits in by_file.into_values() {
+        let mut projected = Vec::with_capacity(edits.len());
+        let mut valid = true;
+        for edit in edits {
+            let file = edit.range.file();
+            let Some(range) = edit.range.to_lsp_range(db, encoding) else {
+                omissions.path(
+                    "an edit cannot be converted to an LSP location",
+                    file.path(db),
+                );
+                valid = false;
+                break;
+            };
+            let Some(location) = range.into_location() else {
+                omissions.path(
+                    "an edit cannot be converted to an LSP location",
+                    file.path(db),
+                );
+                valid = false;
+                break;
+            };
+            projected.push((location.uri, TextEdit::new(location.range, edit.value)));
+        }
+        if valid {
+            for (uri, edit) in projected {
+                changes.entry(uri).or_default().push(edit);
+            }
+        }
+    }
+}
+
+fn normalize_lsp_edits(changes: &mut HashMap<Uri, Vec<TextEdit>>, omissions: &mut Omissions) {
+    changes.retain(|uri, edits| {
+        edits.sort_unstable_by(|left, right| {
+            left.range
+                .cmp(&right.range)
+                .then_with(|| left.new_text.cmp(&right.new_text))
+        });
+        edits.dedup();
+        let mut normalized = Vec::with_capacity(edits.len());
+        let mut pending = std::mem::take(edits).into_iter().peekable();
+        while let Some(edit) = pending.next() {
+            let mut end = edit.range.end;
+            let mut conflicting = false;
+            while let Some(next) = pending.peek()
+                && next.range.start < end
+            {
+                let Some(next) = pending.next() else {
+                    break;
+                };
+                end = end.max(next.range.end);
+                conflicting = true;
+            }
+            if conflicting {
+                omissions.uri("projected edits overlap", uri);
+            } else {
+                normalized.push(edit);
+            }
+        }
+        *edits = normalized;
+        !edits.is_empty()
+    });
+}
+
+fn python_files_in_directory(system: &dyn System, root: &SystemPath) -> Option<Vec<SystemPathBuf>> {
+    let mut files = Vec::new();
+    for entry in system.read_directory(root).ok()? {
+        let entry = entry.ok()?;
+        let file_type = entry.file_type();
+        let path = entry.into_path();
+        if file_type.is_file() && matches!(path.extension(), Some("py" | "pyi")) {
+            files.push(path);
+        } else if file_type.is_directory() {
+            files.extend(python_files_in_directory(system, &path)?);
+        }
+    }
+    Some(files)
+}
+
+fn file_uri_to_path(uri: &Uri) -> Option<SystemPathBuf> {
+    SystemPathBuf::from_path_buf(uri.to_file_path().ok()?).ok()
+}
+
+fn uri_is_non_python_file(uri: &Uri) -> bool {
+    let path: Vec<_> = percent_decode_str(uri.path()).collect();
+    let Some(name) = path.rsplit(|byte| *byte == b'/').next() else {
+        return false;
+    };
+    let Some(dot) = name.iter().rposition(|byte| *byte == b'.') else {
+        return false;
+    };
+    let extension = &name[dot + 1..];
+    extension != b"py" && extension != b"pyi"
+}
+
+#[derive(Default)]
+struct Omissions {
+    any: bool,
+}
+
+impl Omissions {
+    fn record(&mut self, reason: &'static str) {
+        tracing::debug!(reason, "Omitting part of `workspace/willRenameFiles`");
+        self.any = true;
+    }
+
+    fn path(&mut self, reason: &'static str, path: impl std::fmt::Display) {
+        tracing::debug!(
+            reason,
+            path = %path,
+            "Omitting part of `workspace/willRenameFiles`"
+        );
+        self.any = true;
+    }
+
+    fn uri(&mut self, reason: &'static str, uri: impl std::fmt::Display) {
+        tracing::debug!(
+            reason,
+            uri = %uri,
+            "Omitting part of `workspace/willRenameFiles`"
+        );
+        self.any = true;
+    }
+
+    fn rename(
+        &mut self,
+        reason: &'static str,
+        old_path: impl std::fmt::Display,
+        new_path: impl std::fmt::Display,
+    ) {
+        tracing::debug!(
+            reason,
+            old_path = %old_path,
+            new_path = %new_path,
+            "Omitting part of `workspace/willRenameFiles`"
+        );
+        self.any = true;
+    }
+}

--- a/crates/ty_server/src/server/api/requests/will_rename_files.rs
+++ b/crates/ty_server/src/server/api/requests/will_rename_files.rs
@@ -1,0 +1,418 @@
+//! LSP exposure for best-effort Python file and regular-package renames.
+//!
+//! Each supported entry is analyzed in the workspace that owns both paths. A renamed folder may
+//! not contain another workspace. Candidates include indexed and open files plus every physical
+//! Python source moved with a folder. Unsupported entries and failed workspace groups or LSP
+//! documents are omitted without suppressing independent edits.
+//! When that leaves known relevant work unchanged, the server sends one warning for the request.
+
+use std::collections::{BTreeMap, HashMap};
+
+use lsp_types::{
+    FileRename, RenameFilesParams, TextEdit, Uri, WillRenameFilesRequest, WorkspaceEdit,
+};
+use percent_encoding::percent_decode_str;
+use ruff_db::Db as _;
+use ruff_db::files::{File, system_path_to_file};
+use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use ty_ide::{PathRename, will_rename_paths};
+use ty_project::{Db as _, ProjectDatabase};
+
+use crate::document::FileRangeExt;
+use crate::server::api::traits::{
+    BackgroundRequestHandler, RequestHandler, RetriableRequestHandler,
+};
+use crate::session::SessionSnapshot;
+use crate::session::client::Client;
+
+/// Handles `workspace/willRenameFiles` for supported Python modules and packages.
+pub(crate) struct WillRenameFilesHandler;
+
+impl RequestHandler for WillRenameFilesHandler {
+    type RequestType = WillRenameFilesRequest;
+}
+
+impl BackgroundRequestHandler for WillRenameFilesHandler {
+    fn run(
+        snapshot: &SessionSnapshot,
+        client: &Client,
+        params: RenameFilesParams,
+    ) -> crate::server::Result<Option<WorkspaceEdit>> {
+        let result = workspace_edit(snapshot, params);
+        if result.known_omissions {
+            client.show_warning_message(INCOMPLETE_RENAME_WARNING);
+        }
+        Ok(result.edit)
+    }
+}
+
+impl RetriableRequestHandler for WillRenameFilesHandler {
+    const RETRY_ON_CANCELLATION: bool = true;
+}
+
+const INCOMPLETE_RENAME_WARNING: &str = "ty could not safely update every affected Python import or module reference. Some references may remain unchanged after this file operation.";
+
+fn workspace_edit(snapshot: &SessionSnapshot, params: RenameFilesParams) -> WorkspaceEditResult {
+    let mut known_omissions = false;
+    let Some(system) = snapshot.projects().first().map(ProjectDatabase::system) else {
+        if params
+            .files
+            .iter()
+            .any(|rename| !uri_is_non_python_file(&rename.old_uri))
+        {
+            omit(&mut known_omissions, "no project is available");
+        }
+        return WorkspaceEditResult {
+            edit: None,
+            known_omissions,
+        };
+    };
+    let mut groups: BTreeMap<usize, Vec<PendingRename>> = BTreeMap::new();
+
+    for rename in params.files {
+        match prepare_rename(snapshot, system, rename) {
+            Ok(Some(prepared)) => groups
+                .entry(prepared.project)
+                .or_default()
+                .push(prepared.pending),
+            Ok(None) => {}
+            Err(omission) => omission.record(&mut known_omissions),
+        }
+    }
+
+    let mut changes = HashMap::new();
+    for (owner, group) in groups {
+        if snapshot.language_services_disabled(owner) {
+            note_omission_path(
+                "language services are disabled for the workspace",
+                snapshot.workspace_root(owner),
+            );
+            continue;
+        }
+        let db = &snapshot.projects()[owner];
+        let mut moved_files = Vec::new();
+        let mut renames = Vec::new();
+        for pending in group {
+            let mut files = Vec::with_capacity(pending.moved.len());
+            let mut valid = true;
+            for path in pending.moved {
+                if snapshot.enclosing_project_index(&path) != Some(owner) {
+                    omit_path(
+                        &mut known_omissions,
+                        "a moved source belongs to another workspace",
+                        &path,
+                    );
+                    valid = false;
+                    break;
+                }
+                let Ok(file) = system_path_to_file(db, &path) else {
+                    omit_path(
+                        &mut known_omissions,
+                        "a moved source cannot be registered",
+                        &path,
+                    );
+                    valid = false;
+                    break;
+                };
+                files.push(file);
+            }
+            if valid {
+                moved_files.extend(files);
+                renames.push(pending.rename);
+            }
+        }
+        if renames.is_empty() {
+            continue;
+        }
+        let project = db.project();
+        let result = will_rename_paths(
+            db,
+            &renames,
+            project
+                .files(db)
+                .into_iter()
+                .chain(project.open_files(db).iter().copied())
+                .chain(moved_files),
+            |file| {
+                file.path(db)
+                    .as_system_path()
+                    .is_none_or(|path| snapshot.enclosing_project_index(path) == Some(owner))
+            },
+        );
+        known_omissions |= result.has_known_omissions();
+        project_lsp_edits(
+            db,
+            snapshot.position_encoding(),
+            result.into_edits(),
+            &mut changes,
+            &mut known_omissions,
+        );
+    }
+    normalize_lsp_edits(&mut changes, &mut known_omissions);
+    WorkspaceEditResult {
+        edit: (!changes.is_empty()).then(|| WorkspaceEdit::new(Some(changes), None, None)),
+        known_omissions,
+    }
+}
+
+struct WorkspaceEditResult {
+    edit: Option<WorkspaceEdit>,
+    known_omissions: bool,
+}
+
+fn prepare_rename(
+    snapshot: &SessionSnapshot,
+    system: &dyn System,
+    rename: FileRename,
+) -> Result<Option<PreparedRename>, RenameOmission> {
+    let old_path = match file_uri_to_path(&rename.old_uri) {
+        Some(path) => path,
+        None if uri_is_non_python_file(&rename.old_uri) => return Ok(None),
+        None => return Err(RenameOmission::NonLocalUri(rename.old_uri)),
+    };
+
+    let directory = system.is_directory(&old_path);
+    if !directory && !matches!(old_path.extension(), Some("py" | "pyi")) {
+        return Ok(None);
+    }
+
+    let new_path =
+        file_uri_to_path(&rename.new_uri).ok_or(RenameOmission::NonLocalUri(rename.new_uri))?;
+    let moved = if directory {
+        let files = python_files_in_directory(system, &old_path)
+            .ok_or_else(|| RenameOmission::UnreadableDirectory(old_path.clone()))?;
+        if files.is_empty() {
+            return Ok(None);
+        }
+        files
+    } else {
+        if new_path.extension() != old_path.extension() {
+            return Err(RenameOmission::ChangedPythonExtension { old_path, new_path });
+        }
+        Vec::new()
+    };
+
+    let project = snapshot
+        .enclosing_project_index(&old_path)
+        .ok_or_else(|| RenameOmission::OutsideWorkspace(old_path.clone()))?;
+    if snapshot.enclosing_project_index(&new_path) != Some(project) {
+        return Err(RenameOmission::CrossesWorkspaceOwnership { old_path, new_path });
+    }
+    if !moved.is_empty() && snapshot.contains_other_workspace(project, &old_path) {
+        return Err(RenameOmission::ContainsAnotherWorkspace(old_path));
+    }
+
+    let rename = if directory {
+        PathRename::directory(old_path, new_path)
+    } else {
+        PathRename::file(old_path, new_path)
+    };
+
+    Ok(Some(PreparedRename {
+        project,
+        pending: PendingRename { rename, moved },
+    }))
+}
+
+struct PreparedRename {
+    project: usize,
+    pending: PendingRename,
+}
+
+enum RenameOmission {
+    NonLocalUri(String),
+    UnreadableDirectory(SystemPathBuf),
+    ChangedPythonExtension {
+        old_path: SystemPathBuf,
+        new_path: SystemPathBuf,
+    },
+    OutsideWorkspace(SystemPathBuf),
+    CrossesWorkspaceOwnership {
+        old_path: SystemPathBuf,
+        new_path: SystemPathBuf,
+    },
+    ContainsAnotherWorkspace(SystemPathBuf),
+}
+
+impl RenameOmission {
+    fn record(self, known_omissions: &mut bool) {
+        match self {
+            Self::NonLocalUri(uri) => omit_uri(
+                known_omissions,
+                "a rename URI is not a local file path",
+                uri,
+            ),
+            Self::UnreadableDirectory(path) => omit_path(
+                known_omissions,
+                "a renamed directory cannot be read completely",
+                path,
+            ),
+            Self::ChangedPythonExtension { old_path, new_path } => omit_rename(
+                known_omissions,
+                "a Python file rename changes its extension",
+                old_path,
+                new_path,
+            ),
+            Self::OutsideWorkspace(path) => omit_path(
+                known_omissions,
+                "a renamed source is outside every workspace",
+                path,
+            ),
+            Self::CrossesWorkspaceOwnership { old_path, new_path } => omit_rename(
+                known_omissions,
+                "a rename crosses workspace ownership",
+                old_path,
+                new_path,
+            ),
+            Self::ContainsAnotherWorkspace(path) => omit_path(
+                known_omissions,
+                "a renamed directory contains another workspace",
+                path,
+            ),
+        }
+    }
+}
+
+struct PendingRename {
+    rename: PathRename,
+    moved: Vec<SystemPathBuf>,
+}
+
+fn project_lsp_edits(
+    db: &ProjectDatabase,
+    encoding: crate::PositionEncoding,
+    edits: Vec<ty_ide::FileRenameEdit>,
+    changes: &mut HashMap<Uri, Vec<TextEdit>>,
+    known_omissions: &mut bool,
+) {
+    let mut by_file: HashMap<File, Vec<_>> = HashMap::new();
+    for edit in edits {
+        by_file.entry(edit.range.file()).or_default().push(edit);
+    }
+    for edits in by_file.into_values() {
+        let mut projected = Vec::with_capacity(edits.len());
+        let mut valid = true;
+        for edit in edits {
+            let file = edit.range.file();
+            let Some(range) = edit.range.to_lsp_range(db, encoding) else {
+                omit_path(
+                    known_omissions,
+                    "an edit cannot be converted to an LSP location",
+                    file.path(db),
+                );
+                valid = false;
+                break;
+            };
+            let Some(location) = range.into_location() else {
+                omit_path(
+                    known_omissions,
+                    "an edit cannot be converted to an LSP location",
+                    file.path(db),
+                );
+                valid = false;
+                break;
+            };
+            projected.push((location.uri, TextEdit::new(location.range, edit.value)));
+        }
+        if valid {
+            for (uri, edit) in projected {
+                changes.entry(uri).or_default().push(edit);
+            }
+        }
+    }
+}
+
+fn normalize_lsp_edits(changes: &mut HashMap<Uri, Vec<TextEdit>>, known_omissions: &mut bool) {
+    changes.retain(|uri, edits| {
+        edits.sort_unstable_by_key(|edit| edit.range);
+        edits.dedup();
+        if edits
+            .windows(2)
+            .any(|pair| pair[1].range.start < pair[0].range.end)
+        {
+            omit_uri(known_omissions, "projected edits overlap", uri);
+            false
+        } else {
+            true
+        }
+    });
+}
+
+fn python_files_in_directory(system: &dyn System, root: &SystemPath) -> Option<Vec<SystemPathBuf>> {
+    let mut files = Vec::new();
+    for entry in system.read_directory(root).ok()? {
+        let entry = entry.ok()?;
+        let file_type = entry.file_type();
+        let path = entry.into_path();
+        if file_type.is_file() && matches!(path.extension(), Some("py" | "pyi")) {
+            files.push(path);
+        } else if file_type.is_directory() {
+            files.extend(python_files_in_directory(system, &path)?);
+        }
+    }
+    Some(files)
+}
+
+fn file_uri_to_path(uri: &str) -> Option<SystemPathBuf> {
+    let uri = Uri::parse(uri).ok()?;
+    SystemPathBuf::from_path_buf(uri.to_file_path().ok()?).ok()
+}
+
+fn uri_is_non_python_file(uri: &str) -> bool {
+    Uri::parse(uri)
+        .ok()
+        .and_then(|uri| {
+            let path: Vec<_> = percent_decode_str(uri.path()).collect();
+            let name = path.rsplit(|byte| *byte == b'/').next()?;
+            let dot = name.iter().rposition(|byte| *byte == b'.')?;
+            let extension = &name[dot + 1..];
+            Some(extension != b"py" && extension != b"pyi")
+        })
+        .unwrap_or(false)
+}
+
+fn omit(known_omissions: &mut bool, reason: &'static str) {
+    note_omission(reason);
+    *known_omissions = true;
+}
+
+fn omit_path(known_omissions: &mut bool, reason: &'static str, path: impl std::fmt::Display) {
+    note_omission_path(reason, path);
+    *known_omissions = true;
+}
+
+fn omit_uri(known_omissions: &mut bool, reason: &'static str, uri: impl std::fmt::Display) {
+    tracing::debug!(
+        reason,
+        uri = %uri,
+        "Omitting part of `workspace/willRenameFiles`"
+    );
+    *known_omissions = true;
+}
+
+fn omit_rename(
+    known_omissions: &mut bool,
+    reason: &'static str,
+    old_path: impl std::fmt::Display,
+    new_path: impl std::fmt::Display,
+) {
+    tracing::debug!(
+        reason,
+        old_path = %old_path,
+        new_path = %new_path,
+        "Omitting part of `workspace/willRenameFiles`"
+    );
+    *known_omissions = true;
+}
+
+fn note_omission(reason: &'static str) {
+    tracing::debug!(reason, "Omitting part of `workspace/willRenameFiles`");
+}
+
+fn note_omission_path(reason: &'static str, path: impl std::fmt::Display) {
+    tracing::debug!(
+        reason,
+        path = %path,
+        "Omitting part of `workspace/willRenameFiles`"
+    );
+}

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -1137,13 +1137,20 @@ impl Session {
 
     /// Creates a snapshot of the current state of the [`Session`].
     pub(crate) fn snapshot_session(&self) -> SessionSnapshot {
+        let (project_contexts, projects) = self
+            .projects
+            .iter()
+            .map(|(root, project)| {
+                let disabled = self
+                    .workspaces
+                    .settings_for_path(root)
+                    .or_else(|| self.workspaces.settings_virtual_fallback())
+                    .is_some_and(|settings| settings.is_language_services_disabled());
+                ((root.clone(), disabled), project.db.clone())
+            })
+            .unzip();
         SessionSnapshot {
-            projects: self
-                .projects
-                .values()
-                .map(|project| &project.db)
-                .cloned()
-                .collect(),
+            projects,
             index: self.index.clone().unwrap(),
             global_settings: self.global_settings.clone(),
             position_encoding: self.position_encoding,
@@ -1151,6 +1158,7 @@ impl Session {
             resolved_client_capabilities: self.resolved_client_capabilities,
             revision: self.revision,
             client_name: self.client_name,
+            project_contexts,
         }
     }
 
@@ -1429,6 +1437,8 @@ pub(crate) struct SessionSnapshot {
     in_test: bool,
     revision: u64,
     client_name: ClientName,
+    /// Workspace roots and disabled states, in the same order as `projects`.
+    project_contexts: Vec<(SystemPathBuf, bool)>,
 
     /// IMPORTANT: It's important that the databases come last, or at least,
     /// after any `Arc` that we try to extract or mutate in-place using `Arc::into_inner`
@@ -1445,6 +1455,34 @@ pub(crate) struct SessionSnapshot {
 impl SessionSnapshot {
     pub(crate) fn projects(&self) -> &[ProjectDatabase] {
         &self.projects
+    }
+
+    /// Returns the workspace root corresponding to `project`.
+    pub(crate) fn workspace_root(&self, project: usize) -> &SystemPath {
+        &self.project_contexts[project].0
+    }
+
+    /// Returns the closest enclosing workspace, without falling back to another project.
+    pub(crate) fn enclosing_project_index(&self, path: &SystemPath) -> Option<usize> {
+        self.project_contexts
+            .iter()
+            .enumerate()
+            .filter(|(_, (root, _))| path.starts_with(root))
+            .max_by_key(|(_, (root, _))| root.as_str().len())
+            .map(|(index, _)| index)
+    }
+
+    /// Returns whether language services are disabled for the selected workspace.
+    pub(crate) fn language_services_disabled(&self, project: usize) -> bool {
+        self.project_contexts[project].1
+    }
+
+    /// Returns whether `path` contains a workspace other than `project`.
+    pub(crate) fn contains_other_workspace(&self, project: usize, path: &SystemPath) -> bool {
+        self.project_contexts
+            .iter()
+            .enumerate()
+            .any(|(index, (root, _))| index != project && root.starts_with(path))
     }
 
     pub(crate) fn index(&self) -> &Index {

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -1154,13 +1154,20 @@ impl Session {
 
     /// Creates a snapshot of the current state of the [`Session`].
     pub(crate) fn snapshot_session(&self) -> SessionSnapshot {
+        let (project_contexts, projects) = self
+            .projects
+            .iter()
+            .map(|(root, project)| {
+                let disabled = self
+                    .workspaces
+                    .settings_for_path(root)
+                    .or_else(|| self.workspaces.settings_virtual_fallback())
+                    .is_some_and(|settings| settings.is_language_services_disabled());
+                ((root.clone(), disabled), project.db.clone())
+            })
+            .unzip();
         SessionSnapshot {
-            projects: self
-                .projects
-                .values()
-                .map(|project| &project.db)
-                .cloned()
-                .collect(),
+            projects,
             index: self.index.clone().unwrap(),
             global_settings: self.global_settings.clone(),
             position_encoding: self.position_encoding,
@@ -1168,6 +1175,7 @@ impl Session {
             resolved_client_capabilities: self.resolved_client_capabilities,
             revision: self.revision,
             client_name: self.client_name,
+            project_contexts,
         }
     }
 
@@ -1446,6 +1454,8 @@ pub(crate) struct SessionSnapshot {
     in_test: bool,
     revision: u64,
     client_name: ClientName,
+    /// Workspace roots and disabled states, in the same order as `projects`.
+    project_contexts: Vec<(SystemPathBuf, bool)>,
 
     /// IMPORTANT: It's important that the databases come last, or at least,
     /// after any `Arc` that we try to extract or mutate in-place using `Arc::into_inner`
@@ -1462,6 +1472,34 @@ pub(crate) struct SessionSnapshot {
 impl SessionSnapshot {
     pub(crate) fn projects(&self) -> &[ProjectDatabase] {
         &self.projects
+    }
+
+    /// Returns the workspace root corresponding to `project`.
+    pub(crate) fn workspace_root(&self, project: usize) -> &SystemPath {
+        &self.project_contexts[project].0
+    }
+
+    /// Returns the closest enclosing workspace, without falling back to another project.
+    pub(crate) fn enclosing_project_index(&self, path: &SystemPath) -> Option<usize> {
+        self.project_contexts
+            .iter()
+            .enumerate()
+            .filter(|(_, (root, _))| path.starts_with(root))
+            .max_by_key(|(_, (root, _))| root.as_str().len())
+            .map(|(index, _)| index)
+    }
+
+    /// Returns whether language services are disabled for the selected workspace.
+    pub(crate) fn language_services_disabled(&self, project: usize) -> bool {
+        self.project_contexts[project].1
+    }
+
+    /// Returns whether `path` contains a workspace other than `project`.
+    pub(crate) fn contains_other_workspace(&self, project: usize, path: &SystemPath) -> bool {
+        self.project_contexts
+            .iter()
+            .enumerate()
+            .any(|(index, (root, _))| index != project && root.starts_with(path))
     }
 
     pub(crate) fn index(&self) -> &Index {

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -44,6 +44,7 @@ mod rename;
 mod semantic_tokens;
 mod signature_help;
 mod type_hierarchy;
+mod will_rename_files;
 mod workspace_folders;
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
@@ -78,6 +79,7 @@ use lsp_types::{
     WorkspaceDiagnosticParams, WorkspaceDiagnosticReport, WorkspaceDiagnosticRequest,
     WorkspaceEdit, WorkspaceFolder, WorkspaceFoldersChangeEvent, WorkspaceFoldersInitializeParams,
 };
+use lsp_types::{FileRename, WillRenameFilesRequest};
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf, TestSystem};
 use rustc_hash::FxHashMap;
 use tempfile::TempDir;
@@ -917,6 +919,10 @@ impl TestServer {
                 work_done_progress_params: WorkDoneProgressParams::default(),
             }),
         )
+    }
+
+    pub(crate) fn will_rename_files(&mut self, files: Vec<FileRename>) -> Option<WorkspaceEdit> {
+        self.send_request_await::<WillRenameFilesRequest>(lsp_types::RenameFilesParams { files })
     }
 
     /// Send a `textDocument/diagnostic` request for the document at the given path.

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -45,6 +45,7 @@ mod rename;
 mod semantic_tokens;
 mod signature_help;
 mod type_hierarchy;
+mod will_rename_files;
 mod workspace_folders;
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
@@ -80,6 +81,7 @@ use lsp_types::{
     WorkspaceDiagnosticParams, WorkspaceDiagnosticReport, WorkspaceDiagnosticRequest,
     WorkspaceEdit, WorkspaceFolder, WorkspaceFoldersChangeEvent, WorkspaceFoldersInitializeParams,
 };
+use lsp_types::{FileRename, WillRenameFilesRequest};
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf, SystemVirtualPath, TestSystem};
 use rustc_hash::FxHashMap;
 use tempfile::TempDir;
@@ -935,6 +937,10 @@ impl TestServer {
                 work_done_progress_params: WorkDoneProgressParams::default(),
             }),
         )
+    }
+
+    pub(crate) fn will_rename_files(&mut self, files: Vec<FileRename>) -> Option<WorkspaceEdit> {
+        self.send_request_await::<WillRenameFilesRequest>(lsp_types::RenameFilesParams { files })
     }
 
     /// Send a `textDocument/diagnostic` request for the document at the given path.

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
@@ -107,6 +107,26 @@ expression: initialization_result
       "workspaceFolders": {
         "supported": true,
         "changeNotifications": true
+      },
+      "fileOperations": {
+        "willRename": {
+          "filters": [
+            {
+              "scheme": "file",
+              "pattern": {
+                "glob": "**/*.{py,pyi}",
+                "matches": "file"
+              }
+            },
+            {
+              "scheme": "file",
+              "pattern": {
+                "glob": "**",
+                "matches": "folder"
+              }
+            }
+          ]
+        }
       }
     }
   },

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
@@ -107,6 +107,26 @@ expression: initialization_result
       "workspaceFolders": {
         "supported": true,
         "changeNotifications": true
+      },
+      "fileOperations": {
+        "willRename": {
+          "filters": [
+            {
+              "scheme": "file",
+              "pattern": {
+                "glob": "**/*.{py,pyi}",
+                "matches": "file"
+              }
+            },
+            {
+              "scheme": "file",
+              "pattern": {
+                "glob": "**",
+                "matches": "folder"
+              }
+            }
+          ]
+        }
       }
     }
   },

--- a/crates/ty_server/tests/e2e/will_rename_files.rs
+++ b/crates/ty_server/tests/e2e/will_rename_files.rs
@@ -1,0 +1,259 @@
+use std::{collections::HashMap, time::Duration};
+
+use lsp_types::{FileRename, MessageType, ShowMessageNotification, Uri, WorkspaceEdit};
+use ruff_db::system::SystemPath;
+use ty_server::ClientOptions;
+
+use crate::notebook::NotebookBuilder;
+use crate::{TestServer, TestServerBuilder};
+
+#[test]
+fn batch_includes_moved_and_open_sources() -> anyhow::Result<()> {
+    let sub = "import old_pkg\nfrom . import helper\nold_pkg.x\n";
+    let consumer = "import old\nfrom old_pkg import sub\nold.x\n";
+    let mut server = TestServerBuilder::new()?
+        .with_file("ty.toml", "[src]\nexclude = [\"old.py\", \"old_pkg/\"]\n")?
+        .with_file("old.py", "import old_pkg\nold_pkg.x\n")?
+        .with_file("old_pkg/__init__.py", "")?
+        .with_file("old_pkg/helper.py", "x = 2\n")?
+        .with_file("old_pkg/sub.py", sub)?
+        .with_file("consumer.py", consumer)?
+        .build()
+        .wait_until_workspaces_are_initialized();
+    let mut notebook = NotebookBuilder::virtual_file("consumer.ipynb");
+    let cell = notebook
+        .add_python_cell("import old_pkg.sub as old_pkg\n\ndef f():\n    print(old_pkg.x)\n");
+    notebook.open(&mut server);
+    server.collect_publish_diagnostic_notifications(1);
+
+    let edit = rename_edit(&mut server, &[("old.py", "new.py"), ("old_pkg", "new_pkg")])
+        .expect("the supported batch to produce edits");
+    assert_edits(
+        &edit,
+        &server.file_uri("consumer.py"),
+        &[
+            (0, 7, 0, 10, "new"),
+            (1, 5, 1, 12, "new_pkg"),
+            (2, 0, 2, 3, "new"),
+        ],
+    );
+    assert_edits(
+        &edit,
+        &server.file_uri("old_pkg/sub.py"),
+        &[(0, 7, 0, 14, "new_pkg"), (2, 0, 2, 7, "new_pkg")],
+    );
+    assert_edits(
+        &edit,
+        &server.file_uri("old.py"),
+        &[(0, 7, 0, 14, "new_pkg"), (1, 0, 1, 7, "new_pkg")],
+    );
+    assert_edits(&edit, &cell, &[(0, 7, 0, 18, "new_pkg.sub")]);
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(4));
+    Ok(())
+}
+
+#[test]
+fn unsupported_entries_do_not_suppress_independent_edits() -> anyhow::Result<()> {
+    let a = SystemPath::new("repo/a");
+    let b = SystemPath::new("repo/b");
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(a, None)?
+        .with_workspace(b, None)?
+        .with_file("repo/a/old.py", "x = 1\n")?
+        .with_file("repo/a/oldns/mod.py", "x = 2\n")?
+        .with_file("repo/a/notes.txt", "notes\n")?
+        .with_file("repo/a/empty/.gitkeep", "")?
+        .with_file("repo/a/use.py", "import old\nimport oldns.mod\nold.x\n")?
+        .with_file("repo/b/old.py", "x = 3\n")?
+        .with_file("repo/b/use.py", "import old\nold.x\n")?
+        .with_file("repo/outside.py", "x = 4\n")?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    let edit = rename_edit(
+        &mut server,
+        &[
+            ("repo/a/old.py", "repo/a/new.py"),
+            ("repo/a/notes.txt", "repo/a/new.txt"),
+            ("repo/a/empty", "repo/a/renamed_empty"),
+            (
+                "file://remote.example/%FFnotes%2Etxt",
+                "file://remote.example/%FFnew%2Etxt",
+            ),
+        ],
+    )
+    .expect("an unrelated rename should not affect the supported entry");
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/a/use.py"),
+        &[(0, 7, 0, 10, "new"), (2, 0, 2, 3, "new")],
+    );
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(1));
+    assert!(
+        server
+            .try_await_notification::<ShowMessageNotification>(Some(Duration::from_millis(10)))
+            .is_err()
+    );
+    let edit = rename_edit(
+        &mut server,
+        &[
+            ("repo/a/old.py", "repo/a/new.py"),
+            ("repo/a/oldns", "repo/a/newns"),
+        ],
+    )
+    .expect("the supported file rename to survive an unsupported namespace package");
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/a/use.py"),
+        &[(0, 7, 0, 10, "new"), (2, 0, 2, 3, "new")],
+    );
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(1));
+    assert!(
+        server
+            .try_await_notification::<ShowMessageNotification>(Some(Duration::from_millis(10)))
+            .is_err()
+    );
+
+    let edit = rename_edit(
+        &mut server,
+        &[
+            ("repo/a/old.py", "repo/a/new.py"),
+            ("repo/b/old.py", "repo/b/new.py"),
+        ],
+    )
+    .expect("independent workspaces to contribute edits");
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/a/use.py"),
+        &[(0, 7, 0, 10, "new"), (2, 0, 2, 3, "new")],
+    );
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/b/use.py"),
+        &[(0, 7, 0, 10, "new"), (1, 0, 1, 3, "new")],
+    );
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(2));
+
+    for unsupported in [
+        (
+            "file://remote.example/old.py",
+            "file://remote.example/new.py",
+        ),
+        ("repo/a/old.py", "file://remote.example/new.py"),
+        ("repo/outside.py", "repo/outside_new.py"),
+        ("repo/a/old.py", "repo/b/cross.py"),
+        ("repo/a/old.py", "repo/a/new.pyi"),
+    ] {
+        let edit = rename_edit(
+            &mut server,
+            &[unsupported, ("repo/b/old.py", "repo/b/new.py")],
+        )
+        .expect("the independent file rename to survive");
+        assert_edits(
+            &edit,
+            &server.file_uri("repo/b/use.py"),
+            &[(0, 7, 0, 10, "new"), (1, 0, 1, 3, "new")],
+        );
+        assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(1));
+        assert_incomplete_warning(&mut server);
+    }
+    Ok(())
+}
+
+#[test]
+fn coordinated_facets_leave_exports_unchanged() -> anyhow::Result<()> {
+    let mut server = TestServerBuilder::new()?
+        .with_file("pkg/__init__.py", "")?
+        .with_file("pkg/old.py", "class C: ...\n")?
+        .with_file("pkg/old.pyi", "class C: ...\n")?
+        .with_file(
+            "use.py",
+            "from pkg import old\n__all__ = ['old']\nprint(old.C)\n",
+        )?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    let edit = rename_edit(
+        &mut server,
+        &[("pkg/old.py", "pkg/new.py"), ("pkg/old.pyi", "pkg/new.pyi")],
+    )
+    .expect("the coordinated module rename to produce edits");
+    assert_edits(
+        &edit,
+        &server.file_uri("use.py"),
+        &[(0, 16, 0, 19, "new"), (2, 6, 2, 9, "new")],
+    );
+    assert!(
+        server
+            .try_await_notification::<ShowMessageNotification>(Some(Duration::from_millis(10)))
+            .is_err()
+    );
+    Ok(())
+}
+
+#[test]
+fn disabled_workspace_reports_an_incomplete_rename() -> anyhow::Result<()> {
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(
+            SystemPath::new("repo"),
+            Some(ClientOptions::default().with_disable_language_services(true)),
+        )?
+        .with_file("repo/old.py", "x = 1\n")?
+        .with_file("repo/old.pyi", "x: int\n")?
+        .with_file("repo/use.py", "import old\nold.x\n")?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    assert!(rename_edit(&mut server, &[("repo/old.py", "repo/new.py")]).is_none());
+    assert_incomplete_warning(&mut server);
+
+    assert!(rename_edit(&mut server, &[("repo/old.pyi", "repo/new.pyi")]).is_none());
+    assert_incomplete_warning(&mut server);
+    Ok(())
+}
+
+fn assert_incomplete_warning(server: &mut TestServer) {
+    let warning = server.await_notification::<ShowMessageNotification>();
+    assert_eq!(warning.kind, MessageType::Warning);
+    assert_eq!(
+        warning.message,
+        "ty could not safely update all affected Python code. Some imports, references, or exports may remain unchanged after this file operation."
+    );
+}
+
+fn rename_edit(server: &mut TestServer, renames: &[(&str, &str)]) -> Option<WorkspaceEdit> {
+    let files = renames
+        .iter()
+        .map(|(old, new)| FileRename::new(rename_uri(server, old), rename_uri(server, new)))
+        .collect();
+    server.will_rename_files(files)
+}
+
+fn rename_uri(server: &TestServer, path: &str) -> Uri {
+    if path.contains("://") {
+        Uri::parse(path).expect("test rename URI to be valid")
+    } else {
+        server.file_uri(path)
+    }
+}
+
+fn assert_edits(edit: &WorkspaceEdit, uri: &Uri, expected: &[(u32, u32, u32, u32, &str)]) {
+    let edits = edit
+        .changes
+        .as_ref()
+        .and_then(|changes| changes.get(uri))
+        .expect("workspace edit to contain edits for the URI");
+    let actual: Vec<_> = edits
+        .iter()
+        .map(|edit| {
+            (
+                edit.range.start.line,
+                edit.range.start.character,
+                edit.range.end.line,
+                edit.range.end.character,
+                edit.new_text.as_str(),
+            )
+        })
+        .collect();
+    assert_eq!(actual, expected);
+}

--- a/crates/ty_server/tests/e2e/will_rename_files.rs
+++ b/crates/ty_server/tests/e2e/will_rename_files.rs
@@ -1,0 +1,197 @@
+use std::{collections::HashMap, time::Duration};
+
+use lsp_types::{FileRename, MessageType, ShowMessageNotification, Uri, WorkspaceEdit};
+use ruff_db::system::SystemPath;
+
+use crate::notebook::NotebookBuilder;
+use crate::{TestServer, TestServerBuilder};
+
+#[test]
+fn batch_includes_moved_and_open_sources() -> anyhow::Result<()> {
+    let sub = "import old_pkg\nfrom . import helper\nold_pkg.x\n";
+    let consumer = "import old\nfrom old_pkg import sub\nold.x\n";
+    let mut server = TestServerBuilder::new()?
+        .with_file("ty.toml", "[src]\nexclude = [\"old_pkg/\"]\n")?
+        .with_file("old.py", "x = 1\n")?
+        .with_file("old_pkg/__init__.py", "")?
+        .with_file("old_pkg/helper.py", "x = 2\n")?
+        .with_file("old_pkg/sub.py", sub)?
+        .with_file("consumer.py", consumer)?
+        .build()
+        .wait_until_workspaces_are_initialized();
+    let mut notebook = NotebookBuilder::virtual_file("consumer.ipynb");
+    let cell = notebook
+        .add_python_cell("import old_pkg.sub as old_pkg\n\ndef f():\n    print(old_pkg.x)\n");
+    notebook.open(&mut server);
+    server.collect_publish_diagnostic_notifications(1);
+
+    let edit = rename_edit(&mut server, &[("old.py", "new.py"), ("old_pkg", "new_pkg")])
+        .expect("the supported batch to produce edits");
+    assert_edits(
+        &edit,
+        &server.file_uri("consumer.py"),
+        &[
+            (0, 7, 0, 10, "new"),
+            (1, 5, 1, 12, "new_pkg"),
+            (2, 0, 2, 3, "new"),
+        ],
+    );
+    assert_edits(
+        &edit,
+        &server.file_uri("old_pkg/sub.py"),
+        &[(0, 7, 0, 14, "new_pkg"), (2, 0, 2, 7, "new_pkg")],
+    );
+    assert_edits(&edit, &cell, &[(0, 7, 0, 18, "new_pkg.sub")]);
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(3));
+    Ok(())
+}
+
+#[test]
+fn unsupported_entries_do_not_suppress_independent_edits() -> anyhow::Result<()> {
+    let a = SystemPath::new("repo/a");
+    let b = SystemPath::new("repo/b");
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(a, None)?
+        .with_workspace(b, None)?
+        .with_file("repo/a/old.py", "x = 1\n")?
+        .with_file("repo/a/oldns/mod.py", "x = 2\n")?
+        .with_file("repo/a/notes.txt", "notes\n")?
+        .with_file("repo/a/empty/.gitkeep", "")?
+        .with_file("repo/a/use.py", "import old\nimport oldns.mod\nold.x\n")?
+        .with_file("repo/b/old.py", "x = 3\n")?
+        .with_file("repo/b/use.py", "import old\nold.x\n")?
+        .with_file("repo/outside.py", "x = 4\n")?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    let edit = rename_edit(
+        &mut server,
+        &[
+            ("repo/a/old.py", "repo/a/new.py"),
+            ("repo/a/notes.txt", "repo/a/new.txt"),
+            ("repo/a/empty", "repo/a/renamed_empty"),
+            (
+                "file://remote.example/%FFnotes%2Etxt",
+                "file://remote.example/%FFnew%2Etxt",
+            ),
+        ],
+    )
+    .expect("an unrelated rename should not affect the supported entry");
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/a/use.py"),
+        &[(0, 7, 0, 10, "new"), (2, 0, 2, 3, "new")],
+    );
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(1));
+    assert!(
+        server
+            .try_await_notification::<ShowMessageNotification>(Some(Duration::from_millis(10)))
+            .is_err()
+    );
+    let edit = rename_edit(
+        &mut server,
+        &[
+            ("repo/a/old.py", "repo/a/new.py"),
+            ("repo/a/oldns", "repo/a/newns"),
+        ],
+    )
+    .expect("the supported file rename to survive an unsupported namespace package");
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/a/use.py"),
+        &[(0, 7, 0, 10, "new"), (2, 0, 2, 3, "new")],
+    );
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(1));
+    assert_incomplete_warning(&mut server);
+
+    let edit = rename_edit(
+        &mut server,
+        &[
+            ("repo/a/old.py", "repo/a/new.py"),
+            ("repo/b/old.py", "repo/b/new.py"),
+        ],
+    )
+    .expect("independent workspaces to contribute edits");
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/a/use.py"),
+        &[(0, 7, 0, 10, "new"), (2, 0, 2, 3, "new")],
+    );
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/b/use.py"),
+        &[(0, 7, 0, 10, "new"), (1, 0, 1, 3, "new")],
+    );
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(2));
+
+    for unsupported in [
+        (
+            "file://remote.example/old.py",
+            "file://remote.example/new.py",
+        ),
+        ("repo/a/old.py", "file://remote.example/new.py"),
+        ("repo/outside.py", "repo/outside_new.py"),
+        ("repo/a/old.py", "repo/b/cross.py"),
+        ("repo/a/old.py", "repo/a/new.pyi"),
+    ] {
+        let edit = rename_edit(
+            &mut server,
+            &[unsupported, ("repo/b/old.py", "repo/b/new.py")],
+        )
+        .expect("the independent file rename to survive");
+        assert_edits(
+            &edit,
+            &server.file_uri("repo/b/use.py"),
+            &[(0, 7, 0, 10, "new"), (1, 0, 1, 3, "new")],
+        );
+        assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(1));
+        assert_incomplete_warning(&mut server);
+    }
+    Ok(())
+}
+
+fn assert_incomplete_warning(server: &mut TestServer) {
+    let warning = server.await_notification::<ShowMessageNotification>();
+    assert_eq!(warning.kind, MessageType::Warning);
+    assert_eq!(
+        warning.message,
+        "ty could not safely update every affected Python import or module reference. Some references may remain unchanged after this file operation."
+    );
+}
+
+fn rename_edit(server: &mut TestServer, renames: &[(&str, &str)]) -> Option<WorkspaceEdit> {
+    let files = renames
+        .iter()
+        .map(|(old, new)| FileRename::new(rename_uri(server, old), rename_uri(server, new)))
+        .collect();
+    server.will_rename_files(files)
+}
+
+fn rename_uri(server: &TestServer, path: &str) -> String {
+    if path.contains("://") {
+        path.to_string()
+    } else {
+        server.file_uri(path).to_string()
+    }
+}
+
+fn assert_edits(edit: &WorkspaceEdit, uri: &Uri, expected: &[(u32, u32, u32, u32, &str)]) {
+    let edits = edit
+        .changes
+        .as_ref()
+        .and_then(|changes| changes.get(uri))
+        .expect("workspace edit to contain edits for the URI");
+    let actual: Vec<_> = edits
+        .iter()
+        .map(|edit| {
+            (
+                edit.range.start.line,
+                edit.range.start.character,
+                edit.range.end.line,
+                edit.range.end.character,
+                edit.new_text.as_str(),
+            )
+        })
+        .collect();
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This exposes the edit computation from the [preceding PR](https://github.com/astral-sh/ruff/pull/26467) through the LSP `workspace/willRenameFiles` request. Clients are told that ty supports renaming Python files and folders; before the filesystem operation occurs, ty can return a workspace edit that updates affected imports and module references.

The request handler first filters unrelated non-Python entries, then requires every relevant rename in a batch to belong to one workspace. It considers indexed files, open virtual files such as notebook cells, directly renamed sources, and physical Python files beneath a renamed folder, including files excluded from normal project indexing. This ensures that both consumers and moved sources participate in the same edit.

The server preserves the core implementation's all-or-nothing contract across workspace boundaries. Cross-workspace moves, folders containing another workspace, extension-changing Python renames, unreadable moved directories, and failures while converting source edits to LSP locations cause ty to decline the complete relevant batch rather than return partial edits. Each decline records a debug reason.

Returning no workspace edit does not prevent the client from performing the requested filesystem rename. It means only that ty could not provide a complete and safe set of accompanying text edits.

## Test Plan

<!-- How was it tested? -->
