### PR TITLE
[ty] Check nongeneric implementations against generic protocol methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2784,6 +2784,9 @@ class NominalNotGeneric:
     def f(self, input: int) -> int:
         return input
 
+class ProtocolNotGeneric(Protocol):
+    def f(self, input: int) -> int: ...
+
 class GenericReturnsObject(Protocol):
     def f(self, input: FunctionT) -> object: ...
 
@@ -2837,6 +2840,9 @@ static_assert(is_subtype_of(NominalWithSelf, UsesSelf))
 static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalNotGeneric, UsesSelf))
+
+static_assert(not is_subtype_of(ProtocolNotGeneric, NewStyleFunctionScoped))
+static_assert(not is_assignable_to(ProtocolNotGeneric, NewStyleFunctionScoped))
 
 static_assert(is_subtype_of(NominalAcceptsObject, GenericReturnsObject))
 static_assert(is_assignable_to(NominalAcceptsObject, GenericReturnsObject))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2697,7 +2697,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Callable, final
+from typing import Callable, Literal, final
 from typing_extensions import TypeVar, Self, Protocol
 from ty_extensions import is_equivalent_to, static_assert, is_assignable_to, is_subtype_of
 
@@ -2798,6 +2798,13 @@ class NominalIntCallback:
     def m(self, item: int, callback: Callable[[int], str]) -> str:
         return callback(item)
 
+class SingletonBounded(Protocol):
+    def f[T: Literal[1]](self, input: T) -> T: ...
+
+class NominalSingleton:
+    def f(self, input: Literal[1]) -> Literal[1]:
+        return input
+
 class NominalReturningSelfNotGeneric:
     def g(self) -> "NominalReturningSelfNotGeneric":
         return self
@@ -2836,6 +2843,9 @@ static_assert(is_assignable_to(NominalAcceptsObject, GenericReturnsObject))
 
 static_assert(not is_subtype_of(NominalIntCallback, GenericCallback))
 static_assert(not is_assignable_to(NominalIntCallback, GenericCallback))
+
+static_assert(is_subtype_of(NominalSingleton, SingletonBounded))
+static_assert(is_assignable_to(NominalSingleton, SingletonBounded))
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, LegacyFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2697,7 +2697,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import final
+from typing import Callable, final
 from typing_extensions import TypeVar, Self, Protocol
 from ty_extensions import is_equivalent_to, static_assert, is_assignable_to, is_subtype_of
 
@@ -2784,6 +2784,20 @@ class NominalNotGeneric:
     def f(self, input: int) -> int:
         return input
 
+class GenericReturnsObject(Protocol):
+    def f(self, input: FunctionT) -> object: ...
+
+class NominalAcceptsObject:
+    def f(self, input: object) -> object:
+        return input
+
+class GenericCallback(Protocol):
+    def m(self, item: FunctionT, callback: Callable[[FunctionT], str]) -> str: ...
+
+class NominalIntCallback:
+    def m(self, item: int, callback: Callable[[int], str]) -> str:
+        return callback(item)
+
 class NominalReturningSelfNotGeneric:
     def g(self) -> "NominalReturningSelfNotGeneric":
         return self
@@ -2813,10 +2827,15 @@ static_assert(not is_assignable_to(NominalWithSelf, LegacyFunctionScoped))
 static_assert(is_assignable_to(NominalWithSelf, UsesSelf))
 static_assert(is_subtype_of(NominalWithSelf, UsesSelf))
 
-# TODO: these should pass
-static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))  # error: [static-assert-error]
+static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))
+static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalNotGeneric, UsesSelf))
+
+static_assert(is_subtype_of(NominalAcceptsObject, GenericReturnsObject))
+static_assert(is_assignable_to(NominalAcceptsObject, GenericReturnsObject))
+
+static_assert(not is_subtype_of(NominalIntCallback, GenericCallback))
+static_assert(not is_assignable_to(NominalIntCallback, GenericCallback))
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, LegacyFunctionScoped))

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1412,7 +1412,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         self.check_callable_pair(
                             db,
                             source,
-                            rigidify_generic_protocol_target_for_monomorphic_source(
+                            make_protocol_target_typevars_non_inferable_for_nongeneric_source(
                                 db, source, target,
                             ),
                         )
@@ -1628,7 +1628,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 ) else {
                     return self.never();
                 };
