### PR TITLE
[ty] Add support for extra arguments in Pydantic model constructors

### DIFF
--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -291,7 +291,7 @@ impl ModuleKind {
     }
 }
 
-/// Enumeration of various core stdlib modules in which important types are located
+/// Enumeration of modules in which types with dedicated semantic behavior are located.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum_macros::EnumString, get_size2::GetSize)]
 #[cfg_attr(test, derive(strum_macros::EnumIter))]
 #[strum(serialize_all = "snake_case")]
@@ -330,6 +330,9 @@ pub enum KnownModule {
     Numbers,
     #[strum(serialize = "struct", serialize = "_struct")]
     Struct,
+    // Third-party modules
+    #[strum(serialize = "pydantic.main")]
+    PydanticMain,
 }
 
 impl KnownModule {
@@ -361,6 +364,7 @@ impl KnownModule {
             Self::Templatelib => "string.templatelib",
             Self::Numbers => "numbers",
             Self::Struct => "struct",
+            Self::PydanticMain => "pydantic.main",
         }
     }
 
@@ -370,10 +374,47 @@ impl KnownModule {
     }
 
     fn try_from_search_path_and_name(search_path: &SearchPath, name: &ModuleName) -> Option<Self> {
-        if search_path.is_standard_library() {
-            Self::from_str(name.as_str()).ok()
+        let known_module = Self::from_str(name.as_str()).ok()?;
+
+        let is_expected_search_path = if known_module.is_third_party() {
+            search_path.is_third_party()
         } else {
-            None
+            search_path.is_standard_library()
+        };
+
+        is_expected_search_path.then_some(known_module)
+    }
+
+    /// Return `true` if this module is provided by a supported third-party package.
+    pub const fn is_third_party(self) -> bool {
+        match self {
+            Self::PydanticMain => true,
+            Self::Builtins
+            | Self::Enum
+            | Self::Types
+            | Self::Typeshed
+            | Self::TypingExtensions
+            | Self::Typing
+            | Self::Sys
+            | Self::Os
+            | Self::Tempfile
+            | Self::Pathlib
+            | Self::Abc
+            | Self::Dataclasses
+            | Self::Functools
+            | Self::Collections
+            | Self::CollectionsAbc
+            | Self::CollectionsAbcInternal
+            | Self::Inspect
+            | Self::Templatelib
+            | Self::TypeCheckerInternals
+            | Self::TyExtensions
+            | Self::ImportLib
+            | Self::UnittestMock
+            | Self::Uuid
+            | Self::Warnings
+            | Self::Numbers
+            | Self::Struct => false,
         }
     }
 
@@ -425,7 +466,7 @@ mod tests {
     fn known_module_roundtrip_from_str() {
         let stdlib_search_path = SearchPath::vendored_stdlib();
 
-        for module in KnownModule::iter() {
+        for module in KnownModule::iter().filter(|module| !module.is_third_party()) {
             let module_name = module.name();
 
             assert_eq!(

--- a/crates/ty_module_resolver/src/path.rs
+++ b/crates/ty_module_resolver/src/path.rs
@@ -606,6 +606,18 @@ impl SearchPath {
         matches!(&*self.0, SearchPathInner::SitePackages(_))
     }
 
+    /// Is the module on a search path for installed third-party code?
+    pub(crate) fn is_third_party(&self) -> bool {
+        match &*self.0 {
+            SearchPathInner::SitePackages(_) | SearchPathInner::Editable(_) => true,
+            SearchPathInner::Extra(_)
+            | SearchPathInner::FirstParty(_)
+            | SearchPathInner::StandardLibraryCustom(_)
+            | SearchPathInner::StandardLibraryVendored(_)
+            | SearchPathInner::StandardLibraryReal(_) => false,
+        }
+    }
+
     fn is_valid_extension(&self, extension: &str) -> bool {
         if self.is_standard_library() {
             extension == "pyi"

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -20,7 +20,7 @@ class User(BaseModel):
     id: int
     name: str
 
-reveal_type(User.__init__)  # revealed: (self: User, *, id: int, name: str) -> None
+reveal_type(User.__init__)  # revealed: (self: User, *, id: int, name: str, **extra: Any) -> None
 
 user = User(id=1, name="John Doe")
 reveal_type(user.id)  # revealed: int
@@ -43,7 +43,8 @@ class Product(BaseModel):
     tags: list[str] = Field(default_factory=list)
     internal_price_cent: int = Field(gt=0, alias="price_cent")
 
-reveal_type(Product.__init__)  # revealed: (self: Product, *, name: str, tags: list[str] = ..., price_cent: int) -> None
+# revealed: (self: Product, *, name: str, tags: list[str] = ..., price_cent: int, **extra: Any) -> None
+reveal_type(Product.__init__)
 
 product = Product(name="Laptop", price_cent=999_00)
 ```
@@ -69,9 +70,7 @@ Using the internal field name is not possible (the argument will be accepted, bu
 missing):
 
 ```py
-# TODO: This should ideally only report `missing-argument`, not `unknown-argument` (since extra fields are allowed by default)
 # error: [missing-argument]
-# error: [unknown-argument]
 Product(name="Laptop", internal_price_cent=999_00)
 ```
 
@@ -210,9 +209,7 @@ class DefaultOnlyAlias(BaseModel):
     name: int = Field(alias="alias")
 
 DefaultOnlyAlias(alias=1)
-# TODO: This should ideally only report `missing-argument`, not `unknown-argument` (since extra fields are allowed by default)
 # error: [missing-argument]
-# error: [unknown-argument]
 DefaultOnlyAlias(name=1)
 ```
 
@@ -226,7 +223,6 @@ class AliasAndName(BaseModel):
 
 AliasAndName(alias=1)
 # TODO: no errors here
-# error: [unknown-argument]
 # error: [missing-argument]
 AliasAndName(name=1)
 ```
@@ -250,7 +246,6 @@ class OnlyName(BaseModel):
 # TODO: this should be an error
 OnlyName(alias=1)
 # TODO: no errors here
-# error: [unknown-argument]
 # error: [missing-argument]
 OnlyName(name=1)
 ```
@@ -265,8 +260,6 @@ from pydantic import BaseModel, ConfigDict
 class Person(BaseModel):
     name: str
 
-# TODO: no error here
-# error: [unknown-argument]
 Person(name="Alice", something_else=7)
 ```
 
@@ -278,7 +271,24 @@ class PersonWithoutExtras(BaseModel):
 
     name: str
 
-PersonWithoutExtras(name="Alice", something_else=7)  # error: [unknown-argument]
+# TODO: this should be an error once we support `extra="forbid"`
+PersonWithoutExtras(name="Alice", something_else=7)
+```
+
+## Field named `extra`
+
+The variadic keyword parameter uses a collision-free name when the model already has a field named
+`extra`:
+
+```py
+from pydantic import BaseModel
+
+class PersonWithExtraField(BaseModel):
+    extra: int
+
+# revealed: (self: PersonWithExtraField, *, extra: int, **extra_: Any) -> None
+reveal_type(PersonWithExtraField.__init__)
+PersonWithExtraField(extra=1, something_else=2)
 ```
 
 ## Frozen models and fields
@@ -386,6 +396,9 @@ class Settings(BaseSettings):
 # TODO: no error here
 # error: [missing-argument]
 Settings()
+
+# `BaseSettings` defines a specialized constructor and forbids extra values by default.
+Settings(host="localhost", port=8000, something_else=7)  # error: [unknown-argument]
 ```
 
 ## Pydantic dataclasses
@@ -407,6 +420,7 @@ reveal_type(Person.__init__)  # revealed: (self: Person, name: str, age: int = 0
 
 Person(name="Alice")
 Person(name="Alice", age=20)
+Person(name="Alice", something_else=7)  # error: [unknown-argument]
 ```
 
 ## Inherited `ModelMetaclass`
@@ -424,10 +438,11 @@ class User(BaseModel, metaclass=RegistryMeta):
     name: str
     age: int = 0
 
-reveal_type(User.__init__)  # revealed: (self: User, *, name: str, age: int = 0) -> None
+reveal_type(User.__init__)  # revealed: (self: User, *, name: str, age: int = 0, **extra: Any) -> None
 
 User(name="alice")
 User(name="alice", age=1)
+User(name="alice", extra=1)
 
 # error: [missing-argument]
 User()
@@ -470,4 +485,39 @@ class User(BaseModel):
     def validate_model_after(self) -> "User":
         reveal_type(self)  # revealed: Self@validate_model_after
         return self
+```
+
+## First-party modules named `pydantic`
+
+A first-party module that happens to use Pydantic's module and class names should not receive
+Pydantic-specific behavior.
+
+`/src/pydantic/__init__.py`:
+
+```py
+from .main import BaseModel as BaseModel
+```
+
+`/src/pydantic/main.py`:
+
+```py
+from typing import dataclass_transform
+
+@dataclass_transform(kw_only_default=True)
+class ModelMetaclass(type): ...
+
+class BaseModel(metaclass=ModelMetaclass): ...
+```
+
+`/src/main.py`:
+
+```py
+from pydantic import BaseModel
+
+class Person(BaseModel):
+    name: str
+
+reveal_type(Person.__init__)  # revealed: (self: Person, *, name: str) -> None
+Person(name="Alice")
+Person(name="Alice", something_else=7)  # error: [unknown-argument]
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -126,6 +126,7 @@ mod constraints;
 mod context;
 mod context_manager;
 mod cyclic;
+mod dedicated;
 mod diagnostic;
 mod display;
 mod enums;

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -153,6 +153,8 @@ pub enum KnownClass {
     TyExtensionsAsyncIterator,
     TyExtensionsIterable,
     TyExtensionsIterator,
+    // Pydantic
+    PydanticBaseModel,
 }
 
 impl KnownClass {
@@ -279,7 +281,8 @@ impl KnownClass {
             | Self::ProtocolMeta
             | Self::FunctoolsPartial
             | Self::ExtensionTypedDictFallback
-            | Self::TypedDictFallback => Some(Truthiness::Ambiguous),
+            | Self::TypedDictFallback
+            | Self::PydanticBaseModel => Some(Truthiness::Ambiguous),
 
             Self::Tuple => None,
         }
@@ -387,7 +390,8 @@ impl KnownClass {
             | KnownClass::ProtocolMeta
             | KnownClass::Template
             | KnownClass::Path
-            | KnownClass::FunctoolsPartial => false,
+            | KnownClass::FunctoolsPartial
+            | KnownClass::PydanticBaseModel => false,
         }
     }
 
@@ -492,7 +496,8 @@ impl KnownClass {
             | KnownClass::ProtocolMeta
             | KnownClass::Template
             | KnownClass::Path
-            | KnownClass::FunctoolsPartial => false,
+            | KnownClass::FunctoolsPartial
+            | KnownClass::PydanticBaseModel => false,
         }
     }
 
@@ -596,7 +601,8 @@ impl KnownClass {
             | KnownClass::ProtocolMeta
             | KnownClass::Template
             | KnownClass::Path
-            | KnownClass::FunctoolsPartial => false,
+            | KnownClass::FunctoolsPartial
+            | KnownClass::PydanticBaseModel => false,
         }
     }
 
@@ -713,7 +719,8 @@ impl KnownClass {
             | Self::Path
             | Self::FunctoolsPartial
             | Self::Mapping
-            | Self::Sequence => false,
+            | Self::Sequence
+            | Self::PydanticBaseModel => false,
         }
     }
 
@@ -819,7 +826,8 @@ impl KnownClass {
             | KnownClass::FunctoolsPartial
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
-            | KnownClass::Specialization => false,
+            | KnownClass::Specialization
+            | KnownClass::PydanticBaseModel => false,
             KnownClass::NamedTupleFallback
             | KnownClass::TypedDictFallback
             | KnownClass::ExtensionTypedDictFallback => true,
@@ -939,6 +947,7 @@ impl KnownClass {
             Self::Path => "Path",
             Self::FunctoolsPartial => "partial",
             Self::ProtocolMeta => "_ProtocolMeta",
+            Self::PydanticBaseModel => "BaseModel",
         }
     }
 
@@ -966,10 +975,11 @@ impl KnownClass {
         KnownClassDisplay { db, class: self }
     }
 
-    /// Lookup a [`KnownClass`] in typeshed and return a [`Type`] representing all possible instances of
-    /// the class. If this class is generic, this will use the default specialization.
+    /// Look up a [`KnownClass`] in its canonical module and return a [`Type`] representing all
+    /// possible instances of the class. If this class is generic, this will use the default
+    /// specialization.
     ///
-    /// If the class cannot be found in typeshed, a debug-level log message will be emitted stating this.
+    /// If the class cannot be found, a debug-level log message will be emitted stating this.
     #[track_caller]
     pub fn to_instance(self, db: &dyn Db) -> Type<'_> {
         debug_assert_ne!(
@@ -997,11 +1007,11 @@ impl KnownClass {
             .unwrap_or_else(Type::unknown)
     }
 
-    /// Lookup a generic [`KnownClass`] in typeshed and return a [`Type`]
-    /// representing a specialization of that class.
+    /// Look up a generic [`KnownClass`] in its canonical module and return a [`Type`] representing a
+    /// specialization of that class.
     ///
-    /// If the class cannot be found in typeshed, or if you provide a specialization with the wrong
-    /// number of types, a debug-level log message will be emitted stating this.
+    /// If the class cannot be found, or if you provide a specialization with the wrong number of
+    /// types, a debug-level log message will be emitted stating this.
     pub(crate) fn to_specialized_class_type<'t, 'db, T>(
         self,
         db: &'db dyn Db,
@@ -1050,11 +1060,11 @@ impl KnownClass {
         ))
     }
 
-    /// Lookup a [`KnownClass`] in typeshed and return a [`Type`]
-    /// representing all possible instances of the generic class with a specialization.
+    /// Look up a [`KnownClass`] in its canonical module and return a [`Type`] representing all
+    /// possible instances of the generic class with a specialization.
     ///
-    /// If the class cannot be found in typeshed, or if you provide a specialization with the wrong
-    /// number of types, a debug-level log message will be emitted stating this.
+    /// If the class cannot be found, or if you provide a specialization with the wrong number of
+    /// types, a debug-level log message will be emitted stating this.
     #[track_caller]
     pub(crate) fn to_specialized_instance<'t, 'db, T>(
         self,
@@ -1075,15 +1085,18 @@ impl KnownClass {
             .unwrap_or_else(Type::unknown)
     }
 
-    /// Attempt to lookup a [`KnownClass`] in typeshed and return a [`Type`] representing that class-literal.
+    /// Attempt to look up a [`KnownClass`] in its canonical module and return a [`Type`]
+    /// representing that class literal.
     ///
-    /// Return an error if the symbol cannot be found in the expected typeshed module,
-    /// or if the symbol is not a class definition, or if the symbol is possibly unbound.
+    /// Return an error if the symbol cannot be found in the expected module, if the symbol is not a
+    /// class definition, or if the symbol is possibly unbound.
     fn try_to_class_literal_without_logging(
         self,
         db: &dyn Db,
     ) -> Result<StaticClassLiteral<'_>, KnownClassLookupError<'_>> {
-        let symbol = known_module_symbol(db, self.canonical_module(db), self.name(db)).place;
+        let module = self.canonical_module(db);
+        let third_party = module.is_third_party();
+        let symbol = known_module_symbol(db, module, self.name(db)).place;
         match symbol {
             Place::Defined(DefinedPlace {
                 ty: Type::ClassLiteral(ClassLiteral::Static(class_literal)),
@@ -1094,17 +1107,24 @@ impl KnownClass {
                 ty: Type::ClassLiteral(ClassLiteral::Static(class_literal)),
                 definedness: Definedness::PossiblyUndefined,
                 ..
-            }) => Err(KnownClassLookupError::ClassPossiblyUnbound { class_literal }),
+            }) => Err(KnownClassLookupError::ClassPossiblyUnbound {
+                class_literal,
+                third_party,
+            }),
             Place::Defined(DefinedPlace { ty: found_type, .. }) => {
-                Err(KnownClassLookupError::SymbolNotAClass { found_type })
+                Err(KnownClassLookupError::SymbolNotAClass {
+                    found_type,
+                    third_party,
+                })
             }
-            Place::Undefined => Err(KnownClassLookupError::ClassNotFound),
+            Place::Undefined => Err(KnownClassLookupError::ClassNotFound { third_party }),
         }
     }
 
-    /// Lookup a [`KnownClass`] in typeshed and return a [`Type`] representing that class-literal.
+    /// Look up a [`KnownClass`] in its canonical module and return a [`Type`] representing that
+    /// class literal.
     ///
-    /// If the class cannot be found in typeshed, a debug-level log message will be emitted stating this.
+    /// If the class cannot be found, a debug-level log message will be emitted stating this.
     pub(crate) fn try_to_class_literal(self, db: &dyn Db) -> Option<StaticClassLiteral<'_>> {
         #[salsa::interned(heap_size=ruff_memory_usage::heap_size)]
         struct KnownClassArgument {
@@ -1146,19 +1166,20 @@ impl KnownClass {
         known_class_to_class_literal(db, KnownClassArgument::new(db, self))
     }
 
-    /// Lookup a [`KnownClass`] in typeshed and return a [`Type`] representing that class-literal.
+    /// Look up a [`KnownClass`] in its canonical module and return a [`Type`] representing that
+    /// class literal.
     ///
-    /// If the class cannot be found in typeshed, a debug-level log message will be emitted stating this.
+    /// If the class cannot be found, a debug-level log message will be emitted stating this.
     pub(crate) fn to_class_literal(self, db: &dyn Db) -> Type<'_> {
         self.try_to_class_literal(db)
             .map(|class| Type::ClassLiteral(ClassLiteral::Static(class)))
             .unwrap_or_else(Type::unknown)
     }
 
-    /// Lookup a [`KnownClass`] in typeshed and return a [`Type`]
-    /// representing that class and all possible subclasses of the class.
+    /// Look up a [`KnownClass`] in its canonical module and return a [`Type`] representing that class
+    /// and all possible subclasses of the class.
     ///
-    /// If the class cannot be found in typeshed, a debug-level log message will be emitted stating this.
+    /// If the class cannot be found, a debug-level log message will be emitted stating this.
     pub fn to_subclass_of(self, db: &dyn Db) -> Type<'_> {
         self.to_class_literal(db)
             .to_class_type(db)
@@ -1176,8 +1197,8 @@ impl KnownClass {
             .unwrap_or_else(SubclassOfType::subclass_of_unknown)
     }
 
-    /// Return `true` if this symbol can be resolved to a class definition `class` in typeshed,
-    /// *and* `class` is a subclass of `other`.
+    /// Return `true` if this symbol can be resolved to a class definition `class` in its canonical
+    /// module, *and* `class` is a subclass of `other`.
     pub(crate) fn is_subclass_of<'db>(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {
         self.try_to_class_literal_without_logging(db)
             .is_ok_and(|class| class.is_subclass_of(db, None, other))
@@ -1309,6 +1330,7 @@ impl KnownClass {
             Self::Template => KnownModule::Templatelib,
             Self::Path => KnownModule::Pathlib,
             Self::FunctoolsPartial => KnownModule::Functools,
+            Self::PydanticBaseModel => KnownModule::PydanticMain,
         }
     }
 
@@ -1415,7 +1437,8 @@ impl KnownClass {
             | Self::Template
             | Self::Path
             | Self::UnionType
-            | Self::FunctoolsPartial => Some(false),
+            | Self::FunctoolsPartial
+            | Self::PydanticBaseModel => Some(false),
 
             Self::Tuple => None,
         }
@@ -1525,7 +1548,8 @@ impl KnownClass {
             | Self::ProtocolMeta
             | Self::Template
             | Self::Path
-            | Self::FunctoolsPartial => false,
+            | Self::FunctoolsPartial
+            | Self::PydanticBaseModel => false,
         }
     }
 
@@ -1635,6 +1659,7 @@ impl KnownClass {
             "partial" => &[Self::FunctoolsPartial],
             "_ProtocolMeta" => &[Self::ProtocolMeta],
             "_TypedDict" => &[Self::ExtensionTypedDictFallback],
+            "BaseModel" => &[Self::PydanticBaseModel],
             _ => return None,
         };
 
@@ -1730,7 +1755,8 @@ impl KnownClass {
             | Self::AsyncGenerator
             | Self::Template
             | Self::Path
-            | Self::FunctoolsPartial => module == self.canonical_module(db),
+            | Self::FunctoolsPartial
+            | Self::PydanticBaseModel => module == self.canonical_module(db),
             Self::NoneType => matches!(module, KnownModule::Typeshed | KnownModule::Types),
             Self::SpecialForm
             | Self::TypeAliasType
@@ -1894,22 +1920,33 @@ impl KnownClass {
     }
 }
 
-/// Enumeration of ways in which looking up a [`KnownClass`] in typeshed could fail.
+/// Enumeration of ways in which looking up a [`KnownClass`] in its canonical module could fail.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum KnownClassLookupError<'db> {
-    /// There is no symbol by that name in the expected typeshed module.
-    ClassNotFound,
-    /// There is a symbol by that name in the expected typeshed module,
-    /// but it's not a class.
-    SymbolNotAClass { found_type: Type<'db> },
-    /// There is a symbol by that name in the expected typeshed module,
-    /// and it's a class definition, but it's possibly unbound.
+    /// There is no symbol by that name in the expected module.
+    ClassNotFound { third_party: bool },
+    /// There is a symbol by that name in the expected module, but it's not a class.
+    SymbolNotAClass {
+        found_type: Type<'db>,
+        third_party: bool,
+    },
+    /// There is a symbol by that name in the expected module, and it's a class definition, but it's
+    /// possibly unbound.
     ClassPossiblyUnbound {
         class_literal: StaticClassLiteral<'db>,
+        third_party: bool,
     },
 }
 
 impl<'db> KnownClassLookupError<'db> {
+    const fn is_third_party(self) -> bool {
+        match self {
+            Self::ClassNotFound { third_party }
+            | Self::SymbolNotAClass { third_party, .. }
+            | Self::ClassPossiblyUnbound { third_party, .. } => third_party,
+        }
+    }
+
     fn display(&self, db: &'db dyn Db, class: KnownClass) -> impl std::fmt::Display + 'db {
         struct ErrorDisplay<'db> {
             db: &'db dyn Db,
@@ -1923,22 +1960,27 @@ impl<'db> KnownClassLookupError<'db> {
 
                 let class = class.display(db);
                 let python_version = Program::get(db).python_version(db);
+                let location = if error.is_third_party() {
+                    ""
+                } else {
+                    " in typeshed"
+                };
 
                 match error {
-                    KnownClassLookupError::ClassNotFound => write!(
+                    KnownClassLookupError::ClassNotFound { .. } => write!(
                         f,
-                        "Could not find class `{class}` in typeshed on Python {python_version}",
+                        "Could not find class `{class}`{location} on Python {python_version}",
                     ),
-                    KnownClassLookupError::SymbolNotAClass { found_type } => write!(
+                    KnownClassLookupError::SymbolNotAClass { found_type, .. } => write!(
                         f,
-                        "Error looking up `{class}` in typeshed: expected to find a class definition \
+                        "Error looking up `{class}`{location}: expected to find a class definition \
                         on Python {python_version}, but found a symbol of type `{found_type}` instead",
                         found_type = found_type.display(db),
                     ),
                     KnownClassLookupError::ClassPossiblyUnbound { .. } => write!(
                         f,
-                        "Error looking up `{class}` in typeshed on Python {python_version}: \
-                        expected to find a fully bound symbol, but found one that is possibly unbound",
+                        "Error looking up `{class}`{location} on Python {python_version}: expected \
+                        to find a fully bound symbol, but found one that is possibly unbound",
                     ),
                 }
             }
@@ -1971,6 +2013,9 @@ mod tests {
                 source: PythonVersionSource::default(),
             });
         for class in KnownClass::iter() {
+            if class.canonical_module(&db).is_third_party() {
+                continue;
+            }
             let class_name = class.name(&db);
             let class_module =
                 resolve_module_confident(&db, &class.canonical_module(&db).name()).unwrap();
@@ -1999,6 +2044,9 @@ mod tests {
             });
 
         for class in KnownClass::iter() {
+            if class.canonical_module(&db).is_third_party() {
+                continue;
+            }
             // Check the class can be looked up successfully
             class.try_to_class_literal_without_logging(&db).unwrap();
 
@@ -2024,6 +2072,7 @@ mod tests {
         // This makes the test far faster as it minimizes the number of times
         // we need to change the Python version in the loop.
         let mut classes: Vec<(KnownClass, PythonVersion)> = KnownClass::iter()
+            .filter(|class| !class.canonical_module(&db).is_third_party())
             .map(|class| {
                 let version_added = match class {
                     KnownClass::Template => PythonVersion::PY314,

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -34,6 +34,7 @@ use crate::{
             typed_dict::{TypedDictFields, synthesize_typed_dict_method, typed_dict_class_member},
         },
         context::InferContext,
+        dedicated::pydantic,
         definition_expression_type, determine_upper_bound,
         diagnostic::INVALID_DATACLASS_OVERRIDE,
         enums::{enum_metadata, is_enum_class_by_inheritance, try_unwrap_nonmember_value},
@@ -1463,6 +1464,11 @@ impl<'db> StaticClassLiteral<'db> {
             // In the event that we have a mix of keyword-only and positional parameters, we need to sort them
             // so that the keyword-only parameters appear after positional parameters.
             parameters.sort_by_key(Parameter::is_keyword_only);
+
+            if name == "__init__" && pydantic::uses_base_model_init(db, self) {
+                let extra = pydantic::extra_parameter(&parameters);
+                parameters.push(extra);
+            }
 
             let signature = match name {
                 "__new__" | "__init__" => Signature::new_generic(

--- a/crates/ty_python_semantic/src/types/dedicated/mod.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod pydantic;

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -1,0 +1,48 @@
+use ruff_python_ast::name::Name;
+
+use crate::Db;
+use crate::types::member::class_member;
+use crate::types::{ClassBase, KnownClass, Parameter, StaticClassLiteral, Type};
+
+/// Return `true` if `class` should accept extra keywords in its synthesized constructor.
+///
+/// Pydantic uses `BaseModel` as the public marker for models. A class before `BaseModel` in the MRO
+/// can override `__init__`; Pydantic preserves that custom constructor, so it must continue to
+/// control which keywords are accepted. This also avoids widening specialized model bases such as
+/// `RootModel` and `BaseSettings`, which define their own constructors.
+pub(in crate::types) fn uses_base_model_init(db: &dyn Db, class: StaticClassLiteral<'_>) -> bool {
+    for base in class
+        .iter_mro(db, None)
+        .skip(1)
+        .filter_map(ClassBase::into_class)
+        .filter_map(|base| base.static_class_literal(db))
+        .map(|(base, _)| base)
+    {
+        if base.is_known(db, KnownClass::PydanticBaseModel) {
+            return true;
+        }
+
+        if !class_member(db, base.body_scope(db), "__init__").is_undefined() {
+            return false;
+        }
+    }
+
+    false
+}
+
+/// Create the catch-all keyword parameter for a Pydantic model constructor.
+///
+/// Start with `extra` and append underscores until the name does not collide with a model field.
+pub(in crate::types) fn extra_parameter<'db>(parameters: &[Parameter<'db>]) -> Parameter<'db> {
+    let mut name = String::from("extra");
+
+    while parameters
+        .iter()
+        .filter_map(Parameter::name)
+        .any(|parameter_name| parameter_name.as_str() == name)
+    {
+        name.push('_');
+    }
+
+    Parameter::keyword_variadic(Name::new(name)).with_annotated_type(Type::any())
+}


### PR DESCRIPTION
## Summary

This is a first in a series of PRs to add dedicated support for Pydantic to ty. This PR sets up the main infrastructure for detecting Pydantic modules / classes using our `KnownModule`/`KnownClass` mechanism.

It also (partially) implements a first feature of Pydantic support. By default[^1], Pydantic models accept extra arguments in their constructor:

```py
class Person(BaseModel):
    name: str

Person(name="Alice", something_else=7)  # okay
```

closes https://github.com/astral-sh/ty/issues/3639 (This PR removes the false positive. I will track support for `extra="forbid"` and `__pydantic_extra__` separately)

## Test Plan

- Updated Markdown tests
- New tests around known module / class detection

[^1]: That is, unless `extra="forbid"` is specified. We do not add support for this config setting here.