### PR TITLE
[ty] Preserve invariant materialization on generic specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -1302,7 +1302,7 @@ def test_match_generic_container_member_keeps_loop_reachable(
     match value:
         case GenericListOverlapB(values=items):
             for item in items:
-                reveal_type(item)  # revealed: Unknown
+                reveal_type(item)  # revealed: object
 ```
 
 ## Class pattern captures from `Any` and `Unknown`

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -871,6 +871,19 @@ def capybara(top: Top[Invariant[Any]], bottom: Bottom[Invariant[Any]]) -> None:
 
     reveal_type(top.attr)  # revealed: object
     reveal_type(bottom.attr)  # revealed: Never
+
+def slice_list(top: Top[list[Any]], bottom: Bottom[list[Any]]) -> None:
+    reveal_type(top[:])  # revealed: Top[list[Any]]
+    reveal_type(bottom[:])  # revealed: Bottom[list[Any]]
+
+class Mixed[T, U]:
+    first: T
+    second: U
+    nested: list[tuple[Any, U]]
+
+def preserve_unrelated_any(top: Top[Mixed[Any, int]], bottom: Bottom[Mixed[Any, int]]) -> None:
+    reveal_type(top.nested)  # revealed: list[tuple[Any, int]]
+    reveal_type(bottom.nested)  # revealed: list[tuple[Any, int]]
 ```
 
 Alias specializations also preserve the materialization polarity in contravariant positions.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1284,12 +1284,47 @@ impl<'db> Specialization<'db> {
             return self.materialize_impl(db, *materialization_kind, visitor);
         }
 
+        let mut new_materialization_kind = self.materialization_kind(db);
         let types = self.map_types(db, |i, typevar, ty| {
             let tcx = TypeContext::new(tcx.get(i).copied());
-            if typevar.variance(db).is_covariant() {
-                ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
-            } else {
-                ty.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor)
+            match (typevar.variance(db), type_mapping) {
+                (
+                    TypeVarVariance::Invariant,
+                    TypeMapping::ApplySpecializationWithMaterialization {
+                        specialization,
+                        materialization_kind,
+                    },
+                ) => {
+                    // An invariant type argument cannot be materialized in isolation. Keep the
+                    // specialized argument and record the materialization on this specialization.
+                    // Comparing both mappings distinguishes substituted gradual types from
+                    // unrelated gradual types already present in the argument. Use separate
+                    // visitors because their transformation caches are keyed only by type.
+                    let specialized = ty.apply_type_mapping_impl(
+                        db,
+                        &TypeMapping::ApplySpecialization(*specialization),
+                        tcx,
+                        &ApplyTypeMappingVisitor::default(),
+                    );
+
+                    if new_materialization_kind.is_none() {
+                        let materialized = ty.apply_type_mapping_impl(
+                            db,
+                            type_mapping,
+                            tcx,
+                            &ApplyTypeMappingVisitor::default(),
+                        );
+                        if specialized != materialized {
+                            new_materialization_kind = Some(*materialization_kind);
+                        }
+                    }
+
+                    specialized
+                }
+                (variance, _) if variance.is_covariant() => {
+                    ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                }
+                _ => ty.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
             }
         });
 
@@ -1299,8 +1334,9 @@ impl<'db> Specialization<'db> {
         });
 
         // Keep this check in sync with every field that can be transformed above.
-        let specialization_unchanged =
-            matches!(&types, Cow::Borrowed(_)) && tuple_inner == original_tuple_inner;
+        let specialization_unchanged = matches!(&types, Cow::Borrowed(_))
+            && tuple_inner == original_tuple_inner
+            && new_materialization_kind == self.materialization_kind(db);
         if specialization_unchanged {
             self
         } else {
@@ -1308,7 +1344,7 @@ impl<'db> Specialization<'db> {
                 db,
                 self.generic_context(db),
                 types,
-                self.materialization_kind(db),
+                new_materialization_kind,
                 tuple_inner,
             )
         }


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ty/issues/3903

Keep invariant type arguments specialized when materializing gradual types, instead of materializing them in isolation. This fixes getting attributes (etc) in invariant position off of a materialized type.

## Testing

Updated/added mdtests.

### Ecosystem

Ecosystem changes are correct. Added diagnostics reflect code that we previously thought was unreachable or typed as `Never` instead correctly using a top-materialized type.