### PR TITLE
[ty] Support class and static protocol methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3428,6 +3428,44 @@ static_assert(is_assignable_to(AlsoCorrect, ContextManagerProtocol))
 static_assert(not is_assignable_to(MissingDecorator, ContextManagerProtocol))
 ```
 
+Transparent decorators preserve class and static protocol methods:
+
+```py
+from collections.abc import Callable
+from typing import ParamSpec, Protocol, TypeVar
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def transparent(function: Callable[P, R]) -> Callable[P, R]:
+    return function
+
+class StaticProtocol(Protocol):
+    @staticmethod
+    @transparent
+    def method(value: int) -> str: ...
+
+class StaticImplementation:
+    @staticmethod
+    def method(value: int) -> str:
+        return str(value)
+
+class ClassProtocol(Protocol):
+    @classmethod
+    @transparent
+    def method(cls, value: int) -> str: ...
+
+class ClassImplementation:
+    @classmethod
+    def method(cls, value: int) -> str:
+        return str(value)
+
+static_assert(is_subtype_of(StaticImplementation, StaticProtocol))
+static_assert(is_subtype_of(ClassImplementation, ClassProtocol))
+```
+
 ## Equivalence of protocols with method or property members
 
 Two protocols `P1` and `P2`, both with a method member `x`, are considered equivalent if the

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2830,6 +2830,14 @@ from ty_extensions._internal import is_subtype_of, is_assignable_to
 class P(Protocol):
     def m(self, x: int, /) -> None: ...
 
+class PWithClassMethod(Protocol):
+    @classmethod
+    def m(cls, x: int, /) -> None: ...
+
+class PWithStaticMethod(Protocol):
+    @staticmethod
+    def m(x: int, /) -> None: ...
+
 class NominalSubtype:
     def m(self, y: int) -> None: ...
 
@@ -2862,31 +2870,18 @@ static_assert(not is_assignable_to(DefinitelyNotSubtype, P))
 static_assert(not is_assignable_to(NotSubtype, P))
 static_assert(not is_assignable_to(NominalSubtype | NotSubtype, P))
 static_assert(not is_assignable_to(NominalSubtype2 | DefinitelyNotSubtype, P))
-```
 
-A class or static method can satisfy an ordinary method member when it has the right signature on an
-instance. This applies to both nominal classes and other protocols:
-
-```py
-class PWithClassMethod(Protocol):
-    @classmethod
-    def m(cls, x: int, /) -> None: ...
-
-class PWithStaticMethod(Protocol):
-    @staticmethod
-    def m(x: int, /) -> None: ...
-
+# A classmethod or staticmethod can satisfy a regular method member if it has the correct
+# signature when accessed on an instance. The class-side check only establishes that the member
+# is present on the class.
 static_assert(is_assignable_to(NominalWithClassMethod, P))
 static_assert(is_assignable_to(NominalWithStaticMethodGood, P))
 static_assert(is_assignable_to(NominalSubtype | NominalWithClassMethod, P))
 static_assert(is_assignable_to(NominalSubtype | NominalWithStaticMethodGood, P))
 static_assert(is_subtype_of(PWithClassMethod, P))
 static_assert(is_subtype_of(PWithStaticMethod, P))
-```
 
-A static method with an extra parameter does not satisfy the ordinary method member:
-
-```py
+# This staticmethod has an extra parameter when accessed on an instance.
 static_assert(not is_assignable_to(NominalWithStaticMethod, P))
 static_assert(not is_assignable_to(NominalSubtype | NominalWithStaticMethod, P))
 ```
@@ -3290,11 +3285,16 @@ parser: Parser = IntParser
 
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members
 
-The typing specification permits protocols to declare class and static methods, but it does not
-define exactly when another class satisfies such a protocol. ty requires the member to have a
-compatible callable signature when accessed through either the class or an instance. This agrees
-with the basic cases in the
+The typing spec states that protocols may have `@classmethod` or `@staticmethod` method members.
+However, as of 2025/09/24, the spec does not elaborate on how these members should behave with
+regards to subtyping and assignability (nor are there any tests in the typing conformance suite).
+Ty's behaviour is therefore derived from first principles and the
 [mypy test suite](https://github.com/python/mypy/blob/354bea6352ee7a38b05e2f42c874e7d1f7bf557a/test-data/unit/check-protocols.test#L1231-L1263).
+
+A protocol `P` with a `@classmethod` method member `x` can only be satisfied by a nominal type `N`
+if `N.x` is a callable object that evaluates to the same type whether it is accessed on inhabitants
+of `N` or inhabitants of `type[N]`, *and* the signature of `N.x` is equivalent to the signature of
+`P.x` after the descriptor protocol has been invoked on `P.x`:
 
 ```py
 from collections.abc import Callable
@@ -3310,19 +3310,7 @@ class PClassMethod(Protocol):
 class PStaticMethod(Protocol):
     @staticmethod
     def x(val: int) -> str: ...
-```
 
-These protocols expose the same callable signature through both access paths, so they are
-equivalent:
-
-```py
-static_assert(is_equivalent_to(PClassMethod, PStaticMethod))
-```
-
-A non-callable attribute does not satisfy either protocol. An ordinary instance method also fails
-because accessing it through the class leaves its `self` parameter unbound:
-
-```py
 class NNotCallable:
     x = None
 
@@ -3330,15 +3318,26 @@ class NInstanceMethod:
     def x(self, val: int) -> str:
         return "foo"
 
-static_assert(not is_assignable_to(NNotCallable, PClassMethod))
-static_assert(not is_assignable_to(NInstanceMethod, PStaticMethod))
-```
+class NClassMethodGood:
+    @classmethod
+    def x(cls, val: int) -> str:
+        return "foo"
 
-Failure to satisfy a protocol does not prove that two types are disjoint. A subclass can replace the
-`None` attribute, a union may contain a callable value, and an `object` attribute can hold a
-callable at runtime:
+class NClassMethodBad:
+    @classmethod
+    def x(cls, val: str) -> int:
+        return 42
 
-```py
+class NStaticMethodGood:
+    @staticmethod
+    def x(val: int) -> str:
+        return "foo"
+
+class NStaticMethodBad:
+    @staticmethod
+    def x(cls, val: int) -> str:
+        return "foo"
+
 class NMaybeCallable:
     x: Callable[[int], str] | None
 
@@ -3349,64 +3348,10 @@ class F:
 class NObject:
     x: object = F()
 
-static_assert(not is_disjoint_from(NNotCallable, PClassMethod))
-static_assert(not is_disjoint_from(NMaybeCallable, PStaticMethod))
-static_assert(not is_disjoint_from(NObject, PStaticMethod))
-```
-
-A class method can satisfy a static-method protocol, and a static method can satisfy a class-method
-protocol, as long as the visible signatures are compatible:
-
-```py
-class NClassMethodGood:
-    @classmethod
-    def x(cls, val: int) -> str:
-        return "foo"
-
-class NStaticMethodGood:
-    @staticmethod
-    def x(val: int) -> str:
-        return "foo"
-
-static_assert(is_assignable_to(NClassMethodGood, PStaticMethod))
-static_assert(is_assignable_to(NStaticMethodGood, PClassMethod))
-static_assert(is_subtype_of(NClassMethodGood, PStaticMethod))
-static_assert(is_subtype_of(NStaticMethodGood, PClassMethod))
-```
-
-An incompatible signature fails the protocol check, including when it appears in a union:
-
-```py
-class NClassMethodBad:
-    @classmethod
-    def x(cls, val: str) -> int:
-        return 42
-
-class NStaticMethodBad:
-    @staticmethod
-    def x(cls, val: int) -> str:
-        return "foo"
-
-static_assert(not is_assignable_to(NClassMethodBad, PClassMethod))
-static_assert(not is_assignable_to(NStaticMethodBad, PStaticMethod))
-static_assert(not is_assignable_to(NClassMethodGood | NClassMethodBad, PClassMethod))
-```
-
-An instance attribute can override an inherited static method. The instance then no longer satisfies
-the protocol:
-
-```py
 class NStaticMethodShadowed(NStaticMethodGood):
     def __init__(self) -> None:
         self.x: int = 1
 
-static_assert(not is_subtype_of(NStaticMethodShadowed, PStaticMethod))
-```
-
-`Self` in a class-method return type is bound to the implementation class. A method that always
-returns `int` does not satisfy that requirement:
-
-```py
 class PFactory(Protocol):
     @classmethod
     def create(cls) -> Self: ...
@@ -3421,13 +3366,6 @@ class BadFactory:
     def create(cls) -> int:
         return 42
 
-static_assert(is_subtype_of(Factory, PFactory))
-static_assert(not is_assignable_to(BadFactory, PFactory))
-```
-
-Each overload of a class method keeps its own `Self` binding:
-
-```py
 class POverloadedFactory(Protocol):
     @overload
     @classmethod
@@ -3447,6 +3385,53 @@ class OverloadedFactory:
     def create(cls, value: int | str) -> Self:
         return cls()
 
+# `PClassMethod.x` and `PStaticMethod.x` evaluate to callable types with equivalent signatures
+# whether you access them on the protocol class or instances of the protocol.
+# That means that they are equivalent protocols!
+static_assert(is_equivalent_to(PClassMethod, PStaticMethod))
+
+static_assert(not is_assignable_to(NNotCallable, PClassMethod))
+static_assert(not is_assignable_to(NNotCallable, PStaticMethod))
+static_assert(not is_disjoint_from(NNotCallable, PClassMethod))
+static_assert(not is_disjoint_from(NNotCallable, PStaticMethod))
+static_assert(not is_disjoint_from(NMaybeCallable, PStaticMethod))
+static_assert(not is_disjoint_from(NObject, PStaticMethod))
+
+# `NInstanceMethod.x` has the correct type when accessed on an instance of
+# `NInstanceMethod`, but not when accessed on the class object itself
+#
+static_assert(not is_assignable_to(NInstanceMethod, PClassMethod))
+static_assert(not is_assignable_to(NInstanceMethod, PStaticMethod))
+
+# A nominal type with a `@staticmethod` can satisfy a protocol with a `@classmethod`
+# if the staticmethod duck-types the same as the classmethod member
+# both when accessed on the class and when accessed on an instance of the class
+# The same also applies for a nominal type with a `@classmethod` and a protocol
+# with a `@staticmethod` member
+static_assert(is_assignable_to(NClassMethodGood, PClassMethod))
+static_assert(is_assignable_to(NClassMethodGood, PStaticMethod))
+static_assert(is_subtype_of(NClassMethodGood, PClassMethod))
+static_assert(is_subtype_of(NClassMethodGood, PStaticMethod))
+static_assert(not is_assignable_to(NClassMethodBad, PClassMethod))
+static_assert(not is_assignable_to(NClassMethodBad, PStaticMethod))
+static_assert(not is_assignable_to(NClassMethodGood | NClassMethodBad, PClassMethod))
+
+static_assert(is_assignable_to(NStaticMethodGood, PClassMethod))
+static_assert(is_assignable_to(NStaticMethodGood, PStaticMethod))
+static_assert(is_subtype_of(NStaticMethodGood, PClassMethod))
+static_assert(is_subtype_of(NStaticMethodGood, PStaticMethod))
+static_assert(not is_assignable_to(NStaticMethodBad, PClassMethod))
+static_assert(not is_assignable_to(NStaticMethodBad, PStaticMethod))
+static_assert(not is_assignable_to(NStaticMethodGood | NStaticMethodBad, PStaticMethod))
+
+# An instance attribute can override an inherited static method.
+static_assert(not is_subtype_of(NStaticMethodShadowed, PStaticMethod))
+
+# `Self` in the classmethod signature is bound to the implementation type.
+static_assert(is_subtype_of(Factory, PFactory))
+static_assert(not is_assignable_to(BadFactory, PFactory))
+
+# Each overload keeps its own `Self` binding.
 static_assert(is_subtype_of(OverloadedFactory, POverloadedFactory))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3224,6 +3224,7 @@ of `N` or inhabitants of `type[N]`, *and* the signature of `N.x` is equivalent t
 `P.x` after the descriptor protocol has been invoked on `P.x`:
 
 ```py
+from collections.abc import Callable
 from typing import Protocol
 from typing_extensions import Self
 from ty_extensions import static_assert
@@ -3239,6 +3240,9 @@ class PStaticMethod(Protocol):
 
 class NNotCallable:
     x = None
+
+class NMaybeCallable:
+    x: Callable[[int], str] | None
 
 class NInstanceMethod:
     def x(self, val: int) -> str:
@@ -3287,6 +3291,7 @@ static_assert(not is_assignable_to(NNotCallable, PClassMethod))
 static_assert(not is_assignable_to(NNotCallable, PStaticMethod))
 static_assert(is_disjoint_from(NNotCallable, PClassMethod))
 static_assert(is_disjoint_from(NNotCallable, PStaticMethod))
+static_assert(not is_disjoint_from(NMaybeCallable, PStaticMethod))
 
 # `NInstanceMethod.x` has the correct type when accessed on an instance of
 # `NInstanceMethod`, but not when accessed on the class object itself

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3225,6 +3225,49 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolImplicitSelf))
 static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 ```
 
+## Module objects with static-method protocol members
+
+Module objects implement protocols through their public interface. A module-level function can
+therefore satisfy a static-method member with the same signature.
+
+Here, the ordinary method and the static method both describe a callable `(int) -> str` on the
+protocol value. Combining those protocols in a union must not make the module incompatible,
+including when the other possible value has an unknown type.
+
+`factory.py`:
+
+```py
+size: int = 1
+
+def make(value: int) -> str:
+    return str(value)
+```
+
+`main.py`:
+
+```py
+from typing import Protocol
+from ty_extensions import Unknown
+
+import factory
+
+class FactoryObject(Protocol):
+    size: int
+    def make(self, value: int) -> str: ...
+
+class FactoryModule(Protocol):
+    size: int
+
+    @staticmethod
+    def make(value: int) -> str: ...
+
+factory_protocol: FactoryModule = factory
+
+def from_gradual_value(value: Unknown, condition: bool) -> FactoryObject | FactoryModule:
+    candidate = factory if condition else value
+    return candidate
+```
+
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members
 
 The typing specification permits protocols to declare class and static methods, but it does not

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3268,6 +3268,10 @@ class NStaticMethodBad:
     def x(cls, val: int) -> str:
         return "foo"
 
+class NStaticMethodShadowed(NStaticMethodGood):
+    def __init__(self) -> None:
+        self.x: int = 1
+
 class PFactory(Protocol):
     @classmethod
     def create(cls) -> Self: ...
@@ -3319,6 +3323,7 @@ static_assert(is_subtype_of(NStaticMethodGood, PStaticMethod))
 static_assert(not is_assignable_to(NStaticMethodBad, PClassMethod))
 static_assert(not is_assignable_to(NStaticMethodBad, PStaticMethod))
 static_assert(not is_assignable_to(NStaticMethodGood | NStaticMethodBad, PStaticMethod))
+static_assert(not is_subtype_of(NStaticMethodShadowed, PStaticMethod))
 
 # `Self` in the classmethod signature is bound to the implementation type.
 static_assert(is_subtype_of(Factory, PFactory))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3223,11 +3223,7 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 ## Module objects with static-method protocol members
 
 Module objects implement protocols through their public interface. A module-level function can
-therefore satisfy a static-method member with the same signature.
-
-Here, the ordinary method and the static method both describe a callable `(int) -> str` on the
-protocol value. Combining those protocols in a union must not make the module incompatible,
-including when the other possible value has an unknown type.
+therefore satisfy an ordinary or static method member with the same signature.
 
 `factory.py`:
 
@@ -3242,7 +3238,6 @@ def make(value: int) -> str:
 
 ```py
 from typing import Protocol
