### PR TITLE
[ty] Experimentally specify a command to run after an auto-import completion

### DIFF
--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -36,6 +36,7 @@ bitflags::bitflags! {
         const PREFER_MARKDOWN_IN_COMPLETION = 1 << 18;
         const COMPLETION_ITEM_SNIPPET_SUPPORT = 1 << 19;
         const FULL_DIAGNOSTIC_OUTPUT = 1 << 20;
+        const AUTO_IMPORT_COMPLETION_COMMAND = 1 << 21;
     }
 }
 
@@ -180,6 +181,11 @@ impl ResolvedClientCapabilities {
         self.contains(Self::FULL_DIAGNOSTIC_OUTPUT)
     }
 
+    /// Returns `true` if the client supports ty's auto-import completion command.
+    pub(crate) const fn supports_auto_import_completion_command(self) -> bool {
+        self.contains(Self::AUTO_IMPORT_COMPLETION_COMMAND)
+    }
+
     /// Returns `true` if the client supports "label details" in completion items.
     pub(crate) const fn supports_completion_item_label_details(self) -> bool {
         self.contains(Self::COMPLETION_ITEM_LABEL_DETAILS_SUPPORT)
@@ -264,6 +270,16 @@ impl ResolvedClientCapabilities {
             .unwrap_or_default()
         {
             flags |= Self::FULL_DIAGNOSTIC_OUTPUT;
+        }
+
+        if client_capabilities
+            .experimental
+            .as_ref()
+            .and_then(|experimental| experimental.get("autoImportCompletionCommand"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or_default()
+        {
+            flags |= Self::AUTO_IMPORT_COMPLETION_COMMAND;
         }
 
         if text_document

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::time::Instant;
 
 use lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionList,
+    Command, CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionList,
     CompletionParams, CompletionRequest, CompletionResponse, Documentation, InsertTextFormat,
     TextEdit, Uri,
 };
@@ -17,6 +17,8 @@ use crate::server::api::traits::{
 };
 use crate::session::DocumentSnapshot;
 use crate::session::client::Client;
+
+const ORGANIZE_IMPORTS_AFTER_AUTO_IMPORT_COMMAND: &str = "ty.organizeImportsAfterAutoImport";
 
 pub(crate) struct CompletionRequestHandler;
 
@@ -71,6 +73,9 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
 
         // Safety: we just checked that completions is not empty.
         let max_index_len = OneIndexed::new(completions.len()).unwrap().digits().get();
+        let supports_auto_import_completion_command = client_capabilities
+            .supports_auto_import_completion_command()
+            && !snapshot.document().is_cell_or_notebook();
         let items: Vec<CompletionItem> = completions
             .into_iter()
             .enumerate()
@@ -87,6 +92,15 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
                         new_text: edit.content().map(ToString::to_string).unwrap_or_default(),
                     })
                 });
+                let command = (import_edit.is_some() && supports_auto_import_completion_command)
+                    .then(|| Command {
+                        title: "Organize imports".to_string(),
+                        tooltip: None,
+                        command: ORGANIZE_IMPORTS_AFTER_AUTO_IMPORT_COMMAND.to_string(),
+                        arguments: Some(vec![serde_json::Value::String(
+                            snapshot.uri().to_string(),
+                        )]),
+                    });
 
                 let label = comp.label.to_string();
                 let import_suffix = comp
@@ -138,6 +152,7 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
                     insert_text,
                     insert_text_format,
                     additional_text_edits: import_edit.map(|edit| vec![edit]),
+                    command,
                     documentation,
                     ..Default::default()
                 }

--- a/crates/ty_server/tests/e2e/completions.rs
+++ b/crates/ty_server/tests/e2e/completions.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use lsp_types::{Documentation, MarkupKind, Position};
+use lsp_types::{Command, Documentation, MarkupKind, Position};
 use ruff_db::system::SystemPath;
 use ty_server::ClientOptions;
 
@@ -54,6 +54,44 @@ walktr
     Ok(())
 }
 
