### PR TITLE
Inline formatter printing hot paths

### DIFF
--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -443,10 +443,7 @@ impl<'a> Printer<'a> {
 
     // LLVM considers this function too large to inline on its own, but it is called for every
     // text element visited by the printing loop.
-    #[expect(
-        clippy::inline_always,
-        reason = "improves formatter benchmarks by 5-7%"
-    )]
+    #[expect(clippy::inline_always)]
     #[inline(always)]
     fn print_text(&mut self, text: Text) {
         if !self.state.pending_indent.is_empty() {

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -443,6 +443,10 @@ impl<'a> Printer<'a> {
 
     // LLVM considers this function too large to inline on its own, but it is called for every
     // text element visited by the printing loop.
+    #[expect(
+        clippy::inline_always,
+        reason = "improves formatter benchmarks by 5-7%"
+    )]
     #[inline(always)]
     fn print_text(&mut self, text: Text) {
         if !self.state.pending_indent.is_empty() {

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -88,6 +88,9 @@ impl<'a> Printer<'a> {
     }
 
     /// Prints a single element and push the following elements to queue
+    // LLVM considers this function too large to inline on its own, but it is called for every
+    // element visited by the printing loop.
+    #[inline(always)]
     fn print_element(
         &mut self,
         stack: &mut PrintCallStack,
@@ -438,6 +441,9 @@ impl<'a> Printer<'a> {
         Ok(print_mode)
     }
 
+    // LLVM considers this function too large to inline on its own, but it is called for every
+    // text element visited by the printing loop.
+    #[inline(always)]
     fn print_text(&mut self, text: Text) {
         if !self.state.pending_indent.is_empty() {
             let indent = std::mem::take(&mut self.state.pending_indent);


### PR DESCRIPTION
## Summary

The formatter calls `Printer::print_element` for every rendered format element and `Printer::print_text` for every text element. LLVM leaves both private methods out of line even when they are marked `#[inline]` and the release profile uses fat LTO, so these hot loops retain out-of-line calls.

This marks both functions as `#[inline(always)]`, allowing the printing loop and its common text paths to optimize together. It follows the same general source-level inlining approach as #26429 and closed #26473, but targets the printing pass rather than fitting or comment extraction. The methods have a small, fixed set of call sites, and the release binary's `.text` grows by 11,264 bytes (0.36%).

## Performance

To test whether ordinary `#[inline]` is sufficient and whether LTO changes the result, I built the exact base with no annotation, `#[inline]`, and `#[inline(always)]` under both the profiling profile (LTO disabled) and the release profile (fat LTO). Plain `#[inline]` neither removed the out-of-line symbols nor changed `.text`, and CodSpeed reported 0.0% in both profiles. Forced inlining removed both symbols and preserved the improvement under fat LTO:

| Profile | Annotation | Overall impact | `.text` delta |
| --- | --- | ---: | ---: |
| Profiling (no LTO) | `#[inline]` | 0.0% | 0 bytes |
| Profiling (no LTO) | `#[inline(always)]` | +6.2% | +11,152 bytes (+0.35%) |
| Release (fat LTO) | `#[inline]` | 0.0% | 0 bytes |
| Release (fat LTO) | `#[inline(always)]` | +6.0% | +11,264 bytes (+0.36%) |

The release/fat-LTO comparison on the existing non-microbenchmark formatter suite reports:

| Benchmark | Base | Head | Speedup |
| --- | ---: | ---: | ---: |
| `formatter[large/dataset.py]` | 7.53 ms | 7.02 ms | 7.3% |
| `formatter[pydantic/types.py]` | 2.99 ms | 2.79 ms | 7.2% |
| `formatter[numpy/ctypeslib.py]` | 1.57 ms | 1.48 ms | 5.9% |
| `formatter[unicode/pypinyin.py]` | 580.30 µs | 550.17 µs | 5.5% |
| `formatter[numpy/globals.py]` | 217.95 µs | 209.04 µs | 4.3% |
