### PR TITLE
[ty] Infer `ModuleType.__doc__` as `str` in the presence of a docstring

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -12,7 +12,8 @@ reveal_type(__name__)  # revealed: str
 reveal_type(__file__)  # revealed: str
 reveal_type(__loader__)  # revealed: LoaderProtocol | None
 reveal_type(__package__)  # revealed: str | None
-reveal_type(__doc__)  # revealed: str | None
+# This module has no docstring, so `__doc__` is `None`, not the wider `str | None`
+reveal_type(__doc__)  # revealed: None
 reveal_type(__spec__)  # revealed: ModuleSpec | None
 reveal_type(__path__)  # revealed: MutableSequence[str]
 reveal_type(__builtins__)  # revealed: Any
@@ -54,8 +55,8 @@ reveal_type(__init__)
 ## `__doc__` reflects the module's actual docstring
 
 Typeshed says `types.ModuleType.__doc__` is `str | None`, but a module that has a literal docstring
-always has `__doc__` set to that string at runtime. Just like `__file__` above, `__doc__` should be
-narrowed to `str` in that case, rather than the widened `str | None`:
+always has `__doc__` set to that string at runtime. Just like `__file__` above, `__doc__` is
+narrowed to `str` in that case, rather than the wider `str | None`:
 
 ```py
 """I am `typeshed.stdlib.types.ModuleType.__doc__: str | None` and this value is a `str`."""
@@ -76,7 +77,7 @@ redeclaration:
 ```py
 __file__ = None
 __path__: list[str] = []
-__doc__: int  # error: [invalid-declaration] "Cannot declare type `int` for inferred type `str | None`"
+__doc__: int  # error: [invalid-declaration] "Cannot declare type `int` for inferred type `None`"
 # error: [invalid-declaration] "Cannot shadow implicit global attribute `__package__` with declaration of type `int`"
 __package__: int = 42
 __spec__ = 42  # error: [invalid-assignment] "Object of type `Literal[42]` is not assignable to `ModuleSpec | None`"

--- a/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -12,7 +12,6 @@ reveal_type(__name__)  # revealed: str
 reveal_type(__file__)  # revealed: str
 reveal_type(__loader__)  # revealed: LoaderProtocol | None
 reveal_type(__package__)  # revealed: str | None
-# This module has no docstring, so `__doc__` falls back to the typeshed type `str | None`
 reveal_type(__doc__)  # revealed: str | None
 reveal_type(__spec__)  # revealed: ModuleSpec | None
 reveal_type(__path__)  # revealed: MutableSequence[str]
@@ -54,9 +53,9 @@ reveal_type(__init__)
 
 ## `__doc__` reflects the module's actual docstring
 
-Typeshed says `types.ModuleType.__doc__` is `str | None`, but a module that has a literal docstring
-always has `__doc__` set to that string at runtime. Just like `__file__` above, `__doc__` is
-narrowed to `str` in that case, rather than the wider `str | None`:
+Typeshed annotates `types.ModuleType.__doc__` as `str | None`, but a module with a literal docstring
+always has `__doc__` set (unless Python is run in `-OO` mode, which we ignore as a possibility). In
+that case, we narrow `__doc__` to `str`:
 
 ```py
 """Some docstring"""

--- a/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -59,11 +59,9 @@ always has `__doc__` set to that string at runtime. Just like `__file__` above, 
 narrowed to `str` in that case, rather than the wider `str | None`:
 
 ```py
-"""I am `typeshed.stdlib.types.ModuleType.__doc__: str | None` and this value is a `str`."""
+"""Some docstring"""
 
 reveal_type(__doc__)  # revealed: str
-
-__doc__.splitlines()  # not an error
 ```
 
 ## `ModuleType` globals combined with explicit assignments and declarations

--- a/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -12,8 +12,8 @@ reveal_type(__name__)  # revealed: str
 reveal_type(__file__)  # revealed: str
 reveal_type(__loader__)  # revealed: LoaderProtocol | None
 reveal_type(__package__)  # revealed: str | None
-# This module has no docstring, so `__doc__` is `None`, not the wider `str | None`
-reveal_type(__doc__)  # revealed: None
+# This module has no docstring, so `__doc__` falls back to the typeshed type `str | None`
+reveal_type(__doc__)  # revealed: str | None
 reveal_type(__spec__)  # revealed: ModuleSpec | None
 reveal_type(__path__)  # revealed: MutableSequence[str]
 reveal_type(__builtins__)  # revealed: Any
@@ -77,7 +77,7 @@ redeclaration:
 ```py
 __file__ = None
 __path__: list[str] = []
