### PR TITLE
Shrink call keyword capacity

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -816,7 +816,7 @@ impl<'src> Parser<'src> {
         }
 
         let mut args = vec![];
-        let mut keywords = vec![];
+        let mut keywords = ThinVec::new();
         let mut seen_keyword_argument = false; // foo = 1
         let mut seen_keyword_unpacking = false; // **foo
 
@@ -947,15 +947,13 @@ impl<'src> Parser<'src> {
             });
 
         self.expect(TokenKind::Rpar);
-
-        let mut compact_keywords = ThinVec::with_capacity(keywords.len());
-        compact_keywords.extend(keywords);
+        keywords.shrink_to_fit();
 
         let arguments = ast::Arguments {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
             args: args.into_boxed_slice(),
-            keywords: compact_keywords,
+            keywords,
         };
 
         self.validate_arguments(&arguments, has_trailing_comma, context);

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -816,7 +816,7 @@ impl<'src> Parser<'src> {
         }
 
         let mut args = vec![];
-        let mut keywords = vec![];
+        let mut keywords = ThinVec::new();
         let mut seen_keyword_argument = false; // foo = 1
         let mut seen_keyword_unpacking = false; // **foo
 
@@ -947,12 +947,13 @@ impl<'src> Parser<'src> {
             });
 
         self.expect(TokenKind::Rpar);
+        keywords.shrink_to_fit();
 
         let arguments = ast::Arguments {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
             args: args.into_boxed_slice(),
-            keywords: keywords.into(),
+            keywords,
         };
 
         self.validate_arguments(&arguments, has_trailing_comma, context);

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -816,7 +816,7 @@ impl<'src> Parser<'src> {
         }
 
         let mut args = vec![];
-        let mut keywords = ThinVec::new();
+        let mut keywords = vec![];
         let mut seen_keyword_argument = false; // foo = 1
         let mut seen_keyword_unpacking = false; // **foo
 
@@ -947,13 +947,15 @@ impl<'src> Parser<'src> {
             });
 
         self.expect(TokenKind::Rpar);
-        keywords.shrink_to_fit();
+
+        let mut compact_keywords = ThinVec::with_capacity(keywords.len());
+        compact_keywords.extend(keywords);
 
         let arguments = ast::Arguments {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
             args: args.into_boxed_slice(),
-            keywords,
+            keywords: compact_keywords,
         };
 
         self.validate_arguments(&arguments, has_trailing_comma, context);


### PR DESCRIPTION
## Summary

Collect call keywords in a `Vec`, then move them into an exactly sized `ThinVec` before retaining them in the AST. The ordinary conversion preserved the `Vec`'s spare capacity, while constructing and shrinking a `ThinVec` directly added work to the hot parse loop. This keeps the original parsing path and performs one exact-capacity conversion at finalization.

This reduces retained AST memory from 956,062 bytes to 899,358 bytes (-5.93%) and full parsed memory from 1,208,698 bytes to 1,151,994 bytes on the existing five-file benchmark corpus. ty's normalized `parsed_module` memory also fell by 32,384 bytes across three identical runs.

The parser, AST, formatter, linter, and `ruff_db` test suites pass (4,254 tests), with no snapshot changes, and `prek` passes. This PR remains a draft while CodSpeed validates the revised construction strategy.
