### PR TITLE
[ty] Silence ecosystem-analyzer workflow warnings

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -127,15 +127,15 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
           version: "0.11.26"
-          # This job downloads artifacts instead of checking out the repository,
-          # so the usual files that setup-uv would use for its cache-invalidation keys
-          # (pyproject.toml, uv.lock, etc.) aren't available. An empty
-          # glob means "never invalidate setup-uv's cache":
-          # https://github.com/astral-sh/setup-uv/blob/fac544c07dec837d0ccb6301d7b5580bf5edae39/docs/caching.md#cache-dependency-glob
-          cache-dependency-glob: ""
           ignore-empty-workdir: true
+          # The default of `enable-cache: auto` leads to warnings from setup-uv in this job,
+          # since its cache-invalidation keys (pyproject.toml, uv.lock, etc.) aren't available
+          # here. But the cache doesn't help us much here anyway, since the uv binary, the
+          # Python binary, and all pre-built wheels are all excluded from setup-uv's cache.
+          # The cache would only save us from building two Git dependencies which are both
+          # small, pure-Python projects.
+          enable-cache: false
 
       - name: Download ty binaries, flaky project list, and config
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -187,15 +187,15 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
           version: "0.11.26"
-          # This job downloads artifacts instead of checking out the repository,
-          # so the usual files that setup-uv would use for its cache-invalidation keys
-          # (pyproject.toml, uv.lock, etc.) aren't available. An empty
-          # glob means "never invalidate setup-uv's cache":
-          # https://github.com/astral-sh/setup-uv/blob/fac544c07dec837d0ccb6301d7b5580bf5edae39/docs/caching.md#cache-dependency-glob
-          cache-dependency-glob: ""
           ignore-empty-workdir: true
+          # The default of `enable-cache: auto` leads to warnings from setup-uv in this job,
+          # since its cache-invalidation keys (pyproject.toml, uv.lock, etc.) aren't available
+          # here. But the cache doesn't help us much here anyway, since the uv binary, the
+          # Python binary, and all pre-built wheels are all excluded from setup-uv's cache.
+          # The cache would only save us from building two Git dependencies which are both
+          # small, pure-Python projects.
+          enable-cache: false
 
       - name: Download shard diagnostics
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -127,7 +127,9 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          # This job downloads artifacts instead of checking out the repository.
+          # This job downloads artifacts instead of checking out the repository. An empty
+          # glob means "never invalidate setup-uv's cache":
+          # https://github.com/astral-sh/setup-uv/blob/fac544c07dec837d0ccb6301d7b5580bf5edae39/docs/caching.md#cache-dependency-glob
           cache-dependency-glob: ""
           enable-cache: true
           ignore-empty-workdir: true
@@ -183,7 +185,9 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          # This job downloads artifacts instead of checking out the repository.
+          # This job downloads artifacts instead of checking out the repository. An empty
+          # glob means "never invalidate setup-uv's cache":
+          # https://github.com/astral-sh/setup-uv/blob/fac544c07dec837d0ccb6301d7b5580bf5edae39/docs/caching.md#cache-dependency-glob
           cache-dependency-glob: ""
           enable-cache: true
           ignore-empty-workdir: true

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -127,7 +127,10 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
+          # This job downloads artifacts instead of checking out the repository.
+          cache-dependency-glob: ""
           enable-cache: true
+          ignore-empty-workdir: true
           version: "0.11.26"
 
       - name: Download ty binaries, flaky project list, and config
@@ -180,7 +183,10 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
+          # This job downloads artifacts instead of checking out the repository.
+          cache-dependency-glob: ""
           enable-cache: true
+          ignore-empty-workdir: true
           version: "0.11.26"
 
       - name: Download shard diagnostics

--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -127,13 +127,15 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          # This job downloads artifacts instead of checking out the repository. An empty
+          enable-cache: true
+          version: "0.11.26"
+          # This job downloads artifacts instead of checking out the repository,
+          # so the usual files that setup-uv would use for its cache-invalidation keys
+          # (pyproject.toml, uv.lock, etc.) aren't available. An empty
           # glob means "never invalidate setup-uv's cache":
           # https://github.com/astral-sh/setup-uv/blob/fac544c07dec837d0ccb6301d7b5580bf5edae39/docs/caching.md#cache-dependency-glob
           cache-dependency-glob: ""
-          enable-cache: true
           ignore-empty-workdir: true
-          version: "0.11.26"
 
       - name: Download ty binaries, flaky project list, and config
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -185,13 +187,15 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          # This job downloads artifacts instead of checking out the repository. An empty
+          enable-cache: true
+          version: "0.11.26"
+          # This job downloads artifacts instead of checking out the repository,
+          # so the usual files that setup-uv would use for its cache-invalidation keys
+          # (pyproject.toml, uv.lock, etc.) aren't available. An empty
           # glob means "never invalidate setup-uv's cache":
           # https://github.com/astral-sh/setup-uv/blob/fac544c07dec837d0ccb6301d7b5580bf5edae39/docs/caching.md#cache-dependency-glob
           cache-dependency-glob: ""
-          enable-cache: true
           ignore-empty-workdir: true
-          version: "0.11.26"
 
       - name: Download shard diagnostics
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary

The `analyze-shards` and `generate-report` jobs intentionally run without a repository checkout, but `setup-uv` was emitting a ton of warnings on every workflow run as a result: https://github.com/astral-sh/ruff/actions/runs/28787803707?pr=26369 (scroll down to the "Annotations" section of the page after clicking the link).

An empty dependency glob means "never invalidate the cache" for `setup-uv`. The relevant `setup-uv` options are documented as [`cache-dependency-glob`](https://github.com/astral-sh/setup-uv/blob/fac544c07dec837d0ccb6301d7b5580bf5edae39/docs/caching.md#cache-dependency-glob) and [`ignore-empty-workdir`](https://github.com/astral-sh/setup-uv/blob/fac544c07dec837d0ccb6301d7b5580bf5edae39/action.yml#L71-L73).

## Test plan

The ecosystem-analyzer CI job completed successfully and there are no warnings at https://github.com/astral-sh/ruff/actions/runs/28790620373?pr=26558