### PR TITLE
[ty] Add partial materialization support for ty types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -977,3 +977,26 @@ def _(top: Top[AliasedCallable[Any]], bottom: Bottom[AliasedCallable[Any]]) -> N
     reveal_type(top)  # revealed: (Never, /) -> object
     reveal_type(bottom)  # revealed: (object, /) -> Never
 ```
+
+## Recursive generic aliases
+
+Computing both materialization bounds for a deeply nested invariant recursive alias should not
+recompute the bounds exponentially at every level.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing import Generic, TypeAlias, TypeVar
+
+T = TypeVar("T")
+Nested: TypeAlias = "list[Nested[T]]"
+
+class Wrapper(Generic[T]):
+    def __init__(self, value: Nested[T], context: T) -> None: ...
+
+value = [[[[[[[[[[[[[[[[1]], [[]]]]]]]]]]]]]]]]
+Wrapper(value, 1)
+```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -898,9 +898,73 @@ class Mixed[T, U]:
 def preserve_unrelated_any(top: Top[Mixed[Any, int]], bottom: Bottom[Mixed[Any, int]]) -> None:
     reveal_type(top.nested)  # revealed: list[tuple[Any, int]]
     reveal_type(bottom.nested)  # revealed: list[tuple[Any, int]]
+
+class Outer[T]:
+    mapping: dict[T, Any]
+
+def preserve_fixed_attribute_specialization(top: Top[Outer[Any]]) -> None:
+    reveal_type(top.mapping)  # revealed: Top[dict[Any, Any]]
+    for key in top.mapping:
+        reveal_type(key)  # revealed: object
+    for value in top.mapping.values():
+        reveal_type(value)  # revealed: Any
 ```
 
-Alias specializations also preserve the materialization polarity in contravariant positions.
+## Fixed inherited specializations
+
+An `Any` specialization that is fixed by a base class remains gradual when a different type
+parameter is materialized.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any
+from ty_extensions import Bottom, Top
+
+class Base[T, U]:
+    first: T
+    second: U
+
+class Derived[T](Base[T, Any]):
+    pass
+
+def preserve_fixed_top_specialization(top: Top[Derived[Any]]) -> None:
+    reveal_type(top.first)  # revealed: object
+    reveal_type(top.second)  # revealed: Any
+
+def preserve_materialized_bottom_specialization(bottom: Bottom[Derived[Any]]) -> None:
+    reveal_type(bottom.first)  # revealed: Never
+
+def preserve_fixed_bottom_specialization(bottom: Bottom[Derived[Any]]) -> None:
+    reveal_type(bottom.second)  # revealed: Any
+
+class Box[T]:
+    value: T
+
+    def set(self, value: T) -> None: ...
+
+class NestedBase[T, U]:
+    boxed: Box[tuple[T | None, U]]
+
+class NestedDerived[T](NestedBase[T, Any]):
+    pass
+
+def preserve_nested_fixed_top_specialization(top: Top[NestedDerived[Any]]) -> None:
+    reveal_type(top.boxed.value)  # revealed: tuple[object, Any]
+    reveal_type(top.boxed.set)  # revealed: bound method Top[Box[tuple[Any | None, Any]]].set(value: tuple[None, Any]) -> None
+```
+
+## Alias specializations
+
+Alias specializations preserve the materialization polarity in contravariant positions.
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
 from ty_extensions import Top, Bottom

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -76,7 +76,8 @@ use crate::types::function::{
 };
 pub(crate) use crate::types::generics::GenericContext;
 use crate::types::generics::{
-    ApplySpecialization, InferableTypeVars, Specialization, bind_typevar,
+    ApplySpecialization, InferableTypeVars, Specialization, SpecializationMaterialization,
+    bind_typevar,
 };
 use crate::types::infer::InferenceFlags;
 use crate::types::known_instance::{
@@ -6117,13 +6118,13 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         specialization: Specialization<'db>,
     ) -> Type<'db> {
-        let type_mapping = match specialization.materialization_kind(db) {
+        let type_mapping = match specialization.materialization(db) {
             None => TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
                 specialization,
             )),
-            Some(materialization_kind) => TypeMapping::ApplySpecializationWithMaterialization {
+            Some(materialization) => TypeMapping::ApplySpecializationWithMaterialization {
                 specialization: ApplySpecialization::Specialization(specialization),
-                materialization_kind,
+                materialization,
             },
         };
 
