### PR TITLE
[ty] Optimize union and intersection type expressions

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -105,13 +105,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     }
 
     /// Report a runtime error for an invalid PEP 604 union operation.
-    fn report_pep_604_runtime_error(&mut self, binary: &ast::ExprBinOp) {
-        let mut speculative_builder = self.speculate_without_diagnostics();
-        let left_type_value =
-            speculative_builder.infer_expression(&binary.left, TypeContext::default());
-        let right_type_value =
-            speculative_builder.infer_expression(&binary.right, TypeContext::default());
-
+    fn report_pep_604_runtime_error(
+        &self,
+        binary: &ast::ExprBinOp,
+        left_type_value: Type<'db>,
+        right_type_value: Type<'db>,
+    ) {
         let dunder_fails = Type::try_call_bin_op(
             self.db(),
             left_type_value,
@@ -211,13 +210,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
     }
 
-    fn report_intersection_runtime_error(&mut self, binary: &ast::ExprBinOp) {
-        // Infer the operands as values so that the diagnostic reports their runtime types rather
-        // than their interpretation as type expressions.
-        let mut speculative_builder = self.speculate_without_diagnostics();
-        let left_value = speculative_builder.infer_expression(&binary.left, TypeContext::default());
-        let right_value =
-            speculative_builder.infer_expression(&binary.right, TypeContext::default());
+    fn report_intersection_runtime_error(
+        &self,
+        binary: &ast::ExprBinOp,
+        left_value: Type<'db>,
+        right_value: Type<'db>,
+    ) {
         if Type::try_call_bin_op(self.db(), left_value, ast::Operator::BitAnd, right_value).is_err()
         {
             report_unsupported_binary_operation(
@@ -228,6 +226,46 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ast::Operator::BitAnd,
             );
         }
+    }
+
+    fn infer_runtime_binary_expression(
+        &self,
+        builder: &mut Self,
+        left_value: &mut Option<Type<'db>>,
+        leftmost: &ast::Expr,
+        expression: &ast::Expr,
+        binary: &ast::ExprBinOp,
+    ) {
+        let left_value = left_value
+            .get_or_insert_with(|| builder.infer_expression(leftmost, TypeContext::default()));
+        let right_value = builder.infer_expression(&binary.right, TypeContext::default());
+
+        match binary.op {
+            ast::Operator::BitOr => {
+                self.report_pep_604_runtime_error(binary, *left_value, right_value);
+            }
+            ast::Operator::BitAnd => {
+                self.report_intersection_runtime_error(binary, *left_value, right_value);
+            }
+            _ => {}
+        }
+
+        // Preserve the TypedDict-aware inference used for PEP 584 dictionary unions.
+        *left_value = if binary.op == ast::Operator::BitOr
+            && (binary.left.is_dict_expr() || binary.right.is_dict_expr())
+        {
+            builder.infer_expression(expression, TypeContext::default())
+        } else {
+            builder
+                .infer_binary_expression_type(
+                    binary.into(),
+                    false,
+                    *left_value,
+                    right_value,
+                    binary.op,
+                )
+                .unwrap_or(Type::unknown())
+        };
     }
 
     pub(super) fn infer_name_or_attribute_type_expression(
@@ -355,6 +393,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             left = &left_binary.left;
                         }
 
+                        let mut runtime = (!ignore_runtime_errors(self, expression))
+                            .then(|| (self.speculate_without_diagnostics(), None));
+
                         let left_ty = self.infer_type_expression(left);
                         let mut union = UnionBuilder::new(self.db())
                             .unpack_aliases(false)
@@ -366,8 +407,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 .inference_flags
                                 .replace(InferenceFlags::IN_NESTED_TYPE_EXPRESSION, true);
                             let right_ty = self.infer_type_expression(&nested_binary.right);
-                            if !ignore_runtime_errors(self, union_expression) {
-                                self.report_pep_604_runtime_error(nested_binary);
+                            if let Some((runtime_builder, left_value)) = &mut runtime {
+                                self.infer_runtime_binary_expression(
+                                    runtime_builder,
+                                    left_value,
+                                    left,
+                                    union_expression,
+                                    nested_binary,
+                                );
                             }
                             union.add_in_place(right_ty);
                             let prefix_ty = union.clone().build();
@@ -378,8 +425,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         }
 
                         let right_ty = self.infer_type_expression(&binary.right);
-                        if !ignore_runtime_errors(self, expression) {
-                            self.report_pep_604_runtime_error(binary);
+                        if let Some((runtime_builder, left_value)) = &mut runtime {
+                            self.infer_runtime_binary_expression(
+                                runtime_builder,
+                                left_value,
+                                left,
+                                expression,
+                                binary,
+                            );
                         }
                         union.add_in_place(right_ty);
                         union.build()
@@ -398,6 +451,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             left = &left_binary.left;
                         }
 
+                        let mut runtime = (!ignore_runtime_errors(self, expression))
+                            .then(|| (self.speculate_without_diagnostics(), None));
+
                         let left_ty = self.infer_type_expression(left);
                         let mut intersection =
                             IntersectionBuilder::new(self.db()).add_positive(left_ty);
@@ -410,8 +466,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 .inference_flags
                                 .replace(InferenceFlags::IN_NESTED_TYPE_EXPRESSION, true);
                             let right_ty = self.infer_type_expression(&nested_binary.right);
-                            if !ignore_runtime_errors(self, intersection_expression) {
-                                self.report_intersection_runtime_error(nested_binary);
+                            if let Some((runtime_builder, left_value)) = &mut runtime {
+                                self.infer_runtime_binary_expression(
+                                    runtime_builder,
+                                    left_value,
+                                    left,
+                                    intersection_expression,
+                                    nested_binary,
+                                );
                             }
                             intersection = intersection.add_positive(right_ty);
                             let prefix_ty = intersection.clone().build();
@@ -422,8 +484,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         }
 
                         let right_ty = self.infer_type_expression(&binary.right);
-                        if !ignore_runtime_errors(self, expression) {
-                            self.report_intersection_runtime_error(binary);
+                        if let Some((runtime_builder, left_value)) = &mut runtime {
+                            self.infer_runtime_binary_expression(
+                                runtime_builder,
+                                left_value,
+                                left,
+                                expression,
+                                binary,
+                            );
                         }
                         intersection.add_positive(right_ty).build()
                     }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2,6 +2,7 @@ use itertools::Either;
 use ruff_python_ast::helpers::is_dotted_name;
 use ruff_python_ast::{self as ast, PythonVersion};
 use ruff_text_size::Ranged;
+use smallvec::SmallVec;
 
 use super::{DeferredExpressionState, TypeInferenceBuilder};
 use crate::types::call::CallArguments;
@@ -20,11 +21,10 @@ use crate::types::tuple::{TupleSpecBuilder, TupleType};
 use ty_python_core::scope::ScopeKind;
 
 use crate::types::{
-    BindingContext, CallableType, DynamicType, GenericContext, IntersectionBuilder,
-    IntersectionType, KnownClass, KnownInstanceType, LintDiagnosticGuard, LiteralValueTypeKind,
-    Parameter, Parameters, SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeContext,
-    TypeFormType, TypeGuardType, TypeIsType, TypeMapping, TypeVarKind, UnionBuilder, UnionType,
-    any_over_type, todo_type,
+    BindingContext, CallableType, DynamicType, GenericContext, IntersectionBuilder, KnownClass,
+    KnownInstanceType, LintDiagnosticGuard, LiteralValueTypeKind, Parameter, Parameters,
+    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeContext, TypeFormType, TypeGuardType,
+    TypeIsType, TypeMapping, TypeVarKind, UnionBuilder, UnionType, any_over_type, todo_type,
 };
 use crate::{FxOrderSet, Program, add_inferred_python_version_hint_to_diagnostic};
 
@@ -104,6 +104,132 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             })
     }
 
