### PR TITLE
[ty] Compare generic callables directionally

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -386,6 +386,7 @@ class PolyRing(DefaultPrinting, IPolys[T], Generic[T]):
     symbols: tuple[object, ...]
     domain: Domain[T]
 
+    # error: [invalid-method-override]
     def clone(
         self,
         symbols: object | None = None,

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -366,10 +366,11 @@ reveal_type(partial(partial, drop)(1)("x"))  # revealed: Unknown
 reveal_type(partial(partial, drop)("x")(1))  # revealed: Unknown
 ```
 
-## SymPy one-import MRE scaffold (multi-file)
+## SymPy overload regression
 
-Reduced regression lock for a SymPy overload/protocol shape that can panic in the
-overload-assignability path.
+This reduced SymPy example checks that overload comparison does not panic. It also rejects the
+`clone` override: the inherited overload accepts `Domain[S]` and returns `IPolys[S]`, while the
+override always returns `PolyRing[T]`.
 
 ```py
 from __future__ import annotations

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -327,11 +327,11 @@ reveal_type(int | Invalid())  # revealed: Unknown
 reveal_type(Invalid() | list[int])  # revealed: Unknown
 ```
 
-## Custom `__(r)or__` methods on metaclasses are only partially respected
+## Custom union methods on metaclasses are only partially respected
 
-A drawback of our extensive special casing of `|` operations between class objects is that
-`__(r)or__` methods on metaclasses are completely disregarded if two classes are `|`'d together. We
-respect the metaclass dunder if a class is `|`'d with a non-class, however:
+Ty special-cases `|` between class objects, so it ignores a metaclass's `__or__` and `__ror__`
+methods when both operands are classes. The custom method below is also an invalid override of
+`type.__or__`, because it returns `str` instead of a union object:
 
 ```py
 class Meta(type):
@@ -343,17 +343,22 @@ class Foo(metaclass=Meta): ...
 class Bar(metaclass=Meta): ...
 
 X = Foo | Bar
+```
 
-# In an ideal world, perhaps we would respect `Meta.__or__` here and reveal `str`?
-# But we still need to record what the elements are, since (according to the typing spec)
-# `X` is still a valid type alias
+Even though `Meta.__or__` returns `str`, `X` remains a valid union type alias when both operands are
+classes:
+
+```py
 reveal_type(X)  # revealed: <types.UnionType special-form 'Foo | Bar'>
 
 def f(obj: X):
     reveal_type(obj)  # revealed: Foo | Bar
+```
 
-# We do respect the metaclass `__or__` if it's used between a class and a non-class, however:
+Ty uses `Meta.__or__` when the other operand is not a class, so these expressions have type `str`
+and cannot be used as type annotations:
 
+```py
 Y = Foo | 42
 reveal_type(Y)  # revealed: str
 

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -335,6 +335,7 @@ respect the metaclass dunder if a class is `|`'d with a non-class, however:
 
 ```py
 class Meta(type):
+    # error: [invalid-method-override]
     def __or__(self, other) -> str:
         return "Meta"
 

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -878,10 +878,13 @@ class B(A):
 
 class C(A):
     def method(self, x: object) -> Never: ...  # fine
+```
 
+`A.method` accepts an argument of any type. An override restricted to `int` rejects calls that are
+valid for the base method:
+
+```pyi
 class D(A):
-    # `A.method` accepts an argument of any type,
-    # but `D.method` only accepts `int`s
     def method(self, x: int) -> int: ...  # error: [invalid-method-override]
 
 class A2:
@@ -944,11 +947,13 @@ class I3(A3):
 
 class A4:
     def method[T: int](self, x: T) -> T: ...
+```
 
+`A4.method` preserves the caller's exact subtype of `int` in its return type. An override that
+returns `int` loses that promise when passed a `bool` or another subclass:
+
+```pyi
 class B4(A4):
-    # `A4.method` promises that if it is passed a `bool`, it will return a `bool`,
-    # but this is not necessarily true for `B4.method`: if passed a `bool`,
-    # it could return a non-`bool` `int`!
     def method(self, x: int) -> int: ...  # error: [invalid-method-override]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -880,10 +880,9 @@ class C(A):
     def method(self, x: object) -> Never: ...  # fine
 
 class D(A):
-    # TODO: we should emit [invalid-method-override] here:
     # `A.method` accepts an argument of any type,
     # but `D.method` only accepts `int`s
-    def method(self, x: int) -> int: ...
+    def method(self, x: int) -> int: ...  # error: [invalid-method-override]
 
 class A2:
     def method(self, x: int) -> int: ...
@@ -947,11 +946,10 @@ class A4:
     def method[T: int](self, x: T) -> T: ...
 
 class B4(A4):
-    # TODO: we should emit `invalid-method-override` here.
     # `A4.method` promises that if it is passed a `bool`, it will return a `bool`,
     # but this is not necessarily true for `B4.method`: if passed a `bool`,
     # it could return a non-`bool` `int`!
-    def method(self, x: int) -> int: ...
+    def method(self, x: int) -> int: ...  # error: [invalid-method-override]
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2819,6 +2819,15 @@ class ReorderedPairImplementation:
     def f[S, R](self, first: R, second: S) -> tuple[R, S]:
         return first, second
 
+class IntBoundIdentityProtocol(Protocol):
+    def f[T: int](self, input: T) -> T: ...
+
+class GenericListReturnImplementation:
+    def f[S](self, input: S) -> list[S]:
+        return [input]
+
+def requires_int_bound_identity(value: IntBoundIdentityProtocol) -> None: ...
+
 class NominalReturningSelfNotGeneric:
     def g(self) -> "NominalReturningSelfNotGeneric":
         return self
@@ -2860,10 +2869,11 @@ static_assert(is_assignable_to(ObjectBoundImplementation, StrBoundProtocol))
 static_assert(not is_subtype_of(StrBoundImplementation, ObjectBoundProtocol))
 static_assert(not is_assignable_to(StrBoundImplementation, ObjectBoundProtocol))
 
-static_assert(is_subtype_of(GenericListImplementation, NestedListProtocol))
 static_assert(is_assignable_to(GenericListImplementation, NestedListProtocol))
 static_assert(is_subtype_of(ReorderedPairImplementation, PairProtocol))
 static_assert(is_assignable_to(ReorderedPairImplementation, PairProtocol))
+
+requires_int_bound_identity(GenericListReturnImplementation())  # error: [invalid-argument-type]
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, LegacyFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2833,12 +2833,24 @@ def requires_int_bound_identity(value: IntBoundIdentityProtocol) -> None: ...
 class IntOrStrIdentityProtocol(Protocol):
     def f[T: (int, str)](self, input: T) -> T: ...
 
+# Separate overloads cannot jointly cover a generic target. One source overload must satisfy every
+# specialization of the target method.
 class IntOrStrOverloadedImplementation:
     @overload
     def f(self, input: int) -> int: ...
     @overload
     def f(self, input: str) -> str: ...
     def f(self, input: int | str) -> int | str:
+        return input
+
+# A source overload set is valid if one generic overload covers the entire target, regardless of
+# unrelated additional overloads.
+class IntOrStrGenericOverloadedImplementation:
+    @overload
+    def f[T: (int, str)](self, input: T) -> T: ...
+    @overload
+    def f(self, input: bytes) -> bytes: ...
+    def f(self, input: int | str | bytes) -> int | str | bytes:
         return input
 
 def requires_int_or_str_identity(value: IntOrStrIdentityProtocol) -> None: ...
@@ -2890,7 +2902,8 @@ static_assert(is_subtype_of(ReorderedPairImplementation, PairProtocol))
 static_assert(is_assignable_to(ReorderedPairImplementation, PairProtocol))
 
 requires_int_bound_identity(GenericListReturnImplementation())  # error: [invalid-argument-type]
-requires_int_or_str_identity(IntOrStrOverloadedImplementation())
+requires_int_or_str_identity(IntOrStrOverloadedImplementation())  # error: [invalid-argument-type]
+requires_int_or_str_identity(IntOrStrGenericOverloadedImplementation())
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, LegacyFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2805,6 +2805,8 @@ class StrBoundImplementation:
     def f[T: str](self, input: T) -> T:
         return input
 
+def requires_object_bound(value: ObjectBoundProtocol) -> None: ...
+
 class NestedListProtocol(Protocol):
     def f[T](self, input: list[T]) -> list[list[T]]: ...
 
@@ -2881,6 +2883,7 @@ static_assert(is_subtype_of(ObjectBoundImplementation, StrBoundProtocol))
 static_assert(is_assignable_to(ObjectBoundImplementation, StrBoundProtocol))
 static_assert(not is_subtype_of(StrBoundImplementation, ObjectBoundProtocol))
 static_assert(not is_assignable_to(StrBoundImplementation, ObjectBoundProtocol))
+requires_object_bound(StrBoundImplementation())  # error: [invalid-argument-type]
 
 static_assert(is_assignable_to(GenericListImplementation, NestedListProtocol))
 static_assert(is_subtype_of(ReorderedPairImplementation, PairProtocol))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2784,6 +2784,27 @@ class NominalNotGeneric:
     def f(self, input: int) -> int:
         return input
 
+class GenericReturnsObject(Protocol):
+    def f(self, input: FunctionT) -> object: ...
+
+class NominalAcceptsObject:
+    def f(self, input: object) -> object:
+        return input
+
+class ObjectBoundProtocol(Protocol):
+    def f[T: object](self, input: T) -> T: ...
+
+class StrBoundProtocol(Protocol):
+    def f[T: str](self, input: T) -> T: ...
+
+class ObjectBoundImplementation:
+    def f[T: object](self, input: T) -> T:
+        return input
+
+class StrBoundImplementation:
+    def f[T: str](self, input: T) -> T:
+        return input
+
 class NominalReturningSelfNotGeneric:
     def g(self) -> "NominalReturningSelfNotGeneric":
         return self
@@ -2813,10 +2834,17 @@ static_assert(not is_assignable_to(NominalWithSelf, LegacyFunctionScoped))
 static_assert(is_assignable_to(NominalWithSelf, UsesSelf))
 static_assert(is_subtype_of(NominalWithSelf, UsesSelf))
 
-# TODO: these should pass
-static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))  # error: [static-assert-error]
+static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))
+static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalNotGeneric, UsesSelf))
+
+static_assert(is_subtype_of(NominalAcceptsObject, GenericReturnsObject))
+static_assert(is_assignable_to(NominalAcceptsObject, GenericReturnsObject))
+
+static_assert(is_subtype_of(ObjectBoundImplementation, StrBoundProtocol))
+static_assert(is_assignable_to(ObjectBoundImplementation, StrBoundProtocol))
+static_assert(not is_subtype_of(StrBoundImplementation, ObjectBoundProtocol))
+static_assert(not is_assignable_to(StrBoundImplementation, ObjectBoundProtocol))
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, LegacyFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2848,6 +2848,27 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolImplicitSelf))
 static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 ```
 
+### Generic self types
+
+A method type variable used for `self` is specialized to the concrete receiver. It is not chosen
+independently on every call like an ordinary method type variable:
+
+```py
+from typing import Protocol, TypeVar
+from ty_extensions import is_assignable_to, static_assert
+
+SelfT = TypeVar("SelfT", bound="Copyable")
+
+class Copyable(Protocol):
+    def copy(self: SelfT) -> SelfT: ...
+
+class One:
+    def copy(self) -> "One":
+        return One()
+
+static_assert(is_assignable_to(One, Copyable))
+```
+
 ### Concrete implementations
 
 A non-generic method can satisfy a generic protocol method if it accepts every call promised by the

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2697,6 +2697,7 @@ python-version = "3.12"
 ```
 
 ```py
+from collections.abc import Sequence
 from typing import final, overload
 from typing_extensions import TypeVar, Self, Protocol
 from ty_extensions import is_equivalent_to, static_assert, is_assignable_to, is_subtype_of
@@ -2814,6 +2815,15 @@ class GenericListImplementation:
     def f[S](self, input: S) -> list[S]:
         return [input]
 
+class ListIdentityProtocol(Protocol):
+    def f[T](self, input: list[T]) -> list[T]: ...
+
+class SequenceIdentityImplementation:
+    def f[S: Sequence[object]](self, input: S) -> S:
+        return input
+
+def requires_list_identity(value: ListIdentityProtocol) -> None: ...
+
 class PairProtocol(Protocol):
     def f[T, U](self, first: T, second: U) -> tuple[T, U]: ...
 
@@ -2898,6 +2908,8 @@ static_assert(not is_assignable_to(StrBoundImplementation, ObjectBoundProtocol))
 requires_object_bound(StrBoundImplementation())  # error: [invalid-argument-type]
 
 static_assert(is_assignable_to(GenericListImplementation, NestedListProtocol))
+static_assert(is_assignable_to(SequenceIdentityImplementation, ListIdentityProtocol))
+requires_list_identity(SequenceIdentityImplementation())
 static_assert(is_subtype_of(ReorderedPairImplementation, PairProtocol))
 static_assert(is_assignable_to(ReorderedPairImplementation, PairProtocol))
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2805,6 +2805,20 @@ class StrBoundImplementation:
     def f[T: str](self, input: T) -> T:
         return input
 
+class NestedListProtocol(Protocol):
+    def f[T](self, input: list[T]) -> list[list[T]]: ...
+
+class GenericListImplementation:
+    def f[S](self, input: S) -> list[S]:
+        return [input]
+
+class PairProtocol(Protocol):
+    def f[T, U](self, first: T, second: U) -> tuple[T, U]: ...
+
+class ReorderedPairImplementation:
+    def f[S, R](self, first: R, second: S) -> tuple[R, S]:
+        return first, second
+
 class NominalReturningSelfNotGeneric:
     def g(self) -> "NominalReturningSelfNotGeneric":
         return self
@@ -2845,6 +2859,11 @@ static_assert(is_subtype_of(ObjectBoundImplementation, StrBoundProtocol))
 static_assert(is_assignable_to(ObjectBoundImplementation, StrBoundProtocol))
 static_assert(not is_subtype_of(StrBoundImplementation, ObjectBoundProtocol))
 static_assert(not is_assignable_to(StrBoundImplementation, ObjectBoundProtocol))
+
+static_assert(is_subtype_of(GenericListImplementation, NestedListProtocol))
+static_assert(is_assignable_to(GenericListImplementation, NestedListProtocol))
+static_assert(is_subtype_of(ReorderedPairImplementation, PairProtocol))
+static_assert(is_assignable_to(ReorderedPairImplementation, PairProtocol))
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, LegacyFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2849,8 +2849,40 @@ class IntOrStrConstrainedObjectImplementation:
     def f[S: (int, str)](self, input: S) -> object:
         return input
 
+class ConstrainedListProtocol(Protocol):
+    def f[T: (int, str)](self, input: list[T]) -> object: ...
+
+class ConstrainedListImplementation:
+    def f[S: (list[int], list[str])](self, input: S) -> object:
+        return input
+
+class UnusedConstrainedTypevarsImplementation:
+    def f[
+        S01: (int, str),
+        S02: (int, str),
+        S03: (int, str),
+        S04: (int, str),
+        S05: (int, str),
+        S06: (int, str),
+        S07: (int, str),
+        S08: (int, str),
+        S09: (int, str),
+        S10: (int, str),
+        S11: (int, str),
+        S12: (int, str),
+        S13: (int, str),
+        S14: (int, str),
+        S15: (int, str),
+        S16: (int, str),
+        S17: (int, str),
+        S18: (int, str),
+    ](self, input: object) -> object:
+        return input
+
 def requires_int_bound_identity(value: IntBoundIdentityProtocol) -> None: ...
 def requires_int_bound_object(value: IntBoundObjectProtocol) -> None: ...
+def requires_constrained_list(value: ConstrainedListProtocol) -> None: ...
+def requires_generic_returns_object(value: GenericReturnsObject) -> None: ...
 
 class IntOrStrIdentityProtocol(Protocol):
     def f[T: (int, str)](self, input: T) -> T: ...
@@ -2932,6 +2964,10 @@ requires_int_bound_identity(
 )
 static_assert(is_assignable_to(IntOrStrConstrainedObjectImplementation, IntBoundObjectProtocol))
 requires_int_bound_object(IntOrStrConstrainedObjectImplementation())
+static_assert(is_assignable_to(ConstrainedListImplementation, ConstrainedListProtocol))
+requires_constrained_list(ConstrainedListImplementation())
+static_assert(is_assignable_to(UnusedConstrainedTypevarsImplementation, GenericReturnsObject))
+requires_generic_returns_object(UnusedConstrainedTypevarsImplementation())
 static_assert(is_assignable_to(IntOrStrConstrainedIdentityImplementation, IntOrStrIdentityProtocol))
 requires_int_or_str_identity(IntOrStrConstrainedIdentityImplementation())
 requires_int_or_str_identity(IntOrStrOverloadedImplementation())  # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2918,15 +2918,11 @@ static_assert(is_subtype_of(ReorderedPairImplementation, PairProtocol))
 static_assert(is_assignable_to(ReorderedPairImplementation, PairProtocol))
 
 requires_int_bound_identity(GenericListReturnImplementation())  # error: [invalid-argument-type]
-static_assert(
-    not is_assignable_to(IntOrStrConstrainedIdentityImplementation, IntBoundIdentityProtocol)
-)
+static_assert(not is_assignable_to(IntOrStrConstrainedIdentityImplementation, IntBoundIdentityProtocol))
 requires_int_bound_identity(
     IntOrStrConstrainedIdentityImplementation()  # error: [invalid-argument-type]
 )
-static_assert(
-    is_assignable_to(IntOrStrConstrainedIdentityImplementation, IntOrStrIdentityProtocol)
-)
+static_assert(is_assignable_to(IntOrStrConstrainedIdentityImplementation, IntOrStrIdentityProtocol))
 requires_int_or_str_identity(IntOrStrConstrainedIdentityImplementation())
 requires_int_or_str_identity(IntOrStrOverloadedImplementation())  # error: [invalid-argument-type]
 requires_int_or_str_identity(IntOrStrGenericOverloadedImplementation())

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2838,6 +2838,10 @@ class GenericListReturnImplementation:
     def f[S](self, input: S) -> list[S]:
         return [input]
 
+class IntOrStrConstrainedIdentityImplementation:
+    def f[S: (int, str)](self, input: S) -> S:
+        return input
+
 def requires_int_bound_identity(value: IntBoundIdentityProtocol) -> None: ...
 
 class IntOrStrIdentityProtocol(Protocol):
@@ -2914,6 +2918,16 @@ static_assert(is_subtype_of(ReorderedPairImplementation, PairProtocol))
 static_assert(is_assignable_to(ReorderedPairImplementation, PairProtocol))
 
 requires_int_bound_identity(GenericListReturnImplementation())  # error: [invalid-argument-type]
+static_assert(
+    not is_assignable_to(IntOrStrConstrainedIdentityImplementation, IntBoundIdentityProtocol)
+)
+requires_int_bound_identity(
+    IntOrStrConstrainedIdentityImplementation()  # error: [invalid-argument-type]
+)
+static_assert(
+    is_assignable_to(IntOrStrConstrainedIdentityImplementation, IntOrStrIdentityProtocol)
+)
+requires_int_or_str_identity(IntOrStrConstrainedIdentityImplementation())
 requires_int_or_str_identity(IntOrStrOverloadedImplementation())  # error: [invalid-argument-type]
 requires_int_or_str_identity(IntOrStrGenericOverloadedImplementation())
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2696,10 +2696,10 @@ Protocol method members can be generic. They can have generic contexts scoped to
 python-version = "3.12"
 ```
 
+### Type variables scoped to the protocol
+
 ```py
-from collections.abc import Sequence
-from typing import final, overload
-from typing_extensions import TypeVar, Self, Protocol
+from typing_extensions import Protocol, TypeVar
 from ty_extensions import is_equivalent_to, static_assert, is_assignable_to, is_subtype_of
 
 class NewStyleClassScoped[T](Protocol):
@@ -2755,9 +2755,16 @@ static_assert(not is_subtype_of(NominalGeneric[int], NewStyleClassScoped[str]))
 static_assert(not is_subtype_of(NominalGeneric[int], LegacyClassScoped[str]))
 ```
 
-And they can also have generic contexts scoped to the method:
+### Type variables scoped to a method
+
+Unlike a type variable on the protocol, a method type variable is chosen separately for every call.
+An implementation must therefore support every specialization of the method.
 
 ```py
+from typing import final
+from typing_extensions import Protocol, Self, TypeVar
+from ty_extensions import is_assignable_to, is_equivalent_to, is_subtype_of, static_assert
+
 class NewStyleFunctionScoped(Protocol):
     def f[T](self, input: T) -> T: ...
 
@@ -2784,130 +2791,6 @@ class NominalWithSelf:
 class NominalNotGeneric:
     def f(self, input: int) -> int:
         return input
-
-class GenericReturnsObject(Protocol):
-    def f(self, input: FunctionT) -> object: ...
-
-class NominalAcceptsObject:
-    def f(self, input: object) -> object:
-        return input
-
-class ObjectBoundProtocol(Protocol):
-    def f[T: object](self, input: T) -> T: ...
-
-class StrBoundProtocol(Protocol):
-    def f[T: str](self, input: T) -> T: ...
-
-class ObjectBoundImplementation:
-    def f[T: object](self, input: T) -> T:
-        return input
-
-class StrBoundImplementation:
-    def f[T: str](self, input: T) -> T:
-        return input
-
-def requires_object_bound(value: ObjectBoundProtocol) -> None: ...
-
-class NestedListProtocol(Protocol):
-    def f[T](self, input: list[T]) -> list[list[T]]: ...
-
-class GenericListImplementation:
-    def f[S](self, input: S) -> list[S]:
-        return [input]
-
-class ListIdentityProtocol(Protocol):
-    def f[T](self, input: list[T]) -> list[T]: ...
-
-class SequenceIdentityImplementation:
-    def f[S: Sequence[object]](self, input: S) -> S:
-        return input
-
-def requires_list_identity(value: ListIdentityProtocol) -> None: ...
-
-class PairProtocol(Protocol):
-    def f[T, U](self, first: T, second: U) -> tuple[T, U]: ...
-
-class ReorderedPairImplementation:
-    def f[S, R](self, first: R, second: S) -> tuple[R, S]:
-        return first, second
-
-class IntBoundIdentityProtocol(Protocol):
-    def f[T: int](self, input: T) -> T: ...
-
-class GenericListReturnImplementation:
-    def f[S](self, input: S) -> list[S]:
-        return [input]
-
-class IntOrStrConstrainedIdentityImplementation:
-    def f[S: (int, str)](self, input: S) -> S:
-        return input
-
-class IntBoundObjectProtocol(Protocol):
-    def f[T: int](self, input: T) -> object: ...
-
-class IntOrStrConstrainedObjectImplementation:
-    def f[S: (int, str)](self, input: S) -> object:
-        return input
-
-class ConstrainedListProtocol(Protocol):
-    def f[T: (int, str)](self, input: list[T]) -> object: ...
-
-class ConstrainedListImplementation:
-    def f[S: (list[int], list[str])](self, input: S) -> object:
-        return input
-
-class UnusedConstrainedTypevarsImplementation:
-    def f[
-        S01: (int, str),
-        S02: (int, str),
-        S03: (int, str),
-        S04: (int, str),
-        S05: (int, str),
-        S06: (int, str),
-        S07: (int, str),
-        S08: (int, str),
-        S09: (int, str),
-        S10: (int, str),
-        S11: (int, str),
-        S12: (int, str),
-        S13: (int, str),
-        S14: (int, str),
-        S15: (int, str),
-        S16: (int, str),
-        S17: (int, str),
-        S18: (int, str),
-    ](self, input: object) -> object:
-        return input
-
-def requires_int_bound_identity(value: IntBoundIdentityProtocol) -> None: ...
-def requires_int_bound_object(value: IntBoundObjectProtocol) -> None: ...
-def requires_constrained_list(value: ConstrainedListProtocol) -> None: ...
-def requires_generic_returns_object(value: GenericReturnsObject) -> None: ...
-
-class IntOrStrIdentityProtocol(Protocol):
-    def f[T: (int, str)](self, input: T) -> T: ...
-
-# Separate overloads cannot jointly cover a generic target. One source overload must satisfy every
-# specialization of the target method.
-class IntOrStrOverloadedImplementation:
-    @overload
-    def f(self, input: int) -> int: ...
-    @overload
-    def f(self, input: str) -> str: ...
-    def f(self, input: int | str) -> int | str:
-        return input
-
-# A source overload set is valid if one generic overload covers the entire target, regardless of
-# unrelated additional overloads.
-class IntOrStrGenericOverloadedImplementation:
-    @overload
-    def f[T: (int, str)](self, input: T) -> T: ...
-    @overload
-    def f(self, input: bytes) -> bytes: ...
-    def f(self, input: int | str | bytes) -> int | str | bytes:
-        return input
-
-def requires_int_or_str_identity(value: IntOrStrIdentityProtocol) -> None: ...
 
 class NominalReturningSelfNotGeneric:
     def g(self) -> "NominalReturningSelfNotGeneric":
@@ -2942,37 +2825,6 @@ static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalNotGeneric, UsesSelf))
 
