### PR TITLE
[ty] Model loop-carried comprehension walruses

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -2,8 +2,8 @@
 
 ## Later comprehension targets cannot be modeled precisely by the current loop headers
 
-The branch now carries later generator targets through enclosing comprehension loop headers. This
-fixes the type of a target left behind by a completed inner loop:
+An earlier version of the branch carried later generator targets through enclosing comprehension
+loop headers. This fixed the type of a target left behind by a completed inner loop:
 
 ```py
 first = True
@@ -48,3 +48,9 @@ headers. This restores the definite unresolved-reference diagnostic for reads be
 assignment, at the cost of retaining the existing loss of precision for values left behind by prior
 inner iterations. Precise support for both cases should be handled separately as a larger control-
 flow project.
+
+### Resolution
+
+Later generator targets are now excluded from enclosing loop headers. The comprehension mdtests
+cover both the restored first-iteration diagnostic and the intentionally conservative loss of the
+prior inner iteration's target type.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,50 @@
+# Review findings
+
+## Later comprehension targets cannot be modeled precisely by the current loop headers
+
+The branch now carries later generator targets through enclosing comprehension loop headers. This
+fixes the type of a target left behind by a completed inner loop:
+
+```py
+first = True
+[(first := False) for _ in [0, 1] if ((value := "" if first else y) or True) for y in [1]]
+```
+
+On the second outer iteration, `y` has the value from the preceding inner iteration. Omitting `y`
+from the outer header therefore loses its `int` type.
+
+However, the same header also makes a later target appear available before its first assignment:
+
+```py
+[None for a in [0, 1] if (flag := True) if c for c in [1]]
+```
+
+Python raises `UnboundLocalError` when the first outer iteration reads `c`. The base branch reports
+`unresolved-reference`, but carrying `c` through the outer header reduces this to
+`possibly-unresolved-reference`. Because that rule is disabled by default, the branch emits no
+diagnostic in the default configuration.
+
+### Root cause
+
+The use-def map represents a loop header as one merged state. Adding a later target to that state
+preserves the value from prior iterations, but the map does not separately represent the first
+iteration, when that target is still unbound. It also does not retain the correlation needed to
+prove that the valid example reads `y` only after an earlier inner iteration assigned it.
+
+I tried recovering the first-iteration state while reporting the diagnostic by evaluating the
+available narrowing constraints without loop-header definitions. That made the invalid example
+definitely unbound, but it also made the valid example definitely unbound: the use-def data has
+already discarded the iteration and branch correlation needed to distinguish them. The experiment
+was backed out.
+
+### Recommendation
+
+Do not expand this branch into first-iteration-aware or relational loop analysis. That would require
+a broader change to the use-def representation and fixed-point semantics, with equivalent explicit
+nested-loop behavior to consider.
+
+The conservative scoped resolution is to stop carrying later generator targets through enclosing
+headers. This restores the definite unresolved-reference diagnostic for reads before the first
+assignment, at the cost of retaining the existing loss of precision for values left behind by prior
+inner iterations. Precise support for both cases should be handled separately as a larger control-
+flow project.

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2583,15 +2583,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         result_expressions: impl IntoIterator<Item = &'ast ast::Expr>,
         visit_outer_elt: impl FnOnce(&mut Self),
     ) {
-        let mut generators_iter = generators.iter();
-
-        let Some(generator) = generators_iter.next() else {
+        let Some(generator) = generators.first() else {
             unreachable!("Expression must contain at least one generator");
         };
 
         // The `iter` of the first generator is evaluated in the outer scope, while all subsequent
         // nodes are evaluated in the inner scope.
-        let value = self.add_standalone_expression(&generator.iter);
+        let first_value = self.add_standalone_expression(&generator.iter);
         self.visit_expr(&generator.iter);
 
         // Clear the assignment stack before entering the comprehension scope.
@@ -2602,58 +2600,61 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         self.push_scope(scope);
 
-        let bound_places = loop_bindings_visitor::collect_comprehension_named_expression_bindings(
-            generators,
-            result_expressions,
-        );
-        // An assignment expression can read the value written by a previous iteration. Use the
-        // same loop-header definitions as explicit loops so inference iterates those types to a
-        // fixed point.
-        let maybe_loop_header_info = (!bound_places.is_empty()).then(|| {
-            self.synthesize_loop_header_definitions(
-                LoopNodeRef::Comprehension(generator),
-                bound_places,
-            )
-        });
+        let bound_places_by_generator =
+            loop_bindings_visitor::collect_comprehension_named_expression_bindings_by_generator(
+                generators,
+                result_expressions,
+            );
 
-        self.add_unpackable_assignment(
-            &Unpackable::Comprehension {
-                node: generator,
-                first: true,
-            },
-            &generator.target,
-            value,
-        );
+        let mut loop_infos = Vec::with_capacity(generators.len());
+        let mut first_value = Some(first_value);
+        for (index, (generator, bound_places)) in
+            generators.iter().zip(bound_places_by_generator).enumerate()
+        {
+            let value = if let Some(value) = first_value.take() {
+                value
+            } else {
+                let value = self.add_standalone_expression(&generator.iter);
+                self.visit_expr(&generator.iter);
+                value
+            };
 
-        let mut filtered_out_paths = Vec::new();
-        for if_expr in &generator.ifs {
-            filtered_out_paths.push(self.visit_comprehension_filter(if_expr));
-        }
-
-        for generator in generators_iter {
-            let value = self.add_standalone_expression(&generator.iter);
-            self.visit_expr(&generator.iter);
+            // An assignment expression can read the value written by a previous iteration. Use
+            // the same loop-header definitions as explicit loops so inference iterates those types
+            // to a fixed point.
+            let maybe_loop_header_info = (!bound_places.is_empty()).then(|| {
+                self.synthesize_loop_header_definitions(
+                    LoopNodeRef::Comprehension(generator),
+                    bound_places,
+                )
+            });
 
             self.add_unpackable_assignment(
                 &Unpackable::Comprehension {
                     node: generator,
-                    first: false,
+                    first: index == 0,
                 },
                 &generator.target,
                 value,
             );
 
+            let mut filtered_out_paths = Vec::new();
             for if_expr in &generator.ifs {
                 filtered_out_paths.push(self.visit_comprehension_filter(if_expr));
             }
+            loop_infos.push((maybe_loop_header_info, filtered_out_paths));
         }
 
         visit_outer_elt(self);
-        for filtered_out_path in filtered_out_paths {
-            self.flow_merge(filtered_out_path);
-        }
-        if let Some((header_id, bound_place_ids, loop_min_definition_id)) = maybe_loop_header_info {
-            self.populate_loop_header(&bound_place_ids, header_id, loop_min_definition_id);
+        for (maybe_loop_header_info, filtered_out_paths) in loop_infos.into_iter().rev() {
+            for filtered_out_path in filtered_out_paths {
+                self.flow_merge(filtered_out_path);
+            }
+            if let Some((header_id, bound_place_ids, loop_min_definition_id)) =
+                maybe_loop_header_info
+            {
+                self.populate_loop_header(&bound_place_ids, header_id, loop_min_definition_id);
+            }
         }
         let nested_bindings = self.pop_scope();
         self.synthesize_comprehension_binding_definitions(nested_bindings);

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -31,7 +31,7 @@ use crate::definition::{
     DefinitionNodeKey, DefinitionNodeRef, Definitions, DictKeyAssignmentNodeRef,
     ExceptHandlerDefinitionNodeRef, ForStmtDefinitionNodeRef, ImportDefinitionNodeRef,
     ImportFromDefinitionNodeRef, ImportFromSubmoduleDefinitionNodeRef,
-    LambdaParameterDefinitionNodeRef, LoopHeaderDefinitionNodeRef, LoopStmtRef,
+    LambdaParameterDefinitionNodeRef, LoopHeaderDefinitionNodeRef, LoopNodeRef,
     MatchPatternDefinitionNodeRef, NestedBindingExecution, NestedBindingsDefinitionKind,
     ParameterDefinitionNodeRef, StarImportDefinitionNodeRef, WithItemDefinitionNodeRef,
 };
@@ -1697,7 +1697,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     /// bound `ScopedDefinitionId` for definitions created within the loop.
     fn synthesize_loop_header_definitions(
         &mut self,
-        loop_stmt: LoopStmtRef<'ast>,
+        loop_node: LoopNodeRef<'ast>,
         bound_places: Vec<PlaceExpr>,
     ) -> (LoopHeaderId, FxHashSet<ScopedPlaceId>, ScopedDefinitionId) {
         let loop_header_id = self.current_use_def_map_mut().reserve_loop_header();
@@ -1706,7 +1706,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             let place_id = self.add_place(place_expr);
             if bound_place_ids.insert(place_id) {
                 let loop_header_ref = LoopHeaderDefinitionNodeRef {
-                    loop_stmt,
+                    loop_node,
                     place: place_id,
                     loop_header_id,
                 };
@@ -1910,7 +1910,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             let Some(symbol) = self.place_tables[scope_id].symbol_id(name) else {
                 continue;
             };
-            match self.use_def_maps[scope_id].symbol_live_binding_status(symbol) {
+            match self.use_def_maps[scope_id].symbol_live_non_loop_binding_status(self.db, symbol) {
                 LiveBindingStatus::Bound => return LiveBindingStatus::Bound,
                 LiveBindingStatus::PossiblyBound => status = LiveBindingStatus::PossiblyBound,
                 LiveBindingStatus::Unbound => {}
@@ -2580,6 +2580,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         &mut self,
         scope: NodeWithScopeRef,
         generators: &'ast [ast::Comprehension],
+        result_expressions: impl IntoIterator<Item = &'ast ast::Expr>,
         visit_outer_elt: impl FnOnce(&mut Self),
     ) {
         let mut generators_iter = generators.iter();
@@ -2600,6 +2601,20 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let saved_assignments = std::mem::take(&mut self.current_assignments);
 
         self.push_scope(scope);
+
+        let bound_places = loop_bindings_visitor::collect_comprehension_named_expression_bindings(
+            generators,
+            result_expressions,
+        );
+        // An assignment expression can read the value written by a previous iteration. Use the
+        // same loop-header definitions as explicit loops so inference iterates those types to a
+        // fixed point.
+        let maybe_loop_header_info = (!bound_places.is_empty()).then(|| {
+            self.synthesize_loop_header_definitions(
+                LoopNodeRef::Comprehension(generator),
+                bound_places,
+            )
+        });
 
         self.add_unpackable_assignment(
             &Unpackable::Comprehension {
@@ -2636,6 +2651,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         visit_outer_elt(self);
         for filtered_out_path in filtered_out_paths {
             self.flow_merge(filtered_out_path);
+        }
+        if let Some((header_id, bound_place_ids, loop_min_definition_id)) = maybe_loop_header_info {
+            self.populate_loop_header(&bound_place_ids, header_id, loop_min_definition_id);
         }
         let nested_bindings = self.pop_scope();
         self.synthesize_comprehension_binding_definitions(nested_bindings);
@@ -3628,7 +3646,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // Avoid allocating a `LoopHeader` if there are no bound places in this loop.
                 if !bound_places.is_empty() {
                     maybe_loop_header_info = Some(self.synthesize_loop_header_definitions(
-                        LoopStmtRef::While(while_stmt),
+                        LoopNodeRef::While(while_stmt),
                         bound_places,
                     ));
                 }
@@ -3779,7 +3797,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // Avoid allocating a `LoopHeader` if there are no bound places in this loop.
                 if !bound_places.is_empty() {
                     maybe_loop_header_info = Some(self.synthesize_loop_header_definitions(
-                        LoopStmtRef::For(for_stmt),
+                        LoopNodeRef::For(for_stmt),
                         bound_places,
                     ));
                 }
@@ -4721,6 +4739,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 self.with_generators_scope(
                     NodeWithScopeRef::ListComprehension(list_comprehension),
                     generators,
+                    [elt.as_ref()],
                     |builder| builder.visit_expr(elt),
                 );
             }
@@ -4732,6 +4751,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 self.with_generators_scope(
                     NodeWithScopeRef::SetComprehension(set_comprehension),
                     generators,
+                    [elt.as_ref()],
                     |builder| builder.visit_expr(elt),
                 );
             }
@@ -4743,6 +4763,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 self.with_generators_scope(
                     NodeWithScopeRef::GeneratorExpression(generator),
                     generators,
+                    [elt.as_ref()],
                     |builder| builder.visit_expr(elt),
                 );
             }
@@ -4757,6 +4778,9 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 self.with_generators_scope(
                     NodeWithScopeRef::DictComprehension(dict_comprehension),
                     generators,
+                    key.iter()
+                        .map(std::convert::AsRef::as_ref)
+                        .chain(std::iter::once(value.as_ref())),
                     |builder| {
                         if let Some(key) = key {
                             builder.visit_expr(key);

--- a/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
+++ b/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
@@ -25,33 +25,39 @@ pub(crate) fn collect_for_loop_bindings(for_stmt: &ast::StmtFor) -> Vec<PlaceExp
     collector.bound_places
 }
 
-/// Collects assignment-expression targets from the implicit loops in a comprehension.
+/// Collects assignment-expression targets from each implicit loop in a comprehension.
 ///
 /// The first iterable is evaluated outside the comprehension scope, so it is intentionally not
-/// visited. Later iterables, filters, and the result expressions all execute inside the repeated
-/// portion of the comprehension. Generator targets are excluded because each one is freshly
-/// assigned before its uses on an iteration; only assignment expressions can carry a value from a
-/// previous iteration.
-pub(crate) fn collect_comprehension_named_expression_bindings<'ast>(
+/// visited. Each entry contains the bindings that are visible to that generator's back edge:
+/// bindings in its filters, later generators, and the result expressions. Generator targets are
+/// excluded because each one is freshly assigned before its uses on an iteration; only assignment
+/// expressions can carry a value from a previous iteration.
+pub(crate) fn collect_comprehension_named_expression_bindings_by_generator<'ast>(
     generators: &'ast [ast::Comprehension],
     result_expressions: impl IntoIterator<Item = &'ast ast::Expr>,
-) -> Vec<PlaceExpr> {
-    let mut collector = LoopBindingsVisitor::default();
+) -> Vec<Vec<PlaceExpr>> {
+    let result_expressions = result_expressions.into_iter().collect::<Vec<_>>();
 
-    for (index, generator) in generators.iter().enumerate() {
-        if index > 0 {
-            collector.visit_expr(&generator.iter);
-        }
-        for if_expr in &generator.ifs {
-            collector.visit_expr(if_expr);
-        }
-    }
-
-    for expression in result_expressions {
-        collector.visit_expr(expression);
-    }
-
-    collector.bound_places
+    generators
+        .iter()
+        .enumerate()
+        .map(|(index, generator)| {
+            let mut collector = LoopBindingsVisitor::default();
+            for if_expr in &generator.ifs {
+                collector.visit_expr(if_expr);
+            }
+            for later_generator in &generators[index + 1..] {
+                collector.visit_expr(&later_generator.iter);
+                for if_expr in &later_generator.ifs {
+                    collector.visit_expr(if_expr);
+                }
+            }
+            for expression in &result_expressions {
+                collector.visit_expr(expression);
+            }
+            collector.bound_places
+        })
+        .collect()
 }
 
 /// The visitor that collects bindings from explicit loops and assignment-expression bindings from

--- a/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
+++ b/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
@@ -1,5 +1,6 @@
 use ruff_python_ast as ast;
 use ruff_python_ast::visitor::{Visitor, walk_expr, walk_pattern, walk_stmt};
+use std::collections::VecDeque;
 
 use crate::place::PlaceExpr;
 use crate::symbol::Symbol;
@@ -37,29 +38,73 @@ pub(crate) fn collect_comprehension_named_expression_bindings_by_generator<'ast>
     generators: &'ast [ast::Comprehension],
     result_expressions: impl IntoIterator<Item = &'ast ast::Expr>,
 ) -> Vec<Vec<PlaceExpr>> {
-    let result_expressions = result_expressions.into_iter().collect::<Vec<_>>();
+    struct GeneratorBindings {
+        entry: Vec<PlaceExpr>,
+        filters: Vec<PlaceExpr>,
+        has_named_expression: bool,
+    }
 
-    generators
+    let bindings_by_generator = generators
         .iter()
         .enumerate()
         .map(|(index, generator)| {
-            let mut collector = LoopBindingsVisitor::default();
+            let mut entry_collector = LoopBindingsVisitor::default();
+            if index > 0 {
+                entry_collector.visit_expr(&generator.iter);
+            }
+            let mut has_named_expression = !entry_collector.bound_places.is_empty();
+            if index > 0 {
+                entry_collector.add_place_from_target(&generator.target);
+            }
+
+            let mut filter_collector = LoopBindingsVisitor::default();
             for if_expr in &generator.ifs {
-                collector.visit_expr(if_expr);
+                filter_collector.visit_expr(if_expr);
             }
-            for later_generator in &generators[index + 1..] {
-                collector.visit_expr(&later_generator.iter);
-                collector.add_place_from_target(&later_generator.target);
-                for if_expr in &later_generator.ifs {
-                    collector.visit_expr(if_expr);
-                }
+            has_named_expression |= !filter_collector.bound_places.is_empty();
+
+            GeneratorBindings {
+                entry: entry_collector.bound_places,
+                filters: filter_collector.bound_places,
+                has_named_expression,
             }
-            for expression in &result_expressions {
-                collector.visit_expr(expression);
-            }
-            collector.bound_places
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+    let mut result_collector = LoopBindingsVisitor::default();
+    for expression in result_expressions {
+        result_collector.visit_expr(expression);
+    }
+
+    let mut suffix_bindings = VecDeque::from(result_collector.bound_places);
+    let mut suffix_has_named_expression = !suffix_bindings.is_empty();
+    let mut loop_bindings = Vec::with_capacity(generators.len());
+
+    for generator_bindings in bindings_by_generator.into_iter().rev() {
+        let own_has_named_expression = !generator_bindings.filters.is_empty();
+        let header_bindings = if own_has_named_expression || suffix_has_named_expression {
+            generator_bindings
+                .filters
+                .iter()
+                .chain(&suffix_bindings)
+                .cloned()
+                .collect()
+        } else {
+            Vec::new()
+        };
+        loop_bindings.push(header_bindings);
+
+        suffix_has_named_expression |= generator_bindings.has_named_expression;
+        for binding in generator_bindings.filters.into_iter().rev() {
+            suffix_bindings.push_front(binding);
+        }
+        for binding in generator_bindings.entry.into_iter().rev() {
+            suffix_bindings.push_front(binding);
+        }
+    }
+
+    loop_bindings.reverse();
+    loop_bindings
 }
 
 /// The visitor that collects bindings from explicit loops and assignment-expression bindings from
@@ -246,6 +291,41 @@ mod tests {
     use super::*;
     use ruff_python_parser::parse_module;
     use ruff_python_trivia::textwrap::dedent;
+
+    fn collect_comprehension_place_names(code: &str) -> Vec<Vec<String>> {
+        let parsed = parse_module(code).expect("valid Python code");
+        let ast::Stmt::Expr(expression_statement) = &parsed.suite()[0] else {
+            panic!("Expected an expression statement");
+        };
+        let ast::Expr::ListComp(comprehension) = expression_statement.value.as_ref() else {
+            panic!("Expected a list comprehension");
+        };
+
+        collect_comprehension_named_expression_bindings_by_generator(
+            &comprehension.generators,
+            [comprehension.elt.as_ref()],
+        )
+        .into_iter()
+        .map(|bindings| {
+            bindings
+                .into_iter()
+                .map(|place| match place {
+                    PlaceExpr::Symbol(symbol) => symbol.name().to_string(),
+                    PlaceExpr::Member(member) => member.to_string(),
+                })
+                .collect()
+        })
+        .collect()
+    }
+
+    #[test]
+    fn comprehension_without_named_expressions_has_no_loop_bindings() {
+        let bindings = collect_comprehension_place_names(
+            "[item for first in firsts for second in seconds for item in items]",
+        );
+
+        assert_eq!(bindings, vec![Vec::<String>::new(); 3]);
+    }
 
     // Test collecting `while` loop bindings.
 

--- a/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
+++ b/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
@@ -31,9 +31,7 @@ pub(crate) fn collect_for_loop_bindings(for_stmt: &ast::StmtFor) -> Vec<PlaceExp
 /// The first iterable is evaluated outside the comprehension scope, so it is intentionally not
 /// visited. Each entry contains the bindings that are visible to that generator's back edge:
 /// bindings in its filters, later generators, and the result expressions. Generator targets are
-/// excluded from their own loop headers because they are freshly assigned on each iteration. Later
-/// generator targets are included in enclosing loop headers because their value from the preceding
-/// outer iteration can be read before the later generator runs again.
+/// excluded from loop headers because they are unbound before their generator's first iteration.
 pub(crate) fn collect_comprehension_named_expression_bindings_by_generator<'ast>(
     generators: &'ast [ast::Comprehension],
     result_expressions: impl IntoIterator<Item = &'ast ast::Expr>,
@@ -53,9 +51,6 @@ pub(crate) fn collect_comprehension_named_expression_bindings_by_generator<'ast>
                 entry_collector.visit_expr(&generator.iter);
             }
             let mut has_named_expression = !entry_collector.bound_places.is_empty();
-            if index > 0 {
-                entry_collector.add_place_from_target(&generator.target);
-            }
 
             let mut filter_collector = LoopBindingsVisitor::default();
             for if_expr in &generator.ifs {

--- a/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
+++ b/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
@@ -25,9 +25,40 @@ pub(crate) fn collect_for_loop_bindings(for_stmt: &ast::StmtFor) -> Vec<PlaceExp
     collector.bound_places
 }
 
-/// The visitor that powers `collect_while_loop_bindings` and `collect_for_loop_bindings`.
+/// Collects assignment-expression targets from the implicit loops in a comprehension.
 ///
-/// This visitor doesn't walk nested function/class definitions since those are different scopes.
+/// The first iterable is evaluated outside the comprehension scope, so it is intentionally not
+/// visited. Later iterables, filters, and the result expressions all execute inside the repeated
+/// portion of the comprehension. Generator targets are excluded because each one is freshly
+/// assigned before its uses on an iteration; only assignment expressions can carry a value from a
+/// previous iteration.
+pub(crate) fn collect_comprehension_named_expression_bindings<'ast>(
+    generators: &'ast [ast::Comprehension],
+    result_expressions: impl IntoIterator<Item = &'ast ast::Expr>,
+) -> Vec<PlaceExpr> {
+    let mut collector = LoopBindingsVisitor::default();
+
+    for (index, generator) in generators.iter().enumerate() {
+        if index > 0 {
+            collector.visit_expr(&generator.iter);
+        }
+        for if_expr in &generator.ifs {
+            collector.visit_expr(if_expr);
+        }
+    }
+
+    for expression in result_expressions {
+        collector.visit_expr(expression);
+    }
+
+    collector.bound_places
+}
+
+/// The visitor that collects bindings from explicit loops and assignment-expression bindings from
+/// comprehensions.
+///
+/// This visitor doesn't walk nested function, class, or lambda bodies since those are different
+/// scopes.
 #[derive(Debug, Default)]
 pub(crate) struct LoopBindingsVisitor {
     bound_places: Vec<PlaceExpr>,
@@ -161,9 +192,17 @@ impl<'ast> Visitor<'ast> for LoopBindingsVisitor {
     }
 
     fn visit_expr(&mut self, expr: &'ast ast::Expr) {
-        // the walrus operator
-        if let ast::Expr::Named(node) = expr {
-            self.add_place_from_target(&node.target);
+        match expr {
+            // The walrus operator.
+            ast::Expr::Named(node) => self.add_place_from_target(&node.target),
+            // Parameter defaults execute in the current scope, but the lambda body does not.
+            ast::Expr::Lambda(ast::ExprLambda { parameters, .. }) => {
+                if let Some(parameters) = parameters {
+                    self.visit_parameters(parameters);
+                }
+                return;
+            }
+            _ => {}
         }
         walk_expr(self, expr);
     }

--- a/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
+++ b/crates/ty_python_core/src/builder/loop_bindings_visitor.rs
@@ -30,8 +30,9 @@ pub(crate) fn collect_for_loop_bindings(for_stmt: &ast::StmtFor) -> Vec<PlaceExp
 /// The first iterable is evaluated outside the comprehension scope, so it is intentionally not
 /// visited. Each entry contains the bindings that are visible to that generator's back edge:
 /// bindings in its filters, later generators, and the result expressions. Generator targets are
-/// excluded because each one is freshly assigned before its uses on an iteration; only assignment
-/// expressions can carry a value from a previous iteration.
+/// excluded from their own loop headers because they are freshly assigned on each iteration. Later
+/// generator targets are included in enclosing loop headers because their value from the preceding
+/// outer iteration can be read before the later generator runs again.
 pub(crate) fn collect_comprehension_named_expression_bindings_by_generator<'ast>(
     generators: &'ast [ast::Comprehension],
     result_expressions: impl IntoIterator<Item = &'ast ast::Expr>,
@@ -48,6 +49,7 @@ pub(crate) fn collect_comprehension_named_expression_bindings_by_generator<'ast>
             }
             for later_generator in &generators[index + 1..] {
                 collector.visit_expr(&later_generator.iter);
+                collector.add_place_from_target(&later_generator.target);
                 for if_expr in &later_generator.ifs {
                     collector.visit_expr(if_expr);
                 }

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -1586,6 +1586,10 @@ impl LoopHeaderDefinitionKind {
         self.loop_header_id
     }
 
+    pub fn is_comprehension(&self) -> bool {
+        matches!(&self.loop_node, LoopNodeKind::Comprehension(_))
+    }
+
     pub fn place(&self) -> ScopedPlaceId {
         self.place
     }

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -557,15 +557,16 @@ pub(crate) struct ExceptHandlerDefinitionNodeRef<'ast> {
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct LoopHeaderDefinitionNodeRef<'ast> {
-    pub(crate) loop_stmt: LoopStmtRef<'ast>,
+    pub(crate) loop_node: LoopNodeRef<'ast>,
     pub(crate) place: ScopedPlaceId,
     pub(crate) loop_header_id: LoopHeaderId,
 }
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) enum LoopStmtRef<'ast> {
+pub(crate) enum LoopNodeRef<'ast> {
     While(&'ast ast::StmtWhile),
     For(&'ast ast::StmtFor),
+    Comprehension(&'ast ast::Comprehension),
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -783,14 +784,17 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
                 DefinitionKind::TypeVarTuple(AstNodeRef::new(parsed, node))
             }
             DefinitionNodeRef::LoopHeader(LoopHeaderDefinitionNodeRef {
-                loop_stmt,
+                loop_node,
                 place,
                 loop_header_id,
             }) => DefinitionKind::LoopHeader(LoopHeaderDefinitionKind {
                 loop_header_id,
-                loop_stmt: match loop_stmt {
-                    LoopStmtRef::While(stmt) => LoopStmtKind::While(AstNodeRef::new(parsed, stmt)),
-                    LoopStmtRef::For(stmt) => LoopStmtKind::For(AstNodeRef::new(parsed, stmt)),
+                loop_node: match loop_node {
+                    LoopNodeRef::While(stmt) => LoopNodeKind::While(AstNodeRef::new(parsed, stmt)),
+                    LoopNodeRef::For(stmt) => LoopNodeKind::For(AstNodeRef::new(parsed, stmt)),
+                    LoopNodeRef::Comprehension(comprehension) => {
+                        LoopNodeKind::Comprehension(AstNodeRef::new(parsed, comprehension))
+                    }
                 },
                 place,
             }),
@@ -861,9 +865,12 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
             Self::TypeVar(node) => node.into(),
             Self::ParamSpec(node) => node.into(),
             Self::TypeVarTuple(node) => node.into(),
-            Self::LoopHeader(LoopHeaderDefinitionNodeRef { loop_stmt, .. }) => match loop_stmt {
-                LoopStmtRef::While(stmt) => stmt.into(),
-                LoopStmtRef::For(stmt) => stmt.into(),
+            Self::LoopHeader(LoopHeaderDefinitionNodeRef { loop_node, .. }) => match loop_node {
+                LoopNodeRef::While(stmt) => stmt.into(),
+                LoopNodeRef::For(stmt) => stmt.into(),
+                LoopNodeRef::Comprehension(comprehension) => {
+                    DefinitionNodeKey(NodeKey::from_node(comprehension))
+                }
             },
         }
     }
@@ -1563,14 +1570,15 @@ impl ExceptHandlerDefinitionKind {
 pub struct LoopHeaderDefinitionKind {
     /// The `LoopHeader` is reserved before walking the loop and populated afterward.
     loop_header_id: LoopHeaderId,
-    loop_stmt: LoopStmtKind,
+    loop_node: LoopNodeKind,
     place: ScopedPlaceId,
 }
 
 #[derive(Clone, Debug, get_size2::GetSize)]
-pub(crate) enum LoopStmtKind {
+pub(crate) enum LoopNodeKind {
     While(AstNodeRef<ast::StmtWhile>),
     For(AstNodeRef<ast::StmtFor>),
+    Comprehension(AstNodeRef<ast::Comprehension>),
 }
 
 impl LoopHeaderDefinitionKind {
@@ -1583,9 +1591,10 @@ impl LoopHeaderDefinitionKind {
     }
 
     pub fn range(&self, module: &ParsedModuleRef) -> TextRange {
-        match &self.loop_stmt {
-            LoopStmtKind::While(stmt) => stmt.node(module).range(),
-            LoopStmtKind::For(stmt) => stmt.node(module).range(),
+        match &self.loop_node {
+            LoopNodeKind::While(stmt) => stmt.node(module).range(),
+            LoopNodeKind::For(stmt) => stmt.node(module).range(),
+            LoopNodeKind::Comprehension(comprehension) => comprehension.node(module).range(),
         }
     }
 }

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -36,7 +36,7 @@ pub(crate) fn match_subject_place_expressions(subject: &ast::Expr) -> SmallVec<[
 }
 
 /// An expression that can be the target of a `Definition`.
-#[derive(Eq, PartialEq, Debug, get_size2::GetSize)]
+#[derive(Clone, Eq, PartialEq, Debug, get_size2::GetSize)]
 pub enum PlaceExpr {
     /// A simple symbol, e.g. `x`.
     Symbol(Symbol),

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -269,7 +269,8 @@ use crate::use_def::place_state::{
     LiveDeclarationsIterator, PlaceState,
 };
 use crate::{
-    BoundnessAnalysis, EnclosingSnapshotResult, LoopHeader, PossiblyNarrowedPlaces, SemanticIndex,
+    BoundnessAnalysis, Db, EnclosingSnapshotResult, LoopHeader, PossiblyNarrowedPlaces,
+    SemanticIndex,
 };
 
 mod place_state;
@@ -2274,13 +2275,16 @@ impl<'db> UseDefMapBuilder<'db> {
             .map(LiveBinding::binding)
     }
 
-    /// Returns the current boundness of `symbol` after applying pending reachability constraints.
+    /// Returns the current boundness of `symbol` from non-loop bindings after applying pending
+    /// reachability constraints.
     ///
     /// Bindings on statically unreachable paths do not contribute to the result. This is stricter
     /// than [`Symbol::is_bound`](crate::symbol::Symbol::is_bound), which records whether the symbol
-    /// is bound anywhere in the scope without considering control flow.
-    pub(super) fn symbol_live_binding_status(
+    /// is bound anywhere in the scope without considering control flow. Synthetic loop headers do
+    /// not bind the symbol themselves, so they do not contribute either.
+    pub(super) fn symbol_live_non_loop_binding_status(
         &mut self,
+        db: &dyn Db,
         symbol: ScopedSymbolId,
     ) -> LiveBindingStatus {
         let pending = self.pending_reachability.current;
@@ -2301,6 +2305,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 continue;
             }
             match self.definition(binding.binding()) {
+                DefinitionState::Defined(definition) if definition.kind(db).is_loop_header() => {}
                 DefinitionState::Defined(_) => has_binding = true,
                 DefinitionState::Undefined | DefinitionState::Deleted => has_unbound = true,
             }

--- a/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
@@ -237,10 +237,25 @@ def inner_generator_loop_back_edge():
     ]
 ```
 
