### PR TITLE
[ty] Preserve generic materialization through specialization

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -845,6 +845,9 @@ static_assert(not is_assignable_to(Top[InvariantChild[Any]], CovariantBase[A]))
 
 Attributes on top and bottom materializations are specialized on access.
 
+If the type variable appears inside another invariant specialization, the enclosing top or bottom
+materialization is preserved. This applies in both return types and parameter types.
+
 ```toml
 [environment]
 python-version = "3.12"
@@ -859,18 +862,47 @@ class Invariant[T]:
         raise NotImplementedError
 
     def push(self, obj: T) -> None: ...
+    def copy(self) -> "Invariant[T]":
+        raise NotImplementedError
+
+    def replace(self, other: "Invariant[T]") -> None: ...
 
     attr: T
 
 def capybara(top: Top[Invariant[Any]], bottom: Bottom[Invariant[Any]]) -> None:
     reveal_type(top.get)  # revealed: bound method Top[Invariant[Any]].get() -> object
     reveal_type(top.push)  # revealed: bound method Top[Invariant[Any]].push(obj: Never) -> None
+    reveal_type(top.copy)  # revealed: bound method Top[Invariant[Any]].copy() -> Top[Invariant[Any]]
+    # revealed: bound method Top[Invariant[Any]].replace(other: Bottom[Invariant[Any]]) -> None
+    reveal_type(top.replace)
 
     reveal_type(bottom.get)  # revealed: bound method Bottom[Invariant[Any]].get() -> Never
     reveal_type(bottom.push)  # revealed: bound method Bottom[Invariant[Any]].push(obj: object) -> None
+    reveal_type(bottom.copy)  # revealed: bound method Bottom[Invariant[Any]].copy() -> Bottom[Invariant[Any]]
+    # revealed: bound method Bottom[Invariant[Any]].replace(other: Top[Invariant[Any]]) -> None
+    reveal_type(bottom.replace)
 
     reveal_type(top.attr)  # revealed: object
     reveal_type(bottom.attr)  # revealed: Never
+```
+
+Type inference also uses the materialized type arguments. The call below is invalid because a top
+materialization is not assignable to a concrete `dict`, but the inferred return type still uses
+`object` rather than `Any`:
+
+```py
+from typing import Any, TypeVar
+from ty_extensions import Top
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+def project_dict(value: dict[K, V]) -> tuple[K, V]:
+    raise NotImplementedError
+
+def infer_top_dict(value: Top[dict[Any, Any]]) -> None:
+    # error: [invalid-argument-type]
+    reveal_type(project_dict(value))  # revealed: tuple[object, object]
 ```
 
 Alias specializations also preserve the materialization polarity in contravariant positions.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1284,6 +1284,19 @@ impl<'db> Specialization<'db> {
             return self.materialize_impl(db, *materialization_kind, visitor);
         }
 
+        if let TypeMapping::ApplySpecializationWithMaterialization {
+            specialization: ApplySpecialization::Specialization(specialization),
+            materialization_kind,
+        } = type_mapping
+            && self.generic_context(db) == specialization.generic_context(db)
+            && self == self.generic_context(db).identity_specialization(db)
+        {
+            // Preserve an enclosing generic specialization as a unit. Recursively mapping an
+            // identity specialization like `dict[_KT, _VT]` would flip the materialization of its
+            // invariant type variables, turning a top-materialized return type into a bottom one.
+            return specialization.with_materialization_kind(db, Some(*materialization_kind));
+        }
+
         let types = self.map_types(db, |i, typevar, ty| {
             let tcx = TypeContext::new(tcx.get(i).copied());
             if typevar.variance(db).is_covariant() {
@@ -2962,14 +2975,20 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                             .variables(self.db);
                         let formal_specialization =
                             formal_alias.specialization(self.db).types(self.db);
-                        let base_specialization = base_alias.specialization(self.db).types(self.db);
+                        let base_specialization = base_alias.specialization(self.db);
+                        let materialization_kind =
+                            base_specialization.materialization_kind(self.db);
+                        let materialization_visitor = ApplyTypeMappingVisitor::default();
                         for (typevar, formal_ty, base_ty) in itertools::izip!(
                             generic_context,
                             formal_specialization,
-                            base_specialization
+                            base_specialization.types(self.db)
                         ) {
                             let variance = typevar.variance_with_polarity(self.db, polarity);
-                            self.infer_map_impl(*formal_ty, *base_ty, variance, seen)?;
+                            let base_ty = materialization_kind.map_or(*base_ty, |kind| {
+                                base_ty.materialize(self.db, kind, &materialization_visitor)
+                            });
+                            self.infer_map_impl(*formal_ty, base_ty, variance, seen)?;
                         }
                         return Ok(());
                     }


### PR DESCRIPTION
## Summary

Preserve enclosing top and bottom materializations when specializing generic method signatures. When a type variable appears inside another invariant specialization of the same generic class, recursively materializing the individual type variables can invert the result. We now retain the enclosing specialization as a unit:

```python
class Box[T]:
    def copy(self) -> "Box[T]": ...

def f(value: Top[Box[Any]]) -> None:
    reveal_type(value.copy())  # Top[Box[Any]]
```

The same rule applies in parameter types, with the opposite materialization polarity, and for bottom materializations.

We also materialize generic-alias arguments before using them for type-parameter inference. For example, inference from `Top[dict[Any, Any]]` now produces `object` key and value types rather than allowing the underlying `Any` arguments to escape the materialization.

This was split from #25851 so that the general materialization behavior can be reviewed independently. #25851 is stacked on this PR.
