### PR TITLE
[ty] Relaxed `isinstance`/`issubclass` narrowing using gradual intersections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4886,6 +4886,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.18",
  "tracing",
+ "ty_combine",
  "ty_module_resolver",
  "ty_python_core",
  "ty_site_packages",

--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -110,7 +110,7 @@ static ALTAIR: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    3,
+    7,
 );
 
 static COLOUR_SCIENCE: Benchmark = Benchmark::new(

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -83,6 +83,44 @@ any module where the first component contains the substring `test`, use `*test*.
 
 ---
 
+### `generic-narrowing`
+
+Controls how ty narrows to unspecialized generic classes in `isinstance()` and
+`issubclass()` checks.
+
+With `strict`, ty narrows to the top materialization of the class. For example,
+`isinstance(value, list)` narrows a value of type  `object` to `Top[list[Unknown]]`,
+representing the (infinite) union of all possible `list` specializations. Iterating
+over the list would yield values of type `object`.
+
+With `relaxed`, ty narrows to the class's Unknown-specialization instead. The same
+check would narrow a value of type `object` to `list[Unknown]`. Iterating over the list
+would yield values of type `Unknown`, which is more permissive than `object`.
+
+Defaults to `relaxed`.
+
+**Default value**: `relaxed`
+
+**Type**: `strict | relaxed`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.analysis]
+    generic-narrowing = "strict"
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [analysis]
+    generic-narrowing = "strict"
+    ```
+
+---
+
 ### `replace-imports-with-any`
 
 A list of module glob patterns whose imports should be replaced with `typing.Any`.
@@ -573,6 +611,44 @@ any module where the first component contains the substring `test`, use `*test*.
     [overrides.analysis]
     # Suppress errors for all `test` modules except `test.foo`
     allowed-unresolved-imports = ["test.**", "!test.foo"]
+    ```
+
+---
+
+#### `generic-narrowing`
+
+Controls how ty narrows to unspecialized generic classes in `isinstance()` and
+`issubclass()` checks.
+
+With `strict`, ty narrows to the top materialization of the class. For example,
+`isinstance(value, list)` narrows a value of type  `object` to `Top[list[Unknown]]`,
+representing the (infinite) union of all possible `list` specializations. Iterating
+over the list would yield values of type `object`.
+
+With `relaxed`, ty narrows to the class's Unknown-specialization instead. The same
+check would narrow a value of type `object` to `list[Unknown]`. Iterating over the list
+would yield values of type `Unknown`, which is more permissive than `object`.
+
+Defaults to `relaxed`.
+
+**Default value**: `relaxed`
+
+**Type**: `strict | relaxed`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.overrides.analysis]
+    generic-narrowing = "strict"
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [overrides.analysis]
+    generic-narrowing = "strict"
     ```
 
 ---

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -7120,20 +7120,24 @@ Source with applied edits:
     }
 
     #[test]
-    fn hover_narrowed_type_with_top_materialization() {
+    fn hover_type_with_top_materialization() {
         let mut test = inlay_hint_test(
             r#"
-                def f(xyxy: object):
-                    if isinstance(xyxy, list):
-                        x = xyxy
+                from typing import Any
+                from ty_extensions import Top
+
+                def f(xyxy: Top[list[Any]]):
+                    x = xyxy
                 "#,
         );
 
         assert_snapshot!(test.inlay_hints(), @"
 
-        def f(xyxy: object):
-            if isinstance(xyxy, list):
-                x[: Top[list[Unknown]]] = xyxy
+        from typing import Any
+        from ty_extensions import Top
+
+        def f(xyxy: Top[list[Any]]):
+            x[: Top[list[Any]]] = xyxy
 
         ---------------------------------------------
         info[inlay-hint-location]: Inlay Hint Target
@@ -7143,10 +7147,10 @@ Source with applied edits:
            | ^^^
            |
         info: Source
-          --> main2.py:LL:13
+          --> main2.py:LL:9
            |
-        LL |         x[: Top[list[Unknown]]] = xyxy
-           |             ^^^
+        LL |     x[: Top[list[Any]]] = xyxy
+           |         ^^^
            |
 
         info[inlay-hint-location]: Inlay Hint Target
@@ -7156,36 +7160,32 @@ Source with applied edits:
            |       ^^^^
            |
         info: Source
-          --> main2.py:LL:17
+          --> main2.py:LL:13
            |
-        LL |         x[: Top[list[Unknown]]] = xyxy
-           |                 ^^^^
+        LL |     x[: Top[list[Any]]] = xyxy
+           |             ^^^^
            |
 
         info[inlay-hint-location]: Inlay Hint Target
-          --> stdlib/ty_extensions.pyi:LL:1
+          --> stdlib/typing.pyi:LL:7
            |
-        LL | Unknown: _SpecialForm
-           | ^^^^^^^
+        LL | class Any:
+           |       ^^^
            |
         info: Source
-          --> main2.py:LL:22
+          --> main2.py:LL:18
            |
-        LL |         x[: Top[list[Unknown]]] = xyxy
-           |                      ^^^^^^^
+        LL |     x[: Top[list[Any]]] = xyxy
+           |                  ^^^
            |
 
         ---------------------------------------------
         info[inlay-hint-edit]: Inlay hint edits
         --> main.py:1:1
           |
-        1 + from ty_extensions import Top
-        2 + from ty_extensions import Unknown
-        3 |
-        4 | def f(xyxy: object):
-        5 |     if isinstance(xyxy, list):
-          -         x = xyxy
-        6 +         x: Top[list[Unknown]] = xyxy
+        5 | def f(xyxy: Top[list[Any]]):
+          -     x = xyxy
+        6 +     x: Top[list[Any]] = xyxy
           |
         ");
     }

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -37,8 +37,8 @@ use ty_python_core::platform::PythonPlatform;
 use ty_python_core::program::{MisconfigurationStrategy, ProgramSettings};
 use ty_python_semantic::lint::{Level, LintSource, RuleSelection};
 use ty_python_semantic::{
-    AnalysisSettings, PythonEnvironment, PythonVersionFileSource, PythonVersionSource,
-    PythonVersionWithSource, SitePackagesPaths, SysPrefixPathOrigin,
+    AnalysisSettings, GenericNarrowing, PythonEnvironment, PythonVersionFileSource,
+    PythonVersionSource, PythonVersionWithSource, SitePackagesPaths, SysPrefixPathOrigin,
     inferred_python_version_source_annotation,
 };
 use ty_static::EnvVars;
@@ -1532,6 +1532,28 @@ pub struct AnalysisOptions {
         "#
     )]
     pub replace_imports_with_any: Option<Vec<RangedValue<String>>>,
+
+    /// Controls how ty narrows to unspecialized generic classes in `isinstance()` and
+    /// `issubclass()` checks.
+    ///
+    /// With `strict`, ty narrows to the top materialization of the class. For example,
+    /// `isinstance(value, list)` narrows a value of type  `object` to `Top[list[Unknown]]`,
+    /// representing the (infinite) union of all possible `list` specializations. Iterating
+    /// over the list would yield values of type `object`.
+    ///
+    /// With `relaxed`, ty narrows to the class's Unknown-specialization instead. The same
+    /// check would narrow a value of type `object` to `list[Unknown]`. Iterating over the list
+    /// would yield values of type `Unknown`, which is more permissive than `object`.
+    ///
+    /// Defaults to `relaxed`.
+    #[option(
+        default = "relaxed",
+        value_type = "strict | relaxed",
+        example = r#"
+            generic-narrowing = "strict"
+        "#
+    )]
+    pub generic_narrowing: Option<RangedValue<GenericNarrowing>>,
 }
 
 impl AnalysisOptions {
@@ -1544,12 +1566,14 @@ impl AnalysisOptions {
             respect_type_ignore_comments,
             allowed_unresolved_imports,
             replace_imports_with_any,
+            generic_narrowing,
         } = self;
 
         let AnalysisSettings {
             respect_type_ignore_comments: respect_type_ignore_default,
             allowed_unresolved_imports: allowed_unresolved_imports_default,
             replace_imports_with_any: replace_imports_with_any_default,
+            generic_narrowing: generic_narrowing_default,
         } = AnalysisSettings::default();
 
         let allowed_unresolved_imports =
@@ -1579,6 +1603,10 @@ impl AnalysisOptions {
                 .unwrap_or(respect_type_ignore_default),
             allowed_unresolved_imports,
             replace_imports_with_any,
+            generic_narrowing: generic_narrowing
+                .as_deref()
+                .copied()
+                .unwrap_or(generic_narrowing_default),
         }
     }
 }

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -23,6 +23,7 @@ ruff_python_stdlib = { workspace = true }
 ruff_python_trivia = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
+ty_combine = { workspace = true }
 ty_module_resolver = { workspace = true }
 ty_site_packages = { workspace = true }
 ty_python_core = { workspace = true }

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -706,15 +706,14 @@ def _(x: Sequence[int], y: object):
         reveal_type(item)  # revealed: int
 
     if isinstance(y, list):
-        reveal_type(y)  # revealed: Top[list[Unknown]]
+        reveal_type(y)  # revealed: list[Unknown]
         for item in y:
-            reveal_type(item)  # revealed: object
+            reveal_type(item)  # revealed: Unknown
 
     if isinstance(x, list):
-        reveal_type(x)  # revealed: Sequence[int] & Top[list[Unknown]]
+        reveal_type(x)  # revealed: Sequence[int] & list[Unknown]
         for item in x:
-            # int & object simplifies to int
-            reveal_type(item)  # revealed: int
+            reveal_type(item)  # revealed: int & Unknown
 ```
 
 ## Intersection where some elements are not iterable