-### Later generator targets on enclosing back edges
+### Later generator targets
 
-A later generator's target is freshly assigned for each of its own iterations, but its final value
-remains visible when the enclosing generator starts its next iteration:
+A later generator's target is unbound before that generator starts its first iteration. It must not
+be carried through an enclosing loop header, even if a named expression in the suffix causes that
+header to be created:
+
+```py
+def later_generator_target_unbound_on_first_iteration():
+    [
+        None
+        for _ in [0, 1]
+        if later_target  # error: [unresolved-reference]
+        for later_target in [1]
+        if (flag := True)
+    ]
+```
+
+This conservatively loses the final value left behind by a completed inner loop. Modeling both
+states would require correlating the later target with whether its generator has run:
 
 ```py
 def later_generator_target_on_outer_back_edge():
@@ -250,17 +265,13 @@ def later_generator_target_on_outer_back_edge():
         for _ in [0, 1]
         if (
             (
-                later_target_value := ""
-                if later_target_first
-                # TODO: This is also reported for equivalent explicit nested loops because loop
-                # headers do not correlate the two loop-carried bindings.
-                else later_target_y  # error: [possibly-unresolved-reference]
+                later_target_value := "" if later_target_first else later_target_y  # error: [unresolved-reference]
             )
             or True
         )
         for later_target_y in [1]
     ]
-    reveal_type(later_target_value)  # revealed: str | int
+    reveal_type(later_target_value)  # revealed: str | Unknown
 ```
 
 ### Function-local targets

