### PR TITLE
[ty] Preserve TypedDict Mapping inference precision

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1134,18 +1134,32 @@ def _(x: Intersection[Sequence[Unrelated1], Sequence[Unrelated2]]) -> None:
 Dynamic intersection elements do not prevent inference from a `TypedDict` element:
 
 ```py
-from typing import Any, Iterable, TypedDict, TypeVar
+from typing import Any, Iterable, Mapping, TypedDict, TypeVar
 from ty_extensions import Intersection, Unknown
 
 U = TypeVar("U")
+ValueT = TypeVar("ValueT", bound=int)
 
 class OneKeyTD(TypedDict, closed=True):
     x: int
 
+class StringValueTD(TypedDict, closed=True):
+    x: str
+
 def element(x: Iterable[U]) -> U:
+    raise NotImplementedError
+
+def value(x: Mapping[str, ValueT]) -> ValueT:
     raise NotImplementedError
 
 def _(with_any: Intersection[OneKeyTD, Any], with_unknown: Intersection[OneKeyTD, Unknown]):
     reveal_type(element(with_any))  # revealed: Literal["x"]
     reveal_type(element(with_unknown))  # revealed: Literal["x"]
+
+def _(
+    with_any: Intersection[StringValueTD, Any],
+    with_unknown: Intersection[StringValueTD, Unknown],
+):
+    reveal_type(value(with_any))  # revealed: Unknown
+    reveal_type(value(with_unknown))  # revealed: Unknown
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1130,3 +1130,22 @@ def _(x: Intersection[Sequence[Unrelated1], Sequence[Unrelated2]]) -> None:
     # error: [invalid-argument-type] "Argument to function `first` is incorrect: Argument type `Unrelated1` does not satisfy upper bound `Base` of type variable `T`"
     reveal_type(first(x))  # revealed: Unknown
 ```
+
+Dynamic intersection elements do not prevent inference from a `TypedDict` element:
+
+```py
+from typing import Any, Iterable, TypedDict, TypeVar
+from ty_extensions import Intersection, Unknown
+
+U = TypeVar("U")
+
+class OneKeyTD(TypedDict, closed=True):
+    x: int
+
+def element(x: Iterable[U]) -> U:
+    raise NotImplementedError
+
+def _(with_any: Intersection[OneKeyTD, Any], with_unknown: Intersection[OneKeyTD, Unknown]):
+    reveal_type(element(with_any))  # revealed: Literal["x"]
+    reveal_type(element(with_unknown))  # revealed: Literal["x"]
+```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1413,6 +1413,37 @@ Type validation still applies to all fields when provided:
 invalid_type = Message(id="not-an-int", content="Hello")
 ```
 
+## Generic `Mapping` inference
+
+When inferring the type parameters of `Mapping`, `TypedDict` keys are strings and an explicit
+extra-item type contributes to its value type. An explicit `Mapping` in an intersection remains more
+precise:
+
+```py
+from collections.abc import Mapping
+from typing import TypeVar, TypedDict
+from typing_extensions import ReadOnly
+from ty_extensions import Intersection
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+class Movie(TypedDict):
+    title: str
+
+class ReadOnlyExtras(TypedDict, extra_items=ReadOnly[int]):
+    pass
+
+def project(value: Mapping[K, V]) -> tuple[K, V]:
+    raise NotImplementedError
+
+def preserve_mapping_intersection(value: Intersection[Movie, Mapping[str, bytes]]) -> None:
+    reveal_type(project(value))  # revealed: tuple[str, bytes]
+
+def preserve_extra_item_value_type(value: ReadOnlyExtras) -> None:
+    reveal_type(project(value))  # revealed: tuple[str, int]
+```
+
 ## Structural assignability
 
 Assignability between `TypedDict` types is structural, that is, it is based on the presence of keys

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1434,6 +1434,10 @@ class Movie(TypedDict):
 class ReadOnlyExtras(TypedDict, extra_items=ReadOnly[int]):
     pass
 
+class Closed(TypedDict, closed=True):
+    name: str
+    age: int
+
 def project(value: Mapping[K, V]) -> tuple[K, V]:
     raise NotImplementedError
 
@@ -1442,6 +1446,9 @@ def preserve_mapping_intersection(value: Intersection[Movie, Mapping[str, bytes]
 
 def preserve_extra_item_value_type(value: ReadOnlyExtras) -> None:
     reveal_type(project(value))  # revealed: tuple[str, int]
+
+def preserve_closed_value_type(value: Closed) -> None:
+    reveal_type(project(value))  # revealed: tuple[str, int | str]
 ```
 
 ## Structural assignability

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2849,6 +2849,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                                     self.inferable,
                                 )
                                 .is_never_satisfied(self.db)
