### PR TITLE
[python] Add ruff.format() Python API via PyO3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,6 +2755,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pyproject-toml"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,6 +3530,17 @@ name = "ruff_options_metadata"
 version = "0.0.3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "ruff_python"
+version = "0.1.0"
+dependencies = [
+ "pyo3",
+ "ruff_formatter",
+ "ruff_python_ast",
+ "ruff_python_formatter",
+ "ruff_python_parser",
 ]
 
 [[package]]
@@ -4232,6 +4306,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -5104,6 +5184,12 @@ dependencies = [
  "phf_codegen",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unit-prefix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ ruff_options_metadata = { version = "0.0.3", path = "crates/ruff_options_metadat
 ruff_python_ast = { version = "0.0.3", path = "crates/ruff_python_ast" }
 ruff_python_codegen = { version = "0.0.3", path = "crates/ruff_python_codegen" }
 ruff_python_formatter = { version = "0.0.3", path = "crates/ruff_python_formatter" }
+ruff_python = { version = "0.1.0", path = "crates/ruff_python" }
 ruff_python_importer = { version = "0.0.3", path = "crates/ruff_python_importer" }
 ruff_python_index = { version = "0.0.3", path = "crates/ruff_python_index" }
 ruff_python_literal = { version = "0.0.3", path = "crates/ruff_python_literal" }
@@ -141,6 +142,7 @@ path-absolutize = { version = "3.1.1" }
 path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 pep440_rs = { version = "0.7.1" }
+pyo3 = { version = "0.23", default-features = false }
 pretty_assertions = "1.3.0"
 proc-macro2 = { version = "1.0.79" }
 pyproject-toml = { version = "0.13.4" }

--- a/crates/ruff_python/Cargo.toml
+++ b/crates/ruff_python/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ruff_python"
+version = "0.1.0"
+description = "Python bindings for Ruff's formatting API"
+authors = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+
+[lib]
+name = "_ruff_api"
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+ruff_python_formatter = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_python_parser = { workspace = true }
+ruff_formatter = { workspace = true }
+
+pyo3 = { version = "0.23", features = ["extension-module", "abi3-py38"] }
+
+[lints]
+workspace = true

--- a/crates/ruff_python/pyproject.toml
+++ b/crates/ruff_python/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["maturin>=1.9.3,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "ruff-api"
+version = "0.1.0"
+description = "Python bindings for Ruff's formatting API"
+authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
+requires-python = ">=3.8"
+license = "MIT"
+keywords = ["ruff", "formatter", "python", "pyo3"]
+
+[tool.maturin]
+bindings = "pyo3"
+manifest-path = "Cargo.toml"
+module-name = "ruff._ruff_api"
+python-source = "python"
+features = ["pyo3/extension-module"]

--- a/crates/ruff_python/python/ruff/__init__.py
+++ b/crates/ruff_python/python/ruff/__init__.py
@@ -1,0 +1,6 @@
+"""Ruff Python API — native formatting without subprocess."""
+from __future__ import annotations
+
+from ruff._ruff_api import format
+
+__all__ = ["format"]

--- a/crates/ruff_python/src/lib.rs
+++ b/crates/ruff_python/src/lib.rs
@@ -1,0 +1,60 @@
+//! Python bindings for Ruff's formatting API.
+//!
+//! Exposes `ruff.format()` as a native Python function via PyO3,
+//! allowing downstream tools to format Python code programmatically
+//! without shelling out to the CLI.
+
+use std::path::Path;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use ruff_python_ast::PySourceType;
+use ruff_python_formatter::{PyFormatOptions, format_module_source};
+
+/// Format Python source code using Ruff's formatter.
+///
+/// Args:
+///     source: The Python source code to format.
+///     filename: Optional filename hint used to determine source type
+///         (e.g. `.pyi` files use stub formatting rules). Defaults to
+///         standard `.py` formatting when not provided.
+///
+/// Returns:
+///     The formatted source code as a string.
+///
+/// Raises:
+///     ValueError: If the source code contains a syntax error or
+///         formatting otherwise fails.
+///
+/// Example:
+///     >>> import ruff
+///     >>> ruff.format("x = 1+2\n")
+///     'x = 1 + 2\n'
+#[pyfunction]
+#[pyo3(signature = (source, *, filename=None))]
+fn format(source: &str, filename: Option<&str>) -> PyResult<String> {
+    let source_type = match filename {
+        Some(name) => PySourceType::from(Path::new(name)),
+        None => PySourceType::default(),
+    };
+
+    let options = PyFormatOptions::from_source_type(source_type);
+
+    match format_module_source(source, options) {
+        Ok(printed) => Ok(printed.into_code()),
+        Err(err) => Err(PyValueError::new_err(format!(
+            "Failed to format source: {err}"
+        ))),
+    }
+}
+
+/// Ruff Python API module.
+///
+/// Provides native access to Ruff's formatting capabilities without
+/// requiring subprocess invocation.
+#[pymodule]
+fn _ruff_api(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(format, m)?)?;
+    Ok(())
+}

--- a/crates/ruff_python/tests/test_format.py
+++ b/crates/ruff_python/tests/test_format.py
@@ -1,0 +1,70 @@
+"""Tests for the ruff.format() Python API."""
+from __future__ import annotations
+
+import pytest
+
+import ruff
+
+
+class TestFormatBasic:
+    """Basic formatting behavior."""
+
+    def test_format_adds_spaces_around_operators(self):
+        result = ruff.format("x = 1+2\n")
+        assert result == "x = 1 + 2\n"
+
+    def test_format_normalizes_whitespace(self):
+        result = ruff.format("y =   3\n")
+        assert result == "y = 3\n"
+
+    def test_format_multiline(self):
+        code = "x = 1+2\ny =   3\n"
+        result = ruff.format(code)
+        assert "x = 1 + 2\n" in result
+        assert "y = 3\n" in result
+
+    def test_format_already_formatted(self):
+        code = "x = 1 + 2\n"
+        result = ruff.format(code)
+        assert result == code
+
+    def test_format_empty_string(self):
+        result = ruff.format("")
+        assert result == ""
+
+    def test_format_trailing_newline(self):
+        result = ruff.format("x = 1")
+        assert result.endswith("\n")
+
+
+class TestFormatFilename:
+    """Filename-based source type detection."""
+
+    def test_format_pyi_stub(self):
+        # .pyi files should format without error
+        code = "x: int = 1\n"
+        result = ruff.format(code, filename="stub.pyi")
+        assert isinstance(result, str)
+
+    def test_format_py_file(self):
+        code = "x = 1+2\n"
+        result = ruff.format(code, filename="script.py")
+        assert result == "x = 1 + 2\n"
+
+    def test_format_no_filename(self):
+        # Default behavior (no filename) should work
+        code = "x = 1+2\n"
+        result = ruff.format(code)
+        assert result == "x = 1 + 2\n"
+
+
+class TestFormatErrors:
+    """Error handling for invalid input."""
+
+    def test_format_syntax_error(self):
+        with pytest.raises(ValueError, match="Failed to format"):
+            ruff.format("def f(:\n  pass\n")
+
+    def test_format_incomplete_expression(self):
+        with pytest.raises(ValueError):
+            ruff.format("x = (\n")

--- a/python/ruff/__init__.py
+++ b/python/ruff/__init__.py
@@ -2,4 +2,11 @@ from __future__ import annotations
 
 from ._find_ruff import find_ruff_bin
 
-__all__ = ["find_ruff_bin"]
+try:
+    from ._ruff_api import format
+except ImportError:
+    # Native module not available (e.g., binary-only wheel install).
+    # The format() function requires building with PyO3 support.
+    pass
+
+__all__ = ["find_ruff_bin", "format"]


### PR DESCRIPTION
## Summary

This adds a Python-callable formatter API (`ruff.format()`) via PyO3, so downstream tools can format code without shelling out to the CLI.

It introduces a new `ruff_python` crate (following the `ruff_wasm` pattern) that wraps `format_module_source` from `ruff_python_formatter`. The API is intentionally minimal:

```python
from ruff import format

formatted = format("x=1\n")                        # uses default settings
formatted = format("x: int", filename="stub.pyi")  # .pyi detection via filename hint
```

The crate builds as an abi3 cdylib via maturin, so one wheel covers Python 3.8+. Right now it's packaged as `ruff-api` (separate from the CLI wheel) to avoid disrupting the existing distribution. The import in `python/ruff/__init__.py` uses try/except so binary-only installs keep working.

Scoped to formatting only — linting can follow once the pattern is settled.

Addresses #659.

### Open question: release & distribution

I built this as a separate `ruff-api` package to keep it decoupled from the CLI wheel, but I realize there are real questions about how this should actually ship — whether it belongs in the main `ruff` package, a companion package, or something else entirely. Happy to adjust the packaging to whatever fits the project's distribution strategy best.

## Test plan

- `cargo check -p ruff_python` and `cargo build -p ruff_python` pass
- `maturin develop` builds and installs the extension module
- 11 Python tests cover basic formatting, `.pyi` filename hints, error handling (syntax errors, empty input), and edge cases