--- a/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
@@ -237,6 +237,32 @@ def inner_generator_loop_back_edge():
     ]
 ```
 
+### Later generator targets on enclosing back edges
+
+A later generator's target is freshly assigned for each of its own iterations, but its final value
+remains visible when the enclosing generator starts its next iteration:
+
+```py
+def later_generator_target_on_outer_back_edge():
+    later_target_first = True
+    [
+        (later_target_first := False)
+        for _ in [0, 1]
+        if (
+            (
+                later_target_value := ""
+                if later_target_first
+                # TODO: This is also reported for equivalent explicit nested loops because loop
+                # headers do not correlate the two loop-carried bindings.
+                else later_target_y  # error: [possibly-unresolved-reference]
+            )
+            or True
+        )
+        for later_target_y in [1]
+    ]
+    reveal_type(later_target_value)  # revealed: str | int
+```
+
 ### Function-local targets
 
 Even if the assignment is in a branch known not to run, its target belongs to the containing

--- a/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
@@ -185,6 +185,17 @@ The loop-back value does not hide that the name is unbound on the first iteratio
 
 ```py
 def missing_initial_value():
+    [value := value + 1 for _ in [0, 1]]  # error: [unresolved-reference]
+
+def missing_initial_value_after_filter(flag: bool):
+    [value := value + 1 for _ in [0, 1] if flag]  # error: [unresolved-reference]
+
+def missing_initial_value_in_nested_generator():
+    [value := value + 1 for _ in [0, 1] for _ in [0, 1]]  # error: [unresolved-reference]
+
+def possibly_missing_initial_value(flag: bool):
+    if flag:
+        value = 0
     [value := value + 1 for _ in [0, 1]]  # error: [possibly-unresolved-reference]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