@@ -1581,13 +1580,13 @@ simplify to `Never`, leaving only the iterable parts.
 ```py
 def f[T: tuple[int, ...] | int](x: T):
     if isinstance(x, tuple):
-        reveal_type(x)  # revealed: T@f & tuple[object, ...]
+        reveal_type(x)  # revealed: T@f & tuple[Unknown, ...]
         for item in x:
-            # The intersection `(tuple[int, ...] | int) & tuple[object, ...]` distributes to:
-            # `(tuple[int, ...] & tuple[object, ...]) | (int & tuple[object, ...])`
-            # which simplifies to `tuple[int, ...] | Never` = `tuple[int, ...]`
-            # so iterating gives `int`.
-            reveal_type(item)  # revealed: int
+            # The intersection `(tuple[int, ...] | int) & tuple[Unknown, ...]` distributes to:
+            # `(tuple[int, ...] & tuple[Unknown, ...]) | (int & tuple[Unknown, ...])`
+            # which simplifies to `tuple[int, ...] & tuple[Unknown, ...] | Never` = `tuple[int & Unknown, ...]`
+            # so iterating gives `int & Unknown`.
+            reveal_type(item)  # revealed: int & Unknown
 ```
 
 ### TypeVar bound with all iterable but disjoint elements
@@ -1598,14 +1597,14 @@ constraint, those parts should also simplify to `Never`.
 ```py
 def g[T: tuple[int, ...] | list[str]](x: T):
     if isinstance(x, tuple):
-        reveal_type(x)  # revealed: T@g & tuple[object, ...]
+        reveal_type(x)  # revealed: T@g & tuple[Unknown, ...]
         for item in x:
-            # The intersection `(tuple[int, ...] | list[str]) & tuple[object, ...]` distributes to:
-            # `(tuple[int, ...] & tuple[object, ...]) | (list[str] & tuple[object, ...])`
-            # Since `list[str]` is disjoint from `tuple[object, ...]`, this simplifies to:
-            # `tuple[int, ...] | Never` = `tuple[int, ...]`
-            # so iterating gives `int`, NOT `int | str`.
-            reveal_type(item)  # revealed: int
+            # The intersection `(tuple[int, ...] | list[str]) & tuple[Unknown, ...]` distributes to:
+            # `(tuple[int, ...] & tuple[Unknown, ...]) | (list[str] & tuple[Unknown, ...])`
+            # Since `list[str]` is disjoint from `tuple[Unknown, ...]`, this simplifies to:
+            # `tuple[int, ...] & tuple[Unknown, ...] | Never` = `tuple[int & Unknown, ...]`
+            # so iterating gives `int & Unknown`.
+            reveal_type(item)  # revealed: int & Unknown
 ```
 
 ## Iterating over a list with a negated type parameter

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -593,14 +593,19 @@ def i[T: Intersection[type[Bar], type[Baz | Spam]], U: (type[Eggs], type[Ham])](
 
 ## Narrowing with generics
 
+### Strict mode
+
 ```toml
 [environment]
 python-version = "3.12"
+
+[analysis]
+generic-narrowing = "strict"
 ```
 
-Narrowing to a generic class using `isinstance()` uses the top materialization of the generic. With
-a covariant generic, this is equivalent to using the upper bound of the type parameter (by default,
-`object`):
+In `strict` mode, narrowing to a generic class using `isinstance()` uses the top materialization of
+the generic. With a covariant generic, this is equivalent to using the upper bound of the type
+parameter (by default, `object`):
 
 ```py
 from typing import Self
@@ -728,6 +733,303 @@ def _(x: type[object], y: type[object], z: type[object]):
         reveal_type(z)  # revealed: type[Top[Invariant[Unknown]]]
 ```
 
+### Relaxed mode
+
+```toml
+[environment]
+python-version = "3.12"
+
+[analysis]
+generic-narrowing = "relaxed"
+```
+
+In `relaxed` mode, narrowing to a generic class using `isinstance()` uses the
+`Unknown`-specialization of the generic.
+
+```py
+from typing import Self
+
+class Covariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+def _(x: object):
+    if isinstance(x, Covariant):
+        reveal_type(x)  # revealed: Covariant[Unknown]
+        reveal_type(x.get())  # revealed: Unknown
+```
+
+For contravariant generics, we can now `.push` objects of an arbitrary type:
+
+```py
+class Contravariant[T]:
+    def push(self, x: T) -> None: ...
+
+def _(x: object):
+    if isinstance(x, Contravariant):
+        reveal_type(x)  # revealed: Contravariant[Unknown]
+        x.push(42)
+        x.push("foo")
+```
+
+For invariant generics, we have both of these behaviors:
+
+```py
+class Invariant[T]:
+    def push(self, x: T) -> None: ...
+    def get(self) -> T:
+        raise NotImplementedError
+
+def _(x: object):
+    if isinstance(x, Invariant):
+        reveal_type(x)  # revealed: Invariant[Unknown]
+        reveal_type(x.get())  # revealed: Unknown
+        x.push(42)
+        x.push("foo")
+```
+
+The behavior of `issubclass()` is similar.
+
+```py
+def _(x: type[object], y: type[object], z: type[object]):
+    if issubclass(x, Covariant):
+        reveal_type(x)  # revealed: type[Covariant[Unknown]]
+    if issubclass(y, Contravariant):
+        reveal_type(y)  # revealed: type[Contravariant[Unknown]]
+    if issubclass(z, Invariant):
+        reveal_type(z)  # revealed: type[Invariant[Unknown]]
+```
+
+## Use cases: `isinstance` narrowing and generics
+
+### Strict mode
+
+```toml
+[analysis]
+generic-narrowing = "strict"
+```
+
+#### Covariance
+
+Narrowing from `object` via `isinstance(.., Sequence)`:
+
+```py
+from typing import Sequence, final
+
+def _(xs: object):
+    if isinstance(xs, Sequence):
+        reveal_type(xs)  # revealed: Sequence[object]
+        for x in xs:
+            reveal_type(x)  # revealed: object
+    else:
+        reveal_type(xs)  # revealed: ~Sequence[object]
+```
+
+Narrowing from `Item | Sequence[Item]` via `isinstance(.., Sequence)`:
+
+```py
+@final
+class Item: ...
+
+def _(xs: Item | Sequence[Item]):
+    if isinstance(xs, Sequence):
+        reveal_type(xs)  # revealed: Sequence[Item]
+        for x in xs:
+            reveal_type(x)  # revealed: Item
+    else:
+        reveal_type(xs)  # revealed: Item
+```
+
+Narrowing from (non-final) `OpenItem | Sequence[OpenItem]` via `isinstance(.., Sequence)`:
+
+```py
+class OpenItem: ...
+
+def _(xs: OpenItem | Sequence[OpenItem]):
+    if isinstance(xs, Sequence):
+        reveal_type(xs)  # revealed: (OpenItem & Sequence[object]) | Sequence[OpenItem]
+        for x in xs:
+            reveal_type(x)  # revealed: object
+    else:
+        reveal_type(xs)  # revealed: OpenItem & ~Sequence[object]
+```
+
+#### Invariance
+
+Narrowing from `object` via `isinstance(.., list)`:
+
+```py
+def _(xs: object):
+    if isinstance(xs, list):
+        reveal_type(xs)  # revealed: Top[list[Unknown]]
+        for x in xs:
+            reveal_type(x)  # revealed: object
+
+        # This is an error in strict mode:
+        # error: [invalid-argument-type] "Expected `Never`, found `Literal[1]`"
+        xs.append(1)
+
+    else:
+        reveal_type(xs)  # revealed: ~Top[list[Unknown]]
+```
+
+Narrowing from `Item | list[Item]` via `isinstance(.., list)`:
+
+```py
+from typing import final
+
+@final
+class Item: ...
+
+def _(xs: Item | list[Item]):
+    if isinstance(xs, list):
+        reveal_type(xs)  # revealed: list[Item]
+        for x in xs:
+            reveal_type(x)  # revealed: Item
+    else:
+        reveal_type(xs)  # revealed: Item
+```
+
+Narrowing from (non-final) `OpenItem | list[OpenItem]` via `isinstance(.., list)`:
+
+```py
+class OpenItem: ...
+
+def _(xs: OpenItem | list[OpenItem]):
+    if isinstance(xs, list):
+        reveal_type(xs)  # revealed: (OpenItem & Top[list[Unknown]]) | list[OpenItem]
+        for x in xs:
+            reveal_type(x)  # revealed: object
+    else:
+        reveal_type(xs)  # revealed: OpenItem & ~Top[list[Unknown]]
+```
+
+#### Exhaustiveness checking
+
+```py
+def _(xs: list[str] | set[str]) -> str:
+    if isinstance(xs, list):
+        return "it's a list!"
+    elif isinstance(xs, set):
+        return "it's a set!"
+```
+
+### Relaxed mode
+
+The `analysis.generic-narrowing` option can be set to `relaxed` to narrow the positive branch to the
+Unknown-specialization of a generic class without top-materializing it. The negative branch still
+excludes the top materialization because a negative `isinstance` result excludes every
+specialization of the class:
+
+```toml
+[analysis]
+generic-narrowing = "relaxed"
+```
+
+#### Covariance
+
+Narrowing from `object` via `isinstance(.., Sequence)`:
+
+```py
+from typing import Sequence, final
+
+def _(xs: object):
+    if isinstance(xs, Sequence):
+        reveal_type(xs)  # revealed: Sequence[Unknown]
+        for x in xs:
+            reveal_type(x)  # revealed: Unknown
+    else:
+        reveal_type(xs)  # revealed: ~Sequence[object]
+```
+
+Narrowing from `Item | Sequence[Item]` via `isinstance(.., Sequence)`:
+
+```py
+@final
+class Item: ...
+
+def _(xs: Item | Sequence[Item]):
+    if isinstance(xs, Sequence):
+        reveal_type(xs)  # revealed: Sequence[Item] & Sequence[Unknown]
+        for x in xs:
+            reveal_type(x)  # revealed: Item & Unknown
+    else:
+        reveal_type(xs)  # revealed: Item
+```
+
+Narrowing from (non-final) `OpenItem | Sequence[OpenItem]` via `isinstance(.., Sequence)`:
+
+```py
+class OpenItem: ...
+
+def _(xs: OpenItem | Sequence[OpenItem]):
+    if isinstance(xs, Sequence):
+        reveal_type(xs)  # revealed: (OpenItem & Sequence[Unknown]) | (Sequence[OpenItem] & Sequence[Unknown])
+        for x in xs:
+            reveal_type(x)  # revealed: Unknown
+    else:
+        reveal_type(xs)  # revealed: OpenItem & ~Sequence[object]
+```
+
+#### Invariance
+
+Narrowing from `object` via `isinstance(.., list)`:
+
+```py
+def _(xs: object):
+    if isinstance(xs, list):
+        reveal_type(xs)  # revealed: list[Unknown]
+        for x in xs:
+            reveal_type(x)  # revealed: Unknown
+
+        # In relaxed mode, this is fine
+        xs.append(1)
+
+    else:
+        reveal_type(xs)  # revealed: ~Top[list[Unknown]]
+```
+
+Narrowing from `Item | list[Item]` via `isinstance(.., list)`:
+
+```py
+from typing import final
+
+@final
+class Item: ...
+
+def _(xs: Item | list[Item]):
+    if isinstance(xs, list):
+        reveal_type(xs)  # revealed: list[Item]
+        for x in xs:
+            reveal_type(x)  # revealed: Item
+    else:
+        reveal_type(xs)  # revealed: Item
+```
+
+Narrowing from (non-final) `OpenItem | list[OpenItem]` via `isinstance(.., list)`:
+
+```py
+class OpenItem: ...
+
+def _(xs: OpenItem | list[OpenItem]):
+    if isinstance(xs, list):
+        reveal_type(xs)  # revealed: (OpenItem & list[Unknown]) | list[OpenItem]
+        for x in xs:
+            reveal_type(x)  # revealed: Unknown | OpenItem
+    else:
+        reveal_type(xs)  # revealed: OpenItem & ~Top[list[Unknown]]
+```
+
+#### Exhaustiveness checking
+
+```py
+def _(xs: list[str] | set[str]) -> str:
+    if isinstance(xs, list):
+        return "it's a list!"
+    elif isinstance(xs, set):
+        return "it's a set!"
+```
+
 ## Narrowing generic defaults in Python 3.13
 
 When a type parameter has a bare `Any` default, narrowing still materializes the substituted
@@ -747,7 +1049,7 @@ class WithAnyDefault[T = Any]:
 
 def _(x: object):
     if isinstance(x, WithAnyDefault):
-        reveal_type(x.y)  # revealed: tuple[Any, object]
+        reveal_type(x.y)  # revealed: tuple[Any, Unknown]
 ```
 
 Type alias defaults substituted into type parameters still need to be materialized when narrowing:
@@ -762,7 +1064,7 @@ class WithAliasDefault[T = A]:
 
 def _(x: object):
     if isinstance(x, WithAliasDefault):
-        reveal_type(x.y)  # revealed: tuple[A, object]
+        reveal_type(x.y)  # revealed: tuple[A, Unknown]
 ```
 
 ## Narrowing generic `classmethod`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -146,7 +146,7 @@ from typing import Any
 
 def test_isinstance(x: dict[Any, Any] | int) -> None:
     if isinstance(x, Mapping):
-        reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
+        reveal_type(x)  # revealed: dict[Any, Any] | (int & Mapping[Unknown, Unknown])
     else:
         reveal_type(x)  # revealed: int & ~Top[Mapping[Unknown, object]]
 

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -26,6 +26,7 @@ pub use suppression::{
     SuppressFix, UNUSED_IGNORE_COMMENT, is_unused_ignore_comment_lint, suppress_all,
     suppress_single,
 };
+use ty_combine::Combine;
 use ty_module_resolver::ModuleGlobSet;
 use ty_python_core::definition::docstring_from_body;
 use ty_python_core::platform::PythonPlatform;
@@ -101,6 +102,25 @@ pub struct AnalysisSettings {
     pub allowed_unresolved_imports: ModuleGlobSet,
 
     pub replace_imports_with_any: ModuleGlobSet,
+
+    pub generic_narrowing: GenericNarrowing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, get_size2::GetSize)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "kebab-case")
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum GenericNarrowing {
+    Strict,
+    #[default]
+    Relaxed,
+}
+
+impl Combine for GenericNarrowing {
+    fn combine_with(&mut self, _other: Self) {}
 }
 
 impl Default for AnalysisSettings {
@@ -109,6 +129,7 @@ impl Default for AnalysisSettings {
             respect_type_ignore_comments: true,
             allowed_unresolved_imports: ModuleGlobSet::empty(),
             replace_imports_with_any: ModuleGlobSet::empty(),
+            generic_narrowing: GenericNarrowing::default(),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, btree_map::Entry as BTreeEntry, hash_map::Entry};
 
-use crate::Db;
 use crate::reachability::{narrow_type_by_constraint, type_narrowed_by_previous_patterns};
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
@@ -23,6 +22,7 @@ use crate::types::{
     pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
     starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
+use crate::{Db, GenericNarrowing};
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
@@ -447,19 +447,27 @@ impl ClassInfoConstraintFunction {
         db: &'db dyn Db,
         classinfo: Type<'db>,
         is_positive: bool,
+        generic_narrowing: GenericNarrowing,
     ) -> Option<Type<'db>> {
-        let constraint_from_class_literal = |class: ClassLiteral<'db>| match self {
-            ClassInfoConstraintFunction::IsInstance => {
-                Type::instance(db, class.top_materialization(db))
-            }
-            ClassInfoConstraintFunction::IsSubclass => {
-                SubclassOfType::from(db, class.top_materialization(db))
+        let constraint_from_class_literal = |class: ClassLiteral<'db>| {
+            let specialization = match (generic_narrowing, is_positive) {
+                (GenericNarrowing::Relaxed, true) => class.unknown_specialization(db),
+                // A negative result excludes every specialization of the class, even though the
+                // positive branch uses the gradual Unknown-specialization.
+                (GenericNarrowing::Strict, _) | (GenericNarrowing::Relaxed, false) => {
+                    class.top_materialization(db)
+                }
+            };
+
+            match self {
+                ClassInfoConstraintFunction::IsInstance => Type::instance(db, specialization),
+                ClassInfoConstraintFunction::IsSubclass => SubclassOfType::from(db, specialization),
             }
         };
 
         match classinfo {
             Type::TypeAlias(alias) => {
-                self.generate_constraint(db, alias.value_type(db), is_positive)
+                self.generate_constraint(db, alias.value_type(db), is_positive, generic_narrowing)
             }
             Type::ClassLiteral(class_literal) => Some(constraint_from_class_literal(class_literal)),
             Type::SubclassOf(subclass_of_ty) => {
@@ -495,6 +503,7 @@ impl ClassInfoConstraintFunction {
                             db,
                             *element,
                             is_positive,
+                            generic_narrowing,
                         )?);
                     }
                     Some(builder.build())
@@ -504,16 +513,20 @@ impl ClassInfoConstraintFunction {
                 }
             }
             Type::Union(union) => union.try_map(db, |element| {
-                self.generate_constraint(db, *element, is_positive)
+                self.generate_constraint(db, *element, is_positive, generic_narrowing)
             }),
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        self.generate_constraint(db, bound, is_positive)
+                        self.generate_constraint(db, bound, is_positive, generic_narrowing)
                     }
