### PR TITLE
[ty] Preserve exhaustive gradual match patterns

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -97,8 +97,7 @@ python-version = "3.12"
 ```
 
 ```py
-from collections.abc import Mapping
-from typing import Any, assert_never
+from typing import assert_never
 
 class Covariant[T]:
     def get(self) -> T:
@@ -111,72 +110,6 @@ def f(x: Covariant[int]):
         case _:
             reveal_type(x)  # revealed: Never
             assert_never(x)
-
-class Box[T]:
-    value: T
-
-def exhaustive_gradual_class_pattern(value: Box[Any] | int) -> None:
-    match value:
-        case Box(value=_):
-            reveal_type(value)  # revealed: Box[Any] | (int & Top[Box[Unknown]])
-        case int():
-            reveal_type(value)  # revealed: int & ~Top[Box[Any]]
-        case _:
-            assert_never(value)
-
-def exhaustive_gradual_mapping_pattern(value: Mapping[str, Any] | int) -> None:
-    match value:
-        case Mapping():
-            pass
-        case int():
-            pass
-        case _:
-            assert_never(value)
-
-def exhaustive_subject_specific_gradual_class_pattern(
-    value: Box[Mapping[str, Any]] | int,
-) -> None:
-    match value:
-        case Box(value=Mapping()):
-            pass
-        case int():
-            pass
-        case _:
-            reveal_type(value)  # revealed: Never
-            assert_never(value)
-
-def subject_specific_gradual_class_pattern_preserves_other_specializations(
-    value: Box[Mapping[str, Any]] | Box[int],
-) -> None:
-    match value:
-        case Box(value=Mapping()):
-            pass
-        case _:
-            reveal_type(value)  # revealed: Box[int]
-
-def exhaustive_sequence_wrapped_gradual_class_pattern(
-    value: tuple[Mapping[str, Any]] | int,
-) -> None:
-    match value:
-        case [Mapping()]:
-            pass
-        case int():
-            pass
-        case _:
-            reveal_type(value)  # revealed: Never
-            assert_never(value)
-
-def exhaustive_sequence_preserves_previous_exclusions(
-    value: tuple[Box[Any]] | int | str,
-) -> None:
-    match value:
-        case int():
-            pass
-        case [Box(value=_)]:
-            reveal_type(value)  # revealed: tuple[Box[Any]]
-        case _:
-            reveal_type(value)  # revealed: str
-            len(value)  # fine
 ```
 
 ## Class patterns with generic `@final` classes
@@ -2119,6 +2052,78 @@ def possibly_missing_attribute_is_not_exhaustive(
             return 1
 ```
 
+## Exhaustiveness for types containing `Any`
+
+When `Any` appears within a type, it stands for many possible static types. An exhaustive pattern
+must eliminate all of them; otherwise, a contradictory type such as
+`Mapping[str, Any] & ~Mapping[str, Any]` can remain in the final case.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+The order of the first two cases below reproduces issue #3904:
+
+```py
+from collections.abc import Mapping
+from typing import Any, assert_never
+
+def mapping_with_any_is_exhaustive(value: Mapping[str, Any] | int) -> None:
+    match value:
+        case Mapping():
+            pass
+        case int():
+            pass
+        case _:
+            assert_never(value)
+```
+
+Class patterns over generic classes follow the same rule:
+
+```py
+class Box[T]:
+    value: T
+
+def generic_class_with_any_is_exhaustive(value: Box[Any] | int) -> None:
+    match value:
+        case Box(value=_):
+            pass
+        case int():
+            pass
+        case _:
+            assert_never(value)
+```
+
+A nested pattern can be exhaustive for only part of a union. Here the first case removes
+`Box[Mapping[str, Any]]` but must leave `Box[int]` in the final case:
+
+```py
+def nested_pattern_keeps_unmatched_box(
+    value: Box[Mapping[str, Any]] | Box[int],
+) -> None:
+    match value:
+        case Box(value=Mapping()):
+            pass
+        case _:
+            reveal_type(value)  # revealed: Box[int]
+```
+
+The same check applies to a class pattern nested inside a sequence pattern:
+
+```py
+def nested_sequence_pattern_is_exhaustive(
+    value: tuple[Mapping[str, Any]] | int,
+) -> None:
+    match value:
+        case [Mapping()]:
+            pass
+        case int():
+            pass
+        case _:
+            assert_never(value)
+```
+
 ## Sequence exhaustiveness
 
 Sequence patterns also contribute to negative narrowing and exhaustiveness. Exact tuple shapes can
@@ -2194,6 +2199,22 @@ def test_match_exact_mutable_sequence_negative(value: list[int]) -> None:
             pass
         case _:
             reveal_type(value)  # revealed: list[int]