@@ -6365,12 +6366,12 @@ impl<'db> Type<'db> {
                     {
                         let mut current_specialization = specialization.as_specialization(db).unwrap();
                         if let TypeMapping::ApplySpecializationWithMaterialization {
-                            materialization_kind,
+                            materialization,
                             ..
                         } = type_mapping
                         {
                             current_specialization = current_specialization
-                                .with_materialization_kind(db, Some(*materialization_kind));
+                                .with_materialization(db, *materialization);
                         }
                         Type::TypeAlias(alias.apply_specialization(
                             db,
@@ -7472,10 +7473,10 @@ pub enum TypeMapping<'a, 'db> {
     ApplySpecialization(ApplySpecialization<'a, 'db>),
     /// Applies a specialization and materializes only substituted typevars.
     ///
-    /// The `materialization_kind` is flipped in contravariant positions.
+    /// The materialization kind is flipped in contravariant positions.
     ApplySpecializationWithMaterialization {
         specialization: ApplySpecialization<'a, 'db>,
-        materialization_kind: MaterializationKind,
+        materialization: SpecializationMaterialization<'db>,
     },
     /// Replaces any literal types with their corresponding promoted type form (e.g. `Literal["string"]`
     /// to `str`, or `def _() -> int` to `Callable[[], int]`).
@@ -7580,10 +7581,10 @@ impl<'db> TypeMapping<'_, 'db> {
             }
             TypeMapping::ApplySpecializationWithMaterialization {
                 specialization,
-                materialization_kind,
+                materialization,
             } => TypeMapping::ApplySpecializationWithMaterialization {
                 specialization: *specialization,
-                materialization_kind: materialization_kind.flip(),
+                materialization: materialization.flip(),
             },
             TypeMapping::Promote(mode, kind) => TypeMapping::Promote(mode.flip(), *kind),
             TypeMapping::ApplySpecialization(_)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -76,8 +76,8 @@ use crate::types::function::{
 };
 pub(crate) use crate::types::generics::GenericContext;
 use crate::types::generics::{
-    ApplySpecialization, InferableTypeVars, Specialization, SpecializationMaterialization,
-    bind_typevar,
+    ApplySpecialization, InferableTypeVars, InvariantArgumentBounds, Specialization,
+    SpecializationMaterialization, bind_typevar,
 };
 use crate::types::infer::InferenceFlags;
 use crate::types::known_instance::{
@@ -294,8 +294,11 @@ fn definition_expression_annotation<'db>(
 struct ApplyDefaultTypeMapping;
 struct ApplyTopMaterialization;
 struct ApplyBottomMaterialization;
+struct ApplyMaterializationBounds;
 struct ApplyMaterializationEquivalence;
 
+type MaterializationBoundsVisitor<'db> =
+    CycleDetector<ApplyMaterializationBounds, Type<'db>, Option<InvariantArgumentBounds<'db>>, 3>;
 type MaterializationEquivalenceVisitor<'db> =
     Rc<CycleDetector<ApplyMaterializationEquivalence, (Type<'db>, Type<'db>), bool, 1>>;
 
@@ -303,11 +306,13 @@ type MaterializationEquivalenceVisitor<'db> =
 ///
 /// Materialization is the only mapping mode that needs to visit the same type under two different
 /// mappings within a single recursive call chain (`Top` and `Bottom`). Keep separate cycle caches
-/// for those modes so invariant checks can safely reuse one visitor.
+/// for those modes, and memoize the resulting pair, so recursively invariant types do not compute
+/// the same pair exponentially at every nesting level.
 pub(crate) struct ApplyTypeMappingVisitor<'db> {
     default: OnceCell<TypeTransformer<'db, ApplyDefaultTypeMapping>>,
     top_materialization: OnceCell<TypeTransformer<'db, ApplyTopMaterialization>>,
     bottom_materialization: OnceCell<TypeTransformer<'db, ApplyBottomMaterialization>>,
+    materialization_bounds: OnceCell<MaterializationBoundsVisitor<'db>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
 }
 
@@ -315,6 +320,22 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
     fn materialization_equivalence(&self) -> &MaterializationEquivalenceVisitor<'db> {
         self.materialization_equivalence
             .get_or_init(|| Rc::new(CycleDetector::new(true)))
+    }
+
+    fn materialization_bounds(
+        &self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+    ) -> InvariantArgumentBounds<'db> {
+        self.materialization_bounds
+            .get_or_init(|| CycleDetector::new(None))
+            .visit(ty, || {
+                Some(InvariantArgumentBounds::new(
+                    ty.materialize(db, MaterializationKind::Bottom, self),
+                    ty.materialize(db, MaterializationKind::Top, self),
+                ))
+            })
+            .unwrap_or_else(|| InvariantArgumentBounds::new(ty, ty))
     }
 
     pub(crate) fn visit(
@@ -361,6 +382,7 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
             default: OnceCell::new(),
             top_materialization: OnceCell::new(),
             bottom_materialization: OnceCell::new(),
+            materialization_bounds: OnceCell::new(),
             materialization_equivalence,
         }
     }
@@ -372,6 +394,7 @@ impl Default for ApplyTypeMappingVisitor<'_> {
             default: OnceCell::new(),
             top_materialization: OnceCell::new(),
             bottom_materialization: OnceCell::new(),
+            materialization_bounds: OnceCell::new(),
             materialization_equivalence: OnceCell::new(),
         }
     }

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -284,7 +284,7 @@ impl<'db> ConstructorBinding<'db> {
                         db,
                         specialization.generic_context(db),
                         types,
-                        specialization.materialization_kind(db),
+                        specialization.materialization(db),
                         None,
                     )
                 });
@@ -483,7 +483,7 @@ impl<'db> ConstructorBinding<'db> {
             db,
             specialization.generic_context(db),
             types,
-            specialization.materialization_kind(db),
+            specialization.materialization(db),
             None,
         )
     }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -4,8 +4,8 @@ use crate::types::mro::MroIterator;
 use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, ClassLiteral, ClassType, DivergentType, DynamicType, KnownClass,
-    KnownInstanceType, MaterializationKind, SpecialFormType, StaticMroError, Type, TypeContext,
-    TypeMapping, TypedDictModule, todo_type,
+    KnownInstanceType, SpecialFormType, StaticMroError, Type, TypeContext, TypeMapping,
+    TypedDictModule, todo_type,
 };
 use crate::{Db, DisplaySettings};
 
@@ -385,30 +385,23 @@ impl<'db> ClassBase<'db> {
         specialization: Option<Specialization<'db>>,
     ) -> Self {
         if let Some(specialization) = specialization {
-            let new_self = self.apply_type_mapping_impl(
+            let apply = ApplySpecialization::Specialization(specialization);
+            let type_mapping = specialization.materialization(db).map_or(
+                TypeMapping::ApplySpecialization(apply),
+                |materialization| TypeMapping::ApplySpecializationWithMaterialization {
+                    specialization: apply,
+                    materialization,
+                },
+            );
+            self.apply_type_mapping_impl(
                 db,
-                &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
-                    specialization,
-                )),
+                &type_mapping,
                 TypeContext::default(),
                 &ApplyTypeMappingVisitor::default(),
-            );
-            match specialization.materialization_kind(db) {
-                None => new_self,
-                Some(materialization_kind) => new_self.materialize(db, materialization_kind),
-            }
+            )
         } else {
             self
         }