-static_assert(is_subtype_of(NominalAcceptsObject, GenericReturnsObject))
-static_assert(is_assignable_to(NominalAcceptsObject, GenericReturnsObject))
-
-static_assert(is_subtype_of(ObjectBoundImplementation, StrBoundProtocol))
-static_assert(is_assignable_to(ObjectBoundImplementation, StrBoundProtocol))
-static_assert(not is_subtype_of(StrBoundImplementation, ObjectBoundProtocol))
-static_assert(not is_assignable_to(StrBoundImplementation, ObjectBoundProtocol))
-requires_object_bound(StrBoundImplementation())  # error: [invalid-argument-type]
-
-static_assert(is_assignable_to(GenericListImplementation, NestedListProtocol))
-static_assert(is_assignable_to(SequenceIdentityImplementation, ListIdentityProtocol))
-requires_list_identity(SequenceIdentityImplementation())
-static_assert(is_subtype_of(ReorderedPairImplementation, PairProtocol))
-static_assert(is_assignable_to(ReorderedPairImplementation, PairProtocol))
-
-requires_int_bound_identity(GenericListReturnImplementation())  # error: [invalid-argument-type]
-static_assert(not is_assignable_to(IntOrStrConstrainedIdentityImplementation, IntBoundIdentityProtocol))
-requires_int_bound_identity(
-    IntOrStrConstrainedIdentityImplementation()  # error: [invalid-argument-type]
-)
-static_assert(is_assignable_to(IntOrStrConstrainedObjectImplementation, IntBoundObjectProtocol))
-requires_int_bound_object(IntOrStrConstrainedObjectImplementation())
-static_assert(is_assignable_to(ConstrainedListImplementation, ConstrainedListProtocol))
-requires_constrained_list(ConstrainedListImplementation())
-static_assert(is_assignable_to(UnusedConstrainedTypevarsImplementation, GenericReturnsObject))
-requires_generic_returns_object(UnusedConstrainedTypevarsImplementation())
-static_assert(is_assignable_to(IntOrStrConstrainedIdentityImplementation, IntOrStrIdentityProtocol))
-requires_int_or_str_identity(IntOrStrConstrainedIdentityImplementation())
-requires_int_or_str_identity(IntOrStrOverloadedImplementation())  # error: [invalid-argument-type]
-requires_int_or_str_identity(IntOrStrGenericOverloadedImplementation())
-
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, LegacyFunctionScoped))
 
