### PR TITLE
[ty] Fix selection range behavior for strings

### DIFF
--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2135,6 +2135,16 @@ impl BytesLiteral {
             flags: BytesLiteralFlags::empty().with_invalid(),
         }
     }
+
+    /// The range of the byte literal's contents.
+    ///
+    /// This excludes any prefixes, opening quotes or closing quotes.
+    pub fn content_range(&self) -> TextRange {
+        TextRange::new(
+            self.start() + self.flags.opener_len(),
+            self.end() - self.flags.closer_len(),
+        )
+    }
 }
 
 impl From<BytesLiteral> for Expr {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1624,6 +1624,11 @@ impl StringLiteralFlags {
         self
     }
 
+    /// Returns `true` if the parser deemed the string literal invalid.
+    pub const fn is_invalid(self) -> bool {
+        self.0.contains(StringLiteralFlagsInner::INVALID)
+    }
+
     pub const fn prefix(self) -> StringLiteralPrefix {
         if self.0.contains(StringLiteralFlagsInner::U_PREFIX) {
             debug_assert!(
@@ -2043,6 +2048,11 @@ impl BytesLiteralFlags {
     pub fn with_invalid(mut self) -> Self {
         self.0 |= BytesLiteralFlagsInner::INVALID;
         self
+    }
+
+    /// Returns `true` if the parser deemed the bytes literal invalid.
+    pub const fn is_invalid(self) -> bool {
+        self.0.contains(BytesLiteralFlagsInner::INVALID)
     }
 
     pub const fn prefix(self) -> ByteStringPrefix {

--- a/crates/ty_ide/src/selection_range.rs
+++ b/crates/ty_ide/src/selection_range.rs
@@ -52,7 +52,7 @@ fn literal_content_range(node: ruff_python_ast::AnyNodeRef) -> Option<TextRange>
     use ruff_python_ast::AnyNodeRef;
     let range = match node {
         AnyNodeRef::StringLiteral(s) => Some(s.content_range()),
-        AnyNodeRef::BytesLiteral(b) => Some(b.range),
+        AnyNodeRef::BytesLiteral(b) => Some(b.content_range()),
         _ => None,
     };
     range.filter(|&range| range.len() > 0.into())
@@ -343,6 +343,43 @@ result = [(lambda x: x[key.<CURSOR>attr])(item) for item in data if item is not 
           |
         2 | ""
           | ^^
+          |
+        "#);
+    }
+
+    /// Test selection range on a bytes literal
+    #[test]
+    fn test_selection_range_bytes_literal() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+b"he<CURSOR>llo"
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.selection_range(), @r#"
+        info[selection-range]: Selection Range 0
+         --> main.py:1:1
+          |
+        1 | /
+        2 | | b"hello"
+          | |_________^
+          |
+
+        info[selection-range]: Selection Range 1
+         --> main.py:2:1
+          |
+        2 | b"hello"
+          | ^^^^^^^^
+          |
+
+        info[selection-range]: Selection Range 2
+         --> main.py:2:3
+          |
+        2 | b"hello"
+          |   ^^^^^
           |
         "#);
     }

--- a/crates/ty_ide/src/selection_range.rs
+++ b/crates/ty_ide/src/selection_range.rs
@@ -9,7 +9,7 @@ use crate::Db;
 /// The first range in the list is the largest range containing the cursor position.
 pub fn selection_range(db: &dyn Db, file: File, offset: TextSize) -> Vec<TextRange> {
     let parsed = parsed_module(db, file).load(db);
-    let range = TextRange::new(offset, offset);
+    let range = TextRange::empty(offset);
 
     let covering = covering_node(parsed.syntax().into(), range);
 
@@ -22,7 +22,6 @@ pub fn selection_range(db: &dyn Db, file: File, offset: TextSize) -> Vec<TextRan
             if ranges.last() != Some(&range) {
                 ranges.push(range);
             }
-            // Appends additional range if node content is encased by quotes
             if let Some(literal_range) = literal_content_range(node, offset) {
                 ranges.push(literal_range);
             }
@@ -47,12 +46,12 @@ fn should_include_in_selection(node: ruff_python_ast::AnyNodeRef) -> bool {
     }
 }
 
-/// Determines the content range of a string or byte literal if it's non-empty.
+/// Determines the content range of a valid string or byte literal if it's non-empty.
 fn literal_content_range(node: ruff_python_ast::AnyNodeRef, offset: TextSize) -> Option<TextRange> {
     use ruff_python_ast::AnyNodeRef;
     let range = match node {
-        AnyNodeRef::StringLiteral(s) => Some(s.content_range()),
-        AnyNodeRef::BytesLiteral(b) => Some(b.content_range()),
+        AnyNodeRef::StringLiteral(s) if !s.flags.is_invalid() => Some(s.content_range()),
+        AnyNodeRef::BytesLiteral(b) if !b.flags.is_invalid() => Some(b.content_range()),
         _ => None,
     };
     range.filter(|&range| !range.is_empty() && range.contains_inclusive(offset))
@@ -158,6 +157,60 @@ print(\"he<CURSOR>llo\")
           |
         2 | print("hello")
           |        ^^^^^
+          |
+        "#);
+    }
+
+    /// Test selection range when the cursor is in a string literal prefix
+    #[test]
+    fn selection_range_string_literal_prefix() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+r<CURSOR>"hello"
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.selection_range(), @r#"
+        info[selection-range]: Selection Range 0
+         --> main.py:1:1
+          |
+        1 | /
+        2 | | r"hello"
+          | |_________^
+          |
+
+        info[selection-range]: Selection Range 1
+         --> main.py:2:1
+          |
+        2 | r"hello"
+          | ^^^^^^^^
+          |
+        "#);
+    }
+
+    /// Test selection range on a string literal created during parser recovery
+    #[test]
+    fn selection_range_recovered_invalid_string_literal() {
+        let test = CursorTest::builder()
+            .source("main.py", "f\"foo\" b\"b<CURSOR>ar\"")
+            .build();
+
+        assert_snapshot!(test.selection_range(), @r#"
+        info[selection-range]: Selection Range 0
+         --> main.py:1:1
+          |
+        1 | f"foo" b"bar"
+          | ^^^^^^^^^^^^^
+          |
+
+        info[selection-range]: Selection Range 1
+         --> main.py:1:8
+          |
+        1 | f"foo" b"bar"
+          |        ^^^^^^
           |
         "#);
     }
@@ -380,6 +433,36 @@ b"he<CURSOR>llo"
           |
         2 | b"hello"
           |   ^^^^^
+          |
+        "#);
+    }
+
+    /// Test selection range on an invalid bytes literal
+    #[test]
+    fn selection_range_invalid_bytes_literal() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+b"123a𝐁<CURSOR>c"
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.selection_range(), @r#"
+        info[selection-range]: Selection Range 0
+         --> main.py:1:1
+          |
+        1 | /
+        2 | | b"123a𝐁c"
+          | |__________^
+          |
+
+        info[selection-range]: Selection Range 1
+         --> main.py:2:1
+          |
+        2 | b"123a𝐁c"
+          | ^^^^^^^^^
           |
         "#);
     }

--- a/crates/ty_ide/src/selection_range.rs
+++ b/crates/ty_ide/src/selection_range.rs
@@ -69,7 +69,7 @@ mod tests {
 
     /// Test selection range on a simple expression
     #[test]
-    fn test_selection_range_simple_expression() {
+    fn selection_range_simple_expression() {
         let test = CursorTest::builder()
             .source(
                 "main.py",
@@ -113,7 +113,7 @@ x = 1 + <CURSOR>2
 
     /// Test selection range on a function call
     #[test]
-    fn test_selection_range_function_call() {
+    fn selection_range_function_call() {
         let test = CursorTest::builder()
             .source(
                 "main.py",
@@ -164,7 +164,7 @@ print(\"he<CURSOR>llo\")
 
     /// Test selection range on a function definition
     #[test]
-    fn test_selection_range_function_definition() {
+    fn selection_range_function_definition() {
         let test = CursorTest::builder()
             .source(
                 "main.py",
@@ -204,7 +204,7 @@ def my_<CURSOR>function():
 
     /// Test selection range on a class definition
     #[test]
-    fn test_selection_range_class_definition() {
+    fn selection_range_class_definition() {
         let test = CursorTest::builder()
             .source(
                 "main.py",
@@ -247,7 +247,7 @@ class My<CURSOR>Class:
 
     /// Test selection range on a deeply nested expression with comprehension, lambda, and subscript
     #[test]
-    fn test_selection_range_deeply_nested_expression() {
+    fn selection_range_deeply_nested_expression() {
         let test = CursorTest::builder()
             .source(
                 "main.py",
@@ -319,7 +319,7 @@ result = [(lambda x: x[key.<CURSOR>attr])(item) for item in data if item is not 
 
     /// Test selection range on an empty string literal
     #[test]
-    fn test_selection_range_empty_string_literal() {
+    fn selection_range_empty_string_literal() {
         let test = CursorTest::builder()
             .source(
                 "main.py",
@@ -349,7 +349,7 @@ result = [(lambda x: x[key.<CURSOR>attr])(item) for item in data if item is not 
 
     /// Test selection range on a bytes literal
     #[test]
-    fn test_selection_range_bytes_literal() {
+    fn selection_range_bytes_literal() {
         let test = CursorTest::builder()
             .source(
                 "main.py",

--- a/crates/ty_ide/src/selection_range.rs
+++ b/crates/ty_ide/src/selection_range.rs
@@ -23,7 +23,7 @@ pub fn selection_range(db: &dyn Db, file: File, offset: TextSize) -> Vec<TextRan
                 ranges.push(range);
             }
             // Appends additional range if node content is encased by quotes
-            if let Some(literal_range) = literal_content_range(node) {
+            if let Some(literal_range) = literal_content_range(node, offset) {
                 ranges.push(literal_range);
             }
         }
@@ -48,14 +48,14 @@ fn should_include_in_selection(node: ruff_python_ast::AnyNodeRef) -> bool {
 }
 
 /// Determines the content range of a string or byte literal if it's non-empty.
-fn literal_content_range(node: ruff_python_ast::AnyNodeRef) -> Option<TextRange> {
+fn literal_content_range(node: ruff_python_ast::AnyNodeRef, offset: TextSize) -> Option<TextRange> {
     use ruff_python_ast::AnyNodeRef;
     let range = match node {
         AnyNodeRef::StringLiteral(s) => Some(s.content_range()),
         AnyNodeRef::BytesLiteral(b) => Some(b.content_range()),
         _ => None,
     };
-    range.filter(|&range| range.len() > 0.into())
+    range.filter(|&range| !range.is_empty() && range.contains_inclusive(offset))
 }
 
 #[cfg(test)]

--- a/crates/ty_ide/src/selection_range.rs
+++ b/crates/ty_ide/src/selection_range.rs
@@ -22,6 +22,10 @@ pub fn selection_range(db: &dyn Db, file: File, offset: TextSize) -> Vec<TextRan
             if ranges.last() != Some(&range) {
                 ranges.push(range);
             }
+            // Appends additional range if node content is encased by quotes
+            if let Some(literal_range) = literal_content_range(node) {
+                ranges.push(literal_range);
+            }
         }
     }
 
@@ -41,6 +45,17 @@ fn should_include_in_selection(node: ruff_python_ast::AnyNodeRef) -> bool {
 
         _ => true,
     }
+}
+
+/// Determines the content range of a string or byte literal if it's non-empty.
+fn literal_content_range(node: ruff_python_ast::AnyNodeRef) -> Option<TextRange> {
+    use ruff_python_ast::AnyNodeRef;
+    let range = match node {
+        AnyNodeRef::StringLiteral(s) => Some(s.content_range()),
+        AnyNodeRef::BytesLiteral(b) => Some(b.range),
+        _ => None,
+    };
+    range.filter(|&range| range.len() > 0.into())
 }
 
 #[cfg(test)]
@@ -136,6 +151,13 @@ print(\"he<CURSOR>llo\")
           |
         2 | print("hello")
           |       ^^^^^^^
+          |
+
+        info[selection-range]: Selection Range 4
+         --> main.py:2:8
+          |
+        2 | print("hello")
+          |        ^^^^^
           |
         "#);
     }
@@ -293,6 +315,36 @@ result = [(lambda x: x[key.<CURSOR>attr])(item) for item in data if item is not 
           |                            ^^^^
           |
         ");
+    }
+
+    /// Test selection range on an empty string literal
+    #[test]
+    fn test_selection_range_empty_string_literal() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+"<CURSOR>"
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.selection_range(), @r#"
+        info[selection-range]: Selection Range 0
+         --> main.py:1:1
+          |
+        1 | /
+        2 | | ""
+          | |___^
+          |
+
+        info[selection-range]: Selection Range 1
+         --> main.py:2:1
+          |
+        2 | ""
+          | ^^
+          |
+        "#);
     }
 
     impl CursorTest {


### PR DESCRIPTION
## Summary

Closes astral-sh/ty#2882. The selection range for a string/byte literal includes the quotes because the leaf node is a `StringLiteral`. This is different from f-strings which use`InterpolatedStringLiteralElement`. The shrink/expand selection behavior differs between the two, which is addressed in this PR by adding an additional range if the leaf node is a literal type.

I tested this with every possible combination of string modifier (u, r, f, b, t) to make sure the behavior was the same across all cases.

## Test Plan

Updated an existing test and added a new one to cover the empty string edge case. Passed all tests.
