### PR TITLE
[ty] Recognize exhaustive matches on gradual types

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1045,7 +1045,7 @@ def combine[T](first: T, second: T, third: T) -> T:
     });
 }
 
-/// Benchmark for narrowing a large union type through multiple match statements.
+/// Generate a large union narrowed through multiple match cases.
 ///
 /// This is extracted from egglog-python's `pretty.py`, where a ~30-class union type
 /// (`AllDecls`) is narrowed by exhaustive match statements.
@@ -1068,11 +1068,9 @@ def combine[T](first: T, second: T, third: T) -> T:
 ///         ...
 ///         case _: pass
 /// ```
-fn benchmark_large_union_narrowing(criterion: &mut Criterion) {
+fn large_union_narrowing_code(destructure: bool) -> String {
     const NUM_CLASSES: usize = 30;
     const NUM_MATCH_BRANCHES: usize = 29;
-
-    setup_rayon();
 
     let mut code =
         "from __future__ import annotations\nfrom dataclasses import dataclass\n\n".to_string();
@@ -1092,11 +1090,63 @@ fn benchmark_large_union_narrowing(criterion: &mut Criterion) {
 
     code.push_str("def process(decl: AllDecls) -> None:\n    match decl:\n");
     for i in 0..NUM_MATCH_BRANCHES {
-        writeln!(&mut code, "        case C{i}():\n            pass").ok();
+        if destructure {
+            writeln!(
+                &mut code,
+                "        case C{i}(value):\n            assert value == decl.value"
+            )
+            .ok();
+        } else {
+            writeln!(&mut code, "        case C{i}():\n            pass").ok();
+        }
     }
     code.push_str("        case _:\n            pass\n\n");
 
+    if destructure {
+        code.push_str("@dataclass\nclass Holder:\n    decl: AllDecls\n\n");
+        code.push_str("def process_attribute(holder: Holder) -> None:\n    match holder.decl:\n");
+        for i in 0..NUM_MATCH_BRANCHES {
+            writeln!(
+                &mut code,
+                "        case C{i}(value):\n            assert value == holder.decl.value"
+            )
+            .ok();
+        }
+        code.push_str("        case _:\n            pass\n\n");
+    }
+
+    code
+}
+
+/// Benchmark subject-independent class patterns over a large union.
+fn benchmark_large_union_narrowing(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let code = large_union_narrowing_code(false);
+
     criterion.bench_function("ty_micro[large_union_narrowing]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Benchmark subject-dependent class patterns over a large union.
+///
+/// Destructuring each class and using both name and attribute subjects in the case bodies exercises
+/// the prefix-aware negative and related-place constraints used by ordered match cases.
+fn benchmark_large_union_destructuring_narrowing(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let code = large_union_narrowing_code(true);
+
+    criterion.bench_function("ty_micro[large_union_destructuring_narrowing]", |b| {
         b.iter_batched_ref(
             || setup_micro_case(&code),
             |case| {
@@ -1801,6 +1851,7 @@ criterion_group!(
     benchmark_typevar_mapping_small_accumulations,
     benchmark_very_large_tuple,
     benchmark_large_union_narrowing,
+    benchmark_large_union_destructuring_narrowing,
     benchmark_large_isinstance_narrowing,
     benchmark_literal_match_fallthrough,
     benchmark_literal_match_fallthrough_guarded_any,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -148,15 +148,6 @@ def gradual_dict_match_self_is_exhaustive(value: dict[str, Any] | int) -> None:
         case _:
             assert_never(value)
 
-def gradual_member_pattern_is_exhaustive(value: Box[Any] | int) -> None:
-    match value:
-        case Box(value=_):
-            pass
-        case int():
-            pass
-        case _:
-            assert_never(value)
-
 def gradual_member_pattern_narrows_subject_fallthrough(value: Box[Any] | int) -> int:
     match value:
         case Box(value=_):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -156,6 +156,36 @@ def gradual_member_pattern_narrows_subject_fallthrough(value: Box[Any] | int) ->
             reveal_type(value)  # revealed: int
             return value + 1
 
+def gradual_member_pattern_preserves_previous_fallthrough(
+    value: Box[Any] | int | str,
+) -> None:
+    match value:
+        case Box(value=_):
+            pass
+        case int():
+            pass
+        case _:
+            reveal_type(value)  # revealed: str
+
+    match value:
+        case int():
+            pass
+        case Box(value=_):
+            pass
+        case _:
+            reveal_type(value)  # revealed: str
+
+def wrapped_sequence_pattern_preserves_previous_fallthrough(
+    value: tuple[Box[Any]] | int | str,
+) -> None:
+    match value:
+        case int():
+            pass
+        case [Box(value=_)] as matched:
+            reveal_type(matched)  # revealed: tuple[Box[Any]]
+        case _:
+            reveal_type(value)  # revealed: str
+
 def nested_gradual_pattern_is_exhaustive(
     value: tuple[Mapping[str, Any]] | int,
 ) -> None:
@@ -1764,6 +1794,25 @@ def typed_dict_runtime_domain_is_exhaustive(value: DynamicMovie | int) -> None:
             pass
         case _:
             assert_never(value)
+
+def typed_dict_runtime_domain_preserves_previous_fallthrough(
+    value: DynamicMovie | int | str,
+) -> None:
+    match value:
+        case dict():
+            pass
+        case int():
+            pass
+        case _:
+            reveal_type(value)  # revealed: str
+
+    match value:
+        case int():
+            pass
+        case Mapping():
+            pass
+        case _:
+            reveal_type(value)  # revealed: str & ~Top[Mapping[Unknown, object]]
 ```
 
 ## Required `TypedDict` keys

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -150,6 +150,14 @@ def gradual_member_pattern_is_exhaustive(value: Box[Any] | int) -> None:
         case _:
             assert_never(value)
 
+def gradual_member_pattern_narrows_subject_fallthrough(value: Box[Any] | int) -> int:
+    match value:
+        case Box(value=_):
+            return 0
+        case _:
+            reveal_type(value)  # revealed: int
+            return value + 1
+
 def nested_gradual_pattern_is_exhaustive(
     value: tuple[Mapping[str, Any]] | int,
 ) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -2988,6 +2988,15 @@ def _(color: Color):
         case _:
             reveal_type(color)  # revealed: Literal[Color.GREEN, Color.BLUE]
 
+def nested_or_fallthrough(
+    value: Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+) -> None:
+    match value:
+        case ((((((((((((((((0 | 1) | 2) | 3) | 4) | 5) | 6) | 7) | 8) | 9) | 10) | 11) | 12) | 13) | 14) | 15) | 16) | 17:
+            pass
+        case _:
+            reveal_type(value)  # revealed: Literal[18]
+
 class A: ...
 class B: ...
 class C: ...

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -97,7 +97,8 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import assert_never
+from collections.abc import Mapping
+from typing import Any, assert_never
 
 class Covariant[T]:
     def get(self) -> T:
@@ -110,6 +111,64 @@ def f(x: Covariant[int]):
         case _:
             reveal_type(x)  # revealed: Never
             assert_never(x)
+
+class Box[T]:
+    value: T
+
+def gradual_mapping_order_is_exhaustive(value: Mapping[str, Any] | int) -> None:
+    match value:
+        case Mapping():
+            pass
+        case int():
+            pass
+        case _:
+            assert_never(value)
+
+    match value:
+        case int():
+            pass
+        case Mapping():
+            pass
+        case _:
+            assert_never(value)
+
+def gradual_dict_match_self_is_exhaustive(value: dict[str, Any] | int) -> None:
+    match value:
+        case dict(_):
+            pass
+        case int():
+            pass
+        case _:
+            assert_never(value)
+
+def gradual_member_pattern_is_exhaustive(value: Box[Any] | int) -> None:
+    match value:
+        case Box(value=_):
+            pass
+        case int():
+            pass
+        case _:
+            assert_never(value)
+
+def nested_gradual_pattern_is_exhaustive(
+    value: tuple[Mapping[str, Any]] | int,
+) -> None:
+    match value:
+        case [Mapping()]:
+            pass
+        case int():
+            pass
+        case _:
+            assert_never(value)
+
+def gradual_member_pattern_can_be_refutable(value: Box[Any] | int) -> None:
+    match value:
+        case Box(value=int()):
+            pass
+        case int():
+            pass
+        case _:
+            assert_never(value)  # error: [type-assertion-failure]
 ```
 
 ## Class patterns with generic `@final` classes

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -132,6 +132,13 @@ def gradual_mapping_order_is_exhaustive(value: Mapping[str, Any] | int) -> None:
         case _:
             assert_never(value)
 
+def gradual_mapping_uses_runtime_class_domain(value: Mapping[str, Any] | int) -> None:
+    match value:
+        case Mapping():
+            pass
+        case _:
+            reveal_type(value)  # revealed: int & ~Top[Mapping[Unknown, object]]
+
 def gradual_dict_match_self_is_exhaustive(value: dict[str, Any] | int) -> None:
     match value:
         case dict(_):
@@ -1708,7 +1715,8 @@ truthiness-narrowed intersection or a type variable bounded by or constrained to
 
 ```py
 from collections.abc import Mapping
-from typing import TypeVar, TypedDict
+from typing import Any, TypeVar, TypedDict
+from typing_extensions import assert_never
 
 class Movie(TypedDict):
     title: str
@@ -1718,6 +1726,9 @@ class OptionalMovie(TypedDict, total=False):
 
 class Series(TypedDict):
     seasons: int
+
+class DynamicMovie(TypedDict):
+    metadata: Any
 
 T = TypeVar("T", bound=Movie)
 U = TypeVar("U", Movie, Series)
@@ -1753,6 +1764,15 @@ def constrained_typed_dict_pattern_is_exhaustive(value: U) -> int:
     match value:
         case dict():
             return 1
+
+def typed_dict_runtime_domain_is_exhaustive(value: DynamicMovie | int) -> None:
+    match value:
+        case dict():
+            pass
+        case int():
+            pass
+        case _:
+            assert_never(value)
 ```
 
 ## Required `TypedDict` keys

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -205,6 +205,18 @@ def gradual_member_pattern_can_be_refutable(value: Box[Any] | int) -> None:
             pass
         case _:
             assert_never(value)  # error: [type-assertion-failure]
+
+class RecursiveBox[T]:
+    value: T
+
+type RecursiveValue = int | RecursiveBox[RecursiveValue]
+
+def recursive_alias_survives_unchanged_residual(value: RecursiveValue) -> None:
+    match value:
+        case RecursiveBox(value=int()):
+            pass
+        case _:
+            reveal_type(value)  # revealed: int | RecursiveBox[RecursiveValue]
 ```
 
 ## Class patterns with generic `@final` classes

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -201,11 +201,10 @@ use crate::{
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
         ActiveRecursionDetector, CallableTypes, EnumClassLiteral, KnownInstanceType,
-        NarrowingConstraint, PatternCoverage, SpecialFormType, Type, TypeContext, UnionType,
-        callable_pattern_type, definite_match_pattern_type, equality_truthiness, expand_type,
-        infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
-        pattern_binding_fallthrough_type, pattern_coverage_for_subject,
-        sequence_pattern_type_builder, singleton_pattern_type,
+        NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType, callable_pattern_type,
+        definite_match_pattern_type, equality_truthiness, expand_type, infer_narrowing_constraints,
+        infer_same_file_expression_type, mapping_pattern_type, pattern_binding_fallthrough_type,
+        pattern_is_exhaustive_for_subject, sequence_pattern_type_builder, singleton_pattern_type,
     },
 };
 use ruff_index::{Idx, IndexSlice};
@@ -1111,7 +1110,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
     db: &'db dyn Db,
     predicate_kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
-    precomputed_coverage: Option<PatternCoverage<'db>>,
+    precomputed_exhaustiveness: Option<bool>,
 ) -> Truthiness {
     match predicate_kind {
         PatternPredicateKind::Value(value) => {
@@ -1143,18 +1142,17 @@ fn analyze_single_pattern_predicate_kind<'db>(
                 .map(|p| {
                     let narrowed_subject_ty = remaining_subject_ty;
 
-                    let coverage = pattern_coverage_for_subject(db, p, narrowed_subject_ty);
-
-                    let truthiness = if coverage.exhausts_subject() {
-                        Truthiness::AlwaysTrue
-                    } else {
-                        analyze_single_pattern_predicate_kind(
-                            db,
-                            p,
-                            narrowed_subject_ty,
-                            Some(coverage),
-                        )
-                    };
+                    let truthiness =
+                        if pattern_is_exhaustive_for_subject(db, p, narrowed_subject_ty) {
+                            Truthiness::AlwaysTrue
+                        } else {
+                            analyze_single_pattern_predicate_kind(
+                                db,
+                                p,
+                                narrowed_subject_ty,
+                                Some(false),
+                            )
+                        };
 
                     remaining_subject_ty =
                         pattern_binding_fallthrough_type(db, p, narrowed_subject_ty);
@@ -1184,10 +1182,11 @@ fn analyze_single_pattern_predicate_kind<'db>(
                     }
                     _ => return Truthiness::Ambiguous,
                 };
-            let coverage = precomputed_coverage
-                .unwrap_or_else(|| pattern_coverage_for_subject(db, predicate_kind, subject_ty));
+            let exhausts_subject = precomputed_exhaustiveness.unwrap_or_else(|| {
+                pattern_is_exhaustive_for_subject(db, predicate_kind, subject_ty)
+            });
 
-            if coverage.exhausts_subject() {
+            if exhausts_subject {
                 Truthiness::AlwaysTrue
             } else if subject_ty.is_disjoint_from(db, class_ty) {
                 Truthiness::AlwaysFalse
@@ -1225,7 +1224,9 @@ fn analyze_single_pattern_predicate_kind<'db>(
         }
         PatternPredicateKind::As(pattern, _) => pattern
             .as_deref()
-            .map(|p| analyze_single_pattern_predicate_kind(db, p, subject_ty, precomputed_coverage))
+            .map(|p| {
+                analyze_single_pattern_predicate_kind(db, p, subject_ty, precomputed_exhaustiveness)
+            })
             .unwrap_or(Truthiness::AlwaysTrue),
         PatternPredicateKind::Star(_) => Truthiness::AlwaysTrue,
     }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -201,11 +201,11 @@ use crate::{
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
         ActiveRecursionDetector, CallableTypes, EnumClassLiteral, KnownInstanceType,
-        NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType, callable_pattern_type,
-        definite_match_pattern_type, definite_match_pattern_type_for_subject, equality_truthiness,
-        expand_type, infer_narrowing_constraints, infer_same_file_expression_type,
-        mapping_pattern_type, pattern_binding_fallthrough_type, sequence_pattern_type_builder,
-        singleton_pattern_type,
+        NarrowingConstraint, PatternCoverage, SpecialFormType, Type, TypeContext, UnionType,
+        callable_pattern_type, definite_match_pattern_type, equality_truthiness, expand_type,
+        infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
+        pattern_binding_fallthrough_type, pattern_coverage_for_subject,
+        sequence_pattern_type_builder, singleton_pattern_type,
     },
 };
 use ruff_index::{Idx, IndexSlice};
@@ -1111,7 +1111,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
     db: &'db dyn Db,
     predicate_kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
-    precomputed_definite_match_ty: Option<Type<'db>>,
+    precomputed_coverage: Option<PatternCoverage<'db>>,
 ) -> Truthiness {
     match predicate_kind {
         PatternPredicateKind::Value(value) => {
@@ -1143,17 +1143,16 @@ fn analyze_single_pattern_predicate_kind<'db>(
                 .map(|p| {
                     let narrowed_subject_ty = remaining_subject_ty;
 
-                    let definitely_matched =
-                        definite_match_pattern_type_for_subject(db, p, narrowed_subject_ty);
+                    let coverage = pattern_coverage_for_subject(db, p, narrowed_subject_ty);
 
-                    let truthiness = if narrowed_subject_ty.is_subtype_of(db, definitely_matched) {
+                    let truthiness = if coverage.exhausts_subject() {
                         Truthiness::AlwaysTrue
                     } else {
                         analyze_single_pattern_predicate_kind(
                             db,
                             p,
                             narrowed_subject_ty,
-                            Some(definitely_matched),
+                            Some(coverage),
                         )
                     };
 
@@ -1185,13 +1184,10 @@ fn analyze_single_pattern_predicate_kind<'db>(
                     }
                     _ => return Truthiness::Ambiguous,
                 };
-            let definitely_matched = precomputed_definite_match_ty.unwrap_or_else(|| {
-                definite_match_pattern_type_for_subject(db, predicate_kind, subject_ty)
-            });
+            let coverage = precomputed_coverage
+                .unwrap_or_else(|| pattern_coverage_for_subject(db, predicate_kind, subject_ty));
 
-            if subject_ty.is_equivalent_to(db, definitely_matched)
-                || subject_ty.is_subtype_of(db, definitely_matched)
-            {
+            if coverage.exhausts_subject() {
                 Truthiness::AlwaysTrue
             } else if subject_ty.is_disjoint_from(db, class_ty) {
                 Truthiness::AlwaysFalse
@@ -1229,14 +1225,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
         }
         PatternPredicateKind::As(pattern, _) => pattern
             .as_deref()
-            .map(|p| {
-                analyze_single_pattern_predicate_kind(
-                    db,
-                    p,
-                    subject_ty,
-                    precomputed_definite_match_ty,
-                )
-            })
+            .map(|p| analyze_single_pattern_predicate_kind(db, p, subject_ty, precomputed_coverage))
             .unwrap_or(Truthiness::AlwaysTrue),
         PatternPredicateKind::Star(_) => Truthiness::AlwaysTrue,
     }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -494,7 +494,7 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
     }
 
     let truthiness =
-        analyze_single_pattern_predicate_kind(db, predicate.kind(db), narrowed_subject_ty, None);
+        analyze_single_pattern_predicate_kind(db, predicate.kind(db), narrowed_subject_ty, false);
 
     if truthiness == Truthiness::AlwaysTrue && predicate.guard(db).is_some() {
         // Fall back to ambiguous, the guard might change the result.
@@ -1110,7 +1110,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
     db: &'db dyn Db,
     predicate_kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
-    precomputed_exhaustiveness: Option<bool>,
+    known_non_exhaustive: bool,
 ) -> Truthiness {
     match predicate_kind {
         PatternPredicateKind::Value(value) => {
@@ -1146,12 +1146,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
                         if pattern_is_exhaustive_for_subject(db, p, narrowed_subject_ty) {
                             Truthiness::AlwaysTrue
                         } else {
-                            analyze_single_pattern_predicate_kind(
-                                db,
-                                p,
-                                narrowed_subject_ty,
-                                Some(false),
-                            )
+                            analyze_single_pattern_predicate_kind(db, p, narrowed_subject_ty, true)
                         };
 
                     remaining_subject_ty =
@@ -1182,11 +1177,9 @@ fn analyze_single_pattern_predicate_kind<'db>(
                     }
                     _ => return Truthiness::Ambiguous,
                 };
-            let exhausts_subject = precomputed_exhaustiveness.unwrap_or_else(|| {
-                pattern_is_exhaustive_for_subject(db, predicate_kind, subject_ty)
-            });
-
-            if exhausts_subject {
+            if !known_non_exhaustive
+                && pattern_is_exhaustive_for_subject(db, predicate_kind, subject_ty)
+            {
                 Truthiness::AlwaysTrue
             } else if subject_ty.is_disjoint_from(db, class_ty) {
                 Truthiness::AlwaysFalse
@@ -1224,9 +1217,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
         }
         PatternPredicateKind::As(pattern, _) => pattern
             .as_deref()
-            .map(|p| {
-                analyze_single_pattern_predicate_kind(db, p, subject_ty, precomputed_exhaustiveness)
-            })
+            .map(|p| analyze_single_pattern_predicate_kind(db, p, subject_ty, known_non_exhaustive))
             .unwrap_or(Truthiness::AlwaysTrue),
         PatternPredicateKind::Star(_) => Truthiness::AlwaysTrue,
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -35,9 +35,9 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    ClassPatternPositionalSource, callable_pattern_type, class_pattern_positional_sources,
-    definite_match_pattern_type, definite_match_pattern_type_for_subject,
-    exact_sequence_pattern_type, mapping_pattern_type, pattern_binding_fallthrough_type,
+    ClassPatternPositionalSource, PatternCoverage, callable_pattern_type,
+    class_pattern_positional_sources, definite_match_pattern_type, exact_sequence_pattern_type,
+    mapping_pattern_type, pattern_binding_fallthrough_type, pattern_coverage_for_subject,
     sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
     typed_dict_matches_class_pattern,
 };

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -35,9 +35,9 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    ClassPatternPositionalSource, PatternCoverage, callable_pattern_type,
-    class_pattern_positional_sources, definite_match_pattern_type, exact_sequence_pattern_type,
-    mapping_pattern_type, pattern_binding_fallthrough_type, pattern_coverage_for_subject,
+    ClassPatternPositionalSource, callable_pattern_type, class_pattern_positional_sources,
+    definite_match_pattern_type, exact_sequence_pattern_type, mapping_pattern_type,
+    pattern_binding_fallthrough_type, pattern_is_exhaustive_for_subject,
     sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
     typed_dict_matches_class_pattern,
 };

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -482,24 +482,7 @@ fn pattern_is_exhaustive_for_subject(
     pattern: &PatternPredicateKind<'_>,
     subject_ty: Type<'_>,
 ) -> bool {
-    definite_match_type_exhausts_subject(
-        db,
-        subject_ty,
-        definite_match_pattern_type_for_subject(db, pattern, subject_ty),
-    )
-}
-
-/// Return whether a definite-match under-approximation covers the complete subject.
-///
-/// Equivalence is required because gradual types are not subtypes of themselves.
-fn definite_match_type_exhausts_subject(
-    db: &dyn Db,
-    subject_ty: Type<'_>,
-    definitely_matched: Type<'_>,
-) -> bool {
-    subject_ty == definitely_matched
-        || subject_ty.is_subtype_of(db, definitely_matched)
-        || subject_ty.is_equivalent_to(db, definitely_matched)
+    pattern_coverage_for_subject(db, pattern, subject_ty).exhausts_subject()
 }
 
 /// Return whether every value in `subject_ty` is guaranteed to match a mapping pattern.
@@ -571,14 +554,39 @@ fn sequence_pattern_is_exhaustive_for_subject(
         .all(|(element, pattern)| pattern_is_exhaustive_for_subject(db, pattern, *element))
 }
 
-/// Return the values that are statically guaranteed to match `kind`, using `subject_ty` when the
-/// answer depends on the subject.
+/// The statically known coverage of a pattern for a specific subject type.
+#[derive(Clone, Copy)]
+pub(crate) struct PatternCoverage<'db> {
+    definitely_matched_ty: Type<'db>,
+    exhausts_subject: bool,
+}
+
+impl<'db> PatternCoverage<'db> {
+    fn new(definitely_matched_ty: Type<'db>, exhausts_subject: bool) -> Self {
+        Self {
+            definitely_matched_ty,
+            exhausts_subject,
+        }
+    }
+
+    pub(crate) fn definitely_matched_ty(self) -> Type<'db> {
+        self.definitely_matched_ty
+    }
+
+    pub(crate) fn exhausts_subject(self) -> bool {
+        self.exhausts_subject
+    }
+}
+
+/// Return the values that are statically guaranteed to match `kind` and whether they cover the
+/// complete subject.
 ///
-/// This is an under-approximation used for negative narrowing and ordered alternatives: callers
-/// may subtract the result from `subject_ty`. A subject-independent pattern can return a type wider
-/// than `subject_ty`; for example, `case Base()` returns `Base` even for a `Child` subject. Class
-/// patterns need the current subject type when member extraction depends on the subject's statically
-/// known members.
+/// The definite-match type is an under-approximation used for negative narrowing and ordered
+/// alternatives: callers may subtract it from `subject_ty`. Exhaustiveness is tracked separately
+/// because gradual types are not subtypes of themselves. A subject-independent pattern can return a
+/// type wider than `subject_ty`; for example, `case Base()` returns `Base` even for a `Child`
+/// subject. Class patterns need the current subject type when member extraction depends on the
+/// subject's statically known members.
 /// A subject-independent pattern can return its context-free definite-match type directly. A
 /// mapping pattern can use required `TypedDict` fields to establish that every subject value
 /// contains its keys.
@@ -596,24 +604,34 @@ fn sequence_pattern_is_exhaustive_for_subject(
 /// # For a `tuple[Child]` subject, this checks `x` on `Child`, not only on `Base`.
 /// case [Base(x=_)]: ...
 /// ```
-pub(crate) fn definite_match_pattern_type_for_subject<'db>(
+pub(crate) fn pattern_coverage_for_subject<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
-) -> Type<'db> {
+) -> PatternCoverage<'db> {
     if let Some(subject_independent_ty) = subject_independent_definite_match_pattern_type(db, kind)
     {
-        return subject_independent_ty;
+        return PatternCoverage::new(
+            subject_independent_ty,
+            subject_ty.is_subtype_of(db, subject_independent_ty),
+        );
     }
 
     let resolved_subject_ty = subject_ty.resolve_type_alias(db);
     if let Type::Union(union) = resolved_subject_ty {
-        return UnionType::from_elements(
-            db,
-            union
-                .elements(db)
-                .iter()
-                .map(|element| definite_match_pattern_type_for_subject(db, kind, *element)),
+        let coverages = union
+            .elements(db)
+            .iter()
+            .map(|element| pattern_coverage_for_subject(db, kind, *element))
+            .collect::<Vec<_>>();
+        return PatternCoverage::new(
+            UnionType::from_elements(
+                db,
+                coverages
+                    .iter()
+                    .map(|coverage| coverage.definitely_matched_ty()),
+            ),
+            coverages.iter().all(|coverage| coverage.exhausts_subject()),
         );
     }
 
@@ -621,61 +639,87 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
         PatternPredicateKind::Value(value) => {
             let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
             if equality_truthiness(db, resolved_subject_ty, value_ty) == Truthiness::AlwaysTrue {
-                return subject_ty;
+                return PatternCoverage::new(subject_ty, true);
             }
         }
         PatternPredicateKind::Class(kind) => {
             let class_ty = infer_same_file_expression_type(db, kind.class, TypeContext::default());
             match class_ty {
                 Type::ClassLiteral(class) => {
-                    if class_pattern_is_exhaustive(db, class, resolved_subject_ty, kind) {
-                        return subject_ty;
+                    let exhausts_subject =
+                        class_pattern_is_exhaustive(db, class, resolved_subject_ty, kind);
+                    if kind.is_empty() {
+                        let class_instance_ty = Type::instance(db, class.top_materialization(db));
+                        let definitely_matched_ty =
+                            if is_typed_dict_pattern_domain(db, resolved_subject_ty)
+                                && typed_dict_matches_class_pattern(db, class)
+                            {
+                                UnionType::from_two_elements(db, class_instance_ty, subject_ty)
+                            } else {
+                                class_instance_ty
+                            };
+                        return PatternCoverage::new(definitely_matched_ty, exhausts_subject);
+                    }
+                    if exhausts_subject {
+                        return PatternCoverage::new(subject_ty, true);
                     }
                 }
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
                     if kind.is_empty()
                         && subject_ty.is_subtype_of(db, callable_pattern_type(db)) =>
                 {
-                    return callable_pattern_type(db);
+                    return PatternCoverage::new(callable_pattern_type(db), true);
                 }
                 _ => {}
             }
         }
         PatternPredicateKind::Sequence(kind) => {
             return if sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
-                subject_ty
+                PatternCoverage::new(subject_ty, true)
             } else {
                 // A nested subject-dependent pattern rejected the context-free approximation.
                 // Reusing that approximation for the surrounding sequence would reintroduce the
                 // values that the recursive analysis deliberately excluded.
-                Type::Never
+                PatternCoverage::new(Type::Never, false)
             };
         }
         PatternPredicateKind::Mapping(kind) => {
             return if mapping_pattern_is_exhaustive(db, kind, resolved_subject_ty) {
-                subject_ty
+                PatternCoverage::new(subject_ty, true)
             } else {
-                Type::Never
+                PatternCoverage::new(Type::Never, false)
             };
         }
         PatternPredicateKind::Or(patterns) => {
-            return UnionType::from_elements(
-                db,
-                patterns.iter().map(|pattern| {
-                    definite_match_pattern_type_for_subject(db, pattern, subject_ty)
-                }),
+            let mut remaining_subject_ty = subject_ty;
+            let mut definitely_matched = Vec::with_capacity(patterns.len());
+            for pattern in patterns {
+                let coverage = pattern_coverage_for_subject(db, pattern, remaining_subject_ty);
+                definitely_matched.push(coverage.definitely_matched_ty());
+                if coverage.exhausts_subject() {
+                    remaining_subject_ty = Type::Never;
+                    break;
+                }
+                remaining_subject_ty = pattern_fallthrough_type(db, pattern, remaining_subject_ty);
+            }
+            return PatternCoverage::new(
+                UnionType::from_elements(db, definitely_matched),
+                remaining_subject_ty.is_never(),
             );
         }
         PatternPredicateKind::As(Some(pattern), _) => {
-            return definite_match_pattern_type_for_subject(db, pattern, subject_ty);
+            return pattern_coverage_for_subject(db, pattern, subject_ty);
         }
-        _ => return Type::Never,
+        _ => return PatternCoverage::new(Type::Never, false),
     }
 
-    IntersectionBuilder::new(db)
-        .add_positive(subject_ty)
-        .add_positive(definite_match_pattern_type(db, kind))
-        .build()
+    PatternCoverage::new(
+        IntersectionBuilder::new(db)
+            .add_positive(subject_ty)
+            .add_positive(definite_match_pattern_type(db, kind))
+            .build(),
+        false,
+    )
 }
 
 /// Return the part of `subject_ty` that can reach a later alternative after `kind` fails.
@@ -729,7 +773,10 @@ pub(crate) fn pattern_fallthrough_type<'db>(
     {
         let mut removed_element = false;
         let remaining = union.map(db, |element| {
-            if pattern_is_exhaustive_for_subject(db, kind, *element) {
+            let coverage = pattern_coverage_for_subject(db, kind, *element);
+            if coverage.exhausts_subject()
+                && !element.is_subtype_of(db, coverage.definitely_matched_ty())
+            {
                 removed_element = true;
                 Type::Never
             } else {
@@ -741,14 +788,14 @@ pub(crate) fn pattern_fallthrough_type<'db>(
         }
     }
 
-    let definitely_matched = definite_match_pattern_type_for_subject(db, kind, subject_ty);
-    if definite_match_type_exhausts_subject(db, subject_ty, definitely_matched) {
+    let coverage = pattern_coverage_for_subject(db, kind, subject_ty);
+    if coverage.exhausts_subject() {
         return Type::Never;
     }
 
     IntersectionBuilder::new(db)
         .add_positive(subject_ty)
-        .add_negative(definitely_matched)
+        .add_negative(coverage.definitely_matched_ty())
         .build()
 }
 

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -16,8 +16,8 @@ use crate::types::visitor::any_over_type;
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownClass,
     Parameter, Parameters, Signature, SpecialFormType, Type, TypeContext,
-    TypeVarBoundOrConstraints, TypedDictType, UnionType, binding_type, equality_truthiness,
-    infer_same_file_expression_type,
+    TypeVarBoundOrConstraints, TypedDictType, UnionBuilder, UnionType, binding_type,
+    equality_truthiness, infer_same_file_expression_type,
 };
 
 pub(crate) fn singleton_pattern_type(db: &dyn Db, singleton: ast::Singleton) -> Type<'_> {
@@ -482,7 +482,9 @@ pub(crate) fn pattern_is_exhaustive_for_subject(
     pattern: &PatternPredicateKind<'_>,
     subject_ty: Type<'_>,
 ) -> bool {
-    pattern_coverage_for_subject(db, pattern, subject_ty).exhausts_subject
+    pattern_outcome_for_subject(db, pattern, subject_ty)
+        .residual
+        .is_exhausted()
 }
 
 /// Return whether every value in `subject_ty` is guaranteed to match a mapping pattern.
@@ -554,115 +556,341 @@ fn sequence_pattern_is_exhaustive_for_subject(
         .all(|(element, pattern)| pattern_is_exhaustive_for_subject(db, pattern, *element))
 }
 
-/// The statically known coverage of a pattern for a specific subject type.
+/// The values that can reach a later pattern after this pattern fails.
 ///
-/// `definitely_matched_ty` is an under-approximation that is safe to subtract from the subject.
-/// `exhausts_subject` records the stronger subject-specific proof separately because a gradual type
-/// such as `Mapping[str, Any]` is not a subtype of itself even though `case Mapping()` matches every
-/// value it represents.
+/// A shared complement stays symbolic so a union of subjects produces one intersection instead of
+/// a union of independently intersected arms. Equality patterns sometimes require a materialized
+/// residual because Python equality can match values outside the definite-match type.
 #[derive(Clone, Copy)]
-struct PatternCoverage<'db> {
-    definitely_matched_ty: Type<'db>,
-    exhausts_subject: bool,
+enum PatternResidual<'db> {
+    Exhausted,
+    SharedComplement {
+        base: Type<'db>,
+        /// A global under-approximation of values guaranteed to match the pattern wherever they
+        /// overlap `base`. This makes it safe to merge exclusions from separate union arms.
+        excluded: Type<'db>,
+    },
+    Materialized(Type<'db>),
 }
 
-impl<'db> PatternCoverage<'db> {
-    fn new(definitely_matched_ty: Type<'db>, exhausts_subject: bool) -> Self {
+impl<'db> PatternResidual<'db> {
+    fn materialized(subject_ty: Type<'db>) -> Self {
+        if subject_ty.is_never() {
+            Self::Exhausted
+        } else {
+            Self::Materialized(subject_ty)
+        }
+    }
+
+    fn is_exhausted(self) -> bool {
+        matches!(self, Self::Exhausted)
+    }
+
+    fn materialize(self, db: &'db dyn Db) -> Type<'db> {
+        match self {
+            Self::Exhausted => Type::Never,
+            Self::SharedComplement { base, excluded } => IntersectionBuilder::new(db)
+                .add_positive(base)
+                .add_negative(excluded)
+                .build(),
+            Self::Materialized(subject_ty) => subject_ty,
+        }
+    }
+}
+
+/// The statically known outcome of applying a pattern to a specific subject type.
+///
+/// `definitely_matched_ty` is a global under-approximation of values guaranteed to match. The
+/// residual separately records values that may fail, because gradual types cannot use `S & ~S` as
+/// proof that an exhaustive pattern leaves no fallthrough.
+#[derive(Clone, Copy)]
+struct PatternOutcome<'db> {
+    definitely_matched_ty: Type<'db>,
+    residual: PatternResidual<'db>,
+}
+
+impl<'db> PatternOutcome<'db> {
+    fn exhaustive(definitely_matched_ty: Type<'db>) -> Self {
         Self {
             definitely_matched_ty,
-            exhausts_subject,
+            residual: PatternResidual::Exhausted,
+        }
+    }
+
+    fn subtracting(base: Type<'db>, definitely_matched_ty: Type<'db>) -> Self {
+        Self {
+            definitely_matched_ty,
+            residual: PatternResidual::SharedComplement {
+                base,
+                excluded: definitely_matched_ty,
+            },
+        }
+    }
+
+    fn materialized(definitely_matched_ty: Type<'db>, remaining_subject_ty: Type<'db>) -> Self {
+        Self {
+            definitely_matched_ty,
+            residual: PatternResidual::materialized(remaining_subject_ty),
         }
     }
 }
 
-/// Accumulate coverage for ordered `or` alternatives without reanalyzing nested `or` subtrees.
-///
-/// Parenthesized patterns such as `case ((1 | 2) | 3)` retain nested `Or` nodes. Traversing those
-/// nodes into the same accumulator preserves left-to-right fallthrough while keeping analysis
-/// linear in the number of alternatives.
-fn extend_or_pattern_coverage<'db>(
-    db: &'db dyn Db,
-    patterns: &[PatternPredicateKind<'db>],
-    remaining_subject_ty: &mut Type<'db>,
-    definitely_matched: &mut Vec<Type<'db>>,
-) {
-    for pattern in patterns {
-        if remaining_subject_ty.is_never() {
-            break;
-        }
-
-        if let PatternPredicateKind::Or(nested) = pattern {
-            extend_or_pattern_coverage(db, nested, remaining_subject_ty, definitely_matched);
-            continue;
-        }
-
-        let coverage = pattern_coverage_for_subject(db, pattern, *remaining_subject_ty);
-        definitely_matched.push(coverage.definitely_matched_ty);
-        if coverage.exhausts_subject {
-            *remaining_subject_ty = Type::Never;
-        } else {
-            *remaining_subject_ty = pattern_fallthrough_type(db, pattern, *remaining_subject_ty);
-        }
-    }
-}
-
-/// Return the values that are statically guaranteed to match `kind` and whether they cover the
-/// complete subject.
-///
-/// The definite-match type is an under-approximation used for negative narrowing and ordered
-/// alternatives: callers may subtract it from `subject_ty`. Exhaustiveness is tracked separately
-/// because gradual types are not subtypes of themselves. A subject-independent pattern can return a
-/// type wider than `subject_ty`; for example, `case Base()` returns `Base` even for a `Child`
-/// subject. Class patterns need the current subject type when member extraction depends on the
-/// subject's statically known members.
-/// A subject-independent pattern can return its context-free definite-match type directly. A
-/// mapping pattern can use required `TypedDict` fields to establish that every subject value
-/// contains its keys.
-/// This treats access to a definitely bound descriptor as successful even though the descriptor
-/// could raise at runtime. The same rule is propagated through nested sequence, `or`, and `as`
-/// patterns.
-///
-/// ```python
-/// class Base:
-///     x: int
-///
-/// class Child(Base):
-///     pass
-///
-/// # For a `tuple[Child]` subject, this checks `x` on `Child`, not only on `Base`.
-/// case [Base(x=_)]: ...
-/// ```
-fn pattern_coverage_for_subject<'db>(
+/// Return the values guaranteed to match a value pattern and whether they cover the subject.
+fn value_pattern_coverage_for_subject<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
+    value_ty: Type<'db>,
     subject_ty: Type<'db>,
-) -> PatternCoverage<'db> {
-    if let Some(subject_independent_ty) = subject_independent_definite_match_pattern_type(db, kind)
-    {
-        return PatternCoverage::new(
-            subject_independent_ty,
-            subject_ty.is_subtype_of(db, subject_independent_ty),
-        );
-    }
-
+) -> (Type<'db>, bool) {
     let resolved_subject_ty = subject_ty.resolve_type_alias(db);
     if let Type::Union(union) = resolved_subject_ty {
         let mut exhausts_subject = true;
         let definitely_matched_ty = union.map(db, |element| {
-            let coverage = pattern_coverage_for_subject(db, kind, *element);
-            exhausts_subject &= coverage.exhausts_subject;
-            coverage.definitely_matched_ty
+            let (definitely_matched_ty, exhausts_element) =
+                value_pattern_coverage_for_subject(db, kind, value_ty, *element);
+            exhausts_subject &= exhausts_element;
+            definitely_matched_ty
         });
-        return PatternCoverage::new(definitely_matched_ty, exhausts_subject);
+        return (definitely_matched_ty, exhausts_subject);
+    }
+
+    if equality_truthiness(db, resolved_subject_ty, value_ty) == Truthiness::AlwaysTrue {
+        return (subject_ty, true);
+    }
+
+    (
+        IntersectionBuilder::new(db)
+            .add_positive(subject_ty)
+            .add_positive(definite_match_pattern_type(db, kind))
+            .build(),
+        false,
+    )
+}
+
+/// Return a specialized value-pattern residual when Python equality can determine one directly.
+///
+/// Keeping this separate from definite-match coverage lets ordinary fallthrough narrowing avoid a
+/// second per-member traversal of large literal unions.
+fn value_pattern_residual_for_subject<'db>(
+    db: &'db dyn Db,
+    value_ty: Type<'db>,
+    subject_ty: Type<'db>,
+) -> Option<PatternResidual<'db>> {
+    // A subject confined to the same enum cannot contain cross-type values that compare equal to
+    // the pattern, so a shared complement avoids repeated equality evaluation for large enums.
+    if let Some(enum_literal) = value_ty.as_enum_literal()
+        && is_same_enum_pattern_domain(db, subject_ty, enum_literal)
+        && equality_truthiness(db, value_ty, value_ty) == Truthiness::AlwaysTrue
+    {
+        return Some(PatternResidual::SharedComplement {
+            base: subject_ty,
+            excluded: value_ty,
+        });
+    }
+
+    if let Some(constraint) = evaluate_type_equality(db, subject_ty, value_ty, false) {
+        let remaining_subject_ty = IntersectionBuilder::new(db)
+            .add_positive(subject_ty)
+            .add_positive(constraint)
+            .build();
+        return Some(PatternResidual::materialized(remaining_subject_ty));
+    }
+
+    None
+}
+
+/// Analyze a value pattern without losing Python equality semantics.
+fn value_pattern_outcome_for_subject<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+    value_ty: Type<'db>,
+    subject_ty: Type<'db>,
+) -> PatternOutcome<'db> {
+    let (definitely_matched_ty, exhausts_subject) =
+        value_pattern_coverage_for_subject(db, kind, value_ty, subject_ty);
+    if exhausts_subject {
+        return PatternOutcome::exhaustive(definitely_matched_ty);
+    }
+
+    if let Some(residual) = value_pattern_residual_for_subject(db, value_ty, subject_ty) {
+        return PatternOutcome {
+            definitely_matched_ty,
+            residual,
+        };
+    }
+
+    PatternOutcome::subtracting(subject_ty, definitely_matched_ty)
+}
+
+/// Accumulate ordered `or` alternatives without reanalyzing nested `or` subtrees.
+fn extend_or_pattern_outcome<'db>(
+    db: &'db dyn Db,
+    patterns: &[PatternPredicateKind<'db>],
+    residual: &mut PatternResidual<'db>,
+    definitely_matched: &mut Vec<Type<'db>>,
+) {
+    for pattern in patterns {
+        if residual.is_exhausted() {
+            break;
+        }
+
+        if let PatternPredicateKind::Or(nested) = pattern {
+            extend_or_pattern_outcome(db, nested, residual, definitely_matched);
+            continue;
+        }
+
+        let remaining_subject_ty = residual.materialize(db);
+        if remaining_subject_ty.is_never() {
+            *residual = PatternResidual::Exhausted;
+            break;
+        }
+        let outcome = pattern_outcome_for_subject(db, pattern, remaining_subject_ty);
+        definitely_matched.push(outcome.definitely_matched_ty);
+        *residual = outcome.residual;
+    }
+}
+
+/// Apply ordered alternatives to the residual left by each preceding `or` pattern.
+fn or_pattern_outcome_for_subject<'db>(
+    db: &'db dyn Db,
+    patterns: &[PatternPredicateKind<'db>],
+    subject_ty: Type<'db>,
+) -> PatternOutcome<'db> {
+    let mut residual = PatternResidual::materialized(subject_ty);
+    let mut definitely_matched = Vec::with_capacity(patterns.len());
+    extend_or_pattern_outcome(db, patterns, &mut residual, &mut definitely_matched);
+    if residual.materialize(db).is_never() {
+        residual = PatternResidual::Exhausted;
+    }
+    PatternOutcome {
+        definitely_matched_ty: UnionType::from_elements(db, definitely_matched),
+        residual,
+    }
+}
+
+/// Merge outcomes for a subject-dependent pattern over a union without materializing each arm.
+fn union_pattern_outcome<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+    subject_ty: Type<'db>,
+    union: UnionType<'db>,
+) -> PatternOutcome<'db> {
+    let recursively_defined = union.recursively_defined(db);
+    let new_union_builder = || {
+        UnionBuilder::new(db)
+            .unpack_aliases(false)
+            .recursively_defined(recursively_defined)
+    };
+    let mut definitely_matched = new_union_builder();
+    let mut shared_bases = new_union_builder();
+    let mut shared_exclusions = new_union_builder();
+    let mut materialized = new_union_builder();
+    let mut all_exhaustive = true;
+    let mut preserve_original_base = true;
+    let mut definitely_matched_unchanged = true;
+    let mut shared_exclusions_unchanged = true;
+
+    for element in union.elements(db) {
+        let outcome = pattern_outcome_for_subject(db, kind, *element);
+        definitely_matched_unchanged &= outcome.definitely_matched_ty == *element;
+        definitely_matched.add_in_place(outcome.definitely_matched_ty);
+
+        match outcome.residual {
+            PatternResidual::Exhausted => {
+                preserve_original_base = false;
+                shared_exclusions_unchanged = false;
+            }
+            PatternResidual::SharedComplement { base, excluded } => {
+                all_exhaustive = false;
+                preserve_original_base &= base == *element;
+                shared_exclusions_unchanged &= excluded == *element;
+                shared_bases.add_in_place(base);
+                shared_exclusions.add_in_place(excluded);
+            }
+            PatternResidual::Materialized(remaining_subject_ty) => {
+                all_exhaustive = false;
+                preserve_original_base = false;
+                shared_exclusions_unchanged = false;
+                materialized.add_in_place(remaining_subject_ty);
+            }
+        }
+    }
+
+    let definitely_matched_ty = if definitely_matched_unchanged {
+        Type::Union(union)
+    } else {
+        definitely_matched.build()
+    };
+    if all_exhaustive {
+        return PatternOutcome::exhaustive(definitely_matched_ty);
+    }
+
+    let shared_base = if preserve_original_base {
+        subject_ty
+    } else {
+        shared_bases.build()
+    };
+    let shared_excluded = if shared_exclusions_unchanged {
+        Type::Union(union)
+    } else {
+        shared_exclusions.build()
+    };
+    let shared_residual = PatternResidual::SharedComplement {
+        base: shared_base,
+        excluded: shared_excluded,
+    };
+
+    if !materialized.is_empty() {
+        materialized.add_in_place(shared_residual.materialize(db));
+        PatternOutcome::materialized(definitely_matched_ty, materialized.build())
+    } else {
+        PatternOutcome {
+            definitely_matched_ty,
+            residual: shared_residual,
+        }
+    }
+}
+
+/// Return the pattern's definite matches and a symbolic plan for its fallthrough values.
+///
+/// Class patterns need the current subject when member extraction depends on statically known
+/// members. A mapping pattern can use required `TypedDict` fields to establish complete coverage.
+/// Access to a definitely bound descriptor is treated as successful even though it could raise at
+/// runtime; the same rule propagates through nested sequence, `or`, and `as` patterns.
+fn pattern_outcome_for_subject<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+    subject_ty: Type<'db>,
+) -> PatternOutcome<'db> {
+    if let Some(subject_independent_ty) = subject_independent_definite_match_pattern_type(db, kind)
+    {
+        return if subject_ty.is_subtype_of(db, subject_independent_ty) {
+            PatternOutcome::exhaustive(subject_independent_ty)
+        } else {
+            PatternOutcome::subtracting(subject_ty, subject_independent_ty)
+        };
     }
 
     match kind {
         PatternPredicateKind::Value(value) => {
             let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
-            if equality_truthiness(db, resolved_subject_ty, value_ty) == Truthiness::AlwaysTrue {
-                return PatternCoverage::new(subject_ty, true);
-            }
+            return value_pattern_outcome_for_subject(db, kind, value_ty, subject_ty);
         }
+        PatternPredicateKind::Or(patterns) => {
+            return or_pattern_outcome_for_subject(db, patterns, subject_ty);
+        }
+        PatternPredicateKind::As(Some(pattern), _) => {
+            return pattern_outcome_for_subject(db, pattern, subject_ty);
+        }
+        _ => {}
+    }
+
+    let resolved_subject_ty = subject_ty.resolve_type_alias(db);
+    if let Type::Union(union) = resolved_subject_ty {
+        return union_pattern_outcome(db, kind, subject_ty, union);
+    }
+
+    match kind {
         PatternPredicateKind::Class(kind) => {
             let class_ty = infer_same_file_expression_type(db, kind.class, TypeContext::default());
             match class_ty {
@@ -679,65 +907,50 @@ fn pattern_coverage_for_subject<'db>(
                             } else {
                                 class_instance_ty
                             };
-                        return PatternCoverage::new(definitely_matched_ty, exhausts_subject);
+                        return if exhausts_subject {
+                            PatternOutcome::exhaustive(definitely_matched_ty)
+                        } else {
+                            PatternOutcome::subtracting(subject_ty, definitely_matched_ty)
+                        };
                     }
                     if exhausts_subject {
-                        return PatternCoverage::new(subject_ty, true);
+                        return PatternOutcome::exhaustive(subject_ty);
                     }
                 }
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
                     if kind.is_empty()
                         && subject_ty.is_subtype_of(db, callable_pattern_type(db)) =>
                 {
-                    return PatternCoverage::new(callable_pattern_type(db), true);
+                    return PatternOutcome::exhaustive(callable_pattern_type(db));
                 }
                 _ => {}
             }
         }
         PatternPredicateKind::Sequence(kind) => {
             return if sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
-                PatternCoverage::new(subject_ty, true)
+                PatternOutcome::exhaustive(subject_ty)
             } else {
                 // A nested subject-dependent pattern rejected the context-free approximation.
                 // Reusing that approximation for the surrounding sequence would reintroduce the
                 // values that the recursive analysis deliberately excluded.
-                PatternCoverage::new(Type::Never, false)
+                PatternOutcome::subtracting(subject_ty, Type::Never)
             };
         }
         PatternPredicateKind::Mapping(kind) => {
             return if mapping_pattern_is_exhaustive(db, kind, resolved_subject_ty) {
-                PatternCoverage::new(subject_ty, true)
+                PatternOutcome::exhaustive(subject_ty)
             } else {
-                PatternCoverage::new(Type::Never, false)
+                PatternOutcome::subtracting(subject_ty, Type::Never)
             };
         }
