### PR TITLE
[ty] Promote inferred module global write types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1815,6 +1815,36 @@ static_assert(is_subtype_of(UsesMeta, HasX))  # error: [static-assert-error]
 static_assert(is_assignable_to(UsesMeta, HasX))  # error: [static-assert-error]
 ```
 
+An unannotated module global retains its inferred literal type when read. Its write type is
+promoted, because code outside the module can reassign it:
+
+`settings.py`:
+
+```py
+from typing import Literal
+
+debug = True
+mode: Literal["development"] = "development"
+```
+
+`use_settings.py`:
+
+```py
+import settings
+from typing import Protocol
+
+class Options(Protocol):
+    debug: bool
+
+options: Options = settings
+
+reveal_type(settings.debug)  # revealed: Literal[True]
+settings.debug = False
+
+# An explicit literal annotation is not promoted.
+settings.mode = "production"  # error: [invalid-assignment]
+```
+
 ## `ClassVar` attribute members
 
 If a protocol `ClassVarX` has a `ClassVar` attribute member `x` with type `int`, this indicates that

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -36,7 +36,7 @@ pub(super) enum AttributeWriteRequirement<'db> {
     Unconstrained,
     /// The object type does not permit writes at all.
     CannotAssign,
-    /// A module symbol, with its declared type when the symbol is known.
+    /// A module symbol, with its effective write type when the symbol is known.
     ///
     /// `None` represents an unresolved module attribute rather than an unconstrained write.
     Module(Option<Type<'db>>),
@@ -229,7 +229,7 @@ pub(super) fn attribute_write_requirement<'db>(
                 module.static_member(db, attribute)
             };
             AttributeWriteRequirement::Module(match symbol.place {
-                Place::Defined(DefinedPlace { ty, .. }) => Some(ty),
+                Place::Defined(DefinedPlace { ty, .. }) => Some(ty.promote(db)),
                 Place::Undefined => None,
             })
         }


### PR DESCRIPTION
## Summary

An unannotated module global retains its precise inferred literal type when read, but we also used that literal as the type accepted by writes through the module object. This rejected both ordinary external mutation and the corresponding writable protocol relationship:

```python
# settings.py
debug = True

# app.py
import settings
from typing import Protocol

class Options(Protocol):
    debug: bool

settings.debug = False  # error: expected Literal[True]
options: Options = settings  # error: settings.debug is not writable as bool
```

Use regular literal promotion when resolving a module member's write type. Reads remain precise (`settings.debug` is still `Literal[True]`), while external writes accept `bool` and the module can satisfy `Options`. Explicit literal annotations such as `debug: Literal[True]` remain unpromoted.

This is a narrower alternative to [promoting the public read type of every unannotated module global](https://github.com/astral-sh/ty/issues/1822), and fixes the remaining false positive in the typing conformance suite's [`protocols_modules.py`](https://github.com/python/typing/blob/f9664d894c8cbfca8fba44624bdedef09add1aa7/conformance/tests/protocols_modules.py#L25).