@@ -156,14 +156,46 @@ def partial_sum():
     total = 0
     [total := total + value for value in [1, 2]]
     reveal_type(total)  # revealed: int
+```
 
-# TODO: Model repeated comprehension iterations with a fixed point. The second iteration assigns
-# `int`, so the final type should be `str | int` and `value.upper()` should report an error.
+Comprehensions use the same loop-header fixed point as explicit loops. The type exported after the
+comprehension therefore includes values that become possible only after feeding one iteration's
+assignment back into the next iteration:
+
+```py
 def type_changes_across_iterations():
     value = 0
     [value := "" if isinstance(value, int) else 0 for _ in [0, 1]]
-    reveal_type(value)  # revealed: str
-    value.upper()
+    reveal_type(value)  # revealed: str | int
+    value.upper()  # error: [unresolved-attribute]
+```
+
+This requires more than unioning the pre-comprehension type with the first modeled result. The
+second iteration adds `bytes`, which is neither the initial `int` nor the first result `str`:
+
+```py
+def multiple_type_changes_across_iterations():
+    value = 0
+    results = [value := ("" if isinstance(value, int) else b"" if isinstance(value, str) else 0) for _ in [0, 1]]
+    reveal_type(value)  # revealed: str | bytes | int
+    reveal_type(results)  # revealed: list[str | bytes | int]
+```
+
+The loop-back value does not hide that the name is unbound on the first iteration:
+
+```py
+def missing_initial_value():
+    [value := value + 1 for _ in [0, 1]]  # error: [possibly-unresolved-reference]
+```
+
+Filter assignments also feed into later iterations, even when the first assigned value causes that
+iteration's element to be skipped:
+
+```py
+def type_changes_in_filter():
+    value = 0
+    [None for _ in [0, 1] if (value := "" if isinstance(value, int) else 1)]
+    reveal_type(value)  # revealed: str | int
 ```
 
 The same applies when two targets depend on values from earlier iterations:

--- a/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
@@ -220,6 +220,23 @@ def loop_carried_guard():
     reveal_type(value)  # revealed: int
 ```
 