+                                && !positive.is_dynamic()
                             {
                                 found_matching_element = true;
                             }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2797,6 +2797,13 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     self.infer_map_impl(positive, actual, polarity, seen)?;
                 }
             }
+            (formal @ Type::NominalInstance(_), Type::TypedDict(typed_dict)) => {
+                let mapping = KnownClass::Mapping.to_specialized_instance(
+                    self.db,
+                    &[typed_dict.key_type(self.db), typed_dict.value_type(self.db)],
+                );
+                return self.infer_map_impl(formal, mapping, polarity, seen);
+            }
             (_, Type::Intersection(actual_intersection)) => {
                 // Try to infer type mappings by checking against each intersection element. This
                 // is the dual of the `union_formal` arm above, and it handles cases like:
@@ -2813,28 +2820,44 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 //
                 // It's sufficient for one intersection element to satisfy the constraints here.
                 // They don't all have to.
+                let positives: Vec<_> = actual_intersection.iter_positive(self.db).collect();
                 let mut first_error = None;
-                let mut found_matching_element = false;
-                for positive in actual_intersection.iter_positive(self.db) {
-                    let result = self.infer_map_impl(formal, positive, polarity, seen);
-                    if let Err(err) = result {
-                        // TODO: `infer_map_impl` can have side effects even in the error case, so
-                        // to be fully correct here we'd need to snapshot `self.types` before each
-                        // call and roll it back if we get an error. The `Union` arm has the same
-                        // issue above.
-                        first_error.get_or_insert(err);
-                    } else {
-                        // The recursive call to `infer_map_impl` may succeed even if the actual
-                        // type is not assignable to the formal element.
-                        if !positive
-                            .when_assignable_to(self.db, formal, self.constraints, self.inferable)
-                            .is_never_satisfied(self.db)
-                        {
-                            found_matching_element = true;
+
+                for include_typed_dicts in [false, true] {
+                    let mut found_matching_element = false;
+                    for positive in positives.iter().copied().filter(|positive| {
+                        matches!(positive, Type::TypedDict(_)) == include_typed_dicts
+                    }) {
+                        let result = self.infer_map_impl(formal, positive, polarity, seen);
+                        if let Err(err) = result {
+                            // TODO: `infer_map_impl` can have side effects even in the error case,
+                            // so to be fully correct here we'd need to snapshot `self.types` before
+                            // each call and roll it back if we get an error. The `Union` arm has the
+                            // same issue above.
+                            first_error.get_or_insert(err);
+                        } else {
+                            // The recursive call to `infer_map_impl` may succeed even if the actual
+                            // type is not assignable to the formal element.
+                            if !positive
+                                .when_assignable_to(
+                                    self.db,
+                                    formal,
+                                    self.constraints,
+                                    self.inferable,
+                                )
+                                .is_never_satisfied(self.db)
+                            {
+                                found_matching_element = true;
+                            }
                         }
                     }
+
+                    if found_matching_element {
+                        return Ok(());
+                    }
                 }
-                if !found_matching_element && let Some(error) = first_error {
+
+                if let Some(error) = first_error {
                     return Err(error);
                 }
             }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2823,15 +2823,15 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 //
                 // It's sufficient for one intersection element to satisfy the constraints here.
                 // They don't all have to.
-                let positives: Vec<_> = actual_intersection.iter_positive(self.db).collect();
                 let mut first_error = None;
                 let mut found_dynamic_element = false;
 
                 for include_typed_dicts in [false, true] {
                     let mut found_matching_element = false;
-                    for positive in positives.iter().copied().filter(|positive| {
-                        matches!(positive, Type::TypedDict(_)) == include_typed_dicts
-                    }) {
+                    for positive in actual_intersection.iter_positive(self.db) {
+                        if matches!(positive, Type::TypedDict(_)) != include_typed_dicts {
+                            continue;
+                        }
                         let result = self.infer_map_impl(formal, positive, polarity, seen);
                         if let Err(err) = result {
                             // TODO: `infer_map_impl` can have side effects even in the error case,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2825,6 +2825,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // They don't all have to.
                 let positives: Vec<_> = actual_intersection.iter_positive(self.db).collect();
                 let mut first_error = None;
+                let mut found_dynamic_element = false;
 
                 for include_typed_dicts in [false, true] {
                     let mut found_matching_element = false;
@@ -2849,9 +2850,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                                     self.inferable,
                                 )
                                 .is_never_satisfied(self.db)
-                                && !positive.is_dynamic()
                             {
-                                found_matching_element = true;
+                                if positive.is_dynamic() {
+                                    found_dynamic_element = true;
+                                } else {
+                                    found_matching_element = true;
+                                }
                             }
                         }
                     }
@@ -2861,6 +2865,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     }
                 }
 
+                if found_dynamic_element {
+                    return Ok(());
+                }
                 if let Some(error) = first_error {
                     return Err(error);
                 }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2826,10 +2826,15 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 let mut first_error = None;
                 let mut found_dynamic_element = false;
 
-                for include_typed_dicts in [false, true] {
+                // A `TypedDict` infers through a synthesized `Mapping[str, value_type]`, but an
+                // intersection can contain an explicit `Mapping` with more precise type arguments.
+                // Try non-`TypedDict` elements first, and consult `TypedDict`s only if that pass
+                // finds no concrete match. Recreating the iterator only repeats classification;
+                // each element reaches `infer_map_impl` in exactly one pass.
+                for typed_dict_pass in [false, true] {
                     let mut found_matching_element = false;
                     for positive in actual_intersection.iter_positive(self.db) {
-                        if matches!(positive, Type::TypedDict(_)) != include_typed_dicts {
+                        if matches!(positive, Type::TypedDict(_)) != typed_dict_pass {
                             continue;
                         }
                         let result = self.infer_map_impl(formal, positive, polarity, seen);
@@ -2852,6 +2857,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                                 .is_never_satisfied(self.db)
                             {
                                 if positive.is_dynamic() {
+                                    // Dynamic elements are assignable but contribute no useful
+                                    // mapping. Defer them so they neither block `TypedDict`
+                                    // inference nor expose errors that the dynamic element absorbs.
                                     found_dynamic_element = true;
                                 } else {
                                     found_matching_element = true;

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2800,7 +2800,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             (formal @ Type::NominalInstance(_), Type::TypedDict(typed_dict)) => {
                 let mapping = KnownClass::Mapping.to_specialized_instance(
                     self.db,
-                    &[typed_dict.key_type(self.db), typed_dict.value_type(self.db)],
+                    &[
+                        KnownClass::Str.to_instance(self.db),
+                        typed_dict.value_type(self.db),
+                    ],
                 );
                 return self.infer_map_impl(formal, mapping, polarity, seen);
             }


### PR DESCRIPTION
## Summary

When a `TypedDict` was passed to a generic `Mapping[K, V]` parameter, inference could not recover the mapping arguments and fell back to `Unknown`, even when a closed or explicit-extra-item TypedDict exposed a safe value type.

Infer through the same read-only `Mapping[str, value_type]` fallback used by assignability. This keeps implicitly open TypedDict values conservative while preserving the value union for closed and explicit-extra-item TypedDicts:

```python
class Extras(TypedDict, extra_items=ReadOnly[int]):
    pass

def project[K, V](value: Mapping[K, V]) -> tuple[K, V]: ...

def f(value: Extras) -> None:
    reveal_type(project(value))  # tuple[str, int]
```

For intersections, inspect non-TypedDict components first so an explicit, more precise `Mapping` component wins. Dynamic components are deferred: concrete TypedDict inference still gets a chance, while `Any` or `Unknown` remains a fallback when no concrete component can provide valid inference.

The full `ty_python_semantic` suite and file-scoped repository hooks pass.