@@ -2994,6 +2846,209 @@ class BadReturnType:
 
 static_assert(not is_assignable_to(BadReturnType, ShapeProtocolImplicitSelf))
 static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
+```
+
+### Concrete implementations
+
+A non-generic method can satisfy a generic protocol method if it accepts every call promised by the
+protocol. Here, accepting and returning `object` is sufficient for every specialization of
+`[T](T) -> object`:
+
+```py
+from typing import Protocol
+from ty_extensions import is_subtype_of, static_assert
+
+class ReturnsObject(Protocol):
+    def f[T](self, value: T) -> object: ...
+
+class AcceptsObject:
+    def f(self, value: object) -> object:
+        return value
+
+static_assert(is_subtype_of(AcceptsObject, ReturnsObject))
+```
+
+### Bounds on method type variables
+
+An implementation with an `object` bound supports a protocol method with a `str` bound. The reverse
+is not safe, because callers of the protocol may use types other than `str`:
+
+```py
+from typing import Protocol
+from ty_extensions import is_subtype_of, static_assert
+
+class ObjectIdentityProtocol(Protocol):
+    def f[T: object](self, value: T) -> T: ...
+
+class StrIdentityProtocol(Protocol):
+    def f[T: str](self, value: T) -> T: ...
+
+class ObjectIdentity:
+    def f[T: object](self, value: T) -> T:
+        return value
+
+class StrIdentity:
+    def f[T: str](self, value: T) -> T:
+        return value
+
+static_assert(is_subtype_of(ObjectIdentity, StrIdentityProtocol))
+static_assert(not is_subtype_of(StrIdentity, ObjectIdentityProtocol))
+```
+
+### Inferring implementation type variables
+
+When the implementation is also generic, its type variables may be chosen separately for each
+specialization of the protocol method. The mapping may wrap a target type, use a compatible bound,
+or reorder type variables:
+
+```py
+from collections.abc import Sequence
+from typing import Protocol
+from ty_extensions import is_assignable_to, static_assert
+
+class NestedListProtocol(Protocol):
+    def f[T](self, value: list[T]) -> list[list[T]]: ...
+
+class WrapsValue:
+    def f[S](self, value: S) -> list[S]:
+        return [value]
+
+class ListIdentityProtocol(Protocol):
+    def f[T](self, value: list[T]) -> list[T]: ...
+
+class SequenceIdentity:
+    def f[S: Sequence[object]](self, value: S) -> S:
+        return value
+
+class PairProtocol(Protocol):
+    def f[T, U](self, first: T, second: U) -> tuple[T, U]: ...
+
+class ReorderedPair:
+    def f[S, R](self, first: R, second: S) -> tuple[R, S]:
+        return first, second
+
+static_assert(is_assignable_to(WrapsValue, NestedListProtocol))
+static_assert(is_assignable_to(SequenceIdentity, ListIdentityProtocol))
+static_assert(is_assignable_to(ReorderedPair, PairProtocol))
+```
+
+### Constraints on method type variables
+
+A constrained type variable is limited to its listed choices; it is not the same as an upper bound.
+In particular, `[T: int]` includes `bool`, while `[S: (int, str)]` promotes `bool` to `int`. The
+constrained identity method therefore cannot preserve the exact return type promised by the bounded
+protocol, but it does satisfy a protocol with the same constraints:
+
+```py
+from typing import Protocol
+from ty_extensions import is_assignable_to, static_assert
+
+class IntBoundIdentityProtocol(Protocol):
+    def f[T: int](self, value: T) -> T: ...
+
+class IntOrStrIdentityProtocol(Protocol):
+    def f[T: (int, str)](self, value: T) -> T: ...
+
+class IntBoundReturnsObjectProtocol(Protocol):
+    def f[T: int](self, value: T) -> object: ...
+
+class IntOrStrIdentity:
+    def f[S: (int, str)](self, value: S) -> S:
+        return value
+
+static_assert(not is_assignable_to(IntOrStrIdentity, IntBoundIdentityProtocol))
+static_assert(is_assignable_to(IntOrStrIdentity, IntOrStrIdentityProtocol))
+static_assert(is_assignable_to(IntOrStrIdentity, IntBoundReturnsObjectProtocol))
+```
+
+### Constraints that depend on protocol type variables
+
+The implementation's choice may depend on the protocol method's type variable. For `T = int`, the
+implementation below uses `S = list[int]`; for `T = str`, it uses `S = list[str]`:
+
+```py
+from typing import Protocol
+from ty_extensions import is_assignable_to, static_assert
+
+class ConstrainedListProtocol(Protocol):
+    def f[T: (int, str)](self, value: list[T]) -> object: ...
+
+class ConstrainedList:
+    def f[S: (list[int], list[str])](self, value: S) -> object:
+        return value
+
+static_assert(is_assignable_to(ConstrainedList, ConstrainedListProtocol))
+```
+
+### Unused method type variables
+
+Type variables that do not appear in the parameters or return type cannot affect compatibility.
+Their constraints should not multiply the number of combinations that the checker considers:
+
+```py
+from typing import Protocol
+from ty_extensions import is_assignable_to, static_assert
+
+class ReturnsObject(Protocol):
+    def f[T](self, value: T) -> object: ...
+
+class ManyUnusedTypeVariables:
+    def f[
+        S01: (int, str),
+        S02: (int, str),
+        S03: (int, str),
+        S04: (int, str),
+        S05: (int, str),
+        S06: (int, str),
+        S07: (int, str),
+        S08: (int, str),
+        S09: (int, str),
+        S10: (int, str),
+        S11: (int, str),
+        S12: (int, str),
+        S13: (int, str),
+        S14: (int, str),
+        S15: (int, str),
+        S16: (int, str),
+        S17: (int, str),
+        S18: (int, str),
+    ](self, value: object) -> object:
+        return value
+
+static_assert(is_assignable_to(ManyUnusedTypeVariables, ReturnsObject))
+```
+
+### Overloaded implementations
+
+An overloaded implementation satisfies a generic protocol method only if one overload supports the
+entire method. Separate `int` and `str` overloads cannot be combined to cover the two constraints.
+An unrelated overload does not invalidate a generic overload that already covers the method:
+
+```py
+from typing import Protocol, overload
+from ty_extensions import is_assignable_to, static_assert
+
+class IntOrStrIdentityProtocol(Protocol):
+    def f[T: (int, str)](self, value: T) -> T: ...
+
+class SeparateOverloads:
+    @overload
+    def f(self, value: int) -> int: ...
+    @overload
+    def f(self, value: str) -> str: ...
+    def f(self, value: int | str) -> int | str:
+        return value
+
+class GenericOverload:
+    @overload
+    def f[T: (int, str)](self, value: T) -> T: ...
+    @overload
+    def f(self, value: bytes) -> bytes: ...
+    def f(self, value: int | str | bytes) -> int | str | bytes:
+        return value
+
+static_assert(not is_assignable_to(SeparateOverloads, IntOrStrIdentityProtocol))
+static_assert(is_assignable_to(GenericOverload, IntOrStrIdentityProtocol))
 ```
 
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2697,7 +2697,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import final
+from typing import final, overload
 from typing_extensions import TypeVar, Self, Protocol
 from ty_extensions import is_equivalent_to, static_assert, is_assignable_to, is_subtype_of
 
@@ -2828,6 +2828,19 @@ class GenericListReturnImplementation:
 
 def requires_int_bound_identity(value: IntBoundIdentityProtocol) -> None: ...
 
+class IntOrStrIdentityProtocol(Protocol):
+    def f[T: (int, str)](self, input: T) -> T: ...
+
+class IntOrStrOverloadedImplementation:
+    @overload
+    def f(self, input: int) -> int: ...
+    @overload
+    def f(self, input: str) -> str: ...
+    def f(self, input: int | str) -> int | str:
+        return input
+
+def requires_int_or_str_identity(value: IntOrStrIdentityProtocol) -> None: ...
+
 class NominalReturningSelfNotGeneric:
     def g(self) -> "NominalReturningSelfNotGeneric":
         return self
@@ -2874,6 +2887,7 @@ static_assert(is_subtype_of(ReorderedPairImplementation, PairProtocol))
 static_assert(is_assignable_to(ReorderedPairImplementation, PairProtocol))
 
 requires_int_bound_identity(GenericListReturnImplementation())  # error: [invalid-argument-type]
+requires_int_or_str_identity(IntOrStrOverloadedImplementation())
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, LegacyFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2842,7 +2842,15 @@ class IntOrStrConstrainedIdentityImplementation:
     def f[S: (int, str)](self, input: S) -> S:
         return input
 
+class IntBoundObjectProtocol(Protocol):
+    def f[T: int](self, input: T) -> object: ...
+
+class IntOrStrConstrainedObjectImplementation:
+    def f[S: (int, str)](self, input: S) -> object:
+        return input
+
 def requires_int_bound_identity(value: IntBoundIdentityProtocol) -> None: ...
+def requires_int_bound_object(value: IntBoundObjectProtocol) -> None: ...
 
 class IntOrStrIdentityProtocol(Protocol):
     def f[T: (int, str)](self, input: T) -> T: ...
@@ -2922,6 +2930,8 @@ static_assert(not is_assignable_to(IntOrStrConstrainedIdentityImplementation, In
 requires_int_bound_identity(
     IntOrStrConstrainedIdentityImplementation()  # error: [invalid-argument-type]
 )
+static_assert(is_assignable_to(IntOrStrConstrainedObjectImplementation, IntBoundObjectProtocol))
+requires_int_bound_object(IntOrStrConstrainedObjectImplementation())
 static_assert(is_assignable_to(IntOrStrConstrainedIdentityImplementation, IntOrStrIdentityProtocol))
 requires_int_or_str_identity(IntOrStrConstrainedIdentityImplementation())
 requires_int_or_str_identity(IntOrStrOverloadedImplementation())  # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1345,6 +1345,16 @@ from ty_extensions import RegularCallableTypeOf, TypeOf, is_assignable_to, stati
 def identity[T](t: T) -> T:
     return t
 
+def int_identity(t: int) -> int:
+    return t
+
+static_assert(
+    not is_assignable_to(
+        RegularCallableTypeOf[int_identity],
+        RegularCallableTypeOf[identity],
+    )
+)
+
 static_assert(is_assignable_to(TypeOf[identity], Callable[[int], int]))
 static_assert(is_assignable_to(TypeOf[identity], Callable[[str], str]))
 # TODO: This should not be assignable. A generic callable must use one coherent specialization.

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1348,9 +1348,18 @@ def identity[T](t: T) -> T:
 def int_identity(t: int) -> int:
     return t
 
+def returns_int[T](t: T) -> int:
+    return 1
+
 static_assert(
     not is_assignable_to(
         RegularCallableTypeOf[int_identity],
+        RegularCallableTypeOf[identity],
+    )
+)
+static_assert(
+    not is_assignable_to(
+        RegularCallableTypeOf[returns_int],
         RegularCallableTypeOf[identity],
     )
 )

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1344,7 +1344,27 @@ from ty_extensions import RegularCallableTypeOf, TypeOf, is_assignable_to, stati
 
 def identity[T](t: T) -> T:
     return t
+```
 
