### PR TITLE
[flake8-simplify] Add fix safety docs (SIM101, SIM105, SIM108, SIM109, SIM220, SIM221, SIM222, SIM223, SIM401)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -41,6 +41,15 @@ use crate::{AlwaysFixableViolation, Edit, Fix, FixAvailability, Violation};
 ///     pass
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe. Merging the `isinstance` calls into a
+/// single call with a tuple of types requires evaluating every type
+/// expression up front, whereas the original `or` expression only evaluates
+/// them until the first `isinstance` call that returns `True`. If a later
+/// type expression has a side effect (or would raise), the fix causes it to
+/// run unconditionally instead of being skipped by short-circuiting. The fix
+/// may also remove comments contained within the merged expression.
+///
 /// ## References
 /// - [Python documentation: `isinstance`](https://docs.python.org/3/library/functions.html#isinstance)
 #[derive(ViolationMetadata)]
@@ -90,6 +99,15 @@ impl Violation for DuplicateIsinstanceCall {
 ///     ...
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe, as it might change the behaviour if
+/// the compared values override `__eq__` in a way that isn't reflexive.
+/// Unlike the original chain of `==` comparisons, Python's `in` operator
+/// checks identity (`is`) before falling back to `==` for each element of
+/// the tuple, so the rewritten expression can evaluate to `True` even though
+/// every individual `==` comparison in the original expression would have
+/// returned a falsy value.
+///
 /// ## References
 /// - [Python documentation: Membership test operations](https://docs.python.org/3/reference/expressions.html#membership-test-operations)
 #[derive(ViolationMetadata)]
@@ -124,6 +142,14 @@ impl AlwaysFixableViolation for CompareWithTuple {
 /// x and not x
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe, as it assumes that both references
+/// to `x` evaluate identically. If `x`'s type overrides `__bool__` (or
+/// `__len__`) such that its truthiness isn't stable across multiple
+/// evaluations, replacing the expression with `False` can change the
+/// program's behavior. The fix may also remove comments contained within the
+/// expression.
+///
 /// ## References
 /// - [Python documentation: Boolean operations](https://docs.python.org/3/reference/expressions.html#boolean-operations)
 #[derive(ViolationMetadata)]
@@ -156,6 +182,14 @@ impl AlwaysFixableViolation for ExprAndNotExpr {
 /// ```python
 /// x or not x
 /// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe, as it assumes that both references
+/// to `x` evaluate identically. If `x`'s type overrides `__bool__` (or
+/// `__len__`) such that its truthiness isn't stable across multiple
+/// evaluations, replacing the expression with `True` can change the
+/// program's behavior. The fix may also remove comments contained within the
+/// expression.
 ///
 /// ## References
 /// - [Python documentation: Boolean operations](https://docs.python.org/3/reference/expressions.html#boolean-operations)
@@ -212,6 +246,17 @@ pub(crate) enum ContentAround {
 ///
 /// a = x or [1]
 /// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe. To decide how much of the expression
+/// can be dropped, the rule assumes that an operand whose truthiness can't
+/// be determined statically has no side effects, as long as the whole
+/// expression is used in a boolean context (e.g., an `if` test). This
+/// assumption doesn't hold for expressions like attribute accesses, which
+/// aren't treated as having side effects even though they can run arbitrary
+/// code (e.g., through a property) or raise, so such an operand can be
+/// silently dropped without being evaluated. The fix may also remove
+/// comments contained within the replaced range.
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.208")]
 pub(crate) struct ExprOrTrue {
@@ -265,6 +310,17 @@ impl AlwaysFixableViolation for ExprOrTrue {
 ///
 /// a = x and []
 /// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe. To decide how much of the expression
+/// can be dropped, the rule assumes that an operand whose truthiness can't
+/// be determined statically has no side effects, as long as the whole
+/// expression is used in a boolean context (e.g., an `if` test). This
+/// assumption doesn't hold for expressions like attribute accesses, which
+/// aren't treated as having side effects even though they can run arbitrary
+/// code (e.g., through a property) or raise, so such an operand can be
+/// silently dropped without being evaluated. The fix may also remove
+/// comments contained within the replaced range.
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.208")]
 pub(crate) struct ExprAndFalse {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
@@ -50,6 +50,18 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// value = foo.get("bar", 0)
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe. `dict.get(key, default)` evaluates
+/// `default` unconditionally, as an argument to the call, whereas the
+/// original `if`-`else` block (or ternary) only evaluates the default value
+/// when the key is actually missing. Although the rule avoids rewriting
+/// cases where the default value is a call or other obviously effectful
+/// expression, it doesn't treat attribute access as effectful, so a default
+/// like a property can end up being evaluated unconditionally, changing the
+/// program's behavior if that property raises or has side effects. The fix
+/// is only offered when the `if` statement or expression contains no
+/// comments.
+///
 /// ## Options
 ///
 /// The rule will avoid flagging cases where using the resulting `dict.get` call would exceed the

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_if_exp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_if_exp.rs
@@ -55,6 +55,17 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// Ternary operators can also make it harder to measure [code coverage]
 /// with tools that use line profiling.
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe. When the `if` test and the assigned
+/// value are the same (or negations of each other), the rule rewrites the
+/// block to a binary `or`/`and` expression, which evaluates that shared
+/// expression only once, whereas the original `if`-`else` block evaluates it
+/// twice (once for the condition and once more to compute the assigned
+/// value). If the expression doesn't return the same value on each
+/// evaluation (for example, because it accesses a property with side
+/// effects), the fix can change the value assigned to the target. The fix
+/// is only offered when the `if` statement contains no comments.
+///
 /// ## Options
 ///
 /// - `lint.pycodestyle.max-line-length`

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -38,6 +38,19 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 ///     1 / 0
 /// ```
 ///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe. In the original `try`-`except`
+/// block, the handled exception type is only evaluated lazily, once an
+/// exception is actually raised and needs to be matched against it. In the
+/// rewritten code, the exception type is passed as an argument to
+/// `contextlib.suppress`, so it's evaluated eagerly, as soon as the `with`
+/// statement is entered, regardless of whether an exception is ever raised.
+/// If evaluating the exception type can fail (for example, a name that's
+/// only defined later, or an attribute of a module that hasn't finished
+/// initializing), the fix can turn code that previously ran successfully
+/// into a `NameError` or `AttributeError`. The fix is only offered when the
+/// `try` statement contains no comments.
+///
 /// ## References
 /// - [Python documentation: `contextlib.suppress`](https://docs.python.org/3/library/contextlib.html#contextlib.suppress)
 /// - [Python documentation: `try` statement](https://docs.python.org/3/reference/compound_stmts.html#the-try-statement)


### PR DESCRIPTION
## Summary

This PR adds the `## Fix safety` section for the flake8-simplify rules listed in #15584 that were still missing one: SIM101 (`duplicate-isinstance-call`), SIM105 (`suppressible-exception`), SIM108 (`if-else-block-instead-of-if-exp`), SIM109 (`compare-with-tuple`), SIM220 (`expr-and-not-expr`), SIM221 (`expr-or-not-expr`), SIM222 (`expr-or-true`), SIM223 (`expr-and-false`), and SIM401 (`if-else-block-instead-of-dict-get`).

Each section was written after reading that rule's actual fix-construction code so the explanation matches the real behavior rather than generic boilerplate:

- SIM101/SIM222/SIM223 can drop or eagerly evaluate operands that the rule's side-effect check (`contains_effect`) doesn't flag, since it doesn't treat attribute access as effectful — this can change short-circuit behavior.
- SIM109 relies on Python's `in` operator checking identity before `==`, which can diverge from a bare `==` chain when `__eq__` isn't reflexive.
- SIM220/SIM221 assume a name's truthiness is stable across two evaluations.
- SIM401 and SIM108 both change an expression from being evaluated lazily/twice to eagerly/once (`dict.get`'s default argument, and the shared test/body expression in the `and`/`or` rewrite, respectively).
- SIM105 changes the exception type from being evaluated lazily (only when an exception is actually raised) to eagerly (as soon as the `with` block is entered).

This is a pure documentation change — no fix logic, `Fix::unsafe_edit(s)` calls, or rule behavior were modified.

## Test Plan

- `cargo build -p ruff_linter` — clean
- `cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings` — clean
- flake8_simplify test suite for these rules with `INSTA_UPDATE=always` — all 53 tests passed with zero snapshot changes, confirming no behavioral drift
- `cargo dev generate-all` and `prek` run on the changed files