+#[test]
+fn auto_import_completion_command() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = "\
+walktr
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_initialization_options(ClientOptions::default())
+        .with_auto_import_completion_command()
+        .with_full_diagnostic_output()
+        .with_workspace(workspace_root, None)?
+        .with_file(foo, foo_content)?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+
+    let foo_uri = server.file_uri(foo);
+    let completions = server.completion_request(&foo_uri, Position::new(0, 6));
+    let command = completions
+        .first()
+        .and_then(|completion| completion.command.as_ref());
+
+    assert_eq!(
+        command,
+        Some(&Command {
+            title: "Organize imports".to_string(),
+            tooltip: None,
+            command: "ty.organizeImportsAfterAutoImport".to_string(),
+            arguments: Some(vec![serde_json::json!(foo_uri.to_string())]),
+        })
+    );
+
+    Ok(())
+}
+
 /// Tests that disabling auto-import works.
 #[test]
 fn disable_auto_import() -> Result<()> {
@@ -91,6 +129,7 @@ complete_parenth
 
     let mut server = TestServerBuilder::new()?
         .with_initialization_options(ClientOptions::default())
+        .with_auto_import_completion_command()
         .enable_completion_snippets(true)
         .with_workspace(workspace_root, None)?
         .with_file(foo, foo_content)?

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -1390,10 +1390,32 @@ impl TestServerBuilder {
     }
 
     /// Advertise support for ty's fully rendered diagnostic output.
-    pub(crate) fn with_full_diagnostic_output(mut self) -> Self {
-        self.client_capabilities.experimental = Some(serde_json::json!({
-            "fullDiagnosticOutput": true,
-        }));
+    pub(crate) fn with_full_diagnostic_output(self) -> Self {
+        self.with_experimental_capability("fullDiagnosticOutput")
+    }
+
+    /// Advertise support for ty's auto-import completion command.
+    pub(crate) fn with_auto_import_completion_command(self) -> Self {
+        self.with_experimental_capability("autoImportCompletionCommand")
+    }
+
+    fn with_experimental_capability(mut self, capability: &str) -> Self {
+        let experimental = self
+            .client_capabilities
+            .experimental
+            .get_or_insert_with(|| serde_json::json!({}));
+
+        match experimental {
+            serde_json::Value::Object(capabilities) => {
+                capabilities.insert(capability.to_string(), true.into());
+            }
+            experimental => {
+                let mut capabilities = serde_json::Map::new();
+                capabilities.insert(capability.to_string(), true.into());
+                *experimental = serde_json::Value::Object(capabilities);
+            }
+        }
+
         self
     }
 

--- a/crates/ty_server/tests/e2e/notebook.rs
+++ b/crates/ty_server/tests/e2e/notebook.rs
@@ -371,6 +371,7 @@ fn swap_cells() -> anyhow::Result<()> {
 #[test]
 fn auto_import() -> anyhow::Result<()> {
     let mut server = TestServerBuilder::new()?
+        .with_auto_import_completion_command()
         .with_workspace(
             SystemPath::new("src"),
             Some(ClientOptions::default().with_auto_import(true)),
@@ -398,6 +399,13 @@ b: Litera
     server.collect_publish_diagnostic_notifications(2);
 
     let completions = literal_completions(&mut server, &second_cell, Position::new(1, 9));
+
+    assert!(
+        completions
+            .iter()
+            .all(|completion| completion.command.is_none()),
+        "auto-import completions for notebook cells should not include commands"
+    );
 
     insta::with_settings!({
         filters => FILTERS.iter().copied(),

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -51,6 +51,7 @@ def foo() -> str:
         .with_workspace(workspace_root, None)?
         .with_file(foo, foo_content)?
         .with_full_diagnostic_output()
+        .with_auto_import_completion_command()
         .enable_pull_diagnostics(false)
         .build()
         .wait_until_workspaces_are_initialized();


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

/xref https://github.com/astral-sh/ty/issues/3815

## Test Plan

<!-- How was it tested? -->
