### PR TITLE
[ty] Support comprehension walruses in IDE features

### DIFF
--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -90,6 +90,124 @@ mod tests {
     }
 
     #[test]
+    fn references_do_not_mix_global_and_nonlocal_comprehension_walruses() {
+        let test = cursor_test(
+            "
+last = 0
+
+def outer():
+    last = 1
+
+    def write_global():
+        global last
+        [(last := global_item) for global_item in [2]]
+
+    def write_nonlocal():
+        nonlocal last
+        [(last := nonlocal_item) for nonlocal_item in [3]]
+
+    write_global()
+    write_nonlocal()
+    return la<CURSOR>st
+",
+        );
+
+        let output = test.references();
+        assert!(
+            !output.contains("last := global_item"),
+            "references to a function-local variable must exclude a global walrus: {output}"
+        );
+        assert_snapshot!(output, @"
+        info[references]: Found 4 references
+          --> main.py:5:5
+           |
+         5 |     last = 1
+           |     ----
+           |
+          ::: main.py:12:18
+           |
+        12 |         nonlocal last
+           |                  ----
+        13 |         [(last := nonlocal_item) for nonlocal_item in [3]]
+           |           ----
+        14 |
+        15 |     write_global()
+        16 |     write_nonlocal()
+        17 |     return last
+           |            ----
+           |
+        ");
+    }
+
+    #[test]
+    fn comprehension_walrus_references_in_function() {
+        let test = cursor_test(
+            "
+def f(items):
+    [(la<CURSOR>st := item) for item in items]
+    return last
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+         --> main.py:3:7
+          |
+        3 |     [(last := item) for item in items]
+          |       ----
+        4 |     return last
+          |            ----
+          |
+        ");
+    }
+
+    #[test]
+    fn nested_comprehension_walrus_references_in_function() {
+        let test = cursor_test(
+            "
+def f(items):
+    [[(la<CURSOR>st := item) for item in items] for _ in [1]]
+    return last
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+         --> main.py:3:8
+          |
+        3 |     [[(last := item) for item in items] for _ in [1]]
+          |        ----
+        4 |     return last
+          |            ----
+          |
+        ");
+    }
+
+    #[test]
+    fn comprehension_walrus_references_across_files() {
+        let test = CursorTest::builder()
+            .source("lib.py", "[(la<CURSOR>st := item) for item in [1]]\n")
+            .source("main.py", "from lib import last\nprint(last)\n")
+            .build();
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 3 references
+         --> lib.py:1:3
+          |
+        1 | [(last := item) for item in [1]]
+          |   ----
+          |
+         ::: main.py:1:17
+          |
+        1 | from lib import last
+          |                 ----
+        2 | print(last)
+          |       ----
+          |
+        ");
+    }
+
+    #[test]
     fn parameter_references_in_function() {
         let test = cursor_test(
             "

--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -112,12 +112,7 @@ def outer():
 ",
         );
 
-        let output = test.references();
-        assert!(
-            !output.contains("last := global_item"),
-            "references to a function-local variable must exclude a global walrus: {output}"
-        );
-        assert_snapshot!(output, @"
+        assert_snapshot!(test.references(), @"
         info[references]: Found 4 references
           --> main.py:5:5
            |

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -65,12 +65,7 @@ def outer():
 ",
         );
 
-        let output = test.goto_definition();
-        assert!(
-            !output.contains("last := global_item"),
-            "a module-global writer must not define a function-local variable: {output}"
-        );
-        assert_snapshot!(output, @"
+        assert_snapshot!(test.goto_definition(), @"
         info[goto-definition]: Go to definition
           --> main.py:17:12
            |

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -33,7 +33,7 @@ pub fn goto_definition(
 #[cfg(test)]
 pub(super) mod test {
 
-    use crate::tests::{CursorTest, IntoDiagnostic};
+    use crate::tests::{CursorTest, IntoDiagnostic, cursor_test};
     use crate::{NavigationTargets, RangedValue, goto_definition};
     use insta::assert_snapshot;
     use ruff_db::diagnostic::{
@@ -44,10 +44,8 @@ pub(super) mod test {
 
     #[test]
     fn goto_definition_does_not_mix_global_and_nonlocal_comprehension_walruses() {
-        let test = CursorTest::builder()
-            .source(
-                "main.py",
-                "
+        let test = cursor_test(
+            "
 last = 0
 
 def outer():
@@ -65,8 +63,7 @@ def outer():
     write_nonlocal()
     return la<CURSOR>st
 ",
-            )
-            .build();
+        );
 
         let output = test.goto_definition();
         assert!(
@@ -96,16 +93,13 @@ def outer():
 
     #[test]
     fn goto_definition_comprehension_walrus_in_function() {
-        let test = CursorTest::builder()
-            .source(
-                "main.py",
-                "
+        let test = cursor_test(
+            "
 def f(items):
     [(last := item) for item in items]
     return la<CURSOR>st
 ",
-            )
-            .build();
+        );
 
         assert_snapshot!(test.goto_definition(), @"
         info[goto-definition]: Go to definition
@@ -125,16 +119,13 @@ def f(items):
 
     #[test]
     fn goto_definition_nested_comprehension_walrus_in_function() {
-        let test = CursorTest::builder()
-            .source(
-                "main.py",
-                "
+        let test = cursor_test(
+            "
 def f(items):
     [[(last := item) for item in items] for _ in [1]]
     return la<CURSOR>st
 ",
-            )
-            .build();
+        );
 
         assert_snapshot!(test.goto_definition(), @"
         info[goto-definition]: Go to definition
@@ -177,10 +168,8 @@ def f(items):
 
     #[test]
     fn goto_definition_nonlocal_comprehension_walrus() {
-        let test = CursorTest::builder()
-            .source(
-                "main.py",
-                "
+        let test = cursor_test(
+            "
 def outer(items):
     last = 0
 
@@ -191,8 +180,7 @@ def outer(items):
 
     return inner()
 ",
-            )
-            .build();
+        );
 
         assert_snapshot!(test.goto_definition(), @"
         info[goto-definition]: Go to definition

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -43,6 +43,179 @@ pub(super) mod test {
     use ruff_text_size::Ranged;
 
     #[test]
+    fn goto_definition_does_not_mix_global_and_nonlocal_comprehension_walruses() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+last = 0
+
+def outer():
+    last = 1
+
+    def write_global():
+        global last
+        [(last := global_item) for global_item in [2]]
+
+    def write_nonlocal():
+        nonlocal last
+        [(last := nonlocal_item) for nonlocal_item in [3]]
+
+    write_global()
+    write_nonlocal()
+    return la<CURSOR>st
+",
+            )
+            .build();
+
+        let output = test.goto_definition();
+        assert!(
+            !output.contains("last := global_item"),
+            "a module-global writer must not define a function-local variable: {output}"
+        );
+        assert_snapshot!(output, @"
+        info[goto-definition]: Go to definition
+          --> main.py:17:12
+           |
+        17 |     return last
+           |            ^^^^ Clicking here
+           |
+        info: Found 2 definitions
+          --> main.py:5:5
+           |
+         5 |     last = 1
+           |     ----
+           |
+          ::: main.py:13:11
+           |
+        13 |         [(last := nonlocal_item) for nonlocal_item in [3]]
+           |           ----
+           |
+        ");
+    }
+
+    #[test]
+    fn goto_definition_comprehension_walrus_in_function() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+def f(items):
+    [(last := item) for item in items]
+    return la<CURSOR>st
+",
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> main.py:4:12
+          |
+        4 |     return last
+          |            ^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:7
+          |
+        3 |     [(last := item) for item in items]
+          |       ----
+          |
+        ");
+    }
+
+    #[test]
+    fn goto_definition_nested_comprehension_walrus_in_function() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+def f(items):
+    [[(last := item) for item in items] for _ in [1]]
+    return la<CURSOR>st
+",
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> main.py:4:12
+          |
+        4 |     return last
+          |            ^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:3:8
+          |
+        3 |     [[(last := item) for item in items] for _ in [1]]
+          |        ----
+          |
+        ");
+    }
+
+    #[test]
+    fn goto_definition_imported_comprehension_walrus() {
+        let test = CursorTest::builder()
+            .source("lib.py", "[(last := item) for item in [1]]\n")
+            .source("main.py", "from lib import last\nprint(la<CURSOR>st)\n")
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> main.py:2:7
+          |
+        2 | print(last)
+          |       ^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> lib.py:1:3
+          |
+        1 | [(last := item) for item in [1]]
+          |   ----
+          |
+        ");
+    }
+
+    #[test]
+    fn goto_definition_nonlocal_comprehension_walrus() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+def outer(items):
+    last = 0
+
+    def inner():
+        nonlocal last
+        [(last := item) for item in items]
+        return la<CURSOR>st
+
+    return inner()
+",
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> main.py:8:16
+          |
+        8 |         return last
+          |                ^^^^ Clicking here
+          |
+        info: Found 2 definitions
+         --> main.py:3:5
+          |
+        3 |     last = 0
+          |     ----
+        4 |
+        5 |     def inner():
+        6 |         nonlocal last
+        7 |         [(last := item) for item in items]
+          |           ----
+          |
+        ");
+    }
+
+    #[test]
     fn goto_definition_relative_import() {
         let test = CursorTest::builder()
             .source("mypackage/__init__.py", "from . import module_a<CURSOR>")

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -253,10 +253,12 @@ pub(crate) fn has_any_external_visible_definitions(
     definitions.iter().any(|definition| match definition {
         ResolvedDefinition::Definition(definition) => match definition.scope(db).scope(db).kind() {
             ScopeKind::Module | ScopeKind::Class => true,
-            // A comprehension walrus binds in its containing scope. Conservatively search other
-            // files even when that containing scope is local; references are matched semantically.
             ScopeKind::Comprehension => {
                 matches!(definition.kind(db), DefinitionKind::NamedExpression(_))
+                    && definition.place(db).as_symbol().is_some_and(|symbol_id| {
+                        ty_python_core::semantic_index(db, definition.file(db))
+                            .symbol_resolves_to_global_scope(symbol_id, definition.file_scope(db))
+                    })
             }
             ScopeKind::TypeParams
             | ScopeKind::Function
@@ -817,6 +819,23 @@ mod tests {
         for (case, source) in [
             ("module-global", "x<CURSOR> = 1"),
             (
+                "module comprehension walrus",
+                "[(x<CURSOR> := item) for item in [1]]",
+            ),
+            (
+                "nested module comprehension walrus",
+                "[[(x<CURSOR> := item) for item in [1]] for _ in [1]]",
+            ),
+            (
+                "explicit global comprehension walrus",
+                "
+x = 0
+def f():
+    global x
+    [(x<CURSOR> := item) for item in [1]]
+",
+            ),
+            (
                 "class",
                 "
 class C:
@@ -842,6 +861,38 @@ def f():
             ),
             ("lambda", "f = lambda x<CURSOR>: x"),
             ("comprehension", "xs = [x for x<CURSOR> in range(3)]"),
+            (
+                "function comprehension walrus",
+                "
+def f():
+    [(x<CURSOR> := item) for item in [1]]
+    return x
+",
+            ),
+            (
+                "nested function comprehension walrus",
+                "
+def f():
+    [[(x<CURSOR> := item) for item in [1]] for _ in [1]]
+    return x
+",
+            ),
+            (
+                "lambda comprehension walrus",
+                "f = lambda: [(x<CURSOR> := item) for item in [1]]",
+            ),
+            (
+                "explicit nonlocal comprehension walrus",
+                "
+def outer():
+    x = 0
+    def inner():
+        nonlocal x
+        [(x<CURSOR> := item) for item in [1]]
+    inner()
+    return x
+",
+            ),
             ("type parameters", "type Alias[T<CURSOR>] = list[T]"),
         ] {
             let test = cursor_test(source);

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -253,10 +253,14 @@ pub(crate) fn has_any_external_visible_definitions(
     definitions.iter().any(|definition| match definition {
         ResolvedDefinition::Definition(definition) => match definition.scope(db).scope(db).kind() {
             ScopeKind::Module | ScopeKind::Class => true,
+            // A comprehension walrus binds in its containing scope. Conservatively search other
+            // files even when that containing scope is local; references are matched semantically.
+            ScopeKind::Comprehension => {
+                matches!(definition.kind(db), DefinitionKind::NamedExpression(_))
+            }
             ScopeKind::TypeParams
             | ScopeKind::Function
             | ScopeKind::Lambda
-            | ScopeKind::Comprehension
             | ScopeKind::TypeAlias => false,
         },
         ResolvedDefinition::Module(_) | ResolvedDefinition::FileWithRange(_) => true,

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -166,6 +166,102 @@ mod tests {
     }
 
     #[test]
+    fn rename_does_not_mix_global_and_nonlocal_comprehension_walruses() {
+        let test = cursor_test(
+            "
+last = 0
+
+def outer():
+    last = 1
+
+    def write_global():
+        global last
+        [(last := global_item) for global_item in [2]]
+
+    def write_nonlocal():
+        nonlocal last
+        [(last := nonlocal_item) for nonlocal_item in [3]]
+
+    write_global()
+    write_nonlocal()
+    return la<CURSOR>st
+",
+        );
+
+        let output = test.rename("result");
+        assert!(
+            !output.contains("last := global_item"),
+            "renaming a function-local variable must not rename a global walrus: {output}"
+        );
+        assert_snapshot!(output, @"
+        info[rename]: Rename symbol (found 4 locations)
+          --> main.py:5:5
+           |
+         5 |     last = 1
+           |     ^^^^
+           |
+          ::: main.py:12:18
+           |
+        12 |         nonlocal last
+           |                  ----
+        13 |         [(last := nonlocal_item) for nonlocal_item in [3]]
+           |           ----
+        14 |
+        15 |     write_global()
+        16 |     write_nonlocal()
+        17 |     return last
+           |            ----
+           |
+        ");
+    }
+
+    #[test]
+    fn rename_comprehension_walrus_in_function() {
+        let test = cursor_test(
+            "
+def f(items):
+    [(la<CURSOR>st := item) for item in items]
+    return last
+",
+        );
+
+        assert_snapshot!(test.rename("result"), @"
+        info[rename]: Rename symbol (found 2 locations)
+         --> main.py:3:7
+          |
+        3 |     [(last := item) for item in items]
+          |       ^^^^
+        4 |     return last
+          |            ----
+          |
+        ");
+    }
+
+    #[test]
+    fn rename_comprehension_walrus_across_files() {
+        let test = CursorTest::builder()
+            .source("lib.py", "[(la<CURSOR>st := item) for item in [1]]\n")
+            .source("main.py", "from lib import last\nprint(last)\n")
+            .build();
+
+        assert_snapshot!(test.rename("result"), @"
+        info[rename]: Rename symbol (found 3 locations)
+         --> lib.py:1:3
+          |
+        1 | [(last := item) for item in [1]]
+          |   ^^^^
+          |
+         ::: main.py:1:17
+          |
+        1 | from lib import last
+          |                 ----
+        2 | print(last)
+          |       ----
+          |
+        ");
+    }
+
+    #[test]
     fn prepare_rename_parameter() {
         let test = cursor_test(
             "

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -188,12 +188,7 @@ def outer():
 ",
         );
 
-        let output = test.rename("result");
-        assert!(
-            !output.contains("last := global_item"),
-            "renaming a function-local variable must not rename a global walrus: {output}"
-        );
-        assert_snapshot!(output, @"
+        assert_snapshot!(test.rename("result"), @"
         info[rename]: Rename symbol (found 4 locations)
           --> main.py:5:5
            |

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -1603,7 +1603,9 @@ pub struct NestedBindingsDefinitionKind {
 }
 
 impl NestedBindingsDefinitionKind {
-    /// Returns the binding source for each nested declaration, along with whether it is global.
+    /// Returns every nested binding source and whether it was declared `global`.
+    ///
+    /// Use [`Self::visible_binding_sources`] when resolving the binding in a particular scope.
     pub fn binding_sources<'index, 'db>(
         &'index self,
         index: &'index SemanticIndex<'db>,
@@ -1620,6 +1622,53 @@ impl NestedBindingsDefinitionKind {
             };
             Some((declaration.is_global(), bindings))
         })
+    }
+
+    /// Returns nested binding sources that can update the same variable as `scope`.
+    ///
+    /// A synthetic binding can collect both `global` and `nonlocal` writes to one name:
+    ///
+    /// ```python
+    /// x = 0
+    ///
+    /// def outer():
+    ///     x = 1
+    ///
+    ///     def change_global():
+    ///         global x
+    ///         x = 2
+    ///
+    ///     def change_nonlocal():
+    ///         nonlocal x
+    ///         x = 3
+    /// ```
+    ///
+    /// Only `change_nonlocal` can update `outer`'s local `x`. Nested functions also cannot
+    /// capture a class-local variable, so class scopes do not see nonlocal writes to their
+    /// own bindings.
+    pub fn visible_binding_sources<'index, 'db>(
+        &'index self,
+        index: &'index SemanticIndex<'db>,
+        scope: FileScopeId,
+    ) -> impl Iterator<Item = BindingWithConstraintsIterator<'index, 'db>> + 'index {
+        let symbol_id = index.place_table(scope).symbol_id(&self.name);
+        let sees_global = symbol_id
+            .is_some_and(|symbol_id| index.symbol_resolves_to_global_scope(symbol_id, scope));
+        let sees_nonlocal = !sees_global
+            && symbol_id.is_some_and(|symbol_id| {
+                !(index.scope(scope).kind().is_class()
+                    && index.place_table(scope).symbol(symbol_id).is_local())
+            });
+
+        self.binding_sources(index)
+            .filter_map(move |(is_global, bindings)| {
+                (if is_global {
+                    sees_global
+                } else {
+                    sees_nonlocal
+                })
+                .then_some(bindings)
+            })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1034,7 +1034,9 @@ fn collect_implementation_root_classes<'db>(
 /// ```
 ///
 /// The binding for the use in `print` is synthetic, so follow it into the comprehension's
-/// end-of-scope bindings. Nested comprehensions can produce a chain of these proxies.
+/// end-of-scope bindings. Nested comprehensions can produce a chain of these proxies. Only
+/// follow sources that resolve to the same variable, so `global` and `nonlocal` writes do not
+/// become definitions of each other.
 fn user_visible_definitions<'db>(
     db: &'db dyn Db,
     definitions: impl IntoIterator<Item = Definition<'db>>,
@@ -1051,25 +1053,8 @@ fn user_visible_definitions<'db>(
         match definition.kind(db) {
             DefinitionKind::NestedBindings(nested) => {
                 let index = semantic_index(db, definition.file(db));
-                let Some(symbol_id) = definition.place(db).as_symbol() else {
-                    continue;
-                };
-                let scope_id = definition.file_scope(db);
-                let this_scope_sees_global_bindings =
-                    index.symbol_resolves_to_global_scope(symbol_id, scope_id);
-                let this_scope_sees_nonlocal_bindings = !(this_scope_sees_global_bindings
-                    || (index.scope(scope_id).kind().is_class()
-                        && index.place_table(scope_id).symbol(symbol_id).is_local()));
                 let sources = nested
-                    .binding_sources(index)
-                    .filter_map(|(is_global, bindings)| {
-                        (if is_global {
-                            this_scope_sees_global_bindings
-                        } else {
-                            this_scope_sees_nonlocal_bindings
-                        })
-                        .then_some(bindings)
-                    })
+                    .visible_binding_sources(index, definition.file_scope(db))
                     .flatten()
                     .filter_map(|binding| binding.binding.definition());
                 // A lazy function proxy can lead to an eager comprehension proxy. Follow that

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use crate::FxIndexSet;
 use crate::place::builtins_module_scope;
@@ -22,7 +22,7 @@ use ruff_python_ast::{self as ast, AnyNodeRef, name::Name};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 use ty_module_resolver::Module;
-use ty_python_core::definition::{Definition, DefinitionKind};
+use ty_python_core::definition::{Definition, DefinitionKind, NestedBindingExecution};
 use ty_python_core::{attribute_scopes, global_scope, semantic_index, use_def_map};
 
 mod unreachable_code;
@@ -82,10 +82,30 @@ pub fn definitions_for_name<'db>(
             continue; // Name not found in this scope, try parent scope
         };
 
+        let use_def_map = index.use_def_map(scope_id);
+
         // Check if this place is marked as global or nonlocal
         let place_expr = place_table.symbol(symbol_id);
         let is_global = place_expr.is_global();
         let is_nonlocal = place_expr.is_nonlocal();
+
+        if is_global || is_nonlocal {
+            // Assignments in a forwarding scope remain valid navigation targets, including eager
+            // walrus bindings exported from comprehensions.
+            all_definitions.extend(user_visible_definitions(
+                db,
+                use_def_map
+                    .reachable_symbol_bindings(symbol_id)
+                    .filter_map(|binding| binding.binding.definition())
+                    .filter(|definition| match definition.kind(db) {
+                        DefinitionKind::NamedExpression(_) => true,
+                        DefinitionKind::NestedBindings(nested) => {
+                            nested.execution == NestedBindingExecution::Eager
+                        }
+                        _ => false,
+                    }),
+            ));
+        }
 
         // TODO: The current algorithm doesn't return definitions or bindings
         // for other scopes that are outside of this scope hierarchy that target
@@ -100,7 +120,7 @@ pub fn definitions_for_name<'db>(
 
             if let Some(global_symbol_id) = global_place_table.symbol_id(name_str) {
                 let global_use_def_map = ty_python_core::use_def_map(db, global_scope_id);
-                all_definitions.extend(reachable_definitions(
+                all_definitions.extend(user_visible_definitions(
                     db,
                     global_use_def_map
                         .reachable_symbol_bindings(global_symbol_id)
@@ -121,10 +141,8 @@ pub fn definitions_for_name<'db>(
             continue;
         }
 
-        let use_def_map = index.use_def_map(scope_id);
-
         // Get all definitions (both bindings and declarations) for this place
-        all_definitions.extend(reachable_definitions(
+        all_definitions.extend(user_visible_definitions(
             db,
             use_def_map
                 .reachable_symbol_bindings(symbol_id)
@@ -1006,14 +1024,52 @@ fn collect_implementation_root_classes<'db>(
     }
 }
 
-fn reachable_definitions<'db>(
+/// Returns the user-visible definitions represented by a use-def binding.
+///
+/// Comprehension walruses are represented in the containing scope by synthetic eager bindings:
+///
+/// ```python
+/// [(last := item) for item in items]
+/// print(last)  # Go to definition should select `last := item` above.
+/// ```
+///
+/// The binding for the use in `print` is synthetic, so follow it into the comprehension's
+/// end-of-scope bindings. Nested comprehensions can produce a chain of these proxies.
+fn user_visible_definitions<'db>(
     db: &'db dyn Db,
     definitions: impl IntoIterator<Item = Definition<'db>>,
 ) -> FxIndexSet<Definition<'db>> {
-    definitions
-        .into_iter()
-        .filter(|definition| definition.kind(db).is_user_visible())
-        .collect()
+    let mut pending = definitions.into_iter().collect::<VecDeque<_>>();
+    let mut seen = FxHashSet::default();
+    let mut result = FxIndexSet::default();
+
+    while let Some(definition) = pending.pop_front() {
+        if !seen.insert(definition) {
+            continue;
+        }
+
+        match definition.kind(db) {
+            DefinitionKind::NestedBindings(nested) => {
+                let index = semantic_index(db, definition.file(db));
+                let sources = nested
+                    .binding_sources(index)
+                    .flat_map(|(_, bindings)| bindings)
+                    .filter_map(|binding| binding.binding.definition());
+                // A lazy function proxy can lead to an eager comprehension proxy. Follow that
+                // proxy-only chain without exposing ordinary lazy nested assignments.
+                pending.extend(sources.filter(|source| {
+                    nested.execution == NestedBindingExecution::Eager
+                        || matches!(source.kind(db), DefinitionKind::NestedBindings(_))
+                }));
+            }
+            kind if kind.is_user_visible() => {
+                result.insert(definition);
+            }
+            _ => {}
+        }
+    }
+
+    result
 }
 
 fn reachable_implementation_definitions<'db>(
@@ -1073,7 +1129,7 @@ fn resolve_reachable_definitions<'db>(
     symbol_name: &str,
     definitions: impl IntoIterator<Item = Definition<'db>>,
 ) -> Vec<ResolvedDefinition<'db>> {
-    reachable_definitions(db, definitions)
+    user_visible_definitions(db, definitions)
         .into_iter()
         .flat_map(|definition| {
             resolve_definition(
@@ -2320,7 +2376,9 @@ mod resolve_definition {
             }
         }
 
-        definitions
+        super::user_visible_definitions(db, definitions)
+            .into_iter()
+            .collect()
     }
 
     /// Given a definition that may be in a stub file, find the "real" definition in a non-stub.

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1051,9 +1051,26 @@ fn user_visible_definitions<'db>(
         match definition.kind(db) {
             DefinitionKind::NestedBindings(nested) => {
                 let index = semantic_index(db, definition.file(db));
+                let Some(symbol_id) = definition.place(db).as_symbol() else {
+                    continue;
+                };
+                let scope_id = definition.file_scope(db);
+                let this_scope_sees_global_bindings =
+                    index.symbol_resolves_to_global_scope(symbol_id, scope_id);
+                let this_scope_sees_nonlocal_bindings = !(this_scope_sees_global_bindings
+                    || (index.scope(scope_id).kind().is_class()
+                        && index.place_table(scope_id).symbol(symbol_id).is_local()));
                 let sources = nested
                     .binding_sources(index)
-                    .flat_map(|(_, bindings)| bindings)
+                    .filter_map(|(is_global, bindings)| {
+                        (if is_global {
+                            this_scope_sees_global_bindings
+                        } else {
+                            this_scope_sees_nonlocal_bindings
+                        })
+                        .then_some(bindings)
+                    })
+                    .flatten()
                     .filter_map(|binding| binding.binding.definition());
                 // A lazy function proxy can lead to an eager comprehension proxy. Follow that
                 // proxy-only chain without exposing ordinary lazy nested assignments.

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -77,6 +77,14 @@ pub fn unused_bindings(db: &dyn Db, file: ruff_db::files::File) -> Box<[UnusedBi
     let is_stub_file = file.is_stub(db);
     let index = semantic_index(db, file);
     let mut unused = Vec::new();
+    // A used synthetic definition counts as a use of the user-visible definitions it represents.
+    let used_definitions = index.scope_ids().flat_map(|scope_id| {
+        index
+            .use_def_map(scope_id.file_scope_id(db))
+            .all_definitions_with_usage()
+            .filter_map(|(_, state, is_used)| is_used.then_some(state.definition()).flatten())
+    });
+    let used_user_visible_definitions = super::user_visible_definitions(db, used_definitions);
 
     for scope_id in index.scope_ids() {
         let file_scope_id = scope_id.file_scope_id(db);
@@ -107,6 +115,7 @@ pub fn unused_bindings(db: &dyn Db, file: ruff_db::files::File) -> Box<[UnusedBi
             let DefinitionState::Defined(definition) = state else {
                 continue;
             };
+            let is_used = is_used || used_user_visible_definitions.contains(&definition);
 
             if is_used {
                 let DefinitionKind::LoopHeader(loop_header_definition) = definition.kind(db) else {
@@ -158,7 +167,9 @@ pub fn unused_bindings(db: &dyn Db, file: ruff_db::files::File) -> Box<[UnusedBi
 
             // Global and nonlocal assignments target bindings from outer scopes.
             // Treat them as externally managed to avoid false positives here.
-            if symbol.is_global() || symbol.is_nonlocal() {
+            let is_comprehension_named_expression = scope_kind == ScopeKind::Comprehension
+                && matches!(kind, DefinitionKind::NamedExpression(_));
+            if (symbol.is_global() || symbol.is_nonlocal()) && !is_comprehension_named_expression {
                 continue;
             }
 

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -44,7 +44,16 @@ fn should_consider_definition(kind: &DefinitionKind<'_>) -> bool {
     }
 }
 
-/// Returns whether a comprehension walrus belongs to the nearest enclosing local scope.
+/// Returns whether a comprehension walrus belongs to an enclosing function or lambda.
+///
+/// ```python
+/// def last_item(items):
+///     [(last := item) for item in items]
+///     return last
+/// ```
+///
+/// A module-level walrus, or one declared `global` or `nonlocal` in its containing
+/// function, is not a local binding and must not receive an unused-binding diagnostic.
 fn comprehension_named_expression_is_local(
     index: &SemanticIndex<'_>,
     comprehension_scope: FileScopeId,

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -388,34 +388,6 @@ mod tests {
     }
 
     #[test]
-    fn keeps_global_and_nonlocal_comprehension_walruses_separate() -> anyhow::Result<()> {
-        let source = dedent(
-            "
-            last = 0
-
-            def outer():
-                last = 1
-
-                def write_global():
-                    global last
-                    [(last := global_item) for global_item in [2]]
-
-                def write_nonlocal():
-                    nonlocal last
-                    [(last := nonlocal_item) for nonlocal_item in [3]]
-
-                write_global()
-                write_nonlocal()
-                return last
-            ",
-        );
-
-        let names = collect_unused_names(&source)?;
-        assert_eq!(names, Vec::<String>::new());
-        Ok(())
-    }
-
-    #[test]
     fn tracks_comprehension_walruses_in_local_scopes() -> anyhow::Result<()> {
         let source = dedent(
             "

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -44,6 +44,27 @@ fn should_consider_definition(kind: &DefinitionKind<'_>) -> bool {
     }
 }
 
+/// Returns whether a comprehension walrus belongs to the nearest enclosing local scope.
+fn comprehension_named_expression_is_local(
+    index: &SemanticIndex<'_>,
+    comprehension_scope: FileScopeId,
+    name: &str,
+) -> bool {
+    index
+        .ancestor_scopes(comprehension_scope)
+        .skip(1)
+        .find(|(_, scope)| scope.kind() != ScopeKind::Comprehension)
+        .is_some_and(|(scope_id, scope)| {
+            matches!(scope.kind(), ScopeKind::Function | ScopeKind::Lambda)
+                && index
+                    .place_table(scope_id)
+                    .symbol_id(name)
+                    .is_some_and(|symbol_id| {
+                        index.place_table(scope_id).symbol(symbol_id).is_local()
+                    })
+        })
+}
+
 fn function_scope_is_overload_declaration(
     db: &dyn Db,
     index: &SemanticIndex<'_>,
@@ -167,9 +188,12 @@ pub fn unused_bindings(db: &dyn Db, file: ruff_db::files::File) -> Box<[UnusedBi
 
             // Global and nonlocal assignments target bindings from outer scopes.
             // Treat them as externally managed to avoid false positives here.
-            let is_comprehension_named_expression = scope_kind == ScopeKind::Comprehension
-                && matches!(kind, DefinitionKind::NamedExpression(_));
-            if (symbol.is_global() || symbol.is_nonlocal()) && !is_comprehension_named_expression {
+            let is_local_comprehension_named_expression = scope_kind == ScopeKind::Comprehension
+                && matches!(kind, DefinitionKind::NamedExpression(_))
+                && comprehension_named_expression_is_local(index, file_scope_id, name);
+            if (symbol.is_global() || symbol.is_nonlocal())
+                && !is_local_comprehension_named_expression
+            {
                 continue;
             }
 
@@ -289,6 +313,8 @@ mod tests {
         let source = dedent(
             "
             module_dead = 1
+            [(module_walrus := item) for item in [1]]
+            [[(nested_module_walrus := item) for item in [1]] for _ in [1]]
 
             class C:
                 class_dead = 1
@@ -331,6 +357,7 @@ mod tests {
             def mutate_global():
                 global global_value
                 global_value = 1
+                [(global_value := item) for item in [1]]
                 local_dead = 1
 
             def outer():
@@ -339,6 +366,7 @@ mod tests {
                 def inner():
                     nonlocal captured
                     captured = 1
+                    [(captured := item) for item in [1]]
 
                 inner()
                 return captured
@@ -347,6 +375,72 @@ mod tests {
 
         let names = collect_unused_names(&source)?;
         assert_eq!(names, vec!["local_dead"]);
+        Ok(())
+    }
+
+    #[test]
+    fn keeps_global_and_nonlocal_comprehension_walruses_separate() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            last = 0
+
+            def outer():
+                last = 1
+
+                def write_global():
+                    global last
+                    [(last := global_item) for global_item in [2]]
+
+                def write_nonlocal():
+                    nonlocal last
+                    [(last := nonlocal_item) for nonlocal_item in [3]]
+
+                write_global()
+                write_nonlocal()
+                return last
+            ",
+        );
+
+        let names = collect_unused_names(&source)?;
+        assert_eq!(names, Vec::<String>::new());
+        Ok(())
+    }
+
+    #[test]
+    fn tracks_comprehension_walruses_in_local_scopes() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def used(items):
+                [(used_walrus := item) for item in items]
+                return used_walrus
+
+            def unused(items):
+                [(unused_walrus := item) for item in items]
+
+            def nested_used(items):
+                [[(nested_used_walrus := item) for item in items] for _ in [1]]
+                return nested_used_walrus
+
+            def nested_unused(items):
+                [[(nested_unused_walrus := item) for item in items] for _ in [1]]
+
+            used_lambda = lambda items: (
+                [(used_lambda_walrus := item) for item in items],
+                used_lambda_walrus,
+            )
+            unused_lambda = lambda items: [(unused_lambda_walrus := item) for item in items]
+            ",
+        );
+
+        let names = collect_unused_names(&source)?;
+        assert_eq!(
+            names,
+            vec![
+                "nested_unused_walrus",
+                "unused_lambda_walrus",
+                "unused_walrus",
+            ]
+        );
         Ok(())
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2441,61 +2441,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         const MAX_EXACT_NESTED_BINDING_REACHABILITY_NODES: usize = 2048;
 
         let db = self.db();
-        let scope = definition.scope(db);
-        let scope_id = scope.file_scope_id(db);
-        let symbol_id = definition
-            .place(db)
-            .as_symbol()
-            .expect("nested bindings definition should be a symbol");
-        let symbol = self.index.place_table(scope_id).symbol(symbol_id);
-
-        // At the point where a nested bindings definition is first synthesized, we don't
-        // necessarily know whether the current scope will see global or nonlocal bindings.
-        // Consider this example:
-        //
-        //     def outer():
-        //         def inner1():
-        //             global x
-        //             x = 1
-        //         def inner2():
-        //             nonlocal x
-        //             x = 2
-        //         # Nested bindings of both kinds are potentially visible here, but we can't
-        //         # actually use both kinds in the same scope. If `print(x)` comes next, we should
-        //         # only see 2. But if `global x; print(x)` comes next, we should only see 1.
-        //         ...
-        //
-        // By the time we get here in type inference, though, we can ask the semantic index whether
-        // the symbol resolves to the global scope or not. (For free variables, this currently
-        // requires walking ancestor scopes.) If so, we see any nested `global` bindings that were
-        // recorded. If not, we see any nested `nonlocal` ones.
-        //
-        // Note that if `x` is a free variable in this scope, then this synthetic binding will not
-        // shadow `UNBOUND`, and `infer_place_load` will walk to the defining scope and see all the
-        // nested bindings from there via the symbol's public type. However, we still want to
-        // respect locally visible nested bindings in that case, because there might be narrowing
-        // constraints that apply to the public type but not these nested bindings.
-        let this_scope_sees_global_bindings = self
-            .index
-            .symbol_resolves_to_global_scope(symbol_id, scope_id);
-
-        // If a function body binds `x`, it's interested in nested `nonlocal` bindings of `x` too,
-        // because those resolve to the same variable. But if a *class* body binds `x`, it does
-        // *not* want to consider nested bindings of `x`, because those do *not* resolve to the
-        // same variable.
-        let this_scope_sees_nonlocal_bindings = !(this_scope_sees_global_bindings
-            || (scope.scope(db).kind().is_class() && symbol.is_local()));
-
+        let scope_id = definition.file_scope(db);
         let mut binding_sources = nested_bindings_kind
-            .binding_sources(self.index)
-            .filter_map(|(is_global, bindings)| {
-                (if is_global {
-                    this_scope_sees_global_bindings
-                } else {
-                    this_scope_sees_nonlocal_bindings
-                })
-                .then_some(bindings)
-            })
+            .visible_binding_sources(self.index, scope_id)
             .peekable();
         if binding_sources.peek().is_some()
             && self


### PR DESCRIPTION
## Summary

In #26466, we added semantic modeling for walrus targets from comprehensions in the containing semantic scope. This follow-up teaches IDE features to resolve the synthetic eager bindings back to their user-visible walrus definitions.

This makes go-to-definition select the walrus target and allows references and rename to follow module/global comprehension walruses across files.