+Each generator has its own loop back edge. Assignments from an inner generator's previous iteration
+must not restart the outer generator and reapply its filters:
+
+```py
+def inner_generator_loop_back_edge():
+    value = 0
+    [
+        (
+            value.upper(),  # error: [unresolved-attribute]
+            (value := 1),
+        )
+        for _ in [0]
+        if (value := "x")
+        for _ in [0, 1]
+    ]
+```
+
 ### Function-local targets
 
 Even if the assignment is in a branch known not to run, its target belongs to the containing

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -124,6 +124,7 @@ use ty_python_core::narrowing_constraints::ConstraintKey;
 use ty_python_core::node_key::NodeKey;
 use ty_python_core::place::{PlaceExpr, PlaceExprRef};
 use ty_python_core::predicate::PatternPredicate;
+use ty_python_core::reachability_constraints::ScopedReachabilityConstraintId;
 use ty_python_core::scope::{FileScopeId, NodeWithScopeKind, NodeWithScopeRef, ScopeId, ScopeKind};
 use ty_python_core::symbol::{ScopedSymbolId, Symbol};
 use ty_python_core::{
@@ -173,6 +174,41 @@ impl<'db> DeclaredAndInferredType<'db> {
             TypeOrigin::Inferred,
             TypeQualifiers::empty(),
         ))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PlaceLoad<'db> {