-        PatternPredicateKind::Or(patterns) => {
-            let mut remaining_subject_ty = subject_ty;
-            let mut definitely_matched = Vec::with_capacity(patterns.len());
-            extend_or_pattern_coverage(
-                db,
-                patterns,
-                &mut remaining_subject_ty,
-                &mut definitely_matched,
-            );
-            return PatternCoverage::new(
-                UnionType::from_elements(db, definitely_matched),
-                remaining_subject_ty.is_never(),
-            );
-        }
-        PatternPredicateKind::As(Some(pattern), _) => {
-            return pattern_coverage_for_subject(db, pattern, subject_ty);
-        }
-        _ => return PatternCoverage::new(Type::Never, false),
+        _ => return PatternOutcome::subtracting(subject_ty, Type::Never),
     }
 
-    PatternCoverage::new(
-        IntersectionBuilder::new(db)
-            .add_positive(subject_ty)
-            .add_positive(definite_match_pattern_type(db, kind))
-            .build(),
-        false,
-    )
+    let definitely_matched_ty = IntersectionBuilder::new(db)
+        .add_positive(subject_ty)
+        .add_positive(definite_match_pattern_type(db, kind))
+        .build();
+    PatternOutcome::subtracting(subject_ty, definitely_matched_ty)
 }
 
 /// Return the part of `subject_ty` that can reach a later alternative after `kind` fails.
