### PR TITLE
Add "How does Ruff's import sorting compare to isort?" link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ An extremely fast Python linter and code formatter, written in Rust.
 - 🐍 Installable via `pip`
 - 🛠️ `pyproject.toml` support
 - 🤝 Python 3.14 compatibility
-- ⚖️ Drop-in parity with [Flake8](https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8), isort, and [Black](https://docs.astral.sh/ruff/faq/#how-does-ruffs-formatter-compare-to-black)
+- ⚖️ Drop-in parity with [Flake8](https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8), [isort](https://docs.astral.sh/ruff/faq/#how-does-ruffs-import-sorting-compare-to-isort), and [Black](https://docs.astral.sh/ruff/faq/#how-does-ruffs-formatter-compare-to-black)
 - 📦 Built-in caching, to avoid re-analyzing unchanged files
 - 🔧 Fix support, for automatic error correction (e.g., automatically remove unused imports)
 - 📏 Over [900 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -66,6 +66,9 @@ LINK_REWRITES: dict[str, str] = {
     "https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8": (
         "faq.md#how-does-ruffs-linter-compare-to-flake8"
     ),
+    "https://docs.astral.sh/ruff/faq/#how-does-ruffs-import-sorting-compare-to-isort": (
+        "faq.md#how-does-ruffs-import-sorting-compare-to-isort"
+    ),
     "https://docs.astral.sh/ruff/faq/#how-does-ruffs-formatter-compare-to-black": (
         "faq.md#how-does-ruffs-formatter-compare-to-black"
     ),


### PR DESCRIPTION
## Summary

Noticed a small inconsistency where the doc exists, but is only linked to for Flake8 and Black, not isort.

## Test Plan

Look at the file preview and click the link
https://github.com/Avasam/ruff/blob/a42f1cd4b999a36081d371df43334c3204525171/README.md