### PR TITLE
[ty] Experiment with parser-interned ArcStr AST names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3603,6 +3603,7 @@ dependencies = [
  "compact_str",
  "datatest-stable",
  "get-size2",
+ "hashbrown 0.17.1",
  "insta",
  "itertools 0.15.0",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "argfile"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,6 +3480,7 @@ name = "ruff_python_ast"
 version = "0.0.3"
 dependencies = [
  "aho-corasick",
+ "arcstr",
  "arrayvec",
  "bitflags 2.13.0",
  "compact_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ anstream = { version = "1.0.0" }
 anstyle = { version = "1.0.10" }
 anyhow = { version = "1.0.80" }
 arc-swap = { version = "1.7.1" }
+arcstr = { version = "1.2.0", default-features = false }
 argfile = { version = "1.0.0" }
 assert_fs = { version = "1.1.0" }
 rkyv = { version = "0.8.16" }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -25,6 +25,7 @@ ruff_text_size = { workspace = true }
 
 aho-corasick = { workspace = true }
 arrayvec = { workspace = true }
+arcstr = { workspace = true }
 bitflags = { workspace = true }
 compact_str = { workspace = true }
 get-size2 = { workspace = true, optional = true }

--- a/crates/ruff_python_ast/src/frozen_string.rs
+++ b/crates/ruff_python_ast/src/frozen_string.rs
@@ -1,0 +1,318 @@
+//! Immutable string storage for [`crate::name::Name`].
+
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+use std::mem;
+use std::num::NonZeroU8;
+use std::ptr;
+use std::slice;
+use std::str;
+use std::sync::Arc;
+
+/// The number of UTF-8 bytes stored directly inside a [`FrozenCompactString`].
+const INLINE_CAPACITY: usize = 15;
+
+// Heap tags encode the most significant length byte plus one, reserving zero as a niche. Inline
+// tags start above the heap range and encode lengths 0 through 15.
+const HEAP_TAG_MAX: u8 = 128;
+const INLINE_TAG_BASE: u8 = 193;
+const REPR_SIZE: usize = 16;
+const TAIL_SIZE: usize = REPR_SIZE - mem::size_of::<*const ()>() - 1;
+
+/// A 16-byte immutable string with 15 bytes of inline storage and shared heap allocations.
+#[repr(transparent)]
+pub(crate) struct FrozenCompactString(FrozenRepr);
+
+/// A pointer-sized field, byte tail, and niche-bearing final byte.
+///
+/// Inline values reinterpret the first 15 bytes as string storage. Heap values retain the data
+/// pointer returned by `Arc<[u8]>::into_raw`; the tail and final byte encode the slice length.
+#[repr(C)]
+struct FrozenRepr(*const (), [u8; TAIL_SIZE], NonZeroU8);
+
+#[cfg(target_pointer_width = "64")]
+#[repr(C, align(8))]
+struct FrozenInline([u8; INLINE_CAPACITY], NonZeroU8);
+
+#[cfg(target_pointer_width = "32")]
+#[repr(C, align(4))]
+struct FrozenInline([u8; INLINE_CAPACITY], NonZeroU8);
+
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+compile_error!("FrozenCompactString only supports 32-bit and 64-bit targets");
+
+const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenRepr>()];
+const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenInline>()];
+const _: [(); mem::align_of::<FrozenRepr>()] = [(); mem::align_of::<FrozenInline>()];
+const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenCompactString>()];
+const _: [(); REPR_SIZE] = [(); mem::size_of::<Option<FrozenCompactString>>()];
+
+impl FrozenCompactString {
+    #[inline]
+    pub(crate) fn new(text: impl AsRef<str>) -> Self {
+        Self(FrozenRepr::new(text.as_ref()))
+    }
+
+    #[inline]
+    pub(crate) fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    #[inline]
+    #[cfg(any(feature = "get-size", test))]
+    pub(crate) fn is_heap_allocated(&self) -> bool {
+        self.0.is_heap_allocated()
+    }
+}
+
+impl FrozenRepr {
+    #[inline]
+    fn new(text: &str) -> Self {
+        if text.len() <= INLINE_CAPACITY {
+            Self::new_inline(text)
+        } else {
+            Self::new_heap(text)
+        }
+    }
+
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "the inline and tagged representations have identical layouts"
+    )]
+    fn new_inline(text: &str) -> Self {
+        let len = u8::try_from(text.len()).expect("inline strings are at most 15 bytes");
+        let mut inline = FrozenInline([0; INLINE_CAPACITY], tag(INLINE_TAG_BASE + len));
+        inline.0[..text.len()].copy_from_slice(text.as_bytes());
+
+        // SAFETY: `FrozenInline` and `FrozenRepr` have identical size and alignment. The final
+        // byte is nonzero, and raw pointers permit any bit pattern for the inline case.
+        unsafe { mem::transmute(inline) }
+    }
+
+    #[cold]
+    fn new_heap(text: &str) -> Self {
+        let raw = Arc::<[u8]>::into_raw(Arc::from(text.as_bytes()));
+        let len_bytes = text.len().to_le_bytes();
+        let high_byte_index = len_bytes.len() - 1;
+        let mut tail = [0; TAIL_SIZE];
+        tail[..high_byte_index].copy_from_slice(&len_bytes[..high_byte_index]);
+
+        // Rust requires slice allocations to be no larger than `isize::MAX`, so incrementing the
+        // high byte produces a nonzero tag in the heap range.
+        debug_assert!(len_bytes[high_byte_index] < HEAP_TAG_MAX);
+        Self(
+            raw.cast::<u8>().cast::<()>(),
+            tail,
+            tag(len_bytes[high_byte_index] + 1),
+        )
+    }
+
+    #[inline]
+    fn tag(&self) -> u8 {
+        self.2.get()
+    }
+
+    #[inline]
+    fn is_heap_allocated(&self) -> bool {
+        self.tag() <= HEAP_TAG_MAX
+    }
+
+    #[inline]
+    fn heap_len(&self) -> usize {
+        debug_assert!(self.is_heap_allocated());
+
+        let mut bytes = 0usize.to_le_bytes();
+        let high_byte_index = bytes.len() - 1;
+        bytes[..high_byte_index].copy_from_slice(&self.1[..high_byte_index]);
+        bytes[high_byte_index] = self.tag() - 1;
+        usize::from_le_bytes(bytes)
+    }
+
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "the tagged representation stores either inline bytes or a raw Arc slice"
+    )]
+    fn as_str(&self) -> &str {
+        let bytes = if self.is_heap_allocated() {
+            // SAFETY: The pointer and encoded length came from an `Arc<[u8]>` that this value owns
+            // one strong reference to, and the allocation remains immutable for its lifetime.
+            unsafe { &*self.raw_arc_ptr() }
+        } else {
+            let len = self.tag() as usize - INLINE_TAG_BASE as usize;
+            // SAFETY: Inline bytes begin at the same address as the representation, and `len` is
+            // in 0..=15 by construction.
+            unsafe { slice::from_raw_parts(ptr::from_ref(self).cast::<u8>(), len) }
+        };
+
+        // SAFETY: Both representations are created exclusively from valid `str` values and expose
+        // no mutation that could violate UTF-8.
+        unsafe { str::from_utf8_unchecked(bytes) }
+    }
+
+    #[inline]
+    fn raw_arc_ptr(&self) -> *const [u8] {
+        debug_assert!(self.is_heap_allocated());
+        ptr::slice_from_raw_parts(self.0.cast::<u8>(), self.heap_len())
+    }
+}
+
+#[inline]
+#[expect(
+    unsafe_code,
+    reason = "all representation tags are statically constrained to nonzero ranges"
+)]
+fn tag(byte: u8) -> NonZeroU8 {
+    debug_assert!(byte <= HEAP_TAG_MAX || (INLINE_TAG_BASE..=INLINE_TAG_BASE + 15).contains(&byte));
+
+    // SAFETY: Callers only pass 1..=128 or 193..=208.
+    unsafe { NonZeroU8::new_unchecked(byte) }
+}
+
+impl Clone for FrozenRepr {
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "cloning shared storage increments the strong count of its raw Arc pointer"
+    )]
+    fn clone(&self) -> Self {
+        if self.is_heap_allocated() {
+            // SAFETY: `raw_arc_ptr` reconstructs the pointer returned by `Arc::into_raw`, and this
+            // value owns a live strong reference for the duration of this call.
+            unsafe { Arc::increment_strong_count(self.raw_arc_ptr()) };
+        }
+
+        Self(self.0, self.1, self.2)
+    }
+}
+
+impl Drop for FrozenRepr {
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "dropping shared storage releases the strong count of its raw Arc pointer"
+    )]
+    fn drop(&mut self) {
+        if self.is_heap_allocated() {
+            // SAFETY: Each heap representation owns exactly one strong reference corresponding to
+            // this raw pointer. Reconstructing and dropping the Arc releases that reference.
+            unsafe { drop(Arc::from_raw(self.raw_arc_ptr())) };
+        }
+    }
+}
+
+// SAFETY: Inline values contain owned bytes. Heap values hold a strong reference to an immutable
+// `Arc<[u8]>`, which is Send and Sync.
+#[expect(unsafe_code, reason = "the raw pointer owns immutable Arc storage")]
+unsafe impl Send for FrozenRepr {}
+// SAFETY: See the `Send` implementation above; no API exposes mutation of shared storage.
+#[expect(unsafe_code, reason = "the raw pointer owns immutable Arc storage")]
+unsafe impl Sync for FrozenRepr {}
+
+impl Clone for FrozenCompactString {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl Default for FrozenCompactString {
+    fn default() -> Self {
+        Self::new("")
+    }
+}
+
+impl Hash for FrozenCompactString {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl PartialEq for FrozenCompactString {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for FrozenCompactString {}
+
+impl PartialOrd for FrozenCompactString {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for FrozenCompactString {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl From<String> for FrozenCompactString {
+    #[inline]
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    use super::{FrozenCompactString, INLINE_CAPACITY};
+
+    #[test]
+    fn representation_is_16_bytes() {
+        assert_eq!(size_of::<FrozenCompactString>(), 16);
+        assert_eq!(size_of::<Option<FrozenCompactString>>(), 16);
+    }
+
+    #[test]
+    fn inline_and_heap_strings_roundtrip() {
+        for len in 0..=INLINE_CAPACITY {
+            let text = "x".repeat(len);
+            let frozen = FrozenCompactString::new(&text);
+            assert_eq!(frozen.as_str(), text);
+            assert!(!frozen.is_heap_allocated());
+        }
+
+        for text in [
+            "x".repeat(INLINE_CAPACITY + 1),
+            String::from("Python 🐍 and Rust 🦀"),
+        ] {
+            let frozen = FrozenCompactString::new(&text);
+            assert_eq!(frozen.as_str(), text);
+            assert!(frozen.is_heap_allocated());
+        }
+    }
+
+    #[test]
+    fn heap_clones_share_storage() {
+        let frozen = FrozenCompactString::new("a string too long for inline storage");
+        let clone = frozen.clone();
+        assert_eq!(frozen.as_str().as_ptr(), clone.as_str().as_ptr());
+
+        drop(frozen);
+        assert_eq!(clone.as_str(), "a string too long for inline storage");
+    }
+
+    #[test]
+    fn equality_hash_and_order_match_str() {
+        let alpha = FrozenCompactString::new("alpha");
+        let beta = FrozenCompactString::new("beta value too long to store inline");
+        assert!(alpha < beta);
+        assert!(alpha == FrozenCompactString::new("alpha"));
+
+        let mut expected = DefaultHasher::new();
+        "alpha".hash(&mut expected);
+        let mut actual = DefaultHasher::new();
+        alpha.hash(&mut actual);
+        assert_eq!(actual.finish(), expected.finish());
+    }
+}

--- a/crates/ruff_python_ast/src/frozen_string.rs
+++ b/crates/ruff_python_ast/src/frozen_string.rs
@@ -1,56 +1,16 @@
 //! Immutable string storage for [`crate::name::Name`].
 
-use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
-use std::mem;
-use std::num::NonZeroU8;
-use std::ptr;
-use std::slice;
-use std::str;
-use std::sync::Arc;
+use arcstr::ArcStr;
 
-/// The number of UTF-8 bytes stored directly inside a [`FrozenCompactString`].
-const INLINE_CAPACITY: usize = 15;
-
-// Heap tags encode the most significant length byte plus one, reserving zero as a niche. Inline
-// tags start above the heap range and encode lengths 0 through 15.
-const HEAP_TAG_MAX: u8 = 128;
-const INLINE_TAG_BASE: u8 = 193;
-const REPR_SIZE: usize = 16;
-const TAIL_SIZE: usize = REPR_SIZE - mem::size_of::<*const ()>() - 1;
-
-/// A 16-byte immutable string with 15 bytes of inline storage and shared heap allocations.
+/// An immutable, atomically reference-counted string.
+#[derive(Clone, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
-pub(crate) struct FrozenCompactString(FrozenRepr);
-
-/// A pointer-sized field, byte tail, and niche-bearing final byte.
-///
-/// Inline values reinterpret the first 15 bytes as string storage. Heap values retain the data
-/// pointer returned by `Arc<[u8]>::into_raw`; the tail and final byte encode the slice length.
-#[repr(C)]
-struct FrozenRepr(*const (), [u8; TAIL_SIZE], NonZeroU8);
-
-#[cfg(target_pointer_width = "64")]
-#[repr(C, align(8))]
-struct FrozenInline([u8; INLINE_CAPACITY], NonZeroU8);
-
-#[cfg(target_pointer_width = "32")]
-#[repr(C, align(4))]
-struct FrozenInline([u8; INLINE_CAPACITY], NonZeroU8);
-
-#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
-compile_error!("FrozenCompactString only supports 32-bit and 64-bit targets");
-
-const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenRepr>()];
-const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenInline>()];
-const _: [(); mem::align_of::<FrozenRepr>()] = [(); mem::align_of::<FrozenInline>()];
-const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenCompactString>()];
-const _: [(); REPR_SIZE] = [(); mem::size_of::<Option<FrozenCompactString>>()];
+pub(crate) struct FrozenCompactString(ArcStr);
 
 impl FrozenCompactString {
     #[inline]
     pub(crate) fn new(text: impl AsRef<str>) -> Self {
-        Self(FrozenRepr::new(text.as_ref()))
+        Self(ArcStr::from(text.as_ref()))
     }
 
     #[inline]
@@ -61,202 +21,14 @@ impl FrozenCompactString {
     #[inline]
     #[cfg(any(feature = "get-size", test))]
     pub(crate) fn is_heap_allocated(&self) -> bool {
-        self.0.is_heap_allocated()
-    }
-}
-
-impl FrozenRepr {
-    #[inline]
-    fn new(text: &str) -> Self {
-        if text.len() <= INLINE_CAPACITY {
-            Self::new_inline(text)
-        } else {
-            Self::new_heap(text)
-        }
-    }
-
-    #[inline]
-    #[expect(
-        unsafe_code,
-        reason = "the inline and tagged representations have identical layouts"
-    )]
-    fn new_inline(text: &str) -> Self {
-        let len = u8::try_from(text.len()).expect("inline strings are at most 15 bytes");
-        let mut inline = FrozenInline([0; INLINE_CAPACITY], tag(INLINE_TAG_BASE + len));
-        inline.0[..text.len()].copy_from_slice(text.as_bytes());
-
-        // SAFETY: `FrozenInline` and `FrozenRepr` have identical size and alignment. The final
-        // byte is nonzero, and raw pointers permit any bit pattern for the inline case.
-        unsafe { mem::transmute(inline) }
-    }
-
-    #[cold]
-    fn new_heap(text: &str) -> Self {
-        let raw = Arc::<[u8]>::into_raw(Arc::from(text.as_bytes()));
-        let len_bytes = text.len().to_le_bytes();
-        let high_byte_index = len_bytes.len() - 1;
-        let mut tail = [0; TAIL_SIZE];
-        tail[..high_byte_index].copy_from_slice(&len_bytes[..high_byte_index]);
-
-        // Rust requires slice allocations to be no larger than `isize::MAX`, so incrementing the
-        // high byte produces a nonzero tag in the heap range.
-        debug_assert!(len_bytes[high_byte_index] < HEAP_TAG_MAX);
-        Self(
-            raw.cast::<u8>().cast::<()>(),
-            tail,
-            tag(len_bytes[high_byte_index] + 1),
-        )
-    }
-
-    #[inline]
-    fn tag(&self) -> u8 {
-        self.2.get()
-    }
-
-    #[inline]
-    fn is_heap_allocated(&self) -> bool {
-        self.tag() <= HEAP_TAG_MAX
-    }
-
-    #[inline]
-    fn heap_len(&self) -> usize {
-        debug_assert!(self.is_heap_allocated());
-
-        let mut bytes = 0usize.to_le_bytes();
-        let high_byte_index = bytes.len() - 1;
-        bytes[..high_byte_index].copy_from_slice(&self.1[..high_byte_index]);
-        bytes[high_byte_index] = self.tag() - 1;
-        usize::from_le_bytes(bytes)
-    }
-
-    #[inline]
-    #[expect(
-        unsafe_code,
-        reason = "the tagged representation stores either inline bytes or a raw Arc slice"
-    )]
-    fn as_str(&self) -> &str {
-        let bytes = if self.is_heap_allocated() {
-            // SAFETY: The pointer and encoded length came from an `Arc<[u8]>` that this value owns
-            // one strong reference to, and the allocation remains immutable for its lifetime.
-            unsafe { &*self.raw_arc_ptr() }
-        } else {
-            let len = self.tag() as usize - INLINE_TAG_BASE as usize;
-            // SAFETY: Inline bytes begin at the same address as the representation, and `len` is
-            // in 0..=15 by construction.
-            unsafe { slice::from_raw_parts(ptr::from_ref(self).cast::<u8>(), len) }
-        };
-
-        // SAFETY: Both representations are created exclusively from valid `str` values and expose
-        // no mutation that could violate UTF-8.
-        unsafe { str::from_utf8_unchecked(bytes) }
-    }
-
-    #[inline]
-    fn raw_arc_ptr(&self) -> *const [u8] {
-        debug_assert!(self.is_heap_allocated());
-        ptr::slice_from_raw_parts(self.0.cast::<u8>(), self.heap_len())
-    }
-}
-
-#[inline]
-#[expect(
-    unsafe_code,
-    reason = "all representation tags are statically constrained to nonzero ranges"
-)]
-fn tag(byte: u8) -> NonZeroU8 {
-    debug_assert!(byte <= HEAP_TAG_MAX || (INLINE_TAG_BASE..=INLINE_TAG_BASE + 15).contains(&byte));
-
-    // SAFETY: Callers only pass 1..=128 or 193..=208.
-    unsafe { NonZeroU8::new_unchecked(byte) }
-}
-
-impl Clone for FrozenRepr {
-    #[inline]
-    #[expect(
-        unsafe_code,
-        reason = "cloning shared storage increments the strong count of its raw Arc pointer"
-    )]
-    fn clone(&self) -> Self {
-        if self.is_heap_allocated() {
-            // SAFETY: `raw_arc_ptr` reconstructs the pointer returned by `Arc::into_raw`, and this
-            // value owns a live strong reference for the duration of this call.
-            unsafe { Arc::increment_strong_count(self.raw_arc_ptr()) };
-        }
-
-        Self(self.0, self.1, self.2)
-    }
-}
-
-impl Drop for FrozenRepr {
-    #[inline]
-    #[expect(
-        unsafe_code,
-        reason = "dropping shared storage releases the strong count of its raw Arc pointer"
-    )]
-    fn drop(&mut self) {
-        if self.is_heap_allocated() {
-            // SAFETY: Each heap representation owns exactly one strong reference corresponding to
-            // this raw pointer. Reconstructing and dropping the Arc releases that reference.
-            unsafe { drop(Arc::from_raw(self.raw_arc_ptr())) };
-        }
-    }
-}
-
-// SAFETY: Inline values contain owned bytes. Heap values hold a strong reference to an immutable
-// `Arc<[u8]>`, which is Send and Sync.
-#[expect(unsafe_code, reason = "the raw pointer owns immutable Arc storage")]
-unsafe impl Send for FrozenRepr {}
-// SAFETY: See the `Send` implementation above; no API exposes mutation of shared storage.
-#[expect(unsafe_code, reason = "the raw pointer owns immutable Arc storage")]
-unsafe impl Sync for FrozenRepr {}
-
-impl Clone for FrozenCompactString {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl Default for FrozenCompactString {
-    fn default() -> Self {
-        Self::new("")
-    }
-}
-
-impl Hash for FrozenCompactString {
-    #[inline]
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_str().hash(state);
-    }
-}
-
-impl PartialEq for FrozenCompactString {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.as_str() == other.as_str()
-    }
-}
-
-impl Eq for FrozenCompactString {}
-
-impl PartialOrd for FrozenCompactString {
-    #[inline]
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for FrozenCompactString {
-    #[inline]
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.as_str().cmp(other.as_str())
+        !ArcStr::is_static(&self.0)
     }
 }
 
 impl From<String> for FrozenCompactString {
     #[inline]
     fn from(value: String) -> Self {
-        Self::new(value)
+        Self(ArcStr::from(value))
     }
 }
 
