### PR TITLE
[ty] Detect Pydantic model configurations

### DIFF
--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -331,8 +331,12 @@ pub enum KnownModule {
     #[strum(serialize = "struct", serialize = "_struct")]
     Struct,
     // Third-party modules
+    #[strum(serialize = "pydantic.config")]
+    PydanticConfig,
     #[strum(serialize = "pydantic.main")]
     PydanticMain,
+    #[strum(serialize = "pydantic.root_model")]
+    PydanticRootModel,
 }
 
 impl KnownModule {
@@ -364,7 +368,9 @@ impl KnownModule {
             Self::Templatelib => "string.templatelib",
             Self::Numbers => "numbers",
             Self::Struct => "struct",
+            Self::PydanticConfig => "pydantic.config",
             Self::PydanticMain => "pydantic.main",
+            Self::PydanticRootModel => "pydantic.root_model",
         }
     }
 
@@ -388,7 +394,7 @@ impl KnownModule {
     /// Return `true` if this module is provided by a supported third-party package.
     pub const fn is_third_party(self) -> bool {
         match self {
-            Self::PydanticMain => true,
+            Self::PydanticConfig | Self::PydanticMain | Self::PydanticRootModel => true,
             Self::Builtins
             | Self::Enum
             | Self::Types

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -271,8 +271,23 @@ class PersonWithoutExtras(BaseModel):
 
     name: str
 
-# TODO: this should be an error once we support `extra="forbid"`
-PersonWithoutExtras(name="Alice", something_else=7)
+# revealed: (self: PersonWithoutExtras, *, name: str) -> None
+reveal_type(PersonWithoutExtras.__init__)
+PersonWithoutExtras(name="Alice", something_else=7)  # error: [unknown-argument]
+
+class PersonIgnoringExtras(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+
+PersonIgnoringExtras(name="Alice", something_else=7)
+
+class PersonAllowingExtras(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+
+PersonAllowingExtras(name="Alice", something_else=7)
 ```
 
 ## Field named `extra`
@@ -399,6 +414,168 @@ Settings()
 
 # `BaseSettings` defines a specialized constructor and forbids extra values by default.
 Settings(host="localhost", port=8000, something_else=7)  # error: [unknown-argument]
+```
+
+## Root models
+
+Unlike fields on ordinary Pydantic models, a root model's `root` field can be passed either
+positionally or by keyword:
+
+```py
+from pydantic import RootModel
+
+class IntList(RootModel[list[int]]): ...
+
+reveal_type(IntList.__init__)  # revealed: (self: IntList, root: list[int]) -> None
+
+IntList([1, 2, 3])
+IntList(root=[1, 2, 3])
+```
+
+## Model configuration
+
+The tests in this section use `extra` as an exemplary setting, but primarily test how model
+configuration is detected, inherited, merged, and overridden.
+
+```py
+from pydantic import BaseModel, ConfigDict
+
+class ForbidExtras(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+class InheritsForbidExtras(ForbidExtras):
+    name: str
+
+InheritsForbidExtras(name="Alice", something_else=7)  # error: [unknown-argument]
+
+class OverridesForbidExtras(ForbidExtras):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+
+OverridesForbidExtras(name="Alice", something_else=7)
+
+class KeepsInheritedExtraSetting(ForbidExtras):
+    model_config = ConfigDict(strict=True)
+
+    name: str
+
+KeepsInheritedExtraSetting(name="Alice", something_else=7)  # error: [unknown-argument]
+```
+
+Pydantic merges configs from multiple bases from left to right, so the rightmost base takes
+precedence:
+
+```py
+class AllowExtras(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+class RightmostForbids(AllowExtras, ForbidExtras):
+    name: str
+
+RightmostForbids(name="Alice", something_else=7)  # error: [unknown-argument]
+
+class RightmostAllows(ForbidExtras, AllowExtras):
+    name: str
+
+RightmostAllows(name="Alice", something_else=7)
+```
+
+Mixins (classes that do not inherit from `BaseModel`) can also change the configuration:
+
+```py
+class AllowExtrasMixin:
+    model_config = ConfigDict(extra="allow")
+
+class ConfigMixinOverridesForbid(ForbidExtras, AllowExtrasMixin):
+    name: str
+
+ConfigMixinOverridesForbid(name="Alice", something_else=7)
+```
+
+Config values passed as class keywords take precedence over inherited `model_config`s:
+
+```py
+class KeywordForbidsExtras(BaseModel, extra="forbid"):
+    name: str
+
+KeywordForbidsExtras(name="Alice", something_else=7)  # error: [unknown-argument]
+
+class KeywordOverridesForbid(ForbidExtras, extra="allow"):
+    name: str
+
+KeywordOverridesForbid(name="Alice", something_else=7)
+```
+
+The `ConfigDict` class is recognized by identity, including through an import alias:
+
+```py
+from pydantic import ConfigDict as ModelConfig
+
+class AliasedConfigDict(BaseModel):
+    model_config = ModelConfig(extra="forbid")
+
+    name: str
+
+AliasedConfigDict(name="Alice", something_else=7)  # error: [unknown-argument]
+```
+
+Pydantic also accepts a plain dictionary as `model_config`:
+
+```py
+class PlainDictConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    name: str
+
+# TODO: this should be an error
+PlainDictConfig(name="Alice", something_else=7)
+```
+
+## Differences from dataclasses
+
+Pydantic models use `dataclass_transform` to describe their fields and constructor to static type
+checkers, but that does not make them dataclasses or grant them all dataclass-generated behavior. In
+particular, Pydantic allows a required field after one with a default:
+
+```py
+from pydantic import BaseModel
+
+class RequiredAfterDefault(BaseModel):
+    defaulted: int = 0
+    required: int
+
+# revealed: (self: RequiredAfterDefault, *, defaulted: int = 0, required: int, **extra: Any) -> None
+reveal_type(RequiredAfterDefault.__init__)
+RequiredAfterDefault(required=1)
+```
+
+Pydantic models do not expose some of the special attributes of dataclasses:
+
+```py
+RequiredAfterDefault.__dataclass_fields__  # error: [unresolved-attribute]
+RequiredAfterDefault.__dataclass_params__  # error: [unresolved-attribute]
+RequiredAfterDefault.__match_args__  # error: [unresolved-attribute]
+```
+
+They do, however, expose various Pydantic-specific fields (inherited from `BaseModel`), for example:
+
+```py
+reveal_type(RequiredAfterDefault.__pydantic_fields__)  # revealed: dict[str, FieldInfo]
+```
+
+Invalid type qualifiers are diagnosed as Pydantic model fields rather than dataclass fields:
+
+```py
+from typing_extensions import NotRequired, ReadOnly, Required
+
+class InvalidFieldQualifiers(BaseModel):
+    # error: [invalid-type-form] "`NotRequired` is not allowed in Pydantic model fields"
+    not_required: NotRequired[int]
+    # error: [invalid-type-form] "`ReadOnly` is not allowed in Pydantic model fields"
+    read_only: ReadOnly[int]
+    # error: [invalid-type-form] "`Required` is not allowed in Pydantic model fields"
+    required: Required[int]
 ```
 
 ## Pydantic dataclasses

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -534,9 +534,11 @@ PlainDictConfig(name="Alice", something_else=7)
 
 ## Differences from dataclasses
 
-Pydantic models use `dataclass_transform` to describe their fields and constructor to static type
-checkers, but that does not make them dataclasses or grant them all dataclass-generated behavior. In
-particular, Pydantic allows a required field after one with a default:
+Pydantic uses `@dataclass_transform(...)` on its `ModelMetaclass` to help type checkers understand
+that models derived from classes like `BaseModel` (which have `ModelMetaclass` as their metaclass)
+are similar to dataclasses. However, there are some crucial differences.
+
+Pydantic models allow a required field after one with a default:
 
 ```py
 from pydantic import BaseModel

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -250,17 +250,35 @@ impl<'db> CodeGeneratorKind<'db> {
         }
     }
 
-    /// Return `true` if generated fields are treated as instance attributes.
+    /// Return `true` if field declarations should be treated as instance attributes.
+    ///
+    /// For example, a bare annotation in a dataclass body is seen as evidence for the
+    /// existence of an instance attribute, since the field will be set in the generated
+    /// constructor.
+    ///
+    /// ```python
+    /// @dataclass
+    /// class C:
+    ///     value: int
+    ///
+    /// def f(c: C):
+    ///     c.value  # okay, `value` will be set by `C`'s constructor
+    /// ```
     pub(super) const fn treats_fields_as_instance_attributes(self) -> bool {
         matches!(self, Self::DataclassLike(_) | Self::Pydantic(_))
     }
 
-    /// Return `true` if field assignments use the converter's input type.
-    pub(super) const fn uses_converter_input_type_for_assignments(self) -> bool {
-        matches!(self, Self::DataclassLike(_))
-    }
-
     /// Return `true` if the class constructor is synthesized from its fields.
+    ///
+    /// For example, a dataclass field becomes a parameter in the generated constructor:
+    ///
+    /// ```python
+    /// @dataclass
+    /// class C:
+    ///     value: int
+    ///
+    /// C(value=42)
+    /// ```
     pub(super) const fn synthesizes_constructor_signature_from_fields(self) -> bool {
         matches!(self, Self::DataclassLike(_) | Self::Pydantic(_))
     }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -13,6 +13,7 @@ pub(crate) use self::static_literal::{
     ExpandedClassBaseEntry, StaticClassLiteral, expanded_class_base_entries,
 };
 pub(super) use self::typed_dict::{DynamicTypedDictAnchor, DynamicTypedDictLiteral};
+use super::dedicated::pydantic;
 use super::{
     BoundTypeVarInstance, MemberLookupPolicy, MroIterator, SpecialFormType, SubclassOfType, Type,
     TypeQualifiers, class_base::ClassBase, function::FunctionType,
@@ -86,6 +87,8 @@ impl get_size2::GetSize for ClassInstanceFlags {}
 pub(crate) enum CodeGeneratorKind<'db> {
     /// Classes decorated with `@dataclass` or similar dataclass-like decorators
     DataclassLike(Option<DataclassTransformerParams<'db>>),
+    /// Classes inheriting from Pydantic's `BaseModel`.
+    Pydantic(pydantic::ModelMetadata<'db>),
     /// Classes inheriting from `typing.NamedTuple`
     NamedTuple,
     /// Classes inheriting from `typing.TypedDict` or `typing_extensions.TypedDict`
@@ -96,8 +99,8 @@ impl<'db> CodeGeneratorKind<'db> {
     /// Return the code-generation behavior for a class.
     ///
     /// This is invariant across generic specializations. Type arguments affect the types of
-    /// synthesized members, but not whether the class is dataclass-like, a `NamedTuple`, or a
-    /// `TypedDict`.
+    /// synthesized members, but not whether the class is dataclass-like, a Pydantic model, a
+    /// `NamedTuple`, or a `TypedDict`.
     pub(crate) fn from_class(db: &'db dyn Db, class: ClassLiteral<'db>) -> Option<Self> {
         match class {
             ClassLiteral::Static(static_class) => Self::from_static_class(db, static_class),
@@ -134,7 +137,11 @@ impl<'db> CodeGeneratorKind<'db> {
             if class.dataclass_params(db).is_some() {
                 Some(CodeGeneratorKind::DataclassLike(None))
             } else if let Ok((_, Some(info))) = class.try_metaclass(db) {
-                Some(CodeGeneratorKind::DataclassLike(Some(info.params)))
+                Some(CodeGeneratorKind::from_dataclass_transformer(
+                    db,
+                    class,
+                    info.params,
+                ))
             } else if KnownClass::Type
                 .try_to_class_literal(db)
                 .is_none_or(|type_class| {
@@ -153,7 +160,11 @@ impl<'db> CodeGeneratorKind<'db> {
                         })
                     })
             {
-                Some(CodeGeneratorKind::DataclassLike(Some(transformer_params)))
+                Some(CodeGeneratorKind::from_dataclass_transformer(
+                    db,
+                    class,
+                    transformer_params,
+                ))
             } else if class
                 .explicit_bases(db)
                 .contains(&Type::SpecialForm(SpecialFormType::NamedTuple))
@@ -167,6 +178,22 @@ impl<'db> CodeGeneratorKind<'db> {
         }
 
         code_generator_of_static_class(db, class)
+    }
+
+    fn from_dataclass_transformer(
+        db: &'db dyn Db,
+        class: StaticClassLiteral<'db>,
+        transformer_params: DataclassTransformerParams<'db>,
+    ) -> Self {
+        if pydantic::is_model(db, class) {
+            Self::Pydantic(pydantic::ModelMetadata::from_class(
+                db,
+                class,
+                transformer_params,
+            ))
+        } else {
+            Self::DataclassLike(Some(transformer_params))
+        }
     }
 
     fn from_dynamic_class(db: &'db dyn Db, class: DynamicClassLiteral<'db>) -> Option<Self> {
@@ -200,6 +227,7 @@ impl<'db> CodeGeneratorKind<'db> {
         matches!(
             (CodeGeneratorKind::from_class(db, class), self),
             (Some(Self::DataclassLike(_)), Self::DataclassLike(_))
+                | (Some(Self::Pydantic(_)), Self::Pydantic(_))
                 | (Some(Self::NamedTuple), Self::NamedTuple)
                 | (Some(Self::TypedDict), Self::TypedDict)
         )
@@ -208,7 +236,30 @@ impl<'db> CodeGeneratorKind<'db> {
     pub(super) fn dataclass_transformer_params(self) -> Option<DataclassTransformerParams<'db>> {
         match self {
             Self::DataclassLike(params) => params,
+            Self::Pydantic(metadata) => Some(metadata.transformer_params()),
             Self::NamedTuple | Self::TypedDict => None,
+        }
+    }
+
+    /// Return `true` if generated fields are treated as instance attributes.
+    pub(super) const fn treats_fields_as_instance_attributes(self) -> bool {
+        matches!(self, Self::DataclassLike(_) | Self::Pydantic(_))
+    }
+
+    /// Return `true` if field assignments use the converter's input type.
+    pub(super) const fn uses_converter_input_type_for_assignments(self) -> bool {
+        matches!(self, Self::DataclassLike(_))
+    }
+
+    /// Return `true` if the class constructor is synthesized from its fields.
+    pub(super) const fn synthesizes_constructor_signature_from_fields(self) -> bool {
+        matches!(self, Self::DataclassLike(_) | Self::Pydantic(_))
+    }
+
+    pub(super) const fn pydantic_metadata(self) -> Option<pydantic::ModelMetadata<'db>> {
+        match self {
+            Self::Pydantic(metadata) => Some(metadata),
+            Self::DataclassLike(_) | Self::NamedTuple | Self::TypedDict => None,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -241,6 +241,15 @@ impl<'db> CodeGeneratorKind<'db> {
         }
     }
 
+    pub(super) const fn name(self) -> &'static str {
+        match self {
+            Self::DataclassLike(_) => "dataclass",
+            Self::Pydantic(_) => "Pydantic model",
+            Self::NamedTuple => "named tuple",
+            Self::TypedDict => "TypedDict",
+        }
+    }
+
     /// Return `true` if generated fields are treated as instance attributes.
     pub(super) const fn treats_fields_as_instance_attributes(self) -> bool {
         matches!(self, Self::DataclassLike(_) | Self::Pydantic(_))

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -155,6 +155,8 @@ pub enum KnownClass {
     TyExtensionsIterator,
     // Pydantic
     PydanticBaseModel,
+    PydanticConfigDict,
+    PydanticRootModel,
 }
 
 impl KnownClass {
@@ -282,7 +284,9 @@ impl KnownClass {
             | Self::FunctoolsPartial
             | Self::ExtensionTypedDictFallback
             | Self::TypedDictFallback
-            | Self::PydanticBaseModel => Some(Truthiness::Ambiguous),
+            | Self::PydanticBaseModel
+            | Self::PydanticConfigDict
+            | Self::PydanticRootModel => Some(Truthiness::Ambiguous),
 
             Self::Tuple => None,
         }
@@ -391,7 +395,9 @@ impl KnownClass {
             | KnownClass::Template
             | KnownClass::Path
             | KnownClass::FunctoolsPartial
-            | KnownClass::PydanticBaseModel => false,
+            | KnownClass::PydanticBaseModel
+            | KnownClass::PydanticConfigDict
+            | KnownClass::PydanticRootModel => false,
         }
     }
 
@@ -497,7 +503,10 @@ impl KnownClass {
             | KnownClass::Template
             | KnownClass::Path
             | KnownClass::FunctoolsPartial
-            | KnownClass::PydanticBaseModel => false,
+            | KnownClass::PydanticBaseModel
+            | KnownClass::PydanticRootModel => false,
+
+            KnownClass::PydanticConfigDict => true,
         }
     }
 
@@ -602,7 +611,9 @@ impl KnownClass {
             | KnownClass::Template
             | KnownClass::Path
             | KnownClass::FunctoolsPartial
-            | KnownClass::PydanticBaseModel => false,
+            | KnownClass::PydanticBaseModel
+            | KnownClass::PydanticConfigDict
+            | KnownClass::PydanticRootModel => false,
         }
     }
 
@@ -720,7 +731,9 @@ impl KnownClass {
             | Self::FunctoolsPartial
             | Self::Mapping
             | Self::Sequence
-            | Self::PydanticBaseModel => false,
+            | Self::PydanticBaseModel
+            | Self::PydanticConfigDict
+            | Self::PydanticRootModel => false,
         }
     }
 
@@ -827,7 +840,9 @@ impl KnownClass {
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
             | KnownClass::Specialization
-            | KnownClass::PydanticBaseModel => false,
+            | KnownClass::PydanticBaseModel
+            | KnownClass::PydanticConfigDict
+            | KnownClass::PydanticRootModel => false,
             KnownClass::NamedTupleFallback
             | KnownClass::TypedDictFallback
             | KnownClass::ExtensionTypedDictFallback => true,
@@ -948,6 +963,8 @@ impl KnownClass {
             Self::FunctoolsPartial => "partial",
             Self::ProtocolMeta => "_ProtocolMeta",
             Self::PydanticBaseModel => "BaseModel",
+            Self::PydanticConfigDict => "ConfigDict",
+            Self::PydanticRootModel => "RootModel",
         }
     }
 
@@ -1331,6 +1348,8 @@ impl KnownClass {
             Self::Path => KnownModule::Pathlib,
             Self::FunctoolsPartial => KnownModule::Functools,
             Self::PydanticBaseModel => KnownModule::PydanticMain,
+            Self::PydanticConfigDict => KnownModule::PydanticConfig,
+            Self::PydanticRootModel => KnownModule::PydanticRootModel,
         }
     }
 
@@ -1438,7 +1457,9 @@ impl KnownClass {
             | Self::Path
             | Self::UnionType
             | Self::FunctoolsPartial
-            | Self::PydanticBaseModel => Some(false),
+            | Self::PydanticBaseModel
+            | Self::PydanticConfigDict
+            | Self::PydanticRootModel => Some(false),
 
             Self::Tuple => None,
         }
@@ -1549,7 +1570,9 @@ impl KnownClass {
             | Self::Template
             | Self::Path
             | Self::FunctoolsPartial
-            | Self::PydanticBaseModel => false,
+            | Self::PydanticBaseModel
+            | Self::PydanticConfigDict
+            | Self::PydanticRootModel => false,
         }
     }
 
@@ -1660,6 +1683,8 @@ impl KnownClass {
             "_ProtocolMeta" => &[Self::ProtocolMeta],
             "_TypedDict" => &[Self::ExtensionTypedDictFallback],
             "BaseModel" => &[Self::PydanticBaseModel],
+            "ConfigDict" => &[Self::PydanticConfigDict],
+            "RootModel" => &[Self::PydanticRootModel],
             _ => return None,
         };
 
@@ -1756,7 +1781,9 @@ impl KnownClass {
             | Self::Template
             | Self::Path
             | Self::FunctoolsPartial
-            | Self::PydanticBaseModel => module == self.canonical_module(db),
+            | Self::PydanticBaseModel
+            | Self::PydanticConfigDict
+            | Self::PydanticRootModel => module == self.canonical_module(db),
             Self::NoneType => matches!(module, KnownModule::Typeshed | KnownModule::Types),
             Self::SpecialForm
             | Self::TypeAliasType

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2822,10 +2822,11 @@ impl<'db> StaticClassLiteral<'db> {
         db: &'db dyn Db,
         name: &str,
     ) -> Option<Type<'db>> {
-        let field_policy = CodeGeneratorKind::from_static_class(db, self)?;
-        if !field_policy.uses_converter_input_type_for_assignments() {
+        let field_policy @ CodeGeneratorKind::DataclassLike(_) =
+            CodeGeneratorKind::from_static_class(db, self)?
+        else {
             return None;
-        }
+        };
         let fields = self.fields(db, None, field_policy);
         let field = fields.get(name)?;
         if let FieldKind::Dataclass { converter, .. } = field.kind {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -137,6 +137,8 @@ impl<'db> StaticClassLiteral<'db> {
     ///
     /// This covers `@dataclass`-decorated classes, as well as classes created via
     /// `dataclass_transform` (function-based, metaclass-based, and base-class-based).
+    /// This specifically excludes Pydantic models, even though their metaclass also uses
+    /// `dataclass_transform`.
     pub(crate) fn is_dataclass_like(self, db: &'db dyn Db) -> bool {
         matches!(
             CodeGeneratorKind::from_class(db, ClassLiteral::Static(self)),
@@ -787,14 +789,11 @@ impl<'db> StaticClassLiteral<'db> {
         let dataclass_params = self.dataclass_params(db);
 
         let mut transformer_params =
-            if let CodeGeneratorKind::DataclassLike(Some(transformer_params)) = field_policy {
-                Some(DataclassParams::from_transformer_params(
-                    db,
-                    transformer_params,
-                ))
-            } else {
-                None
-            };
+            field_policy
+                .dataclass_transformer_params()
+                .map(|transformer_params| {
+                    DataclassParams::from_transformer_params(db, transformer_params)
+                });
 
         // Dataclass transformer flags can be overwritten using class arguments.
         if let Some(transformer_params) = transformer_params.as_mut() {
@@ -857,6 +856,16 @@ impl<'db> StaticClassLiteral<'db> {
         } else {
             None
         }
+    }
+
+    /// Return `true` if Pydantic's dataclass-transform metadata marks this model as frozen.
+    fn is_frozen_pydantic_model(
+        self,
+        db: &'db dyn Db,
+        field_policy: CodeGeneratorKind<'db>,
+    ) -> bool {
+        matches!(field_policy, CodeGeneratorKind::Pydantic(_))
+            && self.has_dataclass_param(db, field_policy, DataclassFlags::FROZEN)
     }
 
     /// Checks if the given dataclass parameter flag is set for this class.
@@ -1345,6 +1354,9 @@ impl<'db> StaticClassLiteral<'db> {
         }
 
         let field_policy = CodeGeneratorKind::from_class(db, self.into())?;
+        let pydantic_constructor_fields_are_keyword_only =
+            matches!(field_policy, CodeGeneratorKind::Pydantic(_))
+                && pydantic::constructor_fields_are_keyword_only(db, self);
 
         let instance_ty =
             Type::instance(db, self.apply_optional_specialization(db, specialization));
@@ -1434,8 +1446,9 @@ impl<'db> StaticClassLiteral<'db> {
                     field_ty = converter_input_ty;
                 }
 
-                let is_kw_only =
-                    matches!(name, "__replace__" | "_replace") || kw_only.unwrap_or(false);
+                let is_kw_only = matches!(name, "__replace__" | "_replace")
+                    || pydantic_constructor_fields_are_keyword_only
+                    || kw_only.unwrap_or(false);
 
                 // Use the alias name if provided, otherwise use the field name
                 let parameter_name =
@@ -1465,7 +1478,11 @@ impl<'db> StaticClassLiteral<'db> {
             // so that the keyword-only parameters appear after positional parameters.
             parameters.sort_by_key(Parameter::is_keyword_only);
 
-            if name == "__init__" && pydantic::uses_base_model_init(db, self) {
+            if name == "__init__"
+                && field_policy
+                    .pydantic_metadata()
+                    .is_some_and(|metadata| pydantic::model_init_accepts_extra(db, self, metadata))
+            {
                 let extra = pydantic::extra_parameter(&parameters);
                 parameters.push(extra);
             }
@@ -1482,7 +1499,9 @@ impl<'db> StaticClassLiteral<'db> {
         };
 
         match (field_policy, name) {
-            (CodeGeneratorKind::DataclassLike(_), "__init__") => {
+            (field_policy, "__init__")
+                if field_policy.synthesizes_constructor_signature_from_fields() =>
+            {
                 if !self.has_dataclass_param(db, field_policy, DataclassFlags::INIT) {
                     return None;
                 }
@@ -1539,7 +1558,10 @@ impl<'db> StaticClassLiteral<'db> {
                     specialization.map(|s| s.generic_context(db)),
                 )
             }
-            (CodeGeneratorKind::DataclassLike(_), "__lt__" | "__le__" | "__gt__" | "__ge__") => {
+            (
+                field_policy @ CodeGeneratorKind::DataclassLike(_),
+                "__lt__" | "__le__" | "__gt__" | "__ge__",
+            ) => {
                 if !self.has_dataclass_param(db, field_policy, DataclassFlags::ORDER) {
                     return None;
                 }
@@ -1561,7 +1583,7 @@ impl<'db> StaticClassLiteral<'db> {
 
                 Some(Type::function_like_callable(db, signature))
             }
-            (CodeGeneratorKind::DataclassLike(_), "__hash__") => {
+            (field_policy @ CodeGeneratorKind::DataclassLike(_), "__hash__") => {
                 let unsafe_hash =
                     self.has_dataclass_param(db, field_policy, DataclassFlags::UNSAFE_HASH);
                 let frozen = self.has_dataclass_param(db, field_policy, DataclassFlags::FROZEN);
@@ -1585,7 +1607,7 @@ impl<'db> StaticClassLiteral<'db> {
                     None
                 }
             }
-            (CodeGeneratorKind::DataclassLike(_), "__match_args__")
+            (field_policy @ CodeGeneratorKind::DataclassLike(_), "__match_args__")
                 if Program::get(db).python_version(db) >= PythonVersion::PY310 =>
             {
                 if !self.has_dataclass_param(db, field_policy, DataclassFlags::MATCH_ARGS) {
@@ -1608,7 +1630,7 @@ impl<'db> StaticClassLiteral<'db> {
                     .map(|(name, _)| Type::string_literal(db, name));
                 Some(Type::heterogeneous_tuple(db, match_args))
             }
-            (CodeGeneratorKind::DataclassLike(_), "__weakref__")
+            (field_policy @ CodeGeneratorKind::DataclassLike(_), "__weakref__")
                 if Program::get(db).python_version(db) >= PythonVersion::PY311 =>
             {
                 if !self.has_dataclass_param(db, field_policy, DataclassFlags::WEAKREF_SLOT)
@@ -1657,8 +1679,14 @@ impl<'db> StaticClassLiteral<'db> {
 
                 signature_from_fields(vec![self_parameter], instance_ty)
             }
-            (CodeGeneratorKind::DataclassLike(_), "__setattr__") => {
-                if self.is_frozen_dataclass(db) == Some(true) {
+            (
+                field_policy @ (CodeGeneratorKind::DataclassLike(_)
+                | CodeGeneratorKind::Pydantic(_)),
+                "__setattr__",
+            ) => {
+                if self.is_frozen_dataclass(db) == Some(true)
+                    || self.is_frozen_pydantic_model(db, field_policy)
+                {
                     let signature = Signature::new(
                         Parameters::new(
                             db,
@@ -1676,7 +1704,7 @@ impl<'db> StaticClassLiteral<'db> {
                 }
                 None
             }
-            (CodeGeneratorKind::DataclassLike(_), "__slots__")
+            (field_policy @ CodeGeneratorKind::DataclassLike(_), "__slots__")
                 if Program::get(db).python_version(db) >= PythonVersion::PY310 =>
             {
                 self.has_dataclass_param(db, field_policy, DataclassFlags::SLOTS)
@@ -1938,7 +1966,7 @@ impl<'db> StaticClassLiteral<'db> {
 
             match name.as_str() {
                 "__setattr__" | "__delattr__" => {
-                    if let CodeGeneratorKind::DataclassLike(_) = field_policy
+                    if matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
                         && self.is_frozen_dataclass(db) == Some(true)
                     {
                         if let Some(builder) = context.report_lint(
@@ -1955,7 +1983,7 @@ impl<'db> StaticClassLiteral<'db> {
                     }
                 }
                 "__lt__" | "__le__" | "__gt__" | "__ge__" => {
-                    if let CodeGeneratorKind::DataclassLike(_) = field_policy
+                    if matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
                         && self.has_dataclass_param(db, field_policy, DataclassFlags::ORDER)
                     {
                         if let Some(builder) = context.report_lint(
@@ -2106,14 +2134,16 @@ impl<'db> StaticClassLiteral<'db> {
 
                 let kind = match field_policy {
                     CodeGeneratorKind::NamedTuple => FieldKind::NamedTuple { default_ty },
-                    CodeGeneratorKind::DataclassLike(_) => FieldKind::Dataclass {
-                        default_ty,
-                        init_only: attr.is_init_var(),
-                        init,
-                        kw_only,
-                        alias,
-                        converter,
-                    },
+                    CodeGeneratorKind::DataclassLike(_) | CodeGeneratorKind::Pydantic(_) => {
+                        FieldKind::Dataclass {
+                            default_ty,
+                            init_only: attr.is_init_var(),
+                            init,
+                            kw_only,
+                            alias,
+                            converter,
+                        }
+                    }
                     CodeGeneratorKind::TypedDict => {
                         let is_required = if attr.is_required() {
                             // Explicit Required[T] annotation - always required
@@ -2616,9 +2646,10 @@ impl<'db> StaticClassLiteral<'db> {
 
                     // `KW_ONLY` sentinels are markers, not real instance attributes.
                     if declared_ty.is_instance_of(db, KnownClass::KwOnly)
-                        && CodeGeneratorKind::from_static_class(db, self).is_some_and(|policy| {
-                            matches!(policy, CodeGeneratorKind::DataclassLike(_))
-                        })
+                        && matches!(
+                            CodeGeneratorKind::from_static_class(db, self),
+                            Some(CodeGeneratorKind::DataclassLike(_))
+                        )
                     {
                         return Member::unbound();
                     }
@@ -2767,7 +2798,7 @@ impl<'db> StaticClassLiteral<'db> {
         let Some(field_policy) = CodeGeneratorKind::from_static_class(db, self) else {
             return false;
         };
-        if !matches!(field_policy, CodeGeneratorKind::DataclassLike(_)) {
+        if !field_policy.treats_fields_as_instance_attributes() {
             return false;
         }
 
@@ -2792,7 +2823,7 @@ impl<'db> StaticClassLiteral<'db> {
         name: &str,
     ) -> Option<Type<'db>> {
         let field_policy = CodeGeneratorKind::from_static_class(db, self)?;
-        if !matches!(field_policy, CodeGeneratorKind::DataclassLike(_)) {
+        if !field_policy.uses_converter_input_type_for_assignments() {
             return None;
         }
         let fields = self.fields(db, None, field_policy);

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -1,16 +1,262 @@
+use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
+use ty_python_core::definition::DefinitionKind;
 
 use crate::Db;
+use crate::place::{DefinedPlace, Definedness, Place, Provenance};
 use crate::types::member::class_member;
-use crate::types::{ClassBase, KnownClass, Parameter, StaticClassLiteral, Type};
+use crate::types::{
+    ClassBase, DataclassTransformerParams, KnownClass, Parameter, StaticClassLiteral, Type,
+    definition_expression_type,
+};
+
+/// Metadata that controls Pydantic-specific model synthesis.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+pub(crate) struct ModelMetadata<'db> {
+    // TODO: We may want to remove this field and model Pydantic behavior more explicitly.
+    // (since this information is static and doesn't vary between Pydantic models). To do
+    // this, we could only retain field specifier information and expose it through a new
+    // `CodeGeneratorKind` method. Maybe we could even skip the field specifiers as well.
+    transformer_params: DataclassTransformerParams<'db>,
+    config: ModelConfig,
+}
+
+impl<'db> ModelMetadata<'db> {
+    pub(in crate::types) fn from_class(
+        db: &'db dyn Db,
+        class: StaticClassLiteral<'db>,
+        transformer_params: DataclassTransformerParams<'db>,
+    ) -> Self {
+        Self {
+            transformer_params,
+            config: model_config(db, class),
+        }
+    }
+
+    pub(in crate::types) const fn transformer_params(self) -> DataclassTransformerParams<'db> {
+        self.transformer_params
+    }
+
+    const fn accepts_extra(self) -> bool {
+        !matches!(self.config.extra, Some(ExtraBehavior::Forbid))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+struct ModelConfig {
+    /// The `extra` configuration controls whether the synthesized constructor accepts keyword
+    /// arguments that do not correspond to declared model fields.
+    extra: Option<ExtraBehavior>,
+}
+
+impl ModelConfig {
+    const fn unknown() -> Self {
+        Self {
+            extra: Some(ExtraBehavior::Unknown),
+        }
+    }
+
+    /// Merge `other` into this config, with values from `other` taking precedence.
+    fn merge(&mut self, other: Self) {
+        self.extra = other.extra.or(self.extra);
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+enum ExtraBehavior {
+    Allow,
+    Forbid,
+    Ignore,
+    Unknown,
+}
+
+impl ExtraBehavior {
+    fn from_value(value: Option<&str>) -> Self {
+        match value {
+            Some("allow") => Self::Allow,
+            Some("forbid") => Self::Forbid,
+            Some("ignore") => Self::Ignore,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+pub(in crate::types) fn is_model(db: &dyn Db, class: StaticClassLiteral<'_>) -> bool {
+    class
+        .iter_mro(db, None)
+        .filter_map(ClassBase::into_class)
+        .any(|base| base.is_known(db, KnownClass::PydanticBaseModel))
+}
+
+/// Return `true` if fields in `class` are keyword-only constructor parameters.
+///
+/// Pydantic model fields are generally keyword-only, but a root model's `root` field can also be
+/// passed positionally.
+pub(in crate::types) fn constructor_fields_are_keyword_only(
+    db: &dyn Db,
+    class: StaticClassLiteral<'_>,
+) -> bool {
+    !class
+        .iter_mro(db, None)
+        .filter_map(ClassBase::into_class)
+        .any(|base| base.is_known(db, KnownClass::PydanticRootModel))
+}
+
+#[salsa::tracked(
+    cycle_initial=|_, _, _| ModelConfig::unknown(),
+    heap_size=ruff_memory_usage::heap_size,
+)]
+fn model_config<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> ModelConfig {
+    let mut config = ModelConfig::default();
+
+    // Pydantic merges the effective config from each direct base from left to right. A later base
+    // therefore takes precedence over an earlier base.
+    for base in class.explicit_bases(db) {
+        let Some(base) = base.to_class_type(db) else {
+            config = ModelConfig::unknown();
+            continue;
+        };
+        let base_literal = base.class_literal(db);
+        let Some(base) = base_literal.as_static() else {
+            config.merge(ModelConfig::unknown());
+            continue;
+        };
+
+        if is_model(db, base) {
+            config.merge(model_config(db, base));
+        } else if let Some(base_config) = inherited_model_config(db, base) {
+            config.merge(base_config);
+        }
+    }
+
+    if let Some(own_config) = own_model_config(db, class) {
+        config.merge(own_config);
+    }
+    if let Some(class_keyword_config) = class_keyword_config(db, class) {
+        config.merge(class_keyword_config);
+    }
+    config
+}
+
+fn inherited_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelConfig> {
+    for base in class.iter_mro(db, None).filter_map(ClassBase::into_class) {
+        let Some((base, _)) = base.static_class_literal(db) else {
+            return Some(ModelConfig::unknown());
+        };
+        if let Some(config) = own_model_config(db, base) {
+            return Some(config);
+        }
+    }
+    None
+}
+
+fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelConfig> {
+    let model_config = class_member(db, class.body_scope(db), "model_config")
+        .inner
+        .place;
+    let Place::Defined(DefinedPlace {
+        definedness: Definedness::AlwaysDefined,
+        provenance: Provenance::SingleDefinition(definition),
+        ..
+    }) = model_config
+    else {
+        return if model_config.is_undefined() {
+            None
+        } else {
+            Some(ModelConfig {
+                extra: Some(ExtraBehavior::Unknown),
+            })
+        };
+    };
+
+    let module = parsed_module(db, class.file(db)).load(db);
+    let kind = definition.kind(db);
+    let value = match &kind {
+        DefinitionKind::Assignment(assignment) => assignment.value(&module),
+        DefinitionKind::AnnotatedAssignment(assignment) => {
+            let Some(value) = assignment.value(&module) else {
+                return Some(ModelConfig::default());
+            };
+            value
+        }
+        _ => {
+            return Some(ModelConfig {
+                extra: Some(ExtraBehavior::Unknown),
+            });
+        }
+    };
+
+    let Some(call) = value.as_call_expr() else {
+        return Some(ModelConfig {
+            extra: Some(ExtraBehavior::Unknown),
+        });
+    };
+    let callee = definition_expression_type(db, definition, &call.func);
+    if !callee
+        .as_class_literal()
+        .is_some_and(|class| class.is_known(db, KnownClass::PydanticConfigDict))
+    {
+        return Some(ModelConfig {
+            extra: Some(ExtraBehavior::Unknown),
+        });
+    }
+
+    if call
+        .arguments
+        .keywords
+        .iter()
+        .any(|keyword| keyword.arg.is_none())
+    {
+        return Some(ModelConfig {
+            extra: Some(ExtraBehavior::Unknown),
+        });
+    }
+
+    let Some(extra) = call.arguments.find_keyword("extra") else {
+        return Some(ModelConfig::default());
+    };
+    let extra = definition_expression_type(db, definition, &extra.value)
+        .as_string_literal()
+        .map(|literal| literal.value(db));
+
+    Some(ModelConfig {
+        extra: Some(ExtraBehavior::from_value(extra)),
+    })
+}
+
+fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelConfig> {
+    let definition = class.definition(db);
+    let module = parsed_module(db, class.file(db)).load(db);
+    let kind = definition.kind(db);
+    let class_node = kind.as_class()?.node(&module);
+    let arguments = class_node.arguments.as_ref()?;
+    if arguments
+        .keywords
+        .iter()
+        .any(|keyword| keyword.arg.is_none())
+    {
+        return Some(ModelConfig::unknown());
+    }
+    let extra = arguments.find_keyword("extra")?;
+    let extra = definition_expression_type(db, definition, &extra.value)
+        .as_string_literal()
+        .map(|literal| literal.value(db));
+
+    Some(ModelConfig {
+        extra: Some(ExtraBehavior::from_value(extra)),
+    })
+}
 
 /// Return `true` if `class` should accept extra keywords in its synthesized constructor.
-///
-/// Pydantic uses `BaseModel` as the public marker for models. A class before `BaseModel` in the MRO
-/// can override `__init__`; Pydantic preserves that custom constructor, so it must continue to
-/// control which keywords are accepted. This also avoids widening specialized model bases such as
-/// `RootModel` and `BaseSettings`, which define their own constructors.
-pub(in crate::types) fn uses_base_model_init(db: &dyn Db, class: StaticClassLiteral<'_>) -> bool {
+pub(in crate::types) fn model_init_accepts_extra(
+    db: &dyn Db,
+    class: StaticClassLiteral<'_>,
+    metadata: ModelMetadata<'_>,
+) -> bool {
+    if !metadata.accepts_extra() {
+        return false;
+    }
+
     for base in class
         .iter_mro(db, None)
         .skip(1)

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3849,6 +3849,10 @@ pub(super) fn report_invalid_method_override<'db>(
                     "`{overridden_method}` is a generated method created because \
                         `{superclass_name}` is a dataclass"
                 )),
+                CodeGeneratorKind::Pydantic(_) => make_sub(format_args!(
+                    "`{overridden_method}` is a generated method created because \
+                        `{superclass_name}` is a Pydantic model"
+                )),
                 CodeGeneratorKind::NamedTuple => make_sub(format_args!(
                     "`{overridden_method}` is a generated method created because \
                         `{superclass_name}` inherits from `typing.NamedTuple`"

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4795,7 +4795,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             ));
                         }
                     }
-                    Some(CodeGeneratorKind::DataclassLike(_)) => match qualifier {
+                    Some(
+                        class_kind @ (CodeGeneratorKind::DataclassLike(_)
+                        | CodeGeneratorKind::Pydantic(_)),
+                    ) => match qualifier {
                         TypeQualifier::NotRequired
                         | TypeQualifier::ReadOnly
                         | TypeQualifier::Required => {
@@ -4804,9 +4807,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             else {
                                 continue;
                             };
+                            let field_kind = if matches!(class_kind, CodeGeneratorKind::Pydantic(_))
+                            {
+                                "Pydantic model"
+                            } else {
+                                "dataclass"
+                            };
                             builder.into_diagnostic(format_args!(
-                                "`{name}` is not allowed in dataclass fields",
-                                name = qualifier.name()
+                                "`{name}` is not allowed in {field_kind} fields",
+                                name = qualifier.name(),
                             ));
                         }
                         TypeQualifier::ClassVar | TypeQualifier::Final | TypeQualifier::InitVar => {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4807,12 +4807,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             else {
                                 continue;
                             };
-                            let field_kind = if matches!(class_kind, CodeGeneratorKind::Pydantic(_))
-                            {
-                                "Pydantic model"
-                            } else {
-                                "dataclass"
-                            };
+                            let field_kind = class_kind.name();
                             builder.into_diagnostic(format_args!(
                                 "`{name}` is not allowed in {field_kind} fields",
                                 name = qualifier.name(),

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -585,6 +585,9 @@ impl<'db> AllMembers<'db> {
                     }
                 }
             }
+            Some(CodeGeneratorKind::Pydantic(_)) => {
+                // Pydantic's special attributes are declared on and inherited from `BaseModel`.
+            }
             None => {}
         }
     }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -191,15 +191,17 @@ fn check_class_declaration<'db>(
                 diagnostic.info("This will cause the class creation to fail at runtime");
             }
         }
-        Some(policy @ CodeGeneratorKind::DataclassLike(_)) => check_post_init_signature(
-            context,
-            configuration,
-            class,
-            member,
-            *first_reachable_definition,
-            policy,
-        ),
-        Some(CodeGeneratorKind::TypedDict) | None => {}
+        Some(policy @ CodeGeneratorKind::DataclassLike(_)) => {
+            check_post_init_signature(
+                context,
+                configuration,
+                class,
+                member,
+                *first_reachable_definition,
+                policy,
+            );
+        }
+        Some(CodeGeneratorKind::Pydantic(_) | CodeGeneratorKind::TypedDict) | None => {}
     }
 
     if configuration.check_invalid_named_tuple_field_overrides()


### PR DESCRIPTION
## Summary

This PR adds a new `CodeGeneratorKind::Pydantic` which we'll use to further special-case the behavior of Pydantic models. We do *some* of this special-casing here, but for other features, we still fall back to whatever behavior falls out of the implementation for now. Some changes, e.g. around `RootModel`s and frozen Pydantic models, were needed to avoid ecosystem false-positives.

The main purpose of this PR, however, is to add support for detecting model configurations like the following, and to properly merge configurations across inheritance chains. For now, we only handle the `extra` configuration setting, but we will soon add more.

```py
class Person(BaseModel):
    model_config = ConfigDict(extra="forbid")
```

part of https://github.com/astral-sh/ty/issues/2403

## Ecosystem impact

- Most of the new diagnostics on artigraph are arguably true positives, since they set [`extra="forbid"`](https://github.com/artigraph/artigraph/blob/a158a7eae0406c35905d8bb3b2f27a733c2c18bc/src/arti/internal/models.py#L80) for their base model, but then dynamically add new fields to their models at runtime which type checkers can't detect.
- Some of the new diagnostics are definitely true positives, since they appear in tests that are expected to raise exceptions due to too many arguments
- Four diagnostics are false positives which are already tracked in https://github.com/astral-sh/ty/issues/3861 (they were previously hidden by our `**extra` change, but now become visible again because we model `extra="forbid"` behavior)

## Test Plan

New Markdown tests, verified all tests against Pydantic runtime behavior