-from ty_extensions import Unknown
 
 import factory
 
@@ -3256,11 +3251,8 @@ class FactoryModule(Protocol):
     @staticmethod
     def make(value: int) -> str: ...
 
-factory_protocol: FactoryModule = factory
-
-def from_gradual_value(value: Unknown, condition: bool) -> FactoryObject | FactoryModule:
-    candidate = factory if condition else value
-    return candidate
+factory_object: FactoryObject = factory
+factory_module: FactoryModule = factory
 ```
 
 ## Class objects with class-method protocol members

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4081,6 +4081,29 @@ def _(source: NoArgs):
     target: Variadic[Any] = source  # error: [invalid-assignment]
 ```
 
+## Class constructors and static callback protocols
+
+A class object's call signature comes from its constructor. An unrelated `__call__` method on the
+class's instances does not replace that constructor signature when matching a static callback
+protocol:
+
+```py
+from typing import Protocol
+
+class Product:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def __call__(self, text: str) -> str:
+        return text
+
+class Constructor(Protocol):
+    @staticmethod
+    def __call__(value: int) -> Product: ...
+
+constructor: Constructor = Product
+```
+
 ## Generic protocols and union arguments
 
 When a union is passed to a parameter annotated as a generic protocol, each union element can

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3244,6 +3244,13 @@ class NNotCallable:
 class NMaybeCallable:
     x: Callable[[int], str] | None
 
+class F:
+    def __call__(self, val: int) -> str:
+        return "foo"
+
+class NObject:
+    x: object = F()
+
 class NInstanceMethod:
     def x(self, val: int) -> str:
         return "foo"
@@ -3293,9 +3300,10 @@ static_assert(is_equivalent_to(PClassMethod, PStaticMethod))
 
 static_assert(not is_assignable_to(NNotCallable, PClassMethod))
 static_assert(not is_assignable_to(NNotCallable, PStaticMethod))
-static_assert(is_disjoint_from(NNotCallable, PClassMethod))
-static_assert(is_disjoint_from(NNotCallable, PStaticMethod))
+static_assert(not is_disjoint_from(NNotCallable, PClassMethod))
+static_assert(not is_disjoint_from(NNotCallable, PStaticMethod))
 static_assert(not is_disjoint_from(NMaybeCallable, PStaticMethod))
+static_assert(not is_disjoint_from(NObject, PStaticMethod))
 
 # `NInstanceMethod.x` has the correct type when accessed on an instance of
 # `NInstanceMethod`, but not when accessed on the class object itself

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -817,8 +817,8 @@ static_assert(not is_assignable_to(A, HasX))
 class B:
     x: Final = 42
 
-static_assert(not is_subtype_of(A, HasX))
-static_assert(not is_assignable_to(A, HasX))
+static_assert(not is_subtype_of(B, HasX))
+static_assert(not is_assignable_to(B, HasX))
 
 class IntSub(int): ...
 
@@ -2409,7 +2409,7 @@ static_assert(is_subtype_of(HasGetAttr, HasXProperty))
 static_assert(is_assignable_to(HasGetAttr, HasXProperty))
 
 static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))
-static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))
+static_assert(not is_assignable_to(HasGetAttr, HasMutableXAttr))
 
 class HasGetAttrWithUnsuitableReturn:
     def __getattr__(self, attr: str) -> tuple[int, int]:
@@ -3225,6 +3225,7 @@ of `N` or inhabitants of `type[N]`, *and* the signature of `N.x` is equivalent t
 
 ```py
 from typing import Protocol
+from typing_extensions import Self
 from ty_extensions import static_assert
 from ty_extensions._internal import is_subtype_of, is_assignable_to, is_equivalent_to, is_disjoint_from
 
@@ -3263,23 +3264,35 @@ class NStaticMethodBad:
     def x(cls, val: int) -> str:
         return "foo"
 
+class PFactory(Protocol):
+    @classmethod
+    def create(cls) -> Self: ...
+
+class Factory:
+    @classmethod
+    def create(cls) -> Self:
+        return cls()
+
+class BadFactory:
+    @classmethod
+    def create(cls) -> int:
+        return 42
+
 # `PClassMethod.x` and `PStaticMethod.x` evaluate to callable types with equivalent signatures
 # whether you access them on the protocol class or instances of the protocol.
 # That means that they are equivalent protocols!
 static_assert(is_equivalent_to(PClassMethod, PStaticMethod))
 
-# TODO: these should all pass
-static_assert(not is_assignable_to(NNotCallable, PClassMethod))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NNotCallable, PStaticMethod))  # error: [static-assert-error]
-static_assert(is_disjoint_from(NNotCallable, PClassMethod))  # error: [static-assert-error]
-static_assert(is_disjoint_from(NNotCallable, PStaticMethod))  # error: [static-assert-error]
+static_assert(not is_assignable_to(NNotCallable, PClassMethod))
+static_assert(not is_assignable_to(NNotCallable, PStaticMethod))
+static_assert(is_disjoint_from(NNotCallable, PClassMethod))
+static_assert(is_disjoint_from(NNotCallable, PStaticMethod))
 
 # `NInstanceMethod.x` has the correct type when accessed on an instance of
 # `NInstanceMethod`, but not when accessed on the class object itself
 #
-# TODO: these should pass
-static_assert(not is_assignable_to(NInstanceMethod, PClassMethod))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NInstanceMethod, PStaticMethod))  # error: [static-assert-error]
+static_assert(not is_assignable_to(NInstanceMethod, PClassMethod))
+static_assert(not is_assignable_to(NInstanceMethod, PStaticMethod))
 
 # A nominal type with a `@staticmethod` can satisfy a protocol with a `@classmethod`
 # if the staticmethod duck-types the same as the classmethod member
@@ -3288,26 +3301,27 @@ static_assert(not is_assignable_to(NInstanceMethod, PStaticMethod))  # error: [s
 # with a `@staticmethod` member
 static_assert(is_assignable_to(NClassMethodGood, PClassMethod))
 static_assert(is_assignable_to(NClassMethodGood, PStaticMethod))
-# TODO: these should all pass:
-static_assert(is_subtype_of(NClassMethodGood, PClassMethod))  # error: [static-assert-error]
-static_assert(is_subtype_of(NClassMethodGood, PStaticMethod))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NClassMethodBad, PClassMethod))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NClassMethodBad, PStaticMethod))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NClassMethodGood | NClassMethodBad, PClassMethod))  # error: [static-assert-error]
+static_assert(is_subtype_of(NClassMethodGood, PClassMethod))
+static_assert(is_subtype_of(NClassMethodGood, PStaticMethod))
+static_assert(not is_assignable_to(NClassMethodBad, PClassMethod))
+static_assert(not is_assignable_to(NClassMethodBad, PStaticMethod))
+static_assert(not is_assignable_to(NClassMethodGood | NClassMethodBad, PClassMethod))
 
 static_assert(is_assignable_to(NStaticMethodGood, PClassMethod))
 static_assert(is_assignable_to(NStaticMethodGood, PStaticMethod))
-# TODO: these should all pass:
-static_assert(is_subtype_of(NStaticMethodGood, PClassMethod))  # error: [static-assert-error]
-static_assert(is_subtype_of(NStaticMethodGood, PStaticMethod))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NStaticMethodBad, PClassMethod))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NStaticMethodBad, PStaticMethod))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NStaticMethodGood | NStaticMethodBad, PStaticMethod))  # error: [static-assert-error]
+static_assert(is_subtype_of(NStaticMethodGood, PClassMethod))
+static_assert(is_subtype_of(NStaticMethodGood, PStaticMethod))
+static_assert(not is_assignable_to(NStaticMethodBad, PClassMethod))
+static_assert(not is_assignable_to(NStaticMethodBad, PStaticMethod))
+static_assert(not is_assignable_to(NStaticMethodGood | NStaticMethodBad, PStaticMethod))
+
+# `Self` in the classmethod signature is bound to the implementation type.
+static_assert(is_subtype_of(Factory, PFactory))
+static_assert(not is_assignable_to(BadFactory, PFactory))
 ```
 
-Until classmethod protocol members are fully supported, their placeholder representation should not
-incorrectly require a mutable instance attribute. In particular, a frozen dataclass can satisfy a
-protocol bound through a classmethod:
+A classmethod protocol member does not require a mutable instance attribute. In particular, a frozen
+dataclass can satisfy a protocol bound through a classmethod:
 
 ```py
 from dataclasses import dataclass

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3275,6 +3275,35 @@ class IntParser:
 parser: Parser = IntParser
 ```
 
+## Class objects and `Self`-returning class-method protocol members
+
+When a class object is checked against a class-method protocol member, `Self` in the protocol
+signature is bound to instances of the class object rather than to the class object itself:
+
+```py
+from typing import Protocol
+from typing_extensions import Self
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_assignable_to
+
+class FactoryProtocol(Protocol):
+    @classmethod
+    def make(cls) -> Self: ...
+
+class Factory:
+    @classmethod
+    def make(cls) -> Self:
+        return cls()
+
+class BadFactory:
+    @classmethod
+    def make(cls) -> int:
+        return 1
+
+static_assert(is_assignable_to(TypeOf[Factory], FactoryProtocol))
+static_assert(not is_assignable_to(TypeOf[BadFactory], FactoryProtocol))
+```
+
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members
 
 The typing spec states that protocols may have `@classmethod` or `@staticmethod` method members.

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2830,14 +2830,6 @@ from ty_extensions._internal import is_subtype_of, is_assignable_to
 class P(Protocol):
     def m(self, x: int, /) -> None: ...
 
-class PWithClassMethod(Protocol):
-    @classmethod
-    def m(cls, x: int, /) -> None: ...
-
-class PWithStaticMethod(Protocol):
-    @staticmethod
-    def m(x: int, /) -> None: ...
-
 class NominalSubtype:
     def m(self, y: int) -> None: ...
 
@@ -2870,18 +2862,31 @@ static_assert(not is_assignable_to(DefinitelyNotSubtype, P))
 static_assert(not is_assignable_to(NotSubtype, P))
 static_assert(not is_assignable_to(NominalSubtype | NotSubtype, P))
 static_assert(not is_assignable_to(NominalSubtype2 | DefinitelyNotSubtype, P))
+```
 
-# A classmethod or staticmethod can satisfy a regular method member if it has the correct
-# signature when accessed on an instance. The class-side check only establishes that the member
-# is present on the class.
+A class or static method can satisfy an ordinary method member when it has the right signature on an
+instance. This applies to both nominal classes and other protocols:
+
+```py
+class PWithClassMethod(Protocol):
+    @classmethod
+    def m(cls, x: int, /) -> None: ...
+
+class PWithStaticMethod(Protocol):
+    @staticmethod
+    def m(x: int, /) -> None: ...
+
 static_assert(is_assignable_to(NominalWithClassMethod, P))
 static_assert(is_assignable_to(NominalWithStaticMethodGood, P))
 static_assert(is_assignable_to(NominalSubtype | NominalWithClassMethod, P))
 static_assert(is_assignable_to(NominalSubtype | NominalWithStaticMethodGood, P))
 static_assert(is_subtype_of(PWithClassMethod, P))
 static_assert(is_subtype_of(PWithStaticMethod, P))
+```
 
-# This staticmethod has an extra parameter when accessed on an instance.
+A static method with an extra parameter does not satisfy the ordinary method member:
+
+```py
 static_assert(not is_assignable_to(NominalWithStaticMethod, P))
 static_assert(not is_assignable_to(NominalSubtype | NominalWithStaticMethod, P))
 ```
@@ -3222,16 +3227,11 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members
 
-The typing spec states that protocols may have `@classmethod` or `@staticmethod` method members.
-However, as of 2025/09/24, the spec does not elaborate on how these members should behave with
-regards to subtyping and assignability (nor are there any tests in the typing conformance suite).
-Ty's behaviour is therefore derived from first principles and the
+The typing specification permits protocols to declare class and static methods, but it does not
+define exactly when another class satisfies such a protocol. ty requires the member to have a
+compatible callable signature when accessed through either the class or an instance. This agrees
+with the basic cases in the
 [mypy test suite](https://github.com/python/mypy/blob/354bea6352ee7a38b05e2f42c874e7d1f7bf557a/test-data/unit/check-protocols.test#L1231-L1263).
-
-A protocol `P` with a `@classmethod` method member `x` can only be satisfied by a nominal type `N`
-if `N.x` is a callable object that evaluates to the same type whether it is accessed on inhabitants
-of `N` or inhabitants of `type[N]`, *and* the signature of `N.x` is equivalent to the signature of
-`P.x` after the descriptor protocol has been invoked on `P.x`:
 
 ```py
 from collections.abc import Callable
@@ -3247,10 +3247,35 @@ class PClassMethod(Protocol):
 class PStaticMethod(Protocol):
     @staticmethod
     def x(val: int) -> str: ...
+```
 
+These protocols expose the same callable signature through both access paths, so they are
+equivalent:
+
+```py
+static_assert(is_equivalent_to(PClassMethod, PStaticMethod))
+```
+
+A non-callable attribute does not satisfy either protocol. An ordinary instance method also fails
+because accessing it through the class leaves its `self` parameter unbound:
+
+```py
 class NNotCallable:
     x = None
 
+class NInstanceMethod:
+    def x(self, val: int) -> str:
+        return "foo"
+
+static_assert(not is_assignable_to(NNotCallable, PClassMethod))
+static_assert(not is_assignable_to(NInstanceMethod, PStaticMethod))
+```
+
+Failure to satisfy a protocol does not prove that two types are disjoint. A subclass can replace the
+`None` attribute, a union may contain a callable value, and an `object` attribute can hold a
+callable at runtime:
+
+```py
 class NMaybeCallable:
     x: Callable[[int], str] | None
 