@@ -758,63 +971,18 @@ fn pattern_coverage_for_subject<'db>(
 pub(crate) fn pattern_fallthrough_type<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
-    mut subject_ty: Type<'db>,
+    subject_ty: Type<'db>,
 ) -> Type<'db> {
     if let PatternPredicateKind::Value(value) = kind {
         let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
-        // A subject confined to the same enum cannot contain cross-type values that compare equal
-        // to the pattern, so direct subtraction avoids repeated equality evaluation in large enum
-        // matches. This includes narrowed intersections containing `Self` or another type variable
-        // whose upper bound is that enum.
-        if let Some(enum_literal) = value_ty.as_enum_literal()
-            && is_same_enum_pattern_domain(db, subject_ty, enum_literal)
-            && equality_truthiness(db, value_ty, value_ty) == Truthiness::AlwaysTrue
-        {
-            return IntersectionBuilder::new(db)
-                .add_positive(subject_ty)
-                .add_negative(value_ty)
-                .build();
-        }
-        if let Some(constraint) = evaluate_type_equality(db, subject_ty, value_ty, false) {
-            return IntersectionBuilder::new(db)
-                .add_positive(subject_ty)
-                .add_positive(constraint)
-                .build();
+        if let Some(residual) = value_pattern_residual_for_subject(db, value_ty, subject_ty) {
+            return residual.materialize(db);
         }
     }
 
-    // Remove union elements that are guaranteed to match before constructing a subject-dependent
-    // complement. A gradual type does not cancel with its own negation, but an exhaustive pattern
-    // still makes the corresponding union element unreachable.
-    if subject_independent_definite_match_pattern_type(db, kind).is_none()
-        && let Type::Union(union) = subject_ty.resolve_type_alias(db)
-    {
-        let mut removed_element = false;
-        let remaining = union.map(db, |element| {
-            let coverage = pattern_coverage_for_subject(db, kind, *element);
-            if coverage.exhausts_subject
-                && !element.is_subtype_of(db, coverage.definitely_matched_ty)
-            {
-                removed_element = true;
-                Type::Never
-            } else {
-                *element
-            }
-        });
-        if removed_element {
-            subject_ty = remaining;
-        }
-    }
-
-    let coverage = pattern_coverage_for_subject(db, kind, subject_ty);
-    if coverage.exhausts_subject {
-        return Type::Never;
-    }
-
-    IntersectionBuilder::new(db)
-        .add_positive(subject_ty)
-        .add_negative(coverage.definitely_matched_ty)
-        .build()
+    pattern_outcome_for_subject(db, kind, subject_ty)
+        .residual
+        .materialize(db)
 }
 
 /// Return the fallthrough type for a binding that can reach a later match case.

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -477,12 +477,12 @@ fn member_pattern_is_exhaustive(
 }
 
 /// Return whether `pattern` is statically guaranteed to match every value in `subject_ty`.
