### PR TITLE
[ty] Accept composite TypedDict class namespaces

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -204,6 +204,81 @@ def g(attributes: Namespace):
     reveal_type(y.unknown)  # revealed: Unknown
 ```
 
+## Composite `TypedDict` namespaces
+
+Aliases and composite types whose inhabitants are dictionaries are valid namespace arguments. We
+conservatively leave their class attributes unknown rather than attempting to infer which keys are
+present:
+
+```py
+from typing import Protocol, TypeAlias, TypedDict, TypeVar
+from ty_extensions import Intersection
+
+class Attributes(TypedDict):
+    attribute: int
+
+class OtherAttributes(TypedDict):
+    other_attribute: str
+
+class HasClear(Protocol):
+    def clear(self) -> None: ...
+
+NamespaceAlias: TypeAlias = Attributes
+Bounded = TypeVar("Bounded", bound=Attributes)
+Constrained = TypeVar("Constrained", Attributes, OtherAttributes)
+
+def union(attributes: Attributes | dict[str, object]):
+    Y = type("Y", (), attributes)
+    reveal_type(Y)  # revealed: <class 'Y'>
+    reveal_type(Y.attribute)  # revealed: Unknown
+
+def intersection(attributes: Intersection[Attributes, HasClear]):
+    Y = type("Y", (), attributes)
+    reveal_type(Y)  # revealed: <class 'Y'>
+    reveal_type(Y.attribute)  # revealed: Unknown
+
+def legacy_alias(attributes: NamespaceAlias):
+    Y = type("Y", (), attributes)
+    reveal_type(Y)  # revealed: <class 'Y'>
+    reveal_type(Y.attribute)  # revealed: int
+
+def bounded(attributes: Bounded):
+    Y = type("Y", (), attributes)
+    reveal_type(Y)  # revealed: <class 'Y'>
+    reveal_type(Y.attribute)  # revealed: Unknown
+
+def constrained(attributes: Constrained):
+    Y = type("Y", (), attributes)
+    reveal_type(Y)  # revealed: <class 'Y'>
+```
+
+PEP 695 aliases, including recursive aliases, are also accepted without recursively extracting
+members:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypedDict
+
+class Attributes(TypedDict):
+    attribute: int
+
+type NamespaceAlias = Attributes
+type RecursiveNamespace = Attributes | RecursiveNamespace
+
+def aliases(attributes: NamespaceAlias, recursive: RecursiveNamespace):
+    Y = type("Y", (), attributes)
+    Z = type("Z", (), recursive)
+
+    reveal_type(Y)  # revealed: <class 'Y'>
+    reveal_type(Y.attribute)  # revealed: Unknown
+    reveal_type(Z)  # revealed: <class 'Z'>
+    reveal_type(Z.attribute)  # revealed: Unknown
+```
+
 ## Closed TypedDicts (PEP-728)
 
 TODO: We don't support the PEP-728 `closed=True` keyword argument to `TypedDict` yet. When we do, a

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -11,7 +11,9 @@ use crate::types::infer::builder::{
         DynamicClassKind, report_dynamic_mro_errors, report_inconsistent_dynamic_generic_bases,
     },
 };
-use crate::types::{KnownClass, SubclassOfType, Type, TypeContext, definition_expression_type};
+use crate::types::{
+    KnownClass, SubclassOfType, Type, TypeContext, UnionType, definition_expression_type,
+};
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, HasNodeIndex, NodeIndex};
 use ty_python_core::definition::Definition;
@@ -173,12 +175,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 (Box::new([]), true)
             };
 
-        if !matches!(namespace_type, Type::TypedDict(_))
-            && !namespace_type.is_assignable_to(
-                db,
-                KnownClass::Dict
-                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]),
-            )
+        let namespace_target = UnionType::from_two_elements(
+            db,
+            KnownClass::Dict
+                .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]),
+            Type::open_empty_typed_dict(db),
+        );
+
+        if !namespace_type.is_assignable_to(db, namespace_target)
             && let Some(builder) = self
                 .context
                 .report_lint(&INVALID_ARGUMENT_TYPE, namespace_arg)


### PR DESCRIPTION
## Summary

Accept aliases and composite types containing `TypedDict`s as namespace arguments to the three-argument form of `type()`.

`TypedDict` values have exact runtime type `dict`, but they are deliberately not assignable to mutable `dict` types. Prior to this change, we special-cased only a bare `TypedDict`, so valid unions, intersections, PEP 695 aliases, and bounded or constrained type variables produced an `invalid-argument-type` diagnostic:

```python
class Attributes(TypedDict):
    value: int

def f(attributes: Attributes | dict[str, object]) -> None:
    type("Generated", (), attributes)  # now accepted
```

We now validate the namespace against `dict[str, Any] | <open empty TypedDict>`, using the same synthesized open-empty `TypedDict` representation introduced by #25851. This accepts unions, intersections, bounded or constrained type variables, and PEP 695 aliases, including recursive aliases, when the composite is compatible with the runtime dictionary constraint.

For non-bare composites and PEP 695 aliases, namespace attributes remain `Unknown`; we deliberately do not traverse their schemas or promote keys to definite class attributes. A legacy `TypeAlias` that resolves directly to a bare `TypedDict` retains its precise attributes.

This PR is stacked on #26860 (and ultimately #25851) and addresses the three-argument `type()` follow-up that the core PR intentionally leaves out of scope.