+The generic identity function can be used wherever a particular specialization is expected:
+
+```py
+static_assert(is_assignable_to(TypeOf[identity], Callable[[int], int]))
+static_assert(is_assignable_to(TypeOf[identity], Callable[[str], str]))
+# TODO: This should not be assignable. A generic callable must use one coherent specialization.
+# error: [static-assert-error]
+static_assert(not is_assignable_to(TypeOf[identity], Callable[[str], int]))
+
+static_assert(is_assignable_to(RegularCallableTypeOf[identity], Callable[[int], int]))
+static_assert(is_assignable_to(RegularCallableTypeOf[identity], Callable[[str], str]))
+# error: [static-assert-error]
+static_assert(not is_assignable_to(RegularCallableTypeOf[identity], Callable[[str], int]))
+```
+
+The reverse does not hold. A callable that only accepts `int`, or one that always returns `int`,
+cannot replace the generic identity function because a caller may choose another type:
+
+```py
 def int_identity(t: int) -> int:
     return t
 
@@ -1363,18 +1383,12 @@ static_assert(
         RegularCallableTypeOf[identity],
     )
 )
+```
 
-static_assert(is_assignable_to(TypeOf[identity], Callable[[int], int]))
-static_assert(is_assignable_to(TypeOf[identity], Callable[[str], str]))
-# TODO: This should not be assignable. A generic callable must use one coherent specialization.
-# error: [static-assert-error]
-static_assert(not is_assignable_to(TypeOf[identity], Callable[[str], int]))
+Bounds and constraints follow the same rule when the generic callable is used at a particular
+specialization:
 