-    }
-
-    fn materialize(self, db: &'db dyn Db, kind: MaterializationKind) -> Self {
-        self.apply_type_mapping_impl(
-            db,
-            &TypeMapping::Materialize(kind),
-            TypeContext::default(),
-            &ApplyTypeMappingVisitor::default(),
-        )
     }
 
     pub(super) fn has_cyclic_mro(self, db: &'db dyn Db) -> bool {

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -23,7 +23,7 @@ use crate::types::callable::CallableTypeKind;
 use crate::types::class::{ClassLiteral, ClassType, GenericAlias};
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::function::{FunctionType, OverloadLiteral};
-use crate::types::generics::{GenericContext, Specialization};
+use crate::types::generics::{GenericContext, Specialization, SpecializationMaterialization};
 use crate::types::signatures::{
     CallableSignature, Parameter, Parameters, ParametersKind, Signature,
 };
@@ -1732,12 +1732,16 @@ impl<'db> FmtDetailed<'db> for DisplayGenericAlias<'db> {
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f)
         } else {
-            let prefix_details = match self.specialization.materialization_kind(self.db) {
+            let materialization_kind = self
+                .specialization
+                .materialization(self.db)
+                .map(SpecializationMaterialization::kind);
+            let prefix_details = match materialization_kind {
                 None => None,
                 Some(MaterializationKind::Top) => Some(("Top", SpecialFormType::Top)),
                 Some(MaterializationKind::Bottom) => Some(("Bottom", SpecialFormType::Bottom)),
             };
-            let suffix = match self.specialization.materialization_kind(self.db) {
+            let suffix = match materialization_kind {
                 None => "",
                 Some(_) => "]",
             };

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1072,6 +1072,139 @@ impl<'db> GenericContext<'db> {
     }
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
+struct InvariantArgumentBounds<'db> {
+    bottom: Type<'db>,
+    top: Type<'db>,
+}
+
+#[derive(Copy, Clone)]
+struct InvariantArgumentRange<'db> {
+    ty: Type<'db>,
+    kind: MaterializationKind,
+    bounds: Option<InvariantArgumentBounds<'db>>,
+}
+
+impl<'db> InvariantArgumentRange<'db> {
+    const fn new(
+        ty: Type<'db>,
+        kind: MaterializationKind,
+        bounds: Option<InvariantArgumentBounds<'db>>,
+    ) -> Self {
+        Self { ty, kind, bounds }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
+struct MaterializedInvariantArgument<'db> {
+    index: usize,
+    bounds: InvariantArgumentBounds<'db>,
+}
+
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+struct MaterializedInvariantArguments<'db> {
+    #[returns(deref)]
+    arguments: Box<[MaterializedInvariantArgument<'db>]>,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for MaterializedInvariantArguments<'_> {}
+
+/// Describes which invariant arguments participate in a materialized specialization.
+///
+/// Arguments not present in `arguments` are fixed substitutions. In particular, an unrelated
+/// `Any` remains `Any` instead of being materialized along with another argument.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
+pub struct SpecializationMaterialization<'db> {
+    kind: MaterializationKind,
+    arguments: MaterializedInvariantArguments<'db>,
+}
+
+impl<'db> SpecializationMaterialization<'db> {
+    fn new(
+        db: &'db dyn Db,
+        kind: MaterializationKind,
+        arguments: Vec<MaterializedInvariantArgument<'db>>,
+    ) -> Option<Self> {
+        debug_assert!(
+            arguments
+                .windows(2)
+                .all(|arguments| arguments[0].index < arguments[1].index)
+        );
+        (!arguments.is_empty()).then(|| Self {
+            kind,
+            arguments: MaterializedInvariantArguments::new(db, arguments.into_boxed_slice()),
+        })
+    }
+
+    pub(crate) const fn kind(self) -> MaterializationKind {
+        self.kind
+    }
+
+    pub(crate) const fn flip(self) -> Self {
+        Self {
+            kind: self.kind.flip(),
+            arguments: self.arguments,
+        }
+    }
+
+    fn with_kind(self, kind: MaterializationKind) -> Self {
+        Self { kind, ..self }
+    }
+
+    fn argument(self, db: &'db dyn Db, index: usize) -> Option<InvariantArgumentBounds<'db>> {
+        self.arguments
+            .arguments(db)
+            .binary_search_by_key(&index, |argument| argument.index)
+            .ok()
+            .map(|index| self.arguments.arguments(db)[index].bounds)
+    }
+
+    fn entries(self, db: &'db dyn Db) -> &'db [MaterializedInvariantArgument<'db>] {
+        self.arguments.arguments(db)
+    }
+
+    pub(crate) fn project(self, db: &'db dyn Db, index: usize, fallback: Type<'db>) -> Type<'db> {
+        self.argument(db, index)
+            .map_or(fallback, |bounds| match self.kind {
+                MaterializationKind::Top => bounds.top,
+                MaterializationKind::Bottom => bounds.bottom,
+            })
+    }
+
+    fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        let normalize = |ty: Type<'db>| {
+            if nested {
+                ty.recursive_type_normalized_impl(db, div, true)
+            } else {
+                Some(
+                    ty.recursive_type_normalized_impl(db, div, true)
+                        .unwrap_or(div),
+                )
+            }
+        };
+        let arguments = self
+            .entries(db)
+            .iter()
+            .map(|argument| {
+                Some(MaterializedInvariantArgument {
+                    index: argument.index,
+                    bounds: InvariantArgumentBounds {
+                        bottom: normalize(argument.bounds.bottom)?,
+                        top: normalize(argument.bounds.top)?,
+                    },
+                })
+            })
+            .collect::<Option<Vec<_>>>()?;
+        Self::new(db, self.kind, arguments)
+    }
+}
+
 /// An assignment of a specific type to each type variable in a generic scope.
 ///
 /// TODO: Handle nested specializations better, with actual parent links to the specialization of
@@ -1081,14 +1214,9 @@ pub struct Specialization<'db> {
     pub(crate) generic_context: GenericContext<'db>,
     #[returns(deref)]
     pub(crate) types: Box<[Type<'db>]>,
-    /// The materialization kind of the specialization. For example, given an invariant
-    /// generic type `A`, `Top[A[Any]]` is a supertype of all materializations of `A[Any]`,
-    /// and is represented here with `Some(MaterializationKind::Top)`. Similarly,
-    /// `Bottom[A[Any]]` is a subtype of all materializations of `A[Any]`, and is represented
-    /// with `Some(MaterializationKind::Bottom)`.
-    /// The `materialization_kind` field may be non-`None` only if the specialization contains
-    /// dynamic types in invariant positions.
-    pub(crate) materialization_kind: Option<MaterializationKind>,
+    /// The materialized invariant arguments of this specialization. This is `None` for the common
+    /// case and only allocates a sparse sidecar for top/bottom materialized specializations.
+    pub(crate) materialization: Option<SpecializationMaterialization<'db>>,
 
     /// For specializations of `tuple`, we also store more detailed information about the tuple's
     /// elements, above what the class's (single) typevar can represent.
@@ -1107,6 +1235,12 @@ pub(super) fn walk_specialization<'db, V: TypeVisitor<'db> + ?Sized>(
     for ty in specialization.types(db) {
         visitor.visit_type(db, *ty);
     }
+    if let Some(materialization) = specialization.materialization(db) {
+        for argument in materialization.entries(db) {
+            visitor.visit_type(db, argument.bounds.bottom);
+            visitor.visit_type(db, argument.bounds.top);
+        }
+    }
     if let Some(tuple) = specialization.tuple_inner(db) {
         walk_tuple_type(db, tuple, visitor);
     }
@@ -1119,7 +1253,7 @@ impl<'db> Specialization<'db> {
     /// type variables; the caller must retain the outer semantic union in that case.
     pub(super) fn merge_cycle_recovery(self, db: &'db dyn Db, previous: Self) -> Option<Self> {
         if self.generic_context(db) != previous.generic_context(db)
-            || self.materialization_kind(db) != previous.materialization_kind(db)
+            || self.materialization(db) != previous.materialization(db)
             || self.tuple_inner(db) != previous.tuple_inner(db)
         {
             return None;
@@ -1144,7 +1278,7 @@ impl<'db> Specialization<'db> {
             db,
             self.generic_context(db),
             types,
-            self.materialization_kind(db),
+            self.materialization(db),
             self.tuple_inner(db),
         ))
     }
@@ -1188,18 +1322,33 @@ impl<'db> Specialization<'db> {
     ) -> Option<Self> {
         let self_variables = self.generic_context(db).variables_inner(db);
         let self_types = self.types(db);
-        let restricted_variables = generic_context.variables(db);
+        let restricted_variables: Box<[_]> = generic_context.variables(db).collect();
         let restricted_types: Option<Box<[_]>> = restricted_variables
+            .iter()
             .map(|variable| {
                 let index = self_variables.get_index_of(&variable.identity(db))?;
                 self_types.get(index).copied()
             })
             .collect();
+        let restricted_materialization = self.materialization(db).and_then(|materialization| {
+            let arguments = restricted_variables
+                .iter()
+                .enumerate()
+                .filter_map(|(new_index, variable)| {
+                    let old_index = self_variables.get_index_of(&variable.identity(db))?;
+                    Some(MaterializedInvariantArgument {
+                        index: new_index,
+                        bounds: materialization.argument(db, old_index)?,
+                    })
+                })
+                .collect();
+            SpecializationMaterialization::new(db, materialization.kind(), arguments)
+        });
         Some(Self::new(
             db,
             generic_context,
             restricted_types?,
-            self.materialization_kind(db),
+            restricted_materialization,
             None,
         ))
     }
@@ -1216,11 +1365,19 @@ impl<'db> Specialization<'db> {
         db: &'db dyn Db,
         bound_typevar: BoundTypeVarInstance<'db>,
     ) -> Option<Type<'db>> {
+        self.get_with_index(db, bound_typevar).map(|(_, ty)| ty)
+    }
+
+    fn get_with_index(
+        self,
+        db: &'db dyn Db,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) -> Option<(usize, Type<'db>)> {
         let index = self
             .generic_context(db)
             .variables_inner(db)
             .get_index_of(&bound_typevar.identity(db))?;
-        self.types(db).get(index).copied()
+        self.types(db).get(index).copied().map(|ty| (index, ty))
     }
 
     /// Applies a specialization to this specialization. This is used, for instance, when a generic
@@ -1237,30 +1394,27 @@ impl<'db> Specialization<'db> {
     /// That lets us produce the generic alias `A[int]`, which is the corresponding entry in the
     /// MRO of `B[int]`.
     pub(crate) fn apply_specialization(self, db: &'db dyn Db, other: Specialization<'db>) -> Self {
-        let new_specialization = self.apply_type_mapping(
-            db,
-            &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(other)),
+        let apply = ApplySpecialization::Specialization(other);
+        let mapping = other.materialization(db).map_or(
+            TypeMapping::ApplySpecialization(apply),
+            |materialization| TypeMapping::ApplySpecializationWithMaterialization {
+                specialization: apply,
+                materialization,
+            },
         );
-        match other.materialization_kind(db) {
-            None => new_specialization,
-            Some(materialization_kind) => new_specialization.materialize_impl(
-                db,
-                materialization_kind,
-                &ApplyTypeMappingVisitor::default(),
-            ),
-        }
+        self.apply_type_mapping(db, &mapping)
     }
 
-    pub(crate) fn with_materialization_kind(
+    pub(crate) fn with_materialization(
         self,
         db: &'db dyn Db,
-        materialization_kind: Option<MaterializationKind>,
+        materialization: SpecializationMaterialization<'db>,
     ) -> Self {
         Specialization::new(
             db,
             self.generic_context(db),
             self.types(db),
-            materialization_kind,
+            Some(materialization),
             self.tuple_inner(db),
         )
     }
@@ -1284,7 +1438,38 @@ impl<'db> Specialization<'db> {
             return self.materialize_impl(db, *materialization_kind, visitor);
         }
 
-        let mut new_materialization_kind = self.materialization_kind(db);
+        let original_materialization = self.materialization(db);
+        let mut materialization_kind =
+            original_materialization.map(SpecializationMaterialization::kind);
+        let mut materialized_arguments: Vec<MaterializedInvariantArgument<'db>> =
+            original_materialization
+                .map(|materialization| {
+                    materialization
+                        .entries(db)
+                        .iter()
+                        .map(|argument| {
+                            let tcx = TypeContext::new(tcx.get(argument.index).copied());
+                            MaterializedInvariantArgument {
+                                index: argument.index,
+                                bounds: InvariantArgumentBounds {
+                                    bottom: argument.bounds.bottom.apply_type_mapping_impl(
+                                        db,
+                                        type_mapping,
+                                        tcx,
+                                        visitor,
+                                    ),
+                                    top: argument.bounds.top.apply_type_mapping_impl(
+                                        db,
+                                        type_mapping,
+                                        tcx,
+                                        visitor,
+                                    ),
+                                },
+                            }
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
         let types = self.map_types(db, |i, typevar, ty| {
             let tcx = TypeContext::new(tcx.get(i).copied());
             match (typevar.variance(db), type_mapping) {
@@ -1292,7 +1477,7 @@ impl<'db> Specialization<'db> {
                     TypeVarVariance::Invariant,
                     TypeMapping::ApplySpecializationWithMaterialization {
                         specialization,
-                        materialization_kind,
+                        materialization,
                     },
                 ) => {
                     // An invariant type argument cannot be materialized in isolation. Keep the
@@ -1307,15 +1492,33 @@ impl<'db> Specialization<'db> {
                         &ApplyTypeMappingVisitor::default(),
                     );
 
-                    if new_materialization_kind.is_none() {
-                        let materialized = ty.apply_type_mapping_impl(
+                    if original_materialization.is_none() {
+                        let bottom = ty.apply_type_mapping_impl(
                             db,
-                            type_mapping,
+                            &TypeMapping::ApplySpecializationWithMaterialization {
+                                specialization: *specialization,
+                                materialization: materialization
+                                    .with_kind(MaterializationKind::Bottom),
+                            },
                             tcx,
                             &ApplyTypeMappingVisitor::default(),
                         );
-                        if specialized != materialized {
-                            new_materialization_kind = Some(*materialization_kind);
+                        let top = ty.apply_type_mapping_impl(
+                            db,
+                            &TypeMapping::ApplySpecializationWithMaterialization {
+                                specialization: *specialization,
+                                materialization: materialization
+                                    .with_kind(MaterializationKind::Top),
+                            },
+                            tcx,
+                            &ApplyTypeMappingVisitor::default(),
+                        );
+                        if specialized != bottom || specialized != top {
+                            materialization_kind = Some(materialization.kind());
+                            materialized_arguments.push(MaterializedInvariantArgument {
+                                index: i,
+                                bounds: InvariantArgumentBounds { bottom, top },
+                            });
                         }
                     }
 
@@ -1332,11 +1535,13 @@ impl<'db> Specialization<'db> {
         let tuple_inner = original_tuple_inner.and_then(|tuple| {
             tuple.apply_type_mapping_impl(db, type_mapping, TypeContext::default(), visitor)
         });
+        let materialization = materialization_kind
+            .and_then(|kind| SpecializationMaterialization::new(db, kind, materialized_arguments));
 
         // Keep this check in sync with every field that can be transformed above.
         let specialization_unchanged = matches!(&types, Cow::Borrowed(_))
             && tuple_inner == original_tuple_inner
-            && new_materialization_kind == self.materialization_kind(db);
+            && materialization == original_materialization;
         if specialization_unchanged {
             self
         } else {
@@ -1344,7 +1549,7 @@ impl<'db> Specialization<'db> {
                 db,
                 self.generic_context(db),
                 types,
-                new_materialization_kind,
+                materialization,
                 tuple_inner,
             )
         }
@@ -1414,14 +1619,14 @@ impl<'db> Specialization<'db> {
             Some(tuple) => Some(tuple.recursive_type_normalized_impl(db, div, nested)?),
             None => None,
         };
+        let materialization = match self.materialization(db) {
+            Some(materialization) => {
+                Some(materialization.recursive_type_normalized_impl(db, div, nested)?)
+            }
+            None => None,
+        };
         let context = self.generic_context(db);
-        Some(Self::new(
-            db,
-            context,
-            types,
-            self.materialization_kind(db),
-            tuple_inner,
-        ))
+        Some(Self::new(db, context, types, materialization, tuple_inner))
     }
 
     pub(super) fn materialize_impl(
@@ -1432,11 +1637,11 @@ impl<'db> Specialization<'db> {
     ) -> Self {
         // The top and bottom materializations are fully static types already, so materializing them
         // further does nothing.
-        if self.materialization_kind(db).is_some() {
+        if self.materialization(db).is_some() {
             return self;
         }
-        let mut has_dynamic_invariant_typevar = false;
-        let types = self.map_types(db, |_, bound_typevar, vartype| {
+        let mut materialized_arguments = Vec::new();
+        let types = self.map_types(db, |index, bound_typevar, vartype| {
             match specialization_variance(db, bound_typevar) {
                 TypeVarVariance::Bivariant => {
                     // With bivariance, all specializations are subtypes of each other,
@@ -1450,10 +1655,13 @@ impl<'db> Specialization<'db> {
                     vartype.materialize(db, materialization_kind.flip(), visitor)
                 }
                 TypeVarVariance::Invariant => {
-                    let top_materialization =
-                        vartype.materialize(db, MaterializationKind::Top, visitor);
-                    if !visitor.is_equivalent_to_materialization(db, vartype, top_materialization) {
-                        has_dynamic_invariant_typevar = true;
+                    let bottom = vartype.materialize(db, MaterializationKind::Bottom, visitor);
+                    let top = vartype.materialize(db, MaterializationKind::Top, visitor);
+                    if !visitor.is_equivalent_to_materialization(db, vartype, top) {
+                        materialized_arguments.push(MaterializedInvariantArgument {
+                            index,
+                            bounds: InvariantArgumentBounds { bottom, top },
+                        });
                     }
                     vartype
                 }
@@ -1469,15 +1677,12 @@ impl<'db> Specialization<'db> {
                 visitor,
             )
         });
-        let new_materialization_kind = if has_dynamic_invariant_typevar {
-            Some(materialization_kind)
-        } else {
-            None
-        };
+        let materialization =
+            SpecializationMaterialization::new(db, materialization_kind, materialized_arguments);
         // Keep this check in sync with every field that can be transformed above.
         let specialization_unchanged = matches!(&types, Cow::Borrowed(_))
             && tuple_inner == original_tuple_inner
-            && new_materialization_kind == self.materialization_kind(db);
+            && materialization == self.materialization(db);
         if specialization_unchanged {
             self
         } else {
@@ -1485,7 +1690,7 @@ impl<'db> Specialization<'db> {
                 db,
                 self.generic_context(db),
                 types,
-                new_materialization_kind,
+                materialization,
                 tuple_inner,
             )
         }
@@ -1548,19 +1753,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return self.check_tuple_type_pair(db, source_tuple, target_tuple);
         }
 
-        let source_materialization_kind = source.materialization_kind(db);
-        let target_materialization_kind = target.materialization_kind(db);
-
         let types = itertools::izip!(
             generic_context.variables(db),
             source.types(db),
             target.types(db)
-        );
+        )
+        .enumerate();
 
         types.when_all(
             db,
             self.constraints,
-            |(bound_typevar, source_type, target_type)| {
+            |(index, (bound_typevar, source_type, target_type))| {
                 // Subtyping/assignability of each type in the specialization depends on the variance
                 // of the corresponding typevar:
                 //   - covariant: verify that source_type <: target_type
@@ -1571,9 +1774,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     TypeVarVariance::Invariant => self.check_relation_in_invariant_position(
                         db,
                         *source_type,
-                        source_materialization_kind,
+                        source.materialization(db).and_then(|materialization| {
+                            materialization
+                                .argument(db, index)
+                                .map(|bounds| (materialization.kind(), bounds))
+                        }),
                         *target_type,
-                        target_materialization_kind,
+                        target.materialization(db).and_then(|materialization| {
+                            materialization
+                                .argument(db, index)
+                                .map(|bounds| (materialization.kind(), bounds))
+                        }),
                     ),
                     TypeVarVariance::Covariant => {
                         self.check_type_pair(db, *source_type, *target_type)
@@ -1594,9 +1805,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         &self,
         db: &'db dyn Db,
         source_type: Type<'db>,
-        source_materialization: Option<MaterializationKind>,
+        source_materialization: Option<(MaterializationKind, InvariantArgumentBounds<'db>)>,
         target_type: Type<'db>,
-        target_materialization: Option<MaterializationKind>,
+        target_materialization: Option<(MaterializationKind, InvariantArgumentBounds<'db>)>,
     ) -> ConstraintSet<'db, 'c> {
         match (
             source_materialization,
@@ -1605,13 +1816,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ) {
             // Top and bottom materializations are fully static types, so subtyping
             // is the same as assignability.
-            (Some(source_mat), Some(target_mat), _) => self.check_subtyping_in_invariant_position(
-                db,
-                source_type,
-                source_mat,
-                target_type,
-                target_mat,
-            ),
+            (Some((source_mat, source_bounds)), Some((target_mat, target_bounds)), _) => self
+                .check_subtyping_in_invariant_position(
+                    db,
+                    InvariantArgumentRange::new(source_type, source_mat, Some(source_bounds)),
+                    InvariantArgumentRange::new(target_type, target_mat, Some(target_bounds)),
+                ),
             // Subtyping between invariant type parameters without a top/bottom materialization necessitates
             // checking the subtyping relation both ways: `A` must be a subtype of `B` *and* `B` must be a
             // subtype of `A`. The same applies to assignability.
@@ -1633,46 +1843,38 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // For gradual types, A <: B (subtyping) is defined as Top[A] <: Bottom[B]
             (
                 None,
-                Some(target_mat),
+                Some((target_mat, target_bounds)),
                 TypeRelation::Subtyping
                 | TypeRelation::Redundancy { .. }
                 | TypeRelation::SubtypingAssuming,
             ) => self.check_subtyping_in_invariant_position(
                 db,
-                source_type,
-                MaterializationKind::Top,
-                target_type,
-                target_mat,
+                InvariantArgumentRange::new(source_type, MaterializationKind::Top, None),
+                InvariantArgumentRange::new(target_type, target_mat, Some(target_bounds)),
             ),
             (
-                Some(source_mat),
+                Some((source_mat, source_bounds)),
                 None,
                 TypeRelation::Subtyping
                 | TypeRelation::Redundancy { .. }
                 | TypeRelation::SubtypingAssuming,
             ) => self.check_subtyping_in_invariant_position(
                 db,
-                source_type,
-                source_mat,
-                target_type,
-                MaterializationKind::Bottom,
+                InvariantArgumentRange::new(source_type, source_mat, Some(source_bounds)),
+                InvariantArgumentRange::new(target_type, MaterializationKind::Bottom, None),
             ),
             // And A <~ B (assignability) is Bottom[A] <: Top[B]
-            (None, Some(target_mat), TypeRelation::Assignability) => self
+            (None, Some((target_mat, target_bounds)), TypeRelation::Assignability) => self
                 .check_subtyping_in_invariant_position(
                     db,
-                    source_type,
-                    MaterializationKind::Bottom,
-                    target_type,
-                    target_mat,
+                    InvariantArgumentRange::new(source_type, MaterializationKind::Bottom, None),
+                    InvariantArgumentRange::new(target_type, target_mat, Some(target_bounds)),
                 ),
-            (Some(source_mat), None, TypeRelation::Assignability) => self
+            (Some((source_mat, source_bounds)), None, TypeRelation::Assignability) => self
                 .check_subtyping_in_invariant_position(
                     db,
-                    source_type,
-                    source_mat,
-                    target_type,
-                    MaterializationKind::Top,
+                    InvariantArgumentRange::new(source_type, source_mat, Some(source_bounds)),
+                    InvariantArgumentRange::new(target_type, MaterializationKind::Top, None),
                 ),
         }
     }
@@ -1680,24 +1882,44 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     fn check_subtyping_in_invariant_position(
         &self,
         db: &'db dyn Db,
-        source_type: Type<'db>,
-        source_materialization: MaterializationKind,
-        target_type: Type<'db>,
-        target_materialization: MaterializationKind,
+        source: InvariantArgumentRange<'db>,
+        target: InvariantArgumentRange<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let source_top =
-            source_type.materialize(db, MaterializationKind::Top, self.materialization_visitor);
-        let source_bottom = source_type.materialize(
-            db,
-            MaterializationKind::Bottom,
-            self.materialization_visitor,
+        let source_top = source.bounds.map_or_else(
+            || {
+                source
+                    .ty
+                    .materialize(db, MaterializationKind::Top, self.materialization_visitor)
+            },
+            |bounds| bounds.top,
         );
-        let target_top =
-            target_type.materialize(db, MaterializationKind::Top, self.materialization_visitor);
-        let target_bottom = target_type.materialize(
-            db,
-            MaterializationKind::Bottom,
-            self.materialization_visitor,
+        let source_bottom = source.bounds.map_or_else(
+            || {
+                source.ty.materialize(
+                    db,
+                    MaterializationKind::Bottom,
+                    self.materialization_visitor,
+                )
+            },
+            |bounds| bounds.bottom,
+        );
+        let target_top = target.bounds.map_or_else(
+            || {
+                target
+                    .ty
+                    .materialize(db, MaterializationKind::Top, self.materialization_visitor)
+            },
+            |bounds| bounds.top,
+        );
+        let target_bottom = target.bounds.map_or_else(
+            || {
+                target.ty.materialize(
+                    db,
+                    MaterializationKind::Bottom,
+                    self.materialization_visitor,
+                )
+            },
+            |bounds| bounds.bottom,
         );
 
         let is_subtype_of = |source: Type<'db>, target: Type<'db>| {
@@ -1714,7 +1936,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
             self.check_type_pair(db, source, target)
         };
-        match (source_materialization, target_materialization) {
+        match (source.kind, target.kind) {
             // `source` is a subtype of `target` if the range of materializations covered by `source`
             // is a subset of the range covered by `target`.
             (MaterializationKind::Top, MaterializationKind::Top) => {
@@ -1811,10 +2033,12 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                     self.as_relation_checker(TypeRelation::Subtyping)
                         .check_subtyping_in_invariant_position(
                             db,
-                            left_type,
-                            MaterializationKind::Bottom,
-                            right_type,
-                            MaterializationKind::Top,
+                            InvariantArgumentRange::new(
+                                left_type,
+                                MaterializationKind::Bottom,
+                                None,
+                            ),
+                            InvariantArgumentRange::new(right_type, MaterializationKind::Top, None),
                         )
                         .negate(db, self.constraints)
                 }
@@ -1861,11 +2085,20 @@ impl<'db> ApplySpecialization<'_, 'db> {
         db: &'db dyn Db,
         bound_typevar: BoundTypeVarInstance<'db>,
     ) -> Option<Type<'db>> {
+        self.get_with_index(db, bound_typevar)
+            .map(|(_, mapped)| mapped)
+    }
+
+    pub(crate) fn get_with_index(
+        &self,
+        db: &'db dyn Db,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) -> Option<(Option<usize>, Type<'db>)> {
         match self {
             ApplySpecialization::Specialization(specialization)
-            | ApplySpecialization::TypeAlias(specialization) => {
-                specialization.get(db, bound_typevar)
-            }
+            | ApplySpecialization::TypeAlias(specialization) => specialization
+                .get_with_index(db, bound_typevar)
+                .map(|(index, mapped)| (Some(index), mapped)),
             ApplySpecialization::Partial {
                 generic_context,
                 types,
@@ -1875,16 +2108,21 @@ impl<'db> ApplySpecialization<'_, 'db> {
                     .variables_inner(db)
                     .get_index_of(&bound_typevar.identity(db))?;
                 if skip.is_some_and(|skip| skip == index) {
-                    return Some(Type::Never);
+                    return Some((Some(index), Type::Never));
                 }
-                types.get(index).copied()
+                types
+                    .get(index)
+                    .copied()
+                    .map(|mapped| (Some(index), mapped))
             }
-            ApplySpecialization::ReturnCallables(replacements) => {
-                replacements.get(&bound_typevar).copied().map(Type::TypeVar)
-            }
+            ApplySpecialization::ReturnCallables(replacements) => replacements
+                .get(&bound_typevar)
+                .copied()
+                .map(Type::TypeVar)
+                .map(|mapped| (None, mapped)),
             ApplySpecialization::Single(typevar, ty) => {
                 if bound_typevar.is_same_typevar_as(db, *typevar) {
-                    Some(*ty)
+                    Some((None, *ty))
                 } else {
                     None
                 }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1073,9 +1073,15 @@ impl<'db> GenericContext<'db> {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
-struct InvariantArgumentBounds<'db> {
+pub(super) struct InvariantArgumentBounds<'db> {
     bottom: Type<'db>,
     top: Type<'db>,
+}
+
+impl<'db> InvariantArgumentBounds<'db> {
+    pub(super) const fn new(bottom: Type<'db>, top: Type<'db>) -> Self {
+        Self { bottom, top }
+    }
 }
 
 #[derive(Copy, Clone)]
@@ -1655,13 +1661,10 @@ impl<'db> Specialization<'db> {
                     vartype.materialize(db, materialization_kind.flip(), visitor)
                 }
                 TypeVarVariance::Invariant => {
-                    let bottom = vartype.materialize(db, MaterializationKind::Bottom, visitor);
-                    let top = vartype.materialize(db, MaterializationKind::Top, visitor);
-                    if !visitor.is_equivalent_to_materialization(db, vartype, top) {
-                        materialized_arguments.push(MaterializedInvariantArgument {
-                            index,
-                            bounds: InvariantArgumentBounds { bottom, top },
-                        });
+                    let bounds = visitor.materialization_bounds(db, vartype);
+                    if !visitor.is_equivalent_to_materialization(db, vartype, bounds.top) {
+                        materialized_arguments
+                            .push(MaterializedInvariantArgument { index, bounds });
                     }
                     vartype
                 }

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -120,8 +120,8 @@ fn is_invariant_dynamic_generalization_of<'db>(
 
     // Top and bottom materializations are not gradual types.
     if general_class != specific_class
-        || general_specialization.materialization_kind(db).is_some()
-        || specific_specialization.materialization_kind(db).is_some()
+        || general_specialization.materialization(db).is_some()
+        || specific_specialization.materialization(db).is_some()
     {
         return false;
     }

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -78,13 +78,13 @@ impl<'db> PEP695TypeAliasType<'db> {
             let specialization = self
                 .specialization(db)
                 .unwrap_or_else(|| generic_context.default_specialization(db, None));
-            let type_mapping = match specialization.materialization_kind(db) {
+            let type_mapping = match specialization.materialization(db) {
                 None => {
                     TypeMapping::ApplySpecialization(ApplySpecialization::TypeAlias(specialization))
                 }
-                Some(materialization_kind) => TypeMapping::ApplySpecializationWithMaterialization {
+                Some(materialization) => TypeMapping::ApplySpecializationWithMaterialization {
                     specialization: ApplySpecialization::TypeAlias(specialization),
-                    materialization_kind,
+                    materialization,
                 },
             };
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1094,42 +1094,44 @@ impl<'db> BoundTypeVarInstance<'db> {
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Type<'db> {
         let mapped_specialization_type =
-            |specialization: &ApplySpecialization<'a, 'db>| -> Option<Type<'db>> {
+            |specialization: &ApplySpecialization<'a, 'db>| -> Option<(Option<usize>, Type<'db>)> {
                 let typevar = if self.is_paramspec(db) {
                     self.without_paramspec_attr(db)
                 } else {
                     self
                 };
-                specialization.get(db, typevar).map(|ty| {
-                    if let Some(attr) = self.paramspec_attr(db)
-                        && let Type::TypeVar(typevar) = ty
-                        && typevar.is_paramspec(db)
-                    {
-                        return Type::TypeVar(typevar.with_paramspec_attr(db, attr));
-                    }
-                    ty
-                })
+                specialization
+                    .get_with_index(db, typevar)
+                    .map(|(index, ty)| {
+                        if let Some(attr) = self.paramspec_attr(db)
+                            && let Type::TypeVar(typevar) = ty
+                            && typevar.is_paramspec(db)
+                        {
+                            return (index, Type::TypeVar(typevar.with_paramspec_attr(db, attr)));
+                        }
+                        (index, ty)
+                    })
             };
 
         match type_mapping {
             TypeMapping::ApplySpecialization(specialization) => {
-                mapped_specialization_type(specialization).unwrap_or(Type::TypeVar(self))
+                mapped_specialization_type(specialization)
+                    .map(|(_, mapped)| mapped)
+                    .unwrap_or(Type::TypeVar(self))
             }
             TypeMapping::ApplySpecializationWithMaterialization {
                 specialization,
-                materialization_kind,
+                materialization,
             } => mapped_specialization_type(specialization)
-                .map(|mapped| {
-                    // Only materialize if the specialization actually substituted this
-                    // typevar with a different type. A typevar that maps back to itself
-                    // hasn't been substituted and should not be materialized.
+                .map(|(index, mapped)| {
+                    // Only project a materialized argument if the specialization actually
+                    // substituted this typevar. An identity mapping remains a typevar.
                     if mapped == Type::TypeVar(self) {
                         mapped
+                    } else if let Some(index) = index {
+                        materialization.project(db, index, mapped)
                     } else {
-                        // Materialization uses a different mapping mode. Reuse of the outer
-                        // visitor can incorrectly hit a cache entry from specialization.
-                        let materialization_visitor = ApplyTypeMappingVisitor::default();
-                        mapped.materialize(db, *materialization_kind, &materialization_visitor)
+                        mapped
                     }
                 })
                 .unwrap_or(Type::TypeVar(self)),


### PR DESCRIPTION
## Summary
- Add partial materialization support across type construction, display, generics, aliases, and type variables.
- Update constructor binding and set-theoretic type handling to preserve unresolved pieces during materialization.
- Add mdtest coverage for type property materialization behavior.

## Testing
- Added and updated mdtest coverage in `type_properties/materialization.md`.
- Not run (not requested).