### PR TITLE
[ty] Add test suite for pydantic support

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.lock
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.lock
@@ -17,14 +17,18 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pydantic" },
+    { name = "pydantic-settings" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = "==2.12.2" }]
+requires-dist = [
+    { name = "pydantic", specifier = "==2.13.4" },
+    { name = "pydantic-settings", specifier = "==2.14.2" },
+]
 
 [[package]]
 name = "pydantic"
-version = "2.12.2"
+version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -32,38 +36,62 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/35/d319ed522433215526689bad428a94058b6dd12190ce7ddd78618ac14b28/pydantic-2.12.2.tar.gz", hash = "sha256:7b8fa15b831a4bbde9d5b84028641ac3080a4ca2cbd4a621a661687e741624fd", size = 816358, upload-time = "2025-10-14T15:02:21.842Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/98/468cb649f208a6f1279448e6e5247b37ae79cf5e4041186f1e2ef3d16345/pydantic-2.12.2-py3-none-any.whl", hash = "sha256:25ff718ee909acd82f1ff9b1a4acfd781bb23ab3739adaa7144f19a6a4e231ae", size = 460628, upload-time = "2025-10-14T15:02:19.623Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.41.4"
+version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5", size = 457557, upload-time = "2025-10-14T10:23:47.909Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/81/d3b3e95929c4369d30b2a66a91db63c8ed0a98381ae55a45da2cd1cc1288/pydantic_core-2.41.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ab06d77e053d660a6faaf04894446df7b0a7e7aba70c2797465a0a1af00fc887", size = 2099043, upload-time = "2025-10-14T10:20:28.561Z" },
-    { url = "https://files.pythonhosted.org/packages/58/da/46fdac49e6717e3a94fc9201403e08d9d61aa7a770fab6190b8740749047/pydantic_core-2.41.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c53ff33e603a9c1179a9364b0a24694f183717b2e0da2b5ad43c316c956901b2", size = 1910699, upload-time = "2025-10-14T10:20:30.217Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/63/4d948f1b9dd8e991a5a98b77dd66c74641f5f2e5225fee37994b2e07d391/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:304c54176af2c143bd181d82e77c15c41cbacea8872a2225dd37e6544dce9999", size = 1952121, upload-time = "2025-10-14T10:20:32.246Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a7/e5fc60a6f781fc634ecaa9ecc3c20171d238794cef69ae0af79ac11b89d7/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:025ba34a4cf4fb32f917d5d188ab5e702223d3ba603be4d8aca2f82bede432a4", size = 2041590, upload-time = "2025-10-14T10:20:34.332Z" },
-    { url = "https://files.pythonhosted.org/packages/70/69/dce747b1d21d59e85af433428978a1893c6f8a7068fa2bb4a927fba7a5ff/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9f5f30c402ed58f90c70e12eff65547d3ab74685ffe8283c719e6bead8ef53f", size = 2219869, upload-time = "2025-10-14T10:20:35.965Z" },
-    { url = "https://files.pythonhosted.org/packages/83/6a/c070e30e295403bf29c4df1cb781317b6a9bac7cd07b8d3acc94d501a63c/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd96e5d15385d301733113bcaa324c8bcf111275b7675a9c6e88bfb19fc05e3b", size = 2345169, upload-time = "2025-10-14T10:20:37.627Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/83/06d001f8043c336baea7fd202a9ac7ad71f87e1c55d8112c50b745c40324/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98f348cbb44fae6e9653c1055db7e29de67ea6a9ca03a5fa2c2e11a47cff0e47", size = 2070165, upload-time = "2025-10-14T10:20:39.246Z" },
-    { url = "https://files.pythonhosted.org/packages/14/0a/e567c2883588dd12bcbc110232d892cf385356f7c8a9910311ac997ab715/pydantic_core-2.41.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ec22626a2d14620a83ca583c6f5a4080fa3155282718b6055c2ea48d3ef35970", size = 2189067, upload-time = "2025-10-14T10:20:41.015Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/1d/3d9fca34273ba03c9b1c5289f7618bc4bd09c3ad2289b5420481aa051a99/pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3a95d4590b1f1a43bf33ca6d647b990a88f4a3824a8c4572c708f0b45a5290ed", size = 2132997, upload-time = "2025-10-14T10:20:43.106Z" },
-    { url = "https://files.pythonhosted.org/packages/52/70/d702ef7a6cd41a8afc61f3554922b3ed8d19dd54c3bd4bdbfe332e610827/pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:f9672ab4d398e1b602feadcffcdd3af44d5f5e6ddc15bc7d15d376d47e8e19f8", size = 2307187, upload-time = "2025-10-14T10:20:44.849Z" },
-    { url = "https://files.pythonhosted.org/packages/68/4c/c06be6e27545d08b802127914156f38d10ca287a9e8489342793de8aae3c/pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:84d8854db5f55fead3b579f04bda9a36461dab0730c5d570e1526483e7bb8431", size = 2305204, upload-time = "2025-10-14T10:20:46.781Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/e5/35ae4919bcd9f18603419e23c5eaf32750224a89d41a8df1a3704b69f77e/pydantic_core-2.41.4-cp312-cp312-win32.whl", hash = "sha256:9be1c01adb2ecc4e464392c36d17f97e9110fbbc906bcbe1c943b5b87a74aabd", size = 1972536, upload-time = "2025-10-14T10:20:48.39Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c2/49c5bb6d2a49eb2ee3647a93e3dae7080c6409a8a7558b075027644e879c/pydantic_core-2.41.4-cp312-cp312-win_amd64.whl", hash = "sha256:d682cf1d22bab22a5be08539dca3d1593488a99998f9f412137bc323179067ff", size = 2031132, upload-time = "2025-10-14T10:20:50.421Z" },
-    { url = "https://files.pythonhosted.org/packages/06/23/936343dbcba6eec93f73e95eb346810fc732f71ba27967b287b66f7b7097/pydantic_core-2.41.4-cp312-cp312-win_arm64.whl", hash = "sha256:833eebfd75a26d17470b58768c1834dfc90141b7afc6eb0429c21fc5a21dcfb8", size = 1969483, upload-time = "2025-10-14T10:20:52.35Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/48/ae937e5a831b7c0dc646b2ef788c27cd003894882415300ed21927c21efa/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:4f5d640aeebb438517150fdeec097739614421900e4a08db4a3ef38898798537", size = 2112087, upload-time = "2025-10-14T10:22:56.818Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/db/6db8073e3d32dae017da7e0d16a9ecb897d0a4d92e00634916e486097961/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:4a9ab037b71927babc6d9e7fc01aea9e66dc2a4a34dff06ef0724a4049629f94", size = 1920387, upload-time = "2025-10-14T10:22:59.342Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c1/dd3542d072fcc336030d66834872f0328727e3b8de289c662faa04aa270e/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4dab9484ec605c3016df9ad4fd4f9a390bc5d816a3b10c6550f8424bb80b18c", size = 1951495, upload-time = "2025-10-14T10:23:02.089Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c6/db8d13a1f8ab3f1eb08c88bd00fd62d44311e3456d1e85c0e59e0a0376e7/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8a5028425820731d8c6c098ab642d7b8b999758e24acae03ed38a66eca8335", size = 2139008, upload-time = "2025-10-14T10:23:04.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -6,10 +6,12 @@ python-version = "3.12"
 python-platform = "linux"
 
 [project]
-dependencies = ["pydantic==2.12.2"]
+dependencies = ["pydantic==2.13.4", "pydantic-settings==2.14.2"]
 ```
 
 ## Basic model
+
+A basic Pydantic model looks and acts similar to a dataclass:
 
 ```py
 from pydantic import BaseModel
@@ -30,21 +32,381 @@ invalid_user = User(id=2)
 
 ## Usage of `Field`
 
+`Field` is a field-specifier function. In the following example, `tags` has a default value, and
+`internal_price_cent` can be set through its alias `price_cent`:
+
 ```py
 from pydantic import BaseModel, Field
 
 class Product(BaseModel):
-    id: int = Field(init=False)
-    name: str = Field(..., kw_only=False, min_length=1)
-    internal_price_cent: int = Field(..., gt=0, alias="price_cent")
+    name: str = Field(min_length=1)
+    tags: list[str] = Field(default_factory=list)
+    internal_price_cent: int = Field(gt=0, alias="price_cent")
 
-reveal_type(Product.__init__)  # revealed: (self: Product, name: str = ..., *, price_cent: int = ...) -> None
+reveal_type(Product.__init__)  # revealed: (self: Product, *, name: str, tags: list[str] = ..., price_cent: int) -> None
 
-product = Product("Laptop", price_cent=999_00)
+product = Product(name="Laptop", price_cent=999_00)
+```
 
-reveal_type(product.id)  # revealed: int
+The fields have the expected types:
+
+```py
 reveal_type(product.name)  # revealed: str
+reveal_type(product.tags)  # revealed: list[str]
 reveal_type(product.internal_price_cent)  # revealed: int
+```
+
+Omitting the `name` or the `price_cent` is not allowed:
+
+```py
+# error: [missing-argument] "No argument provided for required parameter `name`"
+Product(price_cent=100_00)
+# error: [missing-argument] "No argument provided for required parameter `price_cent`"
+Product(name="Phone")
+```
+
+Using the internal field name is not possible (the argument will be accepted, but `price_cent` is
+missing):
+
+```py
+# TODO: This should ideally only report `missing-argument`, not `unknown-argument` (since extra fields are allowed by default)
+# error: [missing-argument]
+# error: [unknown-argument]
+Product(name="Laptop", internal_price_cent=999_00)
+```
+
+Conversely, accessing a field through the alias is also not allowed:
+
+```py
+product.price_cent  # error: [unresolved-attribute]
+```
+
+## Usage of ellipsis in `Field`
+
+A positional argument of `...` to the `Field` function indicates that the field *has no default and
+is required*:
+
+```py
+from pydantic import BaseModel, Field
+
+class Person(BaseModel):
+    name: str = Field(..., max_length=255)
+
+Person(name="Alice")
+# TODO: this should be an error
+Person()
+```
+
+## Strict and lax mode
+
+Pydantic distinguishes a "strict" mode in which it will error if a value is of the wrong type, and a
+"lax" mode, in which it attempts to coerce the value to the correct type. We model these two modes
+in ty so that static analysis supports the runtime validation behavior when possible.
+
+### Using the model config to enable strict mode
+
+Strict mode can be activated for a whole model:
+
+```py
+from pydantic import BaseModel, ConfigDict
+
+class Person(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    name: str
+    age: int
+
+Person(name="Alice", age=20)  # okay
+Person(name="Alice", age="20")  # error: [invalid-argument-type]
+```
+
+### Lax mode is the default
+
+When no configuration is given, or when `strict=False`, lax mode is used:
+
+```py
+from pydantic import BaseModel, ConfigDict
+
+class Person1(BaseModel):
+    name: str
+    age: int
+
+Person1(name="Alice", age=20)  # okay
+# TODO: no error here
+# error: [invalid-argument-type]
+Person1(name="Alice", age="20")  # okay, coerced
+# error: [invalid-argument-type]
+Person1(name="Alice", age=None)  # error, cannot be coerced
+
+class Person2(BaseModel):
+    model_config = ConfigDict(strict=False)
+
+    name: str
+    age: int
+
+Person2(name="Alice", age=20)  # okay
+# TODO: no error here
+# error: [invalid-argument-type]
+Person2(name="Alice", age="20")  # okay
+# error: [invalid-argument-type]
+Person2(name="Alice", age=None)  # error, cannot be coerced
+```
+
+### Changing a specific field
+
+Strict mode can also be activated for a specific field only:
+
+```py
+from pydantic import BaseModel, ConfigDict, Field
+
+class Person1(BaseModel):
+    name: str
+    age: int = Field(strict=True)
+```
+
+Here, validation is lax for the `name` field (`bytes` is converted to `str`):
+
+```py
+Person1(name="Alice", age=20)
+# TODO: no error here
+# error: [invalid-argument-type]
+Person1(name=b"Alice", age=20)
+```
+
+But `age` is validated in `strict` mode, so the conversion from `str` to `int` is not allowed here:
+
+```py
+Person1(name="Alice", age=20)
+Person1(name="Alice", age="20")  # error: [invalid-argument-type]
+```
+
+The opposite is also possible. A whole model can be in "strict" mode, and a single field can opt
+out:
+
+```py
+class Person2(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    name: str = Field(strict=False)
+    age: int
+
+Person2(name="Alice", age=20)
+# TODO: no error here
+# error: [invalid-argument-type]
+Person2(name=b"Alice", age=20)
+
+Person2(name="Alice", age=20)
+Person2(name="Alice", age="20")  # error: [invalid-argument-type]
+```
+
+## `validate_by_name`, `validate_by_alias`
+
+By default, Pydantic only allows a field to be initialized by its alias name, not by its field name:
+
+```py
+from pydantic import BaseModel, ConfigDict, Field
+
+class DefaultOnlyAlias(BaseModel):
+    name: int = Field(alias="alias")
+
+DefaultOnlyAlias(alias=1)
+# TODO: This should ideally only report `missing-argument`, not `unknown-argument` (since extra fields are allowed by default)
+# error: [missing-argument]
+# error: [unknown-argument]
+DefaultOnlyAlias(name=1)
+```
+
+When `validate_by_name=True`, a field can also be initialized using its internal name:
+
+```py
+class AliasAndName(BaseModel):
+    model_config = ConfigDict(validate_by_name=True)
+
+    name: int = Field(alias="alias")
+
+AliasAndName(alias=1)
+# TODO: no errors here
+# error: [unknown-argument]
+# error: [missing-argument]
+AliasAndName(name=1)
+```
+
+Passing none of these should be an error:
+
+```py
+# Note: this might be hard to support once we implement the feature above?
+# error: [missing-argument]
+AliasAndName()
+```
+
+Conversely, when `validate_by_alias=False`, validation by alias can be disallowed:
+
+```py
+class OnlyName(BaseModel):
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=False)
+
+    name: int = Field(alias="alias")
+
+# TODO: this should be an error
+OnlyName(alias=1)
+# TODO: no errors here
+# error: [unknown-argument]
+# error: [missing-argument]
+OnlyName(name=1)
+```
+
+## Extra fields
+
+By default, Pydantic allows arbitrary extra data which is simply ignored:
+
+```py
+from pydantic import BaseModel, ConfigDict
+
+class Person(BaseModel):
+    name: str
+
+# TODO: no error here
+# error: [unknown-argument]
+Person(name="Alice", something_else=7)
+```
+
+By setting `extra="forbid"`, this can be disallowed:
+
+```py
+class PersonWithoutExtras(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+
+PersonWithoutExtras(name="Alice", something_else=7)  # error: [unknown-argument]
+```
+
+## Frozen models and fields
+
+There are various ways to make a field immutable. A model can be globally frozen using a class
+parameter:
+
+```py
+from pydantic import BaseModel, ConfigDict, Field
+
+class PersonFrozenName1(BaseModel, frozen=True):
+    name: str
+
+person = PersonFrozenName1(name="Alice")
+person.name = "Bob"  # error: [invalid-assignment]
+```
+
+It can also be globally frozen using the model config:
+
+```py
+class PersonFrozenName2(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+
+person = PersonFrozenName2(name="Alice")
+# TODO: This should be an error
+person.name = "Bob"
+```
+
+Finally, individual fields can also be made immutable on a non-frozen model:
+
+```py
+class PersonFrozenName3(BaseModel):
+    name: str = Field(frozen=True)
+    age: int
+
+person = PersonFrozenName3(name="Alice", age=20)
+# TODO: this should be an error
+person.name = "Bob"
+person.age += 1
+```
+
+## Validation of default values
+
+At runtime, default values are *not* validated against the field type annotation, unless
+`validate_default=True` is set. In static analysis, we still need to verify the default values
+against the type annotation. Not doing so would be unsound. We do this unconditionally, even if
+`validate_default=False` (which is also the default):
+
+```py
+from pydantic import BaseModel, ConfigDict, Field
+
+class Person1(BaseModel):
+    # error: [invalid-assignment]
+    name: str = Field(default=None)
+
+class Person2(BaseModel):
+    model_config = ConfigDict(validate_default=False)
+
+    # error: [invalid-assignment]
+    name: str = Field(default=None)
+
+class Person3(BaseModel):
+    model_config = ConfigDict(validate_default=True)
+
+    # error: [invalid-assignment]
+    name: str = Field(default=None)
+
+class Person4(BaseModel):
+    # error: [invalid-assignment]
+    name: str = Field(default=None, validate_default=False)
+
+class Person5(BaseModel):
+    # TODO: this should be an error
+    name: str = Field(default=None, validate_default=True)
+```
+
+## Verification of models
+
+A field without a type annotation leads to a runtime error.
+
+```py
+from pydantic import BaseModel, Field
+
+# TODO: this should ideally be an error
+class PersonUntypedField(BaseModel):
+    name: str
+    age = Field(default=0)
+```
+
+## BaseSettings
+
+A model derived from `BaseSettings` can use environment variables, so we assume that it is okay not
+to provide their values:
+
+```py
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    host: str
+    port: int
+
+# Would succeed at runtime if HOST and PORT environment variables are set
+# TODO: no error here
+# error: [missing-argument]
+Settings()
+```
+
+## Pydantic dataclasses
+
+Pydantic's dataclasses are similar to the standard library dataclasses:
+
+```py
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+@dataclass
+class Person:
+    name: str
+    id: int = Field(default=0, init=False)
+    age: int = Field(default=0)
+
+# `id` is absent in the constructor signature:
+reveal_type(Person.__init__)  # revealed: (self: Person, name: str, age: int = 0) -> None
+
+Person(name="Alice")
+Person(name="Alice", age=20)
 ```
 
 ## Inherited `ModelMetaclass`
@@ -69,9 +431,6 @@ User(name="alice", age=1)
 
 # error: [missing-argument]
 User()
-
-# error: [unknown-argument]
-User(name="alice", extra=1)
 ```
 
 ## Validator and serializer decorators with explicit `@classmethod`


### PR DESCRIPTION
## Summary

Add (hand-written) tests for the basic pydantic features that we want to support. The test assertions have all been verified against the runtime behavior.

We will certainly extend this in the future (e.g. support for `Annotated[int, Field(...)]`, `PrivateAttr`, `RootModel`), but it seems like a good start.

towards https://github.com/astral-sh/ty/issues/2403