### PR TITLE
[ty] Cache callable self binding

### DIFF
--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -435,15 +435,24 @@ impl<'db> GenericContext<'db> {
         db: &'db dyn Db,
         binding_context: Option<BindingContext<'db>>,
     ) -> Self {
-        Self::from_typevar_instances(
-            db,
-            self.variables(db).filter(|bound_typevar| {
-                !(bound_typevar.typevar(db).is_self(db)
-                    && binding_context.is_none_or(|binding_context| {
-                        bound_typevar.binding_context(db) == binding_context
-                    }))
-            }),
-        )
+        #[salsa::tracked]
+        fn remove_self_inner<'db>(
+            db: &'db dyn Db,
+            generic_context: GenericContext<'db>,
+            binding_context: Option<BindingContext<'db>>,
+        ) -> GenericContext<'db> {
+            GenericContext::from_typevar_instances(
+                db,
+                generic_context.variables(db).filter(|bound_typevar| {
+                    !(bound_typevar.typevar(db).is_self(db)
+                        && binding_context.is_none_or(|binding_context| {
+                            bound_typevar.binding_context(db) == binding_context
+                        }))
+                }),
+            )
+        }
+
+        remove_self_inner(db, self, binding_context)
     }
 
     /// Returns the typevars that are inferable in this generic context. This set might include

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1122,6 +1122,7 @@ fn proto_interface_cycle_recover<'db>(
 /// This additional upcasting is required in order for protocols with `__call__` method
 /// members to be considered assignable to `Callable` types, since the `Callable` supertype
 /// of the `__call__` method will be function-like but a `Callable` type is not.
+#[salsa::tracked]
 fn protocol_bind_self<'db>(
     db: &'db dyn Db,
     callable: CallableType<'db>,


### PR DESCRIPTION
## Summary

Binding protocol methods repeatedly rebuilt the same callable signatures and generic contexts during structural compatibility checks.

Cache `protocol_bind_self` and `GenericContext::remove_self` so repeated receiver binding can reuse their results.

This PR is stacked on #26521, which preserves already-normalized parameter storage when binding signatures and owns the associated semantic change.

## Performance

Local CodSpeed-compatible Callgrind simulation on the DateType project benchmark reduced instruction counts by 4.30% (`557,228,444` to `533,291,062`). The frozen-input variant improved by 4.43% (`531,137,027` to `507,607,542`).