+```
+
+Narrowing with a sequence pattern must not bring back a type removed by an earlier case. After the
+first two cases below, only `str` remains:
+
+```py
+def sequence_pattern_preserves_earlier_case(
+    value: tuple[int] | int | str,
+) -> None:
+    match value:
+        case int():
+            pass
+        case [int()]:
+            pass
+        case _:
+            reveal_type(value)  # revealed: str
 ```
 
 Named tuples are statically known tuple subclasses, rather than exact `tuple[...]` instances.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -97,7 +97,8 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import assert_never
+from collections.abc import Mapping
+from typing import Any, assert_never
 
 class Covariant[T]:
     def get(self) -> T:
@@ -110,6 +111,60 @@ def f(x: Covariant[int]):
         case _:
             reveal_type(x)  # revealed: Never
             assert_never(x)
+
+class Box[T]:
+    value: T
+
+def exhaustive_gradual_class_pattern(value: Box[Any] | int) -> None:
+    match value:
+        case Box(value=_):
+            reveal_type(value)  # revealed: Box[Any] | (int & Top[Box[Unknown]])
+        case int():
+            reveal_type(value)  # revealed: int & ~Top[Box[Any]]
+        case _:
+            assert_never(value)
+
+def exhaustive_gradual_mapping_pattern(value: Mapping[str, Any] | int) -> None:
+    match value:
+        case Mapping():
+            pass
+        case int():
+            pass
+        case _:
+            assert_never(value)
+
+def exhaustive_subject_specific_gradual_class_pattern(
+    value: Box[Mapping[str, Any]] | int,
+) -> None:
+    match value:
+        case Box(value=Mapping()):
+            pass
+        case int():
+            pass
+        case _:
+            reveal_type(value)  # revealed: Never
+            assert_never(value)
+
+def subject_specific_gradual_class_pattern_preserves_other_specializations(
+    value: Box[Mapping[str, Any]] | Box[int],
+) -> None:
+    match value:
+        case Box(value=Mapping()):
+            pass
+        case _:
+            reveal_type(value)  # revealed: Box[int]
+
+def exhaustive_sequence_wrapped_gradual_class_pattern(
+    value: tuple[Mapping[str, Any]] | int,
+) -> None:
+    match value:
+        case [Mapping()]:
+            pass
+        case int():
+            pass
+        case _:
+            reveal_type(value)  # revealed: Never
+            assert_never(value)
 ```
 
 ## Class patterns with generic `@final` classes

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -165,6 +165,18 @@ def exhaustive_sequence_wrapped_gradual_class_pattern(
         case _:
             reveal_type(value)  # revealed: Never
             assert_never(value)
+
+def exhaustive_sequence_preserves_previous_exclusions(
+    value: tuple[Box[Any]] | int | str,
+) -> None:
+    match value:
+        case int():
+            pass
+        case [Box(value=_)]:
+            reveal_type(value)  # revealed: tuple[Box[Any]]
+        case _:
+            reveal_type(value)  # revealed: str
+            len(value)  # fine
 ```
 
 ## Class patterns with generic `@final` classes

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -572,6 +572,10 @@ fn sequence_pattern_is_exhaustive_for_subject(
 /// could raise at runtime. The same rule is propagated through nested sequence, `or`, and `as`
 /// patterns.
 ///
+/// When a pattern exhausts a gradual subject, the definite-match type is the subject's top
+/// materialization. Negative narrowing can then eliminate every materialization of the subject,
+/// including when exhaustiveness depends on a nested pattern.
+///
 /// ```python
 /// class Base:
 ///     x: int
@@ -615,7 +619,11 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
             match class_ty {
                 Type::ClassLiteral(class) => {
                     if class_pattern_is_exhaustive(db, class, resolved_subject_ty, kind) {
-                        return subject_ty;
+                        let top_subject_ty = resolved_subject_ty.top_materialization(db);
+                        if !class_pattern_is_exhaustive(db, class, top_subject_ty, kind) {
+                            return subject_ty;
+                        }
+                        return top_subject_ty;
                     }
                 }
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
@@ -628,20 +636,28 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
             }
         }
         PatternPredicateKind::Sequence(kind) => {
-            return if sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
-                subject_ty
-            } else {
+            if !sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
                 // A nested subject-dependent pattern rejected the context-free approximation.
                 // Reusing that approximation for the surrounding sequence would reintroduce the
                 // values that the recursive analysis deliberately excluded.
-                Type::Never
+                return Type::Never;
+            }
+            let top_subject_ty = resolved_subject_ty.top_materialization(db);
+            return if sequence_pattern_is_exhaustive_for_subject(db, kind, top_subject_ty) {
+                top_subject_ty
+            } else {
+                subject_ty
             };
         }
         PatternPredicateKind::Mapping(kind) => {
-            return if mapping_pattern_is_exhaustive(db, kind, resolved_subject_ty) {
-                subject_ty
+            if !mapping_pattern_is_exhaustive(db, kind, resolved_subject_ty) {
+                return Type::Never;
+            }
+            let top_subject_ty = resolved_subject_ty.top_materialization(db);
+            return if mapping_pattern_is_exhaustive(db, kind, top_subject_ty) {
+                top_subject_ty
             } else {
-                Type::Never
+                subject_ty
             };
         }
         PatternPredicateKind::Or(patterns) => {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3518,7 +3518,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         PatternNarrowingResult::Possible(Some(NarrowingConstraints::from_iter([(
             place,
-            NarrowingConstraint::replacement(narrowed_ty),
+            NarrowingConstraint::intersection(narrowed_ty),
         )])))
     }
 


### PR DESCRIPTION
## Summary

Previously, an exhaustive match over a gradual union could leave a false "fallthrough" type depending on the order of the cases:

```python
from collections.abc import Mapping
from typing import Any, assert_never

def handle(value: Mapping[str, Any] | int) -> None:
    match value:
        case Mapping():
            pass
        case int():
            pass
        case _:
            # `main`: `value` is `Mapping[str, Any] & ~Mapping[str, Any] & ~int`,
            # so `assert_never` reports `type-assertion-failure`.
            # This branch: `value` is `Never`, so `assert_never` passes.
            assert_never(value)
```

Previously, pattern analysis returned an exhausted gradual subject itself as the definite-match type. Subtracting that type from the remaining subject could construct `Mapping[str, Any] & ~Mapping[str, Any]`, which intentionally does not simplify to `Never` because the gradual type represents multiple static materializations.

Instead, we now use the top materialization of an exhausted subject as its definite-match type.

Closes https://github.com/astral-sh/ty/issues/3904.
