### PR TITLE
[ty] Preserve literal enum member names

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -872,6 +872,7 @@ class ParsedIntegerValues(int, Enum):
     SECOND = "1"
 
 reveal_type(ParsedIntegerValues.FIRST is ParsedIntegerValues.SECOND)  # revealed: bool
+# TODO really should be `Literal["FIRST"]` since its a known alias
 reveal_type(ParsedIntegerValues.SECOND.name)  # revealed: Literal["SECOND"]
 reveal_type(enum_members(ParsedIntegerValues))  # revealed: Unknown
 ```

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -559,6 +559,24 @@ reveal_type(AnnotatedConnector.GITHUB.value)  # revealed: str
 reveal_type(AnnotatedConnector.GITHUB._value_)  # revealed: str
 ```
 
+Even when a custom `__new__` means that aliases cannot be determined, we assume that an enum
+member's declaration name is canonical when inferring `.name`:
+
+```py
+from enum import IntEnum
+
+class CustomInteger(IntEnum):
+    def __new__(cls, value: int) -> "CustomInteger":
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        return obj
+
+    VALUE = 1
+    ALIAS = 1
+
+reveal_type(CustomInteger.ALIAS.name)  # revealed: Literal["ALIAS"]
+```
+
 ### Inherited `_value_` annotation
 
 A `_value_` annotation on a parent enum is inherited by subclasses. Member values are validated
@@ -854,6 +872,7 @@ class ParsedIntegerValues(int, Enum):
     SECOND = "1"
 
 reveal_type(ParsedIntegerValues.FIRST is ParsedIntegerValues.SECOND)  # revealed: bool
+reveal_type(ParsedIntegerValues.SECOND.name)  # revealed: Literal["SECOND"]
 reveal_type(enum_members(ParsedIntegerValues))  # revealed: Unknown
 ```
 
@@ -906,7 +925,7 @@ class CustomValues(CustomInt, Enum):
 
 reveal_type(CustomValues.FALSE.value)  # revealed: Any
 reveal_type(CustomValues.FALSE is CustomValues.ZERO)  # revealed: bool
-reveal_type(CustomValues.ZERO.name)  # revealed: str
+reveal_type(CustomValues.ZERO.name)  # revealed: Literal["ZERO"]
 reveal_type(enum_members(CustomValues))  # revealed: Unknown
 ```
 
@@ -995,6 +1014,7 @@ class MyModelChoices(IntegerChoices):
     GOOD = 1, "I like this"
 
 reveal_type(MyModelChoices.GOOD.value)  # revealed: Any
+reveal_type(MyModelChoices.GOOD.name)  # revealed: Literal["GOOD"]
 ```
 
 An explicit `_value_` annotation on the transformed enum class still takes precedence, even when the

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -379,12 +379,10 @@ impl<'db> EnumClassLiteral<'db> {
 
     /// Returns the type of `.name`/`._name_` for a given enum member.
     ///
-    /// This is the canonical member name when alias detection is precise, or `str` when the
-    /// declaration may be an alias of another member.
+    /// This is the canonical member name when alias detection is precise. When alias detection is
+    /// inconclusive, we intentionally favor useful literal inference and assume the declaration is
+    /// canonical, even though custom enum construction could make it an alias of another member.
     pub(crate) fn name_type(self, db: &'db dyn Db, name: &Name) -> Option<Type<'db>> {
-        if !self.aliases_are_known(db) {
-            return Some(KnownClass::Str.to_instance(db));
-        }
         self.resolve_member(db, name)
             .map(|name| Type::string_literal(db, name))
     }


### PR DESCRIPTION
## Summary

When we cannot determine whether an enum declaration is an alias, we currently widen its `.name` attribute to `str`. This regressed `IntEnum` and `StrEnum` classes with custom `__new__` methods or enum metaclasses in ty 0.0.56, even though the declaration name is preserved in the common case:

```python
class Medal(IntEnum):
    def __new__(cls, value: int) -> "Medal":
        obj = int.__new__(cls, value)
        obj._value_ = value
        return obj

    GOLD = auto()

reveal_type(Medal.GOLD.name)  # Literal["GOLD"], previously str
```

A custom constructor or metaclass can technically make a declaration an alias of another member, in which case using the declaration spelling is unsound. But we'll now accept that limitation -- it matches Pyright and other type checkers in #3923, avoids surprising differences between otherwise similar enum definitions, and favors the overwhelmingly common case where construction does not create aliases.

When alias detection is precise, we continue to return the canonical member name. The relaxed behavior applies only when the canonical name is unknown, with regression coverage for custom `__new__`, uncertain built-in coercion, user-defined data-type mixins, and transforming enum metaclasses.

Closes https://github.com/astral-sh/ty/issues/3923.