### PR TITLE
[ty] Batch parallel jobs

### DIFF
--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -1,7 +1,8 @@
+use rayon::prelude::*;
 use ruff_db::files::File;
 use ruff_python_ast::name::Name;
 use ty_module_resolver::{Module, ModuleName, all_modules, resolve_real_shadowable_module};
-use ty_project::Db;
+use ty_project::{Db, parallel::ParallelIteratorExt};
 
 use crate::{
     SymbolKind,
@@ -29,75 +30,64 @@ pub fn all_symbols<'db>(
     let is_typing_extensions_available = importing_from.is_stub(db)
         || resolve_real_shadowable_module(db, importing_from, &typing_extensions).is_some();
 
-    let results = std::sync::Mutex::new(Vec::new());
-    {
-        let modules = all_modules(db);
-        let db = Db::dyn_clone(db);
-        let all_symbols_span = &all_symbols_span;
-        let results = &results;
-        let query = &query;
+    let results = all_modules(db)
+        .into_par_iter()
+        .map_with_db(db, |db, module| {
+            let Some(file) = module.file(db) else {
+                return Vec::new();
+            };
+            let name = module.name(db);
 
-        rayon::scope(move |s| {
-            // For each file, extract symbols and add them to results
-            for module in modules {
-                let db = Db::dyn_clone(&*db);
-                let Some(file) = module.file(&*db) else {
-                    continue;
-                };
-                let name = module.name(&*db);
+            // Note that this will always consider namespace
+            // packages to be "not firsty party." This isn't
+            // necessarily correct, and we can probably improve
+            // on this in response to user feedback. (At time
+            // of writing, 2026-02-13, we don't really handle
+            // namespace packages in auto-import anyway.)
+            let is_non_first_party = module.search_path(db).is_none_or(|sp| !sp.is_first_party());
 
-                // Note that this will always consider namespace
-                // packages to be "not firsty party." This isn't
-                // necessarily correct, and we can probably improve
-                // on this in response to user feedback. (At time
-                // of writing, 2026-02-13, we don't really handle
-                // namespace packages in auto-import anyway.)
-                let is_non_first_party = module
-                    .search_path(&*db)
-                    .is_none_or(|sp| !sp.is_first_party());
-
-                // Filter out non-first-party modules that are conventionally
-                // regarded as private or tests.
-                if is_non_first_party && (name.is_private() || name.is_test_module()) {
-                    continue;
-                }
-
-                // TODO: also make it available in `TYPE_CHECKING` blocks
-                // (we'd need https://github.com/astral-sh/ty/issues/1553 to do this well)
-                if !is_typing_extensions_available && name == &typing_extensions {
-                    continue;
-                }
-                s.spawn(move |_| {
-                    let symbols_for_file_span = tracing::debug_span!(
-                        parent: all_symbols_span,
-                        "symbols_for_file_global_only",
-                        path = %file.path(&*db),
-                    );
-                    let _entered = symbols_for_file_span.entered();
-
-                    let mut symbols = vec![];
-                    if query.is_match_symbol_name(module.name(&*db)) {
-                        symbols.push(AllSymbolInfo::from_module(&*db, module, file));
-                    }
-                    for (_, symbol) in symbols_for_file_global_only(&*db, file).search(query) {
-                        // Test functions (starting with `test_`) in third-party
-                        // packages are almost never useful to import.
-                        if is_non_first_party && symbol.name.starts_with("test_") {
-                            continue;
-                        }
-                        symbols.push(AllSymbolInfo::from_non_module_symbol(
-                            &*db,
-                            symbol.to_owned(),
-                            module,
-                            file,
-                        ));
-                    }
-                    results.lock().unwrap().extend(symbols);
-                });
+            // Filter out non-first-party modules that are conventionally
+            // regarded as private or tests.
+            if is_non_first_party && (name.is_private() || name.is_test_module()) {
+                return Vec::new();
             }
-        });
-    }
-    merge::merge(db, results.into_inner().unwrap())
+
+            // TODO: also make it available in `TYPE_CHECKING` blocks
+            // (we'd need https://github.com/astral-sh/ty/issues/1553 to do this well)
+            if !is_typing_extensions_available && name == &typing_extensions {
+                return Vec::new();
+            }
+
+            let symbols_for_file_span = tracing::debug_span!(
+                parent: &all_symbols_span,
+                "symbols_for_file_global_only",
+                path = %file.path(db),
+            );
+            let _entered = symbols_for_file_span.entered();
+
+            let mut symbols = vec![];
+            if query.is_match_symbol_name(module.name(db)) {
+                symbols.push(AllSymbolInfo::from_module(db, module, file));
+            }
+            for (_, symbol) in symbols_for_file_global_only(db, file).search(query) {
+                // Test functions (starting with `test_`) in third-party
+                // packages are almost never useful to import.
+                if is_non_first_party && symbol.name.starts_with("test_") {
+                    continue;
+                }
+                symbols.push(AllSymbolInfo::from_non_module_symbol(
+                    db,
+                    symbol.to_owned(),
+                    module,
+                    file,
+                ));
+            }
+            symbols
+        })
+        .flat_map_iter(|symbols| symbols)
+        .collect();
+
+    merge::merge(db, results)
 }
 
 /// A symbol found in the workspace and dependencies, including the

--- a/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
@@ -2,6 +2,7 @@ use crate::call_hierarchy::{CalleeLeaf, module_detail};
 use crate::goto::{Definitions, GotoTarget, find_goto_target};
 use crate::references::{contains_identifier, has_any_external_visible_definitions};
 use crate::{CallHierarchyItem, Db, SymbolKind};
+use rayon::prelude::*;
 use ruff_db::files::File;
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::helpers::is_dunder;
@@ -11,10 +12,17 @@ use ruff_python_ast::visitor::source_order::{SourceOrderVisitor, TraversalSignal
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use rustc_hash::FxHashMap;
+use ty_project::parallel::{ParallelIteratorExt, minimum_parallel_job_len};
 use ty_python_core::scope::{NodeWithScopeKind, ScopeKind};
 use ty_python_semantic::types::ide_support::static_member_type_for_attribute;
 use ty_python_semantic::types::{PropertyAccessorRole, Type};
 use ty_python_semantic::{HasDefinition as _, HasType as _, ImportAliasResolution, SemanticModel};
+
+/// Salsa snapshots coordinate clone and drop through shared state. For ordinary targets, most
+/// files are rejected by the text prefilter, so process enough files per job to amortize that
+/// coordination. Use a lower minimum than references because matching files do more semantic work,
+/// and dunder targets cannot use the prefilter.
+const MAX_MIN_FILES_PER_PARALLEL_JOB: usize = 16;
 
 /// Find every place in the project that calls the symbol at `offset`, grouped
 /// by enclosing function/method/class/module.
@@ -63,47 +71,37 @@ pub fn incoming_calls(db: &dyn Db, file: File, offset: TextSize) -> Vec<Incoming
     let mut raw = call_sites_for_file(db, file, &target_definitions, target_role, needle);
 
     if is_externally_visible {
-        let result = std::sync::Mutex::new(Vec::<RawCallSite>::new());
         let files = db.project().files(db);
-        {
-            let db_clone = Db::dyn_clone(db);
-            let target_definitions = &target_definitions;
-            let files = &files;
-            let result = &result;
-            // The byte-level text prefilter still pays off as a coarse gate:
-            // files that don't contain the target name (or an import of it)
-            // textually are skipped before any AST work. Files that route the
-            // call through an alias (`from m import foo as bar; bar()`) still
-            // pass the gate because they contain `foo` in the import line.
-            // Dunder calls have no required textual spelling, so the filter
-            // is disabled for them.
-            rayon::scope(move |s| {
-                for other_file in files {
-                    if other_file == file {
-                        continue;
-                    }
-                    let db = Db::dyn_clone(&*db_clone);
-                    s.spawn(move |_| {
-                        let db = &*db;
-                        let source = ruff_db::source::source_text(db, other_file);
-                        if let Some(name) = needle
-                            && !contains_identifier(&source, name)
-                        {
-                            return;
-                        }
-                        let sites = call_sites_for_file(
-                            db,
-                            other_file,
-                            target_definitions,
-                            target_role,
-                            needle,
-                        );
-                        result.lock().unwrap().extend(sites);
-                    });
+        let files: Vec<_> = files
+            .iter()
+            .copied()
+            .filter(|other| *other != file)
+            .collect();
+        let minimum_job_len = minimum_parallel_job_len(files.len(), MAX_MIN_FILES_PER_PARALLEL_JOB);
+        // The byte-level text prefilter still pays off as a coarse gate:
+        // files that don't contain the target name (or an import of it)
+        // textually are skipped before any AST work. Files that route the
+        // call through an alias (`from m import foo as bar; bar()`) still
+        // pass the gate because they contain `foo` in the import line.
+        // Dunder calls have no required textual spelling, so the filter
+        // is disabled for them.
+        let other_sites = files
+            .into_par_iter()
+            .with_min_len(minimum_job_len)
+            .map_with_db(db, |db, other_file| {
+                let source = ruff_db::source::source_text(db, other_file);
+                if let Some(name) = needle
+                    && !contains_identifier(&source, name)
+                {
+                    return Vec::new();
                 }
-            });
-        }
-        raw.extend(result.into_inner().unwrap());
+
+                call_sites_for_file(db, other_file, &target_definitions, target_role, needle)
+            })
+            .flat_map_iter(|sites| sites)
+            .collect::<Vec<_>>();
+
+        raw.extend(other_sites);
     }
 
     // Group by (enclosing scope file, enclosing scope selection range).

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -12,6 +12,7 @@
 
 use crate::goto::{Definitions, GotoTarget};
 use crate::{Db, ReferenceKind, ReferenceTarget};
+use rayon::prelude::*;
 use ruff_db::files::File;
 use ruff_python_ast::find_node::{CoveringNode, covering_node};
 use ruff_python_ast::token::Tokens;
@@ -20,9 +21,17 @@ use ruff_python_ast::{
     visitor::source_order::{SourceOrderVisitor, TraversalSignal},
 };
 use ruff_text_size::Ranged;
+use ty_project::parallel::{ParallelIteratorExt, minimum_parallel_job_len};
 use ty_python_core::definition::{Definition, DefinitionState};
 use ty_python_core::scope::ScopeKind;
 use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticModel};
+
+/// Salsa snapshots coordinate clone and drop through shared state. For cached files that don't
+/// contain the target, that coordination can cost more than the file scan and scales poorly when
+/// many short-lived jobs finish concurrently. A 64-file minimum on large projects amortizes the
+/// task and snapshot overhead. Smaller projects lower the minimum to retain enough work for
+/// stealing.
+const MAX_MIN_FILES_PER_PARALLEL_JOB: usize = 64;
 
 /// Mode for references search behavior
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,53 +114,38 @@ pub(crate) fn references(
     let is_parameter = parameter_owner_is_externally_visible(db, &target_definitions);
 
     if search_across_files && (is_parameter || is_externally_visible_symbol) {
-        let result = std::sync::Mutex::new(Vec::new());
         let files = db.project().files(db);
-
-        {
-            let db = Db::dyn_clone(db);
-            let target_definitions = &target_definitions;
-            let files = &files;
-            let result = &result;
-            let needle = target_text.as_ref();
-
-            rayon::scope(move |s| {
-                for other_file in files {
-                    // Skip the current file as we already processed it
-                    if other_file == file {
-                        continue;
-                    }
-
-                    let db = Db::dyn_clone(&*db);
-
-                    s.spawn(move |_| {
-                        let db = &*db;
-
-                        // First do a simple text search to see if there is a potential match in the file
-                        let source = ruff_db::source::source_text(db, other_file);
-                        if !contains_identifier(&source, needle) {
-                            return;
-                        }
-
-                        // If the target text is found, do the more expensive semantic analysis
-                        let references = if is_externally_visible_symbol {
-                            references_for_file(db, other_file, target_definitions, needle, mode)
-                        } else {
-                            references_for_keyword_arguments_in_file(
-                                db,
-                                other_file,
-                                target_definitions,
-                                needle,
-                                mode,
-                            )
-                        };
-
-                        result.lock().unwrap().extend(references);
-                    });
+        let files: Vec<_> = files
+            .iter()
+            .copied()
+            .filter(|other| *other != file)
+            .collect();
+        let minimum_job_len = minimum_parallel_job_len(files.len(), MAX_MIN_FILES_PER_PARALLEL_JOB);
+        let other_references = files
+            .into_par_iter()
+            .with_min_len(minimum_job_len)
+            .map_with_db(db, |db, other_file| {
+                let source = ruff_db::source::source_text(db, other_file);
+                if !contains_identifier(&source, &target_text) {
+                    return Vec::new();
                 }
-            });
-        }
-        references.extend(result.into_inner().unwrap());
+
+                if is_externally_visible_symbol {
+                    references_for_file(db, other_file, &target_definitions, &target_text, mode)
+                } else {
+                    references_for_keyword_arguments_in_file(
+                        db,
+                        other_file,
+                        &target_definitions,
+                        &target_text,
+                        mode,
+                    )
+                }
+            })
+            .flat_map_iter(|references| references)
+            .collect::<Vec<_>>();
+
+        references.extend(other_references);
     }
 
     if references.is_empty() {

--- a/crates/ty_ide/src/workspace_symbols.rs
+++ b/crates/ty_ide/src/workspace_symbols.rs
@@ -1,6 +1,7 @@
 use crate::symbols::{QueryPattern, SymbolInfo, symbols_for_file};
+use rayon::prelude::*;
 use ruff_db::files::File;
-use ty_project::Db;
+use ty_project::{Db, parallel::ParallelIteratorExt};
 
 /// Get all workspace symbols matching the query string.
 /// Returns symbols from all files in the workspace, filtered by the query.
@@ -17,41 +18,28 @@ pub fn workspace_symbols(db: &dyn Db, query: &str) -> Vec<WorkspaceSymbolInfo> {
 
     let query = QueryPattern::fuzzy(query);
     let files = project.files(db);
-    let results = std::sync::Mutex::new(Vec::new());
-    {
-        let db = Db::dyn_clone(db);
-        let files = &files;
-        let results = &results;
-        let query = &query;
-        let workspace_symbols_span = &workspace_symbols_span;
+    let files: Vec<_> = files.iter().copied().collect();
 
-        rayon::scope(move |s| {
-            // For each file, extract symbols and add them to results
-            #[expect(
-                clippy::iter_over_hash_type,
-                reason = "Rayon task completion already makes result order unspecified"
-            )]
-            for file in files.iter() {
-                let db = Db::dyn_clone(&*db);
-                s.spawn(move |_| {
-                    let symbols_for_file_span = tracing::debug_span!(parent: workspace_symbols_span, "symbols_for_file", ?file);
-                    let _entered = symbols_for_file_span.entered();
+    files
+        .into_par_iter()
+        .map_with_db(db, |db, file| {
+            let symbols_for_file_span = tracing::debug_span!(
+                parent: &workspace_symbols_span,
+                "symbols_for_file",
+                ?file
+            );
+            let _entered = symbols_for_file_span.entered();
 
-                    for (_, symbol) in symbols_for_file(&*db, *file).search(query) {
-                        // It seems like we could do better here than
-                        // locking `results` for every single symbol,
-                        // but this works pretty well as it is.
-                        results.lock().unwrap().push(WorkspaceSymbolInfo {
-                            symbol: symbol.to_owned(),
-                            file: *file,
-                        });
-                    }
-                });
-            }
-        });
-    }
-
-    results.into_inner().unwrap()
+            symbols_for_file(db, file)
+                .search(&query)
+                .map(|(_, symbol)| WorkspaceSymbolInfo {
+                    symbol: symbol.to_owned(),
+                    file,
+                })
+                .collect::<Vec<_>>()
+        })
+        .flat_map_iter(|symbols| symbols)
+        .collect()
 }
 
 /// A symbol found in the workspace, including the file it was found in.

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -4,6 +4,7 @@
 )]
 use crate::glob::{GlobFilterCheckMode, IncludeResult};
 use crate::metadata::options::{OptionDiagnostic, ProgramSettingsDiagnostic};
+use crate::parallel::ParallelIteratorExt;
 use crate::walk::{ProjectFilesFilter, ProjectFilesWalker};
 #[cfg(feature = "testing")]
 pub use db::testing::TestDb;
@@ -12,6 +13,7 @@ use files::{Index, Indexed, IndexedFiles};
 
 use metadata::settings::Settings;
 pub use metadata::{ProjectMetadata, ProjectMetadataError};
+use rayon::prelude::*;
 use ruff_db::diagnostic::{
     Diagnostic, DiagnosticId, Severity, SubDiagnostic, SubDiagnosticSeverity,
 };
@@ -381,51 +383,39 @@ impl Project {
         let open_files = self.open_files(db);
         let check_start = ruff_db::Instant::now();
 
-        {
-            let db = db.clone();
-            let project_span = &project_span;
+        let files: Vec<_> = (&files).into_iter().collect();
 
-            rayon::scope(move |scope| {
-                for file in &files {
-                    let db = db.clone();
-                    let reporter = &*reporter;
+        files
+            .into_par_iter()
+            .for_each_with_project_db(db, |db, file| {
+                db.unwind_if_revision_cancelled();
 
-                    db.unwind_if_revision_cancelled();
+                let check_file_span =
+                    tracing::debug_span!(parent: &project_span, "check_file", ?file);
+                let _entered = check_file_span.entered();
 
-                    scope.spawn(move |_| {
-                        let check_file_span =
-                            tracing::debug_span!(parent: project_span, "check_file", ?file);
-                        let _entered = check_file_span.entered();
+                match check_file_impl(db, file) {
+                    Ok(diagnostics) => {
+                        reporter.report_checked_file(db, file, diagnostics);
 
-                        match check_file_impl(&db, file) {
-                            Ok(diagnostics) => {
-                                reporter.report_checked_file(&db, file, diagnostics);
+                        // This is outside `check_file_impl` to avoid that opening or closing
+                        // a file invalidates the `check_file_impl` query of every file!
+                        if !open_files.contains(&file) {
+                            // The module has already been parsed by `check_file_impl`.
+                            // We only retrieve it here so that we can call `clear` on it.
+                            let parsed = parsed_module(db, file);
 
-                                // This is outside `check_file_impl` to avoid that opening or closing
-                                // a file invalidates the `check_file_impl` query of every file!
-                                if !open_files.contains(&file) {
-                                    // The module has already been parsed by `check_file_impl`.
-                                    // We only retrieve it here so that we can call `clear` on it.
-                                    let parsed = parsed_module(&db, file);
-
-                                    // Drop the AST now that we are done checking this file. It is not currently open,
-                                    // so it is unlikely to be accessed again soon. If any queries need to access the AST
-                                    // from across files, it will be re-parsed.
-                                    parsed.clear();
-                                }
-                            }
-                            Err(io_error) => {
-                                reporter.report_checked_file(
-                                    &db,
-                                    file,
-                                    std::slice::from_ref(io_error),
-                                );
-                            }
+                            // Drop the AST now that we are done checking this file. It is not currently open,
+                            // so it is unlikely to be accessed again soon. If any queries need to access the AST
+                            // from across files, it will be re-parsed.
+                            parsed.clear();
                         }
-                    });
+                    }
+                    Err(io_error) => {
+                        reporter.report_checked_file(db, file, std::slice::from_ref(io_error));
+                    }
                 }
             });
-        };
 
         tracing::debug!(
             "Checking all files took {:.3}s",

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -31,6 +31,7 @@ mod db;
 mod files;
 pub mod glob;
 pub mod metadata;
+pub mod parallel;
 mod walk;
 pub mod watch;
 

--- a/crates/ty_project/src/parallel.rs
+++ b/crates/ty_project/src/parallel.rs
@@ -2,7 +2,7 @@
 
 use rayon::iter::ParallelIterator;
 
-use crate::Db;
+use crate::{Db, ProjectDatabase};
 
 /// Chooses a minimum Rayon job length without starving the worker pool on smaller inputs.
 ///
@@ -40,6 +40,27 @@ pub trait ParallelIteratorExt: ParallelIterator + Sized {
         self.map_with(ParallelDb(Db::dyn_clone(db)), move |db, item| {
             salsa::attach_allow_change(&*db.0, || map(&*db.0, item))
         })
+    }
+
+    /// Runs an operation in parallel with a cloned [`ProjectDatabase`] for each Rayon job.
+    ///
+    /// Rayon's standard scheduling adapters can be applied before this method. For example, an
+    /// indexed iterator can use [`rayon::iter::IndexedParallelIterator::with_min_len`] to reduce
+    /// task and database-cloning overhead.
+    ///
+    /// # Warning
+    ///
+    /// This method uses [`salsa::attach_allow_change`] and must never be called from within a Salsa
+    /// query. It is intended for top-level request and command handlers that are outside the Salsa
+    /// query stack.
+    fn for_each_with_project_db(
+        self,
+        db: &ProjectDatabase,
+        op: impl Fn(&ProjectDatabase, Self::Item) + Send + Sync,
+    ) {
+        self.for_each_with(db.clone(), move |db, item| {
+            salsa::attach_allow_change(db, || op(db, item));
+        });
     }
 }
 

--- a/crates/ty_project/src/parallel.rs
+++ b/crates/ty_project/src/parallel.rs
@@ -1,0 +1,55 @@
+//! Helpers for parallel operations that need an independent Salsa database on each Rayon job.
+
+use rayon::iter::ParallelIterator;
+
+use crate::Db;
+
+/// Chooses a minimum Rayon job length without starving the worker pool on smaller inputs.
+///
+/// The maximum should be an empirically chosen upper bound for the operation's minimum job length.
+/// Larger inputs use that minimum, while smaller inputs lower it to retain enough jobs for work
+/// stealing.
+pub fn minimum_parallel_job_len(item_count: usize, maximum: usize) -> usize {
+    const TARGET_JOBS_PER_THREAD: usize = 4;
+
+    let target_jobs = rayon::current_num_threads().saturating_mul(TARGET_JOBS_PER_THREAD);
+    item_count.div_ceil(target_jobs).clamp(1, maximum.max(1))
+}
+
+/// Extension methods for Rayon parallel iterators that need a Salsa database.
+pub trait ParallelIteratorExt: ParallelIterator + Sized {
+    /// Maps items in parallel with a separate Salsa database for each Rayon job.
+    ///
+    /// Rayon's standard scheduling adapters can be applied before this method. For example, an
+    /// indexed iterator can use [`rayon::iter::IndexedParallelIterator::with_min_len`] to reduce
+    /// task and database-cloning overhead.
+    ///
+    /// # Warning
+    ///
+    /// This method uses [`salsa::attach_allow_change`] and must never be called from within a Salsa
+    /// query. It is intended for top-level request and command handlers that are outside the Salsa
+    /// query stack.
+    fn map_with_db<Output>(
+        self,
+        db: &dyn Db,
+        map: impl Fn(&dyn Db, Self::Item) -> Output + Send + Sync,
+    ) -> impl ParallelIterator<Item = Output>
+    where
+        Output: Send,
+    {
+        self.map_with(ParallelDb(Db::dyn_clone(db)), move |db, item| {
+            salsa::attach_allow_change(&*db.0, || map(&*db.0, item))
+        })
+    }
+}
+
+impl<Iter> ParallelIteratorExt for Iter where Iter: ParallelIterator {}
+
+/// An owned Salsa snapshot that Rayon can clone whenever it splits a parallel iterator.
+struct ParallelDb(Box<dyn Db>);
+
+impl Clone for ParallelDb {
+    fn clone(&self) -> Self {
+        Self(Db::dyn_clone(&*self.0))
+    }
+}


### PR DESCRIPTION
## Summary

We had internal reports where find references feel slow on very large projects, even when all files are already loaded into memory. What makes find references and some other LSP operations different from `check_file` is that we perform minimal work for most file. For find references, the work we do for most files is a simple memchr string search for the identifier. 

Today, we parallelized find references (and other LSP methods) by scheduling a dedicated rayon job for each file. This gives us perfect scheduling, but comes at the cost of creating a rayon Job and cloning (and dropping) a DB handle for every file. For very large projects, this becomes noticeable. Specifically the dropping of the Salsa Db because it contains a `notify_all` call to let other threads know that the handle count was decreased by 1.


This PR refactors our scheduling to make use of `par_iter`, which chunks items (it also supports work stealing, so that threads don't end up idle if one chunk is more compute intense than others). Not only does this speed up operations like find references, I also find it makes the code easier to understand. 

I did set the `with_min_len` for some jobs where doing so showed that it improves performance (measured with multiple thread limits). I did not set it where there was no clear winner. The default is 1. 

Operation | Workers | Main | Patch | Change
-- | -- | -- | -- | --
Find references | 8 | 244.5 ms | 40.5 ms | −83.4%
  | 16 | 305.0 ms | 28.5 ms | −90.7%
  | 32 | 405.5 ms | 26.5 ms | −93.5%
  | 64 | 2,924.0 ms | 27.5 ms | −99.1%
Incoming calls | 8 | 229.0 ms | 53.5 ms | −76.6%
  | 16 | 299.5 ms | 39.0 ms | −87.0%
  | 32 | 399.0 ms | 35.5 ms | −91.1%
  | 64 | 3,176.0 ms | 63.5 ms | −98.0%
Workspace symbols | 8 | 270.5 ms | 216.5 ms | −20.0%
  | 16 | 288.5 ms | 219.0 ms | −24.1%
  | 32 | 289.0 ms | 274.0 ms | −5.2%
  | 64 | 697.5 ms | 293.0 ms | −58.0%



## Test Plan

Manual tests
