### PR TITLE
[ty] Avoid exponential OR-pattern reachability

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1164,6 +1164,7 @@ fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
 }
 
 const NUM_LITERAL_FALLTHROUGH_ARMS: usize = 40;
+const NUM_LITERAL_OR_PATTERN_ALTERNATIVES: usize = 23;
 
 fn is_literal_fallthrough_arm(index: usize) -> bool {
     index.is_multiple_of(8) || index == NUM_LITERAL_FALLTHROUGH_ARMS - 4
@@ -1258,6 +1259,20 @@ fn literal_equality_fallthrough_code() -> String {
     code
 }
 
+fn literal_or_pattern_reachability_code() -> String {
+    let mut code = "from typing import Any\n\ndef check(item: Any) -> None:\n    x: int\n    match item:\n        case ".to_string();
+
+    for index in 0..NUM_LITERAL_OR_PATTERN_ALTERNATIVES {
+        if index > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "{index}").ok();
+    }
+
+    code.push_str(":\n            x = 1\n");
+    code
+}
+
 /// Benchmarks `match` fallthrough over a finite `Literal` subject.
 ///
 /// This generates a large version of this Python shape:
@@ -1338,6 +1353,29 @@ fn benchmark_literal_equality_fallthrough_guarded_any(criterion: &mut Criterion)
         "ty_micro[literal_equality_fallthrough_guarded_any]",
         &literal_equality_fallthrough_code(),
     );
+}
+
+/// Regression benchmark for <https://github.com/astral-sh/ty/issues/3880>.
+///
+/// Reachability analysis for a large literal OR pattern on `Any` used to rebuild the remaining
+/// subject from all preceding alternatives. Assigning to an annotation-only local forces the case
+/// predicate to be evaluated while resolving the live declaration, exposing the exponential
+/// growth.
+fn benchmark_literal_or_pattern_reachability(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let code = literal_or_pattern_reachability_code();
+    criterion.bench_function("ty_micro[literal_or_pattern_reachability]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
 }
 
 fn benchmark_literal_fallthrough(criterion: &mut Criterion, name: &str, code: &str) {
@@ -1767,6 +1805,7 @@ criterion_group!(
     benchmark_literal_match_fallthrough,
     benchmark_literal_match_fallthrough_guarded_any,
     benchmark_literal_equality_fallthrough_guarded_any,
+    benchmark_literal_or_pattern_reachability,
     benchmark_typeis_narrowing,
     benchmark_factored_upper_bounds,
     benchmark_pandas_tdd,

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -200,12 +200,12 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        ActiveRecursionDetector, CallableTypes, EnumClassLiteral, IntersectionBuilder,
-        KnownInstanceType, NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType,
-        callable_pattern_type, definite_match_pattern_type,
-        definite_match_pattern_type_for_subject, equality_truthiness, expand_type,
-        infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
-        pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
+        ActiveRecursionDetector, CallableTypes, EnumClassLiteral, KnownInstanceType,
+        NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType, callable_pattern_type,
+        definite_match_pattern_type, definite_match_pattern_type_for_subject, equality_truthiness,
+        expand_type, infer_narrowing_constraints, infer_same_file_expression_type,
+        mapping_pattern_type, pattern_binding_fallthrough_type, sequence_pattern_type_builder,
+        singleton_pattern_type,
     },
 };
 use ruff_index::{Idx, IndexSlice};
@@ -1137,20 +1137,16 @@ fn analyze_single_pattern_predicate_kind<'db>(
         PatternPredicateKind::Or(predicates) => {
             use std::ops::ControlFlow;
 
-            let mut excluded_types = vec![];
+            let mut remaining_subject_ty = subject_ty;
             let (ControlFlow::Break(truthiness) | ControlFlow::Continue(truthiness)) = predicates
                 .iter()
                 .map(|p| {
-                    let narrowed_subject_ty = IntersectionBuilder::new(db)
-                        .add_positive(subject_ty)
-                        .add_negative(UnionType::from_elements(db, excluded_types.iter()))
-                        .build();
+                    let narrowed_subject_ty = remaining_subject_ty;
 
                     let definitely_matched =
                         definite_match_pattern_type_for_subject(db, p, narrowed_subject_ty);
-                    excluded_types.push(definitely_matched);
 
-                    if narrowed_subject_ty.is_subtype_of(db, definitely_matched) {
+                    let truthiness = if narrowed_subject_ty.is_subtype_of(db, definitely_matched) {
                         Truthiness::AlwaysTrue
                     } else {
                         analyze_single_pattern_predicate_kind(
@@ -1159,7 +1155,11 @@ fn analyze_single_pattern_predicate_kind<'db>(
                             narrowed_subject_ty,
                             Some(definitely_matched),
                         )
-                    }
+                    };
+
+                    remaining_subject_ty =
+                        pattern_binding_fallthrough_type(db, p, narrowed_subject_ty);
+                    truthiness
                 })
                 // this is just a "max", but with a slight optimization:
                 // `AlwaysTrue` is the "greatest" possible element, so we short-circuit if we get there


### PR DESCRIPTION
## Summary

A large OR pattern can take exponential time to analyze when its subject is gradual and the case body forces reachability evaluation, for example by assigning to an annotation-only local.

For each alternative, we previously rebuilt the remaining subject from the original subject minus the union of all preceding definite-match types. Since those definite-match types were themselves computed from the already-narrowed subject, each iteration embedded the previous remainder and repeatedly expanded the resulting unions and intersections.

We now carry one remaining subject through the alternatives. Each alternative is analyzed against its pre-fallthrough type, then the existing equality-aware and mutation-conservative pattern fallthrough logic computes the type passed to the next alternative.

## Benchmark

This adds `ty_micro[literal_or_pattern_reachability]`, which reproduces the issue with 23 literal alternatives while generating the fixture outside the timed closure.

On `main`, the benchmark did not complete within 30 seconds; Criterion estimated 261 seconds for 10 samples. On this branch, it completes in approximately 7.7 ms per iteration.

## Test plan

- `cargo check -p ruff_benchmark --bench ty`
- `cargo bench -p ruff_benchmark --bench ty --no-run`
- `cargo nextest run -p ty_python_semantic`
- focused match reachability and narrowing mdtests
- `uvx prek run --files crates/ty_python_semantic/src/reachability.rs crates/ruff_benchmark/benches/ty.rs`

Closes https://github.com/astral-sh/ty/issues/3880.
