### PR TITLE
[ty] Experiment with Triomphe-backed frozen names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,6 +3492,7 @@ dependencies = [
  "serde_json",
  "thin-vec",
  "thiserror 2.0.18",
+ "triomphe",
 ]
 
 [[package]]
@@ -4598,6 +4599,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "triomphe"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
 
 [[package]]
 name = "tryfn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ tempfile = { version = "3.9.0" }
 test-case = { version = "3.3.1" }
 thiserror = { version = "2.0.0" }
 thin-vec = { version = "0.2.14" }
+triomphe = { version = "0.1.16", default-features = false, features = ["std"] }
 tikv-jemallocator = { version = "0.6.0" }
 toml = { version = "1.0.0" }
 tracing = { version = "0.1.40" }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -37,6 +37,7 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 thin-vec = { workspace = true }
+triomphe = { workspace = true }
 
 [features]
 schemars = ["dep:schemars", "dep:serde_json"]

--- a/crates/ruff_python_ast/src/frozen_string.rs
+++ b/crates/ruff_python_ast/src/frozen_string.rs
@@ -1,0 +1,318 @@
+//! Immutable string storage for [`crate::name::Name`].
+
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+use std::mem;
+use std::num::NonZeroU8;
+use std::ptr;
+use std::slice;
+use std::str;
+use std::sync::Arc;
+
+/// The number of UTF-8 bytes stored directly inside a [`FrozenCompactString`].
+const INLINE_CAPACITY: usize = 15;
+
+// Heap tags encode the most significant length byte plus one, reserving zero as a niche. Inline
+// tags start above the heap range and encode lengths 0 through 15.
+const HEAP_TAG_MAX: u8 = 128;
+const INLINE_TAG_BASE: u8 = 193;
+const REPR_SIZE: usize = 16;
+const TAIL_SIZE: usize = REPR_SIZE - mem::size_of::<*const ()>() - 1;
+
+/// A 16-byte immutable string with 15 bytes of inline storage and shared heap allocations.
+#[repr(transparent)]
+pub(crate) struct FrozenCompactString(FrozenRepr);
+
+/// A pointer-sized field, byte tail, and niche-bearing final byte.
+///
+/// Inline values reinterpret the first 15 bytes as string storage. Heap values retain the data
+/// pointer returned by `Arc<[u8]>::into_raw`; the tail and final byte encode the slice length.
+#[repr(C)]
+struct FrozenRepr(*const (), [u8; TAIL_SIZE], NonZeroU8);
+
+#[cfg(target_pointer_width = "64")]
+#[repr(C, align(8))]
+struct FrozenInline([u8; INLINE_CAPACITY], NonZeroU8);
+
+#[cfg(target_pointer_width = "32")]
+#[repr(C, align(4))]
+struct FrozenInline([u8; INLINE_CAPACITY], NonZeroU8);
+
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+compile_error!("FrozenCompactString only supports 32-bit and 64-bit targets");
+
+const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenRepr>()];
+const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenInline>()];
+const _: [(); mem::align_of::<FrozenRepr>()] = [(); mem::align_of::<FrozenInline>()];
+const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenCompactString>()];
+const _: [(); REPR_SIZE] = [(); mem::size_of::<Option<FrozenCompactString>>()];
+
+impl FrozenCompactString {
+    #[inline]
+    pub(crate) fn new(text: impl AsRef<str>) -> Self {
+        Self(FrozenRepr::new(text.as_ref()))
+    }
+
+    #[inline]
+    pub(crate) fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    #[inline]
+    #[cfg(any(feature = "get-size", test))]
+    pub(crate) fn is_heap_allocated(&self) -> bool {
+        self.0.is_heap_allocated()
+    }
+}
+
+impl FrozenRepr {
+    #[inline]
+    fn new(text: &str) -> Self {
+        if text.len() <= INLINE_CAPACITY {
+            Self::new_inline(text)
+        } else {
+            Self::new_heap(text)
+        }
+    }
+
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "the inline and tagged representations have identical layouts"
+    )]
+    fn new_inline(text: &str) -> Self {
+        let len = u8::try_from(text.len()).expect("inline strings are at most 15 bytes");
+        let mut inline = FrozenInline([0; INLINE_CAPACITY], tag(INLINE_TAG_BASE + len));
+        inline.0[..text.len()].copy_from_slice(text.as_bytes());
+
+        // SAFETY: `FrozenInline` and `FrozenRepr` have identical size and alignment. The final
+        // byte is nonzero, and raw pointers permit any bit pattern for the inline case.
+        unsafe { mem::transmute(inline) }
+    }
+
+    #[cold]
+    fn new_heap(text: &str) -> Self {
+        let raw = Arc::<[u8]>::into_raw(Arc::from(text.as_bytes()));
+        let len_bytes = text.len().to_le_bytes();
+        let high_byte_index = len_bytes.len() - 1;
+        let mut tail = [0; TAIL_SIZE];
+        tail[..high_byte_index].copy_from_slice(&len_bytes[..high_byte_index]);
+
+        // Rust requires slice allocations to be no larger than `isize::MAX`, so incrementing the
+        // high byte produces a nonzero tag in the heap range.
+        debug_assert!(len_bytes[high_byte_index] < HEAP_TAG_MAX);
+        Self(
+            raw.cast::<u8>().cast::<()>(),
+            tail,
+            tag(len_bytes[high_byte_index] + 1),
+        )
+    }
+
+    #[inline]
+    fn tag(&self) -> u8 {
+        self.2.get()
+    }
+
+    #[inline]
+    fn is_heap_allocated(&self) -> bool {
+        self.tag() <= HEAP_TAG_MAX
+    }
+
+    #[inline]
+    fn heap_len(&self) -> usize {
+        debug_assert!(self.is_heap_allocated());
+
+        let mut bytes = 0usize.to_le_bytes();
+        let high_byte_index = bytes.len() - 1;
+        bytes[..high_byte_index].copy_from_slice(&self.1[..high_byte_index]);
+        bytes[high_byte_index] = self.tag() - 1;
+        usize::from_le_bytes(bytes)
+    }
+
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "the tagged representation stores either inline bytes or a raw Arc slice"
+    )]
+    fn as_str(&self) -> &str {
+        let bytes = if self.is_heap_allocated() {
+            // SAFETY: The pointer and encoded length came from an `Arc<[u8]>` that this value owns
+            // one strong reference to, and the allocation remains immutable for its lifetime.
+            unsafe { &*self.raw_arc_ptr() }
+        } else {
+            let len = self.tag() as usize - INLINE_TAG_BASE as usize;
+            // SAFETY: Inline bytes begin at the same address as the representation, and `len` is
+            // in 0..=15 by construction.
+            unsafe { slice::from_raw_parts(ptr::from_ref(self).cast::<u8>(), len) }
+        };
+
+        // SAFETY: Both representations are created exclusively from valid `str` values and expose
+        // no mutation that could violate UTF-8.
+        unsafe { str::from_utf8_unchecked(bytes) }
+    }
+
+    #[inline]
+    fn raw_arc_ptr(&self) -> *const [u8] {
+        debug_assert!(self.is_heap_allocated());
+        ptr::slice_from_raw_parts(self.0.cast::<u8>(), self.heap_len())
+    }
+}
+
+#[inline]
+#[expect(
+    unsafe_code,
+    reason = "all representation tags are statically constrained to nonzero ranges"
+)]
+fn tag(byte: u8) -> NonZeroU8 {
+    debug_assert!(byte <= HEAP_TAG_MAX || (INLINE_TAG_BASE..=INLINE_TAG_BASE + 15).contains(&byte));
+
+    // SAFETY: Callers only pass 1..=128 or 193..=208.
+    unsafe { NonZeroU8::new_unchecked(byte) }
+}
+
+impl Clone for FrozenRepr {
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "cloning shared storage increments the strong count of its raw Arc pointer"
+    )]
+    fn clone(&self) -> Self {
+        if self.is_heap_allocated() {
+            // SAFETY: `raw_arc_ptr` reconstructs the pointer returned by `Arc::into_raw`, and this
+            // value owns a live strong reference for the duration of this call.
+            unsafe { Arc::increment_strong_count(self.raw_arc_ptr()) };
+        }
+
+        Self(self.0, self.1, self.2)
+    }
+}
+
+impl Drop for FrozenRepr {
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "dropping shared storage releases the strong count of its raw Arc pointer"
+    )]
+    fn drop(&mut self) {
+        if self.is_heap_allocated() {
+            // SAFETY: Each heap representation owns exactly one strong reference corresponding to
+            // this raw pointer. Reconstructing and dropping the Arc releases that reference.
+            unsafe { drop(Arc::from_raw(self.raw_arc_ptr())) };
+        }
+    }
+}
+
+// SAFETY: Inline values contain owned bytes. Heap values hold a strong reference to an immutable
+// `Arc<[u8]>`, which is Send and Sync.
+#[expect(unsafe_code, reason = "the raw pointer owns immutable Arc storage")]
+unsafe impl Send for FrozenRepr {}
+// SAFETY: See the `Send` implementation above; no API exposes mutation of shared storage.
+#[expect(unsafe_code, reason = "the raw pointer owns immutable Arc storage")]
+unsafe impl Sync for FrozenRepr {}
+
+impl Clone for FrozenCompactString {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl Default for FrozenCompactString {
+    fn default() -> Self {
+        Self::new("")
+    }
+}
+
+impl Hash for FrozenCompactString {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl PartialEq for FrozenCompactString {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for FrozenCompactString {}
+
+impl PartialOrd for FrozenCompactString {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for FrozenCompactString {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl From<String> for FrozenCompactString {
+    #[inline]
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    use super::{FrozenCompactString, INLINE_CAPACITY};
+
+    #[test]
+    fn representation_is_16_bytes() {
+        assert_eq!(size_of::<FrozenCompactString>(), 16);
+        assert_eq!(size_of::<Option<FrozenCompactString>>(), 16);
+    }
+
+    #[test]
+    fn inline_and_heap_strings_roundtrip() {
+        for len in 0..=INLINE_CAPACITY {
+            let text = "x".repeat(len);
+            let frozen = FrozenCompactString::new(&text);
+            assert_eq!(frozen.as_str(), text);
+            assert!(!frozen.is_heap_allocated());
+        }
+
+        for text in [
+            "x".repeat(INLINE_CAPACITY + 1),
+            String::from("Python 🐍 and Rust 🦀"),
+        ] {
+            let frozen = FrozenCompactString::new(&text);
+            assert_eq!(frozen.as_str(), text);
+            assert!(frozen.is_heap_allocated());
+        }
+    }
+
+    #[test]
+    fn heap_clones_share_storage() {
+        let frozen = FrozenCompactString::new("a string too long for inline storage");
+        let clone = frozen.clone();
+        assert_eq!(frozen.as_str().as_ptr(), clone.as_str().as_ptr());
+
+        drop(frozen);
+        assert_eq!(clone.as_str(), "a string too long for inline storage");
+    }
+
+    #[test]
+    fn equality_hash_and_order_match_str() {
+        let alpha = FrozenCompactString::new("alpha");
+        let beta = FrozenCompactString::new("beta value too long to store inline");
+        assert!(alpha < beta);
+        assert!(alpha == FrozenCompactString::new("alpha"));
+
+        let mut expected = DefaultHasher::new();
+        "alpha".hash(&mut expected);
+        let mut actual = DefaultHasher::new();
+        alpha.hash(&mut actual);
+        assert_eq!(actual.finish(), expected.finish());
+    }
+}

--- a/crates/ruff_python_ast/src/frozen_string.rs
+++ b/crates/ruff_python_ast/src/frozen_string.rs
@@ -2,12 +2,14 @@
 
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
-use std::mem;
+use std::mem::{self, ManuallyDrop};
 use std::num::NonZeroU8;
 use std::ptr;
 use std::slice;
 use std::str;
-use std::sync::Arc;
+
+// Frozen strings never create weak references, so avoid paying for their counter.
+use triomphe::Arc;
 
 /// The number of UTF-8 bytes stored directly inside a [`FrozenCompactString`].
 const INLINE_CAPACITY: usize = 15;
@@ -156,6 +158,18 @@ impl FrozenRepr {
         debug_assert!(self.is_heap_allocated());
         ptr::slice_from_raw_parts(self.0.cast::<u8>(), self.heap_len())
     }
+
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "temporarily reconstructs the owning Arc without releasing its reference"
+    )]
+    fn with_arc<R>(&self, f: impl FnOnce(&Arc<[u8]>) -> R) -> R {
+        // SAFETY: `raw_arc_ptr` reconstructs the pointer returned by `Arc::into_raw`, and this
+        // value keeps that strong reference alive for the duration of the callback.
+        let arc = unsafe { ManuallyDrop::new(Arc::from_raw_slice(self.raw_arc_ptr())) };
+        f(&arc)
+    }
 }
 
 #[inline]
@@ -172,15 +186,12 @@ fn tag(byte: u8) -> NonZeroU8 {
 
 impl Clone for FrozenRepr {
     #[inline]
-    #[expect(
-        unsafe_code,
-        reason = "cloning shared storage increments the strong count of its raw Arc pointer"
-    )]
     fn clone(&self) -> Self {
         if self.is_heap_allocated() {
-            // SAFETY: `raw_arc_ptr` reconstructs the pointer returned by `Arc::into_raw`, and this
-            // value owns a live strong reference for the duration of this call.
-            unsafe { Arc::increment_strong_count(self.raw_arc_ptr()) };
+            self.with_arc(|arc| {
+                // Transfer the cloned strong reference to the returned representation.
+                let _ = Arc::into_raw(arc.clone());
+            });
         }
 
         Self(self.0, self.1, self.2)
@@ -197,7 +208,7 @@ impl Drop for FrozenRepr {
         if self.is_heap_allocated() {
             // SAFETY: Each heap representation owns exactly one strong reference corresponding to
             // this raw pointer. Reconstructing and dropping the Arc releases that reference.
-            unsafe { drop(Arc::from_raw(self.raw_arc_ptr())) };
+            unsafe { drop(Arc::from_raw_slice(self.raw_arc_ptr())) };
         }
     }
 }
@@ -265,6 +276,8 @@ mod tests {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
+    use triomphe::Arc;
+
     use super::{FrozenCompactString, INLINE_CAPACITY};
 
     #[test]
@@ -295,11 +308,15 @@ mod tests {
     #[test]
     fn heap_clones_share_storage() {
         let frozen = FrozenCompactString::new("a string too long for inline storage");
+        assert_eq!(frozen.0.with_arc(Arc::strong_count), 1);
+
         let clone = frozen.clone();
         assert_eq!(frozen.as_str().as_ptr(), clone.as_str().as_ptr());
+        assert_eq!(frozen.0.with_arc(Arc::strong_count), 2);
 
         drop(frozen);
         assert_eq!(clone.as_str(), "a string too long for inline storage");
+        assert_eq!(clone.0.with_arc(Arc::strong_count), 1);
     }
 
     #[test]

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -13,6 +13,7 @@ pub mod comparable;
 pub mod docstrings;
 mod expression;
 pub mod find_node;
+mod frozen_string;
 mod generated;
 pub mod helpers;
 pub mod identifier;

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -6,38 +6,35 @@ use std::ops::Deref;
 use arrayvec::ArrayVec;
 
 use crate::Expr;
+use crate::frozen_string::FrozenCompactString;
 use crate::generated::ExprName;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "cache", derive(ruff_macros::CacheKey))]
-#[cfg_attr(feature = "salsa", derive(salsa::Update))]
-#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 #[cfg_attr(
     feature = "schemars",
     derive(schemars::JsonSchema),
     schemars(with = "String")
 )]