@@ -3261,34 +3286,64 @@ class F:
 class NObject:
     x: object = F()
 
-class NInstanceMethod:
-    def x(self, val: int) -> str:
-        return "foo"
+static_assert(not is_disjoint_from(NNotCallable, PClassMethod))
+static_assert(not is_disjoint_from(NMaybeCallable, PStaticMethod))
+static_assert(not is_disjoint_from(NObject, PStaticMethod))
+```
 
+A class method can satisfy a static-method protocol, and a static method can satisfy a class-method
+protocol, as long as the visible signatures are compatible:
+
+```py
 class NClassMethodGood:
     @classmethod
     def x(cls, val: int) -> str:
         return "foo"
-
-class NClassMethodBad:
-    @classmethod
-    def x(cls, val: str) -> int:
-        return 42
 
 class NStaticMethodGood:
     @staticmethod
     def x(val: int) -> str:
         return "foo"
 
+static_assert(is_assignable_to(NClassMethodGood, PStaticMethod))
+static_assert(is_assignable_to(NStaticMethodGood, PClassMethod))
+static_assert(is_subtype_of(NClassMethodGood, PStaticMethod))
+static_assert(is_subtype_of(NStaticMethodGood, PClassMethod))
+```
+
+An incompatible signature fails the protocol check, including when it appears in a union:
+
+```py
+class NClassMethodBad:
+    @classmethod
+    def x(cls, val: str) -> int:
+        return 42
+
 class NStaticMethodBad:
     @staticmethod
     def x(cls, val: int) -> str:
         return "foo"
 
+static_assert(not is_assignable_to(NClassMethodBad, PClassMethod))
+static_assert(not is_assignable_to(NStaticMethodBad, PStaticMethod))
+static_assert(not is_assignable_to(NClassMethodGood | NClassMethodBad, PClassMethod))
+```
+
+An instance attribute can override an inherited static method. The instance then no longer satisfies
+the protocol:
+
+```py
 class NStaticMethodShadowed(NStaticMethodGood):
     def __init__(self) -> None:
         self.x: int = 1
 
+static_assert(not is_subtype_of(NStaticMethodShadowed, PStaticMethod))
+```
+
+`Self` in a class-method return type is bound to the implementation class. A method that always
+returns `int` does not satisfy that requirement:
+
+```py
 class PFactory(Protocol):
     @classmethod
     def create(cls) -> Self: ...
@@ -3303,6 +3358,13 @@ class BadFactory:
     def create(cls) -> int:
         return 42
 
+static_assert(is_subtype_of(Factory, PFactory))
+static_assert(not is_assignable_to(BadFactory, PFactory))
+```
+
+Each overload of a class method keeps its own `Self` binding:
+
+```py
 class POverloadedFactory(Protocol):
     @overload
     @classmethod
@@ -3322,49 +3384,6 @@ class OverloadedFactory:
     def create(cls, value: int | str) -> Self:
         return cls()
 
-# `PClassMethod.x` and `PStaticMethod.x` evaluate to callable types with equivalent signatures
-# whether you access them on the protocol class or instances of the protocol.
-# That means that they are equivalent protocols!
-static_assert(is_equivalent_to(PClassMethod, PStaticMethod))
-
-static_assert(not is_assignable_to(NNotCallable, PClassMethod))
-static_assert(not is_assignable_to(NNotCallable, PStaticMethod))
-static_assert(not is_disjoint_from(NNotCallable, PClassMethod))
-static_assert(not is_disjoint_from(NNotCallable, PStaticMethod))
-static_assert(not is_disjoint_from(NMaybeCallable, PStaticMethod))
-static_assert(not is_disjoint_from(NObject, PStaticMethod))
-
-# `NInstanceMethod.x` has the correct type when accessed on an instance of
-# `NInstanceMethod`, but not when accessed on the class object itself
-#
-static_assert(not is_assignable_to(NInstanceMethod, PClassMethod))
-static_assert(not is_assignable_to(NInstanceMethod, PStaticMethod))
-
-# A nominal type with a `@staticmethod` can satisfy a protocol with a `@classmethod`
-# if the staticmethod duck-types the same as the classmethod member
-# both when accessed on the class and when accessed on an instance of the class
-# The same also applies for a nominal type with a `@classmethod` and a protocol
-# with a `@staticmethod` member
-static_assert(is_assignable_to(NClassMethodGood, PClassMethod))
-static_assert(is_assignable_to(NClassMethodGood, PStaticMethod))
-static_assert(is_subtype_of(NClassMethodGood, PClassMethod))
-static_assert(is_subtype_of(NClassMethodGood, PStaticMethod))
-static_assert(not is_assignable_to(NClassMethodBad, PClassMethod))
-static_assert(not is_assignable_to(NClassMethodBad, PStaticMethod))
-static_assert(not is_assignable_to(NClassMethodGood | NClassMethodBad, PClassMethod))
-
-static_assert(is_assignable_to(NStaticMethodGood, PClassMethod))
-static_assert(is_assignable_to(NStaticMethodGood, PStaticMethod))
-static_assert(is_subtype_of(NStaticMethodGood, PClassMethod))
-static_assert(is_subtype_of(NStaticMethodGood, PStaticMethod))
-static_assert(not is_assignable_to(NStaticMethodBad, PClassMethod))
-static_assert(not is_assignable_to(NStaticMethodBad, PStaticMethod))
-static_assert(not is_assignable_to(NStaticMethodGood | NStaticMethodBad, PStaticMethod))
-static_assert(not is_subtype_of(NStaticMethodShadowed, PStaticMethod))
-
-# `Self` in the classmethod signature is bound to the implementation type.
-static_assert(is_subtype_of(Factory, PFactory))
-static_assert(not is_assignable_to(BadFactory, PFactory))
 static_assert(is_subtype_of(OverloadedFactory, POverloadedFactory))
 ```
 
@@ -3428,7 +3447,8 @@ static_assert(is_assignable_to(AlsoCorrect, ContextManagerProtocol))
 static_assert(not is_assignable_to(MissingDecorator, ContextManagerProtocol))
 ```
 
-Transparent decorators preserve class and static protocol methods:
+A decorator with a precise callable return type preserves the signatures of class and static
+protocol methods:
 
 ```py
 from collections.abc import Callable
@@ -3439,12 +3459,12 @@ from ty_extensions._internal import is_subtype_of
 P = ParamSpec("P")
 R = TypeVar("R")
 
-def transparent(function: Callable[P, R]) -> Callable[P, R]:
+def preserve_signature(function: Callable[P, R]) -> Callable[P, R]:
     return function
 
 class StaticProtocol(Protocol):
     @staticmethod
-    @transparent
+    @preserve_signature
     def method(value: int) -> str: ...
 
 class StaticImplementation:
@@ -3454,7 +3474,7 @@ class StaticImplementation:
 
 class ClassProtocol(Protocol):
     @classmethod
-    @transparent
+    @preserve_signature
     def method(cls, value: int) -> str: ...
 
 class ClassImplementation:
@@ -3932,7 +3952,7 @@ static_assert(not is_assignable_to(TypeOf[doesnt_satisfy_foo], Foo))
 static_assert(not is_subtype_of(TypeOf[doesnt_satisfy_foo], Foo))
 ```
 
-Generic inference also uses static and class `__call__` members:
+Type-variable inference also uses static and class `__call__` members:
 
 ```py
 from typing import Protocol, TypeVar

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3932,6 +3932,34 @@ static_assert(not is_assignable_to(TypeOf[doesnt_satisfy_foo], Foo))
 static_assert(not is_subtype_of(TypeOf[doesnt_satisfy_foo], Foo))
 ```
 
