### PR TITLE
[ty] Skip collecting string-literal completion types on CLI runs

### DIFF
--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -171,6 +171,9 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
     project.set_verbose(&mut db, verbosity >= VerbosityLevel::Verbose);
     project.set_force_exclude(&mut db, force_exclude);
 
+    // A batch check never serves completions, so skip collecting the expected-type map they need.
+    db.set_collect_expected_types(false);
+
     if !check_paths.is_empty() {
         project.set_included_paths(&mut db, check_paths);
     }

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3191,7 +3191,9 @@ mod tests {
     use ruff_python_ast::helpers::is_dunder;
     use ruff_python_ast::token::{TokenKind, Tokens};
     use ruff_python_parser::{Mode, ParseOptions};
+    use salsa::Setter;
     use ty_module_resolver::ModuleName;
+    use ty_python_core::program::Program;
 
     use crate::CompletionCapabilities;
     use crate::completion::{Completion, completion};
@@ -7555,6 +7557,31 @@ value: Literal["x", "y"] = "<CURSOR>"
     }
 
     #[test]
+    fn string_literal_completions_absent_without_collection() {
+        // When expected-type collection is disabled (as it is for batch/CLI runs), the annotation
+        // no longer drives string-literal completions.
+        let builder = completion_test_builder(
+            r#"
+from typing import Literal
+
+value: Literal["x", "y"] = "<CURSOR>"
+"#,
+        );
+
+        assert_snapshot!(
+            builder
+                .without_expected_types()
+                .skip_keywords()
+                .skip_builtins()
+                .skip_auto_import()
+                .type_signatures()
+                .build()
+                .snapshot(),
+            @"<No completions found>",
+        );
+    }
+
+    #[test]
     fn string_literal_completions_nested_expected_type() {
         let builder = completion_test_builder(
             r#"
@@ -10806,6 +10833,15 @@ raise <CURSOR>
         /// might want to skip keywords but *not* builtins.
         fn skip_keywords(mut self) -> CompletionTestBuilder {
             self.skip_keywords = true;
+            self
+        }
+
+        /// Disables collection of the expected-type map, the way a batch (CLI) run does.
+        fn without_expected_types(mut self) -> CompletionTestBuilder {
+            let program = Program::get(&self.cursor_test.db);
+            program
+                .set_collect_expected_types(&mut self.cursor_test.db)
+                .to(false);
             self
         }
 

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -187,6 +187,17 @@ impl ProjectDatabase {
         }
     }
 
+    /// Controls whether type inference collects the expected-type map that string-literal
+    /// completions depend on. The language server leaves it on; batch (CLI) runs turn it off
+    /// because they never serve completions.
+    pub fn set_collect_expected_types(&mut self, enabled: bool) {
+        if Program::get(self).collect_expected_types(self) != enabled {
+            Program::get(self)
+                .set_collect_expected_types(self)
+                .to(enabled);
+        }
+    }
+
     /// Returns a mutable reference to the system.
     ///
     /// WARNING: Triggers a new revision, canceling other database handles. This can lead to deadlock.

--- a/crates/ty_python_core/src/program.rs
+++ b/crates/ty_python_core/src/program.rs
@@ -20,6 +20,11 @@ pub struct Program {
 
     #[returns(ref)]
     pub search_paths: SearchPaths,
+
+    /// Whether type inference collects the expression-to-expected-type map that string-literal
+    /// completions rely on. On by default; batch runs that never serve completions (the CLI) turn
+    /// it off to avoid building the map for every file.
+    pub collect_expected_types: bool,
 }
 
 impl Program {
@@ -42,7 +47,7 @@ impl Program {
 
         search_paths.try_register_static_roots(db);
 
-        Program::builder(python_version, python_platform, search_paths)
+        Program::builder(python_version, python_platform, search_paths, true)
             .durability(Durability::HIGH)
             .new(db)
     }
@@ -84,6 +89,7 @@ impl Program {
         let python_version = self.python_version_with_source(db).clone();
         let python_platform = self.python_platform(db).clone();
         let search_paths = self.search_paths(db).clone();
+        let collect_expected_types = self.collect_expected_types(db);
 
         self.set_python_version_with_source(db)
             .with_durability(durability)
@@ -94,6 +100,9 @@ impl Program {
         self.set_search_paths(db)
             .with_durability(durability)
             .to(search_paths);
+        self.set_collect_expected_types(db)
+            .with_durability(durability)
+            .to(collect_expected_types);
     }
 
     pub fn custom_stdlib_search_path(self, db: &dyn Db) -> Option<&SystemPath> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6494,11 +6494,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         assert_eq!(previous, None);
     }
 
+    /// Whether inference should record the expected-type map that string-literal completions use.
+    /// Batch runs (the CLI) disable it since they never serve completions.
+    fn collect_expected_types(&self) -> bool {
+        Program::get(self.db()).collect_expected_types(self.db())
+    }
+
     fn store_maybe_expected_type(
         &mut self,
         expression: impl Into<ExpressionNodeKey>,
         ty: Type<'db>,
     ) {
+        if !self.collect_expected_types() {
+            return;
+        }
+
         if !self.has_string_literal_completion_candidates(ty) {
             return;
         }
@@ -6507,6 +6517,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn store_expected_type(&mut self, expression: impl Into<ExpressionNodeKey>, ty: Type<'db>) {
+        if !self.collect_expected_types() {
+            return;
+        }
+
         self.expected_types.insert(expression.into(), ty);
     }
 


### PR DESCRIPTION
Part of astral-sh/ty#3376.

ty builds the `expected_types` map for string-literal completions on every `ty check`, but only the language server ever reads it. So the CLI builds it and throws it away.

This adds a `collect_expected_types` flag on `Program` (on by default) that the CLI turns off, so inference skips the map. Checking doesn't change, nothing on that path reads it.

Only covers the CLI though. The server still builds it eagerly for stdlib and third-party code. Making it fully lazy per scope is the bigger change in the issue, and I left that out for now.

Note: #25546 already does the fuller version. I wrote this one separately, so grab whichever's more useful.

Tested: existing string-literal completion tests pass with the flag on, plus a new one that checks the completions drop when it's off.
