### PR TITLE
Skip empty trivia scans in the source indexer

### DIFF
--- a/crates/ruff_python_index/src/indexer.rs
+++ b/crates/ruff_python_index/src/indexer.rs
@@ -42,22 +42,26 @@ impl Indexer {
         let mut line_start = TextSize::default();
 
         for token in tokens {
-            let trivia = &source[TextRange::new(prev_end, token.start())];
+            let token_start = token.start();
 
-            // Get the trivia between the previous and the current token and detect any newlines.
-            // This is necessary because `RustPython` doesn't emit `[Tok::Newline]` tokens
-            // between any two tokens that form a continuation. That's why we have to extract the
-            // newlines "manually".
-            for (index, text) in trivia.match_indices(['\n', '\r']) {
-                if text == "\r" && trivia.as_bytes().get(index + 1) == Some(&b'\n') {
-                    continue;
-                }
-                continuation_lines.push(line_start);
+            if prev_end != token_start {
+                let trivia = &source[TextRange::new(prev_end, token_start)];
 
-                // SAFETY: Safe because of the len assertion at the top of the function.
-                #[expect(clippy::cast_possible_truncation)]
-                {
-                    line_start = prev_end + TextSize::new((index + 1) as u32);
+                // Get the trivia between the previous and the current token and detect any
+                // newlines. This is necessary because `RustPython` doesn't emit `[Tok::Newline]`
+                // tokens between any two tokens that form a continuation. That's why we have to
+                // extract the newlines "manually".
+                for (index, text) in trivia.match_indices(['\n', '\r']) {
+                    if text == "\r" && trivia.as_bytes().get(index + 1) == Some(&b'\n') {
+                        continue;
+                    }
+                    continuation_lines.push(line_start);
+
+                    // SAFETY: Safe because of the len assertion at the top of the function.
+                    #[expect(clippy::cast_possible_truncation)]
+                    {
+                        line_start = prev_end + TextSize::new((index + 1) as u32);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

`Indexer::from_tokens` scans the trivia between consecutive tokens to find continuation newlines. Most tokens are adjacent, but we still construct an empty slice and run `match_indices` for those pairs.

Skip that scan when the previous token ends where the current token starts. Non-empty gaps continue through the existing newline logic, preserving the indexed continuation lines.

This is split from #26506 so CodSpeed can measure the empty-trivia fast path independently.

## Performance

The [full CodSpeed report](https://app.codspeed.io/astral-sh/ruff/branches/charlie%2Fskip-empty-indexer-trivia) compares `779b0c2` with `dc42d1d`. All 15 linter CPU-simulation measurements improve:

| Configuration | Gain across the five workloads |
| --- | ---: |
| Default rules | 1.06-2.72% |
| All rules | 0.30-0.64% |
| All rules with preview | 0.25-0.53% |

Summing the five default-rules head and base measurements gives a 2.38% aggregate improvement. No individual benchmark crosses CodSpeed's significance threshold, which is why the GitHub bot does not list these gains even though they appear in the full report.