### PR TITLE
[ty] Narrow known dataclasses with `is_dataclass`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1806,6 +1806,28 @@ But calling `asdict` on the class object is not allowed:
 asdict(Foo)
 ```
 
+## `dataclasses.is_dataclass`
+
+`DataclassInstance` uses a read-only class variable as its marker and accepts any materialization of
+the gradual `Field[Any]` type. This allows `is_dataclass` to determine that a known dataclass
+instance always satisfies the protocol:
+
+```py
+from dataclasses import asdict, dataclass, is_dataclass
+
+@dataclass
+class Event:
+    x: int
+
+def serialize(event: Event) -> dict[str, object]:
+    if is_dataclass(event):
+        reveal_type(event)  # revealed: Event
+        return asdict(event)
+    else:
+        reveal_type(event)  # revealed: Never
+        return dict(event)
+```
+
 ## `dataclasses.KW_ONLY`
 
 If an attribute is annotated with `dataclasses.KW_ONLY`, it is not added to the synthesized

--- a/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/__init__.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/__init__.pyi
@@ -22,6 +22,8 @@ from typing import (
     TypeVar,
     overload,
 )
+
+from ty_extensions import Top as _Top
 from typing_extensions import Buffer, LiteralString, Self as _Self
 
 _KT = TypeVar("_KT")
@@ -363,7 +365,7 @@ TraceFunction: TypeAlias = Callable[
 #   https://github.com/python/typeshed/pull/9362
 #   https://github.com/microsoft/pyright/issues/4339
 class DataclassInstance(Protocol):
-    __dataclass_fields__: ClassVar[dict[str, Field[Any]]]
+    __dataclass_fields__: ClassVar[Final[_Top[dict[str, Field[Any]]]]]
 
 # Anything that can be passed to the int/float constructors
 if sys.version_info >= (3, 14):


### PR DESCRIPTION
## Summary

`dataclasses.is_dataclass` is already annotated in typeshed as returning `TypeIs[DataclassInstance | type[DataclassInstance]]`, but we did not consider a known dataclass instance to be a subtype of that target. The false branch therefore retained an impossible intersection instead of simplifying to `Never`:

```python
@dataclass
class Event:
    x: int

def serialize(event: Event) -> dict[str, object]:
    if is_dataclass(event):
        return asdict(event)
    else:
        reveal_type(event)  # previously: Event & ~DataclassInstance & ~type
```

Now that https://github.com/astral-sh/ruff/pull/25332 supports read-only `ClassVar` protocol members, this updates the bundled `_typeshed.DataclassInstance` marker to use `ClassVar[Final[Top[...]]]`. `Final` expresses that protocol matching only requires reading the marker, while `Top` accepts any materialization of the invariant gradual `dict[str, Field[Any]]` type.

This allows the existing `TypeIs` annotation to narrow the false branch to `Never` without a known-function special case for `is_dataclass`.

Closes https://github.com/astral-sh/ty/issues/3443.