-__doc__: int  # error: [invalid-declaration] "Cannot declare type `int` for inferred type `None`"
+__doc__: int  # error: [invalid-declaration] "Cannot declare type `int` for inferred type `str | None`"
 # error: [invalid-declaration] "Cannot shadow implicit global attribute `__package__` with declaration of type `int`"
 __package__: int = 42
 __spec__ = 42  # error: [invalid-assignment] "Object of type `Literal[42]` is not assignable to `ModuleSpec | None`"

--- a/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/moduletype_attrs.md
@@ -51,6 +51,20 @@ reveal_type(__dict__)
 reveal_type(__init__)
 ```
 
+## `__doc__` reflects the module's actual docstring
+
+Typeshed says `types.ModuleType.__doc__` is `str | None`, but a module that has a literal docstring
+always has `__doc__` set to that string at runtime. Just like `__file__` above, `__doc__` should be
+narrowed to `str` in that case, rather than the widened `str | None`:
+
+```py
+"""I am `typeshed.stdlib.types.ModuleType.__doc__: str | None` and this value is a `str`."""
+
+reveal_type(__doc__)  # revealed: str
+
+__doc__.splitlines()  # not an error
+```
+
 ## `ModuleType` globals combined with explicit assignments and declarations
 
 A `ModuleType` attribute can be overridden in the global scope with a different type, but it must be

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -2056,15 +2056,15 @@ pub(crate) mod implicit_globals {
             // None`.
             "__file__" => Place::bound(KnownClass::Str.to_instance(db)).into(),
 
-            // We special-case `__doc__` here because we know its exact value for the current
-            // module: it's `str` if the module has a docstring, and `None` if it doesn't, even
-            // though typeshed says `str | None` unconditionally.
-            "__doc__" => Place::bound(if module_docstring(db, file).is_some() {
-                KnownClass::Str.to_instance(db)
-            } else {
-                Type::none(db)
-            })
-            .into(),
+            // We special-case `__doc__` because a module with a literal docstring has `__doc__`
+            // set to that string at runtime. We only narrow when a docstring is present: `__doc__`
+            // may be set dynamically, so we fall back to the typeshed's `str | None`.
+            "__doc__" if module_docstring(db, file).is_some() => {
+                // Docstrings are stripped in `-OO` optimized mode, but here we assume that the
+                // existence of an actual docstring AND the usage of `__doc__` is reason enough to
+                // believe that it will exist at runtime.
+                Place::bound(KnownClass::Str.to_instance(db)).into()
+            }
 
             "__builtins__" => Place::bound(Type::any()).into(),
 

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -501,7 +501,7 @@ pub(crate) fn global_symbol<'db>(
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
     explicit_global_symbol(db, file, name)
-        .or_fall_back_to(db, || module_type_implicit_global_symbol(db, name))
+        .or_fall_back_to(db, || module_type_implicit_global_symbol(db, file, name))
 }
 
 /// Infers the public type of an imported symbol.
@@ -599,7 +599,7 @@ pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> PlaceAndQua
             // We're looking up in the builtins namespace and not the module, so we should
             // do the normal lookup in `types.ModuleType` and not the special one as in
             // `imported_symbol`.
-            module_type_implicit_global_symbol(db, symbol)
+            module_type_implicit_global_symbol(db, file, symbol)
         });
         // If this symbol is not present in project-level builtins, search in the default ones.
         found_symbol
