### PR TITLE
[ty] Recognize that dedent ends doctest block when parsing docstrings for signature help

### DIFF
--- a/crates/ty_ide/src/docstring/document/preformatted.rs
+++ b/crates/ty_ide/src/docstring/document/preformatted.rs
@@ -44,7 +44,7 @@ impl<'a> MarkdownFence<'a> {
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(super) struct PreformattedBlockScanner<'a> {
     active_markdown_fence: Option<MarkdownFence<'a>>,
-    active_doctest: bool,
+    active_doctest_indent: Option<TextSize>,
     rest_literal_blocks: RestLiteralBlockScanner,
 }
 
@@ -68,15 +68,19 @@ impl<'a> PreformattedBlockScanner<'a> {
             return true;
         }
 
-        if self.active_doctest {
+        if let Some(doctest_indent) = self.active_doctest_indent {
             if line.trim_start_matches(' ').is_empty() {
-                self.active_doctest = false;
+                self.active_doctest_indent = None;
+                return true;
+            } else if indentation(line) < doctest_indent {
+                self.active_doctest_indent = None;
+            } else {
+                return true;
             }
-            return true;
         }
 
         if Self::line_starts_doctest(line) {
-            self.active_doctest = true;
+            self.active_doctest_indent = Some(indentation(line));
             return true;
         }
 

--- a/crates/ty_ide/src/docstring/document/rst.rs
+++ b/crates/ty_ide/src/docstring/document/rst.rs
@@ -1105,6 +1105,29 @@ Section::
     }
 
     #[test]
+    fn parser_recovers_after_dedented_doctest() {
+        let docstring = r#"
+        >>> identity(1)
+        1
+    :param value: Parameter documentation.
+"#;
+
+        let parsed = field_lists(docstring);
+
+        assert_eq!(parsed.len(), 1);
+        assert_debug_snapshot!(&parsed[0].fields, @r#"
+        [
+            Parameter {
+                display_name: "value",
+                lookup_name: "value",
+                ty: None,
+                description: "Parameter documentation.",
+            },
+        ]
+        "#);
+    }
+
+    #[test]
     fn doctests_take_precedence_over_markdown_fences_in_preformatted_blocks() {
         let docstring = "\
 >>> print(\"field list\")


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This fixes a small bug in the logic for recognizing the end of a doctest in docstring. The immediate impact is low because the shape that exposes the bug is uncommon in reStructuredText, but the shape is more common in [the Google and NumPy docstring formats that we hope to render as Markdown soon](https://github.com/astral-sh/ty/issues/1667).

## Test Plan

See included test.
<!-- How was it tested? -->