+    resolved: PlaceAndQualifiers<'db>,
+    unbound_on_first_comprehension_entry: bool,
+}
+
+impl<'db> PlaceLoad<'db> {
+    fn or_fall_back_to(
+        self,
+        db: &'db dyn Db,
+        fallback_fn: impl FnOnce() -> PlaceAndQualifiers<'db>,
+    ) -> Self {
+        let mut fallback_has_binding = false;
+        let resolved = self.resolved.or_fall_back_to(db, || {
+            let fallback = fallback_fn();
+            fallback_has_binding = !fallback.is_undefined();
+            fallback
+        });
+
+        Self {
+            resolved,
+            unbound_on_first_comprehension_entry: self.unbound_on_first_comprehension_entry
+                && !fallback_has_binding,
+        }
+    }
+
+    fn finish(self) -> PlaceAndQualifiers<'db> {
+        if self.unbound_on_first_comprehension_entry {
+            Place::Undefined.with_qualifiers(self.resolved.qualifiers)
+        } else {
+            self.resolved
+        }
     }
 }
 
@@ -9602,7 +9638,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 } else {
                     Place::Undefined.into()
                 }
-            });
+            })
+            .finish();
 
         let ty =
             resolved_after_fallback.unwrap_with_diagnostic(db, |lookup_error| match lookup_error {
@@ -9769,7 +9806,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &self,
         place_expr: PlaceExprRef,
         expr_ref: ast::ExprRef,
-    ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
+    ) -> (PlaceLoad<'db>, Vec<(FileScopeId, ConstraintKey)>) {
         let db = self.db();
         let scope = self.scope();
         let file_scope_id = scope.file_scope_id(db);
@@ -9777,11 +9814,48 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut constraint_keys = vec![];
         let (local_scope_place, use_id) = self.infer_local_place_load(place_expr, expr_ref);
+        // Keep the initial entry state separate while resolving enclosing bindings. A real entry
+        // binding should be unioned with the back edge, but a lone back edge cannot rescue an
+        // unbound read on the first iteration.
+        let unbound_on_first_comprehension_entry = use_id.is_some_and(|use_id| {
+            let mut has_unbound_entry = false;
+            let mut has_comprehension_loop_back = false;
+
+            for binding in self
+                .index
+                .use_def_map(file_scope_id)
+                .bindings_at_use(use_id)
+            {
+                if binding.reachability_constraint == ScopedReachabilityConstraintId::ALWAYS_FALSE {
+                    continue;
+                }
+                match binding.binding {
+                    DefinitionState::Undefined => {
+                        has_unbound_entry = true;
+                    }
+                    DefinitionState::Defined(definition)
+                        if matches!(
+                            definition.kind(db),
+                            DefinitionKind::LoopHeader(header) if header.is_comprehension()
+                        ) =>
+                    {
+                        has_comprehension_loop_back = true;
+                    }
+                    _ => return false,
+                }
+            }
+
+            has_unbound_entry && has_comprehension_loop_back
+        });
         if let Some(use_id) = use_id {
             constraint_keys.push((file_scope_id, ConstraintKey::UseId(use_id)));
         }
 
-        let place = PlaceAndQualifiers::from(local_scope_place).or_fall_back_to(db, || {
+        let place = PlaceLoad {
+            resolved: PlaceAndQualifiers::from(local_scope_place),
+            unbound_on_first_comprehension_entry,
+        }
+        .or_fall_back_to(db, || {
             let mut symbol_resolves_locally = false;
             if let Some(symbol) = place_expr.as_symbol()
                 && let Some(symbol_id) = place_table.symbol_id(symbol.name())
@@ -10060,7 +10134,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
         });
 
-        if let Some(ty) = place.place.ignore_possibly_undefined() {
+        if let Some(ty) = place.resolved.place.ignore_possibly_undefined() {
             self.check_deprecated(expr_ref, ty);
         }
 
@@ -10241,7 +10315,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ty,
                 definedness: Definedness::AlwaysDefined,
                 ..
-            }) = resolved.place
+            }) = resolved.resolved.place
             {
                 assigned_type = Some(ty);
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -196,7 +196,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     ty,
                     definedness: Definedness::AlwaysDefined,
                     ..
-                }) = place.place
+                }) = place.resolved.place
                 {
                     // Even if we can obtain the subscript type based on the assignments, we still perform default type inference
                     // (to store the expression type and to report errors).


### PR DESCRIPTION
## Summary

Stacked on #26466.

The scope PR exports the type assigned by a comprehension walrus from the first modeled pass through the comprehension. That misses values which become possible only after an assignment feeds back into a later iteration:

```py
value = 0
[value := "" if isinstance(value, int) else 0 for _ in [0, 1]]
reveal_type(value)  # str | int
```

This PR models each comprehension generator as an implicit loop and reuses the fixed-point machinery for explicit loops. Each generator gets its own header and back edge, so an inner iteration no longer restarts outer filters. The binding collector walks each generator and result region once, then builds the required suffixes in reverse to avoid quadratic AST traversal.

## First-iteration state

A loop-back definition cannot make a name available before the comprehension's first iteration:

```py
[value := value + 1 for _ in [0, 1]]
```

Python raises `NameError` here. We keep this initial unbound state separate while resolving enclosing and builtin fallbacks, so this remains a definite `unresolved-reference`. A real initial binding clears the marker and is unioned with the back edge; a conditional initial binding remains `possibly-unresolved-reference`.

## Conservative handling of later targets

A later generator target can retain a value from a completed inner loop, but carrying that target through enclosing headers makes it appear available before its first assignment:

```py
[None for a in [0, 1] if (flag := True) if c for c in [1]]
```

Python raises `UnboundLocalError` here. This PR keeps later generator targets out of enclosing headers, preserving the definite `unresolved-reference` diagnostic on the first iteration.

This conservatively loses the type of a target left behind by a prior inner iteration. The first-entry marker above cannot recover that case because doing so requires correlating the target's back-edge value with the control-flow condition that prevents its first-iteration read. `REVIEW.md` documents the investigation and this scoped resolution; precise support for both cases is deferred to a separate relational control-flow project.
