### PR TITLE
Update Rust toolchain to 1.96.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96"
+channel = "1.96.1"


### PR DESCRIPTION
## Summary

Pin Ruff's Rust toolchain to the exact 1.96.1 point release instead of the floating 1.96 channel.

[Rust 1.96.1](https://blog.rust-lang.org/2026/06/30/Rust-1.96.1/) fixes missing retries and timeouts in Cargo's HTTP client along with a MIR miscompilation. This ensures local and CI builds use the repaired release while leaving Ruff's MSRV at 1.94. The full workspace Clippy check and file-scoped repository hooks pass under the new toolchain.