-                self.check_type_pair(db, source, target)
+                if let (Type::Callable(source), Type::Callable(target)) = (source, target) {
+                    self.check_type_pair(
+                        db,
+                        Type::Callable(source),
+                        Type::Callable(
+                            make_protocol_target_typevars_non_inferable_for_nongeneric_source(
+                                db, source, target,
+                            ),
+                        ),
+                    )
+                } else {
+                    self.check_type_pair(db, source, target)
+                }
             }
         };
 
@@ -1982,30 +1994,40 @@ fn protocol_bind_self<'db>(
     )
 }
 
-/// Make method-scoped type variables in a generic protocol method rigid when its implementation
-/// is monomorphic.
+/// Make a protocol target's type variables non-inferable when the source is nongeneric.
 ///
-/// A monomorphic implementation must support every specialization promised by the protocol
-/// method. First, type variables with single-valued upper bounds are replaced by those bounds,
-/// because every specialization has the same runtime value. Removing the remaining generic
-/// context keeps its type variables in the signature but prevents callable matching from choosing
-/// a single convenient specialization for them.
-fn rigidify_generic_protocol_target_for_monomorphic_source<'db>(
+/// A generic protocol method allows callers to use every valid specialization. A nongeneric
+/// implementation must therefore support all of them. Callable matching normally infers type
+/// variables from a target signature's generic context, which can make an incompatible source
+/// appear compatible by choosing one specialization that happens to match it. Removing the target
+/// signature's generic context while leaving its type variables in place prevents that inference.
+///
+/// Type variables with single-valued upper bounds are replaced by those bounds because every
+/// specialization has the same runtime value. If the source is also generic, or the target is not
+/// generic, this returns the target unchanged and leaves the comparison to the existing callable
+/// relation.
+fn make_protocol_target_typevars_non_inferable_for_nongeneric_source<'db>(
     db: &'db dyn Db,
     source: CallableType<'db>,
     target: CallableType<'db>,
 ) -> CallableType<'db> {
-    let has_method_typevars = |callable: CallableType<'db>| {
+    let has_non_self_typevars = |callable: CallableType<'db>| {
         callable.signatures(db).iter().any(|signature| {
+            // A generic context can be temporarily incomplete during recursive inference, so
+            // also inspect the types in the signature itself.
             signature.generic_context.is_some_and(|context| {
                 context
                     .variables(db)
                     .any(|typevar| !typevar.typevar(db).is_self(db))
-            })
+            }) || signature
+                .parameters()
+                .iter()
+                .any(|parameter| parameter.annotated_type().has_non_self_typevar(db))
+                || signature.return_ty.has_non_self_typevar(db)
         })
     };
 
