### PR TITLE
[ruff] Write source files atomically during format, check --fix, and check --add-noqa

### DIFF
--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -301,10 +301,10 @@ impl Cache {
 
 /// Return a [`NamedTempFile`] in the specified directory.
 ///
-/// Sets the permissions of the temporary file to `0o666`, to match the non-temporary file
-/// default. ([`NamedTempFile`] defaults to `0o600`.)
+/// Sets the permissions of the temporary file to `0o666`, to match the
+/// non-temporary file default. ([`NamedTempFile`] defaults to `0o600`.)
 #[cfg(unix)]
-fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
+pub(crate) fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
     use std::os::unix::fs::PermissionsExt;
 
     tempfile::Builder::new()
@@ -314,7 +314,7 @@ fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
 
 /// Return a [`NamedTempFile`] in the specified directory.
 #[cfg(not(unix))]
-fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
+pub(crate) fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
     tempfile::Builder::new().tempfile_in(path)
 }
 

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -41,7 +41,7 @@ use ruff_workspace::resolver::{
 };
 
 use crate::args::{ConfigArguments, FormatArguments, FormatRange};
-use crate::cache::{Cache, FileCacheKey, PackageCacheMap, PackageCaches, tempfile_in};
+use crate::cache::{Cache, FileCacheKey, PackageCacheMap, PackageCaches};
 use crate::{ExitStatus, resolve_default_files};
 
 #[derive(Debug, Copy, Clone, is_macro::Is)]
@@ -288,22 +288,15 @@ pub(crate) fn format_path(
     // Don't write back to the cache if formatting a range.
     let cache = cache.filter(|_| range.is_none());
 
-    // Format the source.
     let format_result = match format_source(&unformatted, Some(path), settings, range)? {
         FormattedSource::Formatted(formatted) => match mode {
             FormatMode::Write => {
-                let mut temp = tempfile_in(path.parent().ok_or_else(|| {
-                    FormatCommandError::Write(
-                        Some(path.to_path_buf()),
-                        io::Error::new(io::ErrorKind::InvalidInput, "path has no parent").into(),
-                    )
-                })?)
-                .map_err(|err| FormatCommandError::Write(Some(path.to_path_buf()), err.into()))?;
+                let mut buffer = Vec::new();
                 formatted
-                    .write(&mut temp)
+                    .write(&mut buffer)
                     .map_err(|err| FormatCommandError::Write(Some(path.to_path_buf()), err))?;
-                temp.persist(path).map_err(|err| {
-                    FormatCommandError::Write(Some(path.to_path_buf()), err.error.into())
+                fs::atomic_write(path, &buffer).map_err(|err| {
+                    FormatCommandError::Write(Some(path.to_path_buf()), err.into())
                 })?;
 
                 if let Some(cache) = cache {

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -1,5 +1,4 @@
 use std::fmt::{Display, Formatter};
-use std::fs::File;
 use std::io;
 use std::io::{Write, stderr, stdout};
 use std::path::{Path, PathBuf};
@@ -42,7 +41,7 @@ use ruff_workspace::resolver::{
 };
 
 use crate::args::{ConfigArguments, FormatArguments, FormatRange};
-use crate::cache::{Cache, FileCacheKey, PackageCacheMap, PackageCaches};
+use crate::cache::{Cache, FileCacheKey, PackageCacheMap, PackageCaches, tempfile_in};
 use crate::{ExitStatus, resolve_default_files};
 
 #[derive(Debug, Copy, Clone, is_macro::Is)]
@@ -293,12 +292,19 @@ pub(crate) fn format_path(
     let format_result = match format_source(&unformatted, Some(path), settings, range)? {
         FormattedSource::Formatted(formatted) => match mode {
             FormatMode::Write => {
-                let mut writer = File::create(path).map_err(|err| {
-                    FormatCommandError::Write(Some(path.to_path_buf()), err.into())
-                })?;
+                let mut temp = tempfile_in(path.parent().ok_or_else(|| {
+                    FormatCommandError::Write(
+                        Some(path.to_path_buf()),
+                        io::Error::new(io::ErrorKind::InvalidInput, "path has no parent").into(),
+                    )
+                })?)
+                .map_err(|err| FormatCommandError::Write(Some(path.to_path_buf()), err.into()))?;
                 formatted
-                    .write(&mut writer)
+                    .write(&mut temp)
                     .map_err(|err| FormatCommandError::Write(Some(path.to_path_buf()), err))?;
+                temp.persist(path).map_err(|err| {
+                    FormatCommandError::Write(Some(path.to_path_buf()), err.error.into())
+                })?;
 
                 if let Some(cache) = cache {
                     if let Ok(cache_key) = FileCacheKey::from_path(path) {

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(target_family = "wasm", allow(dead_code))]
 
 use std::borrow::Cow;
-use std::fs::File;
 use std::io;
 use std::io::Write;
 use std::ops::{Add, AddAssign};
@@ -26,7 +25,7 @@ use ruff_text_size::TextRange;
 use ruff_workspace::Settings;
 use rustc_hash::FxHashMap;
 
-use crate::cache::{Cache, FileCache, FileCacheKey};
+use crate::cache::{Cache, FileCache, FileCacheKey, tempfile_in};
 
 /// A collection of [`Diagnostic`]s and additional information needed to render them.
 ///
@@ -269,7 +268,14 @@ pub(crate) fn lint_path(
             ) {
                 if !fixed.is_empty() {
                     match fix_mode {
-                        flags::FixMode::Apply => transformed.write(&mut File::create(path)?)?,
+                        flags::FixMode::Apply => {
+                            let parent = path.parent().ok_or_else(|| {
+                                io::Error::new(io::ErrorKind::InvalidInput, "path has no parent")
+                            })?;
+                            let mut temp = tempfile_in(parent)?;
+                            transformed.write(&mut temp)?;
+                            temp.persist(path).map_err(|err| err.error)?;
+                        }
                         flags::FixMode::Diff => {
                             write!(
                                 &mut io::stdout().lock(),

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -25,7 +25,7 @@ use ruff_text_size::TextRange;
 use ruff_workspace::Settings;
 use rustc_hash::FxHashMap;
 
-use crate::cache::{Cache, FileCache, FileCacheKey, tempfile_in};
+use crate::cache::{Cache, FileCache, FileCacheKey};
 
 /// A collection of [`Diagnostic`]s and additional information needed to render them.
 ///
@@ -269,12 +269,9 @@ pub(crate) fn lint_path(
                 if !fixed.is_empty() {
                     match fix_mode {
                         flags::FixMode::Apply => {
-                            let parent = path.parent().ok_or_else(|| {
-                                io::Error::new(io::ErrorKind::InvalidInput, "path has no parent")
-                            })?;
-                            let mut temp = tempfile_in(parent)?;
-                            transformed.write(&mut temp)?;
-                            temp.persist(path).map_err(|err| err.error)?;
+                            let mut buffer = Vec::new();
+                            transformed.write(&mut buffer)?;
+                            fs::atomic_write(path, &buffer)?;
                         }
                         flags::FixMode::Diff => {
                             write!(

--- a/crates/ruff_linter/Cargo.toml
+++ b/crates/ruff_linter/Cargo.toml
@@ -64,6 +64,7 @@ similar = { workspace = true }
 smallvec = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 typed-arena = { workspace = true }

--- a/crates/ruff_linter/src/fs.rs
+++ b/crates/ruff_linter/src/fs.rs
@@ -1,9 +1,7 @@
 use std::io::{self, Write};
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
-
-use tempfile::NamedTempFile;
 
 use path_absolutize::Absolutize;
 
@@ -12,33 +10,64 @@ use crate::settings::types::CompiledPerFileIgnoreList;
 
 /// Atomically write `contents` to `path`.
 ///
-/// Writes to a temporary file in the same directory as `path`, then renames
-/// the temporary file over `path`. `rename(2)` is atomic on POSIX, so an
-/// interrupted write leaves the original file intact.
-pub(crate) fn atomic_write(path: &Path, contents: &[u8]) -> io::Result<()> {
-    let parent = path
+/// If `path` is a symbolic link, it is resolved first so the write applies to
+/// the target file.
+/// If `path` is a hard link, it is written to directly to avoid breaking the link.
+/// Otherwise, it writes to a temporary file in the same directory as `path`,
+/// preserving the existing file permissions if it exists (defaulting to 0o666 subject
+/// to umask on Unix if the file is new), then renames the temporary file over `path`.
+pub fn atomic_write(path: &Path, contents: &[u8]) -> io::Result<()> {
+    let resolved_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let metadata = std::fs::metadata(&resolved_path).ok();
+
+    if let Some(ref meta) = metadata {
+        if is_hard_link(meta) {
+            let mut file = std::fs::File::create(&resolved_path)?;
+            file.write_all(contents)?;
+            return Ok(());
+        }
+    }
+
+    let parent = resolved_path
         .parent()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
-    let mut temp = tempfile_in(parent)?;
+
+    #[cfg(unix)]
+    let builder = {
+        let mut builder = tempfile::Builder::new();
+        if let Some(ref meta) = metadata {
+            builder.permissions(meta.permissions());
+        } else {
+            builder.permissions(std::fs::Permissions::from_mode(0o666));
+        }
+        builder
+    };
+    #[cfg(not(unix))]
+    let builder = tempfile::Builder::new();
+
+    let mut temp = builder.tempfile_in(parent)?;
+
+    #[cfg(windows)]
+    {
+        if let Some(ref meta) = metadata {
+            let _ = temp.as_file().set_permissions(meta.permissions());
+        }
+    }
+
     temp.write_all(contents)?;
-    temp.persist(path).map_err(|err| err.error).map(drop)
+    temp.persist(&resolved_path)
+        .map_err(|err| err.error)
+        .map(drop)
 }
 
-/// Return a [`NamedTempFile`] in the specified directory.
-///
-/// Sets permissions to `0o666` on Unix (matching the non-temporary file
-/// default; [`NamedTempFile`] otherwise defaults to `0o600`).
 #[cfg(unix)]
-pub(crate) fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
-    tempfile::Builder::new()
-        .permissions(std::fs::Permissions::from_mode(0o666))
-        .tempfile_in(path)
+fn is_hard_link(metadata: &std::fs::Metadata) -> bool {
+    metadata.nlink() > 1
 }
 
-/// Return a [`NamedTempFile`] in the specified directory.
 #[cfg(not(unix))]
-pub(crate) fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
-    tempfile::Builder::new().tempfile_in(path)
+fn is_hard_link(_metadata: &std::fs::Metadata) -> bool {
+    false
 }
 
 /// Return the current working directory.
@@ -92,4 +121,74 @@ pub fn relativize_path<P: AsRef<Path>>(path: P) -> String {
         return format!("{}", path.display());
     }
     format!("{}", path.display())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn write_new_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("new_file.py");
+        atomic_write(&path, b"print('hello')").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "print('hello')");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn preserves_permissions() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("perm_test.py");
+        std::fs::write(&path, b"original").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        atomic_write(&path, b"updated").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "updated");
+        let metadata = std::fs::metadata(&path).unwrap();
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn respects_symlinks() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("target.py");
+        let symlink = dir.path().join("link.py");
+
+        std::fs::write(&target, b"target content").unwrap();
+        std::os::unix::fs::symlink(&target, &symlink).unwrap();
+
+        atomic_write(&symlink, b"new content").unwrap();
+
+        // Target should be updated
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new content");
+        // Link should still be a symlink pointing to target
+        let metadata = std::fs::symlink_metadata(&symlink).unwrap();
+        assert!(metadata.is_symlink());
+        assert_eq!(std::fs::read_link(&symlink).unwrap(), target);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn respects_hardlinks() {
+        let dir = tempdir().unwrap();
+        let original = dir.path().join("original.py");
+        let link = dir.path().join("link.py");
+
+        std::fs::write(&original, b"original content").unwrap();
+        std::fs::hard_link(&original, &link).unwrap();
+
+        atomic_write(&link, b"new content").unwrap();
+
+        // Both original and link should be updated to new content
+        assert_eq!(std::fs::read_to_string(&original).unwrap(), "new content");
+        assert_eq!(std::fs::read_to_string(&link).unwrap(), "new content");
+
+        // The hard link connection should NOT be severed
+        assert_eq!(std::fs::metadata(&original).unwrap().nlink(), 2);
+        assert_eq!(std::fs::metadata(&link).unwrap().nlink(), 2);
+    }
 }

--- a/crates/ruff_linter/src/fs.rs
+++ b/crates/ruff_linter/src/fs.rs
@@ -1,9 +1,45 @@
+use std::io::{self, Write};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+
+use tempfile::NamedTempFile;
 
 use path_absolutize::Absolutize;
 
 use crate::registry::RuleSet;
 use crate::settings::types::CompiledPerFileIgnoreList;
+
+/// Atomically write `contents` to `path`.
+///
+/// Writes to a temporary file in the same directory as `path`, then renames
+/// the temporary file over `path`. `rename(2)` is atomic on POSIX, so an
+/// interrupted write leaves the original file intact.
+pub(crate) fn atomic_write(path: &Path, contents: &[u8]) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
+    let mut temp = tempfile_in(parent)?;
+    temp.write_all(contents)?;
+    temp.persist(path).map_err(|err| err.error).map(drop)
+}
+
+/// Return a [`NamedTempFile`] in the specified directory.
+///
+/// Sets permissions to `0o666` on Unix (matching the non-temporary file
+/// default; [`NamedTempFile`] otherwise defaults to `0o600`).
+#[cfg(unix)]
+pub(crate) fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
+    tempfile::Builder::new()
+        .permissions(std::fs::Permissions::from_mode(0o666))
+        .tempfile_in(path)
+}
+
+/// Return a [`NamedTempFile`] in the specified directory.
+#[cfg(not(unix))]
+pub(crate) fn tempfile_in(path: &Path) -> io::Result<NamedTempFile> {
+    tempfile::Builder::new().tempfile_in(path)
+}
 
 /// Return the current working directory.
 ///

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt::Display;
-use std::fs;
 use std::ops::Add;
 use std::path::Path;
 
@@ -18,7 +17,7 @@ use rustc_hash::FxHashSet;
 
 use crate::Edit;
 use crate::Locator;
-use crate::fs::relativize_path;
+use crate::fs::{atomic_write, relativize_path};
 use crate::registry::Rule;
 use crate::rule_redirects::get_redirect_target;
 use crate::suppression::Suppressions;
@@ -768,7 +767,7 @@ pub(crate) fn add_noqa(
         suppressions,
     );
 
-    fs::write(path, output)?;
+    atomic_write(path, output.as_bytes()).map_err(anyhow::Error::from)?;
     Ok(count)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

Fixes #26480.

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Currently `ruff format`, `ruff check --fix`, and `ruff check --add-noqa` rewrite source files in place. If the process is interrupted (e.g., via `SIGINT` / `Ctrl-C` or a crash) while a write is happening, affected files can be left truncated to 0 bytes, resulting in data loss.

This PR applies the same atomic write-to-temp + rename introduced for the cache in #9981 to all source-file writes.

## Test Plan

<!-- How was it tested? -->

- Test suite passes.