### PR TITLE
[ty] Materialize class-based protocol interfaces

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/async.md
@@ -241,7 +241,7 @@ async def f(fn: Callable[[int], int | Awaitable[int]]) -> None:
     if is_async_callable(fn):
         reveal_type(fn)  # revealed: ((int, /) -> int | Awaitable[int]) & Top[(...) -> Top[Awaitable[object]]]
         result = fn(1)
-        # This includes `int & Awaitable[object]`: an `int` subtype could define `__await__`.
+        # This includes `int & Top[Awaitable[object]]`: an `int` subtype could define `__await__`.
         reveal_type(result)  # revealed: (int & Top[Awaitable[object]]) | Awaitable[int]
         reveal_type(await result)  # revealed: object
 ```

--- a/crates/ty_python_semantic/resources/mdtest/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/async.md
@@ -150,7 +150,7 @@ def get_any() -> Any:
 async def test():
     x = get_any()
     if inspect.isawaitable(x):
-        reveal_type(x)  # revealed: Any & Awaitable[object]
+        reveal_type(x)  # revealed: Any & Top[Awaitable[object]]
         y = await x
         reveal_type(y)  # revealed: Any
 ```
@@ -239,10 +239,10 @@ def is_async_callable(x: object) -> TypeIs[Top[Callable[..., Awaitable[object]]]
 
 async def f(fn: Callable[[int], int | Awaitable[int]]) -> None:
     if is_async_callable(fn):
-        reveal_type(fn)  # revealed: ((int, /) -> int | Awaitable[int]) & Top[(...) -> Awaitable[object]]
+        reveal_type(fn)  # revealed: ((int, /) -> int | Awaitable[int]) & Top[(...) -> Top[Awaitable[object]]]
         result = fn(1)
         # This includes `int & Awaitable[object]`: an `int` subtype could define `__await__`.
-        reveal_type(result)  # revealed: (int & Awaitable[object]) | Awaitable[int]
+        reveal_type(result)  # revealed: (int & Top[Awaitable[object]]) | Awaitable[int]
         reveal_type(await result)  # revealed: object
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2222,8 +2222,8 @@ asdict(Foo)
 
 ## `dataclasses.is_dataclass`
 
-`is_dataclass` narrows its argument to the `DataclassInstance` protocol. A concrete dataclass
-instance always satisfies that protocol, so the negative branch is unreachable:
+`is_dataclass` recognizes both dataclass instances and dataclass classes. A concrete dataclass
+instance always satisfies the `DataclassInstance` protocol, so the negative branch is unreachable:
 
 ```py
 from dataclasses import dataclass, is_dataclass

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2220,6 +2220,23 @@ But calling `asdict` on the class object is not allowed:
 asdict(Foo)
 ```
 
+## `dataclasses.is_dataclass`
+
+`is_dataclass` narrows its argument to the `DataclassInstance` protocol. A concrete dataclass
+instance always satisfies that protocol, so the negative branch is unreachable:
+
+```py
+from dataclasses import dataclass, is_dataclass
+
+@dataclass
+class Event:
+    x: int
+
+def check(event: Event) -> None:
+    if not is_dataclass(event):
+        reveal_type(event)  # revealed: Never
+```
+
 ## `dataclasses.KW_ONLY`
 
 If an attribute is annotated with `dataclasses.KW_ONLY`, it is not added to the synthesized

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -464,7 +464,7 @@ especially when using various functions from typeshed that are annotated as retu
 purposes, it would usually lead to more intuitive results if `object` was used as the specialization
 for a covariant generic inside the `TypeIs` special form, but this is mitigated by our implicit
 transformation from `TypeIs[SomeCovariantGeneric[Any]]` to `TypeIs[Top[SomeCovariantGeneric[Any]]]`.
-For a nominal covariant generic, this simplifies to `TypeIs[SomeCovariantGeneric[object]]`.
+For a covariant generic class, this simplifies to `TypeIs[SomeCovariantGeneric[object]]`.
 
 ```py
 class Unrelated: ...
@@ -492,8 +492,8 @@ def _(x: Unrelated | Covariant[int]):
 
 ## `TypeIs` narrowing with protocol class variables
 
-`TypeIs` materializes its return type before narrowing. If a protocol class variable is `Any`, a
-class-side read after narrowing therefore has type `object`:
+`TypeIs` materializes the type it uses for narrowing. If a protocol class variable is `Any`, a read
+through the class object after narrowing therefore has type `object`:
 
 ```py
 from typing import Any, ClassVar, Protocol
@@ -508,29 +508,6 @@ def is_has_class_var(x: object) -> TypeIs[HasClassVar]:
 def _(x: object):
     if is_has_class_var(x):
         reveal_type(type(x).x)  # revealed: object
-```
-
-## `TypeIs` narrowing with inherited protocols
-
-Materialization must preserve protocol inheritance when none of the inherited requirements change:
-
-```py
-from typing import Any, Protocol
-from typing_extensions import TypeIs
-
-class Base(Protocol):
-    value: int
-
-class Derived(Base, Protocol):
-    marker: Any
-
-def is_derived(x: object) -> TypeIs[Derived]:
-    return True
-
-def accepts_base(x: Base) -> None: ...
-def _(x: object):
-    if is_derived(x):
-        accepts_base(x)
 ```
 
 ## `TypeGuard` special cases

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -463,8 +463,8 @@ especially when using various functions from typeshed that are annotated as retu
 `TypeIs[SomeCovariantGeneric[Any]]` to avoid false positives in other type checkers. For ty's
 purposes, it would usually lead to more intuitive results if `object` was used as the specialization
 for a covariant generic inside the `TypeIs` special form, but this is mitigated by our implicit
-transformation from `TypeIs[SomeCovariantGeneric[Any]]` to `TypeIs[Top[SomeCovariantGeneric[Any]]]`
-(which just simplifies to `TypeIs[SomeCovariantGeneric[object]]`).
+transformation from `TypeIs[SomeCovariantGeneric[Any]]` to `TypeIs[Top[SomeCovariantGeneric[Any]]]`.
+For a nominal covariant generic, this simplifies to `TypeIs[SomeCovariantGeneric[object]]`.
 
 ```py
 class Unrelated: ...

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -490,6 +490,49 @@ def _(x: Unrelated | Covariant[int]):
     needs_instance_of_unrelated(x)
 ```
 
+## `TypeIs` narrowing with protocol class variables
+
+`TypeIs` materializes its return type before narrowing. If a protocol class variable is `Any`, a
+class-side read after narrowing therefore has type `object`:
+
+```py
+from typing import Any, ClassVar, Protocol
+from typing_extensions import TypeIs
+
+class HasClassVar(Protocol):
+    x: ClassVar[Any]
+
+def is_has_class_var(x: object) -> TypeIs[HasClassVar]:
+    return True
+
+def _(x: object):
+    if is_has_class_var(x):
+        reveal_type(type(x).x)  # revealed: object
+```
+
+## `TypeIs` narrowing with inherited protocols
+
+Materialization must preserve protocol inheritance when none of the inherited requirements change:
+
+```py
+from typing import Any, Protocol
+from typing_extensions import TypeIs
+
+class Base(Protocol):
+    value: int
+
+class Derived(Base, Protocol):
+    marker: Any
+
+def is_derived(x: object) -> TypeIs[Derived]:
+    return True
+
+def accepts_base(x: Base) -> None: ...
+def _(x: object):
+    if is_derived(x):
+        accepts_base(x)
+```
+
 ## `TypeGuard` special cases
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1278,6 +1278,31 @@ def alias_writes(
     bottom.value = 1
 ```
 
+Read and write mappings use separate transformation caches when a materialized specialization is
+nested inside another generic type:
+
+```py
+class Leaf[T](Protocol):
+    value: T
+
+class Outer[T](Protocol):
+    leaf: Leaf[T]
+
+class ReadHolder[T]:
+    @property
+    def outer(self) -> Outer[T]:
+        raise NotImplementedError
+
+def nested_specialization(
+    holder: Top[ReadHolder[Any]],
+    top_leaf: Top[Leaf[Any]],
+    bottom_leaf: Bottom[Leaf[Any]],
+) -> None:
+    reveal_type(holder.outer)  # revealed: Top[Outer[Any]]
+    holder.outer.leaf = bottom_leaf
+    holder.outer.leaf = top_leaf  # error: [invalid-assignment]
+```
+
 Repeated materialization has no further effect when a recursive protocol reference passes through an
 alias:
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -900,6 +900,43 @@ def preserve_unrelated_any(top: Top[Mixed[Any, int]], bottom: Bottom[Mixed[Any, 
     reveal_type(bottom.nested)  # revealed: list[tuple[Any, int]]
 ```
 
+Alias specializations also preserve the materialization polarity in contravariant positions.
+
+```py
+from ty_extensions import Top, Bottom
+from typing import Any, Callable
+
+type Alias[T] = T
+type AliasedCallable[T] = Callable[[Alias[T]], T]
+
+def _(top: Top[AliasedCallable[Any]], bottom: Bottom[AliasedCallable[Any]]) -> None:
+    reveal_type(top)  # revealed: (Never, /) -> object
+    reveal_type(bottom)  # revealed: (object, /) -> Never
+```
+
+When a materialized class specialization is applied to an attribute, the same function-literal type
+can be visited through both the parameter and return positions of a nested callable. Those positions
+use opposite materialization polarities and must not share a transformation cache.
+
+```py
+from ty_extensions import Top, Bottom
+from typing import Any, Callable
+from ty_extensions._internal import TypeOf
+
+class FunctionHolder[T]:
+    def shared(self, value: T) -> T:
+        raise NotImplementedError
+
+    nested: Callable[[TypeOf[shared]], TypeOf[shared]]
+
+def _(top: Top[FunctionHolder[Any]], bottom: Bottom[FunctionHolder[Any]]) -> None:
+    # revealed: (def shared(self, value: object) -> Never, /) -> def shared(self, value: Never) -> object
+    reveal_type(top.nested)
+
+    # revealed: (def shared(self, value: Never) -> object, /) -> def shared(self, value: object) -> Never
+    reveal_type(bottom.nested)
+```
+
 ## Protocols
 
 Materializing a protocol maps each member according to how it is used. Reads are covariant and
@@ -910,35 +947,49 @@ writes are contravariant.
 python-version = "3.12"
 ```
 
-### Member read and write types
+### Instance attributes
 
 For a mutable `Any` attribute, `Top` reads `object` and writes `Never`; `Bottom` does the reverse:
 
 ```py
-from typing import Any, Callable, Protocol
+from typing import Any, Protocol
 from ty_extensions import Bottom, Top
 
 class MutableAny(Protocol):
     value: Any
 
-def invoke[T](factory: Callable[[], T]) -> T:
-    return factory()
-
 def mutable_attributes(top: Top[MutableAny], bottom: Bottom[MutableAny]) -> None:
     reveal_type(top)  # revealed: Top[MutableAny]
     reveal_type(top.value)  # revealed: object
-    reveal_type(type(top))  # revealed: type[Top[MutableAny]]
-    reveal_type(type(top)())  # revealed: Top[MutableAny]
-    reveal_type(invoke(type(top)))  # revealed: Top[MutableAny]
     top.value = 1  # error: [invalid-assignment]
     reveal_type(bottom)  # revealed: Bottom[MutableAny]
     reveal_type(bottom.value)  # revealed: Never
     bottom.value = object()
 ```
 
+The class object of a materialized protocol preserves its instance type when called directly or
+passed through a generic callable:
+
+```py
+from typing import Callable
+
+def invoke[T](factory: Callable[[], T]) -> T:
+    return factory()
+
+def constructors(top: Top[MutableAny]) -> None:
+    reveal_type(type(top))  # revealed: type[Top[MutableAny]]
+    reveal_type(type(top)())  # revealed: Top[MutableAny]
+    reveal_type(invoke(type(top)))  # revealed: Top[MutableAny]
+```
+
+### Writable properties
+
 A property setter is already a write, so its parameter is mapped only once:
 
 ```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
 class WritableAny(Protocol):
     @property
     def value(self) -> Any: ...
@@ -952,7 +1003,7 @@ def writable_properties(top: Top[WritableAny], bottom: Bottom[WritableAny]) -> N
     bottom.value = object()
 ```
 
-### Relations between a protocol and its materializations
+### Protocol relations
 
 `MutableAny` and `Top[MutableAny]` refer to the same protocol class, but they do not have the same
 read and write requirements. Subtyping and union simplification must use those requirements:
@@ -1024,27 +1075,7 @@ class NominalChild(NominalBase, Protocol):
 static_assert(is_subtype_of(Top[NominalChild], NominalBase))
 ```
 
-### Class-side access
-
-Materialization preserves whether a protocol member is available through the class object. Ordinary
-instance attributes remain unavailable through the class object after materialization:
-
-```py
-from typing import Any, Protocol
-from ty_extensions import Bottom, Top
-
-class InstanceOnlyAny(Protocol):
-    value: Any
-
-def instance_only_class_access(
-    top: Top[InstanceOnlyAny],
-    bottom: Bottom[InstanceOnlyAny],
-) -> None:
-    type(top).value  # error: [unresolved-attribute]
-    type(bottom).value  # error: [unresolved-attribute]
-    type(top).value = 1  # error: [invalid-assignment]
-    type(bottom).value = 1  # error: [invalid-assignment]
-```
+### Class variables
 
 Class variables have separate read and write types. `Top` reads `object` and writes `Never`, while
 `Bottom` reads `Never` and writes `object`:
@@ -1066,7 +1097,8 @@ def class_reads(top: Top[ClassVarAny], bottom: Bottom[ClassVarAny]) -> None:
     reveal_type(type(bottom).value)  # revealed: Never
 ```
 
-Class-variable relations and unions use the same mapped read and write types:
+Structural protocol checks use the mapped read and write types as well. `ClassVarInt` satisfies the
+top-materialized protocol, but not the bottom-materialized one:
 
 ```py
 class ClassVarInt:
@@ -1074,8 +1106,12 @@ class ClassVarInt:
 
 static_assert(is_subtype_of(ClassVarInt, Top[ClassVarAny]))
 static_assert(not is_subtype_of(ClassVarInt, Bottom[ClassVarAny]))
-classvar_top_meta: type[Top[ClassVarAny]] = ClassVarInt
+top_class: type[Top[ClassVarAny]] = ClassVarInt
+```
 
+Union simplification preserves the materialized class variable regardless of operand order:
+
+```py
 def class_union_order(
     plain: ClassVarAny,
     top: Top[ClassVarAny],
@@ -1087,10 +1123,15 @@ def class_union_order(
     reveal_type(top_first.value)  # revealed: object
 ```
 
-Ordinary, static, and class methods are available through the class object and use the materialized
-callable signature. Ordinary methods remain unbound:
+### Methods through the class object
+
+Ordinary, static, and class methods use their materialized signatures when accessed through the
+class object. Ordinary methods remain unbound:
 
 ```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
 class DecoratedAny(Protocol):
     def transform(self, value: Any) -> Any: ...
     @staticmethod
@@ -1110,15 +1151,14 @@ def decorated_class_access(
     reveal_type(type(bottom).create)  # revealed: (value: object) -> Never
 ```
 
-### Other members from the protocol class
+### Members outside the protocol interface
 
 `__init__` is not a protocol requirement, but accessing it on a materialized value still uses the
 declaration on the protocol class:
 
 ```py
 from typing import Any, Protocol
-from typing_extensions import TypeIs
-from ty_extensions import Bottom, Top
+from ty_extensions import Top
 
 class ProtocolWithInit(Protocol):
     value: Any
@@ -1129,31 +1169,7 @@ def constructor(top: Top[ProtocolWithInit]) -> None:
     reveal_type(top.__init__)  # revealed: bound method Top[ProtocolWithInit].__init__(value: int) -> None
 ```
 
-Materialization and `TypeIs` narrowing must preserve descriptor binding for class and static
-methods:
-
-```py
-class DescriptorMethods(Protocol):
-    @classmethod
-    def make(cls) -> int: ...
-    @staticmethod
-    def parse() -> str: ...
-
-def is_descriptor_methods(value: object) -> TypeIs[DescriptorMethods]:
-    return True
-
-def descriptor_methods(
-    top: Top[DescriptorMethods],
-    bottom: Bottom[DescriptorMethods],
-    value: object,
-) -> None:
-    reveal_type(top.make())  # revealed: int
-    reveal_type(bottom.parse())  # revealed: str
-    if is_descriptor_methods(value):
-        reveal_type(value.make())  # revealed: int
-```
-
-### Properties
+### Read-only property deletion
 
 Materializing a read-only property must not make it deletable:
 
@@ -1178,8 +1194,10 @@ def property_deletion(
         del value.property  # error: [invalid-assignment]
 ```
 
-The read and write types exposed by a descriptor-decorated property are materialized with their
-respective variance:
+### Descriptor-decorated properties
+
+A descriptor can expose separate read and write types. `Top` maps an `Any` read to `object` and an
+`Any` write to `Never`; `Bottom` maps them in the opposite direction:
 
 ```py
 from typing import Any, Callable, Never, Protocol
@@ -1217,6 +1235,8 @@ static_assert(is_subtype_of(TopDescriptorProperty, Top[DescriptorProperty]))
 static_assert(not is_subtype_of(NarrowBottomDescriptorProperty, Bottom[DescriptorProperty]))
 ```
 
+### Property accessor types
+
 Materializing a property with fully static exposed types is a no-op. The accessor's implicit
 receiver and the setter's return type do not contribute to the property requirement:
 
@@ -1238,10 +1258,15 @@ def fully_static_property(
     reveal_type(bottom)  # revealed: FullyStaticProperty
 ```
 
+### Assigning to properties
+
 A property setter may transform the assigned value. Assigning a literal therefore must not narrow
 subsequent reads to that literal:
 
 ```py
+from typing import Any, Protocol
+from ty_extensions import Top
+
 class TransformingProperty(Protocol):
     marker: Any
 
@@ -1297,10 +1322,14 @@ def generator_delegation(
     reveal_type(generator.__next__())  # revealed: object
     result = yield from generator
     reveal_type(result)  # revealed: object
-    reveal_type(nested.__next__())  # revealed: object
     nested_result = yield from nested
     reveal_type(nested_result)  # revealed: object
+```
 
+The send type is contravariant. A top-materialized generator cannot accept values sent by a
+`Generator[object, object, object]`, while a bottom-materialized generator can:
+
+```py
 def top_generator_send(
     generator: Top[MaterializedGenerator],
 ) -> Generator[object, object, object]:
@@ -1314,13 +1343,13 @@ def bottom_generator_send(
     return result
 ```
 
-### `Self` and legacy type variables
+### `Self` binding
 
 `Self` may appear in `Top[GenericProtocol[Self]]` even when the protocol member itself is `Any`. It
 must still bind to the class through which the attribute is accessed:
 
 ```py
-from typing import Any, Protocol, Self, TypeVar
+from typing import Any, Protocol, Self
 from ty_extensions import Top
 
 class GenericProtocol[T](Protocol):
@@ -1335,9 +1364,14 @@ class SelfContainerChild(SelfContainer):
 reveal_type(SelfContainerChild().member)  # revealed: Top[GenericProtocol[SelfContainerChild]]
 ```
 
+### Legacy type variables
+
 A legacy type variable in the protocol's type arguments still makes the enclosing function generic:
 
 ```py
+from typing import Any, Protocol, TypeVar
+from ty_extensions import Top
+
 T = TypeVar("T")
 
 class LegacyProtocol(Protocol[T]):
@@ -1348,14 +1382,13 @@ def accepts_legacy(value: Top[LegacyProtocol[T]]) -> None: ...
 reveal_type(accepts_legacy)  # revealed: def accepts_legacy[T](value: Top[LegacyProtocol[T]]) -> None
 ```
 
-### Aliases
+### Generic aliases
 
 Expanding a generic alias preserves the materialized write type:
 
 ```py
 from typing import Any, Protocol
-from ty_extensions import Bottom, Top, static_assert
-from ty_extensions._internal import is_equivalent_to
+from ty_extensions import Bottom, Top
 
 class GenericMutable[T](Protocol):
     value: T
@@ -1370,10 +1403,15 @@ def alias_writes(
     bottom.value = object()
 ```
 
-Read and write mappings use separate transformation caches when a materialized specialization is
-nested inside another generic type:
+### Nested generic protocols
+
+A protocol nested inside another generic type preserves its separate read and write requirements
+after materialization:
 
 ```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
 class Leaf[T](Protocol):
     value: T
 
@@ -1395,10 +1433,16 @@ def nested_specialization(
     holder.outer.leaf = top_leaf  # error: [invalid-assignment]
 ```
 
-Repeated materialization has no further effect when a recursive protocol reference passes through an
-alias:
+### Recursive protocols
+
+Materialization terminates when a protocol refers to itself through an alias, including when it is
+applied more than once:
 
 ```py
+from typing import Any, Protocol
+from ty_extensions import Top, static_assert
+from ty_extensions._internal import is_equivalent_to
+
 type RecursiveAlias = RecursiveProtocol
 
 class RecursiveProtocol(Protocol):
@@ -1412,8 +1456,7 @@ static_assert(is_equivalent_to(Top[RecursiveProtocol], Top[Top[RecursiveProtocol
 
 ### Display
 
-Materialized protocols display their polarity around the protocol class while exposing their mapped
-member types:
+Materialized protocols display `Top` and `Bottom` around the protocol class:
 
 ```py
 from typing import Any, Protocol
@@ -1426,41 +1469,4 @@ class ReadAny(Protocol):
 def _(top: Top[ReadAny], bottom: Bottom[ReadAny]) -> None:
     reveal_type(top)  # revealed: Top[ReadAny]
     reveal_type(bottom)  # revealed: Bottom[ReadAny]
-```
-
-Alias specializations also preserve the materialization polarity in contravariant positions.
-
-```py
-from ty_extensions import Top, Bottom
-from typing import Any, Callable
-
-type Alias[T] = T
-type AliasedCallable[T] = Callable[[Alias[T]], T]
-
-def _(top: Top[AliasedCallable[Any]], bottom: Bottom[AliasedCallable[Any]]) -> None:
-    reveal_type(top)  # revealed: (Never, /) -> object
-    reveal_type(bottom)  # revealed: (object, /) -> Never
-```
-
-When a materialized class specialization is applied to an attribute, the same function-literal type
-can be visited through both the parameter and return positions of a nested callable. Those positions
-use opposite materialization polarities and must not share a transformation cache.
-
-```py
-from ty_extensions import Top, Bottom
-from typing import Any, Callable
-from ty_extensions._internal import TypeOf
-
-class FunctionHolder[T]:
-    def shared(self, value: T) -> T:
-        raise NotImplementedError
-
-    nested: Callable[[TypeOf[shared]], TypeOf[shared]]
-
-def _(top: Top[FunctionHolder[Any]], bottom: Bottom[FunctionHolder[Any]]) -> None:
-    # revealed: (def shared(self, value: object) -> Never, /) -> def shared(self, value: Never) -> object
-    reveal_type(top.nested)
-
-    # revealed: (def shared(self, value: Never) -> object, /) -> def shared(self, value: object) -> Never
-    reveal_type(bottom.nested)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -933,7 +933,7 @@ def mutable_attributes(top: Top[MutableAny], bottom: Bottom[MutableAny]) -> None
     top.value = 1  # error: [invalid-assignment]
     reveal_type(bottom)  # revealed: Bottom[MutableAny]
     reveal_type(bottom.value)  # revealed: Never
-    bottom.value = 1
+    bottom.value = object()
 ```
 
 A property setter is already a write, so its parameter is mapped only once:
@@ -949,7 +949,7 @@ def writable_properties(top: Top[WritableAny], bottom: Bottom[WritableAny]) -> N
     reveal_type(top.value)  # revealed: object
     top.value = 1  # error: [invalid-assignment]
     reveal_type(bottom.value)  # revealed: Never
-    bottom.value = 1
+    bottom.value = object()
 ```
 
 ### Relations between a protocol and its materializations
@@ -1029,8 +1029,8 @@ def instance_only_class_access(
     type(bottom).value = 1  # error: [invalid-assignment]
 ```
 
-Class variables have separate read and write types. `Top` permits every read and no writes, while
-`Bottom` permits every write and no reads:
+Class variables have separate read and write types. `Top` reads `object` and writes `Never`, while
+`Bottom` reads `Never` and writes `object`:
 
 ```py
 from typing import Any, ClassVar, Protocol
@@ -1042,7 +1042,7 @@ class ClassVarAny(Protocol):
 
 def class_writes(top: Top[ClassVarAny], bottom: Bottom[ClassVarAny]) -> None:
     type(top).value = 1  # error: [invalid-assignment]
-    type(bottom).value = 1
+    type(bottom).value = object()
 
 def class_reads(top: Top[ClassVarAny], bottom: Bottom[ClassVarAny]) -> None:
     reveal_type(type(top).value)  # revealed: object
@@ -1070,11 +1070,12 @@ def class_union_order(
     reveal_type(top_first.value)  # revealed: object
 ```
 
-Static and class methods are available through the class object and use the materialized callable
-signature:
+Ordinary, static, and class methods are available through the class object and use the materialized
+callable signature. Ordinary methods remain unbound:
 
 ```py
 class DecoratedAny(Protocol):
+    def transform(self, value: Any) -> Any: ...
     @staticmethod
     def parse(value: Any) -> Any: ...
     @classmethod
@@ -1084,8 +1085,10 @@ def decorated_class_access(
     top: Top[DecoratedAny],
     bottom: Bottom[DecoratedAny],
 ) -> None:
+    reveal_type(type(top).transform)  # revealed: (self, /, value: Never) -> object
     reveal_type(type(top).parse)  # revealed: (value: Never) -> object
     reveal_type(type(top).create)  # revealed: (value: Never) -> object
+    reveal_type(type(bottom).transform)  # revealed: (self, /, value: object) -> Never
     reveal_type(type(bottom).parse)  # revealed: (value: object) -> Never
     reveal_type(type(bottom).create)  # revealed: (value: object) -> Never
 ```
@@ -1135,7 +1138,7 @@ def descriptor_methods(
 
 ### Properties
 
-Materializing a property must not discard whether it can be deleted:
+Materializing a read-only property must not make it deletable:
 
 ```py
 from typing import Any, Protocol
@@ -1280,6 +1283,18 @@ def generator_delegation(
     reveal_type(nested.__next__())  # revealed: object
     nested_result = yield from nested
     reveal_type(nested_result)  # revealed: object
+
+def top_generator_send(
+    generator: Top[MaterializedGenerator],
+) -> Generator[object, object, object]:
+    result = yield from generator  # error: [invalid-yield]
+    return result
+
+def bottom_generator_send(
+    generator: Bottom[MaterializedGenerator],
+) -> Generator[object, object, object]:
+    result = yield from generator
+    return result
 ```
 
 ### `Self` and legacy type variables
@@ -1335,7 +1350,7 @@ def alias_writes(
     bottom: Bottom[MutableAlias[Any]],
 ) -> None:
     top.value = 1  # error: [invalid-assignment]
-    bottom.value = 1
+    bottom.value = object()
 ```
 
 Read and write mappings use separate transformation caches when a materialized specialization is
@@ -1393,9 +1408,7 @@ class ReadAny(Protocol):
 
 def _(top: Top[ReadAny], bottom: Bottom[ReadAny]) -> None:
     reveal_type(top)  # revealed: Top[ReadAny]
-    reveal_type(top.value)  # revealed: object
     reveal_type(bottom)  # revealed: Bottom[ReadAny]
-    reveal_type(bottom.value)  # revealed: Never
 ```
 
 Alias specializations also preserve the materialization polarity in contravariant positions.

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1009,6 +1009,26 @@ def _(top: Top[InheritedAny]) -> None:
 
 ### Class-side access
 
+Materialization preserves whether a protocol member is available through the class object. Ordinary
+instance attributes remain unavailable through the class object after materialization:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class InstanceOnlyAny(Protocol):
+    value: Any
+
+def instance_only_class_access(
+    top: Top[InstanceOnlyAny],
+    bottom: Bottom[InstanceOnlyAny],
+) -> None:
+    type(top).value  # error: [unresolved-attribute]
+    type(bottom).value  # error: [unresolved-attribute]
+    type(top).value = 1  # error: [invalid-assignment]
+    type(bottom).value = 1  # error: [invalid-assignment]
+```
+
 Class variables have separate read and write types. `Top` permits every read and no writes, while
 `Bottom` permits every write and no reads:
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1007,6 +1007,23 @@ def _(top: Top[InheritedAny]) -> None:
     requires_int_base(top)  # error: [invalid-argument-type]
 ```
 
+Materializing an unrelated member does not erase explicit protocol inheritance, even when an
+override is structurally incompatible with the base protocol:
+
+```py
+class NominalBase(Protocol):
+    @property
+    def value(self) -> int: ...
+
+class NominalChild(NominalBase, Protocol):
+    marker: Any
+
+    @property
+    def value(self) -> str: ...
+
+static_assert(is_subtype_of(Top[NominalChild], NominalBase))
+```
+
 ### Class-side access
 
 Materialization preserves whether a protocol member is available through the class object. Ordinary

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1158,6 +1158,66 @@ def property_deletion(
         del value.property  # error: [invalid-assignment]
 ```
 
+The read and write types exposed by a descriptor-decorated property are materialized with their
+respective variance:
+
+```py
+from typing import Any, Callable, Never, Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Descriptor:
+    def __get__(self, instance: object, owner: type[object] | None = None) -> Any: ...
+    def __set__(self, instance: object, value: Any) -> None: ...
+
+def descriptor(function: Callable[..., Any]) -> Descriptor:
+    raise NotImplementedError
+
+class DescriptorProperty(Protocol):
+    @descriptor
+    def value(self) -> Any: ...
+
+class TopDescriptorProperty:
+    @property
+    def value(self) -> object:
+        return object()
+
+    @value.setter
+    def value(self, value: Never) -> None: ...
+
+class NarrowBottomDescriptorProperty:
+    @property
+    def value(self) -> Never:
+        raise RuntimeError
+
+    @value.setter
+    def value(self, value: int) -> None: ...
+
+static_assert(is_subtype_of(TopDescriptorProperty, Top[DescriptorProperty]))
+static_assert(not is_subtype_of(NarrowBottomDescriptorProperty, Bottom[DescriptorProperty]))
+```
+
+Materializing a property with fully static exposed types is a no-op. The accessor's implicit
+receiver and the setter's return type do not contribute to the property requirement:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class FullyStaticProperty(Protocol):
+    @property
+    def value(self) -> int: ...
+    @value.setter
+    def value(self, value: int) -> Any: ...
+
+def fully_static_property(
+    top: Top[FullyStaticProperty],
+    bottom: Bottom[FullyStaticProperty],
+) -> None:
+    reveal_type(top)  # revealed: FullyStaticProperty
+    reveal_type(bottom)  # revealed: FullyStaticProperty
+```
+
 A property setter may transform the assigned value. Assigning a literal therefore must not narrow
 subsequent reads to that literal:
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -900,6 +900,399 @@ def preserve_unrelated_any(top: Top[Mixed[Any, int]], bottom: Bottom[Mixed[Any, 
     reveal_type(bottom.nested)  # revealed: list[tuple[Any, int]]
 ```
 
+## Protocols
+
+Materializing a protocol maps each member according to how it is used. Reads are covariant and
+writes are contravariant.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+### Member read and write types
+
+For a mutable `Any` attribute, `Top` reads `object` and writes `Never`; `Bottom` does the reverse:
+
+```py
+from typing import Any, Callable, Protocol
+from ty_extensions import Bottom, Top
+
+class MutableAny(Protocol):
+    value: Any
+
+def invoke[T](factory: Callable[[], T]) -> T:
+    return factory()
+
+def mutable_attributes(top: Top[MutableAny], bottom: Bottom[MutableAny]) -> None:
+    reveal_type(top)  # revealed: Top[MutableAny]
+    reveal_type(top.value)  # revealed: object
+    reveal_type(type(top))  # revealed: type[Top[MutableAny]]
+    reveal_type(type(top)())  # revealed: Top[MutableAny]
+    reveal_type(invoke(type(top)))  # revealed: Top[MutableAny]
+    top.value = 1  # error: [invalid-assignment]
+    reveal_type(bottom)  # revealed: Bottom[MutableAny]
+    reveal_type(bottom.value)  # revealed: Never
+    bottom.value = 1
+```
+
+A property setter is already a write, so its parameter is mapped only once:
+
+```py
+class WritableAny(Protocol):
+    @property
+    def value(self) -> Any: ...
+    @value.setter
+    def value(self, value: Any) -> None: ...
+
+def writable_properties(top: Top[WritableAny], bottom: Bottom[WritableAny]) -> None:
+    reveal_type(top.value)  # revealed: object
+    top.value = 1  # error: [invalid-assignment]
+    reveal_type(bottom.value)  # revealed: Never
+    bottom.value = 1
+```
+
+### Relations between a protocol and its materializations
+
+`MutableAny` and `Top[MutableAny]` refer to the same protocol class, but they do not have the same
+read and write requirements. Subtyping and union simplification must use those requirements:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_subtype_of
+
+class MutableAny(Protocol):
+    value: Any
+
+static_assert(not is_subtype_of(Top[MutableAny], Bottom[MutableAny]))
+static_assert(not is_subtype_of(Top[MutableAny], MutableAny))
+
+def union_order(
+    plain_first: MutableAny | Top[MutableAny],
+    top_first: Top[MutableAny] | MutableAny,
+) -> None:
+    reveal_type(plain_first)  # revealed: Top[MutableAny]
+    reveal_type(top_first)  # revealed: Top[MutableAny]
+    reveal_type(plain_first.value)  # revealed: object
+    reveal_type(top_first.value)  # revealed: object
+```
+
+Inheriting from a protocol must not bypass its materialized write requirement. A nominal subclass
+and a structurally identical class therefore have the same result here:
+
+```py
+class MutableAnySubclass(MutableAny):
+    value: int
+
+class StructuralMutableAny:
+    value: int
+
+static_assert(not is_subtype_of(MutableAnySubclass, Bottom[MutableAny]))
+static_assert(not is_subtype_of(StructuralMutableAny, Bottom[MutableAny]))
+```
+
+An inherited `Any` member is materialized along with members declared directly on the protocol, so
+it cannot satisfy a more specific inherited protocol:
+
+```py
+class GenericBase[T](Protocol):
+    item: T
+
+class InheritedAny(GenericBase[Any], Protocol):
+    marker: Any
+
+def requires_int_base(value: GenericBase[int]) -> None: ...
+def _(top: Top[InheritedAny]) -> None:
+    requires_int_base(top)  # error: [invalid-argument-type]
+```
+
+### Class-side access
+
+Class variables have separate read and write types. `Top` permits every read and no writes, while
+`Bottom` permits every write and no reads:
+
+```py
+from typing import Any, ClassVar, Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_subtype_of
+
+class ClassVarAny(Protocol):
+    value: ClassVar[Any]
+
+def class_writes(top: Top[ClassVarAny], bottom: Bottom[ClassVarAny]) -> None:
+    type(top).value = 1  # error: [invalid-assignment]
+    type(bottom).value = 1
+
+def class_reads(top: Top[ClassVarAny], bottom: Bottom[ClassVarAny]) -> None:
+    reveal_type(type(top).value)  # revealed: object
+    reveal_type(type(bottom).value)  # revealed: Never
+```
+
+Class-variable relations and unions use the same mapped read and write types:
+
+```py
+class ClassVarInt:
+    value: ClassVar[int] = 1
+
+static_assert(is_subtype_of(ClassVarInt, Top[ClassVarAny]))
+static_assert(not is_subtype_of(ClassVarInt, Bottom[ClassVarAny]))
+classvar_top_meta: type[Top[ClassVarAny]] = ClassVarInt
+
+def class_union_order(
+    plain: ClassVarAny,
+    top: Top[ClassVarAny],
+    flag: bool,
+) -> None:
+    plain_first = type(plain) if flag else type(top)
+    top_first = type(top) if flag else type(plain)
+    reveal_type(plain_first.value)  # revealed: object
+    reveal_type(top_first.value)  # revealed: object
+```
+
+Static and class methods are available through the class object and use the materialized callable
+signature:
+
+```py
+class DecoratedAny(Protocol):
+    @staticmethod
+    def parse(value: Any) -> Any: ...
+    @classmethod
+    def create(cls, value: Any) -> Any: ...
+
+def decorated_class_access(
+    top: Top[DecoratedAny],
+    bottom: Bottom[DecoratedAny],
+) -> None:
+    reveal_type(type(top).parse)  # revealed: (value: Never) -> object
+    reveal_type(type(top).create)  # revealed: (value: Never) -> object
+    reveal_type(type(bottom).parse)  # revealed: (value: object) -> Never
+    reveal_type(type(bottom).create)  # revealed: (value: object) -> Never
+```
+
+### Other members from the protocol class
+
+`__init__` is not a protocol requirement, but accessing it on a materialized value still uses the
+declaration on the protocol class:
+
+```py
+from typing import Any, Protocol
+from typing_extensions import TypeIs
+from ty_extensions import Bottom, Top
+
+class ProtocolWithInit(Protocol):
+    value: Any
+
+    def __init__(self, value: int) -> None: ...
+
+def constructor(top: Top[ProtocolWithInit]) -> None:
+    reveal_type(top.__init__)  # revealed: bound method Top[ProtocolWithInit].__init__(value: int) -> None
+```
+
+Materialization and `TypeIs` narrowing must preserve descriptor binding for class and static
+methods:
+
+```py
+class DescriptorMethods(Protocol):
+    @classmethod
+    def make(cls) -> int: ...
+    @staticmethod
+    def parse() -> str: ...
+
+def is_descriptor_methods(value: object) -> TypeIs[DescriptorMethods]:
+    return True
+
+def descriptor_methods(
+    top: Top[DescriptorMethods],
+    bottom: Bottom[DescriptorMethods],
+    value: object,
+) -> None:
+    reveal_type(top.make())  # revealed: int
+    reveal_type(bottom.parse())  # revealed: str
+    if is_descriptor_methods(value):
+        reveal_type(value.make())  # revealed: int
+```
+
+### Properties
+
+Materializing a property must not discard whether it can be deleted:
+
+```py
+from typing import Any, Protocol
+from typing_extensions import TypeIs
+from ty_extensions import Top
+
+class ReadOnlyProperty(Protocol):
+    @property
+    def property(self) -> Any: ...
+
+def is_read_only_property(value: object) -> TypeIs[ReadOnlyProperty]:
+    return True
+
+def property_deletion(
+    top: Top[ReadOnlyProperty],
+    value: object,
+) -> None:
+    del top.property  # error: [invalid-assignment]
+    if is_read_only_property(value):
+        del value.property  # error: [invalid-assignment]
+```
+
+A property setter may transform the assigned value. Assigning a literal therefore must not narrow
+subsequent reads to that literal:
+
+```py
+class TransformingProperty(Protocol):
+    marker: Any
+
+    @property
+    def value(self) -> int: ...
+    @value.setter
+    def value(self, value: int) -> None: ...
+
+def property_assignment_narrowing(top: Top[TransformingProperty]) -> None:
+    top.value = 1
+    reveal_type(top.value)  # revealed: int
+```
+
+### Generic inference through inherited protocols
+
+Generic inference uses the materialized type of an inherited member, not the original `Any`:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Top
+
+class InferenceBase[T](Protocol):
+    @property
+    def item(self) -> T: ...
+
+class InheritedInferenceAny(InferenceBase[Any], Protocol):
+    marker: Any
+
+def infer_item[T](value: InferenceBase[T]) -> T:
+    raise NotImplementedError
+
+def materialized_inference(inherited: Top[InheritedInferenceAny]) -> None:
+    reveal_type(infer_item(inherited))  # revealed: object
+```
+
+### Generator delegation
+
+`yield from` uses the same materialized yield and return types as direct generator methods. Applying
+another materialization must not change a result that no longer contains `Any`:
+
+```py
+from collections.abc import Generator
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class MaterializedGenerator(Generator[Any, Any, Any], Protocol):
+    marker: Any
+
+def generator_delegation(
+    generator: Top[MaterializedGenerator],
+    nested: Bottom[Top[MaterializedGenerator]],
+):
+    reveal_type(generator.__next__())  # revealed: object
+    result = yield from generator
+    reveal_type(result)  # revealed: object
+    reveal_type(nested.__next__())  # revealed: object
+    nested_result = yield from nested
+    reveal_type(nested_result)  # revealed: object
+```
+
+### `Self` and legacy type variables
+
+`Self` may appear in `Top[GenericProtocol[Self]]` even when the protocol member itself is `Any`. It
+must still bind to the class through which the attribute is accessed:
+
+```py
+from typing import Any, Protocol, Self, TypeVar
+from ty_extensions import Top
+
+class GenericProtocol[T](Protocol):
+    value: Any
+
+class SelfContainer:
+    member: Top[GenericProtocol[Self]]
+
+class SelfContainerChild(SelfContainer):
+    pass
+
+reveal_type(SelfContainerChild().member)  # revealed: Top[GenericProtocol[SelfContainerChild]]
+```
+
+A legacy type variable in the protocol's type arguments still makes the enclosing function generic:
+
+```py
+T = TypeVar("T")
+
+class LegacyProtocol(Protocol[T]):
+    value: Any
+
+def accepts_legacy(value: Top[LegacyProtocol[T]]) -> None: ...
+
+reveal_type(accepts_legacy)  # revealed: def accepts_legacy[T](value: Top[LegacyProtocol[T]]) -> None
+```
+
+### Aliases
+
+Expanding a generic alias preserves the materialized write type:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+class GenericMutable[T](Protocol):
+    value: T
+
+type MutableAlias[T] = GenericMutable[T]
+
+def alias_writes(
+    top: Top[MutableAlias[Any]],
+    bottom: Bottom[MutableAlias[Any]],
+) -> None:
+    top.value = 1  # error: [invalid-assignment]
+    bottom.value = 1
+```
+
+Repeated materialization has no further effect when a recursive protocol reference passes through an
+alias:
+
+```py
+type RecursiveAlias = RecursiveProtocol
+
+class RecursiveProtocol(Protocol):
+    marker: Any
+
+    @property
+    def child(self) -> RecursiveAlias: ...
+
+static_assert(is_equivalent_to(Top[RecursiveProtocol], Top[Top[RecursiveProtocol]]))
+```
+
+### Display
+
+Materialized protocols display their polarity around the protocol class while exposing their mapped
+member types:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top
+
+class ReadAny(Protocol):
+    @property
+    def value(self) -> Any: ...
+
+def _(top: Top[ReadAny], bottom: Bottom[ReadAny]) -> None:
+    reveal_type(top)  # revealed: Top[ReadAny]
+    reveal_type(top.value)  # revealed: object
+    reveal_type(bottom)  # revealed: Bottom[ReadAny]
+    reveal_type(bottom.value)  # revealed: Never
+```
+
 Alias specializations also preserve the materialization polarity in contravariant positions.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -947,6 +947,32 @@ writes are contravariant.
 python-version = "3.12"
 ```
 
+### Class-backed protocol specialization during interface construction
+
+An ordinary specialization of a class-backed protocol only maps its class specialization. It must
+not inspect the protocol interface, because the specialization can occur while that same interface
+is being constructed:
+
+```py
+from __future__ import annotations
+
+from typing import Generic, Protocol, TypeVar, overload
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+class Unit(Protocol):
+    def __mul__(self, other: S | Quantity[S]): ...
+
+class Vector(Protocol): ...
+
+class Quantity(Generic[T], Protocol):
+    @overload
+    def __mul__(self, other: Unit | Quantity[S]): ...
+    @overload
+    def __mul__(self, other: Vector) -> Vector: ...
+```
+
 ### Instance attributes
 
 For a mutable `Any` attribute, `Top` reads `object` and writes `Never`; `Bottom` does the reverse:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2722,14 +2722,11 @@ impl<'db> Type<'db> {
         if let Type::ProtocolInstance(protocol) = ty
             && let Some(origin) = protocol.materialized_origin(db)
         {
-            let interface = protocol.interface(db);
-            return if !interface.includes_member(db, name)
-                || origin.interface(db).member_has_todo_type(db, name)
-            {
-                Type::instance(db, *origin).class_member_with_policy(db, name, policy)
-            } else {
-                ty.instance_member(db, name)
-            };
+            return protocol
+                .materialized_interface_member(db, name)
+                .unwrap_or_else(|| {
+                    Type::instance(db, *origin).class_member_with_policy(db, name, policy)
+                });
         }
 
         match ty {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1490,7 +1490,7 @@ impl<'db> Type<'db> {
         match self {
             Type::NominalInstance(instance) => Some(instance.class(db)),
             Type::ProtocolInstance(instance) => {
-                instance.to_nominal_instance(db).map(|i| i.class(db))
+                instance.nominal_origin_instance(db).map(|i| i.class(db))
             }
             Type::TypeAlias(alias) => alias.value_type(db).nominal_class(db),
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).nominal_class(db),
@@ -4586,7 +4586,7 @@ impl<'db> Type<'db> {
                 // checking it structurally again during call inference.
                 if self_instance
                     .as_protocol_instance()
-                    .is_some_and(|protocol| protocol.to_nominal_instance(db).is_some())
+                    .is_some_and(|protocol| protocol.nominal_origin_instance(db).is_some())
                     && signature
                         .overloads
                         .iter()

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6594,16 +6594,12 @@ impl<'db> Type<'db> {
                 }))
             }),
 
-            // Class-backed protocols map through their class specialization without traversing
-            // the interface. Entering the recursive visitor here would make a protocol interface
-            // under construction depend on itself without helping to break the cycle.
+            // A non-materializing mapping on `Protocol::FromClass` only maps the class
+            // specialization, without traversing the protocol interface. Avoid the recursive
+            // visitor in that case: computing its protocol identity inspects the interface, which
+            // can re-enter `cached_protocol_interface` while it is being constructed.
             Type::ProtocolInstance(instance)
-                if instance.is_class_backed()
-                    && !matches!(
-                        type_mapping,
-                        TypeMapping::Materialize(_)
-                            | TypeMapping::ApplySpecializationWithMaterialization { .. }
-                    ) =>
+                if !instance.mapping_traverses_interface(type_mapping) =>
             {
                 Type::ProtocolInstance(
                     instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
@@ -7898,6 +7894,26 @@ pub enum TypeMapping<'a, 'db> {
 }
 
 impl<'db> TypeMapping<'_, 'db> {
+    /// Returns the materialization requested by this mapping, if any.
+    const fn materialization_kind(&self) -> Option<MaterializationKind> {
+        match self {
+            Self::Materialize(kind)
+            | Self::ApplySpecializationWithMaterialization {
+                materialization_kind: kind,
+                ..
+            } => Some(*kind),
+            Self::ApplySpecialization(_)
+            | Self::Promote(..)
+            | Self::BindLegacyTypevars(_)
+            | Self::FreshenBoundTypeVars { .. }
+            | Self::BindSelf(_)
+            | Self::ReplaceSelf { .. }
+            | Self::ReplaceParameterDefaults
+            | Self::EagerExpansion
+            | Self::RescopeReturnCallables(_) => None,
+        }
+    }
+
     /// Update the generic context of a [`Signature`] according to the current type mapping
     pub(crate) fn update_signature_generic_context(
         &self,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -102,7 +102,6 @@ use crate::types::visitor::any_over_type;
 use crate::{Db, FxOrderSet, Program};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 pub use class::{KnownClass, MethodDecorator};
-use instance::Protocol;
 pub use instance::{NominalInstanceType, ProtocolInstanceType};
 pub(crate) use literal::{
     BytesLiteralType, EnumLiteralType, LiteralValueType, LiteralValueTypeKind, StringLiteralType,
@@ -1112,6 +1111,22 @@ struct GeneratorTypes<'db> {
     return_ty: Option<Type<'db>>,
 }
 
+impl<'db> GeneratorTypes<'db> {
+    /// Materializes inherited generator parameters according to their declared variance.
+    ///
+    /// `YieldT` and `ReturnT` are covariant, while `SendT` is contravariant.
+    fn materialize(self, db: &'db dyn Db, kind: MaterializationKind) -> Self {
+        let visitor = ApplyTypeMappingVisitor::default();
+        Self {
+            yield_ty: self.yield_ty.map(|ty| ty.materialize(db, kind, &visitor)),
+            send_ty: self
+                .send_ty
+                .map(|ty| ty.materialize(db, kind.flip(), &visitor)),
+            return_ty: self.return_ty.map(|ty| ty.materialize(db, kind, &visitor)),
+        }
+    }
+}
+
 fn object_type_form(db: &dyn Db) -> Type<'_> {
     TypeFormType::from_type_expression(db, Type::object())
 }
@@ -1363,9 +1378,9 @@ impl<'db> Type<'db> {
                         .any(|ty| ty.is_specialized_generic(db))
             }
             Type::NominalInstance(instance_type) => instance_type.is_definition_generic(db),
-            Type::ProtocolInstance(protocol) => {
-                matches!(protocol.inner, Protocol::FromClass(class) if class.is_generic())
-            }
+            Type::ProtocolInstance(protocol) => protocol
+                .class_origin(db)
+                .is_some_and(|origin| origin.is_generic()),
             Type::TypedDict(typed_dict) => typed_dict
                 .defining_class()
                 .is_some_and(ClassType::is_generic),
@@ -1474,7 +1489,9 @@ impl<'db> Type<'db> {
     pub(crate) fn nominal_class(self, db: &'db dyn Db) -> Option<ClassType<'db>> {
         match self {
             Type::NominalInstance(instance) => Some(instance.class(db)),
-            Type::ProtocolInstance(instance) => instance.to_nominal_instance().map(|i| i.class(db)),
+            Type::ProtocolInstance(instance) => {
+                instance.to_nominal_instance(db).map(|i| i.class(db))
+            }
             Type::TypeAlias(alias) => alias.value_type(db).nominal_class(db),
             Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).nominal_class(db),
             Type::TypeVar(typevar) => {
@@ -2061,7 +2078,7 @@ impl<'db> Type<'db> {
 
             Type::TypedDict(td) => td.defining_class().is_some(),
 
-            Type::ProtocolInstance(ProtocolInstanceType { inner, .. }) => !inner.is_synthesized(),
+            Type::ProtocolInstance(protocol) => protocol.class_origin(db).is_some(),
 
             Type::Dynamic(dynamic) => match dynamic {
                 DynamicType::Any => true,
@@ -2702,6 +2719,18 @@ impl<'db> Type<'db> {
         if let Some(fallback) = ty.materialized_divergent_fallback() {
             return fallback.class_member_with_policy(db, name, policy);
         }
+        if let Type::ProtocolInstance(protocol) = ty
+            && let Some(origin) = protocol.materialized_origin(db)
+        {
+            let interface = protocol.interface(db);
+            return if !interface.includes_member(db, name)
+                || origin.interface(db).member_has_todo_type(db, name)
+            {
+                Type::instance(db, *origin).class_member_with_policy(db, name, policy)
+            } else {
+                ty.instance_member(db, name)
+            };
+        }
 
         match ty {
             Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
@@ -2710,11 +2739,11 @@ impl<'db> Type<'db> {
             Type::Intersection(inter) => inter.map_with_boundness_and_qualifiers(db, |elem| {
                 elem.class_member_with_policy(db, name, policy)
             }),
-            // TODO: Once `to_meta_type` for the synthesized protocol is fully implemented, this handling should be removed.
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::Synthesized(_),
-                ..
-            }) => ty.instance_member(db, name),
+            // TODO: Once `to_meta_type` for synthesized protocols is fully implemented, this
+            // handling should be removed.
+            Type::ProtocolInstance(protocol) if protocol.class_origin(db).is_none() => {
+                ty.instance_member(db, name)
+            }
 
             Type::LiteralValue(literal)
                 if name == "__len__"
@@ -2816,7 +2845,7 @@ impl<'db> Type<'db> {
         let own_class = match self {
             Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                 SubclassOfInner::Protocol(protocol) => {
-                    protocol.class_origin().map(|origin| *origin)
+                    protocol.class_origin(db).map(|origin| *origin)
                 }
                 subclass_of => subclass_of.into_class(db),
             },
@@ -4115,11 +4144,10 @@ impl<'db> Type<'db> {
                 //
                 // Note that we could do this for *all* protocols, but it's only *necessary* for synthesized
                 // ones, and the standard logic is *probably* more performant for class-based protocols?
-                Type::ProtocolInstance(ProtocolInstanceType {
-                    inner: Protocol::Synthesized(protocol),
-                    ..
-                }) if policy.mro_no_object_fallback()
-                    && !protocol.interface().includes_member(db, name_str) =>
+                Type::ProtocolInstance(protocol)
+                    if protocol.class_origin(db).is_none()
+                        && policy.mro_no_object_fallback()
+                        && !protocol.interface(db).includes_member(db, name_str) =>
                 {
                     Place::Undefined.into()
                 }
@@ -4558,7 +4586,7 @@ impl<'db> Type<'db> {
                 // checking it structurally again during call inference.
                 if self_instance
                     .as_protocol_instance()
-                    .is_some_and(|protocol| protocol.to_nominal_instance().is_some())
+                    .is_some_and(|protocol| protocol.to_nominal_instance(db).is_some())
                     && signature
                         .overloads
                         .iter()
@@ -4750,9 +4778,12 @@ impl<'db> Type<'db> {
                     Binding::single(self, Signature::dynamic(Type::Dynamic(dynamic_type))).into()
                 }
                 SubclassOfInner::Class(class) => self.constructor_bindings(db, class),
-                SubclassOfInner::Protocol(protocol) => protocol.class_origin().map_or_else(
+                SubclassOfInner::Protocol(protocol) => protocol.class_origin(db).map_or_else(
                     || Binding::single(self, Signature::dynamic(Type::unknown())).into(),
-                    |origin| self.constructor_bindings(db, *origin),
+                    |origin| {
+                        self.constructor_bindings(db, *origin)
+                            .with_constructed_instance_type(db, Type::ProtocolInstance(protocol))
+                    },
                 ),
                 SubclassOfInner::TypeVar(tvar) => {
                     let constructor_instance_type = Type::TypeVar(tvar);
@@ -5825,10 +5856,16 @@ impl<'db> Type<'db> {
             Type::NominalInstance(instance) => {
                 instance.class(db).iter_mro(db).find_map(from_class_base)
             }
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::FromClass(class),
-                ..
-            }) => class.iter_mro(db).find_map(from_class_base),
+            Type::ProtocolInstance(instance) => {
+                let generator_types = instance
+                    .class_origin(db)
+                    .and_then(|origin| origin.iter_mro(db).find_map(from_class_base));
+                if let Some(kind) = instance.materialization_kind(db) {
+                    generator_types.map(|types| types.materialize(db, kind))
+                } else {
+                    generator_types
+                }
+            }
             Type::Union(union) => {
                 let mut yield_builder = Some(UnionBuilder::new(db));
                 let mut send_builder = Some(UnionBuilder::new(db));
@@ -6560,16 +6597,30 @@ impl<'db> Type<'db> {
                 }))
             }),
 
-            Type::ProtocolInstance(instance) => {
-                // TODO: Add tests for materialization once subtyping/assignability is implemented for
-                // protocols. It _might_ require changing the logic here because:
-                //
-                // > Subtyping for protocol instances involves taking account of the fact that
-                // > read-only property members, and method members, on protocols act covariantly;
-                // > write-only property members act contravariantly; and read/write attribute
-                // > members on protocols act invariantly
-                Type::ProtocolInstance(instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+            // Class-backed protocols map through their class specialization without traversing
+            // the interface. Entering the recursive visitor here would make a protocol interface
+            // under construction depend on itself without helping to break the cycle.
+            Type::ProtocolInstance(instance)
+                if instance.is_class_backed()
+                    && !matches!(
+                        type_mapping,
+                        TypeMapping::Materialize(_)
+                            | TypeMapping::ApplySpecializationWithMaterialization { .. }
+                    ) =>
+            {
+                Type::ProtocolInstance(
+                    instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                )
             }
+
+            Type::ProtocolInstance(instance) => visitor.visit(db, self, type_mapping, || {
+                Type::ProtocolInstance(instance.apply_type_mapping_impl(
+                    db,
+                    type_mapping,
+                    tcx,
+                    visitor,
+                ))
+            }),
 
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(
@@ -7231,7 +7282,9 @@ impl<'db> Type<'db> {
             Self::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Dynamic(_) => None,
                 SubclassOfInner::Class(class) => class.type_definition(db),
-                SubclassOfInner::Protocol(protocol) => protocol.class_origin()?.type_definition(db),
+                SubclassOfInner::Protocol(protocol) => {
+                    protocol.class_origin(db)?.type_definition(db)
+                }
                 SubclassOfInner::TypeVar(bound_typevar) => Some(TypeDefinition::TypeVar(
                     bound_typevar.typevar(db).definition(db)?,
                 )),
@@ -7266,10 +7319,9 @@ impl<'db> Type<'db> {
                 bound_typevar.typevar(db).definition(db)?,
             )),
 
-            Self::ProtocolInstance(protocol) => match protocol.inner {
-                Protocol::FromClass(class) => class.type_definition(db),
-                Protocol::Synthesized(_) => None,
-            },
+            Self::ProtocolInstance(protocol) => protocol
+                .class_origin(db)
+                .and_then(|origin| origin.type_definition(db)),
 
             Self::TypedDict(typed_dict) => typed_dict.type_definition(db),
 

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -648,7 +648,7 @@ pub(super) fn assignment_attribute_members<'db>(
     } else if let Type::ProtocolInstance(protocol) = object_ty
         && let Some(origin) = protocol.materialized_origin_property(db, attribute)
     {
-        Type::instance(db, *origin).class_member(db, attribute.into())
+        Type::instance(db, *origin).class_member(db, attribute)
     } else {
         object_ty.class_member(db, attribute)
     };

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -645,6 +645,10 @@ pub(super) fn assignment_attribute_members<'db>(
             Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
         ) {
         object_ty.member(db, attribute)
+    } else if let Type::ProtocolInstance(protocol) = object_ty
+        && let Some(origin) = protocol.materialized_origin_property(db, attribute)
+    {
+        Type::instance(db, *origin).class_member(db, attribute.into())
     } else {
         object_ty.class_member(db, attribute)
     };

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -637,7 +637,7 @@ impl<'db> BoundSuperType<'db> {
                             let class = match bound {
                                 Type::NominalInstance(instance) => Some(instance.class(db)),
                                 Type::ProtocolInstance(protocol) => protocol
-                                    .to_nominal_instance()
+                                    .to_nominal_instance(db)
                                     .map(|instance| instance.class(db)),
                                 _ => None,
                             };
@@ -693,7 +693,7 @@ impl<'db> BoundSuperType<'db> {
             }
 
             Type::ProtocolInstance(protocol) => {
-                if let Some(nominal_instance) = protocol.to_nominal_instance() {
+                if let Some(nominal_instance) = protocol.to_nominal_instance(db) {
                     SuperOwnerKind::Resolved(Self::resolve_instance_super_owner(
                         db,
                         pivot_class,
@@ -756,7 +756,7 @@ impl<'db> BoundSuperType<'db> {
                         let class = match bound {
                             Type::NominalInstance(instance) => Some(instance.class(db)),
                             Type::ProtocolInstance(protocol) => protocol
-                                .to_nominal_instance()
+                                .to_nominal_instance(db)
                                 .map(|instance| instance.class(db)),
                             _ => None,
                         };

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -637,7 +637,7 @@ impl<'db> BoundSuperType<'db> {
                             let class = match bound {
                                 Type::NominalInstance(instance) => Some(instance.class(db)),
                                 Type::ProtocolInstance(protocol) => protocol
-                                    .to_nominal_instance(db)
+                                    .nominal_origin_instance(db)
                                     .map(|instance| instance.class(db)),
                                 _ => None,
                             };
@@ -693,7 +693,7 @@ impl<'db> BoundSuperType<'db> {
             }
 
             Type::ProtocolInstance(protocol) => {
-                if let Some(nominal_instance) = protocol.to_nominal_instance(db) {
+                if let Some(nominal_instance) = protocol.nominal_origin_instance(db) {
                     SuperOwnerKind::Resolved(Self::resolve_instance_super_owner(
                         db,
                         pivot_class,
@@ -756,7 +756,7 @@ impl<'db> BoundSuperType<'db> {
                         let class = match bound {
                             Type::NominalInstance(instance) => Some(instance.class(db)),
                             Type::ProtocolInstance(protocol) => protocol
-                                .to_nominal_instance(db)
+                                .nominal_origin_instance(db)
                                 .map(|instance| instance.class(db)),
                             _ => None,
                         };

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -151,9 +151,21 @@ impl<'db> Type<'db> {
             // TODO: This is unsound so in future we can consider an opt-in option to disable it.
             Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
                 SubclassOfInner::Class(class) => Some(class.into_callable(db)),
-                SubclassOfInner::Protocol(protocol) => protocol
-                    .class_origin()
-                    .map(|origin| (*origin).into_callable(db)),
+                SubclassOfInner::Protocol(protocol) => protocol.class_origin(db).map(|origin| {
+                    let constructed_ty = Type::ProtocolInstance(protocol);
+                    (*origin).into_callable(db).map(|callable| {
+                        let signatures = callable
+                            .signatures(db)
+                            .into_iter()
+                            .map(|signature| signature.clone().with_return_type(constructed_ty));
+                        CallableType::new(
+                            db,
+                            CallableSignature::from_overloads(signatures),
+                            callable.kind(db),
+                            callable.provenance(db),
+                        )
+                    })
+                }),
                 SubclassOfInner::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         let upcast_callables = bound

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -138,7 +138,7 @@ impl<'db> DefinitionReferenceVisitor<'db> {
         }
 
         let class = match ty {
-            Type::ProtocolInstance(protocol) => *protocol.class_origin()?,
+            Type::ProtocolInstance(protocol) => *protocol.class_origin(db)?,
             Type::TypedDict(typed_dict) => typed_dict.defining_class()?,
             _ => return None,
         };
@@ -198,7 +198,7 @@ impl<'db> TypeVisitor<'db> for DefinitionReferenceVisitor<'db> {
     }
 
     fn visit_protocol_instance_type(&self, db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) {
-        if let Some(class) = protocol.class_origin() {
+        if let Some(class) = protocol.class_origin(db) {
             class.walk_recursive_member_types(db, self);
         }
     }
@@ -229,12 +229,12 @@ impl<'db> TypeAliasType<'db> {
 
 impl<'db> ProtocolInstanceType<'db> {
     fn definition(self, db: &'db dyn Db) -> Option<Definition<'db>> {
-        let (origin, _) = self.class_origin()?.static_class_literal(db)?;
+        let (origin, _) = self.class_origin(db)?.static_class_literal(db)?;
         Some(origin.definition(db))
     }
 
     fn is_recursive(self, db: &'db dyn Db) -> bool {
-        let Some(class) = self.class_origin() else {
+        let Some(class) = self.class_origin(db) else {
             return false;
         };
         let Some((origin, _)) = class.static_class_literal(db) else {

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -26,9 +26,9 @@ use crate::types::tuple::TupleSpec;
 use crate::types::typed_dict::TypedDictSchema;
 use crate::types::typevar::TypeVarInstance;
 use crate::types::{
-    BoundTypeVarInstance, ClassType, DynamicType, ErrorContextTree, LintDiagnosticGuard, Protocol,
-    ProtocolInstanceType, SpecialFormType, SubclassOfInner, Type, TypeContext, TypeVarVariance,
-    binding_type, protocol_class::ProtocolClass,
+    BoundTypeVarInstance, ClassType, DynamicType, ErrorContextTree, LintDiagnosticGuard,
+    SpecialFormType, SubclassOfInner, Type, TypeContext, TypeVarVariance, binding_type,
+    protocol_class::ProtocolClass,
 };
 use crate::types::{KnownInstanceType, MemberLookupPolicy, TypeVarKind, TypedDictType, UnionType};
 use crate::{Db, DisplaySettings, FxIndexMap, Program, declare_lint};
@@ -2837,10 +2837,7 @@ pub(crate) fn report_undeclared_protocol_member(
     /// We also want to avoid suggesting invalid syntax such as `x: <class 'int'> = int`.
     fn should_give_hint<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
         let class = match ty {
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::FromClass(_),
-                ..
-            }) => return true,
+            Type::ProtocolInstance(protocol) if protocol.class_origin(db).is_some() => return true,
             Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                 SubclassOfInner::Class(class) => class,
                 SubclassOfInner::Protocol(_) => return true,

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -32,10 +32,9 @@ use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::visitor::TypeVisitor;
 use crate::types::{
     CallableType, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
-    LiteralValueType, LiteralValueTypeKind, MaterializationKind, PropertyInstanceType, Protocol,
-    ProtocolInstanceType, SpecialFormType, StringLiteralType, SubclassOfInner, SubclassOfType,
-    Type, TypeAliasType, TypeGuardLike, TypedDictModule, TypedDictType, UnionType,
-    WrapperDescriptorKind, visitor,
+    LiteralValueType, LiteralValueTypeKind, MaterializationKind, PropertyInstanceType,
+    SpecialFormType, StringLiteralType, SubclassOfInner, SubclassOfType, Type, TypeAliasType,
+    TypeGuardLike, TypedDictModule, TypedDictType, UnionType, WrapperDescriptorKind, visitor,
 };
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::{FileScopeId, ScopeKind};
@@ -582,10 +581,11 @@ impl<'db> TypeVisitor<'db> for AmbiguousNameCollector<'db> {
             // Visit the class (as if it were a nominal-instance type)
             // rather than the protocol members, if it is a class-based protocol.
             // (For the purposes of displaying the type, we'll use the class name.)
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::FromClass(class),
-                ..
-            }) => return self.visit_type(db, Type::from(class)),
+            Type::ProtocolInstance(protocol) => {
+                if let Some(origin) = protocol.class_origin(db) {
+                    return self.visit_type(db, Type::from(origin));
+                }
+            }
             // no need to recurse into TypeVar bounds/constraints
             Type::TypeVar(_) => return,
             _ => {}
@@ -976,22 +976,38 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     (ClassType::Generic(alias), _) => alias.display_with(self.db, self.settings.clone()).fmt_detailed(f),
                 }
             }
-            Type::ProtocolInstance(protocol) => match protocol.inner {
-                Protocol::FromClass(class) => match *class {
-                    ClassType::NonGeneric(class) => class
-                        .display_with(self.db, self.settings.clone())
-                        .fmt_detailed(f),
-                    ClassType::Generic(alias) => alias
-                        .display_with(self.db, self.settings.clone())
-                        .fmt_detailed(f),
-                },
-                Protocol::Synthesized(synthetic) => {
+            Type::ProtocolInstance(protocol) => {
+                if let Some(class) = protocol.class_origin(self.db) {
+                    let wrapper = match protocol.display_materialization_kind(self.db) {
+                        Some(MaterializationKind::Top) => Some(("Top", SpecialFormType::Top)),
+                        Some(MaterializationKind::Bottom) => {
+                            Some(("Bottom", SpecialFormType::Bottom))
+                        }
+                        None => None,
+                    };
+                    if let Some((name, form)) = wrapper {
+                        f.with_type(Type::SpecialForm(form)).write_str(name)?;
+                        f.write_char('[')?;
+                    }
+                    match *class {
+                        ClassType::NonGeneric(class) => class
+                            .display_with(self.db, self.settings.clone())
+                            .fmt_detailed(f)?,
+                        ClassType::Generic(alias) => alias
+                            .display_with(self.db, self.settings.clone())
+                            .fmt_detailed(f)?,
+                    }
+                    if wrapper.is_some() {
+                        f.write_char(']')?;
+                    }
+                    Ok(())
+                } else {
                     f.set_invalid_type_annotation();
                     f.write_char('<')?;
                     f.with_type(Type::SpecialForm(SpecialFormType::Protocol))
                         .write_str("Protocol")?;
                     f.write_str(" with members ")?;
-                    let interface = synthetic.interface();
+                    let interface = protocol.interface(self.db);
                     let member_list = interface.members(self.db);
                     let num_members = member_list.len();
                     for (i, member) in member_list.enumerate() {
@@ -1003,7 +1019,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     }
                     f.write_char('>')
                 }
-            },
+            }
             Type::PropertyInstance(property) => f
                 .with_type(self.ty)
                 .write_str(property_display_name(self.db, property)),

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3286,7 +3286,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             (
                 formal @ Type::ProtocolInstance(_),
                 actual @ Type::ProtocolInstance(actual_protocol),
-            ) if actual_protocol.is_materialized(self.db) => {
+            ) if actual_protocol.is_materialized() => {
                 let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
                 let when = self.constraints.load(self.db, &when);
                 if self.add_type_mappings_from_constraint_set(when).is_ok() {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2715,7 +2715,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // fallback erases; restrict mixed unions to the protocol used by dictionary constructors.
         if !other_types.is_empty()
             && !matches!(formal, Type::ProtocolInstance(protocol)
-            if protocol.class_origin().is_some_and(|class| {
+            if protocol.class_origin(self.db).is_some_and(|class| {
                 class.is_known(self.db, KnownClass::SupportsKeysAndGetItem)
             }))
         {
@@ -3283,13 +3283,25 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 );
             }
 
+            (
+                formal @ Type::ProtocolInstance(_),
+                actual @ Type::ProtocolInstance(actual_protocol),
+            ) if actual_protocol.is_materialized(self.db) => {
+                let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
+                let when = self.constraints.load(self.db, &when);
+                if self.add_type_mappings_from_constraint_set(when).is_ok() {
+                    self.pending.intersect(self.db, self.constraints, when);
+                }
+                return Ok(());
+            }
+
             (formal, Type::ProtocolInstance(actual_protocol)) => {
                 // TODO: This will only handle protocol classes that explicit inherit
                 // from other generic protocol classes by listing it as a base class.
                 // To handle classes that implicitly implement a generic protocol, we
                 // will need to check the types of the protocol members to be able to
                 // infer the specialization of the protocol that the class implements.
-                if let Some(actual_nominal) = actual_protocol.to_nominal_instance() {
+                if let Some(actual_nominal) = actual_protocol.to_nominal_instance(self.db) {
                     return self.infer_map_impl(
                         formal,
                         Type::NominalInstance(actual_nominal),

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3301,7 +3301,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // To handle classes that implicitly implement a generic protocol, we
                 // will need to check the types of the protocol members to be able to
                 // infer the specialization of the protocol that the class implements.
-                if let Some(actual_nominal) = actual_protocol.to_nominal_instance(self.db) {
+                if let Some(actual_nominal) = actual_protocol.nominal_origin_instance(self.db) {
                     return self.infer_map_impl(
                         formal,
                         Type::NominalInstance(actual_nominal),

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -239,7 +239,7 @@ pub fn definitions_for_attribute<'db>(
     // location for go-to-definition, even though the origin is not a nominal upper bound.
     let subclass_origin = |subclass_of: SubclassOfInner<'db>| {
         let class = match subclass_of {
-            SubclassOfInner::Protocol(protocol) => protocol.class_origin().map(|origin| *origin),
+            SubclassOfInner::Protocol(protocol) => protocol.class_origin(db).map(|origin| *origin),
             subclass_of => subclass_of.into_class(db),
         }?;
         class

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -12061,11 +12061,14 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
                 builder.infer_maybe_standalone_expression(value, TypeContext::default())
             });
             // If the member is a data descriptor, the RHS value may differ from the value actually assigned.
-            if value_ty
-                .class_member(db, &attr.id)
-                .place
-                .ignore_possibly_undefined()
-                .is_some_and(|ty| ty.may_be_data_descriptor(db))
+            if assignment_attribute_members(db, value_ty, &attr.id)
+                .and_then(AssignmentAttributeMembers::type_member)
+                .is_some_and(|member| {
+                    member
+                        .place
+                        .ignore_possibly_undefined()
+                        .is_some_and(|ty| ty.may_be_data_descriptor(db))
+                })
             {
                 builder.discard_dict_key_assignments_for(self.binding);
                 bound_ty = declared_ty;

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1283,7 +1283,6 @@ impl<'db> ProtocolInstanceType<'db> {
                 // different specialization, would add a fresh wrapper every time it is mapped
                 // again. Keep the stable class-backed representation until recursive protocol
                 // materialization can preserve its origin without expanding indefinitely.
-                // TODO: Remove this fallback once https://github.com/astral-sh/ruff/pull/24981 merges.
                 if interface_references_protocol_origin(db, interface, class) {
                     return Self::from_class(mapped_class);
                 }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1000,8 +1000,15 @@ fn interface_references_protocol_origin<'db>(
 }
 
 impl<'db> ProtocolInstanceType<'db> {
-    pub(super) const fn is_class_backed(self) -> bool {
-        matches!(self.inner, Protocol::FromClass(_))
+    /// Returns whether applying `type_mapping` descends into this protocol's interface.
+    pub(super) const fn mapping_traverses_interface(
+        self,
+        type_mapping: &TypeMapping<'_, 'db>,
+    ) -> bool {
+        match self.inner {
+            Protocol::FromClass(_) => type_mapping.materialization_kind().is_some(),
+            Protocol::Synthesized(_) | Protocol::Materialized(_) => true,
+        }
     }
 
     /// Return whether this protocol has an interface produced by materialization.
@@ -1263,20 +1270,13 @@ impl<'db> ProtocolInstanceType<'db> {
     ) -> Self {
         match self.inner {
             Protocol::FromClass(class) => {
-                let materialization_kind = match type_mapping {
-                    TypeMapping::Materialize(kind)
-                    | TypeMapping::ApplySpecializationWithMaterialization {
-                        materialization_kind: kind,
-                        ..
-                    } => *kind,
-                    _ => {
-                        return Self::from_class(class.apply_type_mapping_impl(
-                            db,
-                            type_mapping,
-                            tcx,
-                            visitor,
-                        ));
-                    }
+                let Some(materialization_kind) = type_mapping.materialization_kind() else {
+                    return Self::from_class(class.apply_type_mapping_impl(
+                        db,
+                        type_mapping,
+                        tcx,
+                        visitor,
+                    ));
                 };
                 let interface = class.interface(db);
                 let mapped_class = class.apply_type_mapping_impl(db, type_mapping, tcx, visitor);

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1231,11 +1231,9 @@ impl<'db> ProtocolInstanceType<'db> {
         })
     }
 
-    /// Return a materialized protocol's effective interface member when it should override
-    /// nominal-origin lookup.
+    /// Return a materialized protocol's effective interface member.
     ///
-    /// Members omitted from the interface, or whose origin has a `Todo` type, continue to use the
-    /// nominal origin.
+    /// Members omitted from the interface continue to use the nominal origin.
     pub(super) fn materialized_interface_member(
         self,
         db: &'db dyn Db,
@@ -1245,10 +1243,9 @@ impl<'db> ProtocolInstanceType<'db> {
             return None;
         };
         let interface = materialized.interface(db);
-        let origin = materialized.origin(db);
-        (interface.includes_member(db, name)
-            && !origin.interface(db).member_has_todo_type(db, name))
-        .then(|| interface.instance_member(db, name))
+        interface
+            .includes_member(db, name)
+            .then(|| interface.instance_member(db, name))
     }
 
     pub(crate) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -20,7 +20,7 @@ use crate::types::enums::is_single_member_enum;
 use crate::types::generics::walk_specialization;
 use crate::types::protocol_class::{
     ProtocolClass, has_all_protocol_members_defined, walk_protocol_instance_member,
-    walk_protocol_interface,
+    walk_protocol_interface, walk_protocol_interface_requirements,
 };
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation,
@@ -35,8 +35,9 @@ use crate::types::{
     FindLegacyTypeVarsVisitor, LiteralValueTypeKind, TypeContext, TypeMapping, VarianceInferable,
 };
 use crate::{Db, FxOrderSet};
-pub(super) use synthesized_protocol::SynthesizedProtocolType;
 use ty_python_core::definition::Definition;
+
+use self::interface_protocol::ProtocolInterfaceType;
 
 impl<'db> Type<'db> {
     pub(crate) const fn object() -> Self {
@@ -156,7 +157,8 @@ impl<'db> Type<'db> {
         M: IntoIterator<Item = (&'a str, Type<'db>)>,
     {
         Self::ProtocolInstance(ProtocolInstanceType::synthesized(
-            SynthesizedProtocolType::new(ProtocolInterface::with_property_members(db, members)),
+            db,
+            ProtocolInterface::with_property_members(db, members),
         ))
     }
 
@@ -166,7 +168,8 @@ impl<'db> Type<'db> {
         M: IntoIterator<Item = (&'a str, CallableType<'db>)>,
     {
         Self::ProtocolInstance(ProtocolInstanceType::synthesized(
-            SynthesizedProtocolType::new(ProtocolInterface::with_methods(db, methods)),
+            db,
+            ProtocolInterface::with_methods(db, methods),
         ))
     }
 }
@@ -498,10 +501,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // we can.
         let mut result = self.never();
 
-        if let Some(nominal_instance) = protocol.to_nominal_instance() {
-            let source_protocol_as_nominal = ty
-                .as_protocol_instance()
-                .and_then(ProtocolInstanceType::to_nominal_instance);
+        let source_protocol = ty.as_protocol_instance();
+        let source_protocol_as_nominal =
+            source_protocol.and_then(|protocol| protocol.to_nominal_instance(db));
+        let materialized_source_changes_target = source_protocol.is_some_and(|source| {
+            source.materialization_changes_requirements(db, protocol.interface(db))
+        });
+
+        if !protocol.is_materialized(db)
+            && !materialized_source_changes_target
+            && let Some(nominal_instance) = protocol.to_nominal_instance(db)
+        {
             // if `ty` and `protocol` are *both* protocols, we also need to treat `ty` as if it
             // were a nominal type, or we won't consider a protocol `P` that explicitly inherits
             // from a protocol `Q` to be a subtype of `Q` to be a subtype of `Q` if it overrides
@@ -516,21 +526,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             if result
                 .union(db, self.constraints, nominally_satisfied)
                 .is_trivially_always_satisfied()
-            {
-                return result;
-            }
-
-            // `Generator` special case: compare the type parameters nominally. Prior to 3.13,
-            // its return type does not appear non-recursively in the protocol; from 3.13 onward,
-            // structurally inferring through `close() -> ReturnT | None` can spuriously infer
-            // `None`.
-            // TODO: Remove the Python 3.13+ extension of this special case once
-            // https://github.com/astral-sh/ty/issues/3596 is fixed.
-            if let Some(source_protocol) = ty.as_protocol_instance()
-                && let Protocol::FromClass(source_class) = source_protocol.inner
-                && let Protocol::FromClass(proto_class) = protocol.inner
-                && source_class.is_known(db, KnownClass::Generator)
-                && proto_class.is_known(db, KnownClass::Generator)
             {
                 return result;
             }
@@ -551,9 +546,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // member even though a failed redundancy check only means that we preserve a
             // potentially redundant union arm.
             if matches!(self.relation, TypeRelation::Redundancy { pure: false })
-                && ty
-                    .as_protocol_instance()
-                    .and_then(ProtocolInstanceType::to_nominal_instance)
+                && source_protocol_as_nominal
                     .is_some_and(|source_instance| {
                         source_instance.class(db).class_literal(db)
                             == nominal_instance.class(db).class_literal(db)
@@ -561,6 +554,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             {
                 return nominally_satisfied;
             }
+        }
+
+        // `Generator` special case: compare the type parameters nominally. Prior to 3.13, its
+        // return type does not appear non-recursively in the protocol; from 3.13 onward,
+        // structurally inferring through `close() -> ReturnT | None` can spuriously infer `None`.
+        // TODO: Remove the Python 3.13+ extension of this special case once
+        // https://github.com/astral-sh/ty/issues/3596 is fixed.
+        if let Some(source_protocol) = ty.as_protocol_instance()
+            && let Some(source_class) = source_protocol.class_origin(db)
+            && let Some(proto_class) = protocol.class_origin(db)
+            && source_class.is_known(db, KnownClass::Generator)
+            && proto_class.is_known(db, KnownClass::Generator)
+        {
+            return result;
         }
 
         // Fast path: skip expensive per-member type comparisons when members are plainly
@@ -735,7 +742,7 @@ fn non_recursive_protocol_interface<'db>(
 
             if ty
                 .as_protocol_instance()
-                .and_then(ProtocolInstanceType::to_nominal_instance)
+                .and_then(|protocol| protocol.to_nominal_instance(db))
                 .is_some_and(|instance| instance.class_literal(db) == self.origin)
             {
                 self.found.set(true);
@@ -915,27 +922,179 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
     protocol: ProtocolInstanceType<'db>,
     visitor: &V,
 ) {
-    if visitor.should_visit_lazy_type_attributes() {
-        walk_protocol_interface(db, protocol.inner.interface(db), visitor);
-    } else {
-        match protocol.inner {
-            Protocol::FromClass(class) => {
-                if let Some((_, Some(specialization))) = class.static_class_literal(db) {
-                    walk_specialization(db, specialization, visitor);
-                }
-            }
-            Protocol::Synthesized(synthesized) => {
-                walk_protocol_interface(db, synthesized.interface(), visitor);
+    match protocol.inner {
+        Protocol::FromClass(class) if !visitor.should_visit_lazy_type_attributes() => {
+            if let Some((_, Some(specialization))) = class.static_class_literal(db) {
+                walk_specialization(db, specialization, visitor);
             }
         }
+        Protocol::FromClass(_) | Protocol::Interface(_) => {
+            walk_protocol_interface(db, protocol.inner.interface(db), visitor);
+        }
+    }
+
+    if let Protocol::Interface(interface) = protocol.inner
+        && let Some(origin) = interface.materialized_origin(db)
+        && let Some((_, Some(specialization))) = origin.static_class_literal(db)
+    {
+        walk_specialization(db, specialization, visitor);
     }
 }
 
+/// Returns whether a protocol requirement refers back to its class-backed origin.
+///
+/// Aliases are followed, but nested protocol interfaces are not expanded. A recursive protocol
+/// such as the following must retain its class-backed representation to avoid synthesizing a new
+/// materialized wrapper on every mapping:
+///
+/// ```python
+/// type Alias = P
+///
+/// class P(Protocol):
+///     @property
+///     def child(self) -> Alias: ...
+/// ```
+#[salsa::tracked(returns(copy))]
+fn interface_references_protocol_origin<'db>(
+    db: &'db dyn Db,
+    interface: ProtocolInterface<'db>,
+    protocol: ProtocolClass<'db>,
+) -> bool {
+    struct ProtocolReferenceFinder<'db> {
+        protocol_origin: ClassLiteral<'db>,
+        found: Cell<bool>,
+        recursion_guard: TypeCollector<'db>,
+    }
+
+    impl<'db> TypeVisitor<'db> for ProtocolReferenceFinder<'db> {
+        fn should_visit_lazy_type_attributes(&self) -> bool {
+            false
+        }
+
+        fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
+            self.visit_type(db, type_alias.value_type(db));
+        }
+
+        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+            if self.found.get() {
+                return;
+            }
+
+            if ty
+                .as_protocol_instance()
+                .and_then(|protocol| protocol.class_origin(db))
+                .is_some_and(|origin| origin.class_literal(db) == self.protocol_origin)
+            {
+                self.found.set(true);
+                return;
+            }
+
+            walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+        }
+    }
+
+    let visitor = ProtocolReferenceFinder {
+        protocol_origin: protocol.class_literal(db),
+        found: Cell::new(false),
+        recursion_guard: TypeCollector::default(),
+    };
+    walk_protocol_interface_requirements(db, interface, &visitor);
+    visitor.found.get()
+}
+
 impl<'db> ProtocolInstanceType<'db> {
+    pub(super) const fn is_class_backed(self) -> bool {
+        matches!(self.inner, Protocol::FromClass(_))
+    }
+
+    /// Return whether this protocol has an interface produced by materialization.
+    pub(super) fn is_materialized(self, db: &'db dyn Db) -> bool {
+        matches!(self.inner, Protocol::Interface(interface) if interface.is_materialized(db))
+    }
+
+    pub(super) fn materialization_kind(self, db: &'db dyn Db) -> Option<MaterializationKind> {
+        match self.inner {
+            Protocol::Interface(interface) => interface.materialization_kind(db),
+            Protocol::FromClass(_) => None,
+        }
+    }
+
+    /// Returns the materialization wrapper that must be shown when displaying this protocol.
+    ///
+    /// A generic origin can already carry the wrapper in its specialization, while a covariant
+    /// materialization can be represented directly by its rewritten origin. Only irreducible
+    /// materialized interfaces need an additional `Top[...]` or `Bottom[...]` wrapper.
+    pub(super) fn display_materialization_kind(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<MaterializationKind> {
+        let kind = self.materialization_kind(db)?;
+        let origin = self.materialized_origin(db)?;
+        let origin_already_displays_kind = origin
+            .static_class_literal(db)
+            .and_then(|(_, specialization)| specialization)
+            .and_then(|specialization| specialization.materialization_kind(db))
+            .is_some();
+
+        (!origin_already_displays_kind && self.interface(db) != origin.interface(db))
+            .then_some(kind)
+    }
+
+    /// Returns whether materialization rewrote any member required by `target`.
+    ///
+    /// The nominal MRO shortcut remains valid when materialization changed only unrelated members;
+    /// otherwise the effective interface must participate in the relation.
+    fn materialization_changes_requirements(
+        self,
+        db: &'db dyn Db,
+        target: ProtocolInterface<'db>,
+    ) -> bool {
+        let Protocol::Interface(interface) = self.inner else {
+            return false;
+        };
+        let Some(origin) = interface.materialized_origin(db) else {
+            return false;
+        };
+        interface
+            .interface(db)
+            .differs_for_members_required_by(db, origin.interface(db), target)
+    }
+
     /// Return `true` if this is the standard-library `Hashable` protocol.
     pub(super) fn is_hashable(self, db: &'db dyn Db) -> bool {
-        self.to_nominal_instance()
+        self.to_nominal_instance(db)
             .is_some_and(|instance| instance.class(db).is_known(db, KnownClass::Hashable))
+    }
+
+    /// Returns the class represented by this protocol, if it originated from a class definition.
+    pub(super) fn class_origin(self, db: &'db dyn Db) -> Option<ProtocolClass<'db>> {
+        match self.inner {
+            Protocol::FromClass(class) => Some(class),
+            Protocol::Interface(interface) => interface.materialized_origin(db),
+        }
+    }
+
+    /// Returns the origin of a materialized property for descriptor-aware assignment lookup.
+    ///
+    /// The effective interface carries mapped read and write types, but the origin retains
+    /// descriptor identity and deletion behavior.
+    pub(super) fn materialized_origin_property(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+    ) -> Option<ProtocolClass<'db>> {
+        let origin = self.materialized_origin(db)?;
+        origin
+            .interface(db)
+            .member_is_property(db, name)
+            .then_some(origin)
+    }
+
+    pub(super) fn materialized_origin(self, db: &'db dyn Db) -> Option<ProtocolClass<'db>> {
+        match self.inner {
+            Protocol::Interface(interface) => interface.materialized_origin(db),
+            Protocol::FromClass(_) => None,
+        }
     }
 
     // Keep this method private, so that the only way of constructing `ProtocolInstanceType`
@@ -949,71 +1108,61 @@ impl<'db> ProtocolInstanceType<'db> {
 
     // Keep this method private, so that the only way of constructing `ProtocolInstanceType`
     // instances is through the `Type::instance` constructor function.
-    fn synthesized(synthesized: SynthesizedProtocolType<'db>) -> Self {
+    fn synthesized(db: &'db dyn Db, interface: ProtocolInterface<'db>) -> Self {
         Self {
-            inner: Protocol::Synthesized(synthesized),
+            inner: Protocol::Interface(ProtocolInterfaceType::synthesized(db, interface)),
             _phantom: PhantomData,
         }
     }
 
-    /// Return the class backing a class-based protocol instance.
-    pub(super) fn as_class_based(self) -> Option<ProtocolClass<'db>> {
-        match self.inner {
-            Protocol::FromClass(class) => Some(class),
-            Protocol::Synthesized(_) => None,
-        }
-    }
-
-    /// If this is a class-based protocol, convert the protocol-instance into a nominal instance.
-    ///
-    /// If this is a synthesized protocol that does not correspond to a class definition
-    /// in source code, return `None`. These are "pure" abstract types, that cannot be
-    /// treated in a nominal way.
-    pub(super) fn to_nominal_instance(self) -> Option<NominalInstanceType<'db>> {
-        match self.inner {
-            Protocol::FromClass(class) => Some(NominalInstanceType(
-                NominalInstanceInner::NonTuple(NominalInstanceClass::Plain(*class)),
+    fn materialized(
+        db: &'db dyn Db,
+        interface: ProtocolInterface<'db>,
+        origin: ProtocolClass<'db>,
+        materialization_kind: MaterializationKind,
+    ) -> Self {
+        Self {
+            inner: Protocol::Interface(ProtocolInterfaceType::materialized(
+                db,
+                interface,
+                origin,
+                materialization_kind,
             )),
-            Protocol::Synthesized(_) => None,
+            _phantom: PhantomData,
         }
     }
 
-    /// Return the class that defines this protocol, if it is class-backed.
-    pub(super) const fn class_origin(self) -> Option<ProtocolClass<'db>> {
-        match self.inner {
-            Protocol::FromClass(class) => Some(class),
-            Protocol::Synthesized(_) => None,
-        }
+    /// If this protocol corresponds to a class definition, convert it into a nominal instance.
+    ///
+    /// Pure synthesized protocols have no class origin and cannot be treated nominally.
+    pub(super) fn to_nominal_instance(self, db: &'db dyn Db) -> Option<NominalInstanceType<'db>> {
+        self.class_origin(db).map(|origin| {
+            NominalInstanceType(NominalInstanceInner::NonTuple(NominalInstanceClass::Plain(
+                *origin,
+            )))
+        })
     }
 
     /// Return the structural meta-type of this protocol-instance type.
     pub(super) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
         match self.inner {
             Protocol::FromClass(_) => SubclassOfType::from_protocol(self),
-
-            // TODO: we can and should do better here.
-            //
-            // This is supported by mypy, and should be supported by us as well.
-            // We'll need to come up with a better solution for the meta-type of
-            // synthesized protocols to solve this:
-            //
-            // ```py
-            // from typing import Callable
-            //
-            // def foo(x: Callable[[], int]) -> None:
-            //     reveal_type(type(x))                 # mypy: "type[def (builtins.int) -> builtins.str]"
-            //     reveal_type(type(x).__call__)        # mypy: "def (*args: Any, **kwds: Any) -> Any"
-            // ```
-            Protocol::Synthesized(_) => KnownClass::Type.to_instance(db),
+            Protocol::Interface(interface) => interface.materialized_origin(db).map_or_else(
+                || KnownClass::Type.to_instance(db),
+                |_| SubclassOfType::from_protocol(self),
+            ),
         }
     }
 
-    /// Return the nominal meta-type used for internal class-member lookup on a protocol instance.
+    /// Return the meta-type used for internal class-member lookup on a protocol instance.
+    ///
+    /// Class-backed protocols use their nominal origin for descriptor lookup. Materialized
+    /// protocol members are handled through their effective interface before this fallback.
     pub(super) fn to_nominal_meta_type(self, db: &'db dyn Db) -> Type<'db> {
-        match self.inner {
-            Protocol::FromClass(class) => SubclassOfType::from(db, *class),
-            Protocol::Synthesized(_) => self.to_meta_type(db),
-        }
+        self.class_origin(db).map_or_else(
+            || self.to_meta_type(db),
+            |origin| SubclassOfType::from(db, *origin),
+        )
     }
 
     /// Return `true` if this protocol is a supertype of `object`.
@@ -1065,7 +1214,19 @@ impl<'db> ProtocolInstanceType<'db> {
     pub(crate) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         match self.inner {
             Protocol::FromClass(class) => class.instance_member(db, name),
-            Protocol::Synthesized(synthesized) => synthesized.interface().instance_member(db, name),
+            Protocol::Interface(interface) => {
+                let protocol_interface = interface.interface(db);
+                let Some(origin) = interface.materialized_origin(db) else {
+                    return protocol_interface.instance_member(db, name);
+                };
+                if protocol_interface.includes_member(db, name)
+                    && !origin.interface(db).member_has_todo_type(db, name)
+                {
+                    protocol_interface.instance_member(db, name)
+                } else {
+                    origin.instance_member(db, name)
+                }
+            }
         }
     }
 
@@ -1078,11 +1239,53 @@ impl<'db> ProtocolInstanceType<'db> {
     ) -> Self {
         match self.inner {
             Protocol::FromClass(class) => {
-                Self::from_class(class.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                let materialization_kind = match type_mapping {
+                    TypeMapping::Materialize(kind)
+                    | TypeMapping::ApplySpecializationWithMaterialization {
+                        materialization_kind: kind,
+                        ..
+                    } => *kind,
+                    _ => {
+                        return Self::from_class(class.apply_type_mapping_impl(
+                            db,
+                            type_mapping,
+                            tcx,
+                            visitor,
+                        ));
+                    }
+                };
+                let interface = class.interface(db);
+                let mapped_class = class.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+
+                // A recursive reference is returned unchanged by the mapping visitor. Synthesizing
+                // an interface that still contains the same protocol class, including under a
+                // different specialization, would add a fresh wrapper every time it is mapped
+                // again. Keep the stable class-backed representation until recursive protocol
+                // materialization can preserve its origin without expanding indefinitely.
+                // TODO: Remove this fallback once https://github.com/astral-sh/ruff/pull/24981 merges.
+                if interface_references_protocol_origin(db, interface, class) {
+                    return Self::from_class(mapped_class);
+                }
+
+                let mapped_interface =
+                    interface.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+                if mapped_interface == interface
+                    || interface_references_protocol_origin(db, mapped_interface, class)
+                {
+                    return Self::from_class(mapped_class);
+                }
+
+                Self::materialized(db, mapped_interface, mapped_class, materialization_kind)
             }
-            Protocol::Synthesized(synthesized) => Self::synthesized(
-                synthesized.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-            ),
+            Protocol::Interface(interface) => Self {
+                inner: Protocol::Interface(interface.apply_type_mapping_impl(
+                    db,
+                    type_mapping,
+                    tcx,
+                    visitor,
+                )),
+                _phantom: PhantomData,
+            },
         }
     }
 
@@ -1097,8 +1300,8 @@ impl<'db> ProtocolInstanceType<'db> {
             Protocol::FromClass(class) => {
                 class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
-            Protocol::Synthesized(synthesized) => {
-                synthesized.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            Protocol::Interface(interface) => {
+                interface.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
         }
     }
@@ -1114,12 +1317,11 @@ impl<'db> VarianceInferable<'db> for ProtocolInstanceType<'db> {
     }
 }
 
-/// An enumeration of the two kinds of protocol types: those that originate from a class
-/// definition in source code, and those that are synthesized from a set of members.
+/// The representation of a protocol class or an interned interface.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) enum Protocol<'db> {
     FromClass(ProtocolClass<'db>),
-    Synthesized(SynthesizedProtocolType<'db>),
+    Interface(ProtocolInterfaceType<'db>),
 }
 
 impl<'db> Protocol<'db> {
@@ -1127,7 +1329,7 @@ impl<'db> Protocol<'db> {
     fn interface(self, db: &'db dyn Db) -> ProtocolInterface<'db> {
         match self {
             Self::FromClass(class) => class.interface(db),
-            Self::Synthesized(synthesized) => synthesized.interface(),
+            Self::Interface(interface) => interface.interface(db),
         }
     }
 
@@ -1141,14 +1343,10 @@ impl<'db> Protocol<'db> {
             Self::FromClass(class) => Some(Self::FromClass(
                 class.recursive_type_normalized_impl(db, div, nested)?,
             )),
-            Self::Synthesized(synthesized) => Some(Self::Synthesized(
-                synthesized.recursive_type_normalized_impl(db, div, nested)?,
+            Self::Interface(interface) => Some(Self::Interface(
+                interface.recursive_type_normalized_impl(db, div, nested)?,
             )),
         }
-    }
-
-    pub(super) const fn is_synthesized(self) -> bool {
-        matches!(self, Self::Synthesized(_))
     }
 }
 
@@ -1156,32 +1354,90 @@ impl<'db> VarianceInferable<'db> for Protocol<'db> {
     fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
         match self {
             Protocol::FromClass(class_type) => class_type.variance_of(db, typevar),
-            Protocol::Synthesized(synthesized_protocol_type) => {
-                synthesized_protocol_type.variance_of(db, typevar)
-            }
+            Protocol::Interface(interface) => interface.variance_of(db, typevar),
         }
     }
 }
 
-mod synthesized_protocol {
-    use crate::types::protocol_class::ProtocolInterface;
+mod interface_protocol {
+    use crate::types::protocol_class::{ProtocolClass, ProtocolInterface};
     use crate::types::{
         ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance,
-        FindLegacyTypeVarsVisitor, Type, TypeContext, TypeMapping, TypeVarVariance,
-        VarianceInferable,
+        FindLegacyTypeVarsVisitor, MaterializationKind, Type, TypeContext, TypeMapping,
+        TypeVarVariance, VarianceInferable,
     };
     use crate::{Db, FxOrderSet};
     use ty_python_core::definition::Definition;
 
-    /// A "synthesized" protocol type that is dissociated from a class definition in source code.
+    /// Identifies whether an interned interface is a pure synthesized protocol or the materialized
+    /// view of a class-based protocol.
     #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
-    pub(in crate::types) struct SynthesizedProtocolType<'db>(ProtocolInterface<'db>);
+    pub(in crate::types) enum ProtocolInterfaceKind<'db> {
+        Materialized {
+            origin: ProtocolClass<'db>,
+            materialization_kind: MaterializationKind,
+        },
+        Synthesized,
+    }
 
-    impl<'db> SynthesizedProtocolType<'db> {
-        pub(super) fn new(interface: ProtocolInterface<'db>) -> Self {
-            Self(interface)
+    /// An interned protocol interface.
+    ///
+    /// Keeping the materialized/synthesized distinction inside this interned value lets the
+    /// enclosing [`super::Protocol`] retain its compact two-variant representation.
+    #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+    pub(in crate::types) struct ProtocolInterfaceType<'db> {
+        #[returns(copy)]
+        pub(in crate::types) interface: ProtocolInterface<'db>,
+        #[returns(copy)]
+        pub(in crate::types) kind: ProtocolInterfaceKind<'db>,
+    }
+
+    impl get_size2::GetSize for ProtocolInterfaceType<'_> {}
+
+    impl<'db> ProtocolInterfaceType<'db> {
+        pub(super) fn synthesized(db: &'db dyn Db, interface: ProtocolInterface<'db>) -> Self {
+            Self::new(db, interface, ProtocolInterfaceKind::Synthesized)
         }
 
+        pub(super) fn materialized(
+            db: &'db dyn Db,
+            interface: ProtocolInterface<'db>,
+            origin: ProtocolClass<'db>,
+            materialization_kind: MaterializationKind,
+        ) -> Self {
+            Self::new(
+                db,
+                interface,
+                ProtocolInterfaceKind::Materialized {
+                    origin,
+                    materialization_kind,
+                },
+            )
+        }
+
+        pub(super) fn is_materialized(self, db: &'db dyn Db) -> bool {
+            matches!(self.kind(db), ProtocolInterfaceKind::Materialized { .. })
+        }
+
+        pub(super) fn materialized_origin(self, db: &'db dyn Db) -> Option<ProtocolClass<'db>> {
+            match self.kind(db) {
+                ProtocolInterfaceKind::Materialized { origin, .. } => Some(origin),
+                ProtocolInterfaceKind::Synthesized => None,
+            }
+        }
+
+        pub(super) fn materialization_kind(self, db: &'db dyn Db) -> Option<MaterializationKind> {
+            match self.kind(db) {
+                ProtocolInterfaceKind::Materialized {
+                    materialization_kind,
+                    ..
+                } => Some(materialization_kind),
+                ProtocolInterfaceKind::Synthesized => None,
+            }
+        }
+
+        /// Remaps the effective interface and origin metadata while preserving the first
+        /// materialization's polarity, making nested top/bottom materialization idempotent.
         pub(super) fn apply_type_mapping_impl<'a>(
             self,
             db: &'db dyn Db,
@@ -1189,12 +1445,26 @@ mod synthesized_protocol {
             tcx: TypeContext<'db>,
             visitor: &ApplyTypeMappingVisitor<'db>,
         ) -> Self {
-            Self(
-                self.0
+            let kind = match self.kind(db) {
+                ProtocolInterfaceKind::Materialized {
+                    origin,
+                    materialization_kind,
+                } => ProtocolInterfaceKind::Materialized {
+                    origin: origin.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    materialization_kind,
+                },
+                ProtocolInterfaceKind::Synthesized => ProtocolInterfaceKind::Synthesized,
+            };
+            Self::new(
+                db,
+                self.interface(db)
                     .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                kind,
             )
         }
 
+        /// Collects variables from both the effective interface and the preserved origin
+        /// specialization, where variables omitted from protocol requirements can remain.
         pub(super) fn find_legacy_typevars_impl(
             self,
             db: &'db dyn Db,
@@ -1202,12 +1472,11 @@ mod synthesized_protocol {
             typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
             visitor: &FindLegacyTypeVarsVisitor<'db>,
         ) {
-            self.0
+            self.interface(db)
                 .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
-        }
-
-        pub(in crate::types) fn interface(self) -> ProtocolInterface<'db> {
-            self.0
+            if let Some(origin) = self.materialized_origin(db) {
+                origin.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            }
         }
 
         pub(in crate::types) fn recursive_type_normalized_impl(
@@ -1216,19 +1485,32 @@ mod synthesized_protocol {
             div: Type<'db>,
             nested: bool,
         ) -> Option<Self> {
-            Some(Self(
-                self.0.recursive_type_normalized_impl(db, div, nested)?,
+            let kind = match self.kind(db) {
+                ProtocolInterfaceKind::Materialized {
+                    origin,
+                    materialization_kind,
+                } => ProtocolInterfaceKind::Materialized {
+                    origin: origin.recursive_type_normalized_impl(db, div, nested)?,
+                    materialization_kind,
+                },
+                ProtocolInterfaceKind::Synthesized => ProtocolInterfaceKind::Synthesized,
+            };
+            Some(Self::new(
+                db,
+                self.interface(db)
+                    .recursive_type_normalized_impl(db, div, nested)?,
+                kind,
             ))
         }
     }
 
-    impl<'db> VarianceInferable<'db> for SynthesizedProtocolType<'db> {
+    impl<'db> VarianceInferable<'db> for ProtocolInterfaceType<'db> {
         fn variance_of(
             self,
             db: &'db dyn Db,
             typevar: BoundTypeVarIdentity<'db>,
         ) -> TypeVarVariance {
-            self.0.variance_of(db, typevar)
+            self.interface(db).variance_of(db, typevar)
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -502,9 +502,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let source_protocol = ty.as_protocol_instance();
         let source_protocol_as_nominal =
             source_protocol.and_then(|protocol| protocol.to_nominal_instance(db));
-        let materialized_source_changes_target = source_protocol.is_some_and(|source| {
-            source.materialization_changes_requirements(db, protocol.interface(db))
-        });
+        let materialized_source_changes_target = source_protocol
+            .is_some_and(|source| source.materialization_changes_requirements(db, protocol));
 
         if !protocol.is_materialized()
             && !materialized_source_changes_target
@@ -1044,7 +1043,7 @@ impl<'db> ProtocolInstanceType<'db> {
     fn materialization_changes_requirements(
         self,
         db: &'db dyn Db,
-        target: ProtocolInterface<'db>,
+        target: ProtocolInstanceType<'db>,
     ) -> bool {
         let Protocol::Materialized(materialized) = self.inner else {
             return false;
@@ -1052,7 +1051,7 @@ impl<'db> ProtocolInstanceType<'db> {
         materialized.interface(db).differs_for_members_required_by(
             db,
             materialized.origin(db).interface(db),
-            target,
+            target.interface(db),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -37,7 +37,7 @@ use crate::types::{
 use crate::{Db, FxOrderSet};
 use ty_python_core::definition::Definition;
 
-use self::interface_protocol::ProtocolInterfaceType;
+use self::protocol_types::{MaterializedProtocolType, SynthesizedProtocolType};
 
 impl<'db> Type<'db> {
     pub(crate) const fn object() -> Self {
@@ -157,8 +157,7 @@ impl<'db> Type<'db> {
         M: IntoIterator<Item = (&'a str, Type<'db>)>,
     {
         Self::ProtocolInstance(ProtocolInstanceType::synthesized(
-            db,
-            ProtocolInterface::with_property_members(db, members),
+            SynthesizedProtocolType::new(ProtocolInterface::with_property_members(db, members)),
         ))
     }
 
@@ -168,8 +167,7 @@ impl<'db> Type<'db> {
         M: IntoIterator<Item = (&'a str, CallableType<'db>)>,
     {
         Self::ProtocolInstance(ProtocolInstanceType::synthesized(
-            db,
-            ProtocolInterface::with_methods(db, methods),
+            SynthesizedProtocolType::new(ProtocolInterface::with_methods(db, methods)),
         ))
     }
 }
@@ -508,7 +506,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             source.materialization_changes_requirements(db, protocol.interface(db))
         });
 
-        if !protocol.is_materialized(db)
+        if !protocol.is_materialized()
             && !materialized_source_changes_target
             && let Some(nominal_instance) = protocol.to_nominal_instance(db)
         {
@@ -928,14 +926,13 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
                 walk_specialization(db, specialization, visitor);
             }
         }
-        Protocol::FromClass(_) | Protocol::Interface(_) => {
+        Protocol::FromClass(_) | Protocol::Synthesized(_) | Protocol::Materialized(_) => {
             walk_protocol_interface(db, protocol.inner.interface(db), visitor);
         }
     }
 
-    if let Protocol::Interface(interface) = protocol.inner
-        && let Some(origin) = interface.materialized_origin(db)
-        && let Some((_, Some(specialization))) = origin.static_class_literal(db)
+    if let Protocol::Materialized(materialized) = protocol.inner
+        && let Some((_, Some(specialization))) = materialized.origin(db).static_class_literal(db)
     {
         walk_specialization(db, specialization, visitor);
     }
@@ -1008,14 +1005,14 @@ impl<'db> ProtocolInstanceType<'db> {
     }
 
     /// Return whether this protocol has an interface produced by materialization.
-    pub(super) fn is_materialized(self, db: &'db dyn Db) -> bool {
-        matches!(self.inner, Protocol::Interface(interface) if interface.is_materialized(db))
+    pub(super) fn is_materialized(self) -> bool {
+        matches!(self.inner, Protocol::Materialized(_))
     }
 
     pub(super) fn materialization_kind(self, db: &'db dyn Db) -> Option<MaterializationKind> {
         match self.inner {
-            Protocol::Interface(interface) => interface.materialization_kind(db),
-            Protocol::FromClass(_) => None,
+            Protocol::Materialized(materialized) => Some(materialized.materialization_kind(db)),
+            Protocol::FromClass(_) | Protocol::Synthesized(_) => None,
         }
     }
 
@@ -1049,15 +1046,14 @@ impl<'db> ProtocolInstanceType<'db> {
         db: &'db dyn Db,
         target: ProtocolInterface<'db>,
     ) -> bool {
-        let Protocol::Interface(interface) = self.inner else {
+        let Protocol::Materialized(materialized) = self.inner else {
             return false;
         };
-        let Some(origin) = interface.materialized_origin(db) else {
-            return false;
-        };
-        interface
-            .interface(db)
-            .differs_for_members_required_by(db, origin.interface(db), target)
+        materialized.interface(db).differs_for_members_required_by(
+            db,
+            materialized.origin(db).interface(db),
+            target,
+        )
     }
 
     /// Return `true` if this is the standard-library `Hashable` protocol.
@@ -1070,7 +1066,8 @@ impl<'db> ProtocolInstanceType<'db> {
     pub(super) fn class_origin(self, db: &'db dyn Db) -> Option<ProtocolClass<'db>> {
         match self.inner {
             Protocol::FromClass(class) => Some(class),
-            Protocol::Interface(interface) => interface.materialized_origin(db),
+            Protocol::Materialized(materialized) => Some(materialized.origin(db)),
+            Protocol::Synthesized(_) => None,
         }
     }
 
@@ -1092,8 +1089,8 @@ impl<'db> ProtocolInstanceType<'db> {
 
     pub(super) fn materialized_origin(self, db: &'db dyn Db) -> Option<ProtocolClass<'db>> {
         match self.inner {
-            Protocol::Interface(interface) => interface.materialized_origin(db),
-            Protocol::FromClass(_) => None,
+            Protocol::Materialized(materialized) => Some(materialized.origin(db)),
+            Protocol::FromClass(_) | Protocol::Synthesized(_) => None,
         }
     }
 
@@ -1108,9 +1105,9 @@ impl<'db> ProtocolInstanceType<'db> {
 
     // Keep this method private, so that the only way of constructing `ProtocolInstanceType`
     // instances is through the `Type::instance` constructor function.
-    fn synthesized(db: &'db dyn Db, interface: ProtocolInterface<'db>) -> Self {
+    fn synthesized(synthesized: SynthesizedProtocolType<'db>) -> Self {
         Self {
-            inner: Protocol::Interface(ProtocolInterfaceType::synthesized(db, interface)),
+            inner: Protocol::Synthesized(synthesized),
             _phantom: PhantomData,
         }
     }
@@ -1122,7 +1119,7 @@ impl<'db> ProtocolInstanceType<'db> {
         materialization_kind: MaterializationKind,
     ) -> Self {
         Self {
-            inner: Protocol::Interface(ProtocolInterfaceType::materialized(
+            inner: Protocol::Materialized(MaterializedProtocolType::new(
                 db,
                 interface,
                 origin,
@@ -1146,11 +1143,10 @@ impl<'db> ProtocolInstanceType<'db> {
     /// Return the structural meta-type of this protocol-instance type.
     pub(super) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
         match self.inner {
-            Protocol::FromClass(_) => SubclassOfType::from_protocol(self),
-            Protocol::Interface(interface) => interface.materialized_origin(db).map_or_else(
-                || KnownClass::Type.to_instance(db),
-                |_| SubclassOfType::from_protocol(self),
-            ),
+            Protocol::FromClass(_) | Protocol::Materialized(_) => {
+                SubclassOfType::from_protocol(self)
+            }
+            Protocol::Synthesized(_) => KnownClass::Type.to_instance(db),
         }
     }
 
@@ -1214,11 +1210,10 @@ impl<'db> ProtocolInstanceType<'db> {
     pub(crate) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         match self.inner {
             Protocol::FromClass(class) => class.instance_member(db, name),
-            Protocol::Interface(interface) => {
-                let protocol_interface = interface.interface(db);
-                let Some(origin) = interface.materialized_origin(db) else {
-                    return protocol_interface.instance_member(db, name);
-                };
+            Protocol::Synthesized(synthesized) => synthesized.interface().instance_member(db, name),
+            Protocol::Materialized(materialized) => {
+                let protocol_interface = materialized.interface(db);
+                let origin = materialized.origin(db);
                 if protocol_interface.includes_member(db, name)
                     && !origin.interface(db).member_has_todo_type(db, name)
                 {
@@ -1277,8 +1272,11 @@ impl<'db> ProtocolInstanceType<'db> {
 
                 Self::materialized(db, mapped_interface, mapped_class, materialization_kind)
             }
-            Protocol::Interface(interface) => Self {
-                inner: Protocol::Interface(interface.apply_type_mapping_impl(
+            Protocol::Synthesized(synthesized) => Self::synthesized(
+                synthesized.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            ),
+            Protocol::Materialized(materialized) => Self {
+                inner: Protocol::Materialized(materialized.apply_type_mapping_impl(
                     db,
                     type_mapping,
                     tcx,
@@ -1300,8 +1298,11 @@ impl<'db> ProtocolInstanceType<'db> {
             Protocol::FromClass(class) => {
                 class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
-            Protocol::Interface(interface) => {
-                interface.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            Protocol::Synthesized(synthesized) => {
+                synthesized.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            }
+            Protocol::Materialized(materialized) => {
+                materialized.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
         }
     }
@@ -1317,11 +1318,12 @@ impl<'db> VarianceInferable<'db> for ProtocolInstanceType<'db> {
     }
 }
 
-/// The representation of a protocol class or an interned interface.
+/// A protocol that originates from a class, is synthesized, or has been materialized.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) enum Protocol<'db> {
     FromClass(ProtocolClass<'db>),
-    Interface(ProtocolInterfaceType<'db>),
+    Synthesized(SynthesizedProtocolType<'db>),
+    Materialized(MaterializedProtocolType<'db>),
 }
 
 impl<'db> Protocol<'db> {
@@ -1329,7 +1331,8 @@ impl<'db> Protocol<'db> {
     fn interface(self, db: &'db dyn Db) -> ProtocolInterface<'db> {
         match self {
             Self::FromClass(class) => class.interface(db),
-            Self::Interface(interface) => interface.interface(db),
+            Self::Synthesized(synthesized) => synthesized.interface(),
+            Self::Materialized(materialized) => materialized.interface(db),
         }
     }
 
@@ -1343,8 +1346,11 @@ impl<'db> Protocol<'db> {
             Self::FromClass(class) => Some(Self::FromClass(
                 class.recursive_type_normalized_impl(db, div, nested)?,
             )),
-            Self::Interface(interface) => Some(Self::Interface(
-                interface.recursive_type_normalized_impl(db, div, nested)?,
+            Self::Synthesized(synthesized) => Some(Self::Synthesized(
+                synthesized.recursive_type_normalized_impl(db, div, nested)?,
+            )),
+            Self::Materialized(materialized) => Some(Self::Materialized(
+                materialized.recursive_type_normalized_impl(db, div, nested)?,
             )),
         }
     }
@@ -1354,12 +1360,13 @@ impl<'db> VarianceInferable<'db> for Protocol<'db> {
     fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
         match self {
             Protocol::FromClass(class_type) => class_type.variance_of(db, typevar),
-            Protocol::Interface(interface) => interface.variance_of(db, typevar),
+            Protocol::Synthesized(synthesized) => synthesized.variance_of(db, typevar),
+            Protocol::Materialized(materialized) => materialized.variance_of(db, typevar),
         }
     }
 }
 
-mod interface_protocol {
+mod protocol_types {
     use crate::types::protocol_class::{ProtocolClass, ProtocolInterface};
     use crate::types::{
         ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance,
@@ -1369,75 +1376,15 @@ mod interface_protocol {
     use crate::{Db, FxOrderSet};
     use ty_python_core::definition::Definition;
 
-    /// Identifies whether an interned interface is a pure synthesized protocol or the materialized
-    /// view of a class-based protocol.
+    /// A "synthesized" protocol type that is dissociated from a class definition in source code.
     #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
-    pub(in crate::types) enum ProtocolInterfaceKind<'db> {
-        Materialized {
-            origin: ProtocolClass<'db>,
-            materialization_kind: MaterializationKind,
-        },
-        Synthesized,
-    }
+    pub(in crate::types) struct SynthesizedProtocolType<'db>(ProtocolInterface<'db>);
 
-    /// An interned protocol interface.
-    ///
-    /// Keeping the materialized/synthesized distinction inside this interned value lets the
-    /// enclosing [`super::Protocol`] retain its compact two-variant representation.
-    #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
-    pub(in crate::types) struct ProtocolInterfaceType<'db> {
-        #[returns(copy)]
-        pub(in crate::types) interface: ProtocolInterface<'db>,
-        #[returns(copy)]
-        pub(in crate::types) kind: ProtocolInterfaceKind<'db>,
-    }
-
-    impl get_size2::GetSize for ProtocolInterfaceType<'_> {}
-
-    impl<'db> ProtocolInterfaceType<'db> {
-        pub(super) fn synthesized(db: &'db dyn Db, interface: ProtocolInterface<'db>) -> Self {
-            Self::new(db, interface, ProtocolInterfaceKind::Synthesized)
+    impl<'db> SynthesizedProtocolType<'db> {
+        pub(super) fn new(interface: ProtocolInterface<'db>) -> Self {
+            Self(interface)
         }
 
-        pub(super) fn materialized(
-            db: &'db dyn Db,
-            interface: ProtocolInterface<'db>,
-            origin: ProtocolClass<'db>,
-            materialization_kind: MaterializationKind,
-        ) -> Self {
-            Self::new(
-                db,
-                interface,
-                ProtocolInterfaceKind::Materialized {
-                    origin,
-                    materialization_kind,
-                },
-            )
-        }
-
-        pub(super) fn is_materialized(self, db: &'db dyn Db) -> bool {
-            matches!(self.kind(db), ProtocolInterfaceKind::Materialized { .. })
-        }
-
-        pub(super) fn materialized_origin(self, db: &'db dyn Db) -> Option<ProtocolClass<'db>> {
-            match self.kind(db) {
-                ProtocolInterfaceKind::Materialized { origin, .. } => Some(origin),
-                ProtocolInterfaceKind::Synthesized => None,
-            }
-        }
-
-        pub(super) fn materialization_kind(self, db: &'db dyn Db) -> Option<MaterializationKind> {
-            match self.kind(db) {
-                ProtocolInterfaceKind::Materialized {
-                    materialization_kind,
-                    ..
-                } => Some(materialization_kind),
-                ProtocolInterfaceKind::Synthesized => None,
-            }
-        }
-
-        /// Remaps the effective interface and origin metadata while preserving the first
-        /// materialization's polarity, making nested top/bottom materialization idempotent.
         pub(super) fn apply_type_mapping_impl<'a>(
             self,
             db: &'db dyn Db,
@@ -1445,21 +1392,79 @@ mod interface_protocol {
             tcx: TypeContext<'db>,
             visitor: &ApplyTypeMappingVisitor<'db>,
         ) -> Self {
-            let kind = match self.kind(db) {
-                ProtocolInterfaceKind::Materialized {
-                    origin,
-                    materialization_kind,
-                } => ProtocolInterfaceKind::Materialized {
-                    origin: origin.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                    materialization_kind,
-                },
-                ProtocolInterfaceKind::Synthesized => ProtocolInterfaceKind::Synthesized,
-            };
+            Self(
+                self.0
+                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            )
+        }
+
+        pub(super) fn find_legacy_typevars_impl(
+            self,
+            db: &'db dyn Db,
+            binding_context: Option<Definition<'db>>,
+            typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
+            visitor: &FindLegacyTypeVarsVisitor<'db>,
+        ) {
+            self.0
+                .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+        }
+
+        pub(in crate::types) fn interface(self) -> ProtocolInterface<'db> {
+            self.0
+        }
+
+        pub(in crate::types) fn recursive_type_normalized_impl(
+            self,
+            db: &'db dyn Db,
+            div: Type<'db>,
+            nested: bool,
+        ) -> Option<Self> {
+            Some(Self(
+                self.0.recursive_type_normalized_impl(db, div, nested)?,
+            ))
+        }
+    }
+
+    impl<'db> VarianceInferable<'db> for SynthesizedProtocolType<'db> {
+        fn variance_of(
+            self,
+            db: &'db dyn Db,
+            typevar: BoundTypeVarIdentity<'db>,
+        ) -> TypeVarVariance {
+            self.0.variance_of(db, typevar)
+        }
+    }
+
+    /// The materialized interface of a class-based protocol, together with its origin.
+    #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+    pub(in crate::types) struct MaterializedProtocolType<'db> {
+        #[returns(copy)]
+        pub(in crate::types) interface: ProtocolInterface<'db>,
+        #[returns(copy)]
+        pub(in crate::types) origin: ProtocolClass<'db>,
+        #[returns(copy)]
+        pub(in crate::types) materialization_kind: MaterializationKind,
+    }
+
+    impl get_size2::GetSize for MaterializedProtocolType<'_> {}
+
+    impl<'db> MaterializedProtocolType<'db> {
+        /// Remaps the effective interface and origin while preserving the first materialization's
+        /// polarity, making nested top/bottom materialization idempotent.
+        pub(super) fn apply_type_mapping_impl<'a>(
+            self,
+            db: &'db dyn Db,
+            type_mapping: &TypeMapping<'a, 'db>,
+            tcx: TypeContext<'db>,
+            visitor: &ApplyTypeMappingVisitor<'db>,
+        ) -> Self {
             Self::new(
                 db,
                 self.interface(db)
                     .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                kind,
+                self.origin(db)
+                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                self.materialization_kind(db),
             )
         }
 
@@ -1474,9 +1479,8 @@ mod interface_protocol {
         ) {
             self.interface(db)
                 .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
-            if let Some(origin) = self.materialized_origin(db) {
-                origin.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
-            }
+            self.origin(db)
+                .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
         }
 
         pub(in crate::types) fn recursive_type_normalized_impl(
@@ -1485,26 +1489,18 @@ mod interface_protocol {
             div: Type<'db>,
             nested: bool,
         ) -> Option<Self> {
-            let kind = match self.kind(db) {
-                ProtocolInterfaceKind::Materialized {
-                    origin,
-                    materialization_kind,
-                } => ProtocolInterfaceKind::Materialized {
-                    origin: origin.recursive_type_normalized_impl(db, div, nested)?,
-                    materialization_kind,
-                },
-                ProtocolInterfaceKind::Synthesized => ProtocolInterfaceKind::Synthesized,
-            };
             Some(Self::new(
                 db,
                 self.interface(db)
                     .recursive_type_normalized_impl(db, div, nested)?,
-                kind,
+                self.origin(db)
+                    .recursive_type_normalized_impl(db, div, nested)?,
+                self.materialization_kind(db),
             ))
         }
     }
 
-    impl<'db> VarianceInferable<'db> for ProtocolInterfaceType<'db> {
+    impl<'db> VarianceInferable<'db> for MaterializedProtocolType<'db> {
         fn variance_of(
             self,
             db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1223,21 +1223,33 @@ impl<'db> ProtocolInstanceType<'db> {
         })
     }
 
+    /// Return a materialized protocol's effective interface member when it should override
+    /// nominal-origin lookup.
+    ///
+    /// Members omitted from the interface, or whose origin has a `Todo` type, continue to use the
+    /// nominal origin.
+    pub(super) fn materialized_interface_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+    ) -> Option<PlaceAndQualifiers<'db>> {
+        let Protocol::Materialized(materialized) = self.inner else {
+            return None;
+        };
+        let interface = materialized.interface(db);
+        let origin = materialized.origin(db);
+        (interface.includes_member(db, name)
+            && !origin.interface(db).member_has_todo_type(db, name))
+        .then(|| interface.instance_member(db, name))
+    }
+
     pub(crate) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         match self.inner {
             Protocol::FromClass(class) => class.instance_member(db, name),
             Protocol::Synthesized(synthesized) => synthesized.interface().instance_member(db, name),
-            Protocol::Materialized(materialized) => {
-                let protocol_interface = materialized.interface(db);
-                let origin = materialized.origin(db);
-                if protocol_interface.includes_member(db, name)
-                    && !origin.interface(db).member_has_todo_type(db, name)
-                {
-                    protocol_interface.instance_member(db, name)
-                } else {
-                    origin.instance_member(db, name)
-                }
-            }
+            Protocol::Materialized(materialized) => self
+                .materialized_interface_member(db, name)
+                .unwrap_or_else(|| materialized.origin(db).instance_member(db, name)),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -493,15 +493,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         protocol: ProtocolInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // `ty` might satisfy the protocol nominally, if `protocol` is a class-based protocol and
-        // `ty` has the protocol class in its MRO. This is a much cheaper check than the
-        // structural check we perform below, so we do it first to avoid the structural check when
-        // we can.
+        // Explicit inheritance from a class-based protocol is nominal, even if the subclass
+        // overrides one of its members incompatibly. A materialized source can use that nominal
+        // relation only if materialization left every requirement of the target unchanged.
         let mut result = self.never();
 
         let source_protocol = ty.as_protocol_instance();
         let source_protocol_as_nominal =
             source_protocol.and_then(|protocol| protocol.nominal_origin_instance(db));
+        let is_generator_pair = source_protocol
+            .and_then(|protocol| protocol.class_origin(db))
+            .is_some_and(|class| class.is_known(db, KnownClass::Generator))
+            && protocol
+                .class_origin(db)
+                .is_some_and(|class| class.is_known(db, KnownClass::Generator));
         let materialized_source_changes_target = source_protocol
             .is_some_and(|source| source.materialization_changes_requirements(db, protocol));
 
@@ -527,13 +532,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 return result;
             }
 
-            if let Some(structurally_satisfied) = self.try_check_non_recursive_protocol_members(
-                db,
-                ty,
-                protocol,
-                source_protocol_as_nominal,
-                nominal_instance,
-            ) {
+            if !is_generator_pair
+                && let Some(structurally_satisfied) = self.try_check_non_recursive_protocol_members(
+                    db,
+                    ty,
+                    protocol,
+                    source_protocol_as_nominal,
+                    nominal_instance,
+                )
+            {
                 return result.or(db, self.constraints, || structurally_satisfied);
             }
 
@@ -543,11 +550,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // member even though a failed redundancy check only means that we preserve a
             // potentially redundant union arm.
             if matches!(self.relation, TypeRelation::Redundancy { pure: false })
-                && source_protocol_as_nominal
-                    .is_some_and(|source_instance| {
-                        source_instance.class(db).class_literal(db)
-                            == nominal_instance.class(db).class_literal(db)
-                    })
+                && source_protocol_as_nominal.is_some_and(|source_instance| {
+                    source_instance.class(db).class_literal(db)
+                        == nominal_instance.class(db).class_literal(db)
+                })
             {
                 return nominally_satisfied;
             }
@@ -558,12 +564,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // structurally inferring through `close() -> ReturnT | None` can spuriously infer `None`.
         // TODO: Remove the Python 3.13+ extension of this special case once
         // https://github.com/astral-sh/ty/issues/3596 is fixed.
-        if let Some(source_protocol) = ty.as_protocol_instance()
-            && let Some(source_class) = source_protocol.class_origin(db)
-            && let Some(proto_class) = protocol.class_origin(db)
-            && source_class.is_known(db, KnownClass::Generator)
-            && proto_class.is_known(db, KnownClass::Generator)
-        {
+        if is_generator_pair {
             return result;
         }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1148,6 +1148,20 @@ impl<'db> ProtocolInstanceType<'db> {
             Protocol::FromClass(_) | Protocol::Materialized(_) => {
                 SubclassOfType::from_protocol(self)
             }
+
+            // TODO: we can and should do better here.
+            //
+            // This is supported by mypy, and should be supported by us as well.
+            // We'll need to come up with a better solution for the meta-type of
+            // synthesized protocols to solve this:
+            //
+            // ```py
+            // from typing import Callable
+            //
+            // def foo(x: Callable[[], int]) -> None:
+            //     reveal_type(type(x))                 # mypy: "type[def (builtins.int) -> builtins.str]"
+            //     reveal_type(type(x).__call__)        # mypy: "def (*args: Any, **kwds: Any) -> Any"
+            // ```
             Protocol::Synthesized(_) => KnownClass::Type.to_instance(db),
         }
     }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -501,13 +501,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         let source_protocol = ty.as_protocol_instance();
         let source_protocol_as_nominal =
-            source_protocol.and_then(|protocol| protocol.to_nominal_instance(db));
+            source_protocol.and_then(|protocol| protocol.nominal_origin_instance(db));
         let materialized_source_changes_target = source_protocol
             .is_some_and(|source| source.materialization_changes_requirements(db, protocol));
 
         if !protocol.is_materialized()
             && !materialized_source_changes_target
-            && let Some(nominal_instance) = protocol.to_nominal_instance(db)
+            && let Some(nominal_instance) = protocol.nominal_origin_instance(db)
         {
             // if `ty` and `protocol` are *both* protocols, we also need to treat `ty` as if it
             // were a nominal type, or we won't consider a protocol `P` that explicitly inherits
@@ -739,7 +739,7 @@ fn non_recursive_protocol_interface<'db>(
 
             if ty
                 .as_protocol_instance()
-                .and_then(|protocol| protocol.to_nominal_instance(db))
+                .and_then(|protocol| protocol.nominal_origin_instance(db))
                 .is_some_and(|instance| instance.class_literal(db) == self.origin)
             {
                 self.found.set(true);
@@ -1057,7 +1057,7 @@ impl<'db> ProtocolInstanceType<'db> {
 
     /// Return `true` if this is the standard-library `Hashable` protocol.
     pub(super) fn is_hashable(self, db: &'db dyn Db) -> bool {
-        self.to_nominal_instance(db)
+        self.nominal_origin_instance(db)
             .is_some_and(|instance| instance.class(db).is_known(db, KnownClass::Hashable))
     }
 
@@ -1128,10 +1128,13 @@ impl<'db> ProtocolInstanceType<'db> {
         }
     }
 
-    /// If this protocol corresponds to a class definition, convert it into a nominal instance.
+    /// Return a nominal instance of this protocol's class origin, if it has one.
     ///
     /// Pure synthesized protocols have no class origin and cannot be treated nominally.
-    pub(super) fn to_nominal_instance(self, db: &'db dyn Db) -> Option<NominalInstanceType<'db>> {
+    pub(super) fn nominal_origin_instance(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<NominalInstanceType<'db>> {
         self.class_origin(db).map(|origin| {
             NominalInstanceType(NominalInstanceInner::NonTuple(NominalInstanceClass::Plain(
                 *origin,

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -251,7 +251,7 @@ impl<'db> AllMembers<'db> {
                 }
                 SubclassOfInner::Protocol(protocol) => {
                     if let Some((class_literal, _)) = protocol
-                        .class_origin()
+                        .class_origin(db)
                         .and_then(|origin| origin.static_class_literal(db))
                     {
                         self.extend_with_class_members(db, ty, ClassLiteral::Static(class_literal));

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -563,11 +563,6 @@ impl<'db> ProtocolInterface<'db> {
             .any(|name| self.inner(db).get(name) != other.inner(db).get(name))
     }
 
-    pub(super) fn member_has_todo_type(self, db: &'db dyn Db, name: &str) -> bool {
-        self.member_by_name(db, name)
-            .is_some_and(|member| member.has_todo_type())
-    }
-
     pub(super) fn member_is_property(self, db: &'db dyn Db, name: &str) -> bool {
         self.member_by_name(db, name)
             .is_some_and(|member| member.is_property())

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1248,31 +1248,25 @@ impl<'db> ProtocolMemberData<'db> {
                 class: ProtocolMemberAccess::NONE,
             },
             ProtocolMemberKind::Attribute { read, write } => {
-                self.attribute_capabilities(read, write.map_or(read, |write| read.with_ty(write)))
+                let is_class_var = self.qualifiers.contains(TypeQualifiers::CLASS_VAR);
+                let is_final = self.qualifiers.contains(TypeQualifiers::FINAL);
+                let write = write.map_or(read, |write| read.with_ty(write));
+                ProtocolMemberCapabilities {
+                    instance: ProtocolMemberAccess::new(
+                        Some(read),
+                        (!is_class_var && !is_final)
+                            .then_some(ProtocolMemberWrite::from_type(write)),
+                    ),
+                    class: if is_class_var {
+                        ProtocolMemberAccess::new(
+                            Some(read),
+                            (!is_final).then_some(ProtocolMemberWrite::from_type(write)),
+                        )
+                    } else {
+                        ProtocolMemberAccess::NONE
+                    },
+                }
             }
-        }
-    }
-
-    fn attribute_capabilities(
-        &self,
-        read: ProtocolMemberType<'db>,
-        write: ProtocolMemberType<'db>,
-    ) -> ProtocolMemberCapabilities<'db> {
-        let is_class_var = self.qualifiers.contains(TypeQualifiers::CLASS_VAR);
-        let is_final = self.qualifiers.contains(TypeQualifiers::FINAL);
-        ProtocolMemberCapabilities {
-            instance: ProtocolMemberAccess::new(
-                Some(read),
-                (!is_class_var && !is_final).then_some(ProtocolMemberWrite::from_type(write)),
-            ),
-            class: if is_class_var {
-                ProtocolMemberAccess::new(
-                    Some(read),
-                    (!is_final).then_some(ProtocolMemberWrite::from_type(write)),
-                )
-            } else {
-                ProtocolMemberAccess::NONE
-            },
         }
     }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -368,8 +368,8 @@ pub(super) fn walk_protocol_instance_member<'db, V: super::visitor::TypeVisitor<
                 }
             }
         }
-        ProtocolMemberKind::Attribute(_) => {
-            for member_type in member.data.member_types() {
+        ProtocolMemberKind::Attribute { .. } => {
+            for member_type in member.data.kind.member_types() {
                 if let Some(ty) = member_type.bind_self(db, receiver_ty) {
                     visitor.visit_type(db, ty);
                 }
@@ -919,22 +919,6 @@ impl<'db> ProtocolMemberWrite<'db> {
         }
     }
 
-    fn apply_write_type_mapping_impl<'a>(
-        self,
-        db: &'db dyn Db,
-        type_mapping: &TypeMapping<'a, 'db>,
-        tcx: TypeContext<'db>,
-        visitor: &ApplyTypeMappingVisitor<'db>,
-    ) -> Self {
-        match self {
-            Self::Type(member) => Self::Type(
-                member.apply_write_type_mapping_impl(db, type_mapping, tcx, visitor),
-            ),
-            descriptor @ Self::Descriptor { .. } => {
-                descriptor.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
-            }
-        }
-    }
 }
 
 impl<'db> VarianceInferable<'db> for ProtocolInterface<'db> {
@@ -1078,11 +1062,7 @@ impl<'db> ProtocolMemberType<'db> {
         self.with_ty(ty)
     }
 
-    /// Maps a writable capability contravariantly.
-    ///
-    /// A stored property setter is still a callable, so its value parameter already introduces
-    /// the contravariance required by a write. Other writable capabilities store the exposed
-    /// value type directly and therefore require an explicit polarity flip.
+    /// Maps an attribute write contravariantly.
     fn apply_write_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
@@ -1090,14 +1070,11 @@ impl<'db> ProtocolMemberType<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
-        match self {
-            Self::PropertySetter(_) => self.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-            _ => self.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
-        }
+        self.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor)
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
 /// The types supported by one way of accessing a protocol member.
 ///
 /// `read` is covariant and `write` is contravariant. Either operation can be absent: for example,
@@ -1132,56 +1109,6 @@ impl<'db> ProtocolMemberAccess<'db> {
                     .map(|member| (member.ty(), TypeVarVariance::Contravariant)),
             )
     }
-
-    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
-        Self {
-            read: cycle_normalized_optional_type(db, self.read, previous.read, cycle),
-            write: match (self.write, previous.write) {
-                (Some(current), Some(previous)) => {
-                    Some(current.cycle_normalized(db, previous, cycle))
-                }
-                (Some(current), None) => {
-                    Some(current.cycle_normalized_without_previous(db, cycle))
-                }
-                (None, _) => None,
-            },
-        }
-    }
-
-    fn recursive_type_normalized_impl(
-        self,
-        db: &'db dyn Db,
-        div: Type<'db>,
-        nested: bool,
-    ) -> Option<Self> {
-        Some(Self {
-            read: match self.read {
-                Some(read) => Some(read.recursive_type_normalized_impl(db, div, nested)?),
-                None => None,
-            },
-            write: match self.write {
-                Some(write) => Some(write.recursive_type_normalized_impl(db, div, nested)?),
-                None => None,
-            },
-        })
-    }
-
-    fn apply_type_mapping_impl<'a>(
-        self,
-        db: &'db dyn Db,
-        type_mapping: &TypeMapping<'a, 'db>,
-        tcx: TypeContext<'db>,
-        visitor: &ApplyTypeMappingVisitor<'db>,
-    ) -> Self {
-        Self {
-            read: self
-                .read
-                .map(|read| read.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
-            write: self
-                .write
-                .map(|write| write.apply_write_type_mapping_impl(db, type_mapping, tcx, visitor)),
-        }
-    }
 }
 
 /// The readable and writable types exposed through instance and class access.
@@ -1189,67 +1116,10 @@ impl<'db> ProtocolMemberAccess<'db> {
 /// Instance access and class access each independently record readable and writable types. For
 /// example, a mutable `ClassVar` is readable through both, writable through the class, and
 /// read-only through an instance.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct ProtocolMemberCapabilities<'db> {
     instance: ProtocolMemberAccess<'db>,
     class: ProtocolMemberAccess<'db>,
-}
-
-impl<'db> ProtocolMemberCapabilities<'db> {
-    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
-        Self {
-            instance: self.instance.cycle_normalized(db, previous.instance, cycle),
-            class: self.class.cycle_normalized(db, previous.class, cycle),
-        }
-    }
-
-    fn recursive_type_normalized_impl(
-        self,
-        db: &'db dyn Db,
-        div: Type<'db>,
-        nested: bool,
-    ) -> Option<Self> {
-        Some(Self {
-            instance: self
-                .instance
-                .recursive_type_normalized_impl(db, div, nested)?,
-            class: self.class.recursive_type_normalized_impl(db, div, nested)?,
-        })
-    }
-
-    fn apply_type_mapping_impl<'a>(
-        self,
-        db: &'db dyn Db,
-        type_mapping: &TypeMapping<'a, 'db>,
-        tcx: TypeContext<'db>,
-        visitor: &ApplyTypeMappingVisitor<'db>,
-    ) -> Self {
-        Self {
-            instance: self
-                .instance
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-            class: self
-                .class
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-        }
-    }
-
-    fn member_types(self) -> [Option<ProtocolMemberType<'db>>; 6] {
-        [
-            self.instance.read,
-            self.instance
-                .write
-                .and_then(ProtocolMemberWrite::domain),
-            self.instance
-                .write
-                .and_then(ProtocolMemberWrite::descriptor_type),
-            self.class.read,
-            self.class.write.and_then(ProtocolMemberWrite::domain),
-            self.class
-                .write
-                .and_then(ProtocolMemberWrite::descriptor_type),
-        ]
-    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1276,7 +1146,6 @@ fn cycle_normalized_optional_type<'db>(
 #[derive(Debug, PartialEq, Eq, Clone, Hash, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) struct ProtocolMemberData<'db> {
     kind: ProtocolMemberKind<'db>,
-    mapped_capabilities: Option<ProtocolMemberCapabilities<'db>>,
     qualifiers: TypeQualifiers,
     definition: Option<Definition<'db>>,
 }
@@ -1303,7 +1172,6 @@ impl<'db> ProtocolMemberData<'db> {
                 ProtocolMemberType::with_definition(Type::Callable(callable), definition),
                 method_kind,
             ),
-            mapped_capabilities: None,
             qualifiers: TypeQualifiers::default(),
             definition,
         }
@@ -1316,7 +1184,6 @@ impl<'db> ProtocolMemberData<'db> {
     ) -> Self {
         Self {
             kind: ProtocolMemberKind::Property { read, write },
-            mapped_capabilities: None,
             qualifiers: TypeQualifiers::default(),
             definition,
         }
@@ -1328,10 +1195,10 @@ impl<'db> ProtocolMemberData<'db> {
         definition: Option<Definition<'db>>,
     ) -> Self {
         Self {
-            kind: ProtocolMemberKind::Attribute(ProtocolMemberType::with_definition(
-                ty, definition,
-            )),
-            mapped_capabilities: None,
+            kind: ProtocolMemberKind::Attribute {
+                read: ProtocolMemberType::with_definition(ty, definition),
+                write: None,
+            },
             qualifiers,
             definition,
         }
@@ -1342,10 +1209,6 @@ impl<'db> ProtocolMemberData<'db> {
     /// These are views of the canonical method, property, or attribute representation below;
     /// keeping them derived prevents the stored member kind and its capabilities from diverging.
     fn capabilities(&self, db: &'db dyn Db) -> ProtocolMemberCapabilities<'db> {
-        if let Some(capabilities) = self.mapped_capabilities {
-            return capabilities;
-        }
-
         match self.kind {
             ProtocolMemberKind::Method(member, kind) => {
                 let instance_method = match (member.ty(), kind) {
@@ -1363,45 +1226,38 @@ impl<'db> ProtocolMemberData<'db> {
                 instance: ProtocolMemberAccess::new(read, write),
                 class: ProtocolMemberAccess::NONE,
             },
-            ProtocolMemberKind::Attribute(member_ty) => {
-                let is_class_var = self.qualifiers.contains(TypeQualifiers::CLASS_VAR);
-                let is_final = self.qualifiers.contains(TypeQualifiers::FINAL);
-                ProtocolMemberCapabilities {
-                    instance: ProtocolMemberAccess::new(
-                        Some(member_ty),
-                        (!is_class_var && !is_final)
-                            .then_some(ProtocolMemberWrite::from_type(member_ty)),
-                    ),
-                    class: if is_class_var {
-                        ProtocolMemberAccess::new(
-                            Some(member_ty),
-                            (!is_final).then_some(ProtocolMemberWrite::from_type(member_ty)),
-                        )
-                    } else {
-                        ProtocolMemberAccess::NONE
-                    },
-                }
+            ProtocolMemberKind::Attribute { read, write } => {
+                self.attribute_capabilities(read, write.map_or(read, |write| read.with_ty(write)))
             }
+        }
+    }
+
+    fn attribute_capabilities(
+        &self,
+        read: ProtocolMemberType<'db>,
+        write: ProtocolMemberType<'db>,
+    ) -> ProtocolMemberCapabilities<'db> {
+        let is_class_var = self.qualifiers.contains(TypeQualifiers::CLASS_VAR);
+        let is_final = self.qualifiers.contains(TypeQualifiers::FINAL);
+        ProtocolMemberCapabilities {
+            instance: ProtocolMemberAccess::new(
+                Some(read),
+                (!is_class_var && !is_final).then_some(ProtocolMemberWrite::from_type(write)),
+            ),
+            class: if is_class_var {
+                ProtocolMemberAccess::new(
+                    Some(read),
+                    (!is_final).then_some(ProtocolMemberWrite::from_type(write)),
+                )
+            } else {
+                ProtocolMemberAccess::NONE
+            },
         }
     }
 
     fn cycle_normalized(&self, db: &'db dyn Db, previous: &Self, cycle: &salsa::Cycle) -> Self {
         Self {
             kind: self.kind.cycle_normalized(db, previous.kind, cycle),
-            mapped_capabilities: match (self.mapped_capabilities, previous.mapped_capabilities) {
-                (Some(current), Some(previous)) => {
-                    Some(current.cycle_normalized(db, previous, cycle))
-                }
-                (Some(current), None) => Some(current.cycle_normalized(
-                    db,
-                    ProtocolMemberCapabilities {
-                        instance: ProtocolMemberAccess::NONE,
-                        class: ProtocolMemberAccess::NONE,
-                    },
-                    cycle,
-                )),
-                (None, _) => None,
-            },
             qualifiers: self.qualifiers,
             definition: self.definition,
         }
@@ -1415,12 +1271,6 @@ impl<'db> ProtocolMemberData<'db> {
     ) -> Option<Self> {
         Some(Self {
             kind: self.kind.recursive_type_normalized_impl(db, div, nested)?,
-            mapped_capabilities: match self.mapped_capabilities {
-                Some(capabilities) => {
-                    Some(capabilities.recursive_type_normalized_impl(db, div, nested)?)
-                }
-                None => None,
-            },
             qualifiers: self.qualifiers,
             definition: self.definition,
         })
@@ -1433,39 +1283,27 @@ impl<'db> ProtocolMemberData<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
-        let kind = self
-            .kind
-            .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
-        let mut mapped = Self {
+        let kind = match self.kind {
+            ProtocolMemberKind::Attribute {
+                read: attribute,
+                write,
+            } if !self.qualifiers.contains(TypeQualifiers::FINAL) => {
+                let read = attribute.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+                let write = write
+                    .map_or(attribute, |write| attribute.with_ty(write))
+                    .apply_write_type_mapping_impl(db, type_mapping, tcx, visitor);
+                ProtocolMemberKind::Attribute {
+                    read,
+                    write: (read != write).then_some(write.ty()),
+                }
+            }
+            kind => kind.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+        };
+        Self {
             kind,
-            mapped_capabilities: None,
             qualifiers: self.qualifiers,
             definition: self.definition,
-        };
-        // Method and property callables already encode the variance of their reads and writes.
-        // Their derived capabilities can cut a recursive type at a different point if mapped
-        // separately, so keep the mapped member kind as the canonical representation. Plain
-        // attributes need the sidecar because one stored value type cannot represent their
-        // independently materialized read and write capabilities.
-        if matches!(self.kind, ProtocolMemberKind::Attribute(_)) {
-            let capabilities =
-                self.capabilities(db)
-                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
-            if mapped.capabilities(db) != capabilities {
-                mapped.mapped_capabilities = Some(capabilities);
-            }
         }
-        mapped
-    }
-
-    fn member_types(&self) -> impl Iterator<Item = ProtocolMemberType<'db>> {
-        self.mapped_capabilities
-            .map_or_else(
-                || self.kind.member_types(),
-                ProtocolMemberCapabilities::member_types,
-            )
-            .into_iter()
-            .flatten()
     }
 
     fn find_legacy_typevars_impl(
@@ -1475,7 +1313,7 @@ impl<'db> ProtocolMemberData<'db> {
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         _visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
-        for member_type in self.member_types() {
+        for member_type in self.kind.member_types() {
             member_type
                 .ty()
                 .find_legacy_typevars(db, binding_context, typevars);
@@ -1505,7 +1343,9 @@ impl<'db> ProtocolMemberData<'db> {
                         }
                         d.finish()
                     }
-                    ProtocolMemberKind::Attribute(attribute) => {
+                    ProtocolMemberKind::Attribute {
+                        read: attribute, ..
+                    } => {
                         f.write_str("AttributeMember(")?;
                         write!(f, "`{}`", attribute.ty().display(self.db))?;
                         if self.qualifiers.contains(TypeQualifiers::CLASS_VAR) {
@@ -1532,7 +1372,14 @@ enum ProtocolMemberKind<'db> {
         read: Option<ProtocolMemberType<'db>>,
         write: Option<ProtocolMemberWrite<'db>>,
     },
-    Attribute(ProtocolMemberType<'db>),
+    Attribute {
+        read: ProtocolMemberType<'db>,
+        /// A contravariantly mapped write type when it differs from `read`.
+        ///
+        /// The member-local binding context is shared with `read`, so storing only the type keeps
+        /// the common member representation compact.
+        write: Option<Type<'db>>,
+    },
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
@@ -1543,19 +1390,20 @@ enum ProtocolMethodKind {
 }
 
 impl<'db> ProtocolMemberKind<'db> {
-    fn member_types(self) -> [Option<ProtocolMemberType<'db>>; 6] {
+    fn member_types(self) -> impl Iterator<Item = ProtocolMemberType<'db>> {
         match self {
-            Self::Method(method, _) => [Some(method), None, None, None, None, None],
+            Self::Method(method, _) => [Some(method), None, None],
             Self::Property { read, write } => [
                 read,
                 write.and_then(ProtocolMemberWrite::domain),
                 write.and_then(ProtocolMemberWrite::descriptor_type),
-                None,
-                None,
-                None,
             ],
-            Self::Attribute(attribute) => [Some(attribute), None, None, None, None, None],
+            Self::Attribute { read, write } => {
+                [Some(read), write.map(|write| read.with_ty(write)), None]
+            }
         }
+        .into_iter()
+        .flatten()
     }
 
     fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
@@ -1603,9 +1451,25 @@ impl<'db> ProtocolMemberKind<'db> {
                     (None, _) => None,
                 },
             },
-            (Self::Attribute(current), Self::Attribute(previous)) => {
-                Self::Attribute(current.cycle_normalized(db, previous, cycle))
-            }
+            (
+                Self::Attribute {
+                    read: current_read,
+                    write: current_write,
+                },
+                Self::Attribute {
+                    read: previous_read,
+                    write: previous_write,
+                },
+            ) => Self::Attribute {
+                read: current_read.cycle_normalized(db, previous_read, cycle),
+                write: cycle_normalized_optional_type(
+                    db,
+                    current_write.map(|write| current_read.with_ty(write)),
+                    previous_write.map(|write| previous_read.with_ty(write)),
+                    cycle,
+                )
+                .map(ProtocolMemberType::ty),
+            },
             (current, _) => current,
         }
     }
@@ -1631,9 +1495,13 @@ impl<'db> ProtocolMemberKind<'db> {
                     None => None,
                 },
             },
-            Self::Attribute(attribute) => {
-                Self::Attribute(attribute.recursive_type_normalized_impl(db, div, nested)?)
-            }
+            Self::Attribute { read, write } => Self::Attribute {
+                read: read.recursive_type_normalized_impl(db, div, nested)?,
+                write: match write {
+                    Some(write) => Some(write.recursive_type_normalized_impl(db, div, nested)?),
+                    None => None,
+                },
+            },
         })
     }
 
@@ -1654,9 +1522,14 @@ impl<'db> ProtocolMemberKind<'db> {
                 write: write
                     .map(|write| write.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
             },
-            Self::Attribute(attribute) => {
-                Self::Attribute(attribute.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
-            }
+            Self::Attribute { read, write } => Self::Attribute {
+                read: read.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                write: write.map(|write| {
+                    read.with_ty(write)
+                        .apply_write_type_mapping_impl(db, type_mapping, tcx, visitor)
+                        .ty()
+                }),
+            },
         }
     }
 }
@@ -1687,7 +1560,7 @@ fn walk_protocol_member<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     member: &ProtocolMember<'_, 'db>,
     visitor: &V,
 ) {
-    for member_type in member.data.member_types() {
+    for member_type in member.data.kind.member_types() {
         visitor.visit_type(db, member_type.ty());
     }
 }
@@ -1717,17 +1590,11 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         };
 
         let ProtocolMemberKind::Method(member, _) = self.data.kind else {
-            let is_finite = self
-                .data
-                .kind
-                .member_types()
-                .into_iter()
-                .flatten()
-                .all(|member| {
-                    member
-                        .resolve(db)
-                        .is_some_and(|member| !is_recursive_type(member.ty()))
-                });
+            let is_finite = self.data.kind.member_types().all(|member| {
+                member
+                    .resolve(db)
+                    .is_some_and(|member| !is_recursive_type(member.ty()))
+            });
             return if is_finite {
                 StructuralMemberPriority::Simple
             } else {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -815,6 +815,13 @@ impl<'db> ProtocolMemberWrite<'db> {
         }
     }
 
+    fn resolve(self, db: &'db dyn Db) -> Option<Self> {
+        match self {
+            Self::Type(member) => Some(Self::Type(member.resolve(db)?)),
+            descriptor @ Self::Descriptor { .. } => Some(descriptor),
+        }
+    }
+
     fn bind_requirement(
         self,
         db: &'db dyn Db,
@@ -919,6 +926,25 @@ impl<'db> ProtocolMemberWrite<'db> {
         }
     }
 
+    fn apply_write_type_mapping_impl<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'a, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        match self {
+            Self::Type(member) => {
+                Self::Type(member.apply_write_type_mapping_impl(db, type_mapping, tcx, visitor))
+            }
+            Self::Descriptor { descriptor, domain } => Self::Descriptor {
+                descriptor: descriptor.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                domain: domain.map(|domain| {
+                    domain.apply_write_type_mapping_impl(db, type_mapping, tcx, visitor)
+                }),
+            },
+        }
+    }
 }
 
 impl<'db> VarianceInferable<'db> for ProtocolInterface<'db> {
@@ -1517,6 +1543,30 @@ impl<'db> ProtocolMemberKind<'db> {
                 member.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 kind,
             ),
+            Self::Property { read, write }
+                if matches!(
+                    type_mapping,
+                    TypeMapping::Materialize(_)
+                        | TypeMapping::ApplySpecializationWithMaterialization { .. }
+                ) =>
+            {
+                let resolved_read = read.and_then(|read| read.resolve(db));
+                let resolved_write = write.and_then(|write| write.resolve(db));
+                let mapped_read = resolved_read
+                    .map(|read| read.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+                let mapped_write = resolved_write.map(|write| {
+                    write.apply_write_type_mapping_impl(db, type_mapping, tcx, visitor)
+                });
+
+                if mapped_read == resolved_read && mapped_write == resolved_write {
+                    Self::Property { read, write }
+                } else {
+                    Self::Property {
+                        read: mapped_read,
+                        write: mapped_write,
+                    }
+                }
+            }
             Self::Property { read, write } => Self::Property {
                 read: read.map(|read| read.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
                 write: write

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -368,9 +368,50 @@ pub(super) fn walk_protocol_instance_member<'db, V: super::visitor::TypeVisitor<
                 }
             }
         }
-        ProtocolMemberKind::Attribute(attribute) => {
-            if let Some(ty) = attribute.bind_self(db, receiver_ty) {
-                visitor.visit_type(db, ty);
+        ProtocolMemberKind::Attribute(_) => {
+            for member_type in member.data.member_types() {
+                if let Some(ty) = member_type.bind_self(db, receiver_ty) {
+                    visitor.visit_type(db, ty);
+                }
+            }
+        }
+    }
+}
+
+/// Visits the member types that participate in structural protocol relations.
+///
+/// For methods, the instance-access callable omits the implicit receiver while retaining every
+/// user-visible parameter and the return type. Visiting that form avoids treating the receiver's
+/// protocol type as a recursive member reference.
+pub(super) fn walk_protocol_interface_requirements<
+    'db,
+    V: super::visitor::TypeVisitor<'db> + ?Sized,
+>(
+    db: &'db dyn Db,
+    interface: ProtocolInterface<'db>,
+    visitor: &V,
+) {
+    for member in interface.members(db) {
+        let capabilities = member.capabilities(db);
+        let accesses = if member.is_method() {
+            [Some(capabilities.instance), None]
+        } else {
+            [Some(capabilities.instance), Some(capabilities.class)]
+        };
+        for member_type in accesses
+            .into_iter()
+            .flatten()
+            .flat_map(|access| {
+                [
+                    access.read,
+                    access.write.and_then(ProtocolMemberWrite::domain),
+                    access.write.and_then(ProtocolMemberWrite::descriptor_type),
+                ]
+            })
+            .flatten()
+        {
+            if let Some(member_type) = member_type.resolve(db) {
+                visitor.visit_type(db, member_type.ty());
             }
         }
     }
@@ -504,6 +545,32 @@ impl<'db> ProtocolInterface<'db> {
                         })
                 )
             })
+    }
+
+    /// Returns whether two interfaces differ for any member named by `required`.
+    ///
+    /// Members outside `required` are deliberately ignored so an unrelated materialized member
+    /// does not disable a valid nominal relation.
+    pub(super) fn differs_for_members_required_by(
+        self,
+        db: &'db dyn Db,
+        other: Self,
+        required: Self,
+    ) -> bool {
+        required
+            .inner(db)
+            .keys()
+            .any(|name| self.inner(db).get(name) != other.inner(db).get(name))
+    }
+
+    pub(super) fn member_has_todo_type(self, db: &'db dyn Db, name: &str) -> bool {
+        self.member_by_name(db, name)
+            .is_some_and(|member| member.has_todo_type())
+    }
+
+    pub(super) fn member_is_property(self, db: &'db dyn Db, name: &str) -> bool {
+        self.member_by_name(db, name)
+            .is_some_and(|member| member.is_property())
     }
 
     /// Returns the declared instance-write requirement for a protocol member.
@@ -851,6 +918,23 @@ impl<'db> ProtocolMemberWrite<'db> {
             },
         }
     }
+
+    fn apply_write_type_mapping_impl<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'a, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        match self {
+            Self::Type(member) => Self::Type(
+                member.apply_write_type_mapping_impl(db, type_mapping, tcx, visitor),
+            ),
+            descriptor @ Self::Descriptor { .. } => {
+                descriptor.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+            }
+        }
+    }
 }
 
 impl<'db> VarianceInferable<'db> for ProtocolInterface<'db> {
@@ -993,9 +1077,27 @@ impl<'db> ProtocolMemberType<'db> {
             .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
         self.with_ty(ty)
     }
+
+    /// Maps a writable capability contravariantly.
+    ///
+    /// A stored property setter is still a callable, so its value parameter already introduces
+    /// the contravariance required by a write. Other writable capabilities store the exposed
+    /// value type directly and therefore require an explicit polarity flip.
+    fn apply_write_type_mapping_impl<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'a, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        match self {
+            Self::PropertySetter(_) => self.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            _ => self.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
+        }
+    }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 /// The types supported by one way of accessing a protocol member.
 ///
 /// `read` is covariant and `write` is contravariant. Either operation can be absent: for example,
@@ -1030,6 +1132,56 @@ impl<'db> ProtocolMemberAccess<'db> {
                     .map(|member| (member.ty(), TypeVarVariance::Contravariant)),
             )
     }
+
+    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
+        Self {
+            read: cycle_normalized_optional_type(db, self.read, previous.read, cycle),
+            write: match (self.write, previous.write) {
+                (Some(current), Some(previous)) => {
+                    Some(current.cycle_normalized(db, previous, cycle))
+                }
+                (Some(current), None) => {
+                    Some(current.cycle_normalized_without_previous(db, cycle))
+                }
+                (None, _) => None,
+            },
+        }
+    }
+
+    fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        Some(Self {
+            read: match self.read {
+                Some(read) => Some(read.recursive_type_normalized_impl(db, div, nested)?),
+                None => None,
+            },
+            write: match self.write {
+                Some(write) => Some(write.recursive_type_normalized_impl(db, div, nested)?),
+                None => None,
+            },
+        })
+    }
+
+    fn apply_type_mapping_impl<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'a, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        Self {
+            read: self
+                .read
+                .map(|read| read.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
+            write: self
+                .write
+                .map(|write| write.apply_write_type_mapping_impl(db, type_mapping, tcx, visitor)),
+        }
+    }
 }
 
 /// The readable and writable types exposed through instance and class access.
@@ -1037,10 +1189,67 @@ impl<'db> ProtocolMemberAccess<'db> {
 /// Instance access and class access each independently record readable and writable types. For
 /// example, a mutable `ClassVar` is readable through both, writable through the class, and
 /// read-only through an instance.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 struct ProtocolMemberCapabilities<'db> {
     instance: ProtocolMemberAccess<'db>,
     class: ProtocolMemberAccess<'db>,
+}
+
+impl<'db> ProtocolMemberCapabilities<'db> {
+    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
+        Self {
+            instance: self.instance.cycle_normalized(db, previous.instance, cycle),
+            class: self.class.cycle_normalized(db, previous.class, cycle),
+        }
+    }
+
+    fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        Some(Self {
+            instance: self
+                .instance
+                .recursive_type_normalized_impl(db, div, nested)?,
+            class: self.class.recursive_type_normalized_impl(db, div, nested)?,
+        })
+    }
+
+    fn apply_type_mapping_impl<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'a, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        Self {
+            instance: self
+                .instance
+                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            class: self
+                .class
+                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+        }
+    }
+
+    fn member_types(self) -> [Option<ProtocolMemberType<'db>>; 6] {
+        [
+            self.instance.read,
+            self.instance
+                .write
+                .and_then(ProtocolMemberWrite::domain),
+            self.instance
+                .write
+                .and_then(ProtocolMemberWrite::descriptor_type),
+            self.class.read,
+            self.class.write.and_then(ProtocolMemberWrite::domain),
+            self.class
+                .write
+                .and_then(ProtocolMemberWrite::descriptor_type),
+        ]
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1067,6 +1276,7 @@ fn cycle_normalized_optional_type<'db>(
 #[derive(Debug, PartialEq, Eq, Clone, Hash, get_size2::GetSize, salsa::SalsaValue)]
 pub(super) struct ProtocolMemberData<'db> {
     kind: ProtocolMemberKind<'db>,
+    mapped_capabilities: Option<ProtocolMemberCapabilities<'db>>,
     qualifiers: TypeQualifiers,
     definition: Option<Definition<'db>>,
 }
@@ -1093,6 +1303,7 @@ impl<'db> ProtocolMemberData<'db> {
                 ProtocolMemberType::with_definition(Type::Callable(callable), definition),
                 method_kind,
             ),
+            mapped_capabilities: None,
             qualifiers: TypeQualifiers::default(),
             definition,
         }
@@ -1105,6 +1316,7 @@ impl<'db> ProtocolMemberData<'db> {
     ) -> Self {
         Self {
             kind: ProtocolMemberKind::Property { read, write },
+            mapped_capabilities: None,
             qualifiers: TypeQualifiers::default(),
             definition,
         }
@@ -1119,6 +1331,7 @@ impl<'db> ProtocolMemberData<'db> {
             kind: ProtocolMemberKind::Attribute(ProtocolMemberType::with_definition(
                 ty, definition,
             )),
+            mapped_capabilities: None,
             qualifiers,
             definition,
         }
@@ -1129,6 +1342,10 @@ impl<'db> ProtocolMemberData<'db> {
     /// These are views of the canonical method, property, or attribute representation below;
     /// keeping them derived prevents the stored member kind and its capabilities from diverging.
     fn capabilities(&self, db: &'db dyn Db) -> ProtocolMemberCapabilities<'db> {
+        if let Some(capabilities) = self.mapped_capabilities {
+            return capabilities;
+        }
+
         match self.kind {
             ProtocolMemberKind::Method(member, kind) => {
                 let instance_method = match (member.ty(), kind) {
@@ -1171,6 +1388,20 @@ impl<'db> ProtocolMemberData<'db> {
     fn cycle_normalized(&self, db: &'db dyn Db, previous: &Self, cycle: &salsa::Cycle) -> Self {
         Self {
             kind: self.kind.cycle_normalized(db, previous.kind, cycle),
+            mapped_capabilities: match (self.mapped_capabilities, previous.mapped_capabilities) {
+                (Some(current), Some(previous)) => {
+                    Some(current.cycle_normalized(db, previous, cycle))
+                }
+                (Some(current), None) => Some(current.cycle_normalized(
+                    db,
+                    ProtocolMemberCapabilities {
+                        instance: ProtocolMemberAccess::NONE,
+                        class: ProtocolMemberAccess::NONE,
+                    },
+                    cycle,
+                )),
+                (None, _) => None,
+            },
             qualifiers: self.qualifiers,
             definition: self.definition,
         }
@@ -1184,6 +1415,12 @@ impl<'db> ProtocolMemberData<'db> {
     ) -> Option<Self> {
         Some(Self {
             kind: self.kind.recursive_type_normalized_impl(db, div, nested)?,
+            mapped_capabilities: match self.mapped_capabilities {
+                Some(capabilities) => {
+                    Some(capabilities.recursive_type_normalized_impl(db, div, nested)?)
+                }
+                None => None,
+            },
             qualifiers: self.qualifiers,
             definition: self.definition,
         })
@@ -1196,13 +1433,39 @@ impl<'db> ProtocolMemberData<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
-        Self {
-            kind: self
-                .kind
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+        let kind = self
+            .kind
+            .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+        let mut mapped = Self {
+            kind,
+            mapped_capabilities: None,
             qualifiers: self.qualifiers,
             definition: self.definition,
+        };
+        // Method and property callables already encode the variance of their reads and writes.
+        // Their derived capabilities can cut a recursive type at a different point if mapped
+        // separately, so keep the mapped member kind as the canonical representation. Plain
+        // attributes need the sidecar because one stored value type cannot represent their
+        // independently materialized read and write capabilities.
+        if matches!(self.kind, ProtocolMemberKind::Attribute(_)) {
+            let capabilities =
+                self.capabilities(db)
+                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+            if mapped.capabilities(db) != capabilities {
+                mapped.mapped_capabilities = Some(capabilities);
+            }
         }
+        mapped
+    }
+
+    fn member_types(&self) -> impl Iterator<Item = ProtocolMemberType<'db>> {
+        self.mapped_capabilities
+            .map_or_else(
+                || self.kind.member_types(),
+                ProtocolMemberCapabilities::member_types,
+            )
+            .into_iter()
+            .flatten()
     }
 
     fn find_legacy_typevars_impl(
@@ -1212,7 +1475,7 @@ impl<'db> ProtocolMemberData<'db> {
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         _visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
-        for member_type in self.kind.member_types() {
+        for member_type in self.member_types() {
             member_type
                 .ty()
                 .find_legacy_typevars(db, binding_context, typevars);
@@ -1280,18 +1543,19 @@ enum ProtocolMethodKind {
 }
 
 impl<'db> ProtocolMemberKind<'db> {
-    fn member_types(self) -> impl Iterator<Item = ProtocolMemberType<'db>> {
+    fn member_types(self) -> [Option<ProtocolMemberType<'db>>; 6] {
         match self {
-            Self::Method(method, _) => [Some(method), None, None],
+            Self::Method(method, _) => [Some(method), None, None, None, None, None],
             Self::Property { read, write } => [
                 read,
                 write.and_then(ProtocolMemberWrite::domain),
                 write.and_then(ProtocolMemberWrite::descriptor_type),
+                None,
+                None,
+                None,
             ],
-            Self::Attribute(attribute) => [Some(attribute), None, None],
+            Self::Attribute(attribute) => [Some(attribute), None, None, None, None, None],
         }
-        .into_iter()
-        .flatten()
     }
 
     fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
@@ -1423,7 +1687,7 @@ fn walk_protocol_member<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     member: &ProtocolMember<'_, 'db>,
     visitor: &V,
 ) {
-    for member_type in member.data.kind.member_types() {
+    for member_type in member.data.member_types() {
         visitor.visit_type(db, member_type.ty());
     }
 }
@@ -1453,11 +1717,17 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         };
 
         let ProtocolMemberKind::Method(member, _) = self.data.kind else {
-            let is_finite = self.data.kind.member_types().all(|member| {
-                member
-                    .resolve(db)
-                    .is_some_and(|member| !is_recursive_type(member.ty()))
-            });
+            let is_finite = self
+                .data
+                .kind
+                .member_types()
+                .into_iter()
+                .flatten()
+                .all(|member| {
+                    member
+                        .resolve(db)
+                        .is_some_and(|member| !is_recursive_type(member.ty()))
+                });
             return if is_finite {
                 StructuralMemberPriority::Simple
             } else {

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -951,7 +951,7 @@ impl<'db> IntersectionType<'db> {
         if !self.iter_positive(db).any(|positive| {
             matches!(
                 positive,
-                Type::ProtocolInstance(protocol) if protocol.class_origin().is_some()
+                Type::ProtocolInstance(protocol) if protocol.class_origin(db).is_some()
             )
         }) {
             return None;

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -57,7 +57,8 @@ impl<'db> SubclassOfType<'db> {
         }
     }
 
-    /// Construct the meta-type of a class-backed protocol.
+    /// Construct the structural meta-type of a class-backed protocol while retaining its
+    /// effective interface for member lookup.
     pub(super) const fn from_protocol(protocol: ProtocolInstanceType<'db>) -> Type<'db> {
         Type::SubclassOf(Self {
             subclass_of: SubclassOfInner::Protocol(protocol),
@@ -246,7 +247,7 @@ impl<'db> SubclassOfType<'db> {
         let class_like = match self.subclass_of.with_transposed_type_var(db) {
             SubclassOfInner::Class(class) => Type::from(class),
             SubclassOfInner::Dynamic(dynamic) => Type::Dynamic(dynamic),
-            SubclassOfInner::Protocol(protocol) => Type::from(*protocol.class_origin()?),
+            SubclassOfInner::Protocol(protocol) => Type::from(*protocol.class_origin(db)?),
             SubclassOfInner::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => unreachable!(),
@@ -440,7 +441,8 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 ///
 /// 1. A "subclass of a class": `type[C]` for any class object `C`
 /// 2. A "subclass of a dynamic type": `type[Any]`, `type[Unknown]` and `type[@Todo]`
-/// 3. A protocol meta-type: `type[P]` for a class-backed protocol `P`
+/// 3. A protocol meta-type: `type[P]` for a class-backed protocol `P`, including a materialized
+///    protocol interface
 /// 4. A "subclass of a type variable": `type[T]` for any type variable `T`
 ///
 /// In the long term, we may want to implement <https://github.com/astral-sh/ruff/issues/15381>.

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -444,7 +444,7 @@ pub(super) fn non_any_dynamic_content<'db>(db: &'db dyn Db, ty: Type<'db>) -> Dy
             protocol: ProtocolInstanceType<'db>,
         ) {
             let protocol_ty = Type::ProtocolInstance(protocol);
-            let Some(class) = protocol.as_class_based() else {
+            let Some(class) = protocol.class_origin(db) else {
                 walk_protocol_instance_interface(db, protocol.interface(db), protocol_ty, self);
                 return;
             };


### PR DESCRIPTION
## Summary

Prior to this change, applying a type mapping to a class-based protocol delegated to its wrapped `ClassType`. `Top[P]` and `Bottom[P]` therefore left protocol member types unchanged, even though readable protocol members are covariant and writable members are contravariant.

We now represent a materialized class-based protocol with both its class origin and its rewritten interface. Instance and class read/write capabilities are mapped independently, so top-materializing a mutable `Any` attribute produces an `object` read and a `Never` write, while bottom materialization does the reverse.

Type relations et al now use the effective materialized interface where required. The class origin remains available for nominal inheritance, display, descriptor behavior, and members such as `__init__` that are not protocol requirements.

Incidentally, this fixes the existing `TypeIs` annotation for `dataclasses.is_dataclass`: a known dataclass is now recognized as a subtype of `Top[DataclassInstance]`, so the impossible branch narrows to `Never` without a known-function special case:

```python
@dataclass
class Event:
    x: int

def check(event: Event) -> None:
    if not is_dataclass(event):
        reveal_type(event)  # Never
```

Closes https://github.com/astral-sh/ty/issues/3443.