-fn pattern_is_exhaustive_for_subject(
+pub(crate) fn pattern_is_exhaustive_for_subject(
     db: &dyn Db,
     pattern: &PatternPredicateKind<'_>,
     subject_ty: Type<'_>,
 ) -> bool {
-    pattern_coverage_for_subject(db, pattern, subject_ty).exhausts_subject()
+    pattern_coverage_for_subject(db, pattern, subject_ty).exhausts_subject
 }
 
 /// Return whether every value in `subject_ty` is guaranteed to match a mapping pattern.
@@ -555,8 +555,13 @@ fn sequence_pattern_is_exhaustive_for_subject(
 }
 
 /// The statically known coverage of a pattern for a specific subject type.
+///
+/// `definitely_matched_ty` is an under-approximation that is safe to subtract from the subject.
+/// `exhausts_subject` records the stronger subject-specific proof separately because a gradual type
+/// such as `Mapping[str, Any]` is not a subtype of itself even though `case Mapping()` matches every
+/// value it represents.
 #[derive(Clone, Copy)]
-pub(crate) struct PatternCoverage<'db> {
+struct PatternCoverage<'db> {
     definitely_matched_ty: Type<'db>,
     exhausts_subject: bool,
 }
@@ -568,17 +573,13 @@ impl<'db> PatternCoverage<'db> {
             exhausts_subject,
         }
     }