-                    TypeVarBoundOrConstraints::Constraints(constraints) => {
-                        self.generate_constraint(db, constraints.as_type(db), is_positive)
-                    }
+                    TypeVarBoundOrConstraints::Constraints(constraints) => self
+                        .generate_constraint(
+                            db,
+                            constraints.as_type(db),
+                            is_positive,
+                            generic_narrowing,
+                        ),
                 }
             }
 
@@ -524,9 +537,9 @@ impl ClassInfoConstraintFunction {
             Type::NominalInstance(nominal) => nominal.tuple_spec(db).and_then(|tuple| {
                 UnionType::try_from_elements(
                     db,
-                    tuple
-                        .iter_all_elements()
-                        .map(|element| self.generate_constraint(db, element, is_positive)),
+                    tuple.iter_all_elements().map(|element| {
+                        self.generate_constraint(db, element, is_positive, generic_narrowing)
+                    }),
                 )
             }),
 
@@ -543,9 +556,10 @@ impl ClassInfoConstraintFunction {
                                 db,
                                 KnownClass::NoneType.to_class_literal(db),
                                 is_positive,
+                                generic_narrowing,
                             )
                         } else {
-                            self.generate_constraint(db, element, is_positive)
+                            self.generate_constraint(db, element, is_positive, generic_narrowing)
                         }
                     }),
                 )
@@ -556,15 +570,20 @@ impl ClassInfoConstraintFunction {
                     db,
                     alias.aliased_class().to_class_literal(db),
                     is_positive,
+                    generic_narrowing,
                 ),
                 SpecialFormType::Tuple => self.generate_constraint(
                     db,
                     KnownClass::Tuple.to_class_literal(db),
                     is_positive,
+                    generic_narrowing,
                 ),
-                SpecialFormType::Type => {
-                    self.generate_constraint(db, KnownClass::Type.to_class_literal(db), is_positive)
-                }
+                SpecialFormType::Type => self.generate_constraint(
+                    db,
+                    KnownClass::Type.to_class_literal(db),
+                    is_positive,
+                    generic_narrowing,
+                ),
 
                 // We don't have a good meta-type for `Callable`s right now,
                 // so only apply `isinstance()` narrowing, not `issubclass()`
@@ -929,6 +948,7 @@ fn positive_class_pattern_type<'db>(
                 db,
                 class_expression_ty,
                 true,
+                GenericNarrowing::Strict,
             )
         }
         _ => None,
@@ -1594,7 +1614,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                         )
                     })
                 {
-                    // The pattern class's unknown specialization loses type arguments known
+                    // The pattern class's Unknown-specialization loses type arguments known
                     // through the related subject type. Prefer the subject's member type when it
                     // exists, but retain a member declared only by the pattern class.
                     member_ty = Some(
@@ -3327,8 +3347,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
                 let class_info_ty = inference.expression_type(second_arg);
 
+                let generic_narrowing = self
+                    .db
+                    .analysis_settings(self.scope().file(self.db))
+                    .generic_narrowing;
+
                 function
-                    .generate_constraint(self.db, class_info_ty, is_positive)
+                    .generate_constraint(self.db, class_info_ty, is_positive, generic_narrowing)
                     .map(|constraint| {
                         NarrowingConstraints::from_iter([(
                             place,
@@ -3445,6 +3470,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             self.db,
             KnownClass::Mapping.to_class_literal(self.db),
             true,
+            GenericNarrowing::Strict,
         )?;
 
         Some(NarrowingConstraints::from_iter([(

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -170,6 +170,7 @@ Settings: Settings {
             regex_set: RegexSet([]),
             globs: [],
         },
+        generic_narrowing: Relaxed,
     },
     overrides: [],
 }

--- a/crates/ty_test/src/config.rs
+++ b/crates/ty_test/src/config.rs
@@ -21,7 +21,7 @@ use ruff_db::system::{SystemPath, SystemPathBuf};
 use ruff_python_ast::PythonVersion;
 use serde::{Deserialize, Serialize};
 use ty_python_core::platform::PythonPlatform;
-use ty_python_semantic::lint::Level;
+use ty_python_semantic::{GenericNarrowing, lint::Level};
 
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -127,6 +127,8 @@ pub(crate) struct Analysis {
     pub(crate) allowed_unresolved_imports: Option<Vec<String>>,
 
     pub(crate) replace_imports_with_any: Option<Vec<String>>,
+
+    pub(crate) generic_narrowing: Option<GenericNarrowing>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -63,6 +63,7 @@ impl Db {
                 respect_type_ignore_comments: respect_type_ignore_comments_default,
                 allowed_unresolved_imports: allowed_unresolved_imports_default,
                 replace_imports_with_any: replace_imports_with_any_default,
+                generic_narrowing: generic_narrowing_default,
             } = AnalysisSettings::default();
 
             let allowed_unresolved_imports = if let Some(allowed_unresolved_imports) =
@@ -99,6 +100,9 @@ impl Db {
                     .unwrap_or(respect_type_ignore_comments_default),
                 allowed_unresolved_imports,
                 replace_imports_with_any,
+                generic_narrowing: options
+                    .generic_narrowing
+                    .unwrap_or(generic_narrowing_default),
             }
         } else {
             AnalysisSettings::default()

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -82,6 +82,17 @@
             "$ref": "#/definitions/string"
           }
         },
+        "generic-narrowing": {
+          "description": "Controls how ty narrows to unspecialized generic classes in `isinstance()` and\n`issubclass()` checks.\n\nWith `strict`, ty narrows to the top materialization of the class. For example,\n`isinstance(value, list)` narrows a value of type  `object` to `Top[list[Unknown]]`,\nrepresenting the (infinite) union of all possible `list` specializations. Iterating\nover the list would yield values of type `object`.\n\nWith `relaxed`, ty narrows to the class's Unknown-specialization instead. The same\ncheck would narrow a value of type `object` to `list[Unknown]`. Iterating over the list\nwould yield values of type `Unknown`, which is more permissive than `object`.\n\nDefaults to `relaxed`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GenericNarrowing"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "replace-imports-with-any": {
           "description": "A list of module glob patterns whose imports should be replaced with `typing.Any`.\n\nUnlike `allowed-unresolved-imports`, this setting replaces the module's type information\nwith `typing.Any` even if the module can be resolved. Import diagnostics are\nunconditionally suppressed for matching modules.\n\n- Prefix a pattern with `!` to exclude matching modules\n\nWhen multiple patterns match, later entries take precedence.\n\nGlob patterns can be used in combinations with each other. For example, to suppress errors for\nany module where the first component contains the substring `test`, use `*test*.**`.\n\nWhen multiple patterns match, later entries take precedence.",
           "type": [
@@ -177,6 +188,13 @@
         }
       },
       "additionalProperties": false
+    },
+    "GenericNarrowing": {
+      "type": "string",
+      "enum": [
+        "strict",
+        "relaxed"
+      ]
     },
     "Level": {
       "oneOf": [


### PR DESCRIPTION
## Summary

This PR introduces a new `ty.analysis.generic-narrowing` option that controls how `isinstance` and `issubclass` narrowing works for unspecialized generic classes. When this option is set to `strict`, we use the top materialization of the generic class (e.g. `Top[list[Unknown]]`). This is the current behavior on `main`. However, when the option is set to `relaxed` (the new default), we intersect with `list[Unknown]` directly, leading to a more gradual behavior (see example below). The idea here is to help users migrate from other type checkers. If they want to use a stricter type checking behavior, they can then switch to `generic-narrowing = "strict"` later.

### `strict` (current behavior on `main`)

```py
def f(xs: object):
    if isinstance(xs, list):
        reveal_type(xs)  # Top[list[Unknown]]
        for x in xs:
            reveal_type(x)  # object
        
        xs.push(1)  # error!
```

### `relaxed` (new default behavior)

```py
def f(xs: object):
    if isinstance(xs, list):
        reveal_type(xs)  # list[Unknown]
        for x in xs:
            reveal_type(x)  # Unknown
        
        xs.push(1)  # okay
```

One important detail here is how this new `relaxed` narrowing behavior works in the negative case (in `else` branches, or when using `not isinstance(...)`). I previously tried to simply intersect with `~list[Unknown]`, but this generally leads to leftover gradual types since we're not excluding *all lists*. A [previous experiment shows](https://github.com/astral-sh/ruff/pull/26361) that this leads to ~900 new diagnostics, even after implementing some gradual intersection simplifications. So here, we simply intersect with `~Top[list[Unknown]]` in the negative case, which reflects what the runtime does: it excludes *all* `list` instances. The only downside is that this breaks symmetry: the narrowed type in the `if` branch and the narrowed type in the `else` branch don't recombine to the original type. I haven't seen any practical consequences of this though.

Another alternative that I considered was to introduce [special marked `object*`/`Never*` types](https://github.com/astral-sh/ty/issues/3375). This had a [similar ecosystem impact](https://github.com/astral-sh/ruff/pull/26472), but the implementation is more complex. It also doesn't seem very principled and introduces two new fundamental types that can interact with the rest of the type system in many different ways. Maybe most importantly, I think this would be harder to teach to users. They would have to understand not just what a top-materialization is, but also that these give rise to new `object` and `Never` variants that behave in complex ways that are not clear from their naming. The approach followed in this PR, by contrast, relies on our core concepts (set theoretic gradual types). In the new "relaxed" mode implemented here, users will also see a lot fewer `Top[..]` types. One advantage of the `object*` approach is that it doesn't always "propagate" the gradual nature of the check. For example, when narrowing `Item | Sequence[Item]` via `isinstance(..., Sequence)`, it yields `Sequence[Item] & Sequence[object*] = Sequence[Item]`, instead of the permissive `Sequence[Item & Unknown]` that we get on this branch.

In a follow-up to this PR, I will make a similar change to `TypeIs` narrowing.

closes https://github.com/astral-sh/ty/issues/3476
closes https://github.com/astral-sh/ty/issues/3676
closes https://github.com/astral-sh/ty/issues/3477
closes https://github.com/astral-sh/ty/issues/3375

## Post-merge TODO

- Update the ty documentation, potentially update [this section](https://docs.astral.sh/ty/coming-from-mypy-or-pyright/#stricter-checking-with-ty) in the mypy/pyright migration docs.
- `if isinstance(..., Callable)` should also follow this approach.

## Test plan

- New Markdown tests with a whole new section that includes various use cases that we've seen in user reports.

## Ecosystem

1824 removed diagnostics. Most of the 32 newly added diagnostics are `unused-(type-)ignore-comment`.