### PR TITLE
[ty] Preserve generic variadic callback semantics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3476,6 +3476,25 @@ static_assert(is_subtype_of(TypeOf[tuple[str, ...]], SequenceMaker[str]))  # err
 static_assert(is_subtype_of(TypeOf[tuple[str, ...]], SequenceMaker[int | str]))  # error: [static-assert-error]
 ```
 
+Specializing a type variable to `Any` does not make variadic parameters gradual. The gradual form
+requires the parameters to be explicitly or implicitly annotated with `Any` in the function
+definition:
+
+```py
+from typing import Any, Protocol, TypeVar
+
+T_contra = TypeVar("T_contra", contravariant=True)
+
+class Variadic(Protocol[T_contra]):
+    def __call__(self, *args: T_contra, **kwargs: T_contra) -> None: ...
+
+class NoArgs(Protocol):
+    def __call__(self) -> None: ...
+
+def _(source: NoArgs):
+    target: Variadic[Any] = source  # error: [invalid-assignment]
+```
+
 ## Generic protocols and union arguments
 
 When a union is passed to a parameter annotated as a generic protocol, each union element can

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -2074,7 +2074,7 @@ pub(crate) mod implicit_globals {
             // if at least one global symbol is annotated in the module.
             "__annotate__" if Program::get(db).python_version(db) >= PythonVersion::PY314 => {
                 let signature = Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [Parameter::positional_only(Some(Name::new_static("format")))
                             .with_annotated_type(KnownClass::Int.to_instance(db))],

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2738,7 +2738,7 @@ impl<'db> Type<'db> {
                     _ => None,
                 } && let Ok(length) = i64::try_from(length)
                 {
-                    let parameters = Parameters::new(
+                    let parameters = Parameters::from_annotation(
                         db,
                         [Parameter::positional_only(Some(Name::new_static("self")))
                             .with_annotated_type(self)],
@@ -4307,7 +4307,7 @@ impl<'db> Type<'db> {
             Type::DataclassTransformer(_) => Binding::single(
                 self,
                 Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [Parameter::positional_only(Some(Name::new_static("func")))
                             .with_annotated_type(Type::object())],
@@ -4329,7 +4329,7 @@ impl<'db> Type<'db> {
                         self,
                         Signature::new_generic(
                             Some(GenericContext::from_typevar_instances(db, [val_ty])),
-                            Parameters::new(
+                            Parameters::from_annotation(
                                 db,
                                 [
                                     Parameter::positional_only(Some(Name::new_static("value")))
@@ -4348,7 +4348,7 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new(
-                            Parameters::new(
+                            Parameters::from_annotation(
                                 db,
                                 [Parameter::positional_only(Some(Name::new_static("arg")))
                                     // We need to set the type to `Any` here (instead of `Never`),
@@ -4366,7 +4366,7 @@ impl<'db> Type<'db> {
                 Some(KnownFunction::Cast) => Binding::single(
                     self,
                     Signature::new(
-                        Parameters::new(
+                        Parameters::from_annotation(
                             db,
                             [
                                 Parameter::positional_or_keyword(Name::new_static("typ"))
@@ -4424,12 +4424,15 @@ impl<'db> Type<'db> {
                         [
                             // def dataclass(cls: None, /, *, ...) -> Callable[[type[_T]], type[_T]]: ...
                             Signature::new(
-                                Parameters::new(db, parameters_with_cls(Type::none(db))),
+                                Parameters::from_annotation(
+                                    db,
+                                    parameters_with_cls(Type::none(db)),
+                                ),
                                 Type::unknown(),
                             ),
                             // def dataclass(cls: type[_T], /, *, ...) -> type[_T]: ...
                             Signature::new(
-                                Parameters::new(
+                                Parameters::from_annotation(
                                     db,
                                     parameters_with_cls(KnownClass::Type.to_instance(db)),
                                 ),
@@ -4449,7 +4452,7 @@ impl<'db> Type<'db> {
                             //     weakref_slot: bool = False,
                             // ) -> Callable[[type[_T]], type[_T]]: ...
                             Signature::new(
-                                Parameters::new(db, decorator_factory_parameters),
+                                Parameters::from_annotation(db, decorator_factory_parameters),
                                 Type::unknown(),
                             ),
                         ],
@@ -4515,7 +4518,8 @@ impl<'db> Type<'db> {
             Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar)) => {
                 let parameter = Parameter::positional_or_keyword(Name::new_static("type"))
                     .with_annotated_type(Type::any());
-                let signature = Signature::new(Parameters::new(db, [parameter]), Type::any());
+                let signature =
+                    Signature::new(Parameters::from_annotation(db, [parameter]), Type::any());
                 Binding::single(self, signature).into()
             }
 
@@ -4586,8 +4590,11 @@ impl<'db> Type<'db> {
                 // Intersect with `Any` for the return type to reflect the fact that the `dataclass()`
                 // decorator adds methods to the class
                 let returns = IntersectionType::from_two_elements(db, typevar_meta, Type::any());
-                let signature =
-                    Signature::new_generic(Some(context), Parameters::new(db, parameters), returns);
+                let signature = Signature::new_generic(
+                    Some(context),
+                    Parameters::from_annotation(db, parameters),
+                    returns,
+                );
                 Binding::single(self, signature).into()
             }
 
@@ -4604,7 +4611,7 @@ impl<'db> Type<'db> {
             Type::KnownInstance(KnownInstanceType::NewType(newtype)) => Binding::single(
                 self,
                 Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [Parameter::positional_only(None)
                             .with_annotated_type(newtype.base(db).instance_type(db))],
@@ -4653,7 +4660,7 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new(
-                            Parameters::new(
+                            Parameters::from_annotation(
                                 db,
                                 [Parameter::positional_only(Some(Name::new_static("o")))
                                     .with_annotated_type(Type::any())
@@ -4693,7 +4700,7 @@ impl<'db> Type<'db> {
                         self,
                         [
                             Signature::new(
-                                Parameters::new(
+                                Parameters::from_annotation(
                                     db,
                                     [
                                         Parameter::positional_only(Some(Name::new_static("t")))
@@ -4705,7 +4712,7 @@ impl<'db> Type<'db> {
                                 KnownClass::Super.to_instance(db),
                             ),
                             Signature::new(
-                                Parameters::new(
+                                Parameters::from_annotation(
                                     db,
                                     [Parameter::positional_only(Some(Name::new_static("t")))
                                         .with_annotated_type(Type::any())],
@@ -4737,7 +4744,7 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new(
-                            Parameters::new(
+                            Parameters::from_annotation(
                                 db,
                                 [
                                     Parameter::positional_only(Some(Name::new_static("message")))
@@ -4775,7 +4782,7 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new(
-                            Parameters::new(
+                            Parameters::from_annotation(
                                 db,
                                 [
                                     Parameter::positional_or_keyword(Name::new_static("name"))
@@ -4806,14 +4813,14 @@ impl<'db> Type<'db> {
 
             KnownClass::Property => {
                 let getter_signature = Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [Parameter::positional_only(None).with_annotated_type(Type::any())],
                     ),
                     Type::any(),
                 );
                 let setter_signature = Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(None).with_annotated_type(Type::any()),
@@ -4823,7 +4830,7 @@ impl<'db> Type<'db> {
                     Type::none(db),
                 );
                 let deleter_signature = Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [Parameter::positional_only(None).with_annotated_type(Type::any())],
                     ),
@@ -4834,7 +4841,7 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new(
-                            Parameters::new(
+                            Parameters::from_annotation(
                                 db,
                                 [
                                     Parameter::positional_or_keyword(Name::new_static("fget"))
@@ -4890,7 +4897,7 @@ impl<'db> Type<'db> {
                         self,
                         Signature::new_generic(
                             Some(GenericContext::from_typevar_instances(db, [return_ty])),
-                            Parameters::new(
+                            Parameters::from_annotation(
                                 db,
                                 [
                                     Parameter::positional_only(Some(Name::new_static("func")))
@@ -4936,7 +4943,7 @@ impl<'db> Type<'db> {
                             Signature::new(Parameters::empty(), Type::empty_tuple(db)),
                             Signature::new_generic(
                                 Some(GenericContext::from_typevar_instances(db, [element_ty])),
-                                Parameters::new(
+                                Parameters::from_annotation(
                                     db,
                                     [Parameter::positional_only(Some(Name::new_static(
                                         "iterable",

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -934,7 +934,7 @@ impl<'db> BoundSuperType<'db> {
         {
             let item_parameter = Parameter::positional_only(Some(Name::new_static("item")))
                 .with_annotated_type(Type::unknown());
-            let parameters = Parameters::new(db, [item_parameter]);
+            let parameters = Parameters::from_annotation(db, [item_parameter]);
             let return_type = self.owner(db).owner_type();
             let class_getitem = Type::single_callable(db, Signature::new(parameters, return_type));
             return Place::bound(class_getitem).into();

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -251,7 +251,7 @@ impl<'db> Type<'db> {
                 Some(CallableTypes::one(CallableType::single(
                     db,
                     Signature::new(
-                        Parameters::new(
+                        Parameters::from_annotation(
                             db,
                             [Parameter::positional_only(None)
                                 .with_annotated_type(newtype.base(db).instance_type(db))],

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1559,7 +1559,7 @@ impl<'db> ClassType<'db> {
             let self_parameter = Parameter::positional_only(Some(Name::new_static("self")));
             let index_parameter = Parameter::positional_only(Some(Name::new_static("index")))
                 .with_annotated_type(index_annotation);
-            let parameters = Parameters::new(db, [self_parameter, index_parameter]);
+            let parameters = Parameters::from_annotation(db, [self_parameter, index_parameter]);
             Signature::new(parameters, return_annotation)
         }
 
@@ -1595,7 +1595,7 @@ impl<'db> ClassType<'db> {
                     .map(Type::int_literal)
                     .unwrap_or_else(|| KnownClass::Int.to_instance(db));
 
-                let parameters = Parameters::new(
+                let parameters = Parameters::from_annotation(
                     db,
                     [Parameter::positional_only(Some(Name::new_static("self")))
                         .with_annotated_type(Type::instance(db, self))],
@@ -1837,7 +1837,7 @@ impl<'db> ClassType<'db> {
                         iterable_parameter.with_default_type(Type::empty_tuple(db));
                 }
 
-                let parameters = Parameters::new(
+                let parameters = Parameters::from_annotation(
                     db,
                     [
                         Parameter::positional_only(Some(Name::new_static("self")))

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -57,7 +57,7 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
 
             let signature = Signature::new_generic(
                 Some(generic_context),
-                Parameters::new(db, parameters),
+                Parameters::from_annotation(db, parameters),
                 self_ty,
             );
             Some(Type::function_like_callable(db, signature))
@@ -102,7 +102,7 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
                     .with_definition(field.definition)
             }));
 
-            let signature = Signature::new(Parameters::new(db, parameters), self_ty);
+            let signature = Signature::new(Parameters::from_annotation(db, parameters), self_ty);
             Some(Type::function_like_callable(db, signature))
         }
         "__init__" => {
@@ -622,7 +622,7 @@ impl get_size2::GetSize for NamedTupleSpec<'_> {}
 /// Create a property type for a namedtuple field.
 fn create_field_property<'db>(db: &'db dyn Db, field_ty: Type<'db>) -> Type<'db> {
     let property_getter_signature = Signature::new(
-        Parameters::new(
+        Parameters::from_annotation(
             db,
             [Parameter::positional_only(Some(Name::new_static("self")))],
         ),

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1194,7 +1194,7 @@ impl<'db> StaticClassLiteral<'db> {
                 .get(name)
             {
                 let property_getter_signature = Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [Parameter::positional_only(Some(Name::new_static("self")))],
                     ),
@@ -1473,10 +1473,10 @@ impl<'db> StaticClassLiteral<'db> {
             let signature = match name {
                 "__new__" | "__init__" => Signature::new_generic(
                     inherited_generic_context.or_else(|| self.inherited_generic_context(db)),
-                    Parameters::new(db, parameters),
+                    Parameters::from_annotation(db, parameters),
                     return_ty,
                 ),
-                _ => Signature::new(Parameters::new(db, parameters), return_ty),
+                _ => Signature::new(Parameters::from_annotation(db, parameters), return_ty),
             };
             Some(Type::function_like_callable(db, signature))
         };
@@ -1545,7 +1545,7 @@ impl<'db> StaticClassLiteral<'db> {
                 }
 
                 let signature = Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_or_keyword(Name::new_static("self"))
@@ -1569,7 +1569,7 @@ impl<'db> StaticClassLiteral<'db> {
 
                 if unsafe_hash || (frozen && eq) {
                     let signature = Signature::new(
-                        Parameters::new(
+                        Parameters::from_annotation(
                             db,
                             [Parameter::positional_or_keyword(Name::new_static("self"))
                                 .with_annotated_type(instance_ty)],
@@ -1660,7 +1660,7 @@ impl<'db> StaticClassLiteral<'db> {
             (CodeGeneratorKind::DataclassLike(_), "__setattr__") => {
                 if self.is_frozen_dataclass(db) == Some(true) {
                     let signature = Signature::new(
-                        Parameters::new(
+                        Parameters::from_annotation(
                             db,
                             [
                                 Parameter::positional_or_keyword(Name::new_static("self"))
@@ -1719,7 +1719,7 @@ impl<'db> StaticClassLiteral<'db> {
             Type::instance(db, self.apply_optional_specialization(db, specialization));
         let setattr_signature = |name_ty, return_ty| {
             Signature::new(
-                Parameters::new(
+                Parameters::from_annotation(
                     db,
                     [
                         Parameter::positional_or_keyword(Name::new_static("self"))

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -159,7 +159,7 @@ fn synthesize_typed_dict_init<'db>(
     });
 
     let map_overload = Signature::new(
-        Parameters::new(
+        Parameters::from_annotation(
             db,
             [self_param.clone(), map_param]
                 .into_iter()
@@ -181,7 +181,7 @@ fn synthesize_typed_dict_init<'db>(
     });
 
     let keyword_overload = Signature::new(
-        Parameters::new(
+        Parameters::from_annotation(
             db,
             std::iter::once(self_param)
                 .chain(keyword_field_params)
@@ -215,10 +215,13 @@ fn synthesize_typed_dict_getitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("key")))
                     .with_annotated_type(key_type),
             ];
-            Signature::new(Parameters::new(db, parameters), field.declared_ty)
+            Signature::new(
+                Parameters::from_annotation(db, parameters),
+                field.declared_ty,
+            )
         })
         .chain(std::iter::once(Signature::new(
-            Parameters::new(
+            Parameters::from_annotation(
                 db,
                 [
                     Parameter::positional_only(Some(Name::new_static("self")))
@@ -264,7 +267,7 @@ fn synthesize_typed_dict_setitem<'db>(
             Parameter::positional_only(Some(Name::new_static("value")))
                 .with_annotated_type(Type::any()),
         ];
-        let signature = Signature::new(Parameters::new(db, parameters), Type::none(db));
+        let signature = Signature::new(Parameters::from_annotation(db, parameters), Type::none(db));
         return Type::function_like_callable(db, signature);
     }
 
@@ -279,7 +282,7 @@ fn synthesize_typed_dict_setitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("value")))
                     .with_annotated_type(field.declared_ty),
             ];
-            Signature::new(Parameters::new(db, parameters), Type::none(db))
+            Signature::new(Parameters::from_annotation(db, parameters), Type::none(db))
         })
         .chain(arbitrary_key_mutation_type.map(|value_ty| {
             let parameters = [
@@ -290,7 +293,7 @@ fn synthesize_typed_dict_setitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("value")))
                     .with_annotated_type(value_ty),
             ];
-            Signature::new(Parameters::new(db, parameters), Type::none(db))
+            Signature::new(Parameters::from_annotation(db, parameters), Type::none(db))
         }));
 
     Type::Callable(CallableType::new(
@@ -321,7 +324,7 @@ fn synthesize_typed_dict_delitem<'db>(
             Parameter::positional_only(Some(Name::new_static("key")))
                 .with_annotated_type(Type::Never),
         ];
-        let signature = Signature::new(Parameters::new(db, parameters), Type::none(db));
+        let signature = Signature::new(Parameters::from_annotation(db, parameters), Type::none(db));
         return Type::function_like_callable(db, signature);
     }
 
@@ -334,7 +337,7 @@ fn synthesize_typed_dict_delitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("key")))
                     .with_annotated_type(key_type),
             ];
-            Signature::new(Parameters::new(db, parameters), Type::none(db))
+            Signature::new(Parameters::from_annotation(db, parameters), Type::none(db))
         })
         .chain(supports_arbitrary_key_deletion.then(|| {
             let parameters = [
@@ -343,7 +346,7 @@ fn synthesize_typed_dict_delitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("key")))
                     .with_annotated_type(KnownClass::Str.to_instance(db)),
             ];
-            Signature::new(Parameters::new(db, parameters), Type::none(db))
+            Signature::new(Parameters::from_annotation(db, parameters), Type::none(db))
         }));
 
     Type::Callable(CallableType::new(
@@ -378,7 +381,7 @@ fn synthesize_typed_dict_get<'db>(
                     .with_annotated_type(key_type),
             ];
             let get_sig = Signature::new(
-                Parameters::new(db, get_sig_params),
+                Parameters::from_annotation(db, get_sig_params),
                 if field.is_required() {
                     field.declared_ty
                 } else {
@@ -402,7 +405,7 @@ fn synthesize_typed_dict_get<'db>(
             ];
             let get_with_default_sig = Signature::new_generic(
                 Some(GenericContext::from_typevar_instances(db, [t_default])),
-                Parameters::new(db, get_with_default_sig_params),
+                Parameters::from_annotation(db, get_with_default_sig_params),
                 if field.is_required() {
                     field.declared_ty
                 } else {
@@ -418,7 +421,7 @@ fn synthesize_typed_dict_get<'db>(
                 Either::Left([get_sig, get_with_default_sig].into_iter())
             } else {
                 let get_with_typed_default_sig = Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("self")))
@@ -438,7 +441,7 @@ fn synthesize_typed_dict_get<'db>(
         })
         // Fallback overloads for unknown keys
         .chain(std::iter::once(Signature::new(
-            Parameters::new(
+            Parameters::from_annotation(
                 db,
                 [
                     Parameter::positional_only(Some(Name::new_static("self")))
@@ -467,7 +470,7 @@ fn synthesize_typed_dict_get<'db>(
 
             Signature::new_generic(
                 Some(GenericContext::from_typevar_instances(db, [t_default])),
-                Parameters::new(db, parameters),
+                Parameters::from_annotation(db, parameters),
                 UnionType::from_two_elements(db, fallback_value_ty, Type::TypeVar(t_default)),
             )
         }));
@@ -536,7 +539,8 @@ fn synthesize_typed_dict_update<'db>(
     .into_iter()
     .chain(keyword_parameters);
 
-    let update_signature = Signature::new(Parameters::new(db, parameters), Type::none(db));
+    let update_signature =
+        Signature::new(Parameters::from_annotation(db, parameters), Type::none(db));
     Type::function_like_callable(db, update_signature)
 }
 
@@ -553,7 +557,7 @@ fn synthesize_typed_dict_pop<'db>(
                 .with_annotated_type(instance_ty),
             Parameter::positional_only(Some(Name::new_static("key"))).with_annotated_type(key_ty),
         ];
-        let pop_sig = Signature::new(Parameters::new(db, pop_parameters), value_ty);
+        let pop_sig = Signature::new(Parameters::from_annotation(db, pop_parameters), value_ty);
 
         // Non-generic overload that accepts the value type as the default,
         // providing bidirectional inference context for the default argument.
@@ -565,7 +569,7 @@ fn synthesize_typed_dict_pop<'db>(
                 .with_annotated_type(value_ty),
         ];
         let pop_with_typed_default_sig = Signature::new(
-            Parameters::new(db, pop_with_typed_default_parameters),
+            Parameters::from_annotation(db, pop_with_typed_default_parameters),
             value_ty,
         );
 
@@ -580,7 +584,7 @@ fn synthesize_typed_dict_pop<'db>(
         ];
         let pop_with_default_sig = Signature::new_generic(
             Some(GenericContext::from_typevar_instances(db, [t_default])),
-            Parameters::new(db, pop_with_default_parameters),
+            Parameters::from_annotation(db, pop_with_default_parameters),
             UnionType::from_two_elements(db, value_ty, Type::TypeVar(t_default)),
         );
 
@@ -630,7 +634,10 @@ fn synthesize_typed_dict_setdefault<'db>(
                     .with_annotated_type(field.declared_ty),
             ];
 
-            Signature::new(Parameters::new(db, parameters), field.declared_ty)
+            Signature::new(
+                Parameters::from_annotation(db, parameters),
+                field.declared_ty,
+            )
         })
         .chain(
             typed_dict
@@ -644,7 +651,10 @@ fn synthesize_typed_dict_setdefault<'db>(
                         Parameter::positional_only(Some(Name::new_static("default")))
                             .with_annotated_type(default_ty),
                     ];
-                    Signature::new(Parameters::new(db, parameters), typed_dict.value_type(db))
+                    Signature::new(
+                        Parameters::from_annotation(db, parameters),
+                        typed_dict.value_type(db),
+                    )
                 }),
         );
 
@@ -664,7 +674,7 @@ fn synthesize_typed_dict_no_argument_method<'db>(
     Type::function_like_callable(
         db,
         Signature::new(
-            Parameters::new(
+            Parameters::from_annotation(
                 db,
                 [Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(Type::TypedDict(typed_dict))],
@@ -719,7 +729,7 @@ fn synthesize_typed_dict_merge<'db>(
     ];
 
     overloads = smallvec::smallvec![Signature::new(
-        Parameters::new(db, first_overload_parameters,),
+        Parameters::from_annotation(db, first_overload_parameters,),
         instance_ty,
     )];
 
@@ -748,7 +758,7 @@ fn synthesize_typed_dict_merge<'db>(
                 .with_annotated_type(partial_ty),
         ];
         overloads.push(Signature::new(
-            Parameters::new(db, overload_two_parameters),
+            Parameters::from_annotation(db, overload_two_parameters),
             instance_ty,
         ));
 
@@ -759,7 +769,7 @@ fn synthesize_typed_dict_merge<'db>(
                 .with_annotated_type(dict_param_ty),
         ];
         overloads.push(Signature::new(
-            Parameters::new(db, overload_three_parameters),
+            Parameters::from_annotation(db, overload_three_parameters),
             dict_return_ty,
         ));
     }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3309,7 +3309,7 @@ mod tests {
         return_ty: Option<Type<'db>>,
     ) -> String {
         Signature::new(
-            Parameters::new(db, parameters),
+            Parameters::from_annotation(db, parameters),
             return_ty.unwrap_or(Type::unknown()),
         )
         .display(db)
@@ -3322,7 +3322,7 @@ mod tests {
         return_ty: Option<Type<'db>>,
     ) -> String {
         Signature::new(
-            Parameters::new(db, parameters),
+            Parameters::from_annotation(db, parameters),
             return_ty.unwrap_or(Type::unknown()),
         )
         .display_with(db, super::DisplaySettings::default().multiline())

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7416,7 +7416,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .chain(keyword_only)
                 .chain(keyword_variadic);
 
-            Parameters::new(self.db(), parameters)
+            Parameters::from_annotation(self.db(), parameters)
         } else {
             Parameters::empty()
         };
@@ -7526,7 +7526,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Synthesize overloads for `__getitem__` based on known dictionary elements.
         let getitem_overloads = elements.into_iter().map(|(name, ty)| {
             Signature::new(
-                Parameters::new(
+                Parameters::from_annotation(
                     db,
                     [
                         Parameter::positional_only(Some(Name::new_static("self"))),

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -993,7 +993,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // TODO: `Unpack`
                     Parameters::todo()
                 } else {
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         parameter_types.iter().map(|param_type| {
                             Parameter::positional_only(None).with_annotated_type(*param_type)
@@ -1066,7 +1066,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     {
                         return Ok(Type::paramspec_value_callable(
                             db,
-                            Parameters::new(
+                            Parameters::from_annotation(
                                 db,
                                 [
                                     Parameter::positional_only(None)
@@ -1095,7 +1095,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 // type.
                                 Parameters::unknown()
                             } else {
-                                Parameters::new(
+                                Parameters::from_annotation(
                                     db,
                                     [Parameter::positional_only(None)
                                         .with_annotated_type(param_type)],

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2716,7 +2716,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     // TODO: `Unpack`
                     Parameters::todo()
                 } else {
-                    Parameters::new(
+                    Parameters::from_annotation(
                         self.db(),
                         parameter_types.iter().map(|param_type| {
                             Parameter::positional_only(None).with_annotated_type(*param_type)

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -107,7 +107,7 @@ fn sequence_pattern_getitem_method<'db>(
         .into_iter()
         .map(|(index, element_type)| {
             Signature::new(
-                Parameters::new(
+                Parameters::from_annotation(
                     db,
                     [
                         self_parameter(),
@@ -120,7 +120,7 @@ fn sequence_pattern_getitem_method<'db>(
         });
     let fallback_overload = fallback_return_type.map(|fallback_return_type| {
         Signature::new(
-            Parameters::new(
+            Parameters::from_annotation(
                 db,
                 [
                     self_parameter(),
@@ -170,7 +170,10 @@ pub(crate) fn exact_sequence_pattern_type<'db>(
 
     let self_parameter = || Parameter::positional_only(Some(Name::new_static("self")));
 
-    let len_signature = Signature::new(Parameters::new(db, [self_parameter()]), length_type);
+    let len_signature = Signature::new(
+        Parameters::from_annotation(db, [self_parameter()]),
+        length_type,
+    );
     let len_method = CallableType::function_like(db, len_signature);
 
     let getitem_method = (element_types.len() > 0).then(|| {

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -311,7 +311,7 @@ impl<'db> KnownBoundMethodType<'db> {
             | KnownBoundMethodType::PropertyDunderGet(_) => Either::Left(Either::Left(
                 [
                     Signature::new(
-                        Parameters::new(
+                        Parameters::from_annotation(
                             db,
                             [
                                 Parameter::positional_only(Some(Name::new_static("instance")))
@@ -323,7 +323,7 @@ impl<'db> KnownBoundMethodType<'db> {
                         Type::unknown(),
                     ),
                     Signature::new(
-                        Parameters::new(
+                        Parameters::from_annotation(
                             db,
                             [
                                 Parameter::positional_only(Some(Name::new_static("instance")))
@@ -347,7 +347,7 @@ impl<'db> KnownBoundMethodType<'db> {
             )),
             KnownBoundMethodType::PropertyDunderSet(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("instance")))
@@ -361,7 +361,7 @@ impl<'db> KnownBoundMethodType<'db> {
             }
             KnownBoundMethodType::PropertyDunderDelete(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("instance")))
@@ -373,7 +373,7 @@ impl<'db> KnownBoundMethodType<'db> {
             }
             KnownBoundMethodType::StrStartswith(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("prefix")))
@@ -404,7 +404,7 @@ impl<'db> KnownBoundMethodType<'db> {
 
             KnownBoundMethodType::ConstraintSetRange => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("lower_bound")))
@@ -429,7 +429,7 @@ impl<'db> KnownBoundMethodType<'db> {
 
             KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("ty")))
@@ -444,7 +444,7 @@ impl<'db> KnownBoundMethodType<'db> {
 
             KnownBoundMethodType::ConstraintSetSatisfies(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [Parameter::positional_only(Some(Name::new_static("other")))
                             .with_annotated_type(KnownClass::ConstraintSet.to_instance(db))],
@@ -455,7 +455,7 @@ impl<'db> KnownBoundMethodType<'db> {
 
             KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [Parameter::keyword_only(Name::new_static("inferable"))
                             .with_annotated_type(UnionType::from_two_elements(
@@ -607,7 +607,7 @@ impl WrapperDescriptorKind {
             let descriptor = class.to_instance(db);
             [
                 Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("self")))
@@ -621,7 +621,7 @@ impl WrapperDescriptorKind {
                     Type::unknown(),
                 ),
                 Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("self")))
@@ -652,7 +652,7 @@ impl WrapperDescriptorKind {
             WrapperDescriptorKind::PropertyDunderSet => {
                 let object = Type::object();
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("self")))
@@ -668,7 +668,7 @@ impl WrapperDescriptorKind {
             }
             WrapperDescriptorKind::PropertyDunderDelete => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::new(
+                    Parameters::from_annotation(
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("self")))

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4071,7 +4071,7 @@ fn required_typeddict_key<'db>(
 /// synthesized `TypedDict` used for `TypedDict` arms.
 fn key_membership_contains_protocol<'db>(db: &'db dyn Db, key: &str) -> Type<'db> {
     let signature = Signature::new(
-        Parameters::new(
+        Parameters::from_annotation(
             db,
             [
                 Parameter::positional_only(Some(Name::new_static("self"))),

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -1442,7 +1442,7 @@ fn check_post_init_signature<'db>(
         Parameter::positional_only(Some(name.clone())).with_annotated_type(field.declared_ty)
     });
 
-    let parameters = Parameters::new(
+    let parameters = Parameters::from_annotation(
         db,
         std::iter::chain([first_parameter], following_parameters),
     );

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -93,7 +93,7 @@ impl CallableParams {
     pub(crate) fn into_parameters(self, db: &TestDb) -> Parameters<'_> {
         match self {
             CallableParams::GradualForm => Parameters::gradual_form(),
-            CallableParams::List(params) => Parameters::new(
+            CallableParams::List(params) => Parameters::from_annotation(
                 db,
                 params.into_iter().map(|param| {
                     let parameter = match param.kind {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -953,16 +953,23 @@ impl<'db> Signature<'db> {
     }
 
     pub(crate) fn bind_self(&self, db: &'db dyn Db, self_type: Option<Type<'db>>) -> Self {
-        let mut parameters = self.parameters.iter().cloned().peekable();
-        let removed_receiver = parameters.peek().is_some_and(Parameter::is_positional);
+        let removed_receiver = self.parameters.get(0).is_some_and(Parameter::is_positional);
 
         // TODO: Theoretically, for a signature like `f(*args: *tuple[MyClass, int, *tuple[str, ...]])` with
         // a variadic first parameter, we should also "skip the first parameter" by modifying the tuple type.
-        if removed_receiver {
-            parameters.next();
-        }
-
-        let mut parameters = Parameters::new(db, parameters);
+        let mut parameters = if removed_receiver {
+            let remaining = self.parameters.iter().skip(1).cloned();
+            if self.parameters.is_standard() {
+                // Whether `*args: Any, **kwargs: Any` is gradual is determined from the original
+                // annotations. A standard generic signature must remain standard if specialization
+                // later replaces both annotations with `Any`.
+                Parameters::from_parts(remaining.collect::<Box<[_]>>(), ParametersKind::Standard)
+            } else {
+                Parameters::new(db, remaining)
+            }
+        } else {
+            self.parameters.clone()
+        };
         let mut return_ty = self.return_ty;
         let binding_context = self.definition.map(BindingContext::Definition);
         if let Some(self_type) = self_type

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -280,7 +280,7 @@ impl<'db> CallableSignature<'db> {
                             type_mapping.update_signature_generic_context(db, context)
                         }),
                         definition: self_signature.definition,
-                        parameters: Parameters::new(
+                        parameters: Parameters::from_annotation(
                             db,
                             prefix_parameters
                                 .iter()
@@ -324,7 +324,7 @@ impl<'db> CallableSignature<'db> {
                             parameters: if signature.parameters().is_top() {
                                 signature.parameters().clone()
                             } else {
-                                Parameters::new(
+                                Parameters::from_annotation(
                                     db,
                                     prefix_parameters
                                         .iter()
@@ -761,7 +761,7 @@ impl<'db> Signature<'db> {
             .cycle_normalized(db, previous.return_ty, cycle);
 
         let parameters = if self.parameters.len() == previous.parameters.len() {
-            Parameters::new(
+            Parameters::from_annotation(
                 db,
                 self.parameters
                     .iter()
@@ -800,7 +800,7 @@ impl<'db> Signature<'db> {
             for param in &self.parameters {
                 parameters.push(param.recursive_type_normalized_impl(db, div, nested)?);
             }
-            Parameters::new(db, parameters)
+            Parameters::from_annotation(db, parameters)
         };
         Some(Self {
             generic_context: self.generic_context,
@@ -958,15 +958,7 @@ impl<'db> Signature<'db> {
         // TODO: Theoretically, for a signature like `f(*args: *tuple[MyClass, int, *tuple[str, ...]])` with
         // a variadic first parameter, we should also "skip the first parameter" by modifying the tuple type.
         let mut parameters = if removed_receiver {
-            let remaining = self.parameters.iter().skip(1).cloned();
-            if self.parameters.is_standard() {
-                // Whether `*args: Any, **kwargs: Any` is gradual is determined from the original
-                // annotations. A standard generic signature must remain standard if specialization
-                // later replaces both annotations with `Any`.
-                Parameters::from_parts(remaining.collect::<Box<[_]>>(), ParametersKind::Standard)
-            } else {
-                Parameters::new(db, remaining)
-            }
+            self.parameters.without_first()
         } else {
             self.parameters.clone()
         };
@@ -1159,7 +1151,7 @@ impl<'db> Signature<'db> {
 
         // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
         // below can separate them, which would otherwise prevent expansion.
-        let remaining = Parameters::new(db, remaining).expand_paramspec_variadics(db);
+        let remaining = Parameters::from_annotation(db, remaining).expand_paramspec_variadics(db);
 
         let mut reordered = Vec::with_capacity(remaining.len());
         let mut keyword_only = Vec::new();
@@ -1187,7 +1179,7 @@ impl<'db> Signature<'db> {
         reordered.extend(keyword_variadic);
 
         signature
-            .with_parameters(Parameters::new(db, reordered))
+            .with_parameters(Parameters::from_annotation(db, reordered))
             .with_return_type(return_ty)
     }
 
@@ -2368,7 +2360,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         db,
                         CallableSignature::single(Signature::new_generic(
                             source.generic_context,
-                            Parameters::new(db, source_params.cloned()),
+                            Parameters::from_annotation(db, source_params.cloned()),
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
@@ -2501,7 +2493,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         db,
                         CallableSignature::single(Signature::new_generic(
                             target.generic_context,
-                            Parameters::new(db, target_params.cloned()),
+                            Parameters::from_annotation(db, target_params.cloned()),
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
@@ -3115,6 +3107,10 @@ pub(crate) enum ConcatenateTail<'db> {
 }
 
 /// The kind of parameter list represented.
+///
+/// For annotation-derived parameter lists, the kind records the form of the original annotation
+/// and must be preserved when its parameter types are transformed. In particular, specializing a
+/// standard `(*args: T, **kwargs: T)` parameter list with `T = Any` does not make it gradual.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 pub(crate) enum ParametersKind<'db> {
     /// A standard parameter list.
@@ -3184,7 +3180,12 @@ pub(crate) struct Parameters<'db> {
 }
 
 impl<'db> Parameters<'db> {
-    fn from_parts(value: impl Into<Box<[Parameter<'db>]>>, kind: ParametersKind<'db>) -> Self {
+    /// Create a parameter list with an explicit kind.
+    ///
+    /// This constructor does not infer the kind from the parameter types or normalize an unpacked
+    /// `TypedDict`. Use [`Self::from_annotation`] when the kind should be inferred from
+    /// annotations; preserve the existing kind when transforming a parameter list.
+    pub(crate) fn new(value: impl Into<Box<[Parameter<'db>]>>, kind: ParametersKind<'db>) -> Self {
         Self {
             data: Arc::new(ParametersData {
                 value: value.into(),
@@ -3193,7 +3194,7 @@ impl<'db> Parameters<'db> {
         }
     }
 
-    /// Create a new parameter list from an iterator of parameters.
+    /// Create a parameter list, normalizing it and inferring its kind from annotations.
     ///
     /// The kind of the parameter list is determined based on the provided parameters. Specifically,
     /// if the parameter list contains `*args` and `**kwargs`, then it checks their annotated types
@@ -3201,7 +3202,7 @@ impl<'db> Parameters<'db> {
     /// `ParamSpec`, or a `Concatenate` form. `**kwargs: Unpack[TypedDict]` is normalized here by
     /// synthesizing keyword-only parameters for the unpacked keys and a possible trailing
     /// `**kwargs` parameter for explicit extra items or an open `TypedDict`.
-    pub(crate) fn new(
+    pub(crate) fn from_annotation(
         db: &'db dyn Db,
         parameters: impl IntoIterator<Item = Parameter<'db>>,
     ) -> Self {
@@ -3330,12 +3331,12 @@ impl<'db> Parameters<'db> {
             }
         }
 
-        Self::from_parts(value, kind)
+        Self::new(value, kind)
     }
 
     /// Create an empty parameter list.
     pub(crate) fn empty() -> Self {
-        Self::from_parts(Box::default(), ParametersKind::Standard)
+        Self::new(Box::default(), ParametersKind::Standard)
     }
 
     pub(crate) fn as_slice(&self) -> &[Parameter<'db>] {
@@ -3344,6 +3345,26 @@ impl<'db> Parameters<'db> {
 
     pub(crate) fn kind(&self) -> ParametersKind<'db> {
         self.data.kind
+    }
+
+    /// Return a copy of this parameter list without its first parameter.
+    ///
+    /// Removing the only prefix parameter from a `Concatenate` form leaves the tail as a plain
+    /// gradual or `ParamSpec` parameter list.
+    fn without_first(&self) -> Self {
+        let parameters = self.iter().skip(1).cloned().collect::<Box<[_]>>();
+        let kind = match self.data.kind {
+            ParametersKind::Concatenate(tail)
+                if parameters.first().is_some_and(Parameter::is_variadic) =>
+            {
+                match tail {
+                    ConcatenateTail::Gradual => ParametersKind::Gradual,
+                    ConcatenateTail::ParamSpec(typevar) => ParametersKind::ParamSpec(typevar),
+                }
+            }
+            kind => kind,
+        };
+        Self::new(parameters, kind)
     }
 
     /// Returns `true` if the parameters represent a gradual form using `...` as the only parameter
@@ -3398,7 +3419,7 @@ impl<'db> Parameters<'db> {
 
     /// Return todo parameters: (*args: Todo, **kwargs: Todo)
     pub(crate) fn todo() -> Self {
-        Self::from_parts(
+        Self::new(
             [
                 Parameter::variadic(Name::new_static("args"))
                     .with_annotated_type(todo_type!("todo signature *args")),
@@ -3415,7 +3436,7 @@ impl<'db> Parameters<'db> {
     ///
     /// [`Any`]: DynamicType::Any
     pub(crate) fn gradual_form() -> Self {
-        Self::from_parts(
+        Self::new(
             [
                 Parameter::variadic(Name::new_static("args"))
                     .with_annotated_type(Type::Dynamic(DynamicType::Any)),
@@ -3427,7 +3448,7 @@ impl<'db> Parameters<'db> {
     }
 
     pub(crate) fn paramspec(db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> Self {
-        Self::from_parts(
+        Self::new(
             [
                 Parameter::variadic(Name::new_static("args")).with_annotated_type(Type::TypeVar(
                     typevar.with_paramspec_attr(db, ParamSpecAttrKind::Args),
@@ -3463,7 +3484,7 @@ impl<'db> Parameters<'db> {
             Parameter::keyword_variadic(Name::new_static("kwargs"))
                 .with_annotated_type(kwargs_type),
         ]);
-        Self::from_parts(prefix_params, ParametersKind::Concatenate(concatenate_tail))
+        Self::new(prefix_params, ParametersKind::Concatenate(concatenate_tail))
     }
 
     /// Return parameters that represents an unknown list of parameters.
@@ -3473,7 +3494,7 @@ impl<'db> Parameters<'db> {
     ///
     /// [`Unknown`]: crate::types::DynamicType::Unknown
     pub(crate) fn unknown() -> Self {
-        Self::from_parts(
+        Self::new(
             [
                 Parameter::variadic(Name::new_static("args"))
                     .with_annotated_type(Type::Dynamic(DynamicType::Unknown)),
@@ -3487,7 +3508,7 @@ impl<'db> Parameters<'db> {
     /// Return parameters that represents `(*args: object, **kwargs: object)`, the bottom signature
     /// (accepts any call, so subtype of all other signatures.)
     pub(crate) fn bottom() -> Self {
-        Self::from_parts(
+        Self::new(
             [
                 Parameter::variadic(Name::new_static("args")).with_annotated_type(Type::object()),
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
@@ -3503,7 +3524,7 @@ impl<'db> Parameters<'db> {
     /// and still accepts the empty call `()`; it has to be represented instead as a special
     /// `ParametersKind`.
     pub(crate) fn top() -> Self {
-        Self::from_parts(
+        Self::new(
             // We always emit `called-top-callable` for any call to the top callable (based on the
             // `kind` below), so we otherwise give it the most permissive signature`(*object,
             // **object)`, so that we avoid emitting any other errors about arity mismatches.
@@ -3621,7 +3642,7 @@ impl<'db> Parameters<'db> {
             )
         });
 
