### PR TITLE
[ty] Filter trivial `object` constructors from `type[...]` intersection member lookup and calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -1120,6 +1120,78 @@ def _(x: type[A] & type[B]) -> None:
     reveal_type(x())  # revealed: A & B
 ```
 
+### Class constructors where one element defines `__init__`
+
+When only one element of a `type[...]` intersection defines a non-trivial `__init__`, that
+constructor should be used: the other element only contributes the trivial `object.__init__`, which
+must not veto the call.
+
+Such an intersection is inhabitable: `HasInit` and `Empty` are ordinary classes, so a subclass
+`Both(HasInit, Empty)` exists and `type[Both]` inhabits `type[HasInit] & type[Empty]`. The `x` below
+is therefore a real value (e.g. `Both`), and `x(...)` a real constructor call.
+
+```py
+class HasInit:
+    def __init__(self, x: int) -> None: ...
+
+class Empty: ...
+class Both(HasInit, Empty): ...
+
+def _(x: type[HasInit] & type[Empty]) -> None:
+    # `__init__` resolves to `HasInit.__init__`, not intersected with the trivial
+    # `object.__init__` (which would collapse the signature to `Never`).
+    reveal_type(x.__init__)  # revealed: def __init__(self, x: int) -> None
+    reveal_type(x(1))  # revealed: HasInit
+
+# `Both` inhabits the intersection, so this is a valid call:
+_(Both)
+```
+
+The same holds for `__new__`:
+
+```py
+from typing_extensions import Self
+
+class HasNew:
+    def __new__(cls, x: int) -> Self:
+        return super().__new__(cls)
+
+class Empty2: ...
+
+def _(x: type[HasNew] & type[Empty2]) -> None:
+    reveal_type(x.__new__)  # revealed: def __new__[Self](cls, x: int) -> Self
+    reveal_type(x(1))  # revealed: HasNew
+```
+
+### Failing construction reports only the real constructor's errors
+
+When constructing a `type[...]` intersection with a bad argument, the errors must come only from the
+element that defines a non-trivial constructor. The element that contributes just the trivial
+`object.__init__` must not additionally report the failing argument against `object.__init__`: that
+is a spurious cascade, since `object.__init__` never participates once a sibling defines a real
+constructor (mirroring the member-lookup filtering).
+
+As above, the intersection is inhabited by `Both(Ctor, Empty)`, so `x(...)` is a real constructor
+call whose diagnostics we are checking.
+
+```py
+class Ctor:
+    def __init__(self, x: int) -> None: ...
+
+class Empty: ...
+class Both(Ctor, Empty): ...
+
+def _(x: type[Ctor] & type[Empty]) -> None:
+    # The only real errors belong to `Ctor.__init__`: the missing required `x`,
+    # and the unexpected keyword `y`. No `object.__init__` diagnostic.
+    # error: [missing-argument] "No argument provided for required parameter `x` of `Ctor.__init__`"
+    # error: [unknown-argument] "Argument `y` does not match any known parameter of `Ctor.__init__`"
+    x(y="wrong")
+
+# `Both` inhabits the intersection, so this is a valid call:
+_(Both)
+```
+
 ### Intersection with `Any`
 
 When one intersection element is `Any`, both elements are called. `Any` is callable and returns

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1044,6 +1044,70 @@ fn object_type_form(db: &dyn Db) -> Type<'_> {
     TypeFormType::from_type_expression(db, Type::object())
 }
 
+/// True if `elem` contributes a constructor dunder (`__init__` or `__new__`, per `name_str`)
+/// that is NOT merely `object`'s trivial one.
+///
+/// For a metatype element (`type[X]`), the constructor lives on the instance's MRO, so we
+/// consult `X` (via `to_instance`) with the no-`object` policy; for an instance element, we
+/// consult it directly. Dynamic elements (e.g. `Any`) resolve to `undefined` under
+/// `MRO_NO_OBJECT_FALLBACK`, so they return `false` here (they define no *concrete* constructor)
+/// and are therefore *kept* by the callers, which only ever drop elements this returns `false`
+/// for when some sibling returns `true`.
+fn defines_non_object_constructor<'db>(
+    db: &'db dyn Db,
+    elem: Type<'db>,
+    name_str: &str,
+    policy: MemberLookupPolicy,
+) -> bool {
+    // A dynamic element (`Any`/`Unknown`/`Todo`) resolves *every* attribute, so a naive lookup
+    // would report it as defining a constructor. But it defines no *concrete* one, and dropping
+    // sibling elements on its behalf would discard their real return-type contributions (e.g.
+    // collapsing `type[Foo] & Any` to `Any`). Treat dynamic elements as non-defining so callers
+    // never filter on their account and never drop them.
+    let lookup_on = elem.to_instance(db).unwrap_or(elem);
+    if lookup_on.is_dynamic() {
+        return false;
+    }
+    let no_object_policy = policy | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK;
+    !lookup_on
+        .member_lookup_with_policy_and_receiver(db, name_str.into(), no_object_policy, None)
+        .place
+        .is_undefined()
+}
+
+/// For a constructor dunder `name_str` (`__init__`/`__new__`) looked up on the positive elements
+/// of `intersection`: if *any* element defines a non-`object` constructor, return the subset of
+/// positive elements that do. Otherwise return `None` (the caller should not filter).
+///
+/// This lets us drop siblings whose only constructor is `object`'s trivial one (which would
+/// otherwise inject a spurious `object.__init__` binding), while leaving purely-dynamic
+/// intersections (e.g. `type[Foo] & Any`, where no element defines a concrete constructor)
+/// completely untouched.
+fn intersection_constructor_defining_elements<'db>(
+    db: &'db dyn Db,
+    intersection: IntersectionType<'db>,
+    name_str: &str,
+    policy: MemberLookupPolicy,
+) -> Option<Vec<Type<'db>>> {
+    if name_str != "__init__" && name_str != "__new__" {
+        return None;
+    }
+    let positive = intersection.positive(db);
+    if !positive
+        .iter()
+        .any(|elem| defines_non_object_constructor(db, *elem, name_str, policy))
+    {
+        return None;
+    }
+    Some(
+        positive
+            .iter()
+            .copied()
+            .filter(|elem| defines_non_object_constructor(db, *elem, name_str, policy))
+            .collect(),
+    )
+}
+
 #[salsa::tracked]
 impl<'db> Type<'db> {
     pub(crate) const fn any() -> Self {
@@ -3898,6 +3962,43 @@ impl<'db> Type<'db> {
                         enums::member_lookup_for_enum_complement(db, complement, name_str, policy)
                     } else {
                         let receiver = Some(receiver.unwrap_or(this));
+
+                        // For the constructor dunders `__init__`/`__new__`, an
+                        // intersection element that only inherits `object`'s
+                        // trivial version must not be conjoined with a sibling
+                        // element that defines a real one: `object.__init__` /
+                        // `object.__new__` would otherwise collapse the resolved
+                        // signature to an uninhabitable `Never` (e.g. looking up
+                        // `__init__` on `type[HasInit] & type[Empty]`). This
+                        // mirrors the `MRO_NO_OBJECT_FALLBACK` policy already used
+                        // when resolving a single class's constructor. Restrict to
+                        // the elements that provide a non-`object` definition when
+                        // any of them do.
+                        if let Some(defining) = intersection_constructor_defining_elements(
+                            db,
+                            intersection,
+                            name_str,
+                            policy,
+                        ) {
+                            let filtered = IntersectionType::from_elements(db, defining);
+                            if let Type::Intersection(filtered) = filtered {
+                                return filtered.map_with_boundness_and_qualifiers(db, |elem| {
+                                    elem.member_lookup_with_policy_and_receiver(
+                                        db,
+                                        name_str.into(),
+                                        policy,
+                                        receiver,
+                                    )
+                                });
+                            }
+                            return filtered.member_lookup_with_policy_and_receiver(
+                                db,
+                                name_str.into(),
+                                policy,
+                                receiver,
+                            );
+                        }
+
                         intersection.map_with_boundness_and_qualifiers(db, |elem| {
                             elem.member_lookup_with_policy_and_receiver(
                                 db,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -283,6 +283,13 @@ impl<'db> CallableItem<'db> {
             .map_or(Ok(()), |bindings| bindings.as_result(db))
     }
 
+    /// True if this item is a constructor whose method is `object`'s trivial `__init__`/`__new__`
+    /// (the constructed class defines no constructor of its own).
+    fn uses_trivial_object_constructor(&self, db: &'db dyn Db) -> bool {
+        self.as_constructor()
+            .is_some_and(|binding| binding.uses_trivial_object_constructor(db))
+    }
+
     fn has_own_diagnostics(&self) -> bool {
         self.callable().as_result().is_err()
     }
@@ -441,6 +448,29 @@ impl<'db> BindingsElement<'db> {
                     || item.error_priority(db) == CallErrorPriority::TopCallable
             });
         }
+    }
+
+    /// In a `type[...]` intersection, drop constructor items that only inherit `object`'s trivial
+    /// `__init__`/`__new__` when a sibling item defines a real constructor.
+    ///
+    /// Constructing such an intersection resolves each element's constructor independently, so a
+    /// bare sibling like `Empty` in `type[Ctor] & type[Empty]` injects an `object.__init__`
+    /// binding. Left in place, that binding would spuriously report a failing argument against
+    /// `object.__init__` (and could veto an otherwise-successful call). The real constructor's
+    /// element already governs the resolved signature and return type (mirroring the member-lookup
+    /// filtering), so the trivial one contributes nothing but noise.
+    fn prune_trivial_object_constructors(&mut self, db: &'db dyn Db) {
+        if !self.is_intersection() {
+            return;
+        }
+        let has_real_constructor = self.items.iter().any(|item| {
+            item.as_constructor().is_some() && !item.uses_trivial_object_constructor(db)
+        });
+        if !has_real_constructor {
+            return;
+        }
+        self.items
+            .retain(|item| !item.uses_trivial_object_constructor(db));
     }
 
     /// Returns the error priority for this element (used when all bindings failed).
@@ -1072,6 +1102,13 @@ impl<'db> Bindings<'db> {
                 call_expression_tcx,
                 dataclass_field_specifiers,
             );
+        }
+
+        // Drop trivial `object.__init__`/`__new__` constructor items from `type[...]`
+        // intersections where a sibling defines a real constructor, so they neither veto the call
+        // nor report a bad argument against `object`.
+        for element in &mut self.elements {
+            element.prune_trivial_object_constructors(db);
         }
 
         // For intersection elements with at least one successful binding,

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -4,7 +4,9 @@ use crate::types::call::arguments::CallArguments;
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::generics::Specialization;
 use crate::types::signatures::Parameter;
-use crate::types::{BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeContext};
+use crate::types::{
+    BoundTypeVarInstance, ClassLiteral, DynamicType, MemberLookupPolicy, Type, TypeContext,
+};
 
 /// Bindings for a constructor call.
 ///
@@ -504,6 +506,38 @@ impl<'db> ConstructorBinding<'db> {
 
     fn constructor_kind(&self) -> ConstructorCallableKind {
         self.constructor_context.kind()
+    }
+
+    /// True if this binding's constructor is `object`'s trivial `__init__`/`__new__`, i.e. the
+    /// constructed class defines no constructor of its own and only inherits `object`'s.
+    ///
+    /// Used to suppress this binding within a `type[...]` intersection when a sibling element
+    /// defines a real constructor: `object.__init__` must neither veto the call nor report the
+    /// bad argument against itself.
+    pub(super) fn uses_trivial_object_constructor(&self, db: &'db dyn Db) -> bool {
+        let name = match self.constructor_kind() {
+            ConstructorCallableKind::Init => "__init__",
+            ConstructorCallableKind::New => "__new__",
+            // A metaclass `__call__` is never `object`'s trivial constructor.
+            ConstructorCallableKind::MetaclassCall => return false,
+        };
+        // `constructed_instance_type` is already the constructed *instance* (e.g. `Empty`), so the
+        // dunder is looked up directly on it.
+        let instance = self.constructed_instance_type();
+        // A dynamic instance (e.g. `Any`) resolves every dunder; it is not a *concrete* trivial
+        // constructor and must not be treated as one.
+        if instance.is_dynamic() {
+            return false;
+        }
+        instance
+            .member_lookup_with_policy(
+                db,
+                name.into(),
+                MemberLookupPolicy::NO_INSTANCE_FALLBACK
+                    | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+            )
+            .place
+            .is_undefined()
     }
 }
 


### PR DESCRIPTION
## Summary

When looking up or calling a constructor on an intersection of class objects (`type[X] & type[Y]`) where only one element defines a real constructor, ty incorrectly lets the other element's trivial `object.__init__` / `object.__new__`
participate.

This caused two related bugs:
1. Member lookup: `(type[HasInit] & type[Empty]).__init__` conjoined `object.__init__` into the resolved signature, collapsing it toward `Never`.
2. Construction call: a failing `(type[Ctor] & type[Empty])(...)` call spuriously reported the bad argument against `object.__init__` (or    `object.__new__`), in addition to the real constructor's errors.

This PR filters out the trivial `object` constructor from both paths whenever a sibling intersection element defines a real constructor, mirroring the `MRO_NO_OBJECT_FALLBACK` policy already used when resolving a single class's constructor:

- Member-lookup arm: shared helpers (`defines_non_object_constructor`, `intersection_constructor_defining_elements`) restrict `__init__`/`__new__` resolution to elements that define a non-`object` constructor.
- Construction-call path: `prune_trivial_object_constructors` drops trivial   `object`-constructor bindings from an intersection element when a sibling defines a real one, so they neither veto the call nor report false cascades.

Dynamic elements (e.g. `Any`) are deliberately treated as not defining a concrete constructor, so `type[Foo] & Any` keeps both elements' contributions (`Foo & Any`) rather than being collapsed.

## Test Plan

Added mdtest coverage in `intersection_types.md`:
- `Class constructors where one element defines __init__` / `__new__` (member lookup).
- `Failing construction reports only the real constructor's errors` (construction call).

Full `ty_python_semantic` mdtest suite passes (468 tests); full workspace `cargo test` passes.