### PR TITLE
[ruff] Do not suppress RUF059 when locals() is called

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF059_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF059_0.py
@@ -31,6 +31,19 @@ def f():
     x = 1
 
 
+# Unpacked assignments should still be flagged even with locals().
+def f():
+    bar = (1, 2)
+    locals()
+    (a, b) = bar
+
+
+def f():
+    bar = (1, 2)
+    (a, b) = bar
+    locals()
+
+
 def f():
     _ = 1
     __ = 1

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
@@ -150,9 +150,9 @@ pub(crate) fn deferred_scopes(checker: &Checker) {
         }
 
         if matches!(scope.kind, ScopeKind::Function(_) | ScopeKind::Lambda(_)) {
-            if checker.any_rule_enabled(&[Rule::UnusedVariable, Rule::UnusedUnpackedVariable])
-                && !(scope.uses_locals() && scope.kind.is_function())
-            {
+            let uses_locals = scope.uses_locals() && scope.kind.is_function();
+
+            if checker.any_rule_enabled(&[Rule::UnusedVariable, Rule::UnusedUnpackedVariable]) {
                 let unused_bindings = scope
                     .bindings()
                     .map(|(name, binding_id)| (name, checker.semantic().binding(binding_id)))
@@ -179,7 +179,11 @@ pub(crate) fn deferred_scopes(checker: &Checker) {
                     });
 
                 for (unused_name, unused_binding) in unused_bindings {
-                    if checker.is_rule_enabled(Rule::UnusedVariable) {
+                    // `locals()` makes all local variables implicitly "used"
+                    // since they're accessible through the returned dict. However,
+                    // unpacked assignments (RUF059) are very unlikely to be
+                    // accessed through `locals()`, so we still report those.
+                    if checker.is_rule_enabled(Rule::UnusedVariable) && !uses_locals {
                         pyflakes::rules::unused_variable(checker, unused_name, unused_binding);
                     }
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF059_RUF059_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF059_RUF059_0.py.snap
@@ -71,121 +71,191 @@ help: Prefix it with an underscore or any other dummy variable pattern
    |
 note: This is an unsafe fix and may change runtime behavior
 
-RUF059 [*] Unpacked variable `connection` is never used
-  --> RUF059_0.py:66:24
+RUF059 [*] Unpacked variable `a` is never used
+  --> RUF059_0.py:38:6
    |
-64 |         return None, None
-65 |
-66 |     with connect() as (connection, cursor):
-   |                        ^^^^^^^^^^
-67 |         cursor.execute("SELECT * FROM users")
+36 |     bar = (1, 2)
+37 |     locals()
+38 |     (a, b) = bar
+   |      ^
    |
 help: Prefix it with an underscore or any other dummy variable pattern
    |
-65 |
-   -     with connect() as (connection, cursor):
-66 +     with connect() as (_connection, cursor):
-67 |         cursor.execute("SELECT * FROM users")
+37 |     locals()
+   -     (a, b) = bar
+38 +     (_a, b) = bar
+39 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF059 [*] Unpacked variable `b` is never used
+  --> RUF059_0.py:38:9
+   |
+36 |     bar = (1, 2)
+37 |     locals()
+38 |     (a, b) = bar
+   |         ^
+   |
+help: Prefix it with an underscore or any other dummy variable pattern
+   |
+37 |     locals()
+   -     (a, b) = bar
+38 +     (a, _b) = bar
+39 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF059 [*] Unpacked variable `a` is never used
+  --> RUF059_0.py:43:6
+   |
+41 | def f():
+42 |     bar = (1, 2)
+43 |     (a, b) = bar
+   |      ^
+44 |     locals()
+   |
+help: Prefix it with an underscore or any other dummy variable pattern
+   |
+42 |     bar = (1, 2)
+   -     (a, b) = bar
+43 +     (_a, b) = bar
+44 |     locals()
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF059 [*] Unpacked variable `b` is never used
+  --> RUF059_0.py:43:9
+   |
+41 | def f():
+42 |     bar = (1, 2)
+43 |     (a, b) = bar
+   |         ^
+44 |     locals()
+   |
+help: Prefix it with an underscore or any other dummy variable pattern
+   |
+42 |     bar = (1, 2)
+   -     (a, b) = bar
+43 +     (a, _b) = bar
+44 |     locals()
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF059 [*] Unpacked variable `connection` is never used
-  --> RUF059_0.py:74:24
+  --> RUF059_0.py:79:24
    |
-72 |         return None, None
-73 |
-74 |     with connect() as (connection, cursor):
+77 |         return None, None
+78 |
+79 |     with connect() as (connection, cursor):
    |                        ^^^^^^^^^^
-75 |         cursor.execute("SELECT * FROM users")
+80 |         cursor.execute("SELECT * FROM users")
    |
 help: Prefix it with an underscore or any other dummy variable pattern
    |
-73 |
+78 |
    -     with connect() as (connection, cursor):
-74 +     with connect() as (_connection, cursor):
-75 |         cursor.execute("SELECT * FROM users")
+79 +     with connect() as (_connection, cursor):
+80 |         cursor.execute("SELECT * FROM users")
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF059 [*] Unpacked variable `connection` is never used
+  --> RUF059_0.py:87:24
+   |
+85 |         return None, None
+86 |
+87 |     with connect() as (connection, cursor):
+   |                        ^^^^^^^^^^
+88 |         cursor.execute("SELECT * FROM users")
+   |
+help: Prefix it with an underscore or any other dummy variable pattern
+   |
+86 |
+   -     with connect() as (connection, cursor):
+87 +     with connect() as (_connection, cursor):
+88 |         cursor.execute("SELECT * FROM users")
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF059 [*] Unpacked variable `this` is never used
-  --> RUF059_0.py:79:49
+  --> RUF059_0.py:92:49
    |
-78 | def f():
-79 |     with open("file") as my_file, open("") as ((this, that)):
+91 | def f():
+92 |     with open("file") as my_file, open("") as ((this, that)):
    |                                                 ^^^^
-80 |         print("hello")
+93 |         print("hello")
    |
 help: Prefix it with an underscore or any other dummy variable pattern
    |
-78 | def f():
+91 | def f():
    -     with open("file") as my_file, open("") as ((this, that)):
-79 +     with open("file") as my_file, open("") as ((_this, that)):
-80 |         print("hello")
+92 +     with open("file") as my_file, open("") as ((_this, that)):
+93 |         print("hello")
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF059 [*] Unpacked variable `that` is never used
-  --> RUF059_0.py:79:55
+  --> RUF059_0.py:92:55
    |
-78 | def f():
-79 |     with open("file") as my_file, open("") as ((this, that)):
+91 | def f():
+92 |     with open("file") as my_file, open("") as ((this, that)):
    |                                                       ^^^^
-80 |         print("hello")
+93 |         print("hello")
    |
 help: Prefix it with an underscore or any other dummy variable pattern
    |
-78 | def f():
+91 | def f():
    -     with open("file") as my_file, open("") as ((this, that)):
-79 +     with open("file") as my_file, open("") as ((this, _that)):
-80 |         print("hello")
+92 +     with open("file") as my_file, open("") as ((this, _that)):
+93 |         print("hello")
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF059 [*] Unpacked variable `this` is never used
-  --> RUF059_0.py:86:23
-   |
-84 |     with (
-85 |         open("file") as my_file,
-86 |         open("") as ((this, that)),
-   |                       ^^^^
-87 |     ):
-88 |         print("hello")
-   |
+   --> RUF059_0.py:99:23
+    |
+ 97 |     with (
+ 98 |         open("file") as my_file,
+ 99 |         open("") as ((this, that)),
+    |                       ^^^^
+100 |     ):
+101 |         print("hello")
+    |
 help: Prefix it with an underscore or any other dummy variable pattern
-   |
-85 |         open("file") as my_file,
-   -         open("") as ((this, that)),
-86 +         open("") as ((_this, that)),
-87 |     ):
-   |
+    |
+98  |         open("file") as my_file,
+    -         open("") as ((this, that)),
+99  +         open("") as ((_this, that)),
+100 |     ):
+    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF059 [*] Unpacked variable `that` is never used
-  --> RUF059_0.py:86:29
-   |
-84 |     with (
-85 |         open("file") as my_file,
-86 |         open("") as ((this, that)),
-   |                             ^^^^
-87 |     ):
-88 |         print("hello")
-   |
+   --> RUF059_0.py:99:29
+    |
+ 97 |     with (
+ 98 |         open("file") as my_file,
+ 99 |         open("") as ((this, that)),
+    |                             ^^^^
+100 |     ):
+101 |         print("hello")
+    |
 help: Prefix it with an underscore or any other dummy variable pattern
-   |
-85 |         open("file") as my_file,
-   -         open("") as ((this, that)),
-86 +         open("") as ((this, _that)),
-87 |     ):
-   |
+    |
+98  |         open("file") as my_file,
+    -         open("") as ((this, that)),
+99  +         open("") as ((this, _that)),
+100 |     ):
+    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF059 Unpacked variable `x` is never used
-   --> RUF059_0.py:101:5
+   --> RUF059_0.py:114:5
     |
- 99 | # see: https://github.com/astral-sh/ruff/issues/18507
-100 | def f(_x):
-101 |     x, = "1"
+112 | # see: https://github.com/astral-sh/ruff/issues/18507
+113 | def f(_x):
+114 |     x, = "1"
     |     ^
-102 |     print(_x)
+115 |     print(_x)
     |
 help: Prefix it with an underscore or any other dummy variable pattern


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

Fixes #26522.

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This PR ensures that [`RUF059` (unused unpacked variables)](https://docs.astral.sh/ruff/rules/unused-unpacked-variable/) is still reported even when `locals()` is called in the same scope. Previously, any call to `locals()` would completely suppress both [`F841` (unused variables)](https://docs.astral.sh/ruff/rules/unused-variable/) and `RUF059` in that scope.

Since unpacked variables are rarely accessed dynamically via `locals()` compared to simple assignments, I think it's reasonable to exempt `RUF059` from this suppression. We can leave the `F841` suppression to preserve existing behavior for simple assignments.

Throwing this up as a draft to get some thoughts. cc @btjanaka would you prefer a different direction?

## Test Plan

<!-- How was it tested? -->

- Added test cases to `RUF059_0.py` to verify that unpacked assignments are flagged in scopes that call `locals()`.