@@ -265,47 +37,51 @@ mod tests {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    use super::{FrozenCompactString, INLINE_CAPACITY};
+    use arcstr::ArcStr;
+
+    use super::FrozenCompactString;
 
     #[test]
-    fn representation_is_16_bytes() {
-        assert_eq!(size_of::<FrozenCompactString>(), 16);
-        assert_eq!(size_of::<Option<FrozenCompactString>>(), 16);
+    fn representation_is_pointer_sized() {
+        assert_eq!(size_of::<FrozenCompactString>(), size_of::<usize>());
+        assert_eq!(size_of::<Option<FrozenCompactString>>(), size_of::<usize>());
     }
 
     #[test]
-    fn inline_and_heap_strings_roundtrip() {
-        for len in 0..=INLINE_CAPACITY {
-            let text = "x".repeat(len);
-            let frozen = FrozenCompactString::new(&text);
-            assert_eq!(frozen.as_str(), text);
-            assert!(!frozen.is_heap_allocated());
-        }
+    fn strings_roundtrip() {
+        let empty = FrozenCompactString::new("");
+        assert_eq!(empty.as_str(), "");
+        assert!(!empty.is_heap_allocated());
 
         for text in [
-            "x".repeat(INLINE_CAPACITY + 1),
-            String::from("Python 🐍 and Rust 🦀"),
+            "x",
+            "a string too long for inline storage",
+            "Python 🐍 and Rust 🦀",
         ] {
-            let frozen = FrozenCompactString::new(&text);
+            let frozen = FrozenCompactString::new(text);
             assert_eq!(frozen.as_str(), text);
             assert!(frozen.is_heap_allocated());
         }
     }
 
     #[test]
-    fn heap_clones_share_storage() {
-        let frozen = FrozenCompactString::new("a string too long for inline storage");
+    fn clones_share_storage() {
+        let frozen = FrozenCompactString::new("shared string");
+        assert_eq!(ArcStr::strong_count(&frozen.0), Some(1));
+
         let clone = frozen.clone();
         assert_eq!(frozen.as_str().as_ptr(), clone.as_str().as_ptr());
+        assert_eq!(ArcStr::strong_count(&frozen.0), Some(2));
 
         drop(frozen);
-        assert_eq!(clone.as_str(), "a string too long for inline storage");
+        assert_eq!(clone.as_str(), "shared string");
+        assert_eq!(ArcStr::strong_count(&clone.0), Some(1));
     }
 
     #[test]
     fn equality_hash_and_order_match_str() {
         let alpha = FrozenCompactString::new("alpha");
-        let beta = FrozenCompactString::new("beta value too long to store inline");
+        let beta = FrozenCompactString::new("beta value");
         assert!(alpha < beta);
         assert!(alpha == FrozenCompactString::new("alpha"));
 

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -13,6 +13,7 @@ pub mod comparable;
 pub mod docstrings;
 mod expression;
 pub mod find_node;
+mod frozen_string;
 mod generated;
 pub mod helpers;
 pub mod identifier;

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -6,38 +6,35 @@ use std::ops::Deref;
 use arrayvec::ArrayVec;
 
 use crate::Expr;
+use crate::frozen_string::FrozenCompactString;
 use crate::generated::ExprName;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "cache", derive(ruff_macros::CacheKey))]
-#[cfg_attr(feature = "salsa", derive(salsa::Update))]
-#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 #[cfg_attr(
     feature = "schemars",
     derive(schemars::JsonSchema),
     schemars(with = "String")
 )]
-pub struct Name(compact_str::CompactString);
+pub struct Name(FrozenCompactString);
 
 impl Name {
     #[inline]
     pub fn empty() -> Self {
-        Self(compact_str::CompactString::default())
+        Self(FrozenCompactString::default())
     }
 
     #[inline]
     pub fn new(name: impl AsRef<str>) -> Self {
-        Self(compact_str::CompactString::new(name))
+        Self(FrozenCompactString::new(name))
     }
 
     #[inline]
-    pub const fn new_static(name: &'static str) -> Self {
-        Self(compact_str::CompactString::const_new(name))
+    pub fn new_static(name: &'static str) -> Self {
+        Self::new(name)
     }
 
     pub fn shrink_to_fit(&mut self) {
-        self.0.shrink_to_fit();
+        // Inline storage has a fixed size and shared heap storage has no spare capacity.
     }
 
     pub fn as_str(&self) -> &str {
@@ -45,7 +42,10 @@ impl Name {
     }
 
     pub fn push_str(&mut self, s: &str) {
-        self.0.push_str(s);
+        let mut name = String::with_capacity(self.len() + s.len());
+        name.push_str(self);
+        name.push_str(s);
+        self.0 = FrozenCompactString::from(name);
     }
 }
 
@@ -57,7 +57,7 @@ impl Debug for Name {
 
 impl std::fmt::Write for Name {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        self.0.push_str(s);
+        self.push_str(s);
         Ok(())
     }
 }
@@ -88,49 +88,49 @@ impl Borrow<str> for Name {
 impl<'a> From<&'a str> for Name {
     #[inline]
     fn from(s: &'a str) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
 impl From<String> for Name {
     #[inline]
     fn from(s: String) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
 impl<'a> From<&'a String> for Name {
     #[inline]
     fn from(s: &'a String) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
 impl<'a> From<Cow<'a, str>> for Name {
     #[inline]
     fn from(cow: Cow<'a, str>) -> Self {
-        Name(cow.into())
+        Name::new(cow)
     }
 }
 
 impl From<Box<str>> for Name {
     #[inline]
     fn from(b: Box<str>) -> Self {
-        Name(b.into())
+        Name::new(b)
     }
 }
 
 impl From<compact_str::CompactString> for Name {
     #[inline]
     fn from(value: compact_str::CompactString) -> Self {
-        Self(value)
+        Self::new(value)
     }
 }
 
 impl From<Name> for compact_str::CompactString {
     #[inline]
     fn from(name: Name) -> Self {
-        name.0
+        compact_str::CompactString::new(name.as_str())
     }
 }
 
@@ -143,7 +143,86 @@ impl From<Name> for String {
 
 impl FromIterator<char> for Name {
     fn from_iter<I: IntoIterator<Item = char>>(iter: I) -> Self {
-        Self(iter.into_iter().collect())
+        Self::from(iter.into_iter().collect::<String>())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Name {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_newtype_struct("Name", self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Name {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct NameVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for NameVisitor {
+            type Value = Name;
+
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a Python name")
+            }
+
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let value = <Cow<'de, str> as serde::Deserialize>::deserialize(deserializer)?;
+                Ok(Name::new(value))
+            }
+        }
+
+        deserializer.deserialize_newtype_struct("Name", NameVisitor)
+    }
+}
+
+#[cfg(feature = "cache")]
+impl ruff_cache::CacheKey for Name {
+    fn cache_key(&self, state: &mut ruff_cache::CacheKeyHasher) {
+        ruff_cache::CacheKey::cache_key(self.as_str(), state);
+    }
+}
+
+#[cfg(feature = "get-size")]
+impl get_size2::GetSize for Name {
+    fn get_heap_size_with_tracker<T: get_size2::GetSizeTracker>(
+        &self,
+        mut tracker: T,
+    ) -> (usize, T) {
+        let size = if self.0.is_heap_allocated() && tracker.track(self.as_ptr()) {
+            self.len()
+        } else {
+            0
+        };
+        (size, tracker)
+    }
+}
+
+#[cfg(feature = "salsa")]
+#[expect(
+    unsafe_code,
+    reason = "implements Salsa's unsafe update contract for an owned value"
+)]
+unsafe impl salsa::Update for Name {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        // SAFETY: `Update` guarantees that `old_pointer` is valid and uniquely available for the
+        // duration of this call. `Name` owns all of its data and has no borrowed state.
+        let old_value = unsafe { &mut *old_pointer };
+        if *old_value == new_value {
+            false
+        } else {
+            *old_value = new_value;
+            true
+        }
     }
 }
 
@@ -759,7 +838,39 @@ type SegmentsStack<'a> = ArrayVec<&'a str, SMALL_LEN>;
 
 #[cfg(test)]
 mod tests {
-    use crate::name::SegmentsVec;
+    #[cfg(feature = "get-size")]
+    use get_size2::{GetSize, StandardTracker};
+
+    use crate::Identifier;
+    use crate::name::{Name, SegmentsVec};
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn size() {
+        assert_eq!(std::mem::size_of::<Name>(), 16);
+        assert_eq!(std::mem::size_of::<Option<Name>>(), 16);
+        assert_eq!(std::mem::size_of::<Identifier>(), 32);
+    }
+
+    #[test]
+    #[cfg(all(feature = "serde", feature = "schemars"))]
+    fn serde_roundtrip() {
+        let name = Name::new("Python_🐍");
+        let serialized = serde_json::to_string(&name).unwrap();
+        assert_eq!(serde_json::from_str::<Name>(&serialized).unwrap(), name);
+    }
+
+    #[test]
+    #[cfg(feature = "get-size")]
+    fn heap_size_tracks_shared_storage_once() {
+        assert_eq!(Name::new("inline").get_heap_size(), 0);
+
+        let name = Name::new("a name too long for inline storage");
+        let expected = name.len();
+        let clone = name.clone();
+        let (size, _) = (name, clone).get_heap_size_with_tracker(StandardTracker::new());
+        assert_eq!(size, expected);
+    }
 
     #[test]
     fn empty_vec() {

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -847,9 +847,9 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size() {
-        assert_eq!(std::mem::size_of::<Name>(), 16);
-        assert_eq!(std::mem::size_of::<Option<Name>>(), 16);
-        assert_eq!(std::mem::size_of::<Identifier>(), 32);
+        assert_eq!(std::mem::size_of::<Name>(), 8);
+        assert_eq!(std::mem::size_of::<Option<Name>>(), 8);
+        assert_eq!(std::mem::size_of::<Identifier>(), 24);
     }
 
     #[test]
@@ -863,7 +863,7 @@ mod tests {
     #[test]
     #[cfg(feature = "get-size")]
     fn heap_size_tracks_shared_storage_once() {
-        assert_eq!(Name::new("inline").get_heap_size(), 0);
+        assert_eq!(Name::empty().get_heap_size(), 0);
 
         let name = Name::new("a name too long for inline storage");
         let expected = name.len();

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3896,16 +3896,16 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size() {
-        assert_eq!(std::mem::size_of::<Stmt>(), 96);
-        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 96);
-        assert_eq!(std::mem::size_of::<StmtClassDef>(), 88);
+        assert_eq!(std::mem::size_of::<Stmt>(), 88);
+        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 88);
+        assert_eq!(std::mem::size_of::<StmtClassDef>(), 80);
         assert_eq!(std::mem::size_of::<StmtTry>(), 64);
         assert_eq!(std::mem::size_of::<Mod>(), 32);
-        assert_eq!(std::mem::size_of::<Pattern>(), 80);
+        assert_eq!(std::mem::size_of::<Pattern>(), 72);
         assert_eq!(std::mem::size_of::<Parameters>(), 56);
         assert_eq!(std::mem::size_of::<Arguments>(), 40);
         assert_eq!(std::mem::size_of::<Expr>(), 72);
-        assert_eq!(std::mem::size_of::<ExprAttribute>(), 64);
+        assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 24);
         assert_eq!(std::mem::size_of::<ExprBinOp>(), 32);
         assert_eq!(std::mem::size_of::<ExprBoolOp>(), 40);
@@ -3923,7 +3923,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprLambda>(), 32);
         assert_eq!(std::mem::size_of::<ExprList>(), 40);
         assert_eq!(std::mem::size_of::<ExprListComp>(), 48);
-        assert_eq!(std::mem::size_of::<ExprName>(), 40);
+        assert_eq!(std::mem::size_of::<ExprName>(), 32);
         assert_eq!(std::mem::size_of::<ExprNamed>(), 32);
         assert_eq!(std::mem::size_of::<ExprNoneLiteral>(), 12);
         assert_eq!(std::mem::size_of::<ExprNumberLiteral>(), 40);

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3896,16 +3896,16 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size() {
-        assert_eq!(std::mem::size_of::<Stmt>(), 88);
-        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 88);
-        assert_eq!(std::mem::size_of::<StmtClassDef>(), 80);
+        assert_eq!(std::mem::size_of::<Stmt>(), 80);
+        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 80);
+        assert_eq!(std::mem::size_of::<StmtClassDef>(), 72);
         assert_eq!(std::mem::size_of::<StmtTry>(), 64);
         assert_eq!(std::mem::size_of::<Mod>(), 32);
         assert_eq!(std::mem::size_of::<Pattern>(), 72);
         assert_eq!(std::mem::size_of::<Parameters>(), 56);
         assert_eq!(std::mem::size_of::<Arguments>(), 40);
         assert_eq!(std::mem::size_of::<Expr>(), 72);
-        assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
+        assert_eq!(std::mem::size_of::<ExprAttribute>(), 48);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 24);
         assert_eq!(std::mem::size_of::<ExprBinOp>(), 32);
         assert_eq!(std::mem::size_of::<ExprBoolOp>(), 40);
@@ -3923,7 +3923,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprLambda>(), 32);
         assert_eq!(std::mem::size_of::<ExprList>(), 40);
         assert_eq!(std::mem::size_of::<ExprListComp>(), 48);
-        assert_eq!(std::mem::size_of::<ExprName>(), 32);
+        assert_eq!(std::mem::size_of::<ExprName>(), 24);
         assert_eq!(std::mem::size_of::<ExprNamed>(), 32);
         assert_eq!(std::mem::size_of::<ExprNoneLiteral>(), 12);
         assert_eq!(std::mem::size_of::<ExprNumberLiteral>(), 40);

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -21,6 +21,7 @@ bitflags = { workspace = true }
 bstr = { workspace = true }
 compact_str = { workspace = true }
 get-size2 = { workspace = true }
+hashbrown = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 static_assertions = { workspace = true }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -583,7 +583,8 @@ impl<'src> Parser<'src> {
         }
 
         if self.current_token_kind().is_soft_keyword() {
-            let id = Name::new(self.src_text(range));
+            let text = self.src_text(range);
+            let id = self.intern_name(text);
             self.bump_soft_keyword_as_name();
             return ast::Identifier {
                 id,
@@ -617,7 +618,8 @@ impl<'src> Parser<'src> {
                 range,
             );
 
-            let id = Name::new(self.src_text(range));
+            let text = self.src_text(range);
+            let id = self.intern_name(text);
             self.bump_any();
             ast::Identifier {
                 id,

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use std::str::FromStr;
 
 use bitflags::bitflags;
+use hashbrown::HashSet;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{
@@ -10,6 +11,7 @@ use ruff_python_ast::{
 };
 use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use rustc_hash::FxBuildHasher;
 use thin_vec::ThinVec;
 use unicode_normalization::UnicodeNormalization;
 
@@ -34,12 +36,31 @@ mod statement;
 #[cfg(test)]
 mod tests;
 
+#[derive(Debug, Default)]
+struct NameInterner {
+    names: HashSet<Name, FxBuildHasher>,
+}
+
+impl NameInterner {
+    fn intern(&mut self, text: &str) -> Name {
+        self.names
+            .get_or_insert_with(text, |text| Name::new(text))
+            .clone()
+    }
+
+    fn intern_owned(&mut self, name: Name) -> Name {
+        self.names.get_or_insert(name).clone()
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {
     source: &'src str,
 
     /// Token source for the parser that skips over any non-trivia token.
     tokens: TokenSource<'src>,
+
+    name_interner: NameInterner,
 
     /// Stores all the syntax errors found during the parsing.
     errors: Vec<ParseError>,
@@ -92,6 +113,7 @@ impl<'src> Parser<'src> {
             errors: Vec::new(),
             unsupported_syntax_errors: Vec::new(),
             tokens,
+            name_interner: NameInterner::default(),
             recovery_context: RecoveryContext::empty(),
             prev_token_end: TextSize::new(0),
             start_offset,
@@ -395,12 +417,21 @@ impl<'src> Parser<'src> {
     fn bump_name(&mut self) -> Name {
         let text = self.current_token_text();
         let name = if !self.tokens.current_flags().is_non_ascii_name() {
-            Name::new(text)
+            self.intern_name(text)
         } else {
-            normalize_name(text)
+            let normalized = normalize_name(text);
+            self.intern_owned_name(normalized)
         };
         self.bump(TokenKind::Name);
         name
+    }
+
+    fn intern_name(&mut self, text: &str) -> Name {
+        self.name_interner.intern(text)
+    }
+
+    fn intern_owned_name(&mut self, name: Name) -> Name {
+        self.name_interner.intern_owned(name)
     }
 
     fn bump_int(&mut self) -> Int {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -848,7 +848,7 @@ impl<'src> Parser<'src> {
         // import a.b.c
         // import a .  b  . c
         ast::Identifier {
-            id: Name::from(dotted_name),
+            id: self.intern_owned_name(Name::from(dotted_name)),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,5 +1,7 @@
+use ruff_python_ast::name::Name;
 use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, Stmt};
 
+use super::NameInterner;
 use crate::{Mode, ParseErrorType, ParseOptions, parse, parse_expression, parse_module};
 
 #[test]
@@ -69,6 +71,52 @@ fn nfkc_normalizes_names() {
     };
 
     assert_eq!(name.id.as_str(), "C");
+}
+
+#[test]
+fn repeated_names_share_storage() {
+    for name in ["x", "identifier_longer_than_inline_capacity"] {
+        let source = format!("{name} = {name}");
+        let parsed = parse_module(&source).unwrap();
+        let [Stmt::Assign(assign)] = parsed.suite().as_slice() else {
+            panic!("expected an assignment");
+        };
+        let [Expr::Name(target)] = assign.targets.as_slice() else {
+            panic!("expected a name target");
+        };
+        let Expr::Name(value) = assign.value.as_ref() else {
+            panic!("expected a name value");
+        };
+
+        assert!(std::ptr::eq(target.id.as_str(), value.id.as_str()));
+    }
+}
+
+#[test]
+fn all_names_are_interned() {
+    let mut interner = NameInterner::default();
+    interner.intern("x");
+    assert_eq!(interner.names.len(), 1);
+
+    interner.intern("identifier_longer_than_inline_capacity");
+    assert_eq!(interner.names.len(), 2);
+}
+
+#[test]
+fn normalized_names_share_storage() {
+    let parsed = parse_module("\u{1d49e} = C").unwrap();
+    let [Stmt::Assign(assign)] = parsed.suite().as_slice() else {
+        panic!("expected an assignment");
+    };
+    let [Expr::Name(target)] = assign.targets.as_slice() else {
+        panic!("expected a name target");
+    };
+    let Expr::Name(value) = assign.value.as_ref() else {
+        panic!("expected a name value");
+    };
+
+    assert_eq!(target.id, Name::new("C"));
+    assert!(std::ptr::eq(target.id.as_str(), value.id.as_str()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This draft combines the pointer-sized ArcStr-backed Python AST `Name` representation from #26549 with parser-local interning. Each parser invocation keeps one `Name` per distinct identifier and clones its `ArcStr` handle for repeated occurrences, including normalized names and short names. The table is released when parsing finishes while the AST retains the shared string allocations.

This branch intentionally targets `main` rather than #26549 so CI compares the complete ArcStr-plus-interner design against the existing `CompactString` representation. Relative to #26549, repeated names no longer allocate independently; distinct runtime names still require one ArcStr allocation and one temporary hash-table entry.

The full `ruff_python_parser` suite and targeted Clippy pass locally.
