### PR TITLE
[ty] Update conformance suite pin

### DIFF
--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -36,7 +36,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
-  CONFORMANCE_SUITE_COMMIT: f9664d894c8cbfca8fba44624bdedef09add1aa7
+  CONFORMANCE_SUITE_COMMIT: f4f2952f3ac94d7af819c5c71b60a50a100370e0
   PYTHON_VERSION: 3.12
 
 jobs:


### PR DESCRIPTION
Update the `python/typing` pin to the latest main. This picks up https://github.com/python/typing/pull/2318, which annotates module protocol globals so the conformance test exercises structural compatibility without depending on inference for unannotated globals.