+Generic inference also uses static and class `__call__` members:
+
+```py
+from typing import Protocol, TypeVar
+
+CallbackT = TypeVar("CallbackT")
+
+class StaticCallback(Protocol[CallbackT]):
+    @staticmethod
+    def __call__(value: CallbackT) -> CallbackT: ...
+
+class ClassCallback(Protocol[CallbackT]):
+    @classmethod
+    def __call__(cls, value: CallbackT) -> CallbackT: ...
+
+def use_static(callback: StaticCallback[CallbackT]) -> CallbackT:
+    raise NotImplementedError
+
+def use_class(callback: ClassCallback[CallbackT]) -> CallbackT:
+    raise NotImplementedError
+
+def identity(value: int) -> int:
+    return value
+
+reveal_type(use_static(identity))  # revealed: int
+reveal_type(use_class(identity))  # revealed: int
+```
+
 Class-literals and generic aliases can also be subtypes of callback protocols:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3235,7 +3235,7 @@ of `N` or inhabitants of `type[N]`, *and* the signature of `N.x` is equivalent t
 
 ```py
 from collections.abc import Callable
-from typing import Protocol
+from typing import Protocol, overload
 from typing_extensions import Self
 from ty_extensions import static_assert
 from ty_extensions._internal import is_subtype_of, is_assignable_to, is_equivalent_to, is_disjoint_from
@@ -3303,6 +3303,25 @@ class BadFactory:
     def create(cls) -> int:
         return 42
 
+class POverloadedFactory(Protocol):
+    @overload
+    @classmethod
+    def create(cls, value: int) -> Self: ...
+    @overload
+    @classmethod
+    def create(cls, value: str) -> Self: ...
+
+class OverloadedFactory:
+    @overload
+    @classmethod
+    def create(cls, value: int) -> Self: ...
+    @overload
+    @classmethod
+    def create(cls, value: str) -> Self: ...
+    @classmethod
+    def create(cls, value: int | str) -> Self:
+        return cls()
+
 # `PClassMethod.x` and `PStaticMethod.x` evaluate to callable types with equivalent signatures
 # whether you access them on the protocol class or instances of the protocol.
 # That means that they are equivalent protocols!
@@ -3346,6 +3365,7 @@ static_assert(not is_subtype_of(NStaticMethodShadowed, PStaticMethod))
 # `Self` in the classmethod signature is bound to the implementation type.
 static_assert(is_subtype_of(Factory, PFactory))
 static_assert(not is_assignable_to(BadFactory, PFactory))
+static_assert(is_subtype_of(OverloadedFactory, POverloadedFactory))
 ```
 
 A classmethod protocol member does not require a mutable instance attribute. In particular, a frozen

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3268,6 +3268,26 @@ def from_gradual_value(value: Unknown, condition: bool) -> FactoryObject | Facto
     return candidate
 ```
 
+## Class objects with class-method protocol members
+
+A class object implements a protocol when its directly accessible members have compatible types. The
+corresponding member does not also need to exist on the class object's metaclass:
+
+```py
+from typing import Protocol
+
+class Parser(Protocol):
+    @classmethod
+    def parse(cls, value: str) -> int: ...
+
+class IntParser:
+    @classmethod
+    def parse(cls, value: str) -> int:
+        return int(value)
+
+parser: Parser = IntParser
+```
+
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members
 
 The typing specification permits protocols to declare class and static methods, but it does not

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -817,8 +817,8 @@ static_assert(not is_assignable_to(A, HasX))
 class B:
     x: Final = 42
 
-static_assert(not is_subtype_of(B, HasX))
-static_assert(not is_assignable_to(B, HasX))
+static_assert(not is_subtype_of(A, HasX))
+static_assert(not is_assignable_to(A, HasX))
 
 class IntSub(int): ...
 
@@ -2409,7 +2409,7 @@ static_assert(is_subtype_of(HasGetAttr, HasXProperty))
 static_assert(is_assignable_to(HasGetAttr, HasXProperty))
 
 static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))
-static_assert(not is_assignable_to(HasGetAttr, HasMutableXAttr))
+static_assert(not is_subtype_of(HasGetAttr, HasMutableXAttr))
 
 class HasGetAttrWithUnsuitableReturn:
     def __getattr__(self, attr: str) -> tuple[int, int]:

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2830,6 +2830,14 @@ from ty_extensions._internal import is_subtype_of, is_assignable_to
 class P(Protocol):
     def m(self, x: int, /) -> None: ...
 
+class PWithClassMethod(Protocol):
+    @classmethod
+    def m(cls, x: int, /) -> None: ...
+
+class PWithStaticMethod(Protocol):
+    @staticmethod
+    def m(x: int, /) -> None: ...
+
 class NominalSubtype:
     def m(self, y: int) -> None: ...
 
@@ -2870,6 +2878,8 @@ static_assert(is_assignable_to(NominalWithClassMethod, P))
 static_assert(is_assignable_to(NominalWithStaticMethodGood, P))
 static_assert(is_assignable_to(NominalSubtype | NominalWithClassMethod, P))
 static_assert(is_assignable_to(NominalSubtype | NominalWithStaticMethodGood, P))
+static_assert(is_subtype_of(PWithClassMethod, P))
+static_assert(is_subtype_of(PWithStaticMethod, P))
 
 # This staticmethod has an extra parameter when accessed on an instance.
 static_assert(not is_assignable_to(NominalWithStaticMethod, P))

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3176,9 +3176,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     return Ok(());
                 };
 
-                // The `__call__` method is bound to `self`, so we need to bind it to get the
-                // callable signature that the actual type needs to match.
-                let formal_signature = call_method.bind_self(self.db, None).signatures(self.db);
+                // The protocol interface exposes the callable signature already bound for
+                // instance access.
+                let formal_signature = call_method.signatures(self.db);
 
                 // For callable-signature inference, keep unsatisfiable constraint-set
                 // comparisons non-fatal for now. The hybrid inference/checking pipeline still

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1765,16 +1765,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ) -> ConstraintSet<'db, 'c> {
         let source_capabilities = source_member.capabilities(db);
         let target_capabilities = target_member.capabilities(db);
+
+        if access == ProtocolMemberAccessMode::Class
+            && source_member.is_method()
+            && target_member.is_instance_method()
+        {
+            // The instance-side check is authoritative for an ordinary method's signature. Class
+            // access only establishes that the source member is also present on the class.
+            return ConstraintSet::from_bool(
+                self.constraints,
+                source_capabilities.class.read.is_some(),
+            );
+        }
+
         let (source, target) = match access {
             ProtocolMemberAccessMode::Instance => {
-                (source_capabilities.instance, target_capabilities.instance)
-            }
-            ProtocolMemberAccessMode::Class
-                if source_member.is_instance_method() && target_member.is_instance_method() =>
-            {
-                // The receiver type of an unbound method is specific to the class that
-                // defines it. Compare the corresponding bound access types after separately
-                // establishing that both methods are available through their classes.
                 (source_capabilities.instance, target_capabilities.instance)
             }
             ProtocolMemberAccessMode::Class => {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1968,27 +1968,9 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                 return self.never();
             }
 
-            // Callable upcasting requires every union arm to be callable. Preserve any concrete
-            // callable arm instead of treating the whole-union failure as proof of disjointness.
-            if let Type::Union(union) = ty
-                && union.elements(db).iter().any(|element| {
-                    !element.is_dynamic()
-                        && element
-                            .try_upcast_to_callable_with_policy(db, UpcastPolicy::Sound)
-                            .is_some()
-                })
-            {
-                return union
-                    .elements(db)
-                    .iter()
-                    .when_all(db, self.constraints, |element| {
-                        self.protocol_member_has_disjoint_type_from_ty(db, member, *element)
-                    });
-            }
-
             let Some(callables) = ty.try_upcast_to_callable_with_policy(db, UpcastPolicy::Sound)
             else {
-                return ConstraintSet::from_bool(self.constraints, !member.is_instance_method());
+                return self.never();
             };
 
             callables.iter().when_all(db, self.constraints, |callable| {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -323,12 +323,12 @@ impl<'db> ProtocolInterface<'db> {
     /// Returns the `__call__` method's callable type if this protocol has a `__call__` method member.
     pub(super) fn call_method(self, db: &'db dyn Db) -> Option<CallableType<'db>> {
         self.member_by_name(db, "__call__").and_then(|member| {
-            if !member.is_instance_method() {
+            if !member.is_method() {
                 return None;
             }
             match member
                 .capabilities(db)
-                .class
+                .instance
                 .read
                 .and_then(|read| read.resolve(db))
                 .map(ProtocolMemberType::ty)

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1228,6 +1228,7 @@ fn protocol_member_read_type<'db>(
         return Some(ty);
     }
 
+    // PEP 544 matches module-level functions directly, without descriptor binding on `ModuleType`.
     let place = if access == ProtocolMemberAccessMode::Instance
         && member.is_instance_method()
         && !matches!(ty, Type::ModuleLiteral(_))

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -859,7 +859,7 @@ enum ProtocolMemberKind<'db> {
     Attribute(ProtocolMemberType<'db>),
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 enum ProtocolMethodKind {
     Instance,
     Class,
@@ -1569,11 +1569,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         required_ty: ProtocolMemberType<'db>,
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
-        let fallback_ty = ty.literal_fallback_instance(db).unwrap_or(ty);
         let Some(attribute_type) = protocol_member_read_type(db, ty, receiver_ty, member, access)
         else {
             return self.never();
         };
+
+        // For a method on a class object, `Self` names instances of that class: a
+        // `@classmethod` returning `Self` returns `Factory`, not `type[Factory]`. For a
+        // non-method member, `Self` names the object whose attribute is being checked, so a
+        // class object must stay a class object.
+        let non_method_self_binding_ty = ty.literal_fallback_instance(db).unwrap_or(ty);
+        let method_self_binding_ty = ty
+            .to_instance(db)
+            .or_else(|| ty.literal_fallback_instance(db))
+            .unwrap_or(ty);
 
         // Checking a class object against a protocol's instance capabilities can expose the
         // property descriptor itself rather than the value returned by its getter. Compatibility
@@ -1596,8 +1605,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .when_some_and(db, self.constraints, |callables| {
                     self.check_callables_vs_callable(
                         db,
-                        &callables.map(|callable| callable.apply_self(db, fallback_ty)),
-                        required_callable.apply_self(db, fallback_ty),
+                        &callables.map(|callable| callable.apply_self(db, method_self_binding_ty)),
+                        required_callable.apply_self(db, method_self_binding_ty),
                     )
                 })
         } else if member.is_instance_method() {
@@ -1614,8 +1623,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         if callable.is_function_like(db) {
                             self.check_callable_pair(
                                 db,
-                                callable.bind_self(db, Some(fallback_ty)),
-                                protocol_bind_self(db, required_callable, Some(fallback_ty)),
+                                callable.bind_self(db, Some(method_self_binding_ty)),
+                                protocol_bind_self(
+                                    db,
+                                    required_callable,
+                                    Some(method_self_binding_ty),
+                                ),
                             )
                         } else {
                             self.check_callable_pair(db, *callable, required_callable)
@@ -1632,13 +1645,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             self.check_type_pair(
                 db,
                 attribute_type,
-                Type::Callable(required_callable.apply_self(db, fallback_ty)),
+                Type::Callable(required_callable.apply_self(db, method_self_binding_ty)),
             )
         } else {
-            required_ty.bind_self(db, fallback_ty).when_some_and(
-                db,
-                self.constraints,
-                |required_ty| {
+            required_ty
+                .bind_self(db, non_method_self_binding_ty)
+                .when_some_and(db, self.constraints, |required_ty| {
                     let result = self.check_type_pair(db, attribute_type, required_ty);
                     if let Some(context) = self.report_context()
                         && result.is_never_satisfied(db)
@@ -1649,8 +1661,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         });
                     }
                     result
-                },
-            )
+                })
         }
     }
 
@@ -2030,10 +2041,10 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                 // Disjointness distributes over unions. Compare the overload return arms
                 // directly so that recursive return types do not require canonicalizing an
                 // intermediate union merely to distribute it again.
-                method.signatures(db).iter().when_all(
-                    db,
-                    self.constraints,
-                    |method_signature| {
+                method
+                    .signatures(db)
+                    .iter()
+                    .when_all(db, self.constraints, |method_signature| {
                         callable.signatures(db).iter().when_all(
                             db,
                             self.constraints,
@@ -2045,8 +2056,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                                 )
                             },
                         )
-                    },
-                )
+                    })
             })
         }
     }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1219,8 +1219,10 @@ fn protocol_member_read_type<'db>(
     member: &ProtocolMember<'_, 'db>,
     access: ProtocolMemberAccessMode,
 ) -> Option<Type<'db>> {
+    // A callback protocol describes call syntax. Use the candidate's callable type instead of an
+    // explicitly resolved `__call__` attribute, which can differ for class objects.
     if access == ProtocolMemberAccessMode::Instance
-        && member.is_instance_method()
+        && member.is_method()
         && member.name == "__call__"
     {
         return Some(ty);

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -28,7 +28,6 @@ use crate::{
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
         diagnostic::report_undeclared_protocol_member,
-        todo_type,
     },
 };
 use ty_python_core::{definition::Definition, place::ScopedPlaceId, place_table, use_def_map};
@@ -234,7 +233,12 @@ impl<'db> ProtocolInterface<'db> {
     {
         let members: BTreeMap<_, _> = members
             .into_iter()
-            .map(|(name, callable)| (Name::new(name), ProtocolMemberData::method(callable, None)))
+            .map(|(name, callable)| {
+                (
+                    Name::new(name),
+                    ProtocolMemberData::method(db, callable, None),
+                )
+            })
             .collect();
         Self::new(db, members)
     }
@@ -319,7 +323,7 @@ impl<'db> ProtocolInterface<'db> {
     /// Returns the `__call__` method's callable type if this protocol has a `__call__` method member.
     pub(super) fn call_method(self, db: &'db dyn Db) -> Option<CallableType<'db>> {
         self.member_by_name(db, "__call__").and_then(|member| {
-            if !member.is_method() {
+            if !member.is_instance_method() {
                 return None;
             }
             match member
@@ -650,9 +654,27 @@ pub(super) struct ProtocolMemberData<'db> {
 }
 
 impl<'db> ProtocolMemberData<'db> {
-    fn method(callable: CallableType<'db>, definition: Option<Definition<'db>>) -> Self {
+    fn method(
+        db: &'db dyn Db,
+        callable: CallableType<'db>,
+        definition: Option<Definition<'db>>,
+    ) -> Self {
+        let (method_kind, callable) = if callable.is_classmethod_like(db) {
+            (
+                ProtocolMethodKind::ClassOrStatic,
+                protocol_bind_self(db, callable, None),
+            )
+        } else if callable.is_staticmethod_like(db) {
+            (ProtocolMethodKind::ClassOrStatic, callable.into_regular(db))
+        } else {
+            (ProtocolMethodKind::Instance, callable)
+        };
+
         Self {
-            kind: ProtocolMemberKind::Method(ProtocolMemberType::new(Type::Callable(callable))),
+            kind: ProtocolMemberKind::Method {
+                member: ProtocolMemberType::with_definition(Type::Callable(callable), definition),
+                kind: method_kind,
+            },
             qualifiers: TypeQualifiers::default(),
             definition,
         }
@@ -690,16 +712,16 @@ impl<'db> ProtocolMemberData<'db> {
     /// keeping them derived prevents the stored member kind and its capabilities from diverging.
     fn capabilities(&self, db: &'db dyn Db) -> ProtocolMemberCapabilities<'db> {
         match self.kind {
-            ProtocolMemberKind::Method(method) => {
-                let instance_method = match method.ty() {
-                    Type::Callable(callable) => {
-                        method.with_ty(Type::Callable(protocol_bind_self(db, callable, None)))
+            ProtocolMemberKind::Method { member, kind } => {
+                let instance_method = match (member.ty(), kind) {
+                    (Type::Callable(callable), ProtocolMethodKind::Instance) => {
+                        member.with_ty(Type::Callable(protocol_bind_self(db, callable, None)))
                     }
-                    _ => method,
+                    _ => member,
                 };
                 ProtocolMemberCapabilities {
                     instance: ProtocolMemberAccess::new(Some(instance_method), None),
-                    class: ProtocolMemberAccess::new(Some(method), None),
+                    class: ProtocolMemberAccess::new(Some(member), None),
                 }
             }
             ProtocolMemberKind::Property { read, write } => ProtocolMemberCapabilities {
@@ -709,9 +731,8 @@ impl<'db> ProtocolMemberData<'db> {
             ProtocolMemberKind::Attribute(member_ty) => {
                 let is_class_var = self.qualifiers.contains(TypeQualifiers::CLASS_VAR);
                 let is_final = self.qualifiers.contains(TypeQualifiers::FINAL);
-                // A `Todo` records a protocol member form that is not modeled yet. In particular,
-                // classmethod and staticmethod members currently use the attribute representation;
-                // do not infer a write requirement from that temporary representation.
+                // A `Todo` records a protocol member form that is not modeled yet; do not infer a
+                // write requirement from that temporary representation.
                 let is_todo = member_ty.ty().is_todo();
                 ProtocolMemberCapabilities {
                     instance: ProtocolMemberAccess::new(
@@ -792,8 +813,8 @@ impl<'db> ProtocolMemberData<'db> {
         impl std::fmt::Display for ProtocolMemberDataDisplay<'_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self.kind {
-                    ProtocolMemberKind::Method(method) => {
-                        write!(f, "MethodMember(`{}`)", method.ty().display(self.db))
+                    ProtocolMemberKind::Method { member, .. } => {
+                        write!(f, "MethodMember(`{}`)", member.ty().display(self.db))
                     }
                     ProtocolMemberKind::Property { read, write } => {
                         let mut d = f.debug_struct("PropertyMember");
@@ -827,7 +848,10 @@ impl<'db> ProtocolMemberData<'db> {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 enum ProtocolMemberKind<'db> {
-    Method(ProtocolMemberType<'db>),
+    Method {
+        member: ProtocolMemberType<'db>,
+        kind: ProtocolMethodKind,
+    },
     Property {
         read: Option<ProtocolMemberType<'db>>,
         write: Option<ProtocolMemberType<'db>>,
@@ -835,10 +859,16 @@ enum ProtocolMemberKind<'db> {
     Attribute(ProtocolMemberType<'db>),
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+enum ProtocolMethodKind {
+    Instance,
+    ClassOrStatic,
+}
+
 impl<'db> ProtocolMemberKind<'db> {
     fn member_types(self) -> impl Iterator<Item = ProtocolMemberType<'db>> {
         match self {
-            Self::Method(method) => [Some(method), None],
+            Self::Method { member, .. } => [Some(member), None],
             Self::Property { read, write } => [read, write],
             Self::Attribute(attribute) => [Some(attribute), None],
         }
@@ -848,11 +878,22 @@ impl<'db> ProtocolMemberKind<'db> {
 
     fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
         match (self, previous) {
-            (Self::Method(current), Self::Method(previous)) => {
+            (
+                Self::Method {
+                    member: current,
+                    kind,
+                },
+                Self::Method {
+                    member: previous, ..
+                },
+            ) => {
                 let (Type::Callable(current_callable), Type::Callable(previous_callable)) =
                     (current.ty(), previous.ty())
                 else {
-                    return Self::Method(current.cycle_normalized(db, previous, cycle));
+                    return Self::Method {
+                        member: current.cycle_normalized(db, previous, cycle),
+                        kind,
+                    };
                 };
                 debug_assert_eq!(current_callable.kind(db), previous_callable.kind(db));
                 let signatures = current_callable.signatures(db).cycle_normalized(
@@ -860,12 +901,15 @@ impl<'db> ProtocolMemberKind<'db> {
                     previous_callable.signatures(db),
                     cycle,
                 );
-                Self::Method(current.with_ty(Type::Callable(CallableType::new(
-                    db,
-                    signatures,
-                    current_callable.kind(db),
-                    current_callable.provenance(db),
-                ))))
+                Self::Method {
+                    member: current.with_ty(Type::Callable(CallableType::new(
+                        db,
+                        signatures,
+                        current_callable.kind(db),
+                        current_callable.provenance(db),
+                    ))),
+                    kind,
+                }
             }
             (
                 Self::Property {
@@ -894,9 +938,10 @@ impl<'db> ProtocolMemberKind<'db> {
         nested: bool,
     ) -> Option<Self> {
         Some(match self {
-            Self::Method(method) => {
-                Self::Method(method.recursive_type_normalized_impl(db, div, nested)?)
-            }
+            Self::Method { member, kind } => Self::Method {
+                member: member.recursive_type_normalized_impl(db, div, nested)?,
+                kind,
+            },
             Self::Property { read, write } => Self::Property {
                 read: match read {
                     Some(read) => Some(read.recursive_type_normalized_impl(db, div, nested)?),
@@ -921,9 +966,10 @@ impl<'db> ProtocolMemberKind<'db> {
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         match self {
-            Self::Method(method) => {
-                Self::Method(method.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
-            }
+            Self::Method { member, kind } => Self::Method {
+                member: member.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                kind,
+            },
             Self::Property { read, write } => Self::Property {
                 read: read.map(|read| read.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
                 write: write
@@ -963,7 +1009,17 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
     }
 
     pub(super) fn is_method(&self) -> bool {
-        matches!(self.data.kind, ProtocolMemberKind::Method(_))
+        matches!(self.data.kind, ProtocolMemberKind::Method { .. })
+    }
+
+    fn is_instance_method(&self) -> bool {
+        matches!(
+            self.data.kind,
+            ProtocolMemberKind::Method {
+                kind: ProtocolMethodKind::Instance,
+                ..
+            }
+        )
     }
 
     fn is_property(&self) -> bool {
@@ -1141,7 +1197,7 @@ fn protocol_member_read_type<'db>(
     access: ProtocolMemberAccessMode,
 ) -> Option<Type<'db>> {
     if access == ProtocolMemberAccessMode::Instance
-        && member.is_method()
+        && member.is_instance_method()
         && member.name == "__call__"
     {
         return Some(ty);
@@ -1515,7 +1571,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         required_callable.apply_self(db, fallback_ty),
                     )
                 })
-        } else if member.is_method() {
+        } else if member.is_instance_method() {
             let Some(required_ty) = required_ty.resolve(db) else {
                 return self.never();
             };
@@ -1570,7 +1626,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         required: ProtocolMemberAccess<'db>,
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
-        if access == ProtocolMemberAccessMode::Class && member.is_method() {
+        if access == ProtocolMemberAccessMode::Class && member.is_instance_method() {
             // The instance-side check is authoritative for the signature of a method
             // implementation. Class access only establishes that the member is present. Callable
             // types and several callable literal forms do not expose a useful `__call__` member
@@ -1648,7 +1704,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 )
                 .is_none();
             let class_read_missing = capabilities.class.read.is_some()
-                && !(member.is_method() && member.name == "__call__")
+                && !(member.is_instance_method() && member.name == "__call__")
                 && protocol_member_read_type(
                     db,
                     ty,
@@ -1714,7 +1770,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 (source_capabilities.instance, target_capabilities.instance)
             }
             ProtocolMemberAccessMode::Class
-                if source_member.is_method() && target_member.is_method() =>
+                if source_member.is_instance_method() && target_member.is_instance_method() =>
             {
                 // The receiver type of an unbound method is specific to the class that
                 // defines it. Compare the corresponding bound access types after separately
@@ -1912,35 +1968,37 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                 return self.never();
             }
 
-            ty.try_upcast_to_callable_with_policy(db, UpcastPolicy::Sound)
-                .when_some_and(db, self.constraints, |callables| {
-                    callables.iter().when_all(db, self.constraints, |callable| {
-                        if !callable_has_only_non_never_returns(db, *callable) {
-                            return self.never();
-                        }
+            let Some(callables) = ty.try_upcast_to_callable_with_policy(db, UpcastPolicy::Sound)
+            else {
+                return ConstraintSet::from_bool(self.constraints, !member.is_instance_method());
+            };
 
-                        // Disjointness distributes over unions. Compare the overload return arms
-                        // directly so that recursive return types do not require canonicalizing an
-                        // intermediate union merely to distribute it again.
-                        method.signatures(db).iter().when_all(
+            callables.iter().when_all(db, self.constraints, |callable| {
+                if !callable_has_only_non_never_returns(db, *callable) {
+                    return self.never();
+                }
+
+                // Disjointness distributes over unions. Compare the overload return arms
+                // directly so that recursive return types do not require canonicalizing an
+                // intermediate union merely to distribute it again.
+                method.signatures(db).iter().when_all(
+                    db,
+                    self.constraints,
+                    |method_signature| {
+                        callable.signatures(db).iter().when_all(
                             db,
                             self.constraints,
-                            |method_signature| {
-                                callable.signatures(db).iter().when_all(
+                            |callable_signature| {
+                                self.check_type_pair(
                                     db,
-                                    self.constraints,
-                                    |callable_signature| {
-                                        self.check_type_pair(
-                                            db,
-                                            method_signature.return_ty,
-                                            callable_signature.return_ty,
-                                        )
-                                    },
+                                    method_signature.return_ty,
+                                    callable_signature.return_ty,
                                 )
                             },
                         )
-                    })
-                })
+                    },
+                )
+            })
         }
     }
 }
@@ -2091,19 +2149,14 @@ fn cached_protocol_interface<'db>(
                 Type::Callable(callable)
                     if bound_on_class.is_yes() && callable.is_function_like(db) =>
                 {
-                    ProtocolMemberData::method(callable, definition)
+                    ProtocolMemberData::method(db, callable, definition)
                 }
                 Type::FunctionLiteral(function)
-                    if function.is_staticmethod(db) || function.is_classmethod(db) =>
+                    if bound_on_class.is_yes()
+                        || function.is_staticmethod(db)
+                        || function.is_classmethod(db) =>
                 {
-                    ProtocolMemberData::attribute(
-                        todo_type!("classmethod and staticmethod protocol members"),
-                        qualifiers,
-                        definition,
-                    )
-                }
-                Type::FunctionLiteral(function) if bound_on_class.is_yes() => {
-                    ProtocolMemberData::method(function.into_callable_type(db), definition)
+                    ProtocolMemberData::method(db, function.into_callable_type(db), definition)
                 }
                 _ if bound_on_class.is_yes()
                     && definition

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1968,6 +1968,24 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                 return self.never();
             }
 
+            // Callable upcasting requires every union arm to be callable. Preserve any concrete
+            // callable arm instead of treating the whole-union failure as proof of disjointness.
+            if let Type::Union(union) = ty
+                && union.elements(db).iter().any(|element| {
+                    !element.is_dynamic()
+                        && element
+                            .try_upcast_to_callable_with_policy(db, UpcastPolicy::Sound)
+                            .is_some()
+                })
+            {
+                return union
+                    .elements(db)
+                    .iter()
+                    .when_all(db, self.constraints, |element| {
+                        self.protocol_member_has_disjoint_type_from_ty(db, member, *element)
+                    });
+            }
+
             let Some(callables) = ty.try_upcast_to_callable_with_policy(db, UpcastPolicy::Sound)
             else {
                 return ConstraintSet::from_bool(self.constraints, !member.is_instance_method());

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -664,11 +664,11 @@ impl<'db> ProtocolMemberData<'db> {
     ) -> Self {
         let (method_kind, callable) = if callable.is_classmethod_like(db) {
             (
-                ProtocolMethodKind::ClassOrStatic,
+                ProtocolMethodKind::Class,
                 protocol_bind_self(db, callable, None),
             )
         } else if callable.is_staticmethod_like(db) {
-            (ProtocolMethodKind::ClassOrStatic, callable.into_regular(db))
+            (ProtocolMethodKind::Static, callable.into_regular(db))
         } else {
             (ProtocolMethodKind::Instance, callable)
         };
@@ -859,27 +859,11 @@ enum ProtocolMemberKind<'db> {
     Attribute(ProtocolMemberType<'db>),
 }
 
-/// Describes how descriptor binding exposes a protocol method.
-///
-/// Class and static methods share a variant because both expose the same effective signature
-/// through instance and class access. Class methods have already bound their receiver, while static
-/// methods have no receiver to bind:
-///
-/// ```python
-/// class P(Protocol):
-///     @classmethod
-///     def method(cls, value: int) -> str: ...
-///
-/// p: P
-/// ```
-///
-/// Both `P.method` and `p.method` are viewed as `(int) -> str`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 enum ProtocolMethodKind {
-    /// Instance access binds the receiver; class access leaves it unbound.
     Instance,
