### PR TITLE
[ty] Detect async generator expressions containing await

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -285,6 +285,8 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     ///
     /// [generator functions]: https://docs.python.org/3/glossary.html#term-generator
     generator_functions: FxHashSet<FileScopeId>,
+    /// Hashset of all [`FileScopeId`]s that correspond to asynchronous comprehensions.
+    async_comprehensions: FxHashSet<FileScopeId>,
     /// Snapshots of enclosing-scope place states visible from nested scopes.
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, ScopedEnclosingSnapshotId>,
     /// Errors collected by the `semantic_checker`.
@@ -335,6 +337,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             seen_submodule_imports: FxHashSet::default(),
             imported_modules: FxHashSet::default(),
             generator_functions: FxHashSet::default(),
+            async_comprehensions: FxHashSet::default(),
 
             enclosing_snapshots: FxHashMap::default(),
 
@@ -369,6 +372,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
     fn current_scope_id(&self) -> ScopeId<'db> {
         self.scope_ids_by_scope[self.current_scope()]
+    }
+
+    fn mark_current_comprehension_async(&mut self) {
+        let scope = self.current_scope();
+        if self.scopes[scope].kind() == ScopeKind::Comprehension {
+            self.async_comprehensions.insert(scope);
+        }
     }
 
     pub(crate) fn expect_single_definition(
@@ -2379,7 +2389,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         scope: NodeWithScopeRef,
         generators: &'ast [ast::Comprehension],
         visit_outer_elt: impl FnOnce(&mut Self),
-    ) {
+    ) -> FileScopeId {
         let mut generators_iter = generators.iter();
 
         let Some(generator) = generators_iter.next() else {
@@ -2398,6 +2408,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let saved_assignments = std::mem::take(&mut self.current_assignments);
 
         self.push_scope(scope);
+        let comprehension_scope = self.current_scope();
+
+        if generators.iter().any(|generator| generator.is_async) {
+            self.async_comprehensions.insert(comprehension_scope);
+        }
 
         self.add_unpackable_assignment(
             &Unpackable::Comprehension {
@@ -2434,6 +2449,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.pop_scope();
 
         self.current_assignments = saved_assignments;
+
+        comprehension_scope
     }
 
     fn visit_comprehension_filter(&mut self, if_expr: &'ast ast::Expr) {
@@ -2667,6 +2684,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_snapshots: FrozenMap::from(self.enclosing_snapshots),
             semantic_syntax_errors,
             generator_functions: FrozenSet::from(self.generator_functions),
+            async_comprehensions: FrozenSet::from(self.async_comprehensions),
             narrowing_alias_predicates: FrozenMap::from(self.alias_predicates),
         }
     }
@@ -4488,22 +4506,28 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     elt, generators, ..
                 },
             ) => {
-                self.with_generators_scope(
+                let scope = self.with_generators_scope(
                     NodeWithScopeRef::ListComprehension(list_comprehension),
                     generators,
                     |builder| builder.visit_expr(elt),
                 );
+                if self.async_comprehensions.contains(&scope) {
+                    self.mark_current_comprehension_async();
+                }
             }
             ast::Expr::SetComp(
                 set_comprehension @ ast::ExprSetComp {
                     elt, generators, ..
                 },
             ) => {
-                self.with_generators_scope(
+                let scope = self.with_generators_scope(
                     NodeWithScopeRef::SetComprehension(set_comprehension),
                     generators,
                     |builder| builder.visit_expr(elt),
                 );
+                if self.async_comprehensions.contains(&scope) {
+                    self.mark_current_comprehension_async();
+                }
             }
             ast::Expr::Generator(
                 generator @ ast::ExprGenerator {
@@ -4524,7 +4548,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     ..
                 },
             ) => {
-                self.with_generators_scope(
+                let scope = self.with_generators_scope(
                     NodeWithScopeRef::DictComprehension(dict_comprehension),
                     generators,
                     |builder| {
@@ -4534,6 +4558,9 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                         builder.visit_expr(value);
                     },
                 );
+                if self.async_comprehensions.contains(&scope) {
+                    self.mark_current_comprehension_async();
+                }
             }
             ast::Expr::BoolOp(ast::ExprBoolOp {
                 values,
@@ -4616,6 +4643,10 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 if self.scopes[scope].kind() == ScopeKind::Function {
                     self.generator_functions.insert(scope);
                 }
+                walk_expr(self, expr);
+            }
+            ast::Expr::Await(_) => {
+                self.mark_current_comprehension_async();
                 walk_expr(self, expr);
             }
             _ => {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -339,6 +339,9 @@ pub struct SemanticIndex<'db> {
     /// Set of all generator functions in this file.
     generator_functions: FrozenSet<FileScopeId>,
 
+    /// Set of all asynchronous comprehensions in this file.
+    async_comprehensions: FrozenSet<FileScopeId>,
+
     /// Narrowing alias metadata for predicate leaf names.
     /// When a predicate references an alias variable (e.g., `is_none` from `is_none = x is None`),
     /// the alias Name node is mapped to its aliased expression for constraint-generation time.

--- a/crates/ty_python_core/src/scope.rs
+++ b/crates/ty_python_core/src/scope.rs
@@ -103,6 +103,10 @@ impl FileScopeId {
     pub fn is_generator_function(self, index: &SemanticIndex) -> bool {
         index.generator_functions.contains(&self)
     }
+
+    pub fn is_async_comprehension(self, index: &SemanticIndex) -> bool {
+        index.async_comprehensions.contains(&self)
+    }
 }
 
 #[derive(Debug, salsa::Update, get_size2::GetSize)]

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/generator_expressions.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/generator_expressions.md
@@ -77,3 +77,59 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+An `await` expression in the generator expression's implicit scope also makes it asynchronous:
+
+```py
+async def is_even(value: int) -> bool:
+    return value % 2 == 0
+
+async def filter_values() -> None:
+    values: list[int] = [1, 2, 3]
+    generator = (value for value in values if await is_even(value))
+    reveal_type(generator)  # revealed: AsyncGeneratorType[int, None]
+    await anext(generator, None)
+```
+
+This includes `await` expressions in the yielded element and in the iterable of any `for` clause
+after the first:
+
+```py
+async def get_values(value: int = 0) -> list[int]:
+    return [value]
+
+async def get_value(value: int) -> int:
+    return value
+
+async def await_locations() -> None:
+    reveal_type([await get_value(x)] for x in [1])  # revealed: AsyncGeneratorType[list[int], None]
+    reveal_type(y for x in [1] for y in await get_values(x))  # revealed: AsyncGeneratorType[int, None]
+```
+
+The iterable in the first `for` clause is evaluated in the enclosing scope, so an `await` there does
+not make the generator expression asynchronous. The same rule means that the first iterable of a
+nested generator expression can make the outer generator asynchronous:
+
+```py
+async def first_iterable() -> None:
+    reveal_type(x for x in await get_values())  # revealed: GeneratorType[int, None, None]
+    outer = ((y for y in await get_values()) for _ in [1])
+    reveal_type(outer)  # revealed: AsyncGeneratorType[GeneratorType[int, None, None], None]
+```
+
+An asynchronous nested generator expression does not make the outer generator asynchronous, but an
+asynchronous nested container comprehension does:
+
+```py
+from collections.abc import AsyncIterator
+
+async def async_values() -> AsyncIterator[int]:
+    yield 1
+
+async def nested_comprehensions() -> None:
+    nested_generator = ((await get_value(x) for x in [1]) for _ in [1])
+    reveal_type(nested_generator)  # revealed: GeneratorType[AsyncGeneratorType[int, None], None, None]
+    reveal_type([x async for x in async_values()] for _ in [1])  # revealed: AsyncGeneratorType[list[int], None]
+    reveal_type({x async for x in async_values()} for _ in [1])  # revealed: AsyncGeneratorType[set[int], None]
+    reveal_type({x: x async for x in async_values()} for _ in [1])  # revealed: AsyncGeneratorType[dict[int, int], None]
+```

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6754,22 +6754,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     /// Infer the type of the `iter` expression of the first comprehension.
-    /// Returns the evaluation mode (async or sync) of the comprehension.
-    fn infer_first_comprehension_iter(
-        &mut self,
-        comprehensions: &[ast::Comprehension],
-    ) -> EvaluationMode {
+    fn infer_first_comprehension_iter(&mut self, comprehensions: &[ast::Comprehension]) {
         let mut comprehensions_iter = comprehensions.iter();
         let Some(first_comprehension) = comprehensions_iter.next() else {
             unreachable!("Comprehension must contain at least one generator");
         };
         self.infer_maybe_standalone_expression(&first_comprehension.iter, TypeContext::default());
-
-        if first_comprehension.is_async {
-            EvaluationMode::Async
-        } else {
-            EvaluationMode::Sync
-        }
     }
 
     /// Derive the type context for a generator expression's yielded element from the expected type
@@ -6843,8 +6833,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             parenthesized: _,
         } = generator;
 
-        let evaluation_mode = self.infer_first_comprehension_iter(generators);
-        let yield_tcx = self.generator_yield_type_context(tcx, evaluation_mode);
+        self.infer_first_comprehension_iter(generators);
 
         let Some(scope_id) = self
             .index
@@ -6852,6 +6841,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         else {
             return Type::unknown();
         };
+        let evaluation_mode =
+            EvaluationMode::from_is_async(scope_id.is_async_comprehension(self.index));
+        let yield_tcx = self.generator_yield_type_context(tcx, evaluation_mode);
         let scope = scope_id.to_scope_id(self.db(), self.file());
         let inference = infer_scope_types(self.db(), scope, yield_tcx);
         self.extend_scope(inference);


### PR DESCRIPTION
## Summary

Generator expressions containing `await` are asynchronous even when none of their comprehension clauses use `async for`. Prior to this change, we derived the evaluation mode from the first comprehension clause alone, so expressions such as `(value for value in values if await predicate(value))` were incorrectly inferred as synchronous generators.

Record asynchronous comprehension scopes while building the semantic index, including propagation through nested list, set, and dictionary comprehensions while preserving the leftmost-iterable and nested-generator exceptions. Generator-expression inference now consults that scope metadata to produce `AsyncGeneratorType` whenever the implicit scope is asynchronous.

Add coverage for `await` in yielded expressions, filters, and later iterables, along with the leftmost-iterable rule and nested comprehension propagation.

Closes https://github.com/astral-sh/ty/issues/3723.