-    if has_method_typevars(source) || !has_method_typevars(target) {
+    if has_non_self_typevars(source) || !has_non_self_typevars(target) {
         return target;
     }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -22,8 +22,8 @@ use crate::{
         place_from_declarations,
     },
     types::{
-        ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, ClassBase,
-        ClassType, ErrorContext, FindLegacyTypeVarsVisitor,
+        ApplySpecialization, ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance,
+        CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor,
         InstanceFallbackShadowsNonDataDescriptor, KnownFunction, MemberLookupPolicy,
         PropertyInstanceType, ProtocolInstanceType, SelfBinding, StaticClassLiteral, Type,
         TypeMapping, TypeQualifiers, TypeVarVariance, UnionType, VarianceInferable,
@@ -1986,8 +1986,10 @@ fn protocol_bind_self<'db>(
 /// is monomorphic.
 ///
 /// A monomorphic implementation must support every specialization promised by the protocol
-/// method. Removing the target's generic context keeps its type variables in the signature but
-/// prevents callable matching from choosing a single convenient specialization for them.
+/// method. First, type variables with single-valued upper bounds are replaced by those bounds,
+/// because every specialization has the same runtime value. Removing the remaining generic
+/// context keeps its type variables in the signature but prevents callable matching from choosing
+/// a single convenient specialization for them.
 fn rigidify_generic_protocol_target_for_monomorphic_source<'db>(
     db: &'db dyn Db,
     source: CallableType<'db>,
@@ -2011,6 +2013,26 @@ fn rigidify_generic_protocol_target_for_monomorphic_source<'db>(
         db,
         CallableSignature::from_overloads(target.signatures(db).iter().map(|signature| {
             let mut signature = signature.clone();
+            let singleton_typevars = signature
+                .generic_context
+                .into_iter()
+                .flat_map(|context| context.variables(db))
+                .filter_map(|typevar| {
+                    typevar
+                        .typevar(db)
+                        .upper_bound(db)
+                        .filter(|bound| bound.is_single_valued(db))
+                        .map(|bound| (typevar, bound))
+                })
+                .collect::<Vec<_>>();
+            for (typevar, bound) in singleton_typevars {
+                signature = signature.apply_type_mapping_impl(
+                    db,
+                    &TypeMapping::ApplySpecialization(ApplySpecialization::Single(typevar, bound)),
+                    TypeContext::default(),
+                    &ApplyTypeMappingVisitor::default(),
+                );
+            }
             signature.generic_context = None;
             signature
         })),

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -13,6 +13,7 @@ use crate::types::attribute_write::{
 use crate::types::call::{CallArguments, CallDunderError};
 use crate::types::callable::CallableTypeKind;
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
+use crate::types::signatures::CallableSignature;
 use crate::types::{TypeContext, UpcastPolicy};
 use crate::{
     Db, FxOrderSet,
@@ -1405,11 +1406,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             attribute_type
                 .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
                 .when_some_and(db, self.constraints, |callables| {
-                    self.check_callables_vs_callable(
-                        db,
-                        &callables.map(|callable| callable.apply_self(db, fallback_ty)),
-                        required_callable.apply_self(db, fallback_ty),
-                    )
+                    let target = required_callable.apply_self(db, fallback_ty);
+                    callables.iter().when_all(db, self.constraints, |callable| {
+                        let source = callable.apply_self(db, fallback_ty);
+                        self.check_callable_pair(
+                            db,
+                            source,
+                            rigidify_generic_protocol_target_for_monomorphic_source(
+                                db, source, target,
+                            ),
+                        )
+                    })
                 })
         } else if member.is_method() {
             let Some(required_ty) = required_ty.resolve(db) else {
@@ -1972,6 +1979,43 @@ fn protocol_bind_self<'db>(
         callable.signatures(db).bind_self(db, self_type),
         CallableTypeKind::Regular,
         callable.provenance(db),
+    )
+}
+
+/// Make method-scoped type variables in a generic protocol method rigid when its implementation
+/// is monomorphic.
+///
+/// A monomorphic implementation must support every specialization promised by the protocol
+/// method. Removing the target's generic context keeps its type variables in the signature but
+/// prevents callable matching from choosing a single convenient specialization for them.
+fn rigidify_generic_protocol_target_for_monomorphic_source<'db>(
+    db: &'db dyn Db,
+    source: CallableType<'db>,
+    target: CallableType<'db>,
+) -> CallableType<'db> {
+    let has_method_typevars = |callable: CallableType<'db>| {
+        callable.signatures(db).iter().any(|signature| {
+            signature.generic_context.is_some_and(|context| {
+                context
+                    .variables(db)
+                    .any(|typevar| !typevar.typevar(db).is_self(db))
+            })
+        })
+    };
+
+    if has_method_typevars(source) || !has_method_typevars(target) {
+        return target;
+    }
+
+    CallableType::new(
+        db,
+        CallableSignature::from_overloads(target.signatures(db).iter().map(|signature| {
+            let mut signature = signature.clone();
+            signature.generic_context = None;
+            signature
+        })),
+        target.kind(db),
+        target.provenance(db),
     )
 }
 


### PR DESCRIPTION
## Summary

When checking a nongeneric implementation against a generic protocol method, we previously allowed callable matching to infer the protocol method's type variables from the implementation. This could accept one convenient specialization even though a generic protocol method must support every valid specialization:

```python
from typing import Protocol

class Identity(Protocol):
    def apply[T](self, value: T) -> T: ...

class IntIdentity:
    def apply(self, value: int) -> int:
        return value
```

`IntIdentity` cannot implement `Identity` because it does not support specializations such as `T = str`.

This PR makes target method type variables non-inferable when the source is nongeneric, so the implementation must be compatible with all permitted uses. The same handling is applied when the source is itself a protocol. Type variables with single-valued upper bounds are replaced by those bounds first, preserving valid implementations of requirements such as `def apply[T: Literal[1]](self, value: T) -> T`.

This intentionally addresses the nongeneric-source case. If the source also contains non-`Self` type variables, the existing callable relation continues to handle the comparison. The protocol mdtests cover nominal and protocol sources, nested callback types, broad `object` implementations, and singleton bounds; the full `ty_python_semantic` suite and all-features Clippy pass.