-    /// Instance and class access expose the same effective signature.
-    ClassOrStatic,
+    Class,
+    Static,
 }
 
 impl<'db> ProtocolMemberKind<'db> {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -320,7 +320,10 @@ impl<'db> ProtocolInterface<'db> {
         })
     }
 
-    /// Returns the `__call__` method's callable type if this protocol has a `__call__` method member.
+    /// Returns the callable signature exposed by instance access to a protocol's `__call__`
+    /// method.
+    ///
+    /// The callable is already in its instance-bound form, so callers must not bind it again.
     pub(super) fn call_method(self, db: &'db dyn Db) -> Option<CallableType<'db>> {
         self.member_by_name(db, "__call__").and_then(|member| {
             if !member.is_method() {
@@ -671,10 +674,10 @@ impl<'db> ProtocolMemberData<'db> {
         };
 
         Self {
-            kind: ProtocolMemberKind::Method {
-                member: ProtocolMemberType::with_definition(Type::Callable(callable), definition),
-                kind: method_kind,
-            },
+            kind: ProtocolMemberKind::Method(
+                ProtocolMemberType::with_definition(Type::Callable(callable), definition),
+                method_kind,
+            ),
             qualifiers: TypeQualifiers::default(),
             definition,
         }
@@ -712,7 +715,7 @@ impl<'db> ProtocolMemberData<'db> {
     /// keeping them derived prevents the stored member kind and its capabilities from diverging.
     fn capabilities(&self, db: &'db dyn Db) -> ProtocolMemberCapabilities<'db> {
         match self.kind {
-            ProtocolMemberKind::Method { member, kind } => {
+            ProtocolMemberKind::Method(member, kind) => {
                 let instance_method = match (member.ty(), kind) {
                     (Type::Callable(callable), ProtocolMethodKind::Instance) => {
                         member.with_ty(Type::Callable(protocol_bind_self(db, callable, None)))
@@ -813,7 +816,7 @@ impl<'db> ProtocolMemberData<'db> {
         impl std::fmt::Display for ProtocolMemberDataDisplay<'_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self.kind {
-                    ProtocolMemberKind::Method { member, .. } => {
+                    ProtocolMemberKind::Method(member, _) => {
                         write!(f, "MethodMember(`{}`)", member.ty().display(self.db))
                     }
                     ProtocolMemberKind::Property { read, write } => {
@@ -848,10 +851,7 @@ impl<'db> ProtocolMemberData<'db> {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 enum ProtocolMemberKind<'db> {
-    Method {
-        member: ProtocolMemberType<'db>,
-        kind: ProtocolMethodKind,
-    },
+    Method(ProtocolMemberType<'db>, ProtocolMethodKind),
     Property {
         read: Option<ProtocolMemberType<'db>>,
         write: Option<ProtocolMemberType<'db>>,
@@ -859,16 +859,33 @@ enum ProtocolMemberKind<'db> {
     Attribute(ProtocolMemberType<'db>),
 }
 
+/// Describes how descriptor binding exposes a protocol method.
+///
+/// Class and static methods share a variant because both expose the same effective signature
+/// through instance and class access. Class methods have already bound their receiver, while static
+/// methods have no receiver to bind:
+///
+/// ```python
+/// class P(Protocol):
+///     @classmethod
+///     def method(cls, value: int) -> str: ...
+///
+/// p: P
+/// ```
+///
+/// Both `P.method` and `p.method` are viewed as `(int) -> str`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 enum ProtocolMethodKind {
+    /// Instance access binds the receiver; class access leaves it unbound.
     Instance,
+    /// Instance and class access expose the same effective signature.
     ClassOrStatic,
 }
 
 impl<'db> ProtocolMemberKind<'db> {
     fn member_types(self) -> impl Iterator<Item = ProtocolMemberType<'db>> {
         match self {
-            Self::Method { member, .. } => [Some(member), None],
+            Self::Method(member, _) => [Some(member), None],
             Self::Property { read, write } => [read, write],
             Self::Attribute(attribute) => [Some(attribute), None],
         }
@@ -878,22 +895,11 @@ impl<'db> ProtocolMemberKind<'db> {
 
     fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
         match (self, previous) {
-            (
-                Self::Method {
-                    member: current,
-                    kind,
-                },
-                Self::Method {
-                    member: previous, ..
-                },
-            ) => {
+            (Self::Method(current, kind), Self::Method(previous, _)) => {
                 let (Type::Callable(current_callable), Type::Callable(previous_callable)) =
                     (current.ty(), previous.ty())
                 else {
-                    return Self::Method {
-                        member: current.cycle_normalized(db, previous, cycle),
-                        kind,
-                    };
+                    return Self::Method(current.cycle_normalized(db, previous, cycle), kind);
                 };
                 debug_assert_eq!(current_callable.kind(db), previous_callable.kind(db));
                 let signatures = current_callable.signatures(db).cycle_normalized(
@@ -901,15 +907,15 @@ impl<'db> ProtocolMemberKind<'db> {
                     previous_callable.signatures(db),
                     cycle,
                 );
-                Self::Method {
-                    member: current.with_ty(Type::Callable(CallableType::new(
+                Self::Method(
+                    current.with_ty(Type::Callable(CallableType::new(
                         db,
                         signatures,
                         current_callable.kind(db),
                         current_callable.provenance(db),
                     ))),
                     kind,
-                }
+                )
             }
             (
                 Self::Property {
@@ -938,10 +944,10 @@ impl<'db> ProtocolMemberKind<'db> {
         nested: bool,
     ) -> Option<Self> {
         Some(match self {
-            Self::Method { member, kind } => Self::Method {
-                member: member.recursive_type_normalized_impl(db, div, nested)?,
+            Self::Method(member, kind) => Self::Method(
+                member.recursive_type_normalized_impl(db, div, nested)?,
                 kind,
-            },
+            ),
             Self::Property { read, write } => Self::Property {
                 read: match read {
                     Some(read) => Some(read.recursive_type_normalized_impl(db, div, nested)?),
@@ -966,10 +972,10 @@ impl<'db> ProtocolMemberKind<'db> {
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         match self {
-            Self::Method { member, kind } => Self::Method {
-                member: member.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            Self::Method(member, kind) => Self::Method(
+                member.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 kind,
-            },
+            ),
             Self::Property { read, write } => Self::Property {
                 read: read.map(|read| read.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
                 write: write
@@ -1009,16 +1015,13 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
     }
 
     pub(super) fn is_method(&self) -> bool {
-        matches!(self.data.kind, ProtocolMemberKind::Method { .. })
+        matches!(self.data.kind, ProtocolMemberKind::Method(..))
     }
 
     fn is_instance_method(&self) -> bool {
         matches!(
             self.data.kind,
-            ProtocolMemberKind::Method {
-                kind: ProtocolMethodKind::Instance,
-                ..
-            }
+            ProtocolMemberKind::Method(_, ProtocolMethodKind::Instance)
         )
     }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1593,6 +1593,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         }
                     })
                 })
+        } else if member.is_method() {
+            let Some(required_ty) = required_ty.resolve(db) else {
+                return self.never();
+            };
+            let Type::Callable(required_callable) = required_ty.ty() else {
+                return self.never();
+            };
+            self.check_type_pair(
+                db,
+                attribute_type,
+                Type::Callable(required_callable.apply_self(db, fallback_ty)),
+            )
         } else {
             required_ty.bind_self(db, fallback_ty).when_some_and(
                 db,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2164,7 +2164,7 @@ fn cached_protocol_interface<'db>(
                     definition,
                 ),
                 Type::Callable(callable)
-                    if bound_on_class.is_yes() && callable.is_function_like(db) =>
+                    if bound_on_class.is_yes() && callable.is_method_like(db) =>
                 {
                     ProtocolMemberData::method(db, callable, definition)
                 }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1024,7 +1024,8 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
     /// Returns the accesses that a candidate value must provide for this member.
     ///
     /// A module-level callable can satisfy an ordinary or static method through direct member
-    /// access. The member does not also need to exist on `ModuleType`.
+    /// access. A class object can likewise satisfy a class or static method. The member does not
+    /// also need to exist on the value's meta-type.
     fn implementation_capabilities(
         &self,
         db: &'db dyn Db,
@@ -1038,6 +1039,12 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
                 ProtocolMemberKind::Method(
                     _,
                     ProtocolMethodKind::Instance | ProtocolMethodKind::Static
+                )
+            ) | (
+                Type::ClassLiteral(_),
+                ProtocolMemberKind::Method(
+                    _,
+                    ProtocolMethodKind::Class | ProtocolMethodKind::Static
                 )
             )
         ) {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1203,7 +1203,7 @@ fn protocol_member_read_type<'db>(
         return Some(ty);
     }
 
-    let place = if access == ProtocolMemberAccessMode::Instance && member.is_method() {
+    let place = if access == ProtocolMemberAccessMode::Instance && member.is_instance_method() {
         ty.invoke_descriptor_protocol(
             db,
             ty,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1021,6 +1021,35 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         self.data.capabilities(db)
     }
 
+    /// Returns the accesses that a candidate value must provide for this member.
+    ///
+    /// A module-level callable can satisfy an ordinary or static method through direct member
+    /// access. The member does not also need to exist on `ModuleType`.
+    fn implementation_capabilities(
+        &self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+    ) -> ProtocolMemberCapabilities<'db> {
+        let capabilities = self.capabilities(db);
+        if matches!(
+            (ty, self.data.kind),
+            (
+                Type::ModuleLiteral(_),
+                ProtocolMemberKind::Method(
+                    _,
+                    ProtocolMethodKind::Instance | ProtocolMethodKind::Static
+                )
+            )
+        ) {
+            ProtocolMemberCapabilities {
+                class: ProtocolMemberAccess::NONE,
+                ..capabilities
+            }
+        } else {
+            capabilities
+        }
+    }
+
     fn has_todo_type(&self) -> bool {
         self.data
             .kind
@@ -1190,7 +1219,10 @@ fn protocol_member_read_type<'db>(
         return Some(ty);
     }
 
-    let place = if access == ProtocolMemberAccessMode::Instance && member.is_instance_method() {
+    let place = if access == ProtocolMemberAccessMode::Instance
+        && member.is_instance_method()
+        && !matches!(ty, Type::ModuleLiteral(_))
+    {
         ty.invoke_descriptor_protocol(
             db,
             ty,
@@ -1625,7 +1657,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         required: ProtocolMemberAccess<'db>,
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
-        if access == ProtocolMemberAccessMode::Class && member.is_instance_method() {
+        if access == ProtocolMemberAccessMode::Class
+            && member.is_instance_method()
+            && required.read.is_some()
+        {
             // The instance-side check is authoritative for the signature of a method
             // implementation. Class access only establishes that the member is present. Callable
             // types and several callable literal forms do not expose a useful `__call__` member
@@ -1691,7 +1726,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         member: &ProtocolMember<'_, 'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let capabilities = member.capabilities(db);
+        let capabilities = member.implementation_capabilities(db, ty);
         if let Some(context) = self.report_context() {
             let instance_read_missing = capabilities.instance.read.is_some()
                 && protocol_member_read_type(


### PR DESCRIPTION
## Summary

The typing specification permits protocols to declare class and static methods, but we previously represented these members as placeholder attributes. This PR records whether each protocol method is an instance, class, or static method and derives its instance- and class-access signatures accordingly.

For example, a static method can satisfy a protocol class method when both access paths expose the required callable:

```python
from typing import Protocol
from ty_extensions import is_subtype_of, static_assert

class Parser(Protocol):
    @classmethod
    def parse(cls, data: bytes) -> str: ...

class JsonParser:
    @staticmethod
    def parse(data: bytes) -> str:
        return data.decode()

# main: fails because class and static protocol members are not modeled as methods.
# This branch: passes because both access paths expose `(bytes) -> str`.
static_assert(is_subtype_of(JsonParser, Parser))
```

Receiver-sensitive matching intentionally remains out of scope. For example:

```python
# Both main and this branch ignore this receiver-only use of `T` when matching implementations.
class ReceiverOnly[T](Protocol):
    @classmethod
    def method(cls: type[T]) -> None: ...
```

In more detail: this PR does not use the `cls` annotation to infer `T` from the implementing class, select receiver-specific overloads, or determine protocol variance. The typing specification does not define those interactions, and mypy, Pyright, and Pyrefly do not share a consistent model. Likewise, whether an implementation method generic over `T: str` can satisfy a target method generic over `T: object` is a general callable-relation question, so this PR does not add a protocol-specific rule for it.