### PR TITLE
[ty] Distinguish lax and strict mode for Pydantic models

### DIFF
--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -307,6 +307,10 @@ pub enum KnownModule {
     Os,
     Tempfile,
     Pathlib,
+    Datetime,
+    Decimal,
+    Ipaddress,
+    Re,
     Abc,
     Dataclasses,
     Functools,
@@ -323,6 +327,8 @@ pub enum KnownModule {
     TyExtensions,
     #[strum(serialize = "ty_extensions._internal")]
     TyExtensionsInternal,
+    #[strum(serialize = "ty_extensions.pydantic")]
+    TyExtensionsPydantic,
     #[strum(serialize = "importlib")]
     ImportLib,
     #[strum(serialize = "unittest.mock")]
@@ -339,6 +345,8 @@ pub enum KnownModule {
     PydanticMain,
     #[strum(serialize = "pydantic.root_model")]
     PydanticRootModel,
+    #[strum(serialize = "pydantic.types")]
+    PydanticTypes,
 }
 
 impl KnownModule {
@@ -354,6 +362,10 @@ impl KnownModule {
             Self::Os => "os",
             Self::Tempfile => "tempfile",
             Self::Pathlib => "pathlib",
+            Self::Datetime => "datetime",
+            Self::Decimal => "decimal",
+            Self::Ipaddress => "ipaddress",
+            Self::Re => "re",
             Self::Abc => "abc",
             Self::Dataclasses => "dataclasses",
             Self::Functools => "functools",
@@ -364,6 +376,7 @@ impl KnownModule {
             Self::TypeCheckerInternals => "_typeshed._type_checker_internals",
             Self::TyExtensions => "ty_extensions",
             Self::TyExtensionsInternal => "ty_extensions._internal",
+            Self::TyExtensionsPydantic => "ty_extensions.pydantic",
             Self::ImportLib => "importlib",
             Self::Warnings => "warnings",
             Self::UnittestMock => "unittest.mock",
@@ -374,6 +387,7 @@ impl KnownModule {
             Self::PydanticConfig => "pydantic.config",
             Self::PydanticMain => "pydantic.main",
             Self::PydanticRootModel => "pydantic.root_model",
+            Self::PydanticTypes => "pydantic.types",
         }
     }
 
@@ -397,7 +411,10 @@ impl KnownModule {
     /// Return `true` if this module is provided by a supported third-party package.
     pub const fn is_third_party(self) -> bool {
         match self {
-            Self::PydanticConfig | Self::PydanticMain | Self::PydanticRootModel => true,
+            Self::PydanticConfig
+            | Self::PydanticMain
+            | Self::PydanticRootModel
+            | Self::PydanticTypes => true,
             Self::Builtins
             | Self::Enum
             | Self::Types
@@ -408,6 +425,10 @@ impl KnownModule {
             | Self::Os
             | Self::Tempfile
             | Self::Pathlib
+            | Self::Datetime
+            | Self::Decimal
+            | Self::Ipaddress
+            | Self::Re
             | Self::Abc
             | Self::Dataclasses
             | Self::Functools
@@ -419,6 +440,7 @@ impl KnownModule {
             | Self::TypeCheckerInternals
             | Self::TyExtensions
             | Self::TyExtensionsInternal
+            | Self::TyExtensionsPydantic
             | Self::ImportLib
             | Self::UnittestMock
             | Self::Uuid

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -20,7 +20,7 @@ class User(BaseModel):
     id: int
     name: str
 
-reveal_type(User.__init__)  # revealed: (self: User, *, id: int, name: str, **extra: Any) -> None
+reveal_type(User.__init__)  # revealed: (self: User, *, id: LaxInt, name: LaxStr, **extra: Any) -> None
 
 user = User(id=1, name="John Doe")
 reveal_type(user.id)  # revealed: int
@@ -43,7 +43,7 @@ class Product(BaseModel):
     tags: list[str] = Field(default_factory=list)
     internal_price_cent: int = Field(gt=0, alias="price_cent")
 
-# revealed: (self: Product, *, name: str, tags: list[str] = ..., price_cent: int, **extra: Any) -> None
+# revealed: (self: Product, *, name: LaxStr, tags: Iterable[LaxStr] = ..., price_cent: LaxInt, **extra: Any) -> None
 reveal_type(Product.__init__)
 
 product = Product(name="Laptop", price_cent=999_00)
@@ -131,8 +131,6 @@ class Person1(BaseModel):
     age: int
 
 Person1(name="Alice", age=20)  # okay
-# TODO: no error here
-# error: [invalid-argument-type]
 Person1(name="Alice", age="20")  # okay, coerced
 # error: [invalid-argument-type]
 Person1(name="Alice", age=None)  # error, cannot be coerced
@@ -144,11 +142,393 @@ class Person2(BaseModel):
     age: int
 
 Person2(name="Alice", age=20)  # okay
-# TODO: no error here
-# error: [invalid-argument-type]
 Person2(name="Alice", age="20")  # okay
 # error: [invalid-argument-type]
 Person2(name="Alice", age=None)  # error, cannot be coerced
+```
+
+Scalar types follow the Python-input conversions in Pydantic's [conversion table]:
+
+```py
+import re
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from ipaddress import (
+    IPv4Address,
+    IPv4Interface,
+    IPv4Network,
+    IPv6Address,
+    IPv6Interface,
+    IPv6Network,
+)
+from pathlib import Path
+from re import Pattern
+from uuid import UUID
+
+from pydantic import ByteSize
+
+class LaxBool(BaseModel):
+    value: bool
+
+LaxBool(value=True)
+LaxBool(value=1.0)
+LaxBool(value=1)
+LaxBool(value=Decimal(1))
+LaxBool(value="true")
+LaxBool(value=[True])  # error: [invalid-argument-type]
+
+class LaxBytes(BaseModel):
+    value: bytes
+
+LaxBytes(value=b"foo")
+LaxBytes(value=bytearray(b"foo"))
+LaxBytes(value="foo")
+LaxBytes(value=1)  # error: [invalid-argument-type]
+
+class LaxDate(BaseModel):
+    value: date
+
+LaxDate(value=date(2020, 1, 1))
+LaxDate(value="2020-01-01")
+LaxDate(value=b"2020-01-01")
+LaxDate(value=datetime(2020, 1, 1))
+LaxDate(value=1_577_836_800.0)
+LaxDate(value=1_577_836_800)
+LaxDate(value=Decimal(1_577_836_800))
+LaxDate(value=[2020, 1, 1])  # error: [invalid-argument-type]
+
+class LaxDatetime(BaseModel):
+    value: datetime
+
+LaxDatetime(value=datetime(2020, 1, 1, 12, 0))
+LaxDatetime(value=date(2020, 1, 1))
+LaxDatetime(value=b"2020-01-01T12:00:00")
+LaxDatetime(value="2020-01-01T12:00:00")
+LaxDatetime(value=1_577_880_000.0)
+LaxDatetime(value=1_577_880_000)
+LaxDatetime(value=Decimal(1_577_880_000))
+LaxDatetime(value=[2020, 1, 1, 12, 0])  # error: [invalid-argument-type]
+
+class LaxFloat(BaseModel):
+    value: float
+
+LaxFloat(value=1.0)
+LaxFloat(value=1)
+LaxFloat(value=True)
+LaxFloat(value=b"1.0")
+LaxFloat(value="1.0")
+LaxFloat(value=Decimal("1.0"))
+LaxFloat(value=(1, 0))  # error: [invalid-argument-type]
+
+class LaxInt(BaseModel):
+    value: int
+
+LaxInt(value=1)
+LaxInt(value=True)
+LaxInt(value=b"1")
+LaxInt(value=1.0)
+LaxInt(value="1")
+LaxInt(value=Decimal(1))
+LaxInt(value=(1,))  # error: [invalid-argument-type]
+
+class LaxStr(BaseModel):
+    value: str
+
+LaxStr(value="foo")
+LaxStr(value=b"foo")
+LaxStr(value=bytearray(b"foo"))
+LaxStr(value=1)  # error: [invalid-argument-type]
+
+class LaxTime(BaseModel):
+    value: time
+
+LaxTime(value=time(12, 0))
+LaxTime(value=b"12:00:00")
+LaxTime(value="12:00:00")
+LaxTime(value=43_200.0)
+LaxTime(value=43_200)
+LaxTime(value=Decimal(43_200))
+LaxTime(value=[12, 0])  # error: [invalid-argument-type]
+
+class LaxTimedelta(BaseModel):
+    value: timedelta
+
+LaxTimedelta(value=timedelta(days=1))
+LaxTimedelta(value=b"P1D")
+LaxTimedelta(value="P1D")
+LaxTimedelta(value=86_400.0)
+LaxTimedelta(value=86_400)
+LaxTimedelta(value=Decimal(86_400))
+LaxTimedelta(value=[86_400])  # error: [invalid-argument-type]
+
+class LaxByteSize(BaseModel):
+    value: ByteSize
+
+LaxByteSize(value=1.0)
+LaxByteSize(value=1)
+LaxByteSize(value="1 KiB")
+LaxByteSize(value=Decimal(1))
+LaxByteSize(value=[1, 0])  # error: [invalid-argument-type]
+
+class LaxDecimal(BaseModel):
+    value: Decimal
+
+LaxDecimal(value=Decimal("1.0"))
+LaxDecimal(value=1.0)
+LaxDecimal(value=1)
+LaxDecimal(value="1.0")
+LaxDecimal(value=b"1.0")  # error: [invalid-argument-type]
+
+ipv4_address = IPv4Address("192.0.2.1")
+ipv4_interface = IPv4Interface("192.0.2.0/24")
+ipv4_network = IPv4Network("192.0.2.0/24")
+
+class LaxIPv4Address(BaseModel):
+    value: IPv4Address
+
+LaxIPv4Address(value=ipv4_address)
+LaxIPv4Address(value=ipv4_interface)
+LaxIPv4Address(value=ipv4_address.packed)
+LaxIPv4Address(value=0xC0000201)
+LaxIPv4Address(value="192.0.2.1")
+LaxIPv4Address(value=[192, 0, 2, 1])  # error: [invalid-argument-type]
+
+class LaxIPv4Interface(BaseModel):
+    value: IPv4Interface
+
+LaxIPv4Interface(value=ipv4_interface)
+LaxIPv4Interface(value=ipv4_address)
+LaxIPv4Interface(value=ipv4_address.packed)
+LaxIPv4Interface(value=0xC0000201)
+LaxIPv4Interface(value="192.0.2.1/24")
+LaxIPv4Interface(value=("192.0.2.1", 24))
+LaxIPv4Interface(value=["192.0.2.1", 24])  # error: [invalid-argument-type]
+
+class LaxIPv4Network(BaseModel):
+    value: IPv4Network
+
+LaxIPv4Network(value=ipv4_network)
+LaxIPv4Network(value=ipv4_interface)
+LaxIPv4Network(value=ipv4_address)
+LaxIPv4Network(value=ipv4_network.network_address.packed)
+LaxIPv4Network(value=0xC0000200)
+LaxIPv4Network(value="192.0.2.0/24")
+LaxIPv4Network(value=["192.0.2.0", 24])  # error: [invalid-argument-type]
+
+ipv6_address = IPv6Address("2001:db8::1")
+ipv6_interface = IPv6Interface("2001:db8::/64")
+ipv6_network = IPv6Network("2001:db8::/64")
+
+class LaxIPv6Address(BaseModel):
+    value: IPv6Address
+
+LaxIPv6Address(value=ipv6_address)
+LaxIPv6Address(value=ipv6_interface)
+LaxIPv6Address(value=ipv6_address.packed)
+LaxIPv6Address(value=1)
+LaxIPv6Address(value="2001:db8::1")
+LaxIPv6Address(value=[0x2001, 0xDB8, 1])  # error: [invalid-argument-type]
+
+class LaxIPv6Interface(BaseModel):
+    value: IPv6Interface
+
+LaxIPv6Interface(value=ipv6_interface)
+LaxIPv6Interface(value=ipv6_address)
+LaxIPv6Interface(value=ipv6_address.packed)
+LaxIPv6Interface(value=1)
+LaxIPv6Interface(value="2001:db8::1/64")
+LaxIPv6Interface(value=("2001:db8::1", 64))
+LaxIPv6Interface(value=["2001:db8::1", 64])  # error: [invalid-argument-type]
+
+class LaxIPv6Network(BaseModel):
+    value: IPv6Network
+
+LaxIPv6Network(value=ipv6_network)
+LaxIPv6Network(value=ipv6_interface)
+LaxIPv6Network(value=ipv6_address)
+LaxIPv6Network(value=ipv6_network.network_address.packed)
+LaxIPv6Network(value=1)
+LaxIPv6Network(value="2001:db8::/64")
+LaxIPv6Network(value=["2001:db8::", 64])  # error: [invalid-argument-type]
+
+class LaxPath(BaseModel):
+    value: Path
+
+LaxPath(value=Path("/tmp/foo"))
+LaxPath(value="/tmp/foo")
+LaxPath(value=b"/tmp/foo")  # error: [invalid-argument-type]
+
+class LaxStrPattern(BaseModel):
+    value: Pattern[str]
+
+LaxStrPattern(value=re.compile("foo"))
+LaxStrPattern(value="foo")
+LaxStrPattern(value=b"foo")  # error: [invalid-argument-type]
+
+class LaxBytesPattern(BaseModel):
+    value: Pattern[bytes]
+
+LaxBytesPattern(value=re.compile(b"foo"))
+LaxBytesPattern(value=b"foo")
+LaxBytesPattern(value="foo")  # error: [invalid-argument-type]
+
+class LaxUUID(BaseModel):
+    value: UUID
+
+LaxUUID(value=UUID("12345678-1234-1234-1234-123456789012"))
+LaxUUID(value="12345678-1234-1234-1234-123456789012")
+LaxUUID(value=None)  # error: [invalid-argument-type]
+
+class LaxNone(BaseModel):
+    value: None
+
+LaxNone(value=None)
+LaxNone(value=1)  # error: [invalid-argument-type]
+```
+
+For collections, we widen something like `list[int]` to `Iterable[LaxInt]`. Pydantic can coerce a
+set of specific collection types to `list[int]` (`deque`, `frozenset`, ...), but we cannot use a
+union like `list[LaxInt] | deque[LaxInt] | frozenset[LaxInt] | ...` due to invariance of some of
+these types. Using the covariant `Iterable` is a good approximation, and allows the element type to
+be widened to `LaxInt`.
+
+For mappings, we do the same, but only widen the value type, since `Mapping` is invariant in the key
+type. This can (in principle) lead to false positives, as documented in a comment below.
+
+```py
+from collections import deque
+from collections.abc import Mapping
+
+class LaxListInt(BaseModel):
+    value: list[int]
+
+LaxListInt(value=[1, 2, 3])
+LaxListInt(value=[1, "2", 3.0])
+LaxListInt(value=deque([1, 2, 3]))
+LaxListInt(value={1: None, 2: None, 3: None}.keys())
+LaxListInt(value={"a": 1, "b": 2, "c": "3"}.values())
+LaxListInt(value=frozenset({1, 2, "3"}))
+LaxListInt(value=[1, 2, "3"])
+LaxListInt(value={1, 2, "3"})
+LaxListInt(value=(1, 2, "3"))
+LaxListInt(value=[])
+LaxListInt(value=[1, 2, None])  # error: [invalid-argument-type]
+LaxListInt(value=[1, 2, [3]])  # error: [invalid-argument-type]
+LaxListInt(value=1)  # error: [invalid-argument-type]
+
+# This is rejected by Pydantic at runtime, but we accept it since `str` is
+# a subtype of `Iterable[LaxInt]` (`LaxInt = int | str | ...`).
+LaxListInt(value="abc")
+
+def _(list_int: list[int]):
+    LaxListInt(value=list_int)
+
+class LaxDictStrInt(BaseModel):
+    value: dict[str, int]
+
+LaxDictStrInt(value={"a": 1, "b": 2})
+LaxDictStrInt(value={"a": "1", "b": "2"})
+LaxDictStrInt(value={1: 1, 2: 2})  # error: [invalid-argument-type]
+
+# This is actually supported at runtime, but Mapping is invariant in the
+# key type, so we cannot widen it from `str` to `LaxStr`.
+LaxDictStrInt(value={b"a": 1, b"b": 2})  # error: [invalid-argument-type]
+
+def _(dict_str_int: dict[str, int]):
+    LaxDictStrInt(value=dict_str_int)
+
+def _(dict_str_str: dict[str, str]):
+    LaxDictStrInt(value=dict_str_str)
+
+def _(map_str_int: Mapping[str, int]):
+    LaxDictStrInt(value=map_str_int)
+
+def _(map_str_str: Mapping[str, str]):
+    LaxDictStrInt(value=map_str_str)
+```
+
+This also works for nested collections:
+
+```py
+class Nested(BaseModel):
+    value: list[dict[str, int]]
+
+Nested(value=[{"a": 1}, {"b": "2", "c": 3.0}])
+Nested(value=[{"a": 1}, {"b": None}])  # error: [invalid-argument-type]
+```
+
+For enums, we currently fall back to a very permissive `Any`, because Pydantic allows certain
+conversions that are not further specified in the documentation.
+
+```py
+from enum import Enum
+
+class Color(Enum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+class LaxColor(BaseModel):
+    value: Color
+
+reveal_type(LaxColor.__init__)  # revealed: (self: LaxColor, *, value: Any, **extra: Any) -> None
+
+LaxColor(value=Color.RED)
+LaxColor(value="red")
+# This should ideally be an error:
+LaxColor(value=None)
+```
+
+`Literal` types are not widened, even in lax mode:
+
+```py
+from typing import Literal
+
+class LaxLiterals(BaseModel):
+    value: Literal[1, "a", True]
+
+LaxLiterals(value=1)
+LaxLiterals(value="a")
+LaxLiterals(value=True)
+LaxLiterals(value=2)  # error: [invalid-argument-type]
+LaxLiterals(value="b")  # error: [invalid-argument-type]
+LaxLiterals(value=False)  # error: [invalid-argument-type]
+```
+
+Unions are converted element-wise:
+
+```py
+class LaxUnion(BaseModel):
+    value: int | list[str] | None
+
+reveal_type(LaxUnion.__init__)  # revealed: (self: LaxUnion, *, value: LaxInt | Iterable[LaxStr] | None, **extra: Any) -> None
+
+LaxUnion(value=1)
+LaxUnion(value="1")
+LaxUnion(value=["a", "b"])
+LaxUnion(value=[b"a", b"b"])
+LaxUnion(value=None)
+LaxUnion(value=[1, 2])  # error: [invalid-argument-type]
+
+def _(union: int | list[str] | None):
+    LaxUnion(value=union)
+```
+
+Rewriting also works through type aliases:
+
+```py
+type NestedList = list[int | NestedList]
+
+class LaxNestedList(BaseModel):
+    value: NestedList
+
+LaxNestedList(value=[1, 2, 3])
+LaxNestedList(value=[[1, 2], [3, 4]])
+LaxNestedList(value=[1, "2", 3])
+LaxNestedList(value=[1, [2, "3"], 4])
+LaxNestedList(value=1)  # error: [invalid-argument-type]
+# TODO: this should be an error once we support recursive types
+LaxNestedList(value=[1, [2, None]])
 ```
 
 ### Changing a specific field
@@ -167,8 +547,6 @@ Here, validation is lax for the `name` field (`bytes` is converted to `str`):
 
 ```py
 Person1(name="Alice", age=20)
-# TODO: no error here
-# error: [invalid-argument-type]
 Person1(name=b"Alice", age=20)
 ```
 
@@ -190,12 +568,22 @@ class Person2(BaseModel):
     age: int
 
 Person2(name="Alice", age=20)
-# TODO: no error here
-# error: [invalid-argument-type]
 Person2(name=b"Alice", age=20)
 
 Person2(name="Alice", age=20)
 Person2(name="Alice", age="20")  # error: [invalid-argument-type]
+```
+
+An explicit `None` does not override the model's strict setting:
+
+```py
+class Person3(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    age: int = Field(strict=None)
+
+Person3(age=20)
+Person3(age="20")  # error: [invalid-argument-type]
 ```
 
 ## `validate_by_name`, `validate_by_alias`
@@ -271,7 +659,7 @@ class PersonWithoutExtras(BaseModel):
 
     name: str
 
-# revealed: (self: PersonWithoutExtras, *, name: str) -> None
+# revealed: (self: PersonWithoutExtras, *, name: LaxStr) -> None
 reveal_type(PersonWithoutExtras.__init__)
 PersonWithoutExtras(name="Alice", something_else=7)  # error: [unknown-argument]
 
@@ -301,7 +689,7 @@ from pydantic import BaseModel
 class PersonWithExtraField(BaseModel):
     extra: int
 
-# revealed: (self: PersonWithExtraField, *, extra: int, **extra_: Any) -> None
+# revealed: (self: PersonWithExtraField, *, extra: LaxInt, **extra_: Any) -> None
 reveal_type(PersonWithExtraField.__init__)
 PersonWithExtraField(extra=1, something_else=2)
 ```
@@ -426,7 +814,7 @@ from pydantic import RootModel
 
 class IntList(RootModel[list[int]]): ...
 
-reveal_type(IntList.__init__)  # revealed: (self: IntList, root: list[int]) -> None
+reveal_type(IntList.__init__)  # revealed: (self: IntList, root: Iterable[LaxInt]) -> None
 
 IntList([1, 2, 3])
 IntList(root=[1, 2, 3])
@@ -547,7 +935,7 @@ class RequiredAfterDefault(BaseModel):
     defaulted: int = 0
     required: int
 
-# revealed: (self: RequiredAfterDefault, *, defaulted: int = 0, required: int, **extra: Any) -> None
+# revealed: (self: RequiredAfterDefault, *, defaulted: LaxInt = 0, required: LaxInt, **extra: Any) -> None
 reveal_type(RequiredAfterDefault.__init__)
 RequiredAfterDefault(required=1)
 ```
@@ -617,7 +1005,7 @@ class User(BaseModel, metaclass=RegistryMeta):
     name: str
     age: int = 0
 
-reveal_type(User.__init__)  # revealed: (self: User, *, name: str, age: int = 0, **extra: Any) -> None
+reveal_type(User.__init__)  # revealed: (self: User, *, name: LaxStr, age: LaxInt = 0, **extra: Any) -> None
 
 User(name="alice")
 User(name="alice", age=1)
@@ -700,3 +1088,5 @@ reveal_type(Person.__init__)  # revealed: (self: Person, *, name: str) -> None
 Person(name="Alice")
 Person(name="Alice", something_else=7)  # error: [unknown-argument]
 ```
+
+[conversion table]: https://pydantic.dev/docs/validation/latest/concepts/conversion_table

--- a/crates/ty_python_semantic/resources/mdtest/external/sqlmodel.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/sqlmodel.md
@@ -23,7 +23,7 @@ user = User(id=1, name="John Doe")
 reveal_type(user.id)  # revealed: int
 reveal_type(user.name)  # revealed: str
 
-reveal_type(User.__init__)  # revealed: (self: User, *, id: int, name: str) -> None
+reveal_type(User.__init__)  # revealed: (self: User, *, id: LaxInt, name: LaxStr) -> None
 
 User()  # error: [missing-argument]
 ```

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -34,6 +34,7 @@ use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, PathBound, PathBounds, Solutions,
 };
+use crate::types::dedicated::pydantic::StrictMode;
 use crate::types::diagnostic::{
     CALL_NON_CALLABLE, CALL_TOP_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_DATACLASS,
     MISSING_ARGUMENT, NO_MATCHING_OVERLOAD, PARAMETER_ALREADY_ASSIGNED,
@@ -1714,6 +1715,10 @@ impl<'db> Bindings<'db> {
                         let kw_only = get_argument_type("kw_only", true);
                         let alias = get_argument_type("alias", true);
                         let converter = get_argument_type("converter", true);
+                        let strict = get_argument_type("strict", false)
+                            .map_or(StrictMode::Unspecified, |strict| {
+                                StrictMode::from_field_type(db, strict)
+                            });
 
                         // `dataclasses.field` and field-specifier functions of commonly used
                         // libraries like `pydantic`, `attrs`, and `SQLAlchemy` all return
@@ -1844,7 +1849,9 @@ impl<'db> Bindings<'db> {
                         // are assignable to `T` if the default type of the field is assignable
                         // to `T`. Otherwise, we would error on `name: str = field(default="")`.
                         overload.set_return_type(Type::KnownInstance(KnownInstanceType::Field(
-                            FieldInstance::new(db, default_ty, init, kw_only, alias, converter),
+                            FieldInstance::new(
+                                db, default_ty, init, kw_only, alias, converter, strict,
+                            ),
                         )));
                     }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2419,6 +2419,15 @@ pub(crate) enum FieldKind<'db> {
         /// The first element is the input type (first positional parameter), the second is the
         /// output type (return type of the converter callable).
         converter: Option<(Type<'db>, Type<'db>)>,
+    },
+    /// Pydantic model field metadata
+    Pydantic {
+        /// The type of the default value for this field
+        default_ty: Option<Type<'db>>,
+        /// Whether or not this field should appear in the synthesized constructor signature.
+        init: bool,
+        /// The name for this field in the synthesized constructor signature, if specified.
+        alias: Option<Box<str>>,
         /// The mode selected by Pydantic's `strict` argument.
         strict: pydantic::StrictMode,
     },
@@ -2450,6 +2459,9 @@ impl Field<'_> {
             // A dataclass field is NOT required if `default` (or `default_factory`) is set
             // or if `init` has been set to `False`.
             FieldKind::Dataclass {
+                init, default_ty, ..
+            } => default_ty.is_none() && *init,
+            FieldKind::Pydantic {
                 init, default_ty, ..
             } => default_ty.is_none() && *init,
             FieldKind::TypedDict { is_required, .. } => *is_required,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2419,6 +2419,8 @@ pub(crate) enum FieldKind<'db> {
         /// The first element is the input type (first positional parameter), the second is the
         /// output type (return type of the converter callable).
         converter: Option<(Type<'db>, Type<'db>)>,
+        /// The mode selected by Pydantic's `strict` argument.
+        strict: pydantic::StrictMode,
     },
     /// `TypedDict` field metadata
     TypedDict {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1362,16 +1362,31 @@ impl<'db> StaticClassLiteral<'db> {
 
         let signature_from_fields = |mut parameters: Vec<_>, return_ty: Type<'db>| {
             for (field_name, field) in self.fields(db, specialization, field_policy) {
-                let (init, mut default_ty, kw_only, alias, converter) = match &field.kind {
-                    FieldKind::NamedTuple { default_ty } => (true, *default_ty, None, None, None),
+                let (init, mut default_ty, kw_only, alias, converter, strict) = match &field.kind {
+                    FieldKind::NamedTuple { default_ty } => (
+                        true,
+                        *default_ty,
+                        None,
+                        None,
+                        None,
+                        pydantic::StrictMode::Unspecified,
+                    ),
                     FieldKind::Dataclass {
                         init,
                         default_ty,
                         kw_only,
                         alias,
                         converter,
+                        strict,
                         ..
-                    } => (*init, *default_ty, *kw_only, alias.as_ref(), *converter),
+                    } => (
+                        *init,
+                        *default_ty,
+                        *kw_only,
+                        alias.as_ref(),
+                        *converter,
+                        *strict,
+                    ),
                     FieldKind::TypedDict { .. } => continue,
                 };
                 let mut field_ty = field.declared_ty;
@@ -1443,6 +1458,12 @@ impl<'db> StaticClassLiteral<'db> {
 
                 if let Some((converter_input_ty, _)) = converter {
                     field_ty = converter_input_ty;
+                }
+
+                if name == "__init__"
+                    && let Some(metadata) = field_policy.pydantic_metadata()
+                {
+                    field_ty = pydantic::constructor_parameter_type(db, field_ty, strict, metadata);
                 }
 
                 let is_kw_only = matches!(name, "__replace__" | "_replace")
@@ -2113,12 +2134,14 @@ impl<'db> StaticClassLiteral<'db> {
                 let mut kw_only = None;
                 let mut alias = None;
                 let mut converter = None;
+                let mut strict = pydantic::StrictMode::Unspecified;
                 if let Some(Type::KnownInstance(KnownInstanceType::Field(field))) = default_ty {
                     default_ty = field.default_type(db);
                     init = field.init(db);
                     kw_only = field.kw_only(db);
                     alias.clone_from(field.alias(db));
                     converter = field.converter(db);
+                    strict = field.strict(db);
                 }
 
                 let kind = match field_policy {
@@ -2131,6 +2154,7 @@ impl<'db> StaticClassLiteral<'db> {
                             kw_only,
                             alias,
                             converter,
+                            strict,
                         }
                     }
                     CodeGeneratorKind::TypedDict => {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1377,7 +1377,6 @@ impl<'db> StaticClassLiteral<'db> {
                         kw_only,
                         alias,
                         converter,
-                        strict,
                         ..
                     } => (
                         *init,
@@ -1385,8 +1384,14 @@ impl<'db> StaticClassLiteral<'db> {
                         *kw_only,
                         alias.as_ref(),
                         *converter,
-                        *strict,
+                        pydantic::StrictMode::Unspecified,
                     ),
+                    FieldKind::Pydantic {
+                        init,
+                        default_ty,
+                        alias,
+                        strict,
+                    } => (*init, *default_ty, None, alias.as_ref(), None, *strict),
                     FieldKind::TypedDict { .. } => continue,
                 };
                 let mut field_ty = field.declared_ty;
@@ -2146,17 +2151,20 @@ impl<'db> StaticClassLiteral<'db> {
 
                 let kind = match field_policy {
                     CodeGeneratorKind::NamedTuple => FieldKind::NamedTuple { default_ty },
-                    CodeGeneratorKind::DataclassLike(_) | CodeGeneratorKind::Pydantic(_) => {
-                        FieldKind::Dataclass {
-                            default_ty,
-                            init_only: attr.is_init_var(),
-                            init,
-                            kw_only,
-                            alias,
-                            converter,
-                            strict,
-                        }
-                    }
+                    CodeGeneratorKind::DataclassLike(_) => FieldKind::Dataclass {
+                        default_ty,
+                        init_only: attr.is_init_var(),
+                        init,
+                        kw_only,
+                        alias,
+                        converter,
+                    },
+                    CodeGeneratorKind::Pydantic(_) => FieldKind::Pydantic {
+                        default_ty,
+                        init,
+                        alias,
+                        strict,
+                    },
                     CodeGeneratorKind::TypedDict => {
                         let is_required = if attr.is_required() {
                             // Explicit Required[T] annotation - always required
@@ -2824,7 +2832,7 @@ impl<'db> StaticClassLiteral<'db> {
             FieldKind::Dataclass {
                 init_only: false,
                 ..
-            }
+            } | FieldKind::Pydantic { .. }
         )
     }
 

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -1,13 +1,15 @@
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
+use rustc_hash::FxHashSet;
+use ty_module_resolver::{KnownModule, file_to_module};
 use ty_python_core::definition::DefinitionKind;
 
 use crate::Db;
-use crate::place::{DefinedPlace, Definedness, Place, Provenance};
+use crate::place::{DefinedPlace, Definedness, Place, Provenance, known_module_symbol};
 use crate::types::member::class_member;
 use crate::types::{
-    ClassBase, DataclassTransformerParams, KnownClass, Parameter, StaticClassLiteral, Type,
-    definition_expression_type,
+    ClassBase, DataclassTransformerParams, KnownClass, KnownInstanceType, KnownUnion, Parameter,
+    StaticClassLiteral, Type, UnionType, definition_expression_type,
 };
 
 /// Metadata that controls Pydantic-specific model synthesis.
@@ -47,18 +49,23 @@ struct ModelConfig {
     /// The `extra` configuration controls whether the synthesized constructor accepts keyword
     /// arguments that do not correspond to declared model fields.
     extra: Option<ExtraBehavior>,
+    /// The `strict` configuration controls whether constructor parameters accept values that
+    /// Pydantic can coerce to the declared field type.
+    strict: StrictMode,
 }
 
 impl ModelConfig {
     const fn unknown() -> Self {
         Self {
             extra: Some(ExtraBehavior::Unknown),
+            strict: StrictMode::Unknown,
         }
     }
 
     /// Merge `other` into this config, with values from `other` taking precedence.
     fn merge(&mut self, other: Self) {
         self.extra = other.extra.or(self.extra);
+        self.strict = other.strict.or(self.strict);
     }
 }
 
@@ -77,6 +84,53 @@ impl ExtraBehavior {
             Some("forbid") => Self::Forbid,
             Some("ignore") => Self::Ignore,
             _ => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+pub enum StrictMode {
+    /// No value was specified at this precedence level, so a lower-precedence value can apply.
+    #[default]
+    Unspecified,
+    Lax,
+    Strict,
+    /// A value was specified, but it could not be resolved statically.
+    Unknown,
+}
+
+impl StrictMode {
+    const fn or(self, other: Self) -> Self {
+        if matches!(self, Self::Unspecified) {
+            other
+        } else {
+            self
+        }
+    }
+
+    /// Resolve a strictness value from the type inferred for the model-global `strict` configuration.
+    ///
+    /// `model_config = ConfigDict(strict=None)` means that the model overrides inherited strictness
+    /// configuration with `Unknown`, which is treated as `Lax`.
+    pub(in crate::types) fn from_type(value: Type<'_>) -> Self {
+        if value == Type::bool_literal(true) {
+            Self::Strict
+        } else if value == Type::bool_literal(false) {
+            Self::Lax
+        } else {
+            Self::Unknown
+        }
+    }
+
+    /// Resolve a strictness value from the type inferred for the `strict` configuration on the field.
+    ///
+    /// `Field(strict=None)` means that the field should inherit the model-global strictness configuration,
+    /// so it is treated as `Unspecified`.
+    pub(in crate::types) fn from_field_type(db: &dyn Db, value: Type<'_>) -> Self {
+        if value.is_none(db) {
+            Self::Unspecified
+        } else {
+            Self::from_type(value)
         }
     }
 }
@@ -163,9 +217,7 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
         return if model_config.is_undefined() {
             None
         } else {
-            Some(ModelConfig {
-                extra: Some(ExtraBehavior::Unknown),
-            })
+            Some(ModelConfig::unknown())
         };
     };
 
@@ -180,25 +232,19 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
             value
         }
         _ => {
-            return Some(ModelConfig {
-                extra: Some(ExtraBehavior::Unknown),
-            });
+            return Some(ModelConfig::unknown());
         }
     };
 
     let Some(call) = value.as_call_expr() else {
-        return Some(ModelConfig {
-            extra: Some(ExtraBehavior::Unknown),
-        });
+        return Some(ModelConfig::unknown());
     };
     let callee = definition_expression_type(db, definition, &call.func);
     if !callee
         .as_class_literal()
         .is_some_and(|class| class.is_known(db, KnownClass::PydanticConfigDict))
     {
-        return Some(ModelConfig {
-            extra: Some(ExtraBehavior::Unknown),
-        });
+        return Some(ModelConfig::unknown());
     }
 
     if call
@@ -207,21 +253,23 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
         .iter()
         .any(|keyword| keyword.arg.is_none())
     {
-        return Some(ModelConfig {
-            extra: Some(ExtraBehavior::Unknown),
-        });
+        return Some(ModelConfig::unknown());
     }
 
-    let Some(extra) = call.arguments.find_keyword("extra") else {
-        return Some(ModelConfig::default());
-    };
-    let extra = definition_expression_type(db, definition, &extra.value)
-        .as_string_literal()
-        .map(|literal| literal.value(db));
+    let extra = call.arguments.find_keyword("extra").map(|extra| {
+        let extra = definition_expression_type(db, definition, &extra.value)
+            .as_string_literal()
+            .map(|literal| literal.value(db));
+        ExtraBehavior::from_value(extra)
+    });
+    let strict = call
+        .arguments
+        .find_keyword("strict")
+        .map_or(StrictMode::Unspecified, |strict| {
+            StrictMode::from_type(definition_expression_type(db, definition, &strict.value))
+        });
 
-    Some(ModelConfig {
-        extra: Some(ExtraBehavior::from_value(extra)),
-    })
+    Some(ModelConfig { extra, strict })
 }
 
 fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelConfig> {
@@ -237,14 +285,193 @@ fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<Mo
     {
         return Some(ModelConfig::unknown());
     }
-    let extra = arguments.find_keyword("extra")?;
-    let extra = definition_expression_type(db, definition, &extra.value)
-        .as_string_literal()
-        .map(|literal| literal.value(db));
+    let extra = arguments.find_keyword("extra").map(|extra| {
+        let extra = definition_expression_type(db, definition, &extra.value)
+            .as_string_literal()
+            .map(|literal| literal.value(db));
+        ExtraBehavior::from_value(extra)
+    });
+    let strict = arguments
+        .find_keyword("strict")
+        .map_or(StrictMode::Unspecified, |strict| {
+            StrictMode::from_type(definition_expression_type(db, definition, &strict.value))
+        });
 
-    Some(ModelConfig {
-        extra: Some(ExtraBehavior::from_value(extra)),
-    })
+    (extra.is_some() || !matches!(strict, StrictMode::Unspecified))
+        .then_some(ModelConfig { extra, strict })
+}
+
+/// Return the input type accepted by a Pydantic field's synthesized constructor parameter.
+pub(in crate::types) fn constructor_parameter_type<'db>(
+    db: &'db dyn Db,
+    field_type: Type<'db>,
+    field_strict: StrictMode,
+    metadata: ModelMetadata<'db>,
+) -> Type<'db> {
+    if field_strict.or(metadata.config.strict) == StrictMode::Strict {
+        return field_type;
+    }
+
+    lax_input_type(db, field_type)
+}
+
+/// Return the documented Python input type accepted by Pydantic for `field_type` in lax mode.
+fn lax_input_type<'db>(db: &'db dyn Db, field_type: Type<'db>) -> Type<'db> {
+    lax_input_type_impl(db, field_type, &mut FxHashSet::default())
+}
+
+fn lax_input_type_impl<'db>(
+    db: &'db dyn Db,
+    field_type: Type<'db>,
+    expanding_aliases: &mut FxHashSet<Type<'db>>,
+) -> Type<'db> {
+    if field_type.is_none(db) || matches!(field_type, Type::LiteralValue(_) | Type::SubclassOf(_)) {
+        return field_type;
+    }
+
+    if let Type::TypeAlias(alias) = field_type {
+        if !expanding_aliases.insert(field_type) {
+            return Type::any();
+        }
+        let result = lax_input_type_impl(db, alias.value_type(db), expanding_aliases);
+        expanding_aliases.remove(&field_type);
+        return result;
+    }
+
+    if field_type.as_union().and_then(|union| union.known(db)) == Some(KnownUnion::Float) {
+        return lax_alias(db, "LaxFloat");
+    }
+
+    if let Type::Union(union) = field_type {
+        return UnionType::from_elements_leave_aliases(
+            db,
+            union
+                .elements(db)
+                .iter()
+                .map(|element| lax_input_type_impl(db, *element, expanding_aliases)),
+        );
+    }
+
+    let known_class = field_type
+        .nominal_class(db)
+        .and_then(|class| class.known(db));
+
+    if matches!(
+        known_class,
+        Some(
+            KnownClass::List
+                | KnownClass::Set
+                | KnownClass::FrozenSet
+                | KnownClass::Deque
+                | KnownClass::Sequence
+                | KnownClass::Iterable
+                | KnownClass::Tuple
+        )
+    ) {
+        let Ok(elements) = field_type.try_iterate(db) else {
+            return Type::any();
+        };
+        let element_type =
+            lax_input_type_impl(db, elements.homogeneous_element_type(db), expanding_aliases);
+        return KnownClass::Iterable.to_specialized_instance(db, &[element_type]);
+    }
+
+    if matches!(known_class, Some(KnownClass::Dict | KnownClass::Mapping)) {
+        let Some(specialization) =
+            known_class.and_then(|known_class| field_type.known_specialization(db, known_class))
+        else {
+            return Type::any();
+        };
+        let [key_type, value_type] = specialization.types(db) else {
+            return Type::any();
+        };
+        let value_type = lax_input_type_impl(db, *value_type, expanding_aliases);
+        return KnownClass::Mapping.to_specialized_instance(db, &[*key_type, value_type]);
+    }
+
+    let builtin_alias = match known_class {
+        Some(KnownClass::Bool) => Some("LaxBool"),
+        Some(KnownClass::Bytes) => Some("LaxBytes"),
+        Some(KnownClass::Int) => Some("LaxInt"),
+        Some(KnownClass::Str) => Some("LaxStr"),
+        Some(KnownClass::Path) => Some("LaxPath"),
+        _ => None,
+    };
+    if let Some(alias) = builtin_alias {
+        return lax_alias(db, alias);
+    }
+
+    let Some((module, symbol, class)) = instance_symbol(db, field_type) else {
+        return Type::any();
+    };
+    let symbol_alias = match (module, symbol) {
+        (KnownModule::Datetime, "date") => Some("LaxDate"),
+        (KnownModule::Datetime, "datetime") => Some("LaxDatetime"),
+        (KnownModule::Datetime, "time") => Some("LaxTime"),
+        (KnownModule::Datetime, "timedelta") => Some("LaxTimedelta"),
+        (KnownModule::Decimal, "Decimal") => Some("LaxDecimal"),
+        (KnownModule::Uuid, "UUID") => Some("LaxUUID"),
+        (KnownModule::Ipaddress, "IPv4Address") => Some("LaxIPv4Address"),
+        (KnownModule::Ipaddress, "IPv4Interface") => Some("LaxIPv4Interface"),
+        (KnownModule::Ipaddress, "IPv4Network") => Some("LaxIPv4Network"),
+        (KnownModule::Ipaddress, "IPv6Address") => Some("LaxIPv6Address"),
+        (KnownModule::Ipaddress, "IPv6Interface") => Some("LaxIPv6Interface"),
+        (KnownModule::Ipaddress, "IPv6Network") => Some("LaxIPv6Network"),
+        (KnownModule::PydanticTypes, "ByteSize") => Some("LaxByteSize"),
+        _ => None,
+    };
+    if let Some(alias) = symbol_alias {
+        return lax_alias(db, alias);
+    }
+
+    let alias = if (module, symbol) == (KnownModule::Re, "Pattern") {
+        let Some(specialization) = field_type.specialization_of(db, class) else {
+            return Type::any();
+        };
+        let [pattern_type] = specialization.types(db) else {
+            return Type::any();
+        };
+        if pattern_type
+            .nominal_class(db)
+            .is_some_and(|class| class.is_known(db, KnownClass::Str))
+        {
+            "LaxStrPattern"
+        } else if pattern_type
+            .nominal_class(db)
+            .is_some_and(|class| class.is_known(db, KnownClass::Bytes))
+        {
+            "LaxBytesPattern"
+        } else {
+            return Type::any();
+        }
+    } else {
+        return Type::any();
+    };
+
+    lax_alias(db, alias)
+}
+
+/// Return the known module, name, and class literal for an instance's nominal class.
+fn instance_symbol<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<(KnownModule, &'db str, StaticClassLiteral<'db>)> {
+    let class = ty.nominal_class(db)?.class_literal(db).as_static()?;
+    let module = file_to_module(db, class.file(db))?.known(db)?;
+    Some((module, class.name(db).as_str(), class))
+}
+
+/// Return a lax-input alias like `LaxInt` from `ty_extensions.pydantic`.
+fn lax_alias<'db>(db: &'db dyn Db, name: &str) -> Type<'db> {
+    match known_module_symbol(db, KnownModule::TyExtensionsPydantic, name)
+        .place
+        .ignore_possibly_undefined()
+    {
+        Some(Type::KnownInstance(KnownInstanceType::TypeAliasType(alias))) => {
+            Type::TypeAlias(alias)
+        }
+        _ => Type::any(),
+    }
 }
 
 /// Return `true` if `class` should accept extra keywords in its synthesized constructor.

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -10,6 +10,7 @@ use crate::{
         TypeVarVariance, UnionBuilder,
         class::NamedTupleSpec,
         constraints::OwnedConstraintSet,
+        dedicated::pydantic::StrictMode,
         generics::{Specialization, walk_generic_context},
         newtype::NewType,
         typevar::TypeVarInstance,
@@ -493,6 +494,9 @@ pub struct FieldInstance<'db> {
     /// The first element is the input type (first positional parameter), the second is the
     /// output type (return type of the converter callable).
     pub converter: Option<(Type<'db>, Type<'db>)>,
+
+    /// The mode selected by Pydantic's `strict` argument.
+    pub strict: StrictMode,
 }
 
 // The Salsa heap is tracked separately.
@@ -536,6 +540,7 @@ impl<'db> FieldInstance<'db> {
             self.kw_only(db),
             self.alias(db),
             converter,
+            self.strict(db),
         ))
     }
 }

--- a/crates/ty_vendored/build.rs
+++ b/crates/ty_vendored/build.rs
@@ -24,6 +24,10 @@ const TY_EXTENSIONS_STUBS: &[(&str, &str)] = &[
         "ty_extensions/_internal.pyi",
         "stdlib/ty_extensions/_internal.pyi",
     ),
+    (
+        "ty_extensions/pydantic.pyi",
+        "stdlib/ty_extensions/pydantic.pyi",
+    ),
 ];
 const TYPESHED_ZIP_LOCATION: &str = "/zipped_typeshed.zip";
 

--- a/crates/ty_vendored/ty_extensions/pydantic.pyi
+++ b/crates/ty_vendored/ty_extensions/pydantic.pyi
@@ -1,0 +1,42 @@
+# Input types accepted by Pydantic validation in lax mode. These aliases model Python inputs from
+# Pydantic's conversion table: https://docs.pydantic.dev/latest/concepts/conversion_table/
+
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from ipaddress import (
+    IPv4Address,
+    IPv4Interface,
+    IPv4Network,
+    IPv6Address,
+    IPv6Interface,
+    IPv6Network,
+)
+from pathlib import Path
+from re import Pattern
+from uuid import UUID
+
+type LaxBool = bool | float | int | str | Decimal
+type LaxBytes = bytearray | bytes | str
+type LaxByteSize = float | int | str | Decimal
+type LaxDate = bytes | date | datetime | float | int | str | Decimal
+type LaxDatetime = bytes | date | datetime | float | int | str | Decimal
+type LaxDecimal = float | int | str | Decimal
+type LaxFloat = bool | bytes | float | int | str | Decimal
+type LaxInt = bool | bytes | float | int | str | Decimal
+type LaxIPv4Address = bytes | int | str | IPv4Address | IPv4Interface
+type LaxIPv4Interface = (
+    bytes | int | str | tuple[object, object] | IPv4Address | IPv4Interface
+)
+type LaxIPv4Network = bytes | int | str | IPv4Address | IPv4Interface | IPv4Network
+type LaxIPv6Address = bytes | int | str | IPv6Address | IPv6Interface
+type LaxIPv6Interface = (
+    bytes | int | str | tuple[object, object] | IPv6Address | IPv6Interface
+)
+type LaxIPv6Network = bytes | int | str | IPv6Address | IPv6Interface | IPv6Network
+type LaxPath = str | Path
+type LaxStrPattern = str | Pattern[str]
+type LaxBytesPattern = bytes | Pattern[bytes]
+type LaxStr = bytearray | bytes | str
+type LaxTime = bytes | float | int | str | time | Decimal
+type LaxTimedelta = bytes | float | int | str | timedelta | Decimal
+type LaxUUID = str | UUID


### PR DESCRIPTION
## Summary

By default, Pydantic models can convert input values. This is called ["lax mode"](https://pydantic.dev/docs/validation/latest/concepts/strict_mode/). For example:

```py
class Model(BaseModel):
    values: list[int]

Model(values=[1, 2, 3])             # okay
Model(values=["1", "2", "3"])       # also okay
Model(values=set(["1", "2", "3"]))  # also okay

Model(values=[None])    # error
Model(values=[[1, 2]])  # error
```

Allowed conversions are listed in [this table](https://pydantic.dev/docs/validation/latest/concepts/conversion_table) in Pydantic's documentation. To support this, I ended up converging to a solution that is very similar to what Pyrefly does (according to its documentation, I did not consult the implementation). We add a few type aliases like `type LaxInt = int | bytes | str | float | Decimal` to `ty_extensions.pydantic`, and use those to eagerly transform the input types. For example, we map `list[int] -> Iterable[LaxInt]` (see mdtests for why we use `Iterable`). I did consider several alternatives though:

- A very permissive mode in which we accept `Any` input type in lax mode. I considered this to be a viable alternative since the benefit of modeling this more precisely seems relatively small. Most Pydantic models will be constructed from data that enters through an I/O boundary, not via an explicit `Model(values=[1, 2, 3])` call. So it doesn't seem very likely that we'll catch a lot of errors with this. I ended up rejecting this idea because I didn't like the impact on our LSP: instead of showing useful constructor signatures, we would end up showing `Any` types everywhere.
- Instead of introducing various `IntLax`, `IntStr`, ... type aliases, I started implementing a version where we would have a `Lax[..]` special form. Input types would be converted by simply wrapping the annotated type in `Lax[..]`, e.g. `list[int] -> Lax[list[int]]`. The problem with this is that we would need to apply this type mapping lazily (since we would like to preserve `Lax[list[int]]` in the annotation). This would require an entirely new `Type` enum variant, and would require us to implement the conversion table inside our type relations. This seemed too complex / invasive.

towards https://github.com/astral-sh/ty/issues/2403

## Test Plan

Updated and added Markdown tests, verified every single test against Pydantic's runtime behavior.
