### PR TITLE
[ty] Skip some expensive work when not collecting protocol assignability context

### DIFF
--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -568,8 +568,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     self.type_satisfies_protocol_member(db, ty, &member)
                 })
         };
-        if structurally_satisfied.is_never_satisfied(db) {
-            self.provide_context(|| ErrorContext::TypeNotCompatibleWithProtocol {
+        if let Some(context) = self.report_context()
+            && structurally_satisfied.is_never_satisfied(db)
+        {
+            context.push(ErrorContext::TypeNotCompatibleWithProtocol {
                 ty,
                 protocol: Type::ProtocolInstance(protocol),
             });

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1561,7 +1561,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ProtocolMemberAccessMode::Class,
                 )
             });
-        if result.is_never_satisfied(db) {
+        if self.is_context_collection_enabled() && result.is_never_satisfied(db) {
             self.provide_context(|| ErrorContext::ProtocolMemberIncompatible {
                 member_name: member.name.into(),
             });
@@ -1686,7 +1686,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         )
                     })
                 });
-                if result.is_never_satisfied(db) {
+                if self.is_context_collection_enabled() && result.is_never_satisfied(db) {
                     self.provide_context(|| ErrorContext::ProtocolMemberIncompatible {
                         member_name: target_member.name.into(),
                     });

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1513,7 +1513,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         member: &ProtocolMember<'_, 'db>,
     ) -> ConstraintSet<'db, 'c> {
         let capabilities = member.capabilities(db);
-        if self.is_context_collection_enabled() {
+        if let Some(context) = self.report_context() {
             let instance_read_missing = capabilities.instance.read.is_some()
                 && protocol_member_read_type(
                     db,
@@ -1534,7 +1534,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 )
                 .is_none();
             if instance_read_missing || class_read_missing {
-                self.provide_context(|| ErrorContext::ProtocolMemberNotDefined {
+                context.push(ErrorContext::ProtocolMemberNotDefined {
                     member_name: member.name.into(),
                     ty,
                 });
@@ -1561,8 +1561,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ProtocolMemberAccessMode::Class,
                 )
             });
-        if self.is_context_collection_enabled() && result.is_never_satisfied(db) {
-            self.provide_context(|| ErrorContext::ProtocolMemberIncompatible {
+        if let Some(context) = self.report_context()
+            && result.is_never_satisfied(db)
+        {
+            context.push(ErrorContext::ProtocolMemberIncompatible {
                 member_name: member.name.into(),
             });
         }
@@ -1660,8 +1662,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             .when_all(db, self.constraints, |target_member| {
                 let source_member = source.member_by_name(db, target_member.name);
 
-                if self.is_context_collection_enabled() && source_member.is_none() {
-                    self.provide_context(|| ErrorContext::ProtocolMemberNotDefined {
+                if let Some(context) = self.report_context()
+                    && source_member.is_none()
+                {
+                    context.push(ErrorContext::ProtocolMemberNotDefined {
                         member_name: target_member.name.into(),
                         ty: source_type,
                     });
@@ -1686,8 +1690,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         )
                     })
                 });
-                if self.is_context_collection_enabled() && result.is_never_satisfied(db) {
-                    self.provide_context(|| ErrorContext::ProtocolMemberIncompatible {
+                if let Some(context) = self.report_context()
+                    && result.is_never_satisfied(db)
+                {
+                    context.push(ErrorContext::ProtocolMemberIncompatible {
                         member_name: target_member.name.into(),
                     });
                 }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -867,13 +867,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         ConstraintSet::from_bool(self.constraints, false)
     }
 
-    /// Provide context about a failing (assignability) relation between two types.
-    pub(super) fn provide_context(&self, get_context: impl FnOnce() -> ErrorContext<'db>) {
-        if let Some(context_tree) = &self.context_tree {
-            context_tree.push(get_context);
-        }
-    }
-
     /// Overwrite the error context tree with a new root context and child nodes.
     pub(super) fn set_context(
         &self,
@@ -887,9 +880,17 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
     /// Return true if error context collection is currently enabled.
     pub(super) fn is_context_collection_enabled(&self) -> bool {
+        self.report_context().is_some()
+    }
+
+    /// If error context collection is enabled, returns the current error context tree. You will
+    /// typically use [`push`][ErrorContextTree::push] to add additional information to the error
+    /// context. Returns `None` if error context collection is disabled, allowing you to skip
+    /// expensive checks.
+    pub(super) fn report_context(&self) -> Option<&ErrorContextTree<'db>> {
         self.context_tree
             .as_ref()
-            .is_some_and(ErrorContextTree::is_enabled)
+            .filter(|context| context.is_enabled())
     }
 
     /// Temporarily suppress error context collection for the duration of `f`.
@@ -1519,8 +1520,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     .iter()
                     .when_all(db, self.constraints, |&elem_ty| {
                         let constraint_set = self.check_type_pair(db, elem_ty, target);
-                        if constraint_set.is_never_satisfied(db) {
-                            self.provide_context(|| ErrorContext::NotAllUnionElementsAssignable {
+                        if let Some(context) = self.report_context()
+                            && constraint_set.is_never_satisfied(db)
+                        {
+                            context.push(ErrorContext::NotAllUnionElementsAssignable {
                                 element: elem_ty,
                                 union: source,
                                 target,
@@ -1616,8 +1619,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 .iter()
                 .when_all(db, self.constraints, |&pos_ty| {
                     let constraint_set = self.check_type_pair(db, source, pos_ty);
-                    if constraint_set.is_never_satisfied(db) {
-                        self.provide_context(|| ErrorContext::NotAssignableToIntersectionElement {
+                    if let Some(context) = self.report_context()
+                        && constraint_set.is_never_satisfied(db)
+                    {
+                        context.push(ErrorContext::NotAssignableToIntersectionElement {
                             source,
                             element: pos_ty,
                             intersection: target,
@@ -1850,10 +1855,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
                     let result = self.check_callables_vs_callable(db, &callables, target_callable);
 
-                    if self.should_provide_callable_upcast_context(source)
+                    if let Some(context) = self.report_context()
+                        && self.should_provide_callable_upcast_context(source)
                         && result.is_never_satisfied(db)
                     {
-                        self.provide_context(|| ErrorContext::InferredCallableType {
+                        context.push(ErrorContext::InferredCallableType {
                             source,
                             callable: callables.into_type(db),
                         });
@@ -1907,14 +1913,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     )
                 };
                 let result = self.check_type_pair(db, fallback, target);
-                if result.is_never_satisfied(db) {
-                    if let Type::NominalInstance(instance) = target
-                        && instance.class(db).is_known(db, KnownClass::Dict)
-                    {
-                        self.provide_context(|| {
-                            ErrorContext::TypedDictNotAssignableToDict(typed_dict)
-                        });
-                    }
+                if let Some(context) = self.report_context()
+                    && result.is_never_satisfied(db)
+                    && let Type::NominalInstance(instance) = target
+                    && instance.class(db).is_known(db, KnownClass::Dict)
+                {
+                    context.push(ErrorContext::TypedDictNotAssignableToDict(typed_dict));
                 }
                 result
             }),

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -478,11 +478,10 @@ impl<'db> ErrorContextTree<'db> {
     }
 
     /// Push a new error context node, making the existing tree a child of the new context.
-    pub(crate) fn push(&self, get_context: impl FnOnce() -> ErrorContext<'db>) {
+    pub(crate) fn push(&self, context: ErrorContext<'db>) {
         if !self.is_enabled() {
             return;
         }
-        let context = get_context();
         let root = self.root.take();
         let children = if root.is_empty() { vec![] } else { vec![root] };
         *self.root.borrow_mut() = ErrorContextNode { context, children };

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1890,14 +1890,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 target_positional > source_positional || target.parameters.variadic().is_some();
 
             if target_accepts_extra_positionals {
-                if target_positional > source_positional
+                if let Some(context) = self.report_context()
+                    && target_positional > source_positional
                     && let Some(ParameterKind::KeywordOnly { name, .. }) = source
                         .parameters
                         .iter()
                         .nth(source_positional)
                         .map(Parameter::kind)
                 {
-                    self.provide_context(|| ErrorContext::ParameterMustAcceptPositionalArguments {
+                    context.push(ErrorContext::ParameterMustAcceptPositionalArguments {
                         name: name.clone(),
                     });
                 }
@@ -1915,8 +1916,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let return_type_checks = !result
             .intersect(db, self.constraints, return_type_constraints)
             .is_never_satisfied(db);
-        if !return_type_checks {
-            self.provide_context(|| ErrorContext::IncompatibleReturnTypes {
+        if let Some(context) = self.report_context()
+            && !return_type_checks
+        {
+            context.push(ErrorContext::IncompatibleReturnTypes {
                 source: source.return_ty,
                 target: target.return_ty,
             });
@@ -1949,9 +1952,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
 
             let constraint_set = self.check_type_pair(db, target_ty, source_ty);
-            if constraint_set.is_never_satisfied(db) {
+            if let Some(context) = self.report_context()
+                && constraint_set.is_never_satisfied(db)
+            {
                 let parameter = ParameterDescription::new(target_index, target_name);
-                self.provide_context(|| ErrorContext::IncompatibleParameterTypes {
+                context.push(ErrorContext::IncompatibleParameterTypes {
                     source: source_ty,
                     target: target_ty,
                     parameter,
@@ -2111,10 +2116,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 },
                             ) => {
                                 if self_name != other_name {
-                                    self.provide_context(|| ErrorContext::ParameterNameMismatch {
-                                        source_name: self_name.clone(),
-                                        target_name: other_name.clone(),
-                                    });
+                                    if let Some(context) = self.report_context() {
+                                        context.push(ErrorContext::ParameterNameMismatch {
+                                            source_name: self_name.clone(),
+                                            target_name: other_name.clone(),
+                                        });
+                                    }
                                     return self.never();
                                 }
                                 // The following checks are the same as positional-only parameters.
@@ -2772,11 +2779,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         // `target`, then the non-variadic parameters in `source` must have a default
                         // value.
                         if default_type.is_none() {
-                            let parameter =
-                                ParameterDescription::new(target_index, source_parameter.name());
-                            self.provide_context(|| ErrorContext::ExtraRequiredParameter {
-                                parameter,
-                            });
+                            if let Some(context) = self.report_context() {
+                                let parameter = ParameterDescription::new(
+                                    target_index,
+                                    source_parameter.name(),
+                                );
+                                context.push(ErrorContext::ExtraRequiredParameter { parameter });
+                            }
                             return self.never();
                         }
                     }
@@ -2832,10 +2841,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             },
                         ) => {
                             if source_name != target_name {
-                                self.provide_context(|| ErrorContext::ParameterNameMismatch {
-                                    source_name: source_name.clone(),
-                                    target_name: target_name.clone(),
-                                });
+                                if let Some(context) = self.report_context() {
+                                    context.push(ErrorContext::ParameterNameMismatch {
+                                        source_name: source_name.clone(),
+                                        target_name: target_name.clone(),
+                                    });
+                                }
                                 return self.never();
                             }
                             // The following checks are the same as positional-only parameters.
@@ -2926,12 +2937,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 name: target_name, ..
                             },
                         ) => {
-                            self.provide_context(|| {
-                                ErrorContext::ParameterMustAcceptKeywordArguments {
+                            if let Some(context) = self.report_context() {
+                                context.push(ErrorContext::ParameterMustAcceptKeywordArguments {
                                     source_name: name.clone(),
                                     target_name: target_name.clone(),
-                                }
-                            });
+                                });
+                            }
                             return self.never();
                         }
 
@@ -2940,11 +2951,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             ParameterKind::PositionalOnly { .. }
                             | ParameterKind::PositionalOrKeyword { .. },
                         ) => {
-                            self.provide_context(|| {
-                                ErrorContext::ParameterMustAcceptPositionalArguments {
-                                    name: name.clone(),
-                                }
-                            });
+                            if let Some(context) = self.report_context() {
+                                context.push(
+                                    ErrorContext::ParameterMustAcceptPositionalArguments {
+                                        name: name.clone(),
+                                    },
+                                );
+                            }
                             return self.never();
                         }
 

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -296,8 +296,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             Tuple::Fixed(target) => {
                 let equal_length = source_tuple.0.len() == target.0.len();
 
-                if !equal_length && self.is_eager_assignability() {
-                    self.provide_context(|| ErrorContext::TupleLengthMismatch {
+                if let Some(context) = self.report_context()
+                    && !equal_length
+                    && self.is_eager_assignability()
+                {
+                    context.push(ErrorContext::TupleLengthMismatch {
                         source_len: source_tuple.0.len(),
                         target_len: target_tuple.len(),
                     });
@@ -313,14 +316,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             self.constraints,
                             |(&source, &target)| {
                                 let constraint_set = self.check_type_pair(db, source, target);
-                                if constraint_set.is_never_satisfied(db) {
-                                    self.provide_context(|| {
-                                        ErrorContext::TupleElementNotCompatible {
-                                            source,
-                                            target,
-                                            element_index: n,
-                                            element_count: source_tuple.0.len(),
-                                        }
+                                if let Some(context) = self.report_context()
+                                    && constraint_set.is_never_satisfied(db)
+                                {
+                                    context.push(ErrorContext::TupleElementNotCompatible {
+                                        source,
+                                        target,
+                                        element_index: n,
+                                        element_count: source_tuple.0.len(),
                                     });
                                 }
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -729,19 +729,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // required target fields
                 let Some(source_item_field) = source_items.get(target_item_name) else {
                     // Self is missing a required field.
-                    self.provide_context(|| ErrorContext::TypedDictFieldMissing {
-                        field_name: target_item_name.clone(),
-                        source,
-                    });
+                    if let Some(context) = self.report_context() {
+                        context.push(ErrorContext::TypedDictFieldMissing {
+                            field_name: target_item_name.clone(),
+                            source,
+                        });
+                    }
                     return self.never();
                 };
                 if !source_item_field.is_required() {
                     // A required field is not required in self.
-                    self.provide_context(|| ErrorContext::TypedDictFieldNotRequiredInSource {
-                        field_name: target_item_name.clone(),
-                        source,
-                        target,
-                    });
+                    if let Some(context) = self.report_context() {
+                        context.push(ErrorContext::TypedDictFieldNotRequiredInSource {
+                            field_name: target_item_name.clone(),
+                            source,
+                            target,
+                        });
+                    }
                     return self.never();
                 }
                 if target_item_field.is_read_only() {
@@ -757,11 +761,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 } else {
                     if source_item_field.is_read_only() {
                         // A read-only field can't be assigned to a mutable target.
-                        self.provide_context(|| ErrorContext::TypedDictFieldReadOnlyInSource {
-                            field_name: target_item_name.clone(),
-                            source,
-                            target,
-                        });
+                        if let Some(context) = self.report_context() {
+                            context.push(ErrorContext::TypedDictFieldReadOnlyInSource {
+                                field_name: target_item_name.clone(),
+                                source,
+                                target,
+                            });
+                        }
                         return self.never();
                     }
                     // For mutable fields in the target, the relation needs to apply both
@@ -809,23 +815,27 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     if let Some(source_item_field) = source_items.get(target_item_name) {
                         if source_item_field.is_read_only() {
                             // A read-only field can't be assigned to a mutable target.
-                            self.provide_context(|| ErrorContext::TypedDictFieldReadOnlyInSource {
-                                field_name: target_item_name.clone(),
-                                source,
-                                target,
-                            });
+                            if let Some(context) = self.report_context() {
+                                context.push(ErrorContext::TypedDictFieldReadOnlyInSource {
+                                    field_name: target_item_name.clone(),
+                                    source,
+                                    target,
+                                });
+                            }
                             return self.never();
                         }
                         if source_item_field.is_required() {
                             // A required field can't be assigned to a not-required, mutable field
                             // in the target, because `del` is allowed on the target field.
-                            self.provide_context(|| {
-                                ErrorContext::TypedDictFieldNotRequiredAndMutableInTarget {
-                                    field_name: target_item_name.clone(),
-                                    source,
-                                    target,
-                                }
-                            });
+                            if let Some(context) = self.report_context() {
+                                context.push(
+                                    ErrorContext::TypedDictFieldNotRequiredAndMutableInTarget {
+                                        field_name: target_item_name.clone(),
+                                        source,
+                                        target,
+                                    },
+                                );
+                            }
                             return self.never();
                         }
 
@@ -868,8 +878,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             };
             result.intersect(db, self.constraints, field_constraints);
             if result.is_never_satisfied(db) {
-                if let Some(source_item_field) = source_items.get(target_item_name) {
-                    self.provide_context(|| ErrorContext::TypedDictFieldIncompatible {
+                if let Some(context) = self.report_context()
+                    && let Some(source_item_field) = source_items.get(target_item_name)
+                {
+                    context.push(ErrorContext::TypedDictFieldIncompatible {
                         field_name: target_item_name.clone(),
                         source,
                         target,


### PR DESCRIPTION
The `ConstraintSet::is_never_satisfied` method is, perhaps surprisingly, not necessarily a cheap call. These two calls are used to determine whether to add additional context to a failed assignability check, and so we can guard the calls so that they're only invoked when we're actually collecting context.