### PR TITLE
Avoid per-token source index visitor calls

### DIFF
--- a/crates/ruff_python_index/src/indexer.rs
+++ b/crates/ruff_python_index/src/indexer.rs
@@ -61,9 +61,6 @@ impl Indexer {
                 }
             }
 
-            interpolated_string_ranges_builder.visit_token(token);
-            multiline_ranges_builder.visit_token(token);
-
             match token.kind() {
                 TokenKind::Newline | TokenKind::NonLogicalNewline => {
                     line_start = token.end();
@@ -71,9 +68,20 @@ impl Indexer {
                 TokenKind::Comment => {
                     comment_ranges.push(token.range());
                 }
-                _ if token.string_flags().is_some() => {
-                    // String-like tokens, including f/t-string start, middle, and end tokens, can
-                    // span multiple lines.
+                // String-like tokens, including f/t-string start, middle, and end tokens, can span
+                // multiple lines.
+                TokenKind::FStringStart
+                | TokenKind::FStringEnd
+                | TokenKind::TStringStart
+                | TokenKind::TStringEnd => {
+                    interpolated_string_ranges_builder.visit_token(token);
+                    line_start = source.line_start(token.end());
+                }
+                TokenKind::String | TokenKind::FStringMiddle => {
+                    multiline_ranges_builder.visit_token(token);
+                    line_start = source.line_start(token.end());
+                }
+                TokenKind::TStringMiddle => {
                     line_start = source.line_start(token.end());
                 }
                 _ => {}


### PR DESCRIPTION
## Summary

`Indexer::from_tokens` previously called both range builders and checked string flags for every token, even though only string tokens can affect those indexes or span multiple lines.

Dispatch the existing builders from the token-kind match instead. Interpolated-string boundaries visit the interpolated-range builder, regular strings and f-string middles visit the multiline-range builder, and t-string middles only update the current line start. This preserves the indexed ranges while removing visitor calls and flag lookup from the common non-string path.

The empty-trivia fast path was split into #26507 so CodSpeed can measure the two optimizations independently.

## Performance

The [full CodSpeed report](https://app.codspeed.io/astral-sh/ruff/branches/charlie%2Fcodex-parser-throughput) compares `f673f29` with `dc42d1d`. All 15 linter CPU-simulation measurements improve:

| Configuration | Gain across the five workloads |
| --- | ---: |
| Default rules | 1.52-4.63% |
| All rules | 0.36-1.09% |
| All rules with preview | 0.31-0.89% |

Summing the five default-rules head and base measurements gives a 4.00% aggregate improvement. CodSpeed classifies `linter/default-rules[large/dataset.py]` at 4.63% as a significant improvement; the other measured gains are below its reporting threshold.