-pub struct Name(compact_str::CompactString);
+pub struct Name(FrozenCompactString);
 
 impl Name {
     #[inline]
     pub fn empty() -> Self {
-        Self(compact_str::CompactString::default())
+        Self(FrozenCompactString::default())
     }
 
     #[inline]
     pub fn new(name: impl AsRef<str>) -> Self {
-        Self(compact_str::CompactString::new(name))
+        Self(FrozenCompactString::new(name))
     }
 
     #[inline]
-    pub const fn new_static(name: &'static str) -> Self {
-        Self(compact_str::CompactString::const_new(name))
+    pub fn new_static(name: &'static str) -> Self {
+        Self::new(name)
     }
 
     pub fn shrink_to_fit(&mut self) {
-        self.0.shrink_to_fit();
+        // Inline storage has a fixed size and shared heap storage has no spare capacity.
     }
 
     pub fn as_str(&self) -> &str {
@@ -45,7 +42,10 @@ impl Name {
     }
 
     pub fn push_str(&mut self, s: &str) {
-        self.0.push_str(s);
+        let mut name = String::with_capacity(self.len() + s.len());
+        name.push_str(self);
+        name.push_str(s);
+        self.0 = FrozenCompactString::from(name);
     }
 }
 
@@ -57,7 +57,7 @@ impl Debug for Name {
 
 impl std::fmt::Write for Name {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        self.0.push_str(s);
+        self.push_str(s);
         Ok(())
     }
 }
@@ -88,49 +88,49 @@ impl Borrow<str> for Name {
 impl<'a> From<&'a str> for Name {
     #[inline]
     fn from(s: &'a str) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
 impl From<String> for Name {
     #[inline]
     fn from(s: String) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
 impl<'a> From<&'a String> for Name {
     #[inline]
     fn from(s: &'a String) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
 impl<'a> From<Cow<'a, str>> for Name {
     #[inline]
     fn from(cow: Cow<'a, str>) -> Self {
-        Name(cow.into())
+        Name::new(cow)
     }
 }
 
 impl From<Box<str>> for Name {
     #[inline]
     fn from(b: Box<str>) -> Self {
-        Name(b.into())
+        Name::new(b)
     }
 }
 
 impl From<compact_str::CompactString> for Name {
     #[inline]
     fn from(value: compact_str::CompactString) -> Self {
-        Self(value)
+        Self::new(value)
     }
 }
 
 impl From<Name> for compact_str::CompactString {
     #[inline]
     fn from(name: Name) -> Self {
-        name.0
+        compact_str::CompactString::new(name.as_str())
     }
 }
 
@@ -143,7 +143,86 @@ impl From<Name> for String {
 
 impl FromIterator<char> for Name {
     fn from_iter<I: IntoIterator<Item = char>>(iter: I) -> Self {
-        Self(iter.into_iter().collect())
+        Self::from(iter.into_iter().collect::<String>())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Name {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_newtype_struct("Name", self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Name {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct NameVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for NameVisitor {
+            type Value = Name;
+
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a Python name")
+            }
+
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let value = <Cow<'de, str> as serde::Deserialize>::deserialize(deserializer)?;
+                Ok(Name::new(value))
+            }
+        }
+
+        deserializer.deserialize_newtype_struct("Name", NameVisitor)
+    }
+}
+
+#[cfg(feature = "cache")]
+impl ruff_cache::CacheKey for Name {
+    fn cache_key(&self, state: &mut ruff_cache::CacheKeyHasher) {
+        ruff_cache::CacheKey::cache_key(self.as_str(), state);
+    }
+}
+
+#[cfg(feature = "get-size")]
+impl get_size2::GetSize for Name {
+    fn get_heap_size_with_tracker<T: get_size2::GetSizeTracker>(
+        &self,
+        mut tracker: T,
+    ) -> (usize, T) {
+        let size = if self.0.is_heap_allocated() && tracker.track(self.as_ptr()) {
+            self.len()
+        } else {
+            0
+        };
+        (size, tracker)
+    }
+}
+
+#[cfg(feature = "salsa")]
+#[expect(
+    unsafe_code,
+    reason = "implements Salsa's unsafe update contract for an owned value"
+)]
+unsafe impl salsa::Update for Name {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        // SAFETY: `Update` guarantees that `old_pointer` is valid and uniquely available for the
+        // duration of this call. `Name` owns all of its data and has no borrowed state.
+        let old_value = unsafe { &mut *old_pointer };
+        if *old_value == new_value {
+            false
+        } else {
+            *old_value = new_value;
+            true
+        }
     }
 }
 
@@ -759,7 +838,39 @@ type SegmentsStack<'a> = ArrayVec<&'a str, SMALL_LEN>;
 
 #[cfg(test)]
 mod tests {
-    use crate::name::SegmentsVec;
+    #[cfg(feature = "get-size")]
+    use get_size2::{GetSize, StandardTracker};
+
+    use crate::Identifier;
+    use crate::name::{Name, SegmentsVec};
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn size() {
+        assert_eq!(std::mem::size_of::<Name>(), 16);
+        assert_eq!(std::mem::size_of::<Option<Name>>(), 16);
+        assert_eq!(std::mem::size_of::<Identifier>(), 32);
+    }
+
+    #[test]
+    #[cfg(all(feature = "serde", feature = "schemars"))]
+    fn serde_roundtrip() {
+        let name = Name::new("Python_🐍");
+        let serialized = serde_json::to_string(&name).unwrap();
+        assert_eq!(serde_json::from_str::<Name>(&serialized).unwrap(), name);
+    }
+
+    #[test]
+    #[cfg(feature = "get-size")]
+    fn heap_size_tracks_shared_storage_once() {
+        assert_eq!(Name::new("inline").get_heap_size(), 0);
+
+        let name = Name::new("a name too long for inline storage");
+        let expected = name.len();
+        let clone = name.clone();
+        let (size, _) = (name, clone).get_heap_size_with_tracker(StandardTracker::new());
+        assert_eq!(size, expected);
+    }
 
     #[test]
     fn empty_vec() {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3896,16 +3896,16 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size() {
-        assert_eq!(std::mem::size_of::<Stmt>(), 96);
-        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 96);
-        assert_eq!(std::mem::size_of::<StmtClassDef>(), 88);
+        assert_eq!(std::mem::size_of::<Stmt>(), 88);
+        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 88);
+        assert_eq!(std::mem::size_of::<StmtClassDef>(), 80);
         assert_eq!(std::mem::size_of::<StmtTry>(), 64);
         assert_eq!(std::mem::size_of::<Mod>(), 32);
-        assert_eq!(std::mem::size_of::<Pattern>(), 80);
+        assert_eq!(std::mem::size_of::<Pattern>(), 72);
         assert_eq!(std::mem::size_of::<Parameters>(), 56);
         assert_eq!(std::mem::size_of::<Arguments>(), 40);
         assert_eq!(std::mem::size_of::<Expr>(), 72);
-        assert_eq!(std::mem::size_of::<ExprAttribute>(), 64);
+        assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 24);
         assert_eq!(std::mem::size_of::<ExprBinOp>(), 32);
         assert_eq!(std::mem::size_of::<ExprBoolOp>(), 40);
@@ -3923,7 +3923,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprLambda>(), 32);
         assert_eq!(std::mem::size_of::<ExprList>(), 40);
         assert_eq!(std::mem::size_of::<ExprListComp>(), 48);
-        assert_eq!(std::mem::size_of::<ExprName>(), 40);
+        assert_eq!(std::mem::size_of::<ExprName>(), 32);
         assert_eq!(std::mem::size_of::<ExprNamed>(), 32);
         assert_eq!(std::mem::size_of::<ExprNoneLiteral>(), 12);
         assert_eq!(std::mem::size_of::<ExprNumberLiteral>(), 40);


### PR DESCRIPTION
## Summary

This draft isolates the custom frozen-string representation for Python AST `Name` values and uses `triomphe::Arc<[u8]>` for heap-backed strings. Frozen strings never create weak references, so long names need one atomic strong counter rather than the strong and weak counters in `std::sync::Arc`. The 16-byte value layout and 15-byte inline capacity are unchanged.

This is the Triomphe variant in a three-way comparison: custom FrozenCompactString in #26550, FrozenCompactString + Triomphe here, and ArcStr in #26549. Compared with #26550, this PR only changes the heap owner and adds its dependency; it contains no other optimizations or benchmark/workflow changes from #26544.

In a local Massif microbenchmark that constructs 100,000 unique 24-byte names, requested heap usage fell by 14.7%, or 22.6% including allocator overhead. This intentionally amplifies the heap-backed path; the full `ruff_python_ast` and `ruff_python_parser` test suites pass, as does Clippy for `ruff_python_ast`.