-        Self::new(
+        Self::from_annotation(
             db,
             positional_only
                 .into_iter()
@@ -3667,7 +3688,7 @@ impl<'db> Parameters<'db> {
             .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
             .collect();
 
-        Self::from_parts(value, self.data.kind)
+        Self::new(value, self.data.kind)
     }
     pub(crate) fn len(&self) -> usize {
         self.data.value.len()
@@ -3789,7 +3810,7 @@ impl<'db> Parameters<'db> {
         expanded.extend_from_slice(&self.data.value[..variadic_index]);
         expanded.extend_from_slice(mapped_signature.parameters().as_slice());
         expanded.extend_from_slice(&self.data.value[variadic_index + 2..]);
-        Parameters::new(db, expanded)
+        Parameters::from_annotation(db, expanded)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -572,7 +572,7 @@ impl<'db> TypeVarInstance<'db> {
                 Type::NominalInstance(nominal_instance) => nominal_instance
                     .own_tuple_spec(db)
                     .map_or_else(Parameters::unknown, |tuple_spec| {
-                        Parameters::new(
+                        Parameters::from_annotation(
                             db,
                             tuple_spec
                                 .iter_all_elements()


### PR DESCRIPTION
## Summary

The typing specification treats a callback declared with `*args: Any, **kwargs: Any` as a gradual callable (i.e., accepting any argument list). This rule applies when the parameters themselves are annotated as `Any`; it does not apply to `*args: T, **kwargs: T`, even if a later specialization replaces `T` with `Any`.

When removing `self` from a bound method, we rebuilt the parameters after specializing `T`, so ty saw `Any` and incorrectly treated the callback as accepting any arguments. Preserve the original interpretation of the parameters while removing `self`, and add a regression test for the final missing diagnostic in the typing conformance suite's [`callables_annotation.py`](https://github.com/python/typing/blob/f9664d894c8cbfca8fba44624bdedef09add1aa7/conformance/tests/callables_annotation.py#L159).