+    /// Report a runtime error for an invalid PEP 604 union operation.
+    fn report_pep_604_runtime_error(&mut self, binary: &ast::ExprBinOp) {
+        let mut speculative_builder = self.speculate_without_diagnostics();
+        let left_type_value =
+            speculative_builder.infer_expression(&binary.left, TypeContext::default());
+        let right_type_value =
+            speculative_builder.infer_expression(&binary.right, TypeContext::default());
+
+        let dunder_fails = Type::try_call_bin_op(
+            self.db(),
+            left_type_value,
+            ast::Operator::BitOr,
+            right_type_value,
+        )
+        .is_err();
+
+        // As well as trying the normal dunder lookup, check for a class-literal or generic-alias
+        // operand paired with a string literal. Typeshed annotates `type.__(r)or__` as accepting
+        // `Any`, so the normal lookup does not catch this case.
+        let should_emit_error = dunder_fails
+            || match (left_type_value, right_type_value) {
+                (Type::ClassLiteral(class), Type::LiteralValue(literal))
+                | (Type::LiteralValue(literal), Type::ClassLiteral(class))
+                    if class.metaclass(self.db())
+                        == KnownClass::Type.to_class_literal(self.db()) =>
+                {
+                    !literal.is_enum()
+                }
+                (Type::GenericAlias(_), Type::LiteralValue(literal))
+                | (Type::LiteralValue(literal), Type::GenericAlias(_)) => !literal.is_enum(),
+                _ => false,
+            };
+
+        if !should_emit_error {
+            return;
+        }
+        let Some(builder) = self.context.report_lint(&UNSUPPORTED_OPERATOR, binary) else {
+            return;
+        };
+        let mut diagnostic = builder.into_diagnostic("Unsupported `|` operation");
+
+        if left_type_value.is_equivalent_to(self.db(), right_type_value) {
+            diagnostic.set_primary_message(format_args!(
+                "Both operands have type `{}`",
+                left_type_value.display(self.db())
+            ));
+            diagnostic.set_concise_message(format_args!(
+                "Operator `|` is unsupported between two objects of type `{}`",
+                left_type_value.display(self.db())
+            ));
+        } else {
+            for (operand, ty) in [
+                (&*binary.left, left_type_value),
+                (&*binary.right, right_type_value),
+            ] {
+                diagnostic.annotate(
+                    self.context
+                        .secondary(operand)
+                        .message(format_args!("Has type `{}`", ty.display(self.db()))),
+                );
+            }
+            diagnostic.set_concise_message(format_args!(
+                "Operator `|` is unsupported between objects of type `{}` and `{}`",
+                left_type_value.display(self.db()),
+                right_type_value.display(self.db())
+            ));
+        }
+
+        match self.scope.scope(self.db()).kind() {
+            ScopeKind::TypeAlias => diagnostic.info(
+                "A type alias scope is lazy but will be executed at runtime if the `__value__` \
+                 property is accessed",
+            ),
+            ScopeKind::TypeParams => diagnostic.info(
+                "Type parameter scopes are lazy but may be executed at runtime if the `__bound__`, \
+                 `__value__` or `__constraints__` property of a type parameter is accessed",
+            ),
+            _ => {
+                let python_version = Program::get(self.db()).python_version(self.db());
+
+                if python_version < PythonVersion::PY314 {
+                    diagnostic.info(format_args!(
+                        "All {}s are evaluated at runtime by default on Python <3.14",
+                        self.type_expression_context()
+                    ));
+                    add_inferred_python_version_hint_to_diagnostic(
+                        self.db(),
+                        &mut diagnostic,
+                        "inferring types",
+                    );
+                    if binary.left.is_string_literal_expr() || binary.right.is_string_literal_expr()
+                    {
+                        diagnostic.help(
+                            "Put quotes around the whole union rather than just certain elements",
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn report_experimental_intersection_syntax(&self, binary: &ast::ExprBinOp) {
+        if let Some(builder) = self.context.report_lint(&EXPERIMENTAL_SYNTAX, binary) {
+            builder.into_diagnostic("Intersection type syntax is experimental");
+        }
+    }
+
+    fn report_intersection_runtime_error(&mut self, binary: &ast::ExprBinOp) {
+        // Infer the operands as values so that the diagnostic reports their runtime types rather
+        // than their interpretation as type expressions.
+        let mut speculative_builder = self.speculate_without_diagnostics();
+        let left_value = speculative_builder.infer_expression(&binary.left, TypeContext::default());
+        let right_value =
+            speculative_builder.infer_expression(&binary.right, TypeContext::default());
+        if Type::try_call_bin_op(self.db(), left_value, ast::Operator::BitAnd, right_value).is_err()
+        {
+            report_unsupported_binary_operation(
+                &self.context,
+                binary,
+                left_value,
+                right_value,
+                ast::Operator::BitAnd,
+            );
+        }
+    }
+
     pub(super) fn infer_name_or_attribute_type_expression(
         &self,
         ty: Type<'db>,
@@ -132,7 +258,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
     /// Infer the type of a type expression without storing the result.
     pub(super) fn infer_type_expression_no_store(&mut self, expression: &ast::Expr) -> Type<'db> {
-        let ignore_runtime_errors = |builder: &Self| {
+        let ignore_runtime_errors = |builder: &Self, expression: &ast::Expr| {
             builder.deferred_state.is_deferred()
                 || builder.in_stub()
                 || builder.is_in_type_checking_block(builder.scope(), expression)
@@ -219,171 +345,87 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 match binary.op {
                     // PEP-604 unions are okay, e.g., `int | str`
                     ast::Operator::BitOr => {
-                        let left_ty = self.infer_type_expression(&binary.left);
-                        let right_ty = self.infer_type_expression(&binary.right);
-
-                        // Detect runtime errors from e.g. `int | "bytes"` on Python <3.14 without `__future__` annotations.
-                        if !ignore_runtime_errors(self) {
-                            let mut speculative_builder = self.speculate_without_diagnostics();
-                            // If the left-hand side of the union is itself a PEP-604 union,
-                            // we'll already have checked whether it can be used with `|` in a previous inference step
-                            // and emitted a diagnostic if it was appropriate. We should skip inferring it here to
-                            // avoid duplicate diagnostics; just assume that the l.h.s. is a `UnionType` instance
-                            // in that case.
-                            let left_type_value = speculative_builder
-                                .infer_expression(&binary.left, TypeContext::default());
-                            let right_type_value = speculative_builder
-                                .infer_expression(&binary.right, TypeContext::default());
-
-                            let dunder_fails = Type::try_call_bin_op(
-                                self.db(),
-                                left_type_value,
-                                ast::Operator::BitOr,
-                                right_type_value,
-                            )
-                            .is_err();
-
-                            // As well as trying the normal dunder lookup,
-                            // we also check for the case where one of the operands is a class-literal type
-                            // or generic-alias type and the other is a string literal. The normal dunder lookup
-                            // fails to catch this error, since typeshed annotates `type.__(r)or__` as accepting `Any`.
-                            let should_emit_error = if dunder_fails {
-                                true
-                            } else {
-                                let literal = match (left_type_value, right_type_value) {
-                                    (Type::ClassLiteral(class), Type::LiteralValue(literal))
-                                    | (Type::LiteralValue(literal), Type::ClassLiteral(class))
-                                        if class.metaclass(self.db())
-                                            == KnownClass::Type.to_class_literal(self.db()) =>
-                                    {
-                                        Some(literal)
-                                    }
-                                    (Type::GenericAlias(_), Type::LiteralValue(literal))
-                                    | (Type::LiteralValue(literal), Type::GenericAlias(_)) => {
-                                        Some(literal)
-                                    }
-                                    _ => None,
-                                };
-                                literal.is_some_and(|literal| !literal.is_enum())
-                            };
-
-                            if should_emit_error
-                                && let Some(builder) =
-                                    self.context.report_lint(&UNSUPPORTED_OPERATOR, binary)
-                            {
-                                let mut diagnostic =
-                                    builder.into_diagnostic("Unsupported `|` operation");
-
-                                if left_type_value.is_equivalent_to(self.db(), right_type_value) {
-                                    diagnostic.set_primary_message(format_args!(
-                                        "Both operands have type `{}`",
-                                        left_type_value.display(self.db())
-                                    ));
-                                    diagnostic.set_concise_message(format_args!(
-                                        "Operator `|` is unsupported between \
-                                        two objects of type `{}`",
-                                        left_type_value.display(self.db())
-                                    ));
-                                } else {
-                                    for (operand, ty) in [
-                                        (&*binary.left, left_type_value),
-                                        (&*binary.right, right_type_value),
-                                    ] {
-                                        diagnostic.annotate(
-                                            self.context.secondary(operand).message(format_args!(
-                                                "Has type `{}`",
-                                                ty.display(self.db())
-                                            )),
-                                        );
-                                    }
-                                    diagnostic.set_concise_message(format_args!(
-                                        "Operator `|` is unsupported between \
-                                        objects of type `{}` and `{}`",
-                                        left_type_value.display(self.db()),
-                                        right_type_value.display(self.db())
-                                    ));
-                                }
-
-                                match self.scope.scope(self.db()).kind() {
-                                    ScopeKind::TypeAlias => diagnostic.info(
-                                        "A type alias scope is lazy but will be \
-                                        executed at runtime if the `__value__` property is \
-                                        accessed",
-                                    ),
-                                    ScopeKind::TypeParams => diagnostic.info(
-                                        "Type parameter scopes are lazy but may be \
-                                        executed at runtime if the `__bound__`, `__value__`
-                                        or `__constraints__` property of a type parameter is \
-                                        accessed",
-                                    ),
-                                    _ => {
-                                        let python_version =
-                                            Program::get(self.db()).python_version(self.db());
-
-                                        if python_version < PythonVersion::PY314 {
-                                            diagnostic.info(format_args!(
-                                                "All {}s are evaluated at \
-                                                runtime by default on Python <3.14",
-                                                self.type_expression_context()
-                                            ));
-                                            add_inferred_python_version_hint_to_diagnostic(
-                                                self.db(),
-                                                &mut diagnostic,
-                                                "inferring types",
-                                            );
-                                            if binary.left.is_string_literal_expr()
-                                                || binary.right.is_string_literal_expr()
-                                            {
-                                                diagnostic.help(
-                                                    "Put quotes around the whole union \
-                                                    rather than just certain elements",
-                                                );
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                        let mut nested_unions: SmallVec<[(&ast::Expr, &ast::ExprBinOp); 2]> =
+                            SmallVec::new();
+                        let mut left = &*binary.left;
+                        while let ast::Expr::BinOp(left_binary) = left
+                            && left_binary.op == ast::Operator::BitOr
+                        {
+                            nested_unions.push((left, left_binary));
+                            left = &left_binary.left;
                         }
 
-                        UnionType::from_elements_leave_aliases(self.db(), [left_ty, right_ty])
+                        let left_ty = self.infer_type_expression(left);
+                        let mut union = UnionBuilder::new(self.db())
+                            .unpack_aliases(false)
+                            .add(left_ty);
+
+                        for (union_expression, nested_binary) in nested_unions.into_iter().rev() {
+                            let previously_nested = self
+                                .context
+                                .inference_flags
+                                .replace(InferenceFlags::IN_NESTED_TYPE_EXPRESSION, true);
+                            let right_ty = self.infer_type_expression(&nested_binary.right);
+                            if !ignore_runtime_errors(self, union_expression) {
+                                self.report_pep_604_runtime_error(nested_binary);
+                            }
+                            union.add_in_place(right_ty);
+                            let prefix_ty = union.clone().build();
+                            self.store_expression_type(union_expression, prefix_ty);
+                            self.context
+                                .inference_flags
+                                .set(InferenceFlags::IN_NESTED_TYPE_EXPRESSION, previously_nested);
+                        }
+
+                        let right_ty = self.infer_type_expression(&binary.right);
+                        if !ignore_runtime_errors(self, expression) {
+                            self.report_pep_604_runtime_error(binary);
+                        }
+                        union.add_in_place(right_ty);
+                        union.build()
                     }
                     ast::Operator::BitAnd => {
-                        if let Some(builder) =
-                            self.context.report_lint(&EXPERIMENTAL_SYNTAX, binary)
+                        self.report_experimental_intersection_syntax(binary);
+
+                        let mut nested_intersections: SmallVec<[(&ast::Expr, &ast::ExprBinOp); 2]> =
+                            SmallVec::new();
+                        let mut left = &*binary.left;
+                        while let ast::Expr::BinOp(left_binary) = left
+                            && left_binary.op == ast::Operator::BitAnd
                         {
-                            builder.into_diagnostic("Intersection type syntax is experimental");
+                            self.report_experimental_intersection_syntax(left_binary);
+                            nested_intersections.push((left, left_binary));
+                            left = &left_binary.left;
                         }
 
-                        let left_ty = self.infer_type_expression(&binary.left);
-                        let right_ty = self.infer_type_expression(&binary.right);
+                        let left_ty = self.infer_type_expression(left);
+                        let mut intersection =
+                            IntersectionBuilder::new(self.db()).add_positive(left_ty);
 
-                        if !ignore_runtime_errors(self) {
-                            // Infer the operands as values to report the types used by the runtime
-                            // operation rather than their interpretation as type expressions.
-                            let mut speculative_builder = self.speculate_without_diagnostics();
-                            let left_value = speculative_builder
-                                .infer_expression(&binary.left, TypeContext::default());
-                            let right_value = speculative_builder
-                                .infer_expression(&binary.right, TypeContext::default());
-                            if Type::try_call_bin_op(
-                                self.db(),
-                                left_value,
-                                ast::Operator::BitAnd,
-                                right_value,
-                            )
-                            .is_err()
-                            {
-                                report_unsupported_binary_operation(
-                                    &self.context,
-                                    binary,
-                                    left_value,
-                                    right_value,
-                                    ast::Operator::BitAnd,
-                                );
+                        for (intersection_expression, nested_binary) in
+                            nested_intersections.into_iter().rev()
+                        {
+                            let previously_nested = self
+                                .context
+                                .inference_flags
+                                .replace(InferenceFlags::IN_NESTED_TYPE_EXPRESSION, true);
+                            let right_ty = self.infer_type_expression(&nested_binary.right);
+                            if !ignore_runtime_errors(self, intersection_expression) {
+                                self.report_intersection_runtime_error(nested_binary);
                             }
+                            intersection = intersection.add_positive(right_ty);
+                            let prefix_ty = intersection.clone().build();
+                            self.store_expression_type(intersection_expression, prefix_ty);
+                            self.context
+                                .inference_flags
+                                .set(InferenceFlags::IN_NESTED_TYPE_EXPRESSION, previously_nested);
                         }
 
-                        IntersectionType::from_two_elements(self.db(), left_ty, right_ty)
+                        let right_ty = self.infer_type_expression(&binary.right);
+                        if !ignore_runtime_errors(self, expression) {
+                            self.report_intersection_runtime_error(binary);
+                        }
+                        intersection.add_positive(right_ty).build()
                     }
                     // anything else is an invalid annotation:
                     op => {
@@ -605,7 +647,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 let operand_ty = self.infer_type_expression(operand);
 
-                if !ignore_runtime_errors(self) {
+                if !ignore_runtime_errors(self, expression) {
                     let operand_value = self
                         .speculate_without_diagnostics()
                         .infer_expression(operand, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -346,7 +346,7 @@ impl<'db> Type<'db> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum UnionElement<'db> {
     Type(Type<'db>),
     // A map from integer literals to their promotability.
@@ -529,6 +529,7 @@ const MAX_RECURSIVE_UNION_LITERALS: usize = 5;
 /// Huge enums and string literal sets are not uncommon (especially in generated code), and it's annoying
 /// if reachability analysis etc. fails when analysing these enums.
 const MAX_NON_RECURSIVE_UNION_LITERALS: usize = 8192;
+#[derive(Clone)]
 pub(crate) struct UnionBuilder<'db> {
     elements: Vec<UnionElement<'db>>,
     db: &'db dyn Db,


### PR DESCRIPTION
## Summary

Flatten left-associated union and intersection type expressions in the visitor and build both their semantic and runtime-diagnostic values incrementally. This infers each operand once instead of re-inferring every left prefix, reducing worst-case construction from cubic to quadratic while preserving source-order visitation and stored intermediate types.

In a local single-threaded Callgrind comparison against the previous PR revision, checking Pydantic's `core_schema.py` dropped from 857,292,437 to 804,567,680 instructions (6.15%). A 100-element synthetic intersection remains 2.5x faster.

## Test Plan

Testing: Passed all 716 ty semantic tests, workspace Clippy, changed-file hooks, a full 162-project ecosystem comparison (all 161 stable projects identical; `steam.py` confirmed flaky with same-binary controls), and targeted Pydantic Callgrind and wall-time measurements.
