### PR TITLE
[ty] Unify helpers for creating string-literal types

### DIFF
--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -134,6 +134,48 @@ impl From<Name> for compact_str::CompactString {
     }
 }
 
+#[cfg(feature = "salsa")]
+impl salsa::Lookup<compact_str::CompactString> for Name {
+    #[inline]
+    fn into_owned(self) -> compact_str::CompactString {
+        self.0
+    }
+}
+
+#[cfg(feature = "salsa")]
+impl salsa::Lookup<compact_str::CompactString> for &Name {
+    #[inline]
+    fn into_owned(self) -> compact_str::CompactString {
+        self.0.clone()
+    }
+}
+
+#[cfg(feature = "salsa")]
+impl salsa::HashEqLike<Name> for compact_str::CompactString {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(self, state);
+    }
+
+    #[inline]
+    fn eq(&self, data: &Name) -> bool {
+        self == data.as_str()
+    }
+}
+
+#[cfg(feature = "salsa")]
+impl salsa::HashEqLike<&Name> for compact_str::CompactString {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(self, state);
+    }
+
+    #[inline]
+    fn eq(&self, data: &&Name) -> bool {
+        self == data.as_str()
+    }
+}
+
 impl From<Name> for String {
     #[inline]
     fn from(name: Name) -> Self {

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -547,7 +547,7 @@ impl<'db> SemanticModel<'db> {
                     .map(|string_literal| {
                         let value = string_literal.value(db).to_string();
                         vec![ExpectedStringLiteralCompletion {
-                            ty: Type::string_literal(db, &value),
+                            ty: Type::string_literal(db, &*value),
                             value,
                         }]
                     })

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1775,17 +1775,11 @@ impl<'db> Type<'db> {
     }
 
     /// Create a promotable string literal.
-    pub(crate) fn string_literal(db: &'db dyn Db, string: &str) -> Self {
-        Self::LiteralValue(LiteralValueType::promotable(StringLiteralType::new(
-            db, string,
-        )))
-    }
-
-    /// Create a promotable string literal from an owned [`CompactString`].
-    ///
-    /// On an interning miss, Salsa can store the value directly instead of copying it from a
-    /// borrowed `str`.
-    pub(crate) fn string_literal_owned(db: &'db dyn Db, string: CompactString) -> Self {
+    pub(crate) fn string_literal<T>(db: &'db dyn Db, string: T) -> Self
+    where
+        T: salsa::Lookup<CompactString> + std::hash::Hash,
+        CompactString: salsa::HashEqLike<T>,
+    {
         Self::LiteralValue(LiteralValueType::promotable(StringLiteralType::new(
             db, string,
         )))
@@ -6829,7 +6823,7 @@ impl<'db> Type<'db> {
                 LiteralValueTypeKind::String(_) | LiteralValueTypeKind::LiteralString => *self,
                 LiteralValueTypeKind::Enum(enum_literal) => Type::string_literal(
                     db,
-                    &format!(
+                    compact_str::format_compact!(
                         "{enum_class}.{name}",
                         enum_class = enum_literal.enum_class(db).name(db),
                         name = enum_literal.name(db)
@@ -6837,9 +6831,11 @@ impl<'db> Type<'db> {
                 ),
                 LiteralValueTypeKind::Bytes(_) => KnownClass::Str.to_instance(db),
             },
-            Type::SpecialForm(special_form) => Type::string_literal(db, &special_form.to_string()),
+            Type::SpecialForm(special_form) => {
+                Type::string_literal(db, special_form.to_compact_string())
+            }
             Type::KnownInstance(known_instance) => {
-                Type::string_literal(db, &known_instance.repr(db).to_string())
+                Type::string_literal(db, known_instance.repr(db).to_compact_string())
             }
             ty if ty.is_subtype_of(db, Type::literal_string()) => Type::literal_string(),
             Type::Intersection(intersection) => {
@@ -6861,18 +6857,21 @@ impl<'db> Type<'db> {
     pub(crate) fn repr(&self, db: &'db dyn Db) -> Type<'db> {
         match self {
             Type::LiteralValue(literal) => match literal.kind() {
-                LiteralValueTypeKind::Int(number) => Type::string_literal(db, &number.to_string()),
+                LiteralValueTypeKind::Int(number) => {
+                    Type::string_literal(db, number.to_compact_string())
+                }
                 LiteralValueTypeKind::Bool(true) => Type::string_literal(db, "True"),
                 LiteralValueTypeKind::Bool(false) => Type::string_literal(db, "False"),
-                LiteralValueTypeKind::String(literal) => {
-                    Type::string_literal(db, &format!("'{}'", literal.value(db).escape_default()))
-                }
+                LiteralValueTypeKind::String(literal) => Type::string_literal(
+                    db,
+                    compact_str::format_compact!("'{}'", literal.value(db).escape_default()),
+                ),
                 LiteralValueTypeKind::LiteralString => Type::literal_string(),
                 _ => KnownClass::Str.to_instance(db),
             },
-            Type::SpecialForm(special_form) => Type::string_literal(db, &special_form.to_string()),
+            Type::SpecialForm(special_form) => Type::string_literal(db, &*special_form.to_string()),
             Type::KnownInstance(known_instance) => {
-                Type::string_literal(db, &known_instance.repr(db).to_string())
+                Type::string_literal(db, known_instance.repr(db).to_compact_string())
             }
             // TODO: handle more complex types
             _ => KnownClass::Str.to_instance(db),

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2049,7 +2049,7 @@ impl<'db> Bindings<'db> {
                                                 Type::heterogeneous_tuple(
                                                     db,
                                                     names.iter().map(|name| {
-                                                        Type::string_literal(db, name.as_str())
+                                                        Type::string_literal(db, *name)
                                                     }),
                                                 )
                                             }

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1,3 +1,4 @@
+use compact_str::ToCompactString;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -72,7 +73,7 @@ impl KnownEnumDataTypeMixin {
                 Type::int_literal(i64::from(value))
             }
             (Self::Str, Some(LiteralValueTypeKind::Int(value))) => {
-                Type::string_literal(db, &value.to_string())
+                Type::string_literal(db, value.to_compact_string())
             }
             (Self::Str, Some(LiteralValueTypeKind::Bool(value))) => {
                 Type::string_literal(db, if value { "True" } else { "False" })
@@ -385,7 +386,7 @@ impl<'db> EnumClassLiteral<'db> {
             return Some(KnownClass::Str.to_instance(db));
         }
         self.resolve_member(db, name)
-            .map(|name| Type::string_literal(db, name.as_str()))
+            .map(|name| Type::string_literal(db, name))
     }
 
     pub(crate) fn value_type(self, db: &'db dyn Db, name: &Name) -> Option<Type<'db>> {
@@ -613,7 +614,7 @@ impl<'db> EnumMetadata<'db> {
         let union = self
             .members
             .keys()
-            .map(|name| Type::string_literal(db, name.as_str()))
+            .map(|name| Type::string_literal(db, name))
             .fold(UnionBuilder::new(db), UnionBuilder::add)
             .build();
         Some(union)
@@ -1093,7 +1094,7 @@ pub(crate) fn enum_metadata<'db>(
                                     if Type::ClassLiteral(ClassLiteral::Static(class))
                                         .is_subtype_of(db, KnownClass::StrEnum.to_subclass_of(db))
                                     {
-                                        Type::string_literal(db, &name.to_lowercase())
+                                        Type::string_literal(db, &*name.to_lowercase())
                                     } else {
                                         let custom_mixins: SmallVec<[Option<KnownClass>; 1]> =
                                             class

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1,6 +1,7 @@
 use std::cell::{OnceCell, RefCell};
 use std::rc::Rc;
 
+use compact_str::CompactString;
 use itertools::Itertools;
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
@@ -10936,14 +10937,14 @@ impl From<bool> for DeferredExpressionState {
 /// infers an instance of `builtins.str`.
 #[derive(Debug)]
 struct StringPartsCollector {
-    concatenated: Option<String>,
+    concatenated: Option<CompactString>,
     contains_non_literal_str: bool,
 }
 
 impl StringPartsCollector {
     fn new() -> Self {
         Self {
-            concatenated: Some(String::new()),
+            concatenated: Some(CompactString::new("")),
             contains_non_literal_str: false,
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -688,7 +688,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             let mut value = CompactString::with_capacity(new_length);
                             value.push_str(lhs_value);
                             value.push_str(rhs_value);
-                            Type::string_literal_owned(db, value)
+                            Type::string_literal(db, value)
                         } else {
                             Type::literal_string()
                         };
@@ -719,7 +719,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             })
                         {
                             let new_literal = s.value(db).repeat(n);
-                            Type::string_literal(db, &new_literal)
+                            Type::string_literal(db, &*new_literal)
                         } else {
                             Type::literal_string()
                         };

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -102,7 +102,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let key = keyword_names
                     .get(&elt.node_index().load())
                     .expect("keyword-only dict() fast-path requires named keywords");
-                Type::string_literal(builder.db(), key.as_str())
+                Type::string_literal(builder.db(), key)
             } else {
                 builder.infer_expression(elt, tcx)
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -1,3 +1,4 @@
+use compact_str::ToCompactString;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, NodeIndex, PythonVersion};
 use rustc_hash::FxHashSet;
@@ -166,7 +167,7 @@ fn first_enum_auto_value<'db>(
     start: EnumStart,
 ) -> Type<'db> {
     match base_class {
-        KnownClass::StrEnum => Type::string_literal(db, &name.to_lowercase()),
+        KnownClass::StrEnum => Type::string_literal(db, &*name.to_lowercase()),
         _ => match start {
             EnumStart::Literal(start) => Type::int_literal(start),
             EnumStart::DynamicInt => KnownClass::Int.to_instance(db),
@@ -188,7 +189,7 @@ fn next_auto_value<'db>(
     last_int_value: Option<i64>,
 ) -> Type<'db> {
     match base_class {
-        KnownClass::StrEnum => Type::string_literal(db, &name.to_lowercase()),
+        KnownClass::StrEnum => Type::string_literal(db, &*name.to_lowercase()),
         _ => {
             let Some(last) = last_int_value else {
                 return KnownClass::Int.to_instance(db);
@@ -260,7 +261,7 @@ fn apply_generated_type_mixin_member_values<'db>(
                 .into_iter()
                 .map(|(name, value)| {
                     let value = if let Some(literal) = value.as_int_literal() {
-                        Type::string_literal(db, &literal.to_string())
+                        Type::string_literal(db, literal.to_compact_string())
                     } else if value.is_assignable_to(db, KnownClass::Int.to_instance(db)) {
                         KnownClass::Str.to_instance(db)
                     } else {

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -79,7 +79,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let keys = typed_dict
                         .items(db)
                         .keys()
-                        .map(|key| Type::string_literal(db, key.as_str()))
+                        .map(|key| Type::string_literal(db, key))
                         .collect_vec();
                     (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
                 }

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -11,6 +11,7 @@ use crate::{
         tuple::{TupleSpec, TupleSpecBuilder},
     },
 };
+use compact_str::ToCompactString;
 use ruff_python_ast as ast;
 use std::borrow::Cow;
 use ty_python_core::EvaluationMode;
@@ -132,7 +133,7 @@ impl<'db> Type<'db> {
                             TupleSpec::heterogeneous(
                                 string_literal
                                     .chars()
-                                    .map(|c| Type::string_literal(db, &c.to_string())),
+                                    .map(|c| Type::string_literal(db, c.to_compact_string())),
                             )
                         } else {
                             TupleSpec::homogeneous(Type::literal_string())

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::{self, Display};
 
+use compact_str::{CompactString, ToCompactString};
 use itertools::Itertools;
 use ruff_python_ast as ast;
 
@@ -648,7 +649,7 @@ impl<'db> Type<'db> {
                 i32::try_from(i64_int).ok().map(|i32_int| {
                     let literal_value = literal_ty.value(db);
                     match (&mut literal_value.chars()).py_index(db, i32_int) {
-                        Ok(ch) => Ok(Type::string_literal(db, &ch.to_string())),
+                        Ok(ch) => Ok(Type::string_literal(db, ch.to_compact_string())),
                         Err(_) => Err(SubscriptError::new(
                             Type::unknown(),
                             SubscriptErrorKind::IndexOutOfBounds {
@@ -673,8 +674,8 @@ impl<'db> Type<'db> {
 
                     match chars.py_slice(db, start, stop, step) {
                         Ok(new_chars) => {
-                            let literal = new_chars.collect::<String>();
-                            Ok(Type::string_literal(db, &literal))
+                            let literal = new_chars.collect::<CompactString>();
+                            Ok(Type::string_literal(db, literal))
                         }
                         Err(_) => Err(SubscriptError::new(
                             Type::unknown(),

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -2275,7 +2275,7 @@ impl<'db> Tuple<Type<'db>> {
         let release_level_ty = {
             let elements: Box<[Type<'db>]> = ["alpha", "beta", "candidate", "final"]
                 .iter()
-                .map(|level| Type::string_literal(db, level))
+                .map(|level| Type::string_literal(db, *level))
                 .collect();
 
             // For most unions, it's better to go via `UnionType::from_elements` or use `UnionBuilder`;


### PR DESCRIPTION
## Summary

Rather than having one helper for owned values and another helper for borrowed values, have a single helper that can take `CompactString`, `&str`, `Name` or `&Name` and (in the cases of owned values) passes the owned value directly to Salsa, avoiding unnecessary clones.

Also, collect directly into `CompactString` in various places rather than collecting into a `String` and then converting it to a `CompactString` afterwards.

This is what I was thinking of in my review comment in https://github.com/astral-sh/ruff/pull/26547#discussion_r3529965484

## Test Plan

existing tests