-
-    pub(crate) fn definitely_matched_ty(self) -> Type<'db> {
-        self.definitely_matched_ty
-    }
-
-    pub(crate) fn exhausts_subject(self) -> bool {
-        self.exhausts_subject
-    }
 }
 
 /// Accumulate coverage for ordered `or` alternatives without reanalyzing nested `or` subtrees.
+///
+/// Parenthesized patterns such as `case ((1 | 2) | 3)` retain nested `Or` nodes. Traversing those
+/// nodes into the same accumulator preserves left-to-right fallthrough while keeping analysis
+/// linear in the number of alternatives.
 fn extend_or_pattern_coverage<'db>(
     db: &'db dyn Db,
     patterns: &[PatternPredicateKind<'db>],
@@ -596,8 +597,8 @@ fn extend_or_pattern_coverage<'db>(
         }
 
         let coverage = pattern_coverage_for_subject(db, pattern, *remaining_subject_ty);
-        definitely_matched.push(coverage.definitely_matched_ty());
-        if coverage.exhausts_subject() {
+        definitely_matched.push(coverage.definitely_matched_ty);
+        if coverage.exhausts_subject {
             *remaining_subject_ty = Type::Never;
         } else {
             *remaining_subject_ty = pattern_fallthrough_type(db, pattern, *remaining_subject_ty);
@@ -631,7 +632,7 @@ fn extend_or_pattern_coverage<'db>(
 /// # For a `tuple[Child]` subject, this checks `x` on `Child`, not only on `Base`.
 /// case [Base(x=_)]: ...
 /// ```
-pub(crate) fn pattern_coverage_for_subject<'db>(
+fn pattern_coverage_for_subject<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
@@ -646,20 +647,13 @@ pub(crate) fn pattern_coverage_for_subject<'db>(
 
     let resolved_subject_ty = subject_ty.resolve_type_alias(db);
     if let Type::Union(union) = resolved_subject_ty {
-        let coverages = union
-            .elements(db)
-            .iter()
-            .map(|element| pattern_coverage_for_subject(db, kind, *element))
-            .collect::<Vec<_>>();
-        return PatternCoverage::new(
-            UnionType::from_elements(
-                db,
-                coverages
-                    .iter()
-                    .map(|coverage| coverage.definitely_matched_ty()),
-            ),
-            coverages.iter().all(|coverage| coverage.exhausts_subject()),
-        );
+        let mut exhausts_subject = true;
+        let definitely_matched_ty = union.map(db, |element| {
+            let coverage = pattern_coverage_for_subject(db, kind, *element);
+            exhausts_subject &= coverage.exhausts_subject;
+            coverage.definitely_matched_ty
+        });
+        return PatternCoverage::new(definitely_matched_ty, exhausts_subject);
     }
 
     match kind {
@@ -798,8 +792,8 @@ pub(crate) fn pattern_fallthrough_type<'db>(
         let mut removed_element = false;
         let remaining = union.map(db, |element| {
             let coverage = pattern_coverage_for_subject(db, kind, *element);
-            if coverage.exhausts_subject()
-                && !element.is_subtype_of(db, coverage.definitely_matched_ty())
+            if coverage.exhausts_subject
+                && !element.is_subtype_of(db, coverage.definitely_matched_ty)
             {
                 removed_element = true;
                 Type::Never
@@ -813,13 +807,13 @@ pub(crate) fn pattern_fallthrough_type<'db>(
     }
 
     let coverage = pattern_coverage_for_subject(db, kind, subject_ty);
-    if coverage.exhausts_subject() {
+    if coverage.exhausts_subject {
         return Type::Never;
     }
 
     IntersectionBuilder::new(db)
         .add_positive(subject_ty)
-        .add_negative(coverage.definitely_matched_ty())
+        .add_negative(coverage.definitely_matched_ty)
         .build()
 }
 

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -578,6 +578,33 @@ impl<'db> PatternCoverage<'db> {
     }
 }
 
+/// Accumulate coverage for ordered `or` alternatives without reanalyzing nested `or` subtrees.
+fn extend_or_pattern_coverage<'db>(
+    db: &'db dyn Db,
+    patterns: &[PatternPredicateKind<'db>],
+    remaining_subject_ty: &mut Type<'db>,
+    definitely_matched: &mut Vec<Type<'db>>,
+) {
+    for pattern in patterns {
+        if remaining_subject_ty.is_never() {
+            break;
+        }
+
+        if let PatternPredicateKind::Or(nested) = pattern {
+            extend_or_pattern_coverage(db, nested, remaining_subject_ty, definitely_matched);
+            continue;
+        }
+
+        let coverage = pattern_coverage_for_subject(db, pattern, *remaining_subject_ty);
+        definitely_matched.push(coverage.definitely_matched_ty());
+        if coverage.exhausts_subject() {
+            *remaining_subject_ty = Type::Never;
+        } else {
+            *remaining_subject_ty = pattern_fallthrough_type(db, pattern, *remaining_subject_ty);
+        }
+    }
+}
+
 /// Return the values that are statically guaranteed to match `kind` and whether they cover the
 /// complete subject.
 ///
@@ -693,15 +720,12 @@ pub(crate) fn pattern_coverage_for_subject<'db>(
         PatternPredicateKind::Or(patterns) => {
             let mut remaining_subject_ty = subject_ty;
             let mut definitely_matched = Vec::with_capacity(patterns.len());
-            for pattern in patterns {
-                let coverage = pattern_coverage_for_subject(db, pattern, remaining_subject_ty);
-                definitely_matched.push(coverage.definitely_matched_ty());
-                if coverage.exhausts_subject() {
-                    remaining_subject_ty = Type::Never;
-                    break;
-                }
-                remaining_subject_ty = pattern_fallthrough_type(db, pattern, remaining_subject_ty);
-            }
+            extend_or_pattern_coverage(
+                db,
+                patterns,
+                &mut remaining_subject_ty,
+                &mut definitely_matched,
+            );
             return PatternCoverage::new(
                 UnionType::from_elements(db, definitely_matched),
                 remaining_subject_ty.is_never(),

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -482,10 +482,24 @@ fn pattern_is_exhaustive_for_subject(
     pattern: &PatternPredicateKind<'_>,
     subject_ty: Type<'_>,
 ) -> bool {
-    subject_ty.is_subtype_of(
+    definite_match_type_exhausts_subject(
         db,
+        subject_ty,
         definite_match_pattern_type_for_subject(db, pattern, subject_ty),
     )
+}
+
+/// Return whether a definite-match under-approximation covers the complete subject.
+///
+/// Equivalence is required because gradual types are not subtypes of themselves.
+fn definite_match_type_exhausts_subject(
+    db: &dyn Db,
+    subject_ty: Type<'_>,
+    definitely_matched: Type<'_>,
+) -> bool {
+    subject_ty == definitely_matched
+        || subject_ty.is_subtype_of(db, definitely_matched)
+        || subject_ty.is_equivalent_to(db, definitely_matched)
 }
 
 /// Return whether every value in `subject_ty` is guaranteed to match a mapping pattern.
@@ -682,7 +696,7 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
 pub(crate) fn pattern_fallthrough_type<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
-    subject_ty: Type<'db>,
+    mut subject_ty: Type<'db>,
 ) -> Type<'db> {
     if let PatternPredicateKind::Value(value) = kind {
         let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
@@ -707,11 +721,34 @@ pub(crate) fn pattern_fallthrough_type<'db>(
         }
     }
 
+    // Remove union elements that are guaranteed to match before constructing a subject-dependent
+    // complement. A gradual type does not cancel with its own negation, but an exhaustive pattern
+    // still makes the corresponding union element unreachable.
+    if subject_independent_definite_match_pattern_type(db, kind).is_none()
+        && let Type::Union(union) = subject_ty.resolve_type_alias(db)
+    {
+        let mut removed_element = false;
+        let remaining = union.map(db, |element| {
+            if pattern_is_exhaustive_for_subject(db, kind, *element) {
+                removed_element = true;
+                Type::Never
+            } else {
+                *element
+            }
+        });
+        if removed_element {
+            subject_ty = remaining;
+        }
+    }
+
+    let definitely_matched = definite_match_pattern_type_for_subject(db, kind, subject_ty);
+    if definite_match_type_exhausts_subject(db, subject_ty, definitely_matched) {
+        return Type::Never;
+    }
+
     IntersectionBuilder::new(db)
         .add_positive(subject_ty)
-        .add_negative(definite_match_pattern_type_for_subject(
-            db, kind, subject_ty,
-        ))
+        .add_negative(definitely_matched)
         .build()
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3677,6 +3677,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         Some(constraints)
     }
 
+    /// Return constraints that a value pattern induces on the container or receiver of `subject`.
+    ///
+    /// The direct constraint on `subject` is handled by the caller. This handles tagged tuple and
+    /// `TypedDict` subscripts and nominal attributes whose owners can be narrowed by the match.
     fn evaluate_match_pattern_value_related_places(
         &mut self,
         subject: Expression<'db>,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1202,16 +1202,11 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PatternPredicateKind::Singleton(singleton) => PatternNarrowingResult::Possible(
                 self.evaluate_match_pattern_singleton(subject, *singleton, is_positive),
             ),
-            PatternPredicateKind::Class(kind) => {
-                PatternNarrowingResult::Possible(self.evaluate_match_pattern_class(
-                    subject,
-                    kind.class,
-                    pattern_predicate_kind,
-                    is_positive,
-                ))
-            }
+            PatternPredicateKind::Class(kind) => PatternNarrowingResult::Possible(
+                self.evaluate_match_pattern_class(subject, kind.class, is_positive),
+            ),
             PatternPredicateKind::Mapping(_) => PatternNarrowingResult::Possible(
-                self.evaluate_match_pattern_mapping(subject, pattern_predicate_kind, is_positive),
+                self.evaluate_match_pattern_mapping(subject, is_positive),
             ),
             PatternPredicateKind::Sequence(kind) => {
                 self.evaluate_match_pattern_sequence(subject, kind, is_positive)
@@ -1238,8 +1233,65 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Option<NarrowingConstraints<'db>> {
         let kind = pattern.kind(self.db);
         let subject = pattern.subject(self.db);
+        let subject_node = subject.node_ref(self.db).node(self.module);
+        if !is_positive && let Some(subject_place) = PlaceExpr::try_from_expr(subject_node) {
+            let mut constraints = if matches!(subject_place, PlaceExpr::Member(_)) {
+                self.evaluate_negative_pattern_related_places(kind, subject)
+            } else {
+                None
+            };
+
+            let subject_ty =
+                infer_same_file_expression_type(self.db, subject, TypeContext::default());
+            let subject_ty = type_narrowed_by_previous_patterns(self.db, pattern, subject_ty);
+            let fallthrough_ty = pattern_binding_fallthrough_type(self.db, kind, subject_ty);
+            if fallthrough_ty != subject_ty {
+                constraints.get_or_insert_default().insert(
+                    self.expect_place(&subject_place),
+                    NarrowingConstraint::replacement(fallthrough_ty),
+                );
+            }
+
+            return constraints;
+        }
+
         self.evaluate_pattern_predicate_kind(kind, subject, is_positive)
             .into_constraints()
+    }
+
+    /// Return negative-pattern constraints on places related to `subject`, excluding the direct
+    /// constraint on `subject` itself.
+    fn evaluate_negative_pattern_related_places(
+        &mut self,
+        kind: &PatternPredicateKind<'db>,
+        subject: Expression<'db>,
+    ) -> Option<NarrowingConstraints<'db>> {
+        match kind {
+            PatternPredicateKind::Value(value) => {
+                let value_ty =
+                    infer_same_file_expression_type(self.db, *value, TypeContext::default());
+                let constraints =
+                    self.evaluate_match_pattern_value_related_places(subject, value_ty, false);
+                (!constraints.is_empty()).then_some(constraints)
+            }
+            PatternPredicateKind::Or(patterns) => {
+                patterns.iter().fold(None, |constraints, pattern| {
+                    Self::merge_optional_constraints_and(
+                        constraints,
+                        self.evaluate_negative_pattern_related_places(pattern, subject),
+                    )
+                })
+            }
+            PatternPredicateKind::As(Some(pattern), _) => {
+                self.evaluate_negative_pattern_related_places(pattern, subject)
+            }
+            PatternPredicateKind::As(None, _)
+            | PatternPredicateKind::Class(_)
+            | PatternPredicateKind::Mapping(_)
+            | PatternPredicateKind::Sequence(_)
+            | PatternPredicateKind::Singleton(_)
+            | PatternPredicateKind::Star(_) => None,
+        }
     }
 }
 
@@ -3410,11 +3462,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         &mut self,
         subject: Expression<'db>,
         cls: Expression<'db>,
-        pattern: &PatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
         if !is_positive {
-            return self.evaluate_negative_match_pattern(subject, pattern);
+            return None;
         }
 
         let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
@@ -3431,11 +3482,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     fn evaluate_match_pattern_mapping(
         &mut self,
         subject: Expression<'db>,
-        pattern: &PatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
         if !is_positive {
-            return self.evaluate_negative_match_pattern(subject, pattern);
+            return None;
         }
 
         let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
@@ -3449,25 +3499,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         Some(NarrowingConstraints::from_iter([(
             place,
             NarrowingConstraint::intersection(mapping_type),
-        )]))
-    }
-
-    fn evaluate_negative_match_pattern(
-        &self,
-        subject: Expression<'db>,
-        pattern: &PatternPredicateKind<'db>,
-    ) -> Option<NarrowingConstraints<'db>> {
-        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
-        let place = self.expect_place(&subject_place);
-        let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
-        let fallthrough_ty = pattern_binding_fallthrough_type(self.db, pattern, subject_ty);
-        if fallthrough_ty == subject_ty {
-            return None;
-        }
-
-        Some(NarrowingConstraints::from_iter([(
-            place,
-            NarrowingConstraint::intersection(fallthrough_ty),
         )]))
     }
 
@@ -3637,6 +3668,24 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             })
             .unwrap_or_default();
 
