### PR TITLE
[ty] Build module names directly in CompactString

### DIFF
--- a/crates/ty_module_resolver/src/module_name.rs
+++ b/crates/ty_module_resolver/src/module_name.rs
@@ -253,22 +253,14 @@ impl ModuleName {
         if !is_identifier(first_part) {
             return None;
         }
-        let name = if let Some(second_part) = components.next() {
-            if !is_identifier(second_part) {
+        let mut name = CompactString::from(first_part);
+        for part in components {
+            if !is_identifier(part) {
                 return None;
             }
-            let mut name = format!("{first_part}.{second_part}");
-            for part in components {
-                if !is_identifier(part) {
-                    return None;
-                }
-                name.push('.');
-                name.push_str(part);
-            }
-            CompactString::from(&name)
-        } else {
-            CompactString::from(first_part)
-        };
+            name.push('.');
+            name.push_str(part);
+        }
         Some(Self(name))
     }
 


### PR DESCRIPTION
## Summary

`ModuleName::from_components` previously joined multi-part module names in a temporary `String`, then copied the completed name into a `CompactString`.

Build the name directly in `CompactString` while validating each component, avoiding the temporary allocation and final copy.

## Performance

A local Criterion benchmark measured the following runtime changes:

| Input | Before | After | Change |
| --- | ---: | ---: | ---: |
| One valid component | 7.04 ns | 6.78 ns | -3.65% |
| Two valid components | 80.70 ns | 14.64 ns | -81.86% |
| Four valid components | 103.31 ns | 90.37 ns | -12.52% |
| Invalid final component | 93.21 ns | 59.67 ns | -35.98% |
| Invalid first component | 4.03 ns | 4.06 ns | Unchanged |