-static_assert(is_assignable_to(RegularCallableTypeOf[identity], Callable[[int], int]))
-static_assert(is_assignable_to(RegularCallableTypeOf[identity], Callable[[str], str]))
-# error: [static-assert-error]
-static_assert(not is_assignable_to(RegularCallableTypeOf[identity], Callable[[str], int]))
-
+```py
 def bounded[T_bound: object](t: T_bound) -> T_bound:
     return t
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -406,6 +406,15 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         Self::constrain_typevar_with_bounds(db, builder, typevar, None, Some(upper))
     }
 
+    /// Returns the constraints describing the typevar's valid specializations.
+    pub(crate) fn valid_specializations(
+        db: &'db dyn Db,
+        builder: &'c ConstraintSetBuilder<'db>,
+        typevar: BoundTypeVarInstance<'db>,
+    ) -> Self {
+        Self::from_node(builder, typevar.valid_specializations(db, builder))
+    }
+
     /// Verifies that this constraint set was created by `builder`
     #[track_caller]
     fn verify_builder(self, builder: &'c ConstraintSetBuilder<'db>) {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -628,6 +628,35 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         })
     }
 
+    /// Computes structural solutions without restricting them to each typevar's declared domain.
+    ///
+    /// Callers must validate every returned solution against the corresponding declaration before
+    /// using it. This is useful when a solution can depend on another constrained typevar, because
+    /// the dependent type can be valid for every specialization without being equal to one fixed
+    /// constraint.
+    pub(crate) fn structural_solutions(
+        self,
+        db: &'db dyn Db,
+        builder: &'c ConstraintSetBuilder<'db>,
+    ) -> Solutions<'db> {
+        self.solutions_with(db, builder, |_variance, path_bound| {
+            if let Some(lower) = path_bound.lower {
+                if !path_bound.upper.is_satisfied_by(db, lower)
+                    && path_bound
+                        .upper
+                        .when_satisfied_by(db, builder, lower)
+                        .is_never_satisfied(db)
+                {
+                    return Err(());
+                }
+                return Ok(Some(lower));
+            }
+            Ok(path_bound
+                .has_upper()
+                .then(|| path_bound.upper.materialize_exact(db)))
+        })
+    }
+
     pub(crate) fn solutions_with(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -406,15 +406,6 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         Self::constrain_typevar_with_bounds(db, builder, typevar, None, Some(upper))
     }
 
-    /// Returns the constraints describing the typevar's valid specializations.
-    pub(crate) fn valid_specializations(
-        db: &'db dyn Db,
-        builder: &'c ConstraintSetBuilder<'db>,
-        typevar: BoundTypeVarInstance<'db>,
-    ) -> Self {
-        Self::from_node(builder, typevar.valid_specializations(db, builder))
-    }
-
     /// Verifies that this constraint set was created by `builder`
     #[track_caller]
     fn verify_builder(self, builder: &'c ConstraintSetBuilder<'db>) {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1405,12 +1405,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             attribute_type
                 .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
                 .when_some_and(db, self.constraints, |callables| {
-                    self.with_universal_callable_target_typevars()
-                        .check_callables_vs_callable(
-                            db,
-                            &callables.map(|callable| callable.apply_self(db, fallback_ty)),
-                            required_callable.apply_self(db, fallback_ty),
-                        )
+                    self.check_callables_vs_callable(
+                        db,
+                        &callables.map(|callable| callable.apply_self(db, fallback_ty)),
+                        required_callable.apply_self(db, fallback_ty),
+                    )
                 })
         } else if member.is_method() {
             let Some(required_ty) = required_ty.resolve(db) else {
@@ -1422,16 +1421,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             attribute_type
                 .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
                 .when_some_and(db, self.constraints, |callables| {
-                    let checker = self.with_universal_callable_target_typevars();
                     callables.iter().when_all(db, self.constraints, |callable| {
                         if callable.is_function_like(db) {
-                            checker.check_callable_pair(
+                            self.check_callable_pair(
                                 db,
                                 callable.bind_self(db, Some(fallback_ty)),
                                 protocol_bind_self(db, required_callable, Some(fallback_ty)),
                             )
                         } else {
-                            checker.check_callable_pair(db, *callable, required_callable)
+                            self.check_callable_pair(db, *callable, required_callable)
                         }
                     })
                 })
@@ -1623,12 +1621,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 ) else {
                     return self.never();
                 };
-                if source_member.is_method() && target_member.is_method() {
-                    self.with_universal_callable_target_typevars()
-                        .check_type_pair(db, source, target)
-                } else {
-                    self.check_type_pair(db, source, target)
-                }
+                self.check_type_pair(db, source, target)
             }
         };
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1405,11 +1405,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             attribute_type
                 .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
                 .when_some_and(db, self.constraints, |callables| {
-                    self.check_callables_vs_callable(
-                        db,
-                        &callables.map(|callable| callable.apply_self(db, fallback_ty)),
-                        required_callable.apply_self(db, fallback_ty),
-                    )
+                    self.with_universal_callable_target_typevars()
+                        .check_callables_vs_callable(
+                            db,
+                            &callables.map(|callable| callable.apply_self(db, fallback_ty)),
+                            required_callable.apply_self(db, fallback_ty),
+                        )
                 })
         } else if member.is_method() {
             let Some(required_ty) = required_ty.resolve(db) else {
@@ -1421,15 +1422,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             attribute_type
                 .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
                 .when_some_and(db, self.constraints, |callables| {
+                    let checker = self.with_universal_callable_target_typevars();
                     callables.iter().when_all(db, self.constraints, |callable| {
                         if callable.is_function_like(db) {
-                            self.check_callable_pair(
+                            checker.check_callable_pair(
                                 db,
                                 callable.bind_self(db, Some(fallback_ty)),
                                 protocol_bind_self(db, required_callable, Some(fallback_ty)),
                             )
                         } else {
-                            self.check_callable_pair(db, *callable, required_callable)
+                            checker.check_callable_pair(db, *callable, required_callable)
                         }
                     })
                 })
@@ -1621,7 +1623,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 ) else {
                     return self.never();
                 };
-                self.check_type_pair(db, source, target)
+                if source_member.is_method() && target_member.is_method() {
+                    self.with_universal_callable_target_typevars()
+                        .check_type_pair(db, source, target)
+                } else {
+                    self.check_type_pair(db, source, target)
+                }
             }
         };
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -877,13 +877,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         }
     }
 
-    pub(super) fn with_lazy_typevar_evaluation(&self) -> Self {
-        Self {
-            typevar_evaluation: TypeVarEvaluation::Lazy,
-            ..self.clone()
-        }
-    }
-
     pub(super) const fn is_eager_assignability(&self) -> bool {
         self.relation.is_assignability()
             && matches!(self.typevar_evaluation, TypeVarEvaluation::Eager)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -849,6 +849,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         }
     }
 
+    pub(super) fn with_lazy_typevar_evaluation(&self) -> Self {
+        Self {
+            typevar_evaluation: TypeVarEvaluation::Lazy,
+            ..self.clone()
+        }
+    }
+
     pub(super) const fn is_eager_assignability(&self) -> bool {
         self.relation.is_assignability()
             && matches!(self.typevar_evaluation, TypeVarEvaluation::Eager)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -877,6 +877,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         }
     }
 
+    pub(super) fn with_lazy_typevar_evaluation(&self) -> Self {
+        Self {
+            typevar_evaluation: TypeVarEvaluation::Lazy,
+            ..self.clone()
+        }
+    }
+
     pub(super) const fn is_eager_assignability(&self) -> bool {
         self.relation.is_assignability()
             && matches!(self.typevar_evaluation, TypeVarEvaluation::Eager)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -345,7 +345,6 @@ impl<'db> Type<'db> {
             inferable,
             relation: TypeRelation::SubtypingAssuming,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            universal_callable_target_typevars: false,
             context_tree: None,
             given: assuming,
             relation_visitor: &relation_visitor,
@@ -383,7 +382,6 @@ impl<'db> Type<'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            universal_callable_target_typevars: false,
             context_tree: Some(ErrorContextTree::new()),
             given: ConstraintSet::from_bool(&builder, false),
             relation_visitor: &HasRelationToVisitor::default(&builder),
@@ -588,7 +586,6 @@ impl<'db> Type<'db> {
             inferable,
             relation,
             typevar_evaluation,
-            universal_callable_target_typevars: false,
             context_tree: None,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor: &relation_visitor,
@@ -744,12 +741,6 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) inferable: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
     pub(super) typevar_evaluation: TypeVarEvaluation,
-    /// Treat type variables bound by a target callable as universally quantified.
-    ///
-    /// This is enabled while checking a protocol method implementation, which must support every
-    /// specialization exposed by the protocol method. It is consumed by the outer signature pair
-    /// so nested callable types use their ordinary relation rules.
-    pub(super) universal_callable_target_typevars: bool,
     context_tree: Option<ErrorContextTree<'db>>,
     pub(super) given: ConstraintSet<'db, 'c>,
 
@@ -779,7 +770,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable,
             relation: TypeRelation::Subtyping,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            universal_callable_target_typevars: false,
             context_tree: None,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -801,7 +791,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
-            universal_callable_target_typevars: false,
             context_tree: None,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -823,7 +812,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
-            universal_callable_target_typevars: false,
             context_tree: Some(ErrorContextTree::new()),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -845,7 +833,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            universal_callable_target_typevars: false,
             context_tree: Some(ErrorContextTree::new()),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -858,21 +845,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     pub(super) fn with_inferable_typevars(&self, inferable: InferableTypeVars<'db>) -> Self {
         Self {
             inferable,
-            ..self.clone()
-        }
-    }
-
-    /// Return a checker that requires callable sources to support every target specialization.
-    pub(super) fn with_universal_callable_target_typevars(&self) -> Self {
-        Self {
-            universal_callable_target_typevars: true,
-            ..self.clone()
-        }
-    }
-
-    pub(super) fn without_universal_callable_target_typevars(&self) -> Self {
-        Self {
-            universal_callable_target_typevars: false,
             ..self.clone()
         }
     }
@@ -2370,7 +2342,6 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
         TypeRelationChecker {
             relation: TypeRelation::Redundancy { pure: true },
             typevar_evaluation: TypeVarEvaluation::Eager,
-            universal_callable_target_typevars: false,
             constraints: self.constraints,
             context_tree: None,
             given: self.given,
@@ -2456,7 +2427,6 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         TypeRelationChecker {
             relation,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            universal_callable_target_typevars: false,
             constraints: self.constraints,
             inferable: self.inferable,
             context_tree: None,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -345,6 +345,7 @@ impl<'db> Type<'db> {
             inferable,
             relation: TypeRelation::SubtypingAssuming,
             typevar_evaluation: TypeVarEvaluation::Eager,
+            universal_callable_target_typevars: false,
             context_tree: None,
             given: assuming,
             relation_visitor: &relation_visitor,
@@ -382,6 +383,7 @@ impl<'db> Type<'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
+            universal_callable_target_typevars: false,
             context_tree: Some(ErrorContextTree::new()),
             given: ConstraintSet::from_bool(&builder, false),
             relation_visitor: &HasRelationToVisitor::default(&builder),
@@ -586,6 +588,7 @@ impl<'db> Type<'db> {
             inferable,
             relation,
             typevar_evaluation,
+            universal_callable_target_typevars: false,
             context_tree: None,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor: &relation_visitor,
@@ -741,6 +744,12 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) inferable: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
     pub(super) typevar_evaluation: TypeVarEvaluation,
+    /// Treat type variables bound by a target callable as universally quantified.
+    ///
+    /// This is enabled while checking a protocol method implementation, which must support every
+    /// specialization exposed by the protocol method. It is consumed by the outer signature pair
+    /// so nested callable types use their ordinary relation rules.
+    pub(super) universal_callable_target_typevars: bool,
     context_tree: Option<ErrorContextTree<'db>>,
     pub(super) given: ConstraintSet<'db, 'c>,
 
@@ -770,6 +779,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable,
             relation: TypeRelation::Subtyping,
             typevar_evaluation: TypeVarEvaluation::Eager,
+            universal_callable_target_typevars: false,
             context_tree: None,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -791,6 +801,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
+            universal_callable_target_typevars: false,
             context_tree: None,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -812,6 +823,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
+            universal_callable_target_typevars: false,
             context_tree: Some(ErrorContextTree::new()),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -833,6 +845,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
+            universal_callable_target_typevars: false,
             context_tree: Some(ErrorContextTree::new()),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -845,6 +858,21 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     pub(super) fn with_inferable_typevars(&self, inferable: InferableTypeVars<'db>) -> Self {
         Self {
             inferable,
+            ..self.clone()
+        }
+    }
+
+    /// Return a checker that requires callable sources to support every target specialization.
+    pub(super) fn with_universal_callable_target_typevars(&self) -> Self {
+        Self {
+            universal_callable_target_typevars: true,
+            ..self.clone()
+        }
+    }
+
+    pub(super) fn without_universal_callable_target_typevars(&self) -> Self {
+        Self {
+            universal_callable_target_typevars: false,
             ..self.clone()
         }
     }
@@ -2342,6 +2370,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
         TypeRelationChecker {
             relation: TypeRelation::Redundancy { pure: true },
             typevar_evaluation: TypeVarEvaluation::Eager,
+            universal_callable_target_typevars: false,
             constraints: self.constraints,
             context_tree: None,
             given: self.given,
@@ -2427,6 +2456,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         TypeRelationChecker {
             relation,
             typevar_evaluation: TypeVarEvaluation::Eager,
+            universal_callable_target_typevars: false,
             constraints: self.constraints,
             inferable: self.inferable,
             context_tree: None,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -536,7 +536,6 @@ pub(crate) struct SignatureRelationKey<'db> {
     target_definition: Definition<'db>,
     relation: TypeRelation,
     typevar_evaluation: TypeVarEvaluation,
-    universal_target_typevars: bool,
 }
 
 impl<'db> SignatureRelationKey<'db> {
@@ -545,14 +544,12 @@ impl<'db> SignatureRelationKey<'db> {
         target: &Signature<'db>,
         relation: TypeRelation,
         typevar_evaluation: TypeVarEvaluation,
-        universal_target_typevars: bool,
     ) -> Option<Self> {
         Some(Self {
             source_definition: source.definition?,
             target_definition: target.definition?,
             relation,
             typevar_evaluation,
-            universal_target_typevars,
         })
     }
 }
@@ -1748,9 +1745,26 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let target_binds_typevars = target
-            .generic_context
-            .is_some_and(|context| context.variables(db).next().is_some());
+        self.check_signature_pair_impl(db, source, target, false)
+    }
+
+    /// Check two generic signatures using the established inference relation.
+    fn check_signature_pair_with_inferred_typevars(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        self.check_signature_pair_impl(db, source, target, true)
+    }
+
+    fn check_signature_pair_impl(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+        infer_target_typevars: bool,
+    ) -> ConstraintSet<'db, 'c> {
         // Freshen callable-local typevars so same-source typevars in the two signatures do not
         // collide. The relation below decides which fresh variables are inferable.
         let freshened_source;
@@ -1778,12 +1792,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target
         };
         let unaligned_source = source;
-        let nested_checker = self.without_universal_callable_target_typevars();
 
         // Positional alpha-renaming is a common fast path and avoids forcing recursive protocol
         // members while their interfaces are still being inferred.
-        let aligned_source = self
-            .universal_callable_target_typevars
+        let aligned_source = (!infer_target_typevars)
             .then(|| source.generic_context.zip(target.generic_context))
             .flatten()
             .and_then(|(source_context, target_context)| {
@@ -1819,7 +1831,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             .require_bound_or_constraints(db)
                             .as_type(db)
                             .apply_specialization(db, specialization);
-                        nested_checker.check_type_pair(db, target_domain, source_domain)
+                        self.check_type_pair(db, target_domain, source_domain)
                     },
                 );
                 Some((
@@ -1833,7 +1845,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Variables bound directly by the target signature are universal. Other variables pulled
         // into its inferable set through bounds or specializations belong to the surrounding
         // inference context and remain inferable.
-        let target_inferable = if self.universal_callable_target_typevars && target_binds_typevars {
+        let target_inferable = if infer_target_typevars {
+            target.inferable_typevars(db)
+        } else {
             InferableTypeVars::from_typevars(
                 db,
                 target
@@ -1846,17 +1860,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     })
                     .collect::<FxOrderSet<_>>(),
             )
-        } else {
-            target.inferable_typevars(db)
         };
         let inferable = source_inferable.merge(db, target_inferable);
         let inferable = self.inferable.merge(db, inferable);
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let checker = self.with_inferable_typevars(inferable);
-        let nested_checker = checker.without_universal_callable_target_typevars();
         let when = checker.with_signature_recursion_guard(source, target, || {
-            nested_checker.check_signature_pair_inner(db, source, target)
+            checker.check_signature_pair_inner(db, source, target)
         });
 
         // But the caller does not need to consider those extra typevars. Whatever constraint set
@@ -1868,7 +1879,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             self.constraints,
             source_inferable.iter(db).chain(target_inferable.iter(db)),
         );
-        if !self.universal_callable_target_typevars {
+        if infer_target_typevars {
             return when;
         }
         if unaligned_source.generic_context.is_none() || target.generic_context.is_none() {
@@ -1890,8 +1901,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         } else {
             positional.or(db, self.constraints, || {
                 self.without_context_collection(|| {
-                    self.without_universal_callable_target_typevars()
-                        .check_signature_pair(db, unaligned_source, target)
+                    self.check_signature_pair_with_inferred_typevars(db, unaligned_source, target)
                 })
             })
         }
@@ -1908,7 +1918,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target,
             self.relation,
             self.typevar_evaluation,
-            self.universal_callable_target_typevars,
         ) else {
             return work();
         };

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1993,6 +1993,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
             }
             TypeVarBoundOrConstraints::Constraints(source_constraints) => {
+                if specialized
+                    .as_typevar()
+                    .is_some_and(|specialized| specialized.is_same_typevar_as(db, source))
+                {
+                    return self.always();
+                }
+                let checker = self.with_lazy_typevar_evaluation();
                 let source_accepts_constraint = |candidate| {
                     source_constraints.elements(db).iter().copied().when_any(
                         db,
@@ -2000,29 +2007,22 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         |source_constraint| {
                             let source_constraint =
                                 source_constraint.apply_specialization(db, specialization);
-                            self.check_type_pair(db, candidate, source_constraint).and(
-                                db,
-                                self.constraints,
-                                || self.check_type_pair(db, source_constraint, candidate),
-                            )
+                            checker
+                                .check_type_pair(db, candidate, source_constraint)
+                                .and(db, self.constraints, || {
+                                    checker.check_type_pair(db, source_constraint, candidate)
+                                })
                         },
                     )
                 };
-
-                if let Type::TypeVar(target) = specialized {
-                    let TypeVarBoundOrConstraints::Constraints(target_constraints) =
-                        target.typevar(db).require_bound_or_constraints(db)
-                    else {
-                        return self.never();
-                    };
-                    target_constraints.elements(db).iter().copied().when_all(
+                ConstraintSet::from_bool(
+                    self.constraints,
+                    source_accepts_constraint(specialized).satisfied_by_all_typevars(
                         db,
                         self.constraints,
-                        source_accepts_constraint,
-                    )
-                } else {
-                    source_accepts_constraint(specialized)
-                }
+                        self.inferable,
+                    ),
+                )
             }
         }
     }
@@ -2056,21 +2056,55 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let Some(source_context) = source.generic_context else {
             return self.never();
         };
-        let source_domain =
-            source_context
+        let relation = checker.with_signature_recursion_guard(source, target, || {
+            checker.check_signature_pair_inner(db, source, target)
+        });
+        // Prefer a structural solution such as `S = list[T]`, which preserves how the source
+        // specialization depends on each rigid target specialization. If that is not valid for a
+        // constrained source variable, also try the source's declared alternatives; this models
+        // promotion such as choosing `S = int` for every `T` bounded by `int`.
+        let structural_solutions = relation
+            .remove_noninferable(db, self.constraints, source_inferable)
+            .structural_solutions(db, self.constraints);
+        self.check_signature_pair_with_source_solutions(
+            db,
+            source,
+            target,
+            source_context,
+            structural_solutions,
+        )
+        .or(db, self.constraints, || {
+            let source_domain = source_context
                 .variables(db)
+                // An unused variable cannot affect assignability. Including its constrained
+                // alternatives here would needlessly multiply the solver's paths.
+                .filter(|typevar| source.variance_of(db, *typevar) != TypeVarVariance::Bivariant)
                 .when_all(db, self.constraints, |typevar| {
                     ConstraintSet::valid_specializations(db, self.constraints, typevar)
                 });
-        let when = checker.with_signature_recursion_guard(source, target, || {
-            source_domain.and(db, self.constraints, || {
-                checker.check_signature_pair_inner(db, source, target)
-            })
-        });
-        let solutions = match when
-            .remove_noninferable(db, self.constraints, source_inferable)
-            .solutions(db, self.constraints)
-        {
+            let domain_solutions = source_domain
+                .and(db, self.constraints, || relation)
+                .remove_noninferable(db, self.constraints, source_inferable)
+                .solutions(db, self.constraints);
+            self.check_signature_pair_with_source_solutions(
+                db,
+                source,
+                target,
+                source_context,
+                domain_solutions,
+            )
+        })
+    }
+
+    fn check_signature_pair_with_source_solutions(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+        source_context: GenericContext<'db>,
+        solutions: Solutions<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        let solutions = match solutions {
             Solutions::Unsatisfiable => return self.never(),
             Solutions::Unconstrained => vec![Vec::new()],
             Solutions::Constrained(solutions) => solutions,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -536,6 +536,7 @@ pub(crate) struct SignatureRelationKey<'db> {
     target_definition: Definition<'db>,
     relation: TypeRelation,
     typevar_evaluation: TypeVarEvaluation,
+    universal_target_typevars: bool,
 }
 
 impl<'db> SignatureRelationKey<'db> {
@@ -544,12 +545,14 @@ impl<'db> SignatureRelationKey<'db> {
         target: &Signature<'db>,
         relation: TypeRelation,
         typevar_evaluation: TypeVarEvaluation,
+        universal_target_typevars: bool,
     ) -> Option<Self> {
         Some(Self {
             source_definition: source.definition?,
             target_definition: target.definition?,
             relation,
             typevar_evaluation,
+            universal_target_typevars,
         })
     }
 }
@@ -1745,10 +1748,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // If either signature is generic, freshen that signature's typevars before considering
-        // them inferable for this relation. The relation only needs to find one specialization of
-        // each generic callable that causes the check to succeed, but those callable-local
-        // specializations must not collide with any same-source typevars in the other signature.
+        let target_binds_typevars = target
+            .generic_context
+            .is_some_and(|context| context.variables(db).next().is_some());
+        // Freshen callable-local typevars so same-source typevars in the two signatures do not
+        // collide. The relation below decides which fresh variables are inferable.
         let freshened_source;
         let source = if source.generic_context != target.generic_context
             && let Some(generic_context) = source.generic_context
@@ -1773,27 +1777,100 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         } else {
             target
         };
+        let nested_checker = self.without_universal_callable_target_typevars();
+
+        // A generic source can be specialized for each target specialization. Align equivalent
+        // generic contexts positionally, while requiring the source domain to cover the target
+        // domain.
+        let aligned_source = self
+            .universal_callable_target_typevars
+            .then(|| source.generic_context.zip(target.generic_context))
+            .flatten()
+            .and_then(|(source_context, target_context)| {
+                let source_typevars = source_context.variables(db).collect::<Vec<_>>();
+                let target_typevars = target_context.variables(db).collect::<Vec<_>>();
+                if source_typevars.len() != target_typevars.len()
+                    || source_typevars
+                        .iter()
+                        .zip(&target_typevars)
+                        .any(|(source, target)| source.is_paramspec(db) != target.is_paramspec(db))
+                {
+                    return None;
+                }
+
+                let specialization = source_context.specialize(
+                    db,
+                    target_typevars
+                        .iter()
+                        .copied()
+                        .map(Type::TypeVar)
+                        .collect::<Vec<_>>(),
+                );
+                let generic_context_check = target_typevars.iter().zip(&source_typevars).when_all(
+                    db,
+                    self.constraints,
+                    |(target, source)| {
+                        let target_domain = target
+                            .typevar(db)
+                            .require_bound_or_constraints(db)
+                            .as_type(db);
+                        let source_domain = source
+                            .typevar(db)
+                            .require_bound_or_constraints(db)
+                            .as_type(db)
+                            .apply_specialization(db, specialization);
+                        nested_checker.check_type_pair(db, target_domain, source_domain)
+                    },
+                );
+                Some((
+                    source.apply_specialization(db, specialization),
+                    generic_context_check,
+                ))
+            });
+        let source = aligned_source.as_ref().map_or(source, |(source, _)| source);
 
         let source_inferable = source.inferable_typevars(db);
-        let target_inferable = target.inferable_typevars(db);
+        // Variables bound directly by the target signature are universal. Other variables pulled
+        // into its inferable set through bounds or specializations belong to the surrounding
+        // inference context and remain inferable.
+        let target_inferable = if self.universal_callable_target_typevars && target_binds_typevars {
+            InferableTypeVars::from_typevars(
+                db,
+                target
+                    .inferable_typevars(db)
+                    .iter(db)
+                    .filter(|typevar| {
+                        target
+                            .generic_context
+                            .is_none_or(|context| !context.contains(db, *typevar))
+                    })
+                    .collect::<FxOrderSet<_>>(),
+            )
+        } else {
+            target.inferable_typevars(db)
+        };
         let inferable = source_inferable.merge(db, target_inferable);
         let inferable = self.inferable.merge(db, inferable);
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let checker = self.with_inferable_typevars(inferable);
+        let nested_checker = checker.without_universal_callable_target_typevars();
         let when = checker.with_signature_recursion_guard(source, target, || {
-            checker.check_signature_pair_inner(db, source, target)
+            nested_checker.check_signature_pair_inner(db, source, target)
         });
 
         // But the caller does not need to consider those extra typevars. Whatever constraint set
         // we produce, we reduce it back down to the inferable set that the caller asked about.
         // If we introduced new inferable typevars, those will be existentially quantified away
         // before returning.
-        when.reduce_inferable(
+        let when = when.reduce_inferable(
             db,
             self.constraints,
             source_inferable.iter(db).chain(target_inferable.iter(db)),
-        )
+        );
+        aligned_source.map_or(when, |(_, generic_context_check)| {
+            generic_context_check.and(db, self.constraints, || when)
+        })
     }
 
     fn with_signature_recursion_guard(
@@ -1807,6 +1884,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target,
             self.relation,
             self.typevar_evaluation,
+            self.universal_callable_target_typevars,
         ) else {
             return work();
         };

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1692,6 +1692,24 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
             // source is possibly overloaded while target is definitely not overloaded.
             (_, [target_signature]) => {
+                // Universal target variables must be evaluated after the source overloads have
+                // been combined. Until callable-level universal projection can preserve that
+                // coverage, retain the established overload relation instead of rejecting each
+                // overload independently.
+                if self.universal_callable_target_typevars
+                    && target_signature
+                        .generic_context
+                        .is_some_and(|context| context.variables(db).next().is_some())
+                {
+                    return self
+                        .without_universal_callable_target_typevars()
+                        .check_callable_signature_pair_inner(
+                            db,
+                            source_overloads,
+                            target_overloads,
+                        );
+                }
+
                 if let Some(aggregate_relation) = self.try_unary_overload_aggregate_relation(
                     db,
                     source_overloads,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -35,8 +35,8 @@ use crate::types::typevar::{BoundTypeVarIdentity, max_typevar_freshness_matching
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, ErrorContext,
     ErrorContextTree, FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind,
-    ParamSpecAttrKind, ParameterDescription, SelfBinding, TypeContext, TypeMapping, TypeVarNonce,
-    TypeVarBoundOrConstraints, TypedDictType, UnionBuilder, VarianceInferable,
+    ParamSpecAttrKind, ParameterDescription, SelfBinding, TypeContext, TypeMapping,
+    TypeVarBoundOrConstraints, TypeVarNonce, TypedDictType, UnionBuilder, VarianceInferable,
     infer_complete_scope_types, todo_type,
 };
 use crate::{Db, FxOrderSet};
@@ -1746,6 +1746,26 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        self.check_signature_pair_impl(db, source, target, false)
+    }
+
+    /// Check two signatures while inferring both signatures' type variables.
+    fn check_signature_pair_with_inferred_typevars(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        self.check_signature_pair_impl(db, source, target, true)
+    }
+
+    fn check_signature_pair_impl(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+        infer_target_typevars: bool,
+    ) -> ConstraintSet<'db, 'c> {
         // Freshen callable-local typevars so same-source typevars in the two signatures do not
         // collide. The relation below decides which fresh variables are inferable.
         let freshened_source;
@@ -1776,9 +1796,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // Positional alpha-renaming is a common fast path and avoids forcing recursive protocol
         // members while their interfaces are still being inferred.
-        let aligned_source = source
-            .generic_context
-            .zip(target.generic_context)
+        let aligned_source = (!infer_target_typevars)
+            .then(|| source.generic_context.zip(target.generic_context))
+            .flatten()
             .and_then(|(source_context, target_context)| {
                 let source_typevars = source_context.variables(db).collect::<Vec<_>>();
                 let target_typevars = target_context.variables(db).collect::<Vec<_>>();
@@ -1822,18 +1842,22 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Variables bound directly by the target signature are universal. Other variables pulled
         // into its inferable set through bounds or specializations belong to the surrounding
         // inference context and remain inferable.
-        let target_inferable = InferableTypeVars::from_typevars(
-            db,
-            target
-                .inferable_typevars(db)
-                .iter(db)
-                .filter(|typevar| {
-                    target
-                        .generic_context
-                        .is_none_or(|context| !context.contains(db, *typevar))
-                })
-                .collect::<FxOrderSet<_>>(),
-        );
+        let target_inferable = if infer_target_typevars {
+            target.inferable_typevars(db)
+        } else {
+            InferableTypeVars::from_typevars(
+                db,
+                target
+                    .inferable_typevars(db)
+                    .iter(db)
+                    .filter(|typevar| {
+                        target
+                            .generic_context
+                            .is_none_or(|context| !context.contains(db, *typevar))
+                    })
+                    .collect::<FxOrderSet<_>>(),
+            )
+        };
         let inferable = source_inferable.merge(db, target_inferable);
         let inferable = self.inferable.merge(db, inferable);
 
@@ -1852,6 +1876,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             self.constraints,
             source_inferable.iter(db).chain(target_inferable.iter(db)),
         );
+        if infer_target_typevars {
+            return when;
+        }
         if unaligned_source.generic_context.is_none() || target.generic_context.is_none() {
             return when;
         }
@@ -1862,13 +1889,76 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         );
         if positional.is_always_satisfied(db) {
             positional
-        } else {
+        } else if self.typevar_evaluation == TypeVarEvaluation::Eager {
             positional.or(db, self.constraints, || {
                 self.without_context_collection(|| {
                     self.check_signature_pair_with_inferred_source(db, unaligned_source, target)
                 })
             })
+        } else if aligned_source
+            .as_ref()
+            .is_some_and(|(_, generic_context_check)| generic_context_check.is_never_satisfied(db))
+        {
+            self.without_context_collection(|| {
+                self.check_signature_pair_with_inferred_source_for_inference(
+                    db,
+                    unaligned_source,
+                    target,
+                )
+            })
+        } else {
+            positional.or(db, self.constraints, || {
+                self.without_context_collection(|| {
+                    self.check_signature_pair_with_inferred_typevars(db, unaligned_source, target)
+                })
+            })
         }
+    }
+
+    /// Infer a source specialization when both signatures are part of an outer inference goal.
+    fn check_signature_pair_with_inferred_source_for_inference(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        let source_inferable = source.inferable_typevars(db);
+        let target_inferable = InferableTypeVars::from_typevars(
+            db,
+            target
+                .inferable_typevars(db)
+                .iter(db)
+                .filter(|typevar| {
+                    target
+                        .generic_context
+                        .is_none_or(|context| !context.contains(db, *typevar))
+                })
+                .collect::<FxOrderSet<_>>(),
+        );
+        let inferable = self
+            .inferable
+            .merge(db, source_inferable.merge(db, target_inferable));
+        let checker = self.with_inferable_typevars(inferable);
+        let source_domain = source.generic_context.map_or_else(
+            || checker.always(),
+            |context| {
+                context
+                    .variables(db)
+                    .when_all(db, self.constraints, |typevar| {
+                        ConstraintSet::valid_specializations(db, self.constraints, typevar)
+                    })
+            },
+        );
+        let when = checker.with_signature_recursion_guard(source, target, || {
+            source_domain.and(db, self.constraints, || {
+                checker.check_signature_pair_inner(db, source, target)
+            })
+        });
+        when.reduce_inferable(
+            db,
+            self.constraints,
+            source_inferable.iter(db).chain(target_inferable.iter(db)),
+        )
     }
 
     /// Check that a source type variable can be specialized to `specialized` without erasing the
@@ -1881,11 +1971,27 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         specialization: Specialization<'db>,
     ) -> ConstraintSet<'db, 'c> {
         match source.typevar(db).require_bound_or_constraints(db) {
-            TypeVarBoundOrConstraints::UpperBound(bound) => self.check_type_pair(
-                db,
-                specialized,
-                bound.apply_specialization(db, specialization),
-            ),
+            TypeVarBoundOrConstraints::UpperBound(source_bound) => {
+                let source_bound = source_bound.apply_specialization(db, specialization);
+                if let Type::TypeVar(target) = specialized {
+                    match target.typevar(db).require_bound_or_constraints(db) {
+                        TypeVarBoundOrConstraints::UpperBound(target_bound) => {
+                            self.check_type_pair(db, target_bound, source_bound)
+                        }
+                        TypeVarBoundOrConstraints::Constraints(target_constraints) => {
+                            target_constraints.elements(db).iter().copied().when_all(
+                                db,
+                                self.constraints,
+                                |target_constraint| {
+                                    self.check_type_pair(db, target_constraint, source_bound)
+                                },
+                            )
+                        }
+                    }
+                } else {
+                    self.check_type_pair(db, specialized, source_bound)
+                }
+            }
             TypeVarBoundOrConstraints::Constraints(source_constraints) => {
                 let source_accepts_constraint = |candidate| {
                     source_constraints.elements(db).iter().copied().when_any(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -401,9 +401,10 @@ impl<'db> CallableSignature<'db> {
         }
     }
 
-    /// Binds the first (presumably `self`) parameter of this signature. If a `self_type` is
-    /// provided, we will replace any occurrences of `typing.Self` in the parameter and return
-    /// annotations with that type.
+    /// Binds the first (presumably `self`) parameter of this signature. An explicit generic self
+    /// type is specialized to `self_type`, or preserved as `typing.Self` if the receiver is not
+    /// known yet. Any existing occurrences of `typing.Self` are also replaced when `self_type` is
+    /// provided.
     pub(crate) fn bind_self(&self, db: &'db dyn Db, self_type: Option<Type<'db>>) -> Self {
         Self {
             overloads: self
@@ -954,19 +955,60 @@ impl<'db> Signature<'db> {
     }
 
     pub(crate) fn bind_self(&self, db: &'db dyn Db, self_type: Option<Type<'db>>) -> Self {
-        let removed_receiver = self.parameters.get(0).is_some_and(Parameter::is_positional);
+        let specialized;
+        let signature = if let Some(generic_context) = self.generic_context
+            && let Some(first_parameter) = self.parameters.get(0)
+            && first_parameter.is_positional()
+            && !first_parameter.inferred_annotation
+            && let Type::TypeVar(self_typevar) = first_parameter.annotated_type()
+            && !self_typevar.typevar(db).is_self(db)
+            && generic_context.contains(db, self_typevar.identity(db))
+            && let Some(specialized_self) = self_type.or_else(|| {
+                // Protocol capabilities bind methods before the implementation type is known.
+                // Preserve the generic receiver until it can be bound to that type.
+                match self_typevar.typevar(db).require_bound_or_constraints(db) {
+                    TypeVarBoundOrConstraints::UpperBound(upper_bound) => {
+                        Some(Type::TypeVar(BoundTypeVarInstance::synthetic_self(
+                            db,
+                            upper_bound,
+                            self_typevar.binding_context(db),
+                        )))
+                    }
+                    TypeVarBoundOrConstraints::Constraints(_) => None,
+                }
+            }) {
+            let specialization = generic_context.specialize_recursive(
+                db,
+                generic_context.variables(db).map(|typevar| {
+                    Some(if typevar.identity(db) == self_typevar.identity(db) {
+                        specialized_self
+                    } else {
+                        Type::TypeVar(typevar)
+                    })
+                }),
+            );
+            specialized = self.apply_specialization(db, specialization);
+            &specialized
+        } else {
+            self
+        };
+
+        let removed_receiver = signature
+            .parameters
+            .get(0)
+            .is_some_and(Parameter::is_positional);
 
         // TODO: Theoretically, for a signature like `f(*args: *tuple[MyClass, int, *tuple[str, ...]])` with
         // a variadic first parameter, we should also "skip the first parameter" by modifying the tuple type.
         let mut parameters = if removed_receiver {
-            self.parameters.without_first()
+            signature.parameters.without_first()
         } else {
-            self.parameters.clone()
+            signature.parameters.clone()
         };
-        let mut return_ty = self.return_ty;
-        let binding_context = self.definition.map(BindingContext::Definition);
+        let mut return_ty = signature.return_ty;
+        let binding_context = signature.definition.map(BindingContext::Definition);
         if let Some(self_type) = self_type
-            && self.needs_self_mapping(db, removed_receiver)
+            && signature.needs_self_mapping(db, removed_receiver)
         {
             let self_mapping =
                 TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
@@ -979,10 +1021,10 @@ impl<'db> Signature<'db> {
             return_ty = return_ty.apply_type_mapping(db, &self_mapping, TypeContext::default());
         }
         Self {
-            generic_context: self
+            generic_context: signature
                 .generic_context
                 .map(|generic_context| generic_context.remove_self(db, binding_context)),
-            definition: self.definition,
+            definition: signature.definition,
             parameters,
             return_ty,
         }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -20,7 +20,7 @@ use smallvec::{SmallVec, smallvec_inline};
 use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{
-    ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
+    ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, Solutions,
 };
 use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::generics::{
@@ -1745,26 +1745,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        self.check_signature_pair_impl(db, source, target, false)
-    }
-
-    /// Check two generic signatures using the established inference relation.
-    fn check_signature_pair_with_inferred_typevars(
-        &self,
-        db: &'db dyn Db,
-        source: &Signature<'db>,
-        target: &Signature<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        self.check_signature_pair_impl(db, source, target, true)
-    }
-
-    fn check_signature_pair_impl(
-        &self,
-        db: &'db dyn Db,
-        source: &Signature<'db>,
-        target: &Signature<'db>,
-        infer_target_typevars: bool,
-    ) -> ConstraintSet<'db, 'c> {
         // Freshen callable-local typevars so same-source typevars in the two signatures do not
         // collide. The relation below decides which fresh variables are inferable.
         let freshened_source;
@@ -1795,9 +1775,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // Positional alpha-renaming is a common fast path and avoids forcing recursive protocol
         // members while their interfaces are still being inferred.
-        let aligned_source = (!infer_target_typevars)
-            .then(|| source.generic_context.zip(target.generic_context))
-            .flatten()
+        let aligned_source = source
+            .generic_context
+            .zip(target.generic_context)
             .and_then(|(source_context, target_context)| {
                 let source_typevars = source_context.variables(db).collect::<Vec<_>>();
                 let target_typevars = target_context.variables(db).collect::<Vec<_>>();
@@ -1845,22 +1825,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Variables bound directly by the target signature are universal. Other variables pulled
         // into its inferable set through bounds or specializations belong to the surrounding
         // inference context and remain inferable.
-        let target_inferable = if infer_target_typevars {
-            target.inferable_typevars(db)
-        } else {
-            InferableTypeVars::from_typevars(
-                db,
-                target
-                    .inferable_typevars(db)
-                    .iter(db)
-                    .filter(|typevar| {
-                        target
-                            .generic_context
-                            .is_none_or(|context| !context.contains(db, *typevar))
-                    })
-                    .collect::<FxOrderSet<_>>(),
-            )
-        };
+        let target_inferable = InferableTypeVars::from_typevars(
+            db,
+            target
+                .inferable_typevars(db)
+                .iter(db)
+                .filter(|typevar| {
+                    target
+                        .generic_context
+                        .is_none_or(|context| !context.contains(db, *typevar))
+                })
+                .collect::<FxOrderSet<_>>(),
+        );
         let inferable = source_inferable.merge(db, target_inferable);
         let inferable = self.inferable.merge(db, inferable);
 
@@ -1879,9 +1855,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             self.constraints,
             source_inferable.iter(db).chain(target_inferable.iter(db)),
         );
-        if infer_target_typevars {
-            return when;
-        }
         if unaligned_source.generic_context.is_none() || target.generic_context.is_none() {
             return when;
         }
@@ -1892,25 +1865,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         );
         if positional.is_always_satisfied(db) {
             positional
-        } else if aligned_source
-            .as_ref()
-            .is_some_and(|(_, generic_context_check)| generic_context_check.is_never_satisfied(db))
-        {
-            // Inferring the target here would erase the domain mismatch, so infer only a source
-            // specialization while keeping the target variables rigid.
-            self.without_context_collection(|| {
-                self.check_signature_pair_with_inferred_source(db, unaligned_source, target)
-            })
         } else {
             positional.or(db, self.constraints, || {
                 self.without_context_collection(|| {
-                    self.check_signature_pair_with_inferred_typevars(db, unaligned_source, target)
+                    self.check_signature_pair_with_inferred_source(db, unaligned_source, target)
                 })
             })
         }
     }
 
-    /// Infer a source specialization for a rigid generic target.
+    /// Infer a source specialization, then verify it against the rigid generic target.
     fn check_signature_pair_with_inferred_source(
         &self,
         db: &'db dyn Db,
@@ -1933,27 +1897,54 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let inferable = self
             .inferable
             .merge(db, source_inferable.merge(db, target_inferable));
-        let checker = self.with_inferable_typevars(inferable);
-        let source_domain = source.generic_context.map_or_else(
-            || checker.always(),
-            |context| {
-                context
-                    .variables(db)
-                    .when_all(db, self.constraints, |typevar| {
-                        ConstraintSet::valid_specializations(db, self.constraints, typevar)
-                    })
-            },
-        );
+        let checker = self
+            .with_inferable_typevars(inferable)
+            .with_lazy_typevar_evaluation();
+        let Some(source_context) = source.generic_context else {
+            return self.never();
+        };
         let when = checker.with_signature_recursion_guard(source, target, || {
-            source_domain.and(db, self.constraints, || {
-                checker.check_signature_pair_inner(db, source, target)
-            })
+            checker.check_signature_pair_inner(db, source, target)
         });
-        when.reduce_inferable(
-            db,
-            self.constraints,
-            source_inferable.iter(db).chain(target_inferable.iter(db)),
-        )
+        let solutions = match when
+            .remove_noninferable(db, self.constraints, source_inferable)
+            .solutions(db, self.constraints)
+        {
+            Solutions::Unsatisfiable => return self.never(),
+            Solutions::Unconstrained => vec![Vec::new()],
+            Solutions::Constrained(solutions) => solutions,
+        };
+
+        solutions.iter().when_any(db, self.constraints, |solution| {
+            let specialization = source_context.specialize_recursive(
+                db,
+                source_context.variables(db).map(|typevar| {
+                    Some(
+                        solution
+                            .iter()
+                            .find(|binding| binding.bound_typevar == typevar)
+                            .map_or(Type::TypeVar(typevar), |binding| binding.solution),
+                    )
+                }),
+            );
+            let specialized_source = source.apply_specialization(db, specialization);
+            let specialization_is_valid = source_context
+                .variables(db)
+                .zip(specialization.types(db))
+                .when_all(db, self.constraints, |(typevar, specialized)| {
+                    let domain = typevar
+                        .typevar(db)
+                        .require_bound_or_constraints(db)
+                        .as_type(db)
+                        .apply_specialization(db, specialization);
+                    self.check_type_pair(db, *specialized, domain)
+                });
+            specialization_is_valid.and(db, self.constraints, || {
+                self.with_signature_recursion_guard(&specialized_source, target, || {
+                    self.check_signature_pair_inner(db, &specialized_source, target)
+                })
+            })
+        })
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1692,24 +1692,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
             // source is possibly overloaded while target is definitely not overloaded.
             (_, [target_signature]) => {
-                // Universal target variables must be evaluated after the source overloads have
-                // been combined. Until callable-level universal projection can preserve that
-                // coverage, retain the established overload relation instead of rejecting each
-                // overload independently.
-                if self.universal_callable_target_typevars
-                    && target_signature
-                        .generic_context
-                        .is_some_and(|context| context.variables(db).next().is_some())
-                {
-                    return self
-                        .without_universal_callable_target_typevars()
-                        .check_callable_signature_pair_inner(
-                            db,
-                            source_overloads,
-                            target_overloads,
-                        );
-                }
-
                 if let Some(aggregate_relation) = self.try_unary_overload_aggregate_relation(
                     db,
                     source_overloads,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1879,64 +1879,22 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             || self.never(),
             |(_, generic_context_check)| generic_context_check.and(db, self.constraints, || when),
         );
-        if positional.is_always_satisfied(db) {
+        if positional.is_always_satisfied(db)
+            || aligned_source
+                .as_ref()
+                .is_some_and(|(_, generic_context_check)| {
+                    generic_context_check.is_never_satisfied(db)
+                })
+        {
             positional
         } else {
             positional.or(db, self.constraints, || {
                 self.without_context_collection(|| {
-                    self.check_signature_pair_with_inferred_source(db, unaligned_source, target)
+                    self.without_universal_callable_target_typevars()
+                        .check_signature_pair(db, unaligned_source, target)
                 })
             })
         }
-    }
-
-    /// Check a generic source by inferring its specialization from a universal generic target.
-    fn check_signature_pair_with_inferred_source(
-        &self,
-        db: &'db dyn Db,
-        source: &Signature<'db>,
-        target: &Signature<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        let source_inferable = source.inferable_typevars(db);
-        let target_inferable = InferableTypeVars::from_typevars(
-            db,
-            target
-                .inferable_typevars(db)
-                .iter(db)
-                .filter(|typevar| {
-                    target
-                        .generic_context
-                        .is_none_or(|context| !context.contains(db, *typevar))
-                })
-                .collect::<FxOrderSet<_>>(),
-        );
-        let inferable = self
-            .inferable
-            .merge(db, source_inferable.merge(db, target_inferable));
-        let checker = self.with_inferable_typevars(inferable);
-        let nested_checker = checker
-            .without_universal_callable_target_typevars()
-            .with_lazy_typevar_evaluation();
-        let source_domain = source.generic_context.map_or_else(
-            || checker.always(),
-            |context| {
-                context
-                    .variables(db)
-                    .when_all(db, self.constraints, |typevar| {
-                        ConstraintSet::valid_specializations(db, self.constraints, typevar)
-                    })
-            },
-        );
-        let when = checker.with_signature_recursion_guard(source, target, || {
-            source_domain.and(db, self.constraints, || {
-                nested_checker.check_signature_pair_inner(db, source, target)
-            })
-        });
-        when.reduce_inferable(
-            db,
-            self.constraints,
-            source_inferable.iter(db).chain(target_inferable.iter(db)),
-        )
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1777,11 +1777,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         } else {
             target
         };
+        let unaligned_source = source;
         let nested_checker = self.without_universal_callable_target_typevars();
 
-        // A generic source can be specialized for each target specialization. Align equivalent
-        // generic contexts positionally, while requiring the source domain to cover the target
-        // domain.
+        // Positional alpha-renaming is a common fast path and avoids forcing recursive protocol
+        // members while their interfaces are still being inferred.
         let aligned_source = self
             .universal_callable_target_typevars
             .then(|| source.generic_context.zip(target.generic_context))
@@ -1868,9 +1868,75 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             self.constraints,
             source_inferable.iter(db).chain(target_inferable.iter(db)),
         );
-        aligned_source.map_or(when, |(_, generic_context_check)| {
-            generic_context_check.and(db, self.constraints, || when)
-        })
+        if !self.universal_callable_target_typevars {
+            return when;
+        }
+        if unaligned_source.generic_context.is_none() || target.generic_context.is_none() {
+            return when;
+        }
+
+        let positional = aligned_source.as_ref().map_or_else(
+            || self.never(),
+            |(_, generic_context_check)| generic_context_check.and(db, self.constraints, || when),
+        );
+        if positional.is_always_satisfied(db) {
+            positional
+        } else {
+            positional.or(db, self.constraints, || {
+                self.without_context_collection(|| {
+                    self.check_signature_pair_with_inferred_source(db, unaligned_source, target)
+                })
+            })
+        }
+    }
+
+    /// Check a generic source by inferring its specialization from a universal generic target.
+    fn check_signature_pair_with_inferred_source(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        let source_inferable = source.inferable_typevars(db);
+        let target_inferable = InferableTypeVars::from_typevars(
+            db,
+            target
+                .inferable_typevars(db)
+                .iter(db)
+                .filter(|typevar| {
+                    target
+                        .generic_context
+                        .is_none_or(|context| !context.contains(db, *typevar))
+                })
+                .collect::<FxOrderSet<_>>(),
+        );
+        let inferable = self
+            .inferable
+            .merge(db, source_inferable.merge(db, target_inferable));
+        let checker = self.with_inferable_typevars(inferable);
+        let nested_checker = checker
+            .without_universal_callable_target_typevars()
+            .with_lazy_typevar_evaluation();
+        let source_domain = source.generic_context.map_or_else(
+            || checker.always(),
+            |context| {
+                context
+                    .variables(db)
+                    .when_all(db, self.constraints, |typevar| {
+                        ConstraintSet::valid_specializations(db, self.constraints, typevar)
+                    })
+            },
+        );
+        let when = checker.with_signature_recursion_guard(source, target, || {
+            source_domain.and(db, self.constraints, || {
+                nested_checker.check_signature_pair_inner(db, source, target)
+            })
+        });
+        when.reduce_inferable(
+            db,
+            self.constraints,
+            source_inferable.iter(db).chain(target_inferable.iter(db)),
+        )
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1890,14 +1890,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             || self.never(),
             |(_, generic_context_check)| generic_context_check.and(db, self.constraints, || when),
         );
-        if positional.is_always_satisfied(db)
-            || aligned_source
-                .as_ref()
-                .is_some_and(|(_, generic_context_check)| {
-                    generic_context_check.is_never_satisfied(db)
-                })
-        {
+        if positional.is_always_satisfied(db) {
             positional
+        } else if aligned_source
+            .as_ref()
+            .is_some_and(|(_, generic_context_check)| generic_context_check.is_never_satisfied(db))
+        {
+            // Inferring the target here would erase the domain mismatch, so infer only a source
+            // specialization while keeping the target variables rigid.
+            self.without_context_collection(|| {
+                self.check_signature_pair_with_inferred_source(db, unaligned_source, target)
+            })
         } else {
             positional.or(db, self.constraints, || {
                 self.without_context_collection(|| {
@@ -1905,6 +1908,52 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 })
             })
         }
+    }
+
+    /// Infer a source specialization for a rigid generic target.
+    fn check_signature_pair_with_inferred_source(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        let source_inferable = source.inferable_typevars(db);
+        let target_inferable = InferableTypeVars::from_typevars(
+            db,
+            target
+                .inferable_typevars(db)
+                .iter(db)
+                .filter(|typevar| {
+                    target
+                        .generic_context
+                        .is_none_or(|context| !context.contains(db, *typevar))
+                })
+                .collect::<FxOrderSet<_>>(),
+        );
+        let inferable = self
+            .inferable
+            .merge(db, source_inferable.merge(db, target_inferable));
+        let checker = self.with_inferable_typevars(inferable);
+        let source_domain = source.generic_context.map_or_else(
+            || checker.always(),
+            |context| {
+                context
+                    .variables(db)
+                    .when_all(db, self.constraints, |typevar| {
+                        ConstraintSet::valid_specializations(db, self.constraints, typevar)
+                    })
+            },
+        );
+        let when = checker.with_signature_recursion_guard(source, target, || {
+            source_domain.and(db, self.constraints, || {
+                checker.check_signature_pair_inner(db, source, target)
+            })
+        });
+        when.reduce_inferable(
+            db,
+            self.constraints,
+            source_inferable.iter(db).chain(target_inferable.iter(db)),
+        )
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -36,7 +36,8 @@ use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, ErrorContext,
     ErrorContextTree, FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind,
     ParamSpecAttrKind, ParameterDescription, SelfBinding, TypeContext, TypeMapping, TypeVarNonce,
-    TypedDictType, UnionBuilder, VarianceInferable, infer_complete_scope_types, todo_type,
+    TypeVarBoundOrConstraints, TypedDictType, UnionBuilder, VarianceInferable,
+    infer_complete_scope_types, todo_type,
 };
 use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
@@ -1802,16 +1803,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     db,
                     self.constraints,
                     |(target, source)| {
-                        let target_domain = target
-                            .typevar(db)
-                            .require_bound_or_constraints(db)
-                            .as_type(db);
-                        let source_domain = source
-                            .typevar(db)
-                            .require_bound_or_constraints(db)
-                            .as_type(db)
-                            .apply_specialization(db, specialization);
-                        self.check_type_pair(db, target_domain, source_domain)
+                        self.check_source_typevar_specialization(
+                            db,
+                            *source,
+                            Type::TypeVar(*target),
+                            specialization,
+                        )
                     },
                 );
                 Some((
@@ -1874,6 +1871,56 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         }
     }
 
+    /// Check that a source type variable can be specialized to `specialized` without erasing the
+    /// difference between an upper bound and a constrained domain.
+    fn check_source_typevar_specialization(
+        &self,
+        db: &'db dyn Db,
+        source: BoundTypeVarInstance<'db>,
+        specialized: Type<'db>,
+        specialization: Specialization<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        match source.typevar(db).require_bound_or_constraints(db) {
+            TypeVarBoundOrConstraints::UpperBound(bound) => self.check_type_pair(
+                db,
+                specialized,
+                bound.apply_specialization(db, specialization),
+            ),
+            TypeVarBoundOrConstraints::Constraints(source_constraints) => {
+                let source_accepts_constraint = |candidate| {
+                    source_constraints.elements(db).iter().copied().when_any(
+                        db,
+                        self.constraints,
+                        |source_constraint| {
+                            let source_constraint =
+                                source_constraint.apply_specialization(db, specialization);
+                            self.check_type_pair(db, candidate, source_constraint).and(
+                                db,
+                                self.constraints,
+                                || self.check_type_pair(db, source_constraint, candidate),
+                            )
+                        },
+                    )
+                };
+
+                if let Type::TypeVar(target) = specialized {
+                    let TypeVarBoundOrConstraints::Constraints(target_constraints) =
+                        target.typevar(db).require_bound_or_constraints(db)
+                    else {
+                        return self.never();
+                    };
+                    target_constraints.elements(db).iter().copied().when_all(
+                        db,
+                        self.constraints,
+                        source_accepts_constraint,
+                    )
+                } else {
+                    source_accepts_constraint(specialized)
+                }
+            }
+        }
+    }
+
     /// Infer a source specialization, then verify it against the rigid generic target.
     fn check_signature_pair_with_inferred_source(
         &self,
@@ -1932,12 +1979,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .variables(db)
                 .zip(specialization.types(db))
                 .when_all(db, self.constraints, |(typevar, specialized)| {
-                    let domain = typevar
-                        .typevar(db)
-                        .require_bound_or_constraints(db)
-                        .as_type(db)
-                        .apply_specialization(db, specialization);
-                    self.check_type_pair(db, *specialized, domain)
+                    self.check_source_typevar_specialization(
+                        db,
+                        typevar,
+                        *specialized,
+                        specialization,
+                    )
                 });
             specialization_is_valid.and(db, self.constraints, || {
                 self.with_signature_recursion_guard(&specialized_source, target, || {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1253,6 +1253,21 @@ impl<'db> Signature<'db> {
         }
     }
 
+    /// Returns inferable type variables that are referenced by this signature's generic context
+    /// but bound by an enclosing context, such as a generic class.
+    fn outer_inferable_typevars(&self, db: &'db dyn Db) -> InferableTypeVars<'db> {
+        let Some(generic_context) = self.generic_context else {
+            return InferableTypeVars::None;
+        };
+        InferableTypeVars::from_typevars(
+            db,
+            self.inferable_typevars(db)
+                .iter(db)
+                .filter(|typevar| !generic_context.contains(db, *typevar))
+                .collect::<FxOrderSet<_>>(),
+        )
+    }
+
     pub(crate) fn is_non_generic(&self) -> bool {
         self.generic_context.is_none()
     }
@@ -1749,16 +1764,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         self.check_signature_pair_impl(db, source, target, false)
     }
 
-    /// Check two signatures while inferring both signatures' type variables.
-    fn check_signature_pair_with_inferred_typevars(
-        &self,
-        db: &'db dyn Db,
-        source: &Signature<'db>,
-        target: &Signature<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        self.check_signature_pair_impl(db, source, target, true)
-    }
-
+    /// Checks a signature pair using positional type-variable alignment where possible, then
+    /// falls back to inferred source specialization when the target's local variables are rigid.
     fn check_signature_pair_impl(
         &self,
         db: &'db dyn Db,
@@ -1845,18 +1852,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let target_inferable = if infer_target_typevars {
             target.inferable_typevars(db)
         } else {
-            InferableTypeVars::from_typevars(
-                db,
-                target
-                    .inferable_typevars(db)
-                    .iter(db)
-                    .filter(|typevar| {
-                        target
-                            .generic_context
-                            .is_none_or(|context| !context.contains(db, *typevar))
-                    })
-                    .collect::<FxOrderSet<_>>(),
-            )
+            target.outer_inferable_typevars(db)
         };
         let inferable = source_inferable.merge(db, target_inferable);
         let inferable = self.inferable.merge(db, inferable);
@@ -1909,13 +1905,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         } else {
             positional.or(db, self.constraints, || {
                 self.without_context_collection(|| {
-                    self.check_signature_pair_with_inferred_typevars(db, unaligned_source, target)
+                    self.check_signature_pair_impl(db, unaligned_source, target, true)
                 })
             })
         }
     }
 
-    /// Infer a source specialization when both signatures are part of an outer inference goal.
+    /// Infers a source specialization when both signatures contribute to an outer inference goal.
+    ///
+    /// The source's declared domain is included before its variables are abstracted away, while
+    /// the target's callable-local variables remain rigid.
     fn check_signature_pair_with_inferred_source_for_inference(
         &self,
         db: &'db dyn Db,
@@ -1923,18 +1922,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
         let source_inferable = source.inferable_typevars(db);
-        let target_inferable = InferableTypeVars::from_typevars(
-            db,
-            target
-                .inferable_typevars(db)
-                .iter(db)
-                .filter(|typevar| {
-                    target
-                        .generic_context
-                        .is_none_or(|context| !context.contains(db, *typevar))
-                })
-                .collect::<FxOrderSet<_>>(),
-        );
+        let target_inferable = target.outer_inferable_typevars(db);
         let inferable = self
             .inferable
             .merge(db, source_inferable.merge(db, target_inferable));
@@ -1961,7 +1949,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         )
     }
 
-    /// Check that a source type variable can be specialized to `specialized` without erasing the
+    /// Checks that a source type variable can be specialized to `specialized` without erasing the
     /// difference between an upper bound and a constrained domain.
     fn check_source_typevar_specialization(
         &self,
@@ -2027,7 +2015,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         }
     }
 
-    /// Infer a source specialization, then verify it against the rigid generic target.
+    /// Infers a source specialization, then verifies it against the rigid generic target.
+    ///
+    /// The inferred specialization may depend on a target type variable. For example, the source
+    /// below satisfies the target by choosing `S = list[T]` for each target specialization:
+    ///
+    /// ```python
+    /// def source[S](value: S) -> list[S]: ...
+    /// def target[T](value: list[T]) -> list[list[T]]: ...
+    /// ```
     fn check_signature_pair_with_inferred_source(
         &self,
         db: &'db dyn Db,
@@ -2035,18 +2031,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
         let source_inferable = source.inferable_typevars(db);
-        let target_inferable = InferableTypeVars::from_typevars(
-            db,
-            target
-                .inferable_typevars(db)
-                .iter(db)
-                .filter(|typevar| {
-                    target
-                        .generic_context
-                        .is_none_or(|context| !context.contains(db, *typevar))
-                })
-                .collect::<FxOrderSet<_>>(),
-        );
+        let target_inferable = target.outer_inferable_typevars(db);
         let inferable = self
             .inferable
             .merge(db, source_inferable.merge(db, target_inferable));
@@ -2096,6 +2081,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         })
     }
 