+        constraints.extend(self.evaluate_match_pattern_value_related_places(
+            subject,
+            value_ty,
+            is_positive,
+        ));
+
+        Some(constraints)
+    }
+
+    fn evaluate_match_pattern_value_related_places(
+        &mut self,
+        subject: Expression<'db>,
+        value_ty: Type<'db>,
+        is_positive: bool,
+    ) -> NarrowingConstraints<'db> {
+        let subject_node = subject.node_ref(self.db).node(self.module);
+        let mut constraints = NarrowingConstraints::default();
+
         // Narrow tagged unions of `TypedDict`s with `Literal` keys, for example:
         //
         //     class Foo(TypedDict):
@@ -3683,7 +3732,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }
         }
 
-        Some(constraints)
+        constraints
     }
 
     fn evaluate_match_pattern_or(

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -18,10 +18,9 @@ use crate::types::{
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
     Parameter, Parameters, Signature, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness,
     Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
-    class_pattern_positional_sources, definite_match_pattern_type_for_subject,
-    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
-    pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
+    class_pattern_positional_sources, exact_sequence_pattern_type, infer_expression_types,
+    mapping_pattern_type, pattern_binding_fallthrough_type, sequence_pattern_type_builder,
+    singleton_pattern_type, starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
@@ -3461,15 +3460,14 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject_place);
         let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
-        let definitely_matched =
-            definite_match_pattern_type_for_subject(self.db, pattern, subject_ty);
-        if definitely_matched.is_never() {
+        let fallthrough_ty = pattern_binding_fallthrough_type(self.db, pattern, subject_ty);
+        if fallthrough_ty == subject_ty {
             return None;
         }
 
         Some(NarrowingConstraints::from_iter([(
             place,
-            NarrowingConstraint::intersection(definitely_matched.negate(self.db)),
+            NarrowingConstraint::intersection(fallthrough_ty),
         )]))
     }
 


### PR DESCRIPTION
## Summary

An exhaustive match over a gradual union could leave a false fallthrough whose type depended on the order of the cases:

```python
from collections.abc import Mapping
from typing import Any, assert_never

def handle(value: Mapping[str, Any] | int) -> None:
    match value:
        case Mapping():
            pass
        case int():
            pass
        case _:
            assert_never(value)
```

Subject-aware pattern analysis previously used the definite-match type both as the set of values safe to subtract and as proof that a pattern covers its complete subject. For the `Mapping` arm, this could construct `Mapping[str, Any] & ~Mapping[str, Any]`. That intersection intentionally does not simplify to `Never` because gradual types are not subtypes of themselves.

Track subject-specific exhaustiveness separately from the definite-match type. Empty class patterns retain their nominal runtime class domain, including the concrete `TypedDict` subject when its runtime `dict` relationship extends beyond static subtyping. When another subject-dependent pattern proves that it exhausts a gradual union arm, remove that arm before constructing the remaining complement.

Negative match narrowing now computes one absolute fallthrough from the subject after every preceding unguarded case. Constraints on related parent places, such as a tagged union matched through `x.tag` or `x[0]`, are collected separately. This preserves ordered fallthrough without repeatedly embedding the complete subject in intersection constraints.

Ordered `or` alternatives continue to update the remaining subject from left to right. Nested `or` nodes share one flattened coverage traversal, avoiding repeated subtree analysis while retaining the same semantics. The mdtests cover both case orders, runtime `Mapping` and `dict` domains, `TypedDict`, generic and nested patterns, related-place narrowing, and a refutable counterexample. Separate large-union benchmarks retain the common empty-class case and exercise destructuring patterns over both name and attribute subjects.

Closes https://github.com/astral-sh/ty/issues/3904.
