### PR TITLE
[ty] Preserve uncertain reflected operator dispatch

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/binary/custom.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/custom.md
@@ -260,20 +260,21 @@ class No:
     def __rfloordiv__(self, other) -> Literal["r//"]:
         return "r//"
 
-# Subclass reflected dunder methods take precedence over the superclass's regular dunders.
-reveal_type(Yes() + Sub())  # revealed: Literal["r+"]
-reveal_type(Yes() - Sub())  # revealed: Literal["r-"]
-reveal_type(Yes() * Sub())  # revealed: Literal["r*"]
-reveal_type(Yes() @ Sub())  # revealed: Literal["r@"]
-reveal_type(Yes() / Sub())  # revealed: Literal["r/"]
-reveal_type(Yes() % Sub())  # revealed: Literal["r%"]
-reveal_type(Yes() ** Sub())  # revealed: Literal["r**"]
-reveal_type(Yes() << Sub())  # revealed: Literal["r<<"]
-reveal_type(Yes() >> Sub())  # revealed: Literal["r>>"]
-reveal_type(Yes() | Sub())  # revealed: Literal["r|"]
-reveal_type(Yes() ^ Sub())  # revealed: Literal["r^"]
-reveal_type(Yes() & Sub())  # revealed: Literal["r&"]
-reveal_type(Yes() // Sub())  # revealed: Literal["r//"]
+# Subclass reflected dunder methods may take precedence over the superclass's regular dunders,
+# depending on the operands' runtime classes.
+reveal_type(Yes() + Sub())  # revealed: Literal["r+", "+"]
+reveal_type(Yes() - Sub())  # revealed: Literal["r-", "-"]
+reveal_type(Yes() * Sub())  # revealed: Literal["r*", "*"]
+reveal_type(Yes() @ Sub())  # revealed: Literal["r@", "@"]
+reveal_type(Yes() / Sub())  # revealed: Literal["r/", "/"]
+reveal_type(Yes() % Sub())  # revealed: Literal["r%", "%"]
+reveal_type(Yes() ** Sub())  # revealed: Literal["r**", "**"]
+reveal_type(Yes() << Sub())  # revealed: Literal["r<<", "<<"]
+reveal_type(Yes() >> Sub())  # revealed: Literal["r>>", ">>"]
+reveal_type(Yes() | Sub())  # revealed: Literal["r|", "|"]
+reveal_type(Yes() ^ Sub())  # revealed: Literal["r^", "^"]
+reveal_type(Yes() & Sub())  # revealed: Literal["r&", "&"]
+reveal_type(Yes() // Sub())  # revealed: Literal["r//", "//"]
 
 # But for an unrelated class, the superclass regular dunders are used.
 reveal_type(Yes() + No())  # revealed: Literal["+"]

--- a/crates/ty_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/instances.md
@@ -194,28 +194,27 @@ reveal_type(C() + C())  # revealed: int
 ## Reflected precedence for subtypes (in some cases)
 
 If the right-hand operand is a subtype of the left-hand operand and has a different implementation
-of the reflected method, the reflected method on the right-hand operand takes precedence.
+of the reflected method, its reflected method may take precedence. The static types do not tell us
+whether the left operand has runtime class `A` or a subclass such as `B`, so both methods can be
+called at runtime.
 
 ```py
+from typing import Literal
+
 class A:
-    def __add__(self, other) -> str:
-        return "foo"
-
-    def __radd__(self, other) -> str:
-        return "foo"
-
-class MyString(str): ...
+    def __add__(self, other) -> Literal["left"]:
+        return "left"
 
 class B(A):
-    def __radd__(self, other) -> MyString:
-        return MyString()
+    def __radd__(self, other) -> Literal["right"]:
+        return "right"
 
-reveal_type(A() + B())  # revealed: MyString
+reveal_type(A() + B())  # revealed: Literal["right", "left"]
 
 # N.B. Still a subtype of `A`, even though `A` does not appear directly in the class's `__bases__`
 class C(B): ...
 
-reveal_type(A() + C())  # revealed: MyString
+reveal_type(A() + C())  # revealed: Literal["right", "left"]
 ```
 
 ## Reflected precedence uses runtime classes
@@ -223,10 +222,12 @@ reveal_type(A() + C())  # revealed: MyString
 `IntFlag` values are commonly accumulated into a mask that starts at the integer zero. At runtime,
 the first `|=` produces a `Permission`, because reflected-method precedence depends on the operands'
 runtime classes. The enum literal is not a subtype of the specific integer literal `0`, but its
-runtime class is a strict subclass of `int`:
+runtime class is a strict subclass of `int`. The same applies when the right operand is a TypeVar
+whose upper bound has that runtime-class relationship:
 
 ```py
 from enum import IntFlag, auto
+from typing import TypeVar
 
 class Permission(IntFlag):
     READ = auto()
@@ -241,15 +242,22 @@ def permissions_for(editable: bool) -> Permission:
         permissions |= Permission.WRITE
 
     return permissions
+
+P = TypeVar("P", bound=Permission)
+
+def add_permission(permission: P) -> P:
+    reveal_type(0 | permission)  # revealed: P@add_permission
+    return 0 | permission
 ```
 
-## Bounded TypeVars do not have an exact runtime class
+## TypeVars and NewTypes do not have an exact runtime class
 
-The upper bound of a TypeVar is not necessarily its runtime class. The bound therefore cannot be
-used to decide whether the right-hand operand's reflected method takes precedence:
+The upper bound of a TypeVar is not necessarily its runtime class, so it cannot decide definitively
+whether the right-hand operand's reflected method takes precedence. A `NewType` constructor also
+returns its argument unchanged, so an inhabitant can have a runtime class below the NewType's base:
 
 ```py
-from typing import Literal, TypeVar
+from typing import Literal, NewType, TypeVar
 
 class Base:
     def __add__(self, other: object) -> Literal["base"]:
@@ -261,9 +269,21 @@ class Child(Base):
 
 T = TypeVar("T", bound=Base)
 
-def add_child(left: T) -> Literal["base"]:
-    reveal_type(left + Child())  # revealed: Literal["base"]
+def add_child(left: T) -> Literal["base", "child"]:
+    reveal_type(left + Child())  # revealed: Literal["child", "base"]
     return left + Child()
+
+U = TypeVar("U", bound=Child)
+
+def add_typevar(left: Base, right: U) -> Literal["base", "child"]:
+    reveal_type(left + right)  # revealed: Literal["child", "base"]
+    return left + right
+
+NewChild = NewType("NewChild", Child)
+
+def add_newtype(left: Base, right: NewChild) -> Literal["base", "child"]:
+    reveal_type(left + right)  # revealed: Literal["child", "base"]
+    return left + right
 ```
 
 ## Reflected precedence 2

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -1,5 +1,5 @@
 use super::context::InferContext;
-use super::{Signature, Type, TypeContext};
+use super::{Signature, Type, TypeContext, UnionType};
 use crate::Db;
 use crate::place::Provenance;
 use crate::types::call::bind::BindingError;
@@ -10,6 +10,71 @@ mod arguments;
 pub(crate) mod bind;
 pub(super) use arguments::{Argument, CallArguments};
 pub(super) use bind::{Binding, Bindings, CallableBinding, MatchedArgument};
+
+/// Whether the right operand's reflected method has priority based on the possible runtime
+/// classes of both operands.
+///
+/// `Possibly` requires preserving both dispatch results because the static types admit runtime
+/// pairs for which either method has priority.
+#[derive(PartialEq, Eq)]
+enum ReflectedMethodPriority {
+    Never,
+    Possibly,
+    Definitely,
+}
+
+/// Returns whether every inhabitant of `ty` has the same nominal runtime class.
+///
+/// This is intentionally conservative: a false negative only widens a binary operation's result,
+/// while a false positive could discard a valid normal-method result.
+fn has_exact_runtime_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty {
+        Type::LiteralValue(_) => true,
+        Type::NominalInstance(instance) => instance.class(db).is_final(db),
+        Type::TypeAlias(alias) => has_exact_runtime_class(db, alias.value_type(db)),
+        _ => false,
+    }
+}
+
+/// Classifies reflected-method priority from the operands' static types.
+///
+/// For example, an integer literal has exact runtime class `int`, so an `IntFlag` operand is
+/// definitely a strict subclass. By contrast, an inhabitant of `Base` may itself have runtime
+/// class `Child`, making reflected priority for `Base + Child` only possible.
+///
+/// ```python
+/// class Base: ...
+/// class Child(Base): ...
+///
+/// left: Base
+/// right: Child
+/// left + right
+/// ```
+fn reflected_method_priority<'db>(
+    db: &'db dyn Db,
+    left_ty: Type<'db>,
+    right_ty: Type<'db>,
+) -> ReflectedMethodPriority {
+    if left_ty == right_ty {
+        return ReflectedMethodPriority::Never;
+    }
+
+    if let (Some(left_class), Some(right_class)) =
+        (left_ty.nominal_class(db), right_ty.nominal_class(db))
+        && left_class.class_literal(db) != right_class.class_literal(db)
+        && right_class.is_subclass_of(db, left_class)
+    {
+        if has_exact_runtime_class(db, left_ty) {
+            ReflectedMethodPriority::Definitely
+        } else {
+            ReflectedMethodPriority::Possibly
+        }
+    } else if right_ty.is_subtype_of(db, left_ty) {
+        ReflectedMethodPriority::Possibly
+    } else {
+        ReflectedMethodPriority::Never
+    }
+}
 
 impl<'db> Type<'db> {
     /// Memoize the pure return-type part of binary dunder resolution so repeated identical
@@ -62,28 +127,13 @@ impl<'db> Type<'db> {
         //
         // [1] https://docs.python.org/3/reference/datamodel.html#object.__radd__
 
-        // Reflected-method precedence is based on the operands' runtime classes, not on whether
-        // one value type is a subtype of the other. This matters for literals: an enum literal can
-        // have a class that is a strict subclass of `int` even though it is not a subtype of a
-        // specific integer literal.
-        //
-        // Technically, the type equality check is not required for correctness: equal value types
-        // have the same runtime class and reflected implementation. It provides a fast path for
-        // the common case and avoids the runtime-class checks and two class member lookups below.
-        let right_is_strict_subclass = left_ty != right_ty
-            && match (left_ty.nominal_class(db), right_ty.nominal_class(db)) {
-                (Some(left_class), Some(right_class))
-                    if !left_ty.is_type_var() && !right_ty.is_type_var() =>
-                {
-                    left_class.class_literal(db) != right_class.class_literal(db)
-                        && right_class.is_subclass_of(db, left_class)
-                }
-                _ => right_ty.is_subtype_of(db, left_ty),
-            };
+        // Runtime classes determine reflected priority, but static operand types may only
+        // establish that priority conditionally.
+        let reflected_priority = reflected_method_priority(db, left_ty, right_ty);
 
         let left_class = left_ty.to_meta_type(db);
         let right_class = right_ty.to_meta_type(db);
-        if right_is_strict_subclass {
+        if reflected_priority != ReflectedMethodPriority::Never {
             let reflected_dunder = op.reflected_dunder();
             let rhs_reflected = right_class.member(db, reflected_dunder).place;
             // TODO: if `rhs_reflected` is possibly unbound, we should union the two possible
@@ -92,15 +142,16 @@ impl<'db> Type<'db> {
                 && !rhs_reflected
                     .is_equal_ignoring_provenance(left_class.member(db, reflected_dunder).place)
             {
-                return Ok(right_ty
-                    .try_call_dunder_with_policy(
-                        db,
-                        reflected_dunder,
-                        &mut CallArguments::positional([left_ty]),
-                        TypeContext::default(),
-                        policy,
-                    )
-                    .or_else(|_| {
+                let call_on_right_instance = right_ty.try_call_dunder_with_policy(
+                    db,
+                    reflected_dunder,
+                    &mut CallArguments::positional([left_ty]),
+                    TypeContext::default(),
+                    policy,
+                );
+
+                if reflected_priority == ReflectedMethodPriority::Definitely {
+                    return Ok(call_on_right_instance.or_else(|_| {
                         left_ty.try_call_dunder_with_policy(
                             db,
                             op.dunder(),
@@ -109,6 +160,31 @@ impl<'db> Type<'db> {
                             policy,
                         )
                     })?);
+                }
+
+                let call_on_left_instance = left_ty.try_call_dunder_with_policy(
+                    db,
+                    op.dunder(),
+                    &mut CallArguments::positional([right_ty]),
+                    TypeContext::default(),
+                    policy,
+                );
+
+                return match (call_on_right_instance, call_on_left_instance) {
+                    (Ok(right_bindings), Ok(left_bindings)) => {
+                        let callable_type = UnionType::from_two_elements(
+                            db,
+                            right_bindings.callable_type(),
+                            left_bindings.callable_type(),
+                        );
+                        Ok(Bindings::from_union(
+                            callable_type,
+                            [right_bindings, left_bindings],
+                        ))
+                    }
+                    (Ok(bindings), Err(_)) | (Err(_), Ok(bindings)) => Ok(bindings),
+                    (Err(_), Err(error)) => Err(error.into()),
+                };
             }
         }
 


### PR DESCRIPTION
## Summary

This is a follow-up to #26434 that preserves both binary-operation dispatch results when static operand types do not determine their exact runtime classes.

For `left: Base` and `right: Child`, the runtime operands may be `Base + Child`, where `Child.__radd__` has priority, or `Child + Child`, where `Base.__add__` is called. We previously selected only the reflected result from the static subtype relationship.

This change classifies reflected priority as never, possible, or definite. Possible priority unions the normal and reflected call bindings; definite priority remains precise for exact left runtime classes such as the integer literal in `0 | Permission.READ`. Bounded TypeVars and NewTypes use the same conservative distinction.

```python
from typing import Literal

class Base:
    def __add__(self, other: object) -> Literal["base"]:
        return "base"

class Child(Base):
    def __radd__(self, other: object) -> Literal["child"]:
        return "child"

def add(left: Base, right: Child) -> Literal["base", "child"]:
    return left + right
```
