### PR TITLE
perf(formatter): inline AnyNodeRef range access

### DIFF
--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -685,6 +685,8 @@ def write_anynoderef(out: list[str], ast: Ast) -> None:
 
     out.append("""
         impl ruff_text_size::Ranged for AnyNodeRef<'_> {
+            #[expect(clippy::inline_always, reason = "enables constant-folding for known `AnyNodeRef` variants")]
+            #[inline(always)]
             fn range(&self) -> ruff_text_size::TextRange {
                 match self {
     """)

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -6889,6 +6889,11 @@ impl<'a> From<&'a crate::Identifier> for AnyNodeRef<'a> {
 }
 
 impl ruff_text_size::Ranged for AnyNodeRef<'_> {
+    #[expect(
+        clippy::inline_always,
+        reason = "enables constant-folding for known `AnyNodeRef` variants"
+    )]
+    #[inline(always)]
     fn range(&self) -> ruff_text_size::TextRange {
         match self {
             AnyNodeRef::ModModule(node) => node.range(),

--- a/crates/ruff_python_formatter/src/comments/visitor.rs
+++ b/crates/ruff_python_formatter/src/comments/visitor.rs
@@ -70,6 +70,11 @@ impl<'a, 'builder> CommentsVisitor<'a, 'builder> {
 }
 
 impl<'ast> SourceOrderVisitor<'ast> for CommentsVisitor<'ast, '_> {
+    #[expect(
+        clippy::inline_always,
+        reason = "enables constant-folding of `AnyNodeRef` helpers"
+    )]
+    #[inline(always)]
     fn enter_node(&mut self, node: AnyNodeRef<'ast>) -> TraversalSignal {
         let node_range = node.range();
 
@@ -111,6 +116,11 @@ impl<'ast> SourceOrderVisitor<'ast> for CommentsVisitor<'ast, '_> {
         }
     }
 
+    #[expect(
+        clippy::inline_always,
+        reason = "enables constant-folding of `AnyNodeRef` helpers"
+    )]
+    #[inline(always)]
     fn leave_node(&mut self, node: AnyNodeRef<'ast>) {
         // We are leaving this node, pop it from the parent stack.
         self.parents.pop();
@@ -147,6 +157,11 @@ impl<'ast> SourceOrderVisitor<'ast> for CommentsVisitor<'ast, '_> {
         self.preceding_node = Some(node);
     }
 
+    #[expect(
+        clippy::inline_always,
+        reason = "enables constant-folding of `AnyNodeRef` helpers"
+    )]
+    #[inline(always)]
     fn visit_body(&mut self, body: &'ast [Stmt]) {
         match body {
             [] => {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

I had codex look at improving performance, based on https://github.com/oxc-project/oxc/pull/17459.

Inline `AnyNodeRef::range` and the formatter comment visitor callbacks that call it during source-order traversal. This lets the compiler see the concrete `AnyNodeRef` variant at hot call sites and fold away the large generated match.

Formatter benchmark results improved across the sampled fixtures:

| Fixture | Before | After | Change |
| --- | ---: | ---: | ---: |
| large_dataset.py | 1.2636 ms | 1.1948 ms | -5.45% |
| numpy_ctypeslib.py | 288.17 us | 266.36 us | -7.81% |
| numpy_globals.py | 22.055 us | 21.078 us | -5.58% |
| pydantic_types.py | 525.96 us | 495.98 us | -5.07% |
| unicode_pypinyin.py | 73.862 us | 70.939 us | -4.91% |

## What's going on?

The hot path is formatter comment extraction.

Before, source-order traversal builds an `AnyNodeRef` for each AST node, then `CommentsVisitor::enter_node` / `leave_node` call generic range helpers on it:

```rust
fn walk_stmt(visitor, stmt: &Stmt) {
    let node = AnyNodeRef::from(stmt);

    visitor.enter_node(node);
    stmt.visit_source_order(visitor);
    visitor.leave_node(node);
}

fn enter_node(&mut self, node: AnyNodeRef) {
    let node_range = node.range(); // huge match on AnyNodeRef
    ...
}

impl Ranged for AnyNodeRef {
    fn range(&self) -> TextRange {
        match self {
            AnyNodeRef::StmtFunctionDef(node) => node.range(),
            AnyNodeRef::StmtClassDef(node) => node.range(),
            AnyNodeRef::ExprCall(node) => node.range(),
            AnyNodeRef::ExprName(node) => node.range(),
            AnyNodeRef::Keyword(node) => node.range(),
            // many more variants...
        }
    }
}
```

The problem: without inlining, `enter_node` calls `AnyNodeRef::range` as a generic helper, so the compiled code may retain the full `AnyNodeRef` match.

After, `AnyNodeRef::range` and the formatter visitor callbacks are `#[inline(always)]`:

```rust
#[inline(always)]
fn enter_node(&mut self, node: AnyNodeRef) {
    let node_range = node.range();
    ...
}

impl Ranged for AnyNodeRef {
    #[inline(always)]
    fn range(&self) -> TextRange {
        match self {
            AnyNodeRef::StmtFunctionDef(node) => node.range(),
            AnyNodeRef::ExprCall(node) => node.range(),
            // ...
        }
    }
}
```

At call sites like:

```rust
let node = AnyNodeRef::StmtFunctionDef(stmt);
visitor.enter_node(node);
```

the compiler can inline through `enter_node` into `range`, see that `node` is definitely `AnyNodeRef::StmtFunctionDef`, and reduce the helper to:

```rust
let node_range = stmt.range();
```

So the big match over every AST node kind disappears for those statically known traversal calls. The “helpers being matched” are mainly `AnyNodeRef::range()` calls, plus derived `Ranged` methods like `node.start()` and `node.end()` that internally depend on `range()`.

## Test Plan

<!-- How was it tested? -->

This is a perf optimization - it should be covered by existing tests