@@ -1985,11 +1985,13 @@ fn is_reexported(db: &dyn Db, definition: Definition<'_>) -> bool {
 }
 
 pub(crate) mod implicit_globals {
+    use ruff_db::files::File;
     use ruff_python_ast as ast;
     use ruff_python_ast::name::Name;
 
     use crate::Program;
     use crate::db::Db;
+    use crate::module_docstring;
     use crate::place::{Definedness, PlaceAndQualifiers};
     use crate::types::{
         ClassLiteral, KnownClass, MemberLookupPolicy, Parameter, Parameters, Signature, Type,
@@ -2045,6 +2047,7 @@ pub(crate) mod implicit_globals {
     /// global scope if they're being imported **from a different file**.
     pub(crate) fn module_type_implicit_global_symbol<'db>(
         db: &'db dyn Db,
+        file: File,
         name: &str,
     ) -> PlaceAndQualifiers<'db> {
         match name {
@@ -2052,6 +2055,16 @@ pub(crate) mod implicit_globals {
             // lookup in a Python module, it is always a string, even though typeshed says `str |
             // None`.
             "__file__" => Place::bound(KnownClass::Str.to_instance(db)).into(),
+
+            // We special-case `__doc__` here because we know its exact value for the current
+            // module: it's `str` if the module has a docstring, and `None` if it doesn't, even
+            // though typeshed says `str | None` unconditionally.
+            "__doc__" => Place::bound(if module_docstring(db, file).is_some() {
+                KnownClass::Str.to_instance(db)
+            } else {
+                Type::none(db)
+            })
+            .into(),
 
             "__builtins__" => Place::bound(Type::any()).into(),
 
@@ -2171,6 +2184,7 @@ pub(crate) mod implicit_globals {
     /// for the current module, not `str | None`).
     pub(crate) fn all_implicit_module_globals(
         db: &dyn Db,
+        file: File,
     ) -> impl Iterator<Item = (Name, Type<'_>)> + '_ {
         // Special-cased implicit globals that are not in `module_type_symbols`
         let special_cased = ["__builtins__", "__debug__", "__warningregistry__"]
@@ -2184,7 +2198,7 @@ pub(crate) mod implicit_globals {
         special_cased
             .chain(module_type_syms)
             .filter_map(move |name| {
-                let place = module_type_implicit_global_symbol(db, name.as_str());
+                let place = module_type_implicit_global_symbol(db, file, name.as_str());
                 // Only include bound symbols
                 place.place.ignore_possibly_undefined().map(|ty| (name, ty))
             })

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -257,7 +257,7 @@ impl<'db> SemanticModel<'db> {
         // keeps the correct types (e.g., `__file__` is `str` for the current module,
         // not `str | None`).
         completions.extend(
-            all_implicit_module_globals(self.db).map(|(name, ty)| Completion {
+            all_implicit_module_globals(self.db, self.file).map(|(name, ty)| Completion {
                 name,
                 ty: Some(ty),
                 builtin: true,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1477,7 +1477,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let PlaceExprRef::Symbol(symbol) = &place
                 && scope.is_global()
             {
-                module_type_implicit_global_symbol(self.db(), symbol.name())
+                module_type_implicit_global_symbol(self.db(), self.file(), symbol.name())
             } else {
                 Place::Undefined.into()
             }
@@ -1531,9 +1531,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if file_scope_id.is_global() {
                     let place_table = self.index.place_table(file_scope_id);
                     let place = place_table.place(definition.place(self.db()));
+                    let file = self.file();
                     if let Some(module_type_implicit_declaration) = place
                         .as_symbol()
-                        .map(|symbol| module_type_implicit_global_symbol(self.db(), symbol.name()))
+                        .map(|symbol| {
+                            module_type_implicit_global_symbol(self.db(), file, symbol.name())
+                        })
                         .and_then(|place| place.place.ignore_possibly_undefined())
                     {
                         let declared_type = declared_ty.inner_type();
@@ -5464,7 +5467,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     continue;
                 }
             }
-            if !module_type_implicit_global_symbol(self.db(), name)
+            if !module_type_implicit_global_symbol(self.db(), self.file(), name)
                 .place
                 .is_undefined()
             {
@@ -9552,7 +9555,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Check the "implicit globals" such as `__doc__`, `__file__`, `__name__`, etc.
             // These are looked up as attributes on `types.ModuleType`.
             .or_fall_back_to(db, || {
-                module_type_implicit_global_symbol(db, symbol_name).map_type(|ty| {
+                module_type_implicit_global_symbol(db, self.file(), symbol_name).map_type(|ty| {
                     self.narrow_place_with_applicable_constraints(
                         PlaceExprRef::from(&expr),
                         ty,


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This change fixes https://github.com/astral-sh/ty/issues/3877 "Type of `__doc__` should not be `str | None` when docstring exists"

The approach follows the same method that is already used for `ModuleType.__file__`, which is also in `module_type_implicit_global_symbol`.

## Test Plan

Initially-failing test included, and existing tests updated to reflect this change.

fyi @millerdev @sharkdp 