+    /// Applies candidate source solutions and checks each specialized source against the original
+    /// target, including validation against the source variables' declared domains.
     fn check_signature_pair_with_source_solutions(
         &self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2056,8 +2056,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let Some(source_context) = source.generic_context else {
             return self.never();
         };
+        let source_domain =
+            source_context
+                .variables(db)
+                .when_all(db, self.constraints, |typevar| {
+                    ConstraintSet::valid_specializations(db, self.constraints, typevar)
+                });
         let when = checker.with_signature_recursion_guard(source, target, || {
-            checker.check_signature_pair_inner(db, source, target)
+            source_domain.and(db, self.constraints, || {
+                checker.check_signature_pair_inner(db, source, target)
+            })
         });
         let solutions = match when
             .remove_noninferable(db, self.constraints, source_inferable)


### PR DESCRIPTION
## Summary

When comparing generic callables, we previously inferred type variables from both signatures. This treated a generic target like one convenient specialization, so an implementation could be accepted even though it did not support every call promised by the target:

```python
from typing import Protocol

class Identity(Protocol):
    def apply[T](self, value: T) -> T: ...

class IntIdentity:
    def apply(self, value: int) -> int:
        return value
```

`IntIdentity` cannot implement `Identity` because callers may specialize `T` to types other than `int`.

This PR makes callable comparison directional. Type variables bound by the source signature may be specialized, while variables bound by the target signature remain fixed. When positional type-variable alignment is insufficient, we infer a source specialization and then check that specialized source against the original target. This permits mappings such as `S = list[T]` while still requiring the source to work for every valid `T`.

Bounds and constraints remain distinct throughout alignment and source inference, including source choices that depend on a constrained target variable. Overloaded sources must contain one overload that independently covers the entire generic target; separate concrete overloads cannot be combined to cover different target specializations. Lazy constraint evaluation retains the existing two-sided inference behavior needed when the callable comparison is itself part of an outer inference goal.

The mdtests separate changed behavior from preservation and performance guards, covering concrete and generic sources, bounds, constraints, dependent specializations, reordered type variables, and overloads. The full `ty_python_semantic` suite and all-features Clippy pass on the rebased branch.
