### PR TITLE
[ty] Avoid narrowing attributes with custom __setattr__

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -181,6 +181,34 @@ c.desc = -1
 reveal_type(c.desc)  # revealed: int
 ```
 
+### Do not narrow attributes assigned through a custom `__setattr__`
+
+A custom `__setattr__` can transform or discard the value being assigned. Subsequent reads must use
+the attribute's read type instead of the type of the assigned value.
+
+```py
+from typing import Any
+
+class Props:
+    def __getattr__(self, name: str) -> Any: ...
+    def __setattr__(self, name: str, value: Any) -> None: ...
+
+def f(props: Props) -> None:
+    props.status = "Closed"
+    reveal_type(props.status)  # revealed: Any
+    props.status.name
+
+class SetAttrBase:
+    def __setattr__(self, name: str, value: object) -> None: ...
+
+class WithDeclaredAttribute(SetAttrBase):
+    status: int | str
+
+def g(obj: WithDeclaredAttribute) -> None:
+    obj.status = 1
+    reveal_type(obj.status)  # revealed: int | str
+```
+
 ## Subscript
 
 ### Specialization for builtin types

--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -207,6 +207,17 @@ class WithDeclaredAttribute(SetAttrBase):
 def g(obj: WithDeclaredAttribute) -> None:
     obj.status = 1
     reveal_type(obj.status)  # revealed: int | str
+    if hasattr(obj, "other"):
+        obj.status = 1
+        reveal_type(obj.status)  # revealed: int | str
+
+class WithoutSetAttr:
+    status: int | str
+
+def h(obj: WithoutSetAttr) -> None:
+    if hasattr(obj, "other"):
+        obj.status = 1
+        reveal_type(obj.status)  # revealed: Literal[1]
 ```
 
 ## Subscript

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2746,9 +2746,11 @@ impl<'db> Type<'db> {
             }),
             // TODO: Once `to_meta_type` for the synthesized protocol is fully implemented, this handling should be removed.
             Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::Synthesized(_),
+                inner: Protocol::Synthesized(synthesized),
                 ..
-            }) => self.instance_member(db, &name),
+            }) => synthesized
+                .interface()
+                .instance_member_with_policy(db, &name, policy),
 
             Type::LiteralValue(literal) if name == "__len__" => {
                 if let Some(length) = match literal.kind() {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11248,13 +11248,26 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
             let value_ty = builder.try_expression_type(value).unwrap_or_else(|| {
                 builder.infer_maybe_standalone_expression(value, TypeContext::default())
             });
-            // If the member is a data descriptor, the RHS value may differ from the value actually assigned.
-            if value_ty
-                .class_member(db, attr.id.clone())
-                .place
-                .ignore_possibly_undefined()
-                .is_some_and(|ty| ty.may_be_data_descriptor(db))
-            {
+            if (
+                // A custom `__setattr__` may transform or discard the assigned value.
+                !value_ty
+                    .class_member_with_policy(
+                        db,
+                        "__setattr__".into(),
+                        MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
+                            | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK
+                            | MemberLookupPolicy::REQUIRE_CONCRETE,
+                    )
+                    .place
+                    .is_undefined()
+            ) || (
+                // A data descriptor may store a value different from the RHS.
+                value_ty
+                    .class_member(db, attr.id.clone())
+                    .place
+                    .ignore_possibly_undefined()
+                    .is_some_and(|ty| ty.may_be_data_descriptor(db))
+            ) {
                 builder.discard_dict_key_assignments_for(self.binding);
                 bound_ty = declared_ty;
             }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -337,6 +337,16 @@ impl<'db> ProtocolInterface<'db> {
     }
 
     pub(super) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        self.instance_member_with_policy(db, name, MemberLookupPolicy::default())
+    }
+
+    /// Resolve an interface member, applying `policy` when a missing member falls back to `object`.
+    pub(super) fn instance_member_with_policy(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        policy: MemberLookupPolicy,
+    ) -> PlaceAndQualifiers<'db> {
         self.member_by_name(db, name)
             .map(|member| {
                 let capabilities = member.capabilities(db);
@@ -351,7 +361,7 @@ impl<'db> ProtocolInterface<'db> {
                     qualifiers: member.qualifiers(),
                 }
             })
-            .unwrap_or_else(|| Type::object().member(db, name))
+            .unwrap_or_else(|| Type::object().member_lookup_with_policy(db, name.into(), policy))
     }
 
     pub(super) fn recursive_type_normalized_impl(


### PR DESCRIPTION
## Summary

After assigning to an attribute, we normally narrow subsequent reads to the assigned value's type. That is unsound when the object's class defines a custom `__setattr__`, because the method may transform or discard the value instead of storing it directly.

This treats a custom `__setattr__` as another write path that invalidates assignment narrowing, alongside the existing handling for data descriptors. Subsequent reads instead use the attribute's declared or fallback read type, and finding a custom setter short-circuits the descriptor lookup.

```python
from typing import Any

class Props:
    def __getattr__(self, name: str) -> Any: ...
    def __setattr__(self, name: str, value: Any) -> None: ...

def update(props: Props) -> None:
    props.status = "Closed"
    reveal_type(props.status)  # Any
```

Closes https://github.com/astral-sh/ty/issues/3846.
