### PR TITLE
[ty] Refine parameter kind handling across ty semantic analysis

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -156,6 +156,52 @@ p = partial(f, 1)
 reveal_type(p)  # revealed: partial[(**kwargs: str) -> bool]
 ```
 
+### Specialized generic variadics remain non-gradual
+
+Specializing variadic parameter types to `Any` does not make them gradual when constructing a
+`partial`:
+
+```py
+from functools import partial
+from typing import Any, Callable, Generic, TypeVar
+from ty_extensions import TypeOf, is_subtype_of, static_assert
+
+T = TypeVar("T")
+
+class C(Generic[T]):
+    def method(self, *args: T, **kwargs: T) -> None: ...
+
+callback = partial(C[Any]().method)
+reveal_type(callback)  # revealed: partial[(*args: Any, **kwargs: Any) -> None]
+# Unlike a gradual callable, this standard variadic callable is a subtype of a no-argument callable.
+static_assert(is_subtype_of(TypeOf[callback], Callable[[], None]))
+```
+
+### Expanded ParamSpec variadics preserve non-gradual parameters
+
+When a `partial` expands specialized `P.args` and `P.kwargs`, it preserves the kind of the
+parameters inferred for `P`:
+
+```py
+from functools import partial
+from typing import Any, Callable, Generic, ParamSpec, TypeVar
+from ty_extensions import TypeOf, is_subtype_of, static_assert
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+class C(Generic[T]):
+    def method(self, *args: T, **kwargs: T) -> None: ...
+
+def invoke(callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None:
+    callback(*args, **kwargs)
+
+callback = partial(invoke, C[Any]().method)
+reveal_type(callback)  # revealed: partial[(*args: Any, **kwargs: Any) -> None]
+# Unlike a gradual callable, this standard variadic callable is a subtype of a no-argument callable.
+static_assert(is_subtype_of(TypeOf[callback], Callable[[], None]))
+```
+
 ### Defaults preserved
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -266,6 +266,32 @@ class Cyclic:
 reveal_type(Cyclic("").data)
 ```
 
+## Cycle normalization preserves non-gradual variadic parameters
+
+Normalizing a recursive implicit-attribute type does not reinterpret specialized variadic parameters
+as gradual:
+
+```py
+from typing import Any, Callable, Generic, TypeVar
+from ty_extensions import TypeOf, is_subtype_of, static_assert
+
+T = TypeVar("T")
+flag: bool
+
+class C(Generic[T]):
+    def method(self, *args: T, **kwargs: T) -> None: ...
+
+c = C[Any]()
+
+class Recursive:
+    def __init__(self, other: "Recursive"):
+        self.callback = c.method if flag else other.callback
+
+def check(value: Recursive):
+    reveal_type(value.callback)  # revealed: bound method C[Any].method(*args: Any, **kwargs: Any) -> None
+    static_assert(is_subtype_of(TypeOf[value.callback], Callable[[], None]))
+```
+
 ## Decorated methods with implicit class attributes
 
 This is a regression test for <https://github.com/astral-sh/ty/issues/3471>.

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -366,6 +366,52 @@ reveal_type(partial(partial, drop)(1)("x"))  # revealed: Unknown
 reveal_type(partial(partial, drop)("x")(1))  # revealed: Unknown
 ```
 
+## ParamSpec substitution preserves non-gradual variadic parameters
+
+Specializing variadic parameter types to `Any` does not make the parameter list gradual when it is
+substituted for a `ParamSpec`:
+
+```py
+from typing import Any, Callable, Generic, ParamSpec, TypeVar
+from ty_extensions import TypeOf, is_subtype_of, static_assert
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+class C(Generic[T]):
+    def method(self, *args: T, **kwargs: T) -> None: ...
+
+def identity(callback: Callable[P, None]) -> Callable[P, None]:
+    return callback
+
+callback = identity(C[Any]().method)
+reveal_type(callback)  # revealed: (*args: Any, **kwargs: Any) -> None
+static_assert(is_subtype_of(TypeOf[callback], Callable[[], None]))
+```
+
+## ParamSpec inference preserves non-gradual residual parameters
+
+Removing a `Concatenate` prefix while inferring a `ParamSpec` also preserves whether the remaining
+parameters are gradual:
+
+```py
+from typing import Any, Callable, Concatenate, Generic, ParamSpec, TypeVar
+from ty_extensions import TypeOf, is_subtype_of, static_assert
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+class C(Generic[T]):
+    def method(self, first: int, *args: T, **kwargs: T) -> None: ...
+
+def strip_first(callback: Callable[Concatenate[int, P], None]) -> Callable[P, None]:
+    raise NotImplementedError
+
+callback = strip_first(C[Any]().method)
+reveal_type(callback)  # revealed: (*args: Any, **kwargs: Any) -> None
+static_assert(is_subtype_of(TypeOf[callback], Callable[[], None]))
+```
+
 ## SymPy one-import MRE scaffold (multi-file)
 
 Reduced regression lock for a SymPy overload/protocol shape that can panic in the

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -2074,11 +2074,10 @@ pub(crate) mod implicit_globals {
             // if at least one global symbol is annotated in the module.
             "__annotate__" if Program::get(db).python_version(db) >= PythonVersion::PY314 => {
                 let signature = Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [Parameter::positional_only(Some(Name::new_static("format")))
-                            .with_annotated_type(KnownClass::Int.to_instance(db))],
-                    ),
+                    Parameters::standard([Parameter::positional_only(Some(Name::new_static(
+                        "format",
+                    )))
+                    .with_annotated_type(KnownClass::Int.to_instance(db))]),
                     KnownClass::Dict.to_specialized_instance(
                         db,
                         &[KnownClass::Str.to_instance(db), Type::any()],

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -86,7 +86,7 @@ pub use crate::types::method::{BoundMethodType, KnownBoundMethodType, WrapperDes
 use crate::types::mro::{MroIterator, StaticMroError};
 pub(crate) use crate::types::narrow::{NarrowingConstraint, infer_narrowing_constraints};
 use crate::types::newtype::NewType;
-use crate::types::signatures::walk_signature;
+use crate::types::signatures::{ConcatenateTail, walk_signature};
 pub(crate) use crate::types::signatures::{Parameter, Parameters};
 use crate::types::special_form::TypeQualifier;
 use crate::types::tuple::TupleSpec;
@@ -2742,11 +2742,10 @@ impl<'db> Type<'db> {
                     _ => None,
                 } && let Ok(length) = i64::try_from(length)
                 {
-                    let parameters = Parameters::from_annotation(
-                        db,
-                        [Parameter::positional_only(Some(Name::new_static("self")))
-                            .with_annotated_type(self)],
-                    );
+                    let parameters = Parameters::standard([Parameter::positional_only(Some(
+                        Name::new_static("self"),
+                    ))
+                    .with_annotated_type(self)]);
                     Place::bound(Type::function_like_callable(
                         db,
                         Signature::new(parameters, Type::int_literal(length)),
@@ -4311,11 +4310,10 @@ impl<'db> Type<'db> {
             Type::DataclassTransformer(_) => Binding::single(
                 self,
                 Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [Parameter::positional_only(Some(Name::new_static("func")))
-                            .with_annotated_type(Type::object())],
-                    ),
+                    Parameters::standard([Parameter::positional_only(Some(Name::new_static(
+                        "func",
+                    )))
+                    .with_annotated_type(Type::object())]),
                     Type::unknown(),
                 ),
             )
@@ -4333,15 +4331,12 @@ impl<'db> Type<'db> {
                         self,
                         Signature::new_generic(
                             Some(GenericContext::from_typevar_instances(db, [val_ty])),
-                            Parameters::from_annotation(
-                                db,
-                                [
-                                    Parameter::positional_only(Some(Name::new_static("value")))
-                                        .with_annotated_type(Type::TypeVar(val_ty)),
-                                    Parameter::positional_only(Some(Name::new_static("type")))
-                                        .with_annotated_type(object_type_form(db)),
-                                ],
-                            ),
+                            Parameters::standard([
+                                Parameter::positional_only(Some(Name::new_static("value")))
+                                    .with_annotated_type(Type::TypeVar(val_ty)),
+                                Parameter::positional_only(Some(Name::new_static("type")))
+                                    .with_annotated_type(object_type_form(db)),
+                            ]),
                             Type::TypeVar(val_ty),
                         ),
                     )
@@ -4352,15 +4347,14 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new(
-                            Parameters::from_annotation(
-                                db,
-                                [Parameter::positional_only(Some(Name::new_static("arg")))
-                                    // We need to set the type to `Any` here (instead of `Never`),
-                                    // in order for every `assert_never` call to pass the argument
-                                    // check. If we set it to `Never`, we'll get invalid-argument-type
-                                    // errors instead of `type-assertion-failure` errors.
-                                    .with_annotated_type(Type::any())],
-                            ),
+                            Parameters::standard([Parameter::positional_only(Some(
+                                Name::new_static("arg"),
+                            ))
+                            // We need to set the type to `Any` here (instead of `Never`),
+                            // in order for every `assert_never` call to pass the argument
+                            // check. If we set it to `Never`, we'll get invalid-argument-type
+                            // errors instead of `type-assertion-failure` errors.
+                            .with_annotated_type(Type::any())]),
                             Type::Never,
                         ),
                     )
@@ -4370,15 +4364,12 @@ impl<'db> Type<'db> {
                 Some(KnownFunction::Cast) => Binding::single(
                     self,
                     Signature::new(
-                        Parameters::from_annotation(
-                            db,
-                            [
-                                Parameter::positional_or_keyword(Name::new_static("typ"))
-                                    .with_annotated_type(object_type_form(db)),
-                                Parameter::positional_or_keyword(Name::new_static("val"))
-                                    .with_annotated_type(Type::any()),
-                            ],
-                        ),
+                        Parameters::standard([
+                            Parameter::positional_or_keyword(Name::new_static("typ"))
+                                .with_annotated_type(object_type_form(db)),
+                            Parameter::positional_or_keyword(Name::new_static("val"))
+                                .with_annotated_type(Type::any()),
+                        ]),
                         Type::any(),
                     ),
                 )
@@ -4428,18 +4419,14 @@ impl<'db> Type<'db> {
                         [
                             // def dataclass(cls: None, /, *, ...) -> Callable[[type[_T]], type[_T]]: ...
                             Signature::new(
-                                Parameters::from_annotation(
-                                    db,
-                                    parameters_with_cls(Type::none(db)),
-                                ),
+                                Parameters::standard(parameters_with_cls(Type::none(db))),
                                 Type::unknown(),
                             ),
                             // def dataclass(cls: type[_T], /, *, ...) -> type[_T]: ...
                             Signature::new(
-                                Parameters::from_annotation(
-                                    db,
-                                    parameters_with_cls(KnownClass::Type.to_instance(db)),
-                                ),
+                                Parameters::standard(parameters_with_cls(
+                                    KnownClass::Type.to_instance(db),
+                                )),
                                 Type::unknown(),
                             ),
                             // def dataclass(
@@ -4456,7 +4443,7 @@ impl<'db> Type<'db> {
                             //     weakref_slot: bool = False,
                             // ) -> Callable[[type[_T]], type[_T]]: ...
                             Signature::new(
-                                Parameters::from_annotation(db, decorator_factory_parameters),
+                                Parameters::standard(decorator_factory_parameters),
                                 Type::unknown(),
                             ),
                         ],
@@ -4522,8 +4509,7 @@ impl<'db> Type<'db> {
             Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar)) => {
                 let parameter = Parameter::positional_or_keyword(Name::new_static("type"))
                     .with_annotated_type(Type::any());
-                let signature =
-                    Signature::new(Parameters::from_annotation(db, [parameter]), Type::any());
+                let signature = Signature::new(Parameters::standard([parameter]), Type::any());
                 Binding::single(self, signature).into()
             }
 
@@ -4596,7 +4582,7 @@ impl<'db> Type<'db> {
                 let returns = IntersectionType::from_two_elements(db, typevar_meta, Type::any());
                 let signature = Signature::new_generic(
                     Some(context),
-                    Parameters::from_annotation(db, parameters),
+                    Parameters::standard(parameters),
                     returns,
                 );
                 Binding::single(self, signature).into()
@@ -4615,11 +4601,8 @@ impl<'db> Type<'db> {
             Type::KnownInstance(KnownInstanceType::NewType(newtype)) => Binding::single(
                 self,
                 Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [Parameter::positional_only(None)
-                            .with_annotated_type(newtype.base(db).instance_type(db))],
-                    ),
+                    Parameters::standard([Parameter::positional_only(None)
+                        .with_annotated_type(newtype.base(db).instance_type(db))]),
                     Type::NewTypeInstance(newtype),
                 ),
             )
@@ -4664,12 +4647,11 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new(
-                            Parameters::from_annotation(
-                                db,
-                                [Parameter::positional_only(Some(Name::new_static("o")))
-                                    .with_annotated_type(Type::any())
-                                    .with_default_type(Type::bool_literal(false))],
-                            ),
+                            Parameters::standard([Parameter::positional_only(Some(
+                                Name::new_static("o"),
+                            ))
+                            .with_annotated_type(Type::any())
+                            .with_default_type(Type::bool_literal(false))]),
                             KnownClass::Bool.to_instance(db),
                         ),
                     )
@@ -4704,23 +4686,19 @@ impl<'db> Type<'db> {
                         self,
                         [
                             Signature::new(
-                                Parameters::from_annotation(
-                                    db,
-                                    [
-                                        Parameter::positional_only(Some(Name::new_static("t")))
-                                            .with_annotated_type(Type::any()),
-                                        Parameter::positional_only(Some(Name::new_static("obj")))
-                                            .with_annotated_type(Type::any()),
-                                    ],
-                                ),
+                                Parameters::standard([
+                                    Parameter::positional_only(Some(Name::new_static("t")))
+                                        .with_annotated_type(Type::any()),
+                                    Parameter::positional_only(Some(Name::new_static("obj")))
+                                        .with_annotated_type(Type::any()),
+                                ]),
                                 KnownClass::Super.to_instance(db),
                             ),
                             Signature::new(
-                                Parameters::from_annotation(
-                                    db,
-                                    [Parameter::positional_only(Some(Name::new_static("t")))
-                                        .with_annotated_type(Type::any())],
-                                ),
+                                Parameters::standard([Parameter::positional_only(Some(
+                                    Name::new_static("t"),
+                                ))
+                                .with_annotated_type(Type::any())]),
                                 KnownClass::Super.to_instance(db),
                             ),
                             Signature::new(Parameters::empty(), KnownClass::Super.to_instance(db)),
@@ -4748,23 +4726,20 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new(
-                            Parameters::from_annotation(
-                                db,
-                                [
-                                    Parameter::positional_only(Some(Name::new_static("message")))
-                                        .with_annotated_type(Type::literal_string()),
-                                    Parameter::keyword_only(Name::new_static("category"))
-                                        .with_annotated_type(UnionType::from_two_elements(
-                                            db,
-                                            warning_class_type,
-                                            Type::none(db),
-                                        ))
-                                        .with_default_type(warning_class_type),
-                                    Parameter::keyword_only(Name::new_static("stacklevel"))
-                                        .with_annotated_type(KnownClass::Int.to_instance(db))
-                                        .with_default_type(Type::int_literal(1)),
-                                ],
-                            ),
+                            Parameters::standard([
+                                Parameter::positional_only(Some(Name::new_static("message")))
+                                    .with_annotated_type(Type::literal_string()),
+                                Parameter::keyword_only(Name::new_static("category"))
+                                    .with_annotated_type(UnionType::from_two_elements(
+                                        db,
+                                        warning_class_type,
+                                        Type::none(db),
+                                    ))
+                                    .with_default_type(warning_class_type),
+                                Parameter::keyword_only(Name::new_static("stacklevel"))
+                                    .with_annotated_type(KnownClass::Int.to_instance(db))
+                                    .with_default_type(Type::int_literal(1)),
+                            ]),
                             KnownClass::Deprecated.to_instance(db),
                         ),
                     )
@@ -4786,28 +4761,25 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new(
-                            Parameters::from_annotation(
-                                db,
-                                [
-                                    Parameter::positional_or_keyword(Name::new_static("name"))
-                                        .with_annotated_type(KnownClass::Str.to_instance(db)),
-                                    Parameter::positional_or_keyword(Name::new_static("value"))
-                                        .with_annotated_type(object_type_form(db)),
-                                    Parameter::keyword_only(Name::new_static("type_params"))
-                                        .with_annotated_type(Type::homogeneous_tuple(
+                            Parameters::standard([
+                                Parameter::positional_or_keyword(Name::new_static("name"))
+                                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+                                Parameter::positional_or_keyword(Name::new_static("value"))
+                                    .with_annotated_type(object_type_form(db)),
+                                Parameter::keyword_only(Name::new_static("type_params"))
+                                    .with_annotated_type(Type::homogeneous_tuple(
+                                        db,
+                                        UnionType::from_elements(
                                             db,
-                                            UnionType::from_elements(
-                                                db,
-                                                [
-                                                    KnownClass::TypeVar.to_instance(db),
-                                                    KnownClass::ParamSpec.to_instance(db),
-                                                    KnownClass::TypeVarTuple.to_instance(db),
-                                                ],
-                                            ),
-                                        ))
-                                        .with_default_type(Type::empty_tuple(db)),
-                                ],
-                            ),
+                                            [
+                                                KnownClass::TypeVar.to_instance(db),
+                                                KnownClass::ParamSpec.to_instance(db),
+                                                KnownClass::TypeVarTuple.to_instance(db),
+                                            ],
+                                        ),
+                                    ))
+                                    .with_default_type(Type::empty_tuple(db)),
+                            ]),
                             Type::unknown(),
                         ),
                     )
@@ -4817,27 +4789,22 @@ impl<'db> Type<'db> {
 
             KnownClass::Property => {
                 let getter_signature = Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [Parameter::positional_only(None).with_annotated_type(Type::any())],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(None).with_annotated_type(Type::any())
+                    ]),
                     Type::any(),
                 );
                 let setter_signature = Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(None).with_annotated_type(Type::any()),
-                            Parameter::positional_only(None).with_annotated_type(Type::any()),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(None).with_annotated_type(Type::any()),
+                        Parameter::positional_only(None).with_annotated_type(Type::any()),
+                    ]),
                     Type::none(db),
                 );
                 let deleter_signature = Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [Parameter::positional_only(None).with_annotated_type(Type::any())],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(None).with_annotated_type(Type::any())
+                    ]),
                     Type::any(),
                 );
 
@@ -4845,39 +4812,36 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new(
-                            Parameters::from_annotation(
-                                db,
-                                [
-                                    Parameter::positional_or_keyword(Name::new_static("fget"))
-                                        .with_annotated_type(UnionType::from_two_elements(
-                                            db,
-                                            Type::single_callable(db, getter_signature),
-                                            Type::none(db),
-                                        ))
-                                        .with_default_type(Type::none(db)),
-                                    Parameter::positional_or_keyword(Name::new_static("fset"))
-                                        .with_annotated_type(UnionType::from_two_elements(
-                                            db,
-                                            Type::single_callable(db, setter_signature),
-                                            Type::none(db),
-                                        ))
-                                        .with_default_type(Type::none(db)),
-                                    Parameter::positional_or_keyword(Name::new_static("fdel"))
-                                        .with_annotated_type(UnionType::from_two_elements(
-                                            db,
-                                            Type::single_callable(db, deleter_signature),
-                                            Type::none(db),
-                                        ))
-                                        .with_default_type(Type::none(db)),
-                                    Parameter::positional_or_keyword(Name::new_static("doc"))
-                                        .with_annotated_type(UnionType::from_two_elements(
-                                            db,
-                                            KnownClass::Str.to_instance(db),
-                                            Type::none(db),
-                                        ))
-                                        .with_default_type(Type::none(db)),
-                                ],
-                            ),
+                            Parameters::standard([
+                                Parameter::positional_or_keyword(Name::new_static("fget"))
+                                    .with_annotated_type(UnionType::from_two_elements(
+                                        db,
+                                        Type::single_callable(db, getter_signature),
+                                        Type::none(db),
+                                    ))
+                                    .with_default_type(Type::none(db)),
+                                Parameter::positional_or_keyword(Name::new_static("fset"))
+                                    .with_annotated_type(UnionType::from_two_elements(
+                                        db,
+                                        Type::single_callable(db, setter_signature),
+                                        Type::none(db),
+                                    ))
+                                    .with_default_type(Type::none(db)),
+                                Parameter::positional_or_keyword(Name::new_static("fdel"))
+                                    .with_annotated_type(UnionType::from_two_elements(
+                                        db,
+                                        Type::single_callable(db, deleter_signature),
+                                        Type::none(db),
+                                    ))
+                                    .with_default_type(Type::none(db)),
+                                Parameter::positional_or_keyword(Name::new_static("doc"))
+                                    .with_annotated_type(UnionType::from_two_elements(
+                                        db,
+                                        KnownClass::Str.to_instance(db),
+                                        Type::none(db),
+                                    ))
+                                    .with_default_type(Type::none(db)),
+                            ]),
                             Type::unknown(),
                         ),
                     )
@@ -4901,9 +4865,9 @@ impl<'db> Type<'db> {
                         self,
                         Signature::new_generic(
                             Some(GenericContext::from_typevar_instances(db, [return_ty])),
-                            Parameters::from_annotation(
+                            Parameters::concatenate(
                                 db,
-                                [
+                                vec![
                                     Parameter::positional_only(Some(Name::new_static("func")))
                                         .with_annotated_type(Type::single_callable(
                                             db,
@@ -4912,11 +4876,8 @@ impl<'db> Type<'db> {
                                                 Type::TypeVar(return_ty),
                                             ),
                                         )),
-                                    Parameter::variadic(Name::new_static("args"))
-                                        .with_annotated_type(Type::any()),
-                                    Parameter::keyword_variadic(Name::new_static("kwargs"))
-                                        .with_annotated_type(Type::any()),
                                 ],
+                                ConcatenateTail::Gradual,
                             ),
                             KnownClass::FunctoolsPartial
                                 .to_specialized_instance(db, &[Type::TypeVar(return_ty)]),
@@ -4947,18 +4908,13 @@ impl<'db> Type<'db> {
                             Signature::new(Parameters::empty(), Type::empty_tuple(db)),
                             Signature::new_generic(
                                 Some(GenericContext::from_typevar_instances(db, [element_ty])),
-                                Parameters::from_annotation(
-                                    db,
-                                    [Parameter::positional_only(Some(Name::new_static(
-                                        "iterable",
-                                    )))
-                                    .with_annotated_type(
-                                        KnownClass::Iterable.to_specialized_instance(
-                                            db,
-                                            &[Type::TypeVar(element_ty)],
-                                        ),
-                                    )],
-                                ),
+                                Parameters::standard([Parameter::positional_only(Some(
+                                    Name::new_static("iterable"),
+                                ))
+                                .with_annotated_type(
+                                    KnownClass::Iterable
+                                        .to_specialized_instance(db, &[Type::TypeVar(element_ty)]),
+                                )]),
                                 Type::homogeneous_tuple(db, Type::TypeVar(element_ty)),
                             ),
                         ],

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -934,7 +934,7 @@ impl<'db> BoundSuperType<'db> {
         {
             let item_parameter = Parameter::positional_only(Some(Name::new_static("item")))
                 .with_annotated_type(Type::unknown());
-            let parameters = Parameters::from_annotation(db, [item_parameter]);
+            let parameters = Parameters::standard([item_parameter]);
             let return_type = self.owner(db).owner_type();
             let class_getitem = Type::single_callable(db, Signature::new(parameters, return_type));
             return Place::bound(class_getitem).into();

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -251,11 +251,8 @@ impl<'db> Type<'db> {
                 Some(CallableTypes::one(CallableType::single(
                     db,
                     Signature::new(
-                        Parameters::from_annotation(
-                            db,
-                            [Parameter::positional_only(None)
-                                .with_annotated_type(newtype.base(db).instance_type(db))],
-                        ),
+                        Parameters::standard([Parameter::positional_only(None)
+                            .with_annotated_type(newtype.base(db).instance_type(db))]),
                         Type::NewTypeInstance(newtype),
                     ),
                 )))

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1552,14 +1552,13 @@ impl<'db> ClassType<'db> {
         name: &str,
     ) -> Member<'db> {
         fn synthesize_getitem_overload_signature<'db>(
-            db: &'db dyn Db,
             index_annotation: Type<'db>,
             return_annotation: Type<'db>,
         ) -> Signature<'db> {
             let self_parameter = Parameter::positional_only(Some(Name::new_static("self")));
             let index_parameter = Parameter::positional_only(Some(Name::new_static("index")))
                 .with_annotated_type(index_annotation);
-            let parameters = Parameters::from_annotation(db, [self_parameter, index_parameter]);
+            let parameters = Parameters::standard([self_parameter, index_parameter]);
             Signature::new(parameters, return_annotation)
         }
 
@@ -1595,11 +1594,10 @@ impl<'db> ClassType<'db> {
                     .map(Type::int_literal)
                     .unwrap_or_else(|| KnownClass::Int.to_instance(db));
 
-                let parameters = Parameters::from_annotation(
-                    db,
-                    [Parameter::positional_only(Some(Name::new_static("self")))
-                        .with_annotated_type(Type::instance(db, self))],
-                );
+                let parameters = Parameters::standard([Parameter::positional_only(Some(
+                    Name::new_static("self"),
+                ))
+                .with_annotated_type(Type::instance(db, self))]);
 
                 let synthesized_dunder_method =
                     Type::function_like_callable(db, Signature::new(parameters, return_type));
@@ -1732,7 +1730,6 @@ impl<'db> ClassType<'db> {
                                 );
 
                                 Some(synthesize_getitem_overload_signature(
-                                    db,
                                     index_annotation,
                                     return_type,
                                 ))
@@ -1750,7 +1747,6 @@ impl<'db> ClassType<'db> {
                         //    __getitem__(self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[str | float | bytes, ...]
                         //
                         overload_signatures.push(synthesize_getitem_overload_signature(
-                            db,
                             KnownClass::SupportsIndex.to_instance(db),
                             all_elements_unioned,
                         ));
@@ -1760,7 +1756,6 @@ impl<'db> ClassType<'db> {
                             [KnownClass::SupportsIndex.to_instance(db), Type::none(db)],
                         );
                         overload_signatures.push(synthesize_getitem_overload_signature(
-                            db,
                             KnownClass::Slice.to_specialized_instance(
                                 db,
                                 &[slice_bound, slice_bound, slice_bound],
@@ -1837,14 +1832,11 @@ impl<'db> ClassType<'db> {
                         iterable_parameter.with_default_type(Type::empty_tuple(db));
                 }
 
-                let parameters = Parameters::from_annotation(
-                    db,
-                    [
-                        Parameter::positional_only(Some(Name::new_static("self")))
-                            .with_annotated_type(SubclassOfType::from(db, self)),
-                        iterable_parameter,
-                    ],
-                );
+                let parameters = Parameters::standard([
+                    Parameter::positional_only(Some(Name::new_static("self")))
+                        .with_annotated_type(SubclassOfType::from(db, self)),
+                    iterable_parameter,
+                ]);
 
                 let synthesized_dunder = Type::function_like_callable(
                     db,

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -57,7 +57,7 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
 
             let signature = Signature::new_generic(
                 Some(generic_context),
-                Parameters::from_annotation(db, parameters),
+                Parameters::standard(parameters),
                 self_ty,
             );
             Some(Type::function_like_callable(db, signature))
@@ -102,7 +102,7 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
                     .with_definition(field.definition)
             }));
 
-            let signature = Signature::new(Parameters::from_annotation(db, parameters), self_ty);
+            let signature = Signature::new(Parameters::standard(parameters), self_ty);
             Some(Type::function_like_callable(db, signature))
         }
         "__init__" => {
@@ -622,10 +622,7 @@ impl get_size2::GetSize for NamedTupleSpec<'_> {}
 /// Create a property type for a namedtuple field.
 fn create_field_property<'db>(db: &'db dyn Db, field_ty: Type<'db>) -> Type<'db> {
     let property_getter_signature = Signature::new(
-        Parameters::from_annotation(
-            db,
-            [Parameter::positional_only(Some(Name::new_static("self")))],
-        ),
+        Parameters::standard([Parameter::positional_only(Some(Name::new_static("self")))]),
         field_ty,
     );
     let property_getter = Type::single_callable(db, property_getter_signature);

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1194,10 +1194,9 @@ impl<'db> StaticClassLiteral<'db> {
                 .get(name)
             {
                 let property_getter_signature = Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [Parameter::positional_only(Some(Name::new_static("self")))],
-                    ),
+                    Parameters::standard([Parameter::positional_only(Some(Name::new_static(
+                        "self",
+                    )))]),
                     field.declared_ty,
                 );
                 let property_getter = Type::single_callable(db, property_getter_signature);
@@ -1473,10 +1472,10 @@ impl<'db> StaticClassLiteral<'db> {
             let signature = match name {
                 "__new__" | "__init__" => Signature::new_generic(
                     inherited_generic_context.or_else(|| self.inherited_generic_context(db)),
-                    Parameters::from_annotation(db, parameters),
+                    Parameters::standard(parameters),
                     return_ty,
                 ),
-                _ => Signature::new(Parameters::from_annotation(db, parameters), return_ty),
+                _ => Signature::new(Parameters::standard(parameters), return_ty),
             };
             Some(Type::function_like_callable(db, signature))
         };
@@ -1545,17 +1544,14 @@ impl<'db> StaticClassLiteral<'db> {
                 }
 
                 let signature = Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_or_keyword(Name::new_static("self"))
-                                // TODO: could be `Self`.
-                                .with_annotated_type(instance_ty),
-                            Parameter::positional_or_keyword(Name::new_static("other"))
-                                // TODO: could be `Self`.
-                                .with_annotated_type(instance_ty),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_or_keyword(Name::new_static("self"))
+                            // TODO: could be `Self`.
+                            .with_annotated_type(instance_ty),
+                        Parameter::positional_or_keyword(Name::new_static("other"))
+                            // TODO: could be `Self`.
+                            .with_annotated_type(instance_ty),
+                    ]),
                     KnownClass::Bool.to_instance(db),
                 );
 
@@ -1569,11 +1565,10 @@ impl<'db> StaticClassLiteral<'db> {
 
                 if unsafe_hash || (frozen && eq) {
                     let signature = Signature::new(
-                        Parameters::from_annotation(
-                            db,
-                            [Parameter::positional_or_keyword(Name::new_static("self"))
-                                .with_annotated_type(instance_ty)],
-                        ),
+                        Parameters::standard([Parameter::positional_or_keyword(Name::new_static(
+                            "self",
+                        ))
+                        .with_annotated_type(instance_ty)]),
                         KnownClass::Int.to_instance(db),
                     );
 
@@ -1660,15 +1655,12 @@ impl<'db> StaticClassLiteral<'db> {
             (CodeGeneratorKind::DataclassLike(_), "__setattr__") => {
                 if self.is_frozen_dataclass(db) == Some(true) {
                     let signature = Signature::new(
-                        Parameters::from_annotation(
-                            db,
-                            [
-                                Parameter::positional_or_keyword(Name::new_static("self"))
-                                    .with_annotated_type(instance_ty),
-                                Parameter::positional_or_keyword(Name::new_static("name")),
-                                Parameter::positional_or_keyword(Name::new_static("value")),
-                            ],
-                        ),
+                        Parameters::standard([
+                            Parameter::positional_or_keyword(Name::new_static("self"))
+                                .with_annotated_type(instance_ty),
+                            Parameter::positional_or_keyword(Name::new_static("name")),
+                            Parameter::positional_or_keyword(Name::new_static("value")),
+                        ]),
                         Type::Never,
                     );
 
@@ -1719,16 +1711,13 @@ impl<'db> StaticClassLiteral<'db> {
             Type::instance(db, self.apply_optional_specialization(db, specialization));
         let setattr_signature = |name_ty, return_ty| {
             Signature::new(
-                Parameters::from_annotation(
-                    db,
-                    [
-                        Parameter::positional_or_keyword(Name::new_static("self"))
-                            .with_annotated_type(instance_ty),
-                        Parameter::positional_or_keyword(Name::new_static("name"))
-                            .with_annotated_type(name_ty),
-                        Parameter::positional_or_keyword(Name::new_static("value")),
-                    ],
-                ),
+                Parameters::standard([
+                    Parameter::positional_or_keyword(Name::new_static("self"))
+                        .with_annotated_type(instance_ty),
+                    Parameter::positional_or_keyword(Name::new_static("name"))
+                        .with_annotated_type(name_ty),
+                    Parameter::positional_or_keyword(Name::new_static("value")),
+                ]),
                 return_ty,
             )
         };

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -159,8 +159,7 @@ fn synthesize_typed_dict_init<'db>(
     });
 
     let map_overload = Signature::new(
-        Parameters::from_annotation(
-            db,
+        Parameters::standard(
             [self_param.clone(), map_param]
                 .into_iter()
                 .chain(params_with_default)
@@ -181,8 +180,7 @@ fn synthesize_typed_dict_init<'db>(
     });
 
     let keyword_overload = Signature::new(
-        Parameters::from_annotation(
-            db,
+        Parameters::standard(
             std::iter::once(self_param)
                 .chain(keyword_field_params)
                 .chain(keyword_rest_param),
@@ -215,21 +213,15 @@ fn synthesize_typed_dict_getitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("key")))
                     .with_annotated_type(key_type),
             ];
-            Signature::new(
-                Parameters::from_annotation(db, parameters),
-                field.declared_ty,
-            )
+            Signature::new(Parameters::standard(parameters), field.declared_ty)
         })
         .chain(std::iter::once(Signature::new(
-            Parameters::from_annotation(
-                db,
-                [
-                    Parameter::positional_only(Some(Name::new_static("self")))
-                        .with_annotated_type(instance_ty),
-                    Parameter::positional_only(Some(Name::new_static("key")))
-                        .with_annotated_type(KnownClass::Str.to_instance(db)),
-                ],
-            ),
+            Parameters::standard([
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+            ]),
             if typed_dict.explicit_extra_items(db).is_some() {
                 typed_dict.value_type(db)
             } else {
@@ -267,7 +259,7 @@ fn synthesize_typed_dict_setitem<'db>(
             Parameter::positional_only(Some(Name::new_static("value")))
                 .with_annotated_type(Type::any()),
         ];
-        let signature = Signature::new(Parameters::from_annotation(db, parameters), Type::none(db));
+        let signature = Signature::new(Parameters::standard(parameters), Type::none(db));
         return Type::function_like_callable(db, signature);
     }
 
@@ -282,7 +274,7 @@ fn synthesize_typed_dict_setitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("value")))
                     .with_annotated_type(field.declared_ty),
             ];
-            Signature::new(Parameters::from_annotation(db, parameters), Type::none(db))
+            Signature::new(Parameters::standard(parameters), Type::none(db))
         })
         .chain(arbitrary_key_mutation_type.map(|value_ty| {
             let parameters = [
@@ -293,7 +285,7 @@ fn synthesize_typed_dict_setitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("value")))
                     .with_annotated_type(value_ty),
             ];
-            Signature::new(Parameters::from_annotation(db, parameters), Type::none(db))
+            Signature::new(Parameters::standard(parameters), Type::none(db))
         }));
 
     Type::Callable(CallableType::new(
@@ -324,7 +316,7 @@ fn synthesize_typed_dict_delitem<'db>(
             Parameter::positional_only(Some(Name::new_static("key")))
                 .with_annotated_type(Type::Never),
         ];
-        let signature = Signature::new(Parameters::from_annotation(db, parameters), Type::none(db));
+        let signature = Signature::new(Parameters::standard(parameters), Type::none(db));
         return Type::function_like_callable(db, signature);
     }
 
@@ -337,7 +329,7 @@ fn synthesize_typed_dict_delitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("key")))
                     .with_annotated_type(key_type),
             ];
-            Signature::new(Parameters::from_annotation(db, parameters), Type::none(db))
+            Signature::new(Parameters::standard(parameters), Type::none(db))
         })
         .chain(supports_arbitrary_key_deletion.then(|| {
             let parameters = [
@@ -346,7 +338,7 @@ fn synthesize_typed_dict_delitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("key")))
                     .with_annotated_type(KnownClass::Str.to_instance(db)),
             ];
-            Signature::new(Parameters::from_annotation(db, parameters), Type::none(db))
+            Signature::new(Parameters::standard(parameters), Type::none(db))
         }));
 
     Type::Callable(CallableType::new(
@@ -381,7 +373,7 @@ fn synthesize_typed_dict_get<'db>(
                     .with_annotated_type(key_type),
             ];
             let get_sig = Signature::new(
-                Parameters::from_annotation(db, get_sig_params),
+                Parameters::standard(get_sig_params),
                 if field.is_required() {
                     field.declared_ty
                 } else {
@@ -405,7 +397,7 @@ fn synthesize_typed_dict_get<'db>(
             ];
             let get_with_default_sig = Signature::new_generic(
                 Some(GenericContext::from_typevar_instances(db, [t_default])),
-                Parameters::from_annotation(db, get_with_default_sig_params),
+                Parameters::standard(get_with_default_sig_params),
                 if field.is_required() {
                     field.declared_ty
                 } else {
@@ -421,17 +413,14 @@ fn synthesize_typed_dict_get<'db>(
                 Either::Left([get_sig, get_with_default_sig].into_iter())
             } else {
                 let get_with_typed_default_sig = Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("self")))
-                                .with_annotated_type(instance_ty),
-                            Parameter::positional_only(Some(Name::new_static("key")))
-                                .with_annotated_type(key_type),
-                            Parameter::positional_only(Some(Name::new_static("default")))
-                                .with_annotated_type(field.declared_ty),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("self")))
+                            .with_annotated_type(instance_ty),
+                        Parameter::positional_only(Some(Name::new_static("key")))
+                            .with_annotated_type(key_type),
+                        Parameter::positional_only(Some(Name::new_static("default")))
+                            .with_annotated_type(field.declared_ty),
+                    ]),
                     field.declared_ty,
                 );
                 Either::Right(
@@ -441,15 +430,12 @@ fn synthesize_typed_dict_get<'db>(
         })
         // Fallback overloads for unknown keys
         .chain(std::iter::once(Signature::new(
-            Parameters::from_annotation(
-                db,
-                [
-                    Parameter::positional_only(Some(Name::new_static("self")))
-                        .with_annotated_type(instance_ty),
-                    Parameter::positional_only(Some(Name::new_static("key")))
-                        .with_annotated_type(KnownClass::Str.to_instance(db)),
-                ],
-            ),
+            Parameters::standard([
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+            ]),
             UnionType::from_two_elements(db, fallback_value_ty, Type::none(db)),
         )))
         .chain(std::iter::once({
@@ -470,7 +456,7 @@ fn synthesize_typed_dict_get<'db>(
 
             Signature::new_generic(
                 Some(GenericContext::from_typevar_instances(db, [t_default])),
-                Parameters::from_annotation(db, parameters),
+                Parameters::standard(parameters),
                 UnionType::from_two_elements(db, fallback_value_ty, Type::TypeVar(t_default)),
             )
         }));
@@ -539,8 +525,7 @@ fn synthesize_typed_dict_update<'db>(
     .into_iter()
     .chain(keyword_parameters);
 
-    let update_signature =
-        Signature::new(Parameters::from_annotation(db, parameters), Type::none(db));
+    let update_signature = Signature::new(Parameters::standard(parameters), Type::none(db));
     Type::function_like_callable(db, update_signature)
 }
 
@@ -557,7 +542,7 @@ fn synthesize_typed_dict_pop<'db>(
                 .with_annotated_type(instance_ty),
             Parameter::positional_only(Some(Name::new_static("key"))).with_annotated_type(key_ty),
         ];
-        let pop_sig = Signature::new(Parameters::from_annotation(db, pop_parameters), value_ty);
+        let pop_sig = Signature::new(Parameters::standard(pop_parameters), value_ty);
 
         // Non-generic overload that accepts the value type as the default,
         // providing bidirectional inference context for the default argument.
@@ -569,7 +554,7 @@ fn synthesize_typed_dict_pop<'db>(
                 .with_annotated_type(value_ty),
         ];
         let pop_with_typed_default_sig = Signature::new(
-            Parameters::from_annotation(db, pop_with_typed_default_parameters),
+            Parameters::standard(pop_with_typed_default_parameters),
             value_ty,
         );
 
@@ -584,7 +569,7 @@ fn synthesize_typed_dict_pop<'db>(
         ];
         let pop_with_default_sig = Signature::new_generic(
             Some(GenericContext::from_typevar_instances(db, [t_default])),
-            Parameters::from_annotation(db, pop_with_default_parameters),
+            Parameters::standard(pop_with_default_parameters),
             UnionType::from_two_elements(db, value_ty, Type::TypeVar(t_default)),
         );
 
@@ -634,10 +619,7 @@ fn synthesize_typed_dict_setdefault<'db>(
                     .with_annotated_type(field.declared_ty),
             ];
 
-            Signature::new(
-                Parameters::from_annotation(db, parameters),
-                field.declared_ty,
-            )
+            Signature::new(Parameters::standard(parameters), field.declared_ty)
         })
         .chain(
             typed_dict
@@ -651,10 +633,7 @@ fn synthesize_typed_dict_setdefault<'db>(
                         Parameter::positional_only(Some(Name::new_static("default")))
                             .with_annotated_type(default_ty),
                     ];
-                    Signature::new(
-                        Parameters::from_annotation(db, parameters),
-                        typed_dict.value_type(db),
-                    )
+                    Signature::new(Parameters::standard(parameters), typed_dict.value_type(db))
                 }),
         );
 
@@ -674,11 +653,8 @@ fn synthesize_typed_dict_no_argument_method<'db>(
     Type::function_like_callable(
         db,
         Signature::new(
-            Parameters::from_annotation(
-                db,
-                [Parameter::positional_only(Some(Name::new_static("self")))
-                    .with_annotated_type(Type::TypedDict(typed_dict))],
-            ),
+            Parameters::standard([Parameter::positional_only(Some(Name::new_static("self")))
+                .with_annotated_type(Type::TypedDict(typed_dict))]),
             return_ty,
         ),
     )
@@ -729,7 +705,7 @@ fn synthesize_typed_dict_merge<'db>(
     ];
 
     overloads = smallvec::smallvec![Signature::new(
-        Parameters::from_annotation(db, first_overload_parameters,),
+        Parameters::standard(first_overload_parameters),
         instance_ty,
     )];
 
@@ -758,7 +734,7 @@ fn synthesize_typed_dict_merge<'db>(
                 .with_annotated_type(partial_ty),
         ];
         overloads.push(Signature::new(
-            Parameters::from_annotation(db, overload_two_parameters),
+            Parameters::standard(overload_two_parameters),
             instance_ty,
         ));
 
@@ -769,7 +745,7 @@ fn synthesize_typed_dict_merge<'db>(
                 .with_annotated_type(dict_param_ty),
         ];
         overloads.push(Signature::new(
-            Parameters::from_annotation(db, overload_three_parameters),
+            Parameters::standard(overload_three_parameters),
             dict_return_ty,
         ));
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7519,14 +7519,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Synthesize overloads for `__getitem__` based on known dictionary elements.
         let getitem_overloads = elements.into_iter().map(|(name, ty)| {
             Signature::new(
-                Parameters::from_annotation(
-                    db,
-                    [
-                        Parameter::positional_only(Some(Name::new_static("self"))),
-                        Parameter::positional_or_keyword(Name::new_static("key"))
-                            .with_annotated_type(Type::string_literal(db, name)),
-                    ],
-                ),
+                Parameters::standard([
+                    Parameter::positional_only(Some(Name::new_static("self"))),
+                    Parameter::positional_or_keyword(Name::new_static("key"))
+                        .with_annotated_type(Type::string_literal(db, name)),
+                ]),
                 ty,
             )
         });

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -107,27 +107,21 @@ fn sequence_pattern_getitem_method<'db>(
         .into_iter()
         .map(|(index, element_type)| {
             Signature::new(
-                Parameters::from_annotation(
-                    db,
-                    [
-                        self_parameter(),
-                        Parameter::positional_only(Some(Name::new_static("index")))
-                            .with_annotated_type(Type::int_literal(index)),
-                    ],
-                ),
+                Parameters::standard([
+                    self_parameter(),
+                    Parameter::positional_only(Some(Name::new_static("index")))
+                        .with_annotated_type(Type::int_literal(index)),
+                ]),
                 element_type,
             )
         });
     let fallback_overload = fallback_return_type.map(|fallback_return_type| {
         Signature::new(
-            Parameters::from_annotation(
-                db,
-                [
-                    self_parameter(),
-                    Parameter::positional_only(Some(Name::new_static("index")))
-                        .with_annotated_type(KnownClass::Int.to_instance(db)),
-                ],
-            ),
+            Parameters::standard([
+                self_parameter(),
+                Parameter::positional_only(Some(Name::new_static("index")))
+                    .with_annotated_type(KnownClass::Int.to_instance(db)),
+            ]),
             fallback_return_type,
         )
     });
@@ -170,10 +164,7 @@ pub(crate) fn exact_sequence_pattern_type<'db>(
 
     let self_parameter = || Parameter::positional_only(Some(Name::new_static("self")));
 
-    let len_signature = Signature::new(
-        Parameters::from_annotation(db, [self_parameter()]),
-        length_type,
-    );
+    let len_signature = Signature::new(Parameters::standard([self_parameter()]), length_type);
     let len_method = CallableType::function_like(db, len_signature);
 
     let getitem_method = (element_types.len() > 0).then(|| {

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -311,32 +311,26 @@ impl<'db> KnownBoundMethodType<'db> {
             | KnownBoundMethodType::PropertyDunderGet(_) => Either::Left(Either::Left(
                 [
                     Signature::new(
-                        Parameters::from_annotation(
-                            db,
-                            [
-                                Parameter::positional_only(Some(Name::new_static("instance")))
-                                    .with_annotated_type(Type::none(db)),
-                                Parameter::positional_only(Some(Name::new_static("owner")))
-                                    .with_annotated_type(KnownClass::Type.to_instance(db)),
-                            ],
-                        ),
+                        Parameters::standard([
+                            Parameter::positional_only(Some(Name::new_static("instance")))
+                                .with_annotated_type(Type::none(db)),
+                            Parameter::positional_only(Some(Name::new_static("owner")))
+                                .with_annotated_type(KnownClass::Type.to_instance(db)),
+                        ]),
                         Type::unknown(),
                     ),
                     Signature::new(
-                        Parameters::from_annotation(
-                            db,
-                            [
-                                Parameter::positional_only(Some(Name::new_static("instance")))
-                                    .with_annotated_type(Type::object()),
-                                Parameter::positional_only(Some(Name::new_static("owner")))
-                                    .with_annotated_type(UnionType::from_two_elements(
-                                        db,
-                                        KnownClass::Type.to_instance(db),
-                                        Type::none(db),
-                                    ))
-                                    .with_default_type(Type::none(db)),
-                            ],
-                        ),
+                        Parameters::standard([
+                            Parameter::positional_only(Some(Name::new_static("instance")))
+                                .with_annotated_type(Type::object()),
+                            Parameter::positional_only(Some(Name::new_static("owner")))
+                                .with_annotated_type(UnionType::from_two_elements(
+                                    db,
+                                    KnownClass::Type.to_instance(db),
+                                    Type::none(db),
+                                ))
+                                .with_default_type(Type::none(db)),
+                        ]),
                         Type::unknown(),
                     ),
                 ]
@@ -347,74 +341,62 @@ impl<'db> KnownBoundMethodType<'db> {
             )),
             KnownBoundMethodType::PropertyDunderSet(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("instance")))
-                                .with_annotated_type(Type::object()),
-                            Parameter::positional_only(Some(Name::new_static("value")))
-                                .with_annotated_type(Type::object()),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("instance")))
+                            .with_annotated_type(Type::object()),
+                        Parameter::positional_only(Some(Name::new_static("value")))
+                            .with_annotated_type(Type::object()),
+                    ]),
                     Type::unknown(),
                 )))
             }
             KnownBoundMethodType::PropertyDunderDelete(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("instance")))
-                                .with_annotated_type(Type::object()),
-                        ],
-                    ),
+                    Parameters::standard([Parameter::positional_only(Some(Name::new_static(
+                        "instance",
+                    )))
+                    .with_annotated_type(Type::object())]),
                     Type::unknown(),
                 )))
             }
             KnownBoundMethodType::StrStartswith(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("prefix")))
-                                .with_annotated_type(UnionType::from_two_elements(
-                                    db,
-                                    KnownClass::Str.to_instance(db),
-                                    Type::homogeneous_tuple(db, KnownClass::Str.to_instance(db)),
-                                )),
-                            Parameter::positional_only(Some(Name::new_static("start")))
-                                .with_annotated_type(UnionType::from_two_elements(
-                                    db,
-                                    KnownClass::SupportsIndex.to_instance(db),
-                                    Type::none(db),
-                                ))
-                                .with_default_type(Type::none(db)),
-                            Parameter::positional_only(Some(Name::new_static("end")))
-                                .with_annotated_type(UnionType::from_two_elements(
-                                    db,
-                                    KnownClass::SupportsIndex.to_instance(db),
-                                    Type::none(db),
-                                ))
-                                .with_default_type(Type::none(db)),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("prefix")))
+                            .with_annotated_type(UnionType::from_two_elements(
+                                db,
+                                KnownClass::Str.to_instance(db),
+                                Type::homogeneous_tuple(db, KnownClass::Str.to_instance(db)),
+                            )),
+                        Parameter::positional_only(Some(Name::new_static("start")))
+                            .with_annotated_type(UnionType::from_two_elements(
+                                db,
+                                KnownClass::SupportsIndex.to_instance(db),
+                                Type::none(db),
+                            ))
+                            .with_default_type(Type::none(db)),
+                        Parameter::positional_only(Some(Name::new_static("end")))
+                            .with_annotated_type(UnionType::from_two_elements(
+                                db,
+                                KnownClass::SupportsIndex.to_instance(db),
+                                Type::none(db),
+                            ))
+                            .with_default_type(Type::none(db)),
+                    ]),
                     KnownClass::Bool.to_instance(db),
                 )))
             }
 
             KnownBoundMethodType::ConstraintSetRange => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("lower_bound")))
-                                .with_annotated_type(object_type_form()),
-                            Parameter::positional_only(Some(Name::new_static("typevar")))
-                                .with_annotated_type(object_type_form()),
-                            Parameter::positional_only(Some(Name::new_static("upper_bound")))
-                                .with_annotated_type(object_type_form()),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("lower_bound")))
+                            .with_annotated_type(object_type_form()),
+                        Parameter::positional_only(Some(Name::new_static("typevar")))
+                            .with_annotated_type(object_type_form()),
+                        Parameter::positional_only(Some(Name::new_static("upper_bound")))
+                            .with_annotated_type(object_type_form()),
+                    ]),
                     KnownClass::ConstraintSet.to_instance(db),
                 )))
             }
@@ -429,45 +411,38 @@ impl<'db> KnownBoundMethodType<'db> {
 
             KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("ty")))
-                                .with_annotated_type(object_type_form()),
-                            Parameter::positional_only(Some(Name::new_static("of")))
-                                .with_annotated_type(object_type_form()),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("ty")))
+                            .with_annotated_type(object_type_form()),
+                        Parameter::positional_only(Some(Name::new_static("of")))
+                            .with_annotated_type(object_type_form()),
+                    ]),
                     KnownClass::ConstraintSet.to_instance(db),
                 )))
             }
 
             KnownBoundMethodType::ConstraintSetSatisfies(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [Parameter::positional_only(Some(Name::new_static("other")))
-                            .with_annotated_type(KnownClass::ConstraintSet.to_instance(db))],
-                    ),
+                    Parameters::standard([Parameter::positional_only(Some(Name::new_static(
+                        "other",
+                    )))
+                    .with_annotated_type(KnownClass::ConstraintSet.to_instance(db))]),
                     KnownClass::ConstraintSet.to_instance(db),
                 )))
             }
 
             KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_) => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [Parameter::keyword_only(Name::new_static("inferable"))
-                            .with_annotated_type(UnionType::from_two_elements(
+                    Parameters::standard([Parameter::keyword_only(Name::new_static("inferable"))
+                        .with_annotated_type(UnionType::from_two_elements(
+                            db,
+                            TypeFormType::from_type_expression(
                                 db,
-                                TypeFormType::from_type_expression(
-                                    db,
-                                    Type::homogeneous_tuple(db, Type::object()),
-                                ),
-                                Type::none(db),
-                            ))
-                            .with_default_type(Type::none(db))],
-                    ),
+                                Type::homogeneous_tuple(db, Type::object()),
+                            ),
+                            Type::none(db),
+                        ))
+                        .with_default_type(Type::none(db))]),
                     KnownClass::Bool.to_instance(db),
                 )))
             }
@@ -607,36 +582,30 @@ impl WrapperDescriptorKind {
             let descriptor = class.to_instance(db);
             [
                 Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("self")))
-                                .with_annotated_type(descriptor),
-                            Parameter::positional_only(Some(Name::new_static("instance")))
-                                .with_annotated_type(none),
-                            Parameter::positional_only(Some(Name::new_static("owner")))
-                                .with_annotated_type(type_instance),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("self")))
+                            .with_annotated_type(descriptor),
+                        Parameter::positional_only(Some(Name::new_static("instance")))
+                            .with_annotated_type(none),
+                        Parameter::positional_only(Some(Name::new_static("owner")))
+                            .with_annotated_type(type_instance),
+                    ]),
                     Type::unknown(),
                 ),
                 Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("self")))
-                                .with_annotated_type(descriptor),
-                            Parameter::positional_only(Some(Name::new_static("instance")))
-                                .with_annotated_type(Type::object()),
-                            Parameter::positional_only(Some(Name::new_static("owner")))
-                                .with_annotated_type(UnionType::from_two_elements(
-                                    db,
-                                    type_instance,
-                                    none,
-                                ))
-                                .with_default_type(none),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("self")))
+                            .with_annotated_type(descriptor),
+                        Parameter::positional_only(Some(Name::new_static("instance")))
+                            .with_annotated_type(Type::object()),
+                        Parameter::positional_only(Some(Name::new_static("owner")))
+                            .with_annotated_type(UnionType::from_two_elements(
+                                db,
+                                type_instance,
+                                none,
+                            ))
+                            .with_default_type(none),
+                    ]),
                     Type::unknown(),
                 ),
             ]
@@ -652,31 +621,25 @@ impl WrapperDescriptorKind {
             WrapperDescriptorKind::PropertyDunderSet => {
                 let object = Type::object();
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("self")))
-                                .with_annotated_type(KnownClass::Property.to_instance(db)),
-                            Parameter::positional_only(Some(Name::new_static("instance")))
-                                .with_annotated_type(object),
-                            Parameter::positional_only(Some(Name::new_static("value")))
-                                .with_annotated_type(object),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("self")))
+                            .with_annotated_type(KnownClass::Property.to_instance(db)),
+                        Parameter::positional_only(Some(Name::new_static("instance")))
+                            .with_annotated_type(object),
+                        Parameter::positional_only(Some(Name::new_static("value")))
+                            .with_annotated_type(object),
+                    ]),
                     Type::unknown(),
                 )))
             }
             WrapperDescriptorKind::PropertyDunderDelete => {
                 Either::Right(std::iter::once(Signature::new(
-                    Parameters::from_annotation(
-                        db,
-                        [
-                            Parameter::positional_only(Some(Name::new_static("self")))
-                                .with_annotated_type(KnownClass::Property.to_instance(db)),
-                            Parameter::positional_only(Some(Name::new_static("instance")))
-                                .with_annotated_type(Type::object()),
-                        ],
-                    ),
+                    Parameters::standard([
+                        Parameter::positional_only(Some(Name::new_static("self")))
+                            .with_annotated_type(KnownClass::Property.to_instance(db)),
+                        Parameter::positional_only(Some(Name::new_static("instance")))
+                            .with_annotated_type(Type::object()),
+                    ]),
                     Type::unknown(),
                 )))
             }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4071,14 +4071,11 @@ fn required_typeddict_key<'db>(
 /// synthesized `TypedDict` used for `TypedDict` arms.
 fn key_membership_contains_protocol<'db>(db: &'db dyn Db, key: &str) -> Type<'db> {
     let signature = Signature::new(
-        Parameters::from_annotation(
-            db,
-            [
-                Parameter::positional_only(Some(Name::new_static("self"))),
-                Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(Type::string_literal(db, key)),
-            ],
-        ),
+        Parameters::standard([
+            Parameter::positional_only(Some(Name::new_static("self"))),
+            Parameter::positional_only(Some(Name::new_static("key")))
+                .with_annotated_type(Type::string_literal(db, key)),
+        ]),
         Type::bool_literal(true),
     );
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -1442,10 +1442,8 @@ fn check_post_init_signature<'db>(
         Parameter::positional_only(Some(name.clone())).with_annotated_type(field.declared_ty)
     });
 
-    let parameters = Parameters::from_annotation(
-        db,
-        std::iter::chain([first_parameter], following_parameters),
-    );
+    let parameters =
+        Parameters::standard(std::iter::chain([first_parameter], following_parameters));
 
     let expected_signature = CallableType::single(db, Signature::new(parameters, Type::object()));
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -275,31 +275,26 @@ impl<'db> CallableSignature<'db> {
         ) -> Option<CallableSignature<'db>> {
             match paramspec_value {
                 Type::TypeVar(typevar) if typevar.is_paramspec(db) => {
+                    let prefix_parameters = prefix_parameters
+                        .iter()
+                        .map(|param| param.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                        .collect::<Vec<_>>();
+                    let parameters = if prefix_parameters.is_empty() {
+                        Parameters::paramspec(db, typevar)
+                    } else {
+                        Parameters::concatenate(
+                            db,
+                            prefix_parameters,
+                            ConcatenateTail::ParamSpec(typevar),
+                        )
+                    };
+
                     Some(CallableSignature::single(Signature {
                         generic_context: self_signature.generic_context.map(|context| {
                             type_mapping.update_signature_generic_context(db, context)
                         }),
                         definition: self_signature.definition,
-                        parameters: Parameters::from_annotation(
-                            db,
-                            prefix_parameters
-                                .iter()
-                                .map(|param| {
-                                    param.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
-                                })
-                                .chain([
-                                    Parameter::variadic(Name::new_static("args"))
-                                        .with_annotated_type(Type::TypeVar(
-                                            typevar
-                                                .with_paramspec_attr(db, ParamSpecAttrKind::Args),
-                                        )),
-                                    Parameter::keyword_variadic(Name::new_static("kwargs"))
-                                        .with_annotated_type(Type::TypeVar(
-                                            typevar
-                                                .with_paramspec_attr(db, ParamSpecAttrKind::Kwargs),
-                                        )),
-                                ]),
-                        ),
+                        parameters,
                         return_ty: self_signature.return_ty.apply_type_mapping_impl(
                             db,
                             type_mapping,
@@ -321,24 +316,11 @@ impl<'db> CallableSignature<'db> {
                                 }),
                             ),
                             definition: signature.definition,
-                            parameters: if signature.parameters().is_top() {
-                                signature.parameters().clone()
-                            } else {
-                                Parameters::from_annotation(
-                                    db,
-                                    prefix_parameters
-                                        .iter()
-                                        .map(|param| {
-                                            param.apply_type_mapping_impl(
-                                                db,
-                                                type_mapping,
-                                                tcx,
-                                                visitor,
-                                            )
-                                        })
-                                        .chain(signature.parameters().iter().cloned()),
-                                )
-                            },
+                            parameters: signature.parameters().with_prefix(
+                                prefix_parameters.iter().map(|param| {
+                                    param.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                                }),
+                            ),
                             return_ty: self_signature.return_ty.apply_type_mapping_impl(
                                 db,
                                 type_mapping,
@@ -761,12 +743,13 @@ impl<'db> Signature<'db> {
             .cycle_normalized(db, previous.return_ty, cycle);
 
         let parameters = if self.parameters.len() == previous.parameters.len() {
-            Parameters::from_annotation(
-                db,
+            Parameters::new(
                 self.parameters
                     .iter()
                     .zip(previous.parameters.iter())
-                    .map(|(curr, prev)| curr.cycle_normalized(db, prev, cycle)),
+                    .map(|(curr, prev)| curr.cycle_normalized(db, prev, cycle))
+                    .collect::<Box<[_]>>(),
+                self.parameters.kind(),
             )
         } else {
             debug_assert_eq!(previous.parameters, Parameters::bottom());
@@ -800,7 +783,7 @@ impl<'db> Signature<'db> {
             for param in &self.parameters {
                 parameters.push(param.recursive_type_normalized_impl(db, div, nested)?);
             }
-            Parameters::from_annotation(db, parameters)
+            Parameters::new(parameters, self.parameters.kind())
         };
         Some(Self {
             generic_context: self.generic_context,
@@ -1151,7 +1134,10 @@ impl<'db> Signature<'db> {
 
         // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
         // below can separate them, which would otherwise prevent expansion.
-        let remaining = Parameters::from_annotation(db, remaining).expand_paramspec_variadics(db);
+        let remaining = signature
+            .parameters
+            .with_transformed_parameters(remaining)
+            .expand_paramspec_variadics(db);
 
         let mut reordered = Vec::with_capacity(remaining.len());
         let mut keyword_only = Vec::new();
@@ -1178,8 +1164,10 @@ impl<'db> Signature<'db> {
         reordered.extend(keyword_only);
         reordered.extend(keyword_variadic);
 
+        let reordered = remaining.with_transformed_parameters(reordered);
+
         signature
-            .with_parameters(Parameters::from_annotation(db, reordered))
+            .with_parameters(reordered)
             .with_return_type(return_ty)
     }
 
@@ -2356,11 +2344,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     }
 
                     let (source_params, _) = parameters.into_remaining();
+                    let source_params = source
+                        .parameters
+                        .with_transformed_parameters(source_params.cloned());
                     let lower = Type::Callable(CallableType::new(
                         db,
                         CallableSignature::single(Signature::new_generic(
                             source.generic_context,
-                            Parameters::from_annotation(db, source_params.cloned()),
+                            source_params,
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
@@ -2489,11 +2480,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     }
 
                     let (_, target_params) = parameters.into_remaining();
+                    let target_params = target
+                        .parameters
+                        .with_transformed_parameters(target_params.cloned());
                     let upper = Type::Callable(CallableType::new(
                         db,
                         CallableSignature::single(Signature::new_generic(
                             target.generic_context,
-                            Parameters::from_annotation(db, target_params.cloned()),
+                            target_params,
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
@@ -3183,8 +3177,9 @@ impl<'db> Parameters<'db> {
     /// Create a parameter list with an explicit kind.
     ///
     /// This constructor does not infer the kind from the parameter types or normalize an unpacked
-    /// `TypedDict`. Use [`Self::from_annotation`] when the kind should be inferred from
-    /// annotations; preserve the existing kind when transforming a parameter list.
+    /// `TypedDict`. Use [`Self::standard`] for a known-standard list and
+    /// [`Self::from_annotation`] when the kind should be inferred from annotations; preserve the
+    /// existing kind when transforming a parameter list.
     pub(crate) fn new(value: impl Into<Box<[Parameter<'db>]>>, kind: ParametersKind<'db>) -> Self {
         Self {
             data: Arc::new(ParametersData {
@@ -3336,7 +3331,15 @@ impl<'db> Parameters<'db> {
 
     /// Create an empty parameter list.
     pub(crate) fn empty() -> Self {
-        Self::new(Box::default(), ParametersKind::Standard)
+        Self::standard([])
+    }
+
+    /// Create a standard parameter list without inferring its kind or normalizing annotations.
+    pub(crate) fn standard(parameters: impl IntoIterator<Item = Parameter<'db>>) -> Self {
+        Self::new(
+            parameters.into_iter().collect::<Box<[_]>>(),
+            ParametersKind::Standard,
+        )
     }
 
     pub(crate) fn as_slice(&self) -> &[Parameter<'db>] {
@@ -3347,24 +3350,113 @@ impl<'db> Parameters<'db> {
         self.data.kind
     }
 
+    /// Return a copy of this parameter list with the given prefix parameters.
+    fn with_prefix(&self, prefix_parameters: impl IntoIterator<Item = Parameter<'db>>) -> Self {
+        let mut prefix_parameters = prefix_parameters.into_iter().collect::<Vec<_>>();
+        if prefix_parameters.is_empty() || self.is_top() {
+            return self.clone();
+        }
+
+        let kind = match self.data.kind {
+            ParametersKind::Standard => ParametersKind::Standard,
+            ParametersKind::Gradual
+                if prefix_parameters.iter().all(Parameter::is_positional_only)
+                    && matches!(
+                        self.data.value.as_ref(),
+                        [variadic, keyword_variadic]
+                            if variadic.is_variadic()
+                                && keyword_variadic.is_keyword_variadic()
+                    ) =>
+            {
+                ParametersKind::Concatenate(ConcatenateTail::Gradual)
+            }
+            ParametersKind::Gradual => ParametersKind::Gradual,
+            ParametersKind::ParamSpec(typevar) => {
+                ParametersKind::Concatenate(ConcatenateTail::ParamSpec(typevar))
+            }
+            ParametersKind::Concatenate(tail) => ParametersKind::Concatenate(tail),
+            ParametersKind::Top => return self.clone(),
+        };
+
+        prefix_parameters.extend(self.iter().cloned());
+        Self::new(prefix_parameters, kind)
+    }
+
+    /// Rebuild this parameter list after transforming its existing parameters.
+    ///
+    /// Unlike [`Self::from_annotation`], this preserves the provenance of the original parameter
+    /// list instead of inferring a new kind from the transformed annotation types. Structural
+    /// kinds are normalized when a transformation removes or rearranges their tail parameters.
+    fn with_transformed_parameters(
+        &self,
+        parameters: impl IntoIterator<Item = Parameter<'db>>,
+    ) -> Self {
+        let parameters = parameters.into_iter().collect::<Box<[_]>>();
+        let variadic_index = parameters.iter().position(Parameter::is_variadic);
+        let keyword_variadic_index = parameters.iter().position(Parameter::is_keyword_variadic);
+
+        let kind = match self.data.kind {
+            ParametersKind::Standard => ParametersKind::Standard,
+            ParametersKind::Gradual
+                if variadic_index.is_some() && keyword_variadic_index.is_some() =>
+            {
+                ParametersKind::Gradual
+            }
+            ParametersKind::Gradual => ParametersKind::Standard,
+            ParametersKind::Top => ParametersKind::Top,
+            ParametersKind::ParamSpec(typevar) => {
+                if matches!((variadic_index, keyword_variadic_index), (Some(0), Some(1)))
+                    && parameters.len() == 2
+                {
+                    ParametersKind::ParamSpec(typevar)
+                } else {
+                    ParametersKind::Standard
+                }
+            }
+            ParametersKind::Concatenate(tail) => {
+                let Some(variadic_index) = variadic_index else {
+                    return Self::standard(parameters);
+                };
+                let Some(keyword_variadic_index) = keyword_variadic_index else {
+                    return Self::standard(parameters);
+                };
+                let prefix = &parameters[..variadic_index];
+                let has_adjacent_tail = keyword_variadic_index == variadic_index + 1;
+
+                match tail {
+                    ConcatenateTail::Gradual => {
+                        if has_adjacent_tail
+                            && !prefix.is_empty()
+                            && prefix.iter().all(Parameter::is_positional_only)
+                        {
+                            ParametersKind::Concatenate(tail)
+                        } else {
+                            ParametersKind::Gradual
+                        }
+                    }
+                    ConcatenateTail::ParamSpec(typevar) if has_adjacent_tail => {
+                        if prefix.is_empty() {
+                            ParametersKind::ParamSpec(typevar)
+                        } else if prefix.iter().all(Parameter::is_positional) {
+                            ParametersKind::Concatenate(tail)
+                        } else {
+                            ParametersKind::Standard
+                        }
+                    }
+                    ConcatenateTail::ParamSpec(_) => ParametersKind::Standard,
+                }
+            }
+        };
+
+        Self::new(parameters, kind)
+    }
+
     /// Return a copy of this parameter list without its first parameter.
     ///
     /// Removing the only prefix parameter from a `Concatenate` form leaves the tail as a plain
     /// gradual or `ParamSpec` parameter list.
     fn without_first(&self) -> Self {
-        let parameters = self.iter().skip(1).cloned().collect::<Box<[_]>>();
-        let kind = match self.data.kind {
-            ParametersKind::Concatenate(tail)
-                if parameters.first().is_some_and(Parameter::is_variadic) =>
-            {
-                match tail {
-                    ConcatenateTail::Gradual => ParametersKind::Gradual,
-                    ConcatenateTail::ParamSpec(typevar) => ParametersKind::ParamSpec(typevar),
-                }
-            }
-            kind => kind,
-        };
-        Self::new(parameters, kind)
+        self.with_transformed_parameters(self.iter().skip(1).cloned())
     }
 
     /// Returns `true` if the parameters represent a gradual form using `...` as the only parameter
@@ -3806,11 +3898,18 @@ impl<'db> Parameters<'db> {
             return self.clone();
         };
 
-        let mut expanded = Vec::with_capacity(self.len());
-        expanded.extend_from_slice(&self.data.value[..variadic_index]);
-        expanded.extend_from_slice(mapped_signature.parameters().as_slice());
-        expanded.extend_from_slice(&self.data.value[variadic_index + 2..]);
-        Parameters::from_annotation(db, expanded)
+        let expanded = mapped_signature
+            .parameters()
+            .with_prefix(self.data.value[..variadic_index].iter().cloned());
+        if variadic_index + 2 == self.len() {
+            expanded
+        } else {
+            let parameters = expanded
+                .iter()
+                .cloned()
+                .chain(self.data.value[variadic_index + 2..].iter().cloned());
+            expanded.with_transformed_parameters(parameters)
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -572,8 +572,7 @@ impl<'db> TypeVarInstance<'db> {
                 Type::NominalInstance(nominal_instance) => nominal_instance
                     .own_tuple_spec(db)
                     .map_or_else(Parameters::unknown, |tuple_spec| {
-                        Parameters::from_annotation(
-                            db,
+                        Parameters::standard(
                             tuple_spec
                                 .iter_all_elements()
                                 .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),


### PR DESCRIPTION
## Summary

Follow up to https://github.com/astral-sh/ruff/pull/26521: update callable, method, override, and signature handling to account for parameter kinds more consistently.

That PR left a number of similar cases (where we were wrongly making a generic callable gradual after specializing it to Any) unfixed, and introduced a `Parameter::from_annotation` method that was still wrongly used in many non-annotation locations.

* Introduce a `Parameters::standard` helper for creating an always-non-gradual synthetic callable. Many prior uses of `Parameter::from_annotation` are switched to use this instead. By lines, this is the bulk of the diff.
* Cycle normalization uses `::new` and explicitly passes on the `ParametersKind`, rather than using `::from_annotation`.
* Introduce `::with_prefix` and `::with_transformed_parameters` constructors for cloning existing signatures with new prefix parameters or transformed parameters, respectively. These have only a few uses.

After this PR, `::from_annotation` is used only in cases that actually come from user annotations directly.

## Testing

Added mdtests.