### PR TITLE
[ty] Experiment with 24-byte shared AST names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,6 +3596,7 @@ dependencies = [
  "compact_str",
  "datatest-stable",
  "get-size2",
+ "hashbrown 0.17.1",
  "insta",
  "itertools 0.15.0",
  "memchr",

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -10,10 +10,6 @@ documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 
-[package.metadata.cargo-shear]
-# Used via `CacheKey` macro expansion.
-ignored = ["ruff_cache"]
-
 [lib]
 
 [dependencies]

--- a/crates/ruff_python_ast/src/frozen_string.rs
+++ b/crates/ruff_python_ast/src/frozen_string.rs
@@ -1,0 +1,450 @@
+//! Immutable string storage for [`crate::name::Name`].
+
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+use std::mem;
+use std::num::NonZeroU8;
+use std::ptr;
+use std::slice;
+use std::str;
+use std::sync::Arc;
+
+/// The number of UTF-8 bytes stored directly inside a [`FrozenCompactString`].
+pub(crate) const INLINE_CAPACITY: usize = 24;
+
+// Short inline strings use an invalid UTF-8 trailing byte to encode lengths 0 through 23. A
+// 24-byte UTF-8 string always ends in ASCII or a continuation byte, so its final byte is the tag.
+const SHORT_INLINE_TAG_BASE: u8 = 0b1100_0000;
+const SHORT_INLINE_TAG_MAX: u8 = 0b1101_0111;
+const STATIC_TAG: u8 = 0b1111_1110;
+const HEAP_TAG: u8 = 0b1111_1111;
+const REPR_SIZE: usize = 24;
+const TAIL_SIZE: usize = REPR_SIZE - mem::size_of::<*const ()>() - mem::size_of::<usize>() - 1;
+
+/// A 24-byte immutable string with 24 bytes of inline storage and shared heap allocations.
+#[repr(transparent)]
+pub(crate) struct FrozenCompactString(FrozenRepr);
+
+/// A data pointer, length, byte tail, and niche-bearing final byte.
+///
+/// Inline values reinterpret all 24 bytes as string storage. Heap values retain the data pointer
+/// returned by `Arc<[u8]>::into_raw`; static values retain a borrowed pointer and length.
+#[repr(C)]
+struct FrozenRepr(*const (), usize, [u8; TAIL_SIZE], NonZeroU8);
+
+#[cfg(target_pointer_width = "64")]
+#[repr(C, align(8))]
+struct FrozenInline([u8; INLINE_CAPACITY - 1], NonZeroU8);
+
+#[cfg(target_pointer_width = "32")]
+#[repr(C, align(4))]
+struct FrozenInline([u8; INLINE_CAPACITY - 1], NonZeroU8);
+
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+compile_error!("FrozenCompactString only supports 32-bit and 64-bit targets");
+
+const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenRepr>()];
+const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenInline>()];
+const _: [(); mem::align_of::<FrozenRepr>()] = [(); mem::align_of::<FrozenInline>()];
+const _: [(); REPR_SIZE] = [(); mem::size_of::<FrozenCompactString>()];
+const _: [(); REPR_SIZE] = [(); mem::size_of::<Option<FrozenCompactString>>()];
+
+impl FrozenCompactString {
+    #[inline]
+    pub(crate) fn new(text: impl AsRef<str>) -> Self {
+        Self(FrozenRepr::new(text.as_ref()))
+    }
+
+    #[inline]
+    pub(crate) const fn new_static(text: &'static str) -> Self {
+        Self(FrozenRepr::new_static(text))
+    }
+
+    #[inline]
+    pub(crate) fn concat(left: &str, right: &str) -> Self {
+        Self(FrozenRepr::concat(left, right))
+    }
+
+    #[inline]
+    pub(crate) fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    #[inline]
+    #[cfg(any(feature = "get-size", test))]
+    pub(crate) fn is_heap_allocated(&self) -> bool {
+        self.0.is_heap_allocated()
+    }
+}
+
+impl FrozenRepr {
+    #[inline]
+    fn new(text: &str) -> Self {
+        match text.len() {
+            0..INLINE_CAPACITY => Self::new_short_inline(text),
+            INLINE_CAPACITY if text.as_bytes()[INLINE_CAPACITY - 1] != 0 => {
+                Self::new_full_inline(text)
+            }
+            _ => Self::new_heap(text),
+        }
+    }
+
+    #[inline]
+    const fn new_static(text: &'static str) -> Self {
+        Self(
+            text.as_ptr().cast::<()>(),
+            text.len(),
+            [0; TAIL_SIZE],
+            nonzero(STATIC_TAG),
+        )
+    }
+
+    #[inline]
+    fn concat(left: &str, right: &str) -> Self {
+        let len = left
+            .len()
+            .checked_add(right.len())
+            .expect("combined string is too large");
+
+        if len <= INLINE_CAPACITY {
+            let mut bytes = [0; INLINE_CAPACITY];
+            let (left_bytes, right_bytes) = bytes[..len].split_at_mut(left.len());
+            left_bytes.copy_from_slice(left.as_bytes());
+            right_bytes.copy_from_slice(right.as_bytes());
+
+            if len < INLINE_CAPACITY {
+                let len = u8::try_from(len).expect("inline strings are shorter than 24 bytes");
+                bytes[INLINE_CAPACITY - 1] = SHORT_INLINE_TAG_BASE + len;
+                return Self::from_inline_bytes(bytes);
+            }
+            if bytes[INLINE_CAPACITY - 1] != 0 {
+                return Self::from_inline_bytes(bytes);
+            }
+        }
+
+        Self::new_heap_concat(left, right)
+    }
+
+    #[inline]
+    fn new_short_inline(text: &str) -> Self {
+        debug_assert!(text.len() < INLINE_CAPACITY);
+        let mut bytes = [0; INLINE_CAPACITY];
+        bytes[..text.len()].copy_from_slice(text.as_bytes());
+        let len = u8::try_from(text.len()).expect("inline strings are shorter than 24 bytes");
+        bytes[INLINE_CAPACITY - 1] = SHORT_INLINE_TAG_BASE + len;
+        Self::from_inline_bytes(bytes)
+    }
+
+    #[inline]
+    fn new_full_inline(text: &str) -> Self {
+        debug_assert_eq!(text.len(), INLINE_CAPACITY);
+        debug_assert_ne!(text.as_bytes()[INLINE_CAPACITY - 1], 0);
+        let mut bytes = [0; INLINE_CAPACITY];
+        bytes.copy_from_slice(text.as_bytes());
+        Self::from_inline_bytes(bytes)
+    }
+
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "the inline and tagged representations have identical layouts"
+    )]
+    fn from_inline_bytes(bytes: [u8; INLINE_CAPACITY]) -> Self {
+        debug_assert_ne!(bytes[INLINE_CAPACITY - 1], 0);
+
+        // SAFETY: The byte array and `FrozenRepr` have identical sizes. The final byte is nonzero,
+        // and raw pointers permit any bit pattern for inline values.
+        unsafe { mem::transmute(bytes) }
+    }
+
+    #[cold]
+    fn new_heap(text: &str) -> Self {
+        Self::from_heap_storage(Arc::from(text.as_bytes()))
+    }
+
+    #[cold]
+    #[expect(
+        unsafe_code,
+        reason = "the new Arc allocation is initialized from two valid string slices"
+    )]
+    fn new_heap_concat(left: &str, right: &str) -> Self {
+        let len = left
+            .len()
+            .checked_add(right.len())
+            .expect("combined string is too large");
+        let mut storage = Arc::<[u8]>::new_uninit_slice(len);
+        let destination = Arc::get_mut(&mut storage)
+            .expect("a newly allocated Arc has no other strong or weak references")
+            .as_mut_ptr()
+            .cast::<u8>();
+
+        // SAFETY: `destination` points to `len` uninitialized bytes in a new allocation. The two
+        // source slices contain exactly `len` initialized bytes and cannot overlap that allocation.
+        unsafe {
+            ptr::copy_nonoverlapping(left.as_ptr(), destination, left.len());
+            ptr::copy_nonoverlapping(right.as_ptr(), destination.add(left.len()), right.len());
+        }
+
+        // SAFETY: The two copies above initialized every byte in the allocation.
+        Self::from_heap_storage(unsafe { storage.assume_init() })
+    }
+
+    #[inline]
+    fn from_heap_storage(storage: Arc<[u8]>) -> Self {
+        let len = storage.len();
+        Self(
+            Arc::into_raw(storage).cast::<u8>().cast::<()>(),
+            len,
+            [0; TAIL_SIZE],
+            nonzero(HEAP_TAG),
+        )
+    }
+
+    #[inline]
+    fn tag(&self) -> u8 {
+        self.3.get()
+    }
+
+    #[inline]
+    fn is_heap_allocated(&self) -> bool {
+        self.tag() == HEAP_TAG
+    }
+
+    #[inline]
+    fn is_static(&self) -> bool {
+        self.tag() == STATIC_TAG
+    }
+
+    #[inline]
+    fn inline_len(&self) -> usize {
+        debug_assert!(!self.is_heap_allocated() && !self.is_static());
+        if self.tag() < SHORT_INLINE_TAG_BASE {
+            INLINE_CAPACITY
+        } else {
+            debug_assert!(self.tag() <= SHORT_INLINE_TAG_MAX);
+            usize::from(self.tag() - SHORT_INLINE_TAG_BASE)
+        }
+    }
+
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "the tagged representation stores inline bytes, a raw Arc slice, or static data"
+    )]
+    fn as_str(&self) -> &str {
+        let bytes = if self.is_heap_allocated() {
+            // SAFETY: The pointer and length came from an `Arc<[u8]>` that this value owns one
+            // strong reference to, and the allocation remains immutable for its lifetime.
+            unsafe { &*self.raw_arc_ptr() }
+        } else if self.is_static() {
+            // SAFETY: The pointer and length came from a valid `&'static str`.
+            unsafe { slice::from_raw_parts(self.0.cast::<u8>(), self.1) }
+        } else {
+            // SAFETY: Inline bytes begin at the same address as the representation, and
+            // `inline_len` is in 0..=24 by construction.
+            unsafe { slice::from_raw_parts(ptr::from_ref(self).cast::<u8>(), self.inline_len()) }
+        };
+
+        // SAFETY: Every representation is created exclusively from valid `str` values and exposes
+        // no mutation that could violate UTF-8.
+        unsafe { str::from_utf8_unchecked(bytes) }
+    }
+
+    #[inline]
+    fn raw_arc_ptr(&self) -> *const [u8] {
+        debug_assert!(self.is_heap_allocated());
+        ptr::slice_from_raw_parts(self.0.cast::<u8>(), self.1)
+    }
+}
+
+#[expect(
+    unsafe_code,
+    reason = "all representation tags are statically constrained to nonzero values"
+)]
+const fn nonzero(byte: u8) -> NonZeroU8 {
+    debug_assert!(byte != 0);
+
+    // SAFETY: Callers only pass the nonzero static and heap tag constants.
+    unsafe { NonZeroU8::new_unchecked(byte) }
+}
+
+impl Clone for FrozenRepr {
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "cloning shared storage increments the strong count of its raw Arc pointer"
+    )]
+    fn clone(&self) -> Self {
+        if self.is_heap_allocated() {
+            // SAFETY: `raw_arc_ptr` reconstructs the pointer returned by `Arc::into_raw`, and this
+            // value owns a live strong reference for the duration of this call.
+            unsafe { Arc::increment_strong_count(self.raw_arc_ptr()) };
+        }
+
+        Self(self.0, self.1, self.2, self.3)
+    }
+}
+
+impl Drop for FrozenRepr {
+    #[inline]
+    #[expect(
+        unsafe_code,
+        reason = "dropping shared storage releases the strong count of its raw Arc pointer"
+    )]
+    fn drop(&mut self) {
+        if self.is_heap_allocated() {
+            // SAFETY: Each heap representation owns exactly one strong reference corresponding to
+            // this raw pointer. Reconstructing and dropping the Arc releases that reference.
+            unsafe { drop(Arc::from_raw(self.raw_arc_ptr())) };
+        }
+    }
+}
+
+// SAFETY: Inline values contain owned bytes. Heap values hold a strong reference to immutable
+// `Arc<[u8]>` storage, and static values point to immutable data.
+#[expect(
+    unsafe_code,
+    reason = "the raw pointer owns or borrows immutable storage"
+)]
+unsafe impl Send for FrozenRepr {}
+// SAFETY: See the `Send` implementation above; no API exposes mutation of shared storage.
+#[expect(
+    unsafe_code,
+    reason = "the raw pointer owns or borrows immutable storage"
+)]
+unsafe impl Sync for FrozenRepr {}
+
+impl Clone for FrozenCompactString {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl Default for FrozenCompactString {
+    fn default() -> Self {
+        Self::new("")
+    }
+}
+
+impl Hash for FrozenCompactString {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl PartialEq for FrozenCompactString {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for FrozenCompactString {}
+
+impl PartialOrd for FrozenCompactString {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for FrozenCompactString {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    use super::{FrozenCompactString, INLINE_CAPACITY};
+
+    const STATIC: FrozenCompactString =
+        FrozenCompactString::new_static("a static string longer than inline storage");
+
+    #[test]
+    fn representation_is_24_bytes() {
+        assert_eq!(size_of::<FrozenCompactString>(), 24);
+        assert_eq!(size_of::<Option<FrozenCompactString>>(), 24);
+    }
+
+    #[test]
+    fn inline_heap_and_static_strings_roundtrip() {
+        for len in 0..=INLINE_CAPACITY {
+            let text = "x".repeat(len);
+            let frozen = FrozenCompactString::new(&text);
+            assert_eq!(frozen.as_str(), text);
+            assert!(!frozen.is_heap_allocated());
+        }
+
+        for text in [
+            "x".repeat(INLINE_CAPACITY + 1),
+            format!("{}\0", "x".repeat(INLINE_CAPACITY - 1)),
+            String::from("Python 🐍 and Rust 🦀"),
+        ] {
+            let frozen = FrozenCompactString::new(&text);
+            assert_eq!(frozen.as_str(), text);
+            assert!(frozen.is_heap_allocated());
+        }
+
+        assert_eq!(
+            STATIC.as_str(),
+            "a static string longer than inline storage"
+        );
+        assert!(!STATIC.is_heap_allocated());
+    }
+
+    #[test]
+    fn heap_clones_share_storage() {
+        let frozen = FrozenCompactString::new("a string too long for inline storage");
+        let clone = frozen.clone();
+        assert_eq!(frozen.as_str().as_ptr(), clone.as_str().as_ptr());
+
+        drop(frozen);
+        assert_eq!(clone.as_str(), "a string too long for inline storage");
+    }
+
+    #[test]
+    fn concatenated_strings_roundtrip() {
+        for (left, right, is_heap_allocated) in [
+            ("", "short", false),
+            ("abcdefghijk", "lmnopqrstuvwx", false),
+            ("abcdefghijkl", "mnopqrstuvwx", false),
+            ("abcdefghijkl", "mnopqrstuvwxy", true),
+            ("Python 🐍", " and Rust 🦀", true),
+        ] {
+            let expected = format!("{left}{right}");
+            let frozen = FrozenCompactString::concat(left, right);
+            assert_eq!(frozen.as_str(), expected);
+            assert_eq!(frozen.is_heap_allocated(), is_heap_allocated);
+
+            let clone = frozen.clone();
+            assert_eq!(clone.as_str(), expected);
+            if is_heap_allocated {
+                assert_eq!(frozen.as_str().as_ptr(), clone.as_str().as_ptr());
+            }
+
+            drop(frozen);
+            assert_eq!(clone.as_str(), expected);
+        }
+    }
+
+    #[test]
+    fn equality_hash_and_order_match_str() {
+        let alpha = FrozenCompactString::new("alpha");
+        let beta = FrozenCompactString::new("beta value too long to store inline");
+        assert!(alpha < beta);
+        assert!(alpha == FrozenCompactString::new("alpha"));
+
+        let mut expected = DefaultHasher::new();
+        "alpha".hash(&mut expected);
+        let mut actual = DefaultHasher::new();
+        alpha.hash(&mut actual);
+        assert_eq!(actual.finish(), expected.finish());
+    }
+}

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -13,6 +13,7 @@ pub mod comparable;
 pub mod docstrings;
 mod expression;
 pub mod find_node;
+mod frozen_string;
 mod generated;
 pub mod helpers;
 pub mod identifier;

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -6,38 +6,38 @@ use std::ops::Deref;
 use arrayvec::ArrayVec;
 
 use crate::Expr;
+use crate::frozen_string::FrozenCompactString;
 use crate::generated::ExprName;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "cache", derive(ruff_macros::CacheKey))]
-#[cfg_attr(feature = "salsa", derive(salsa::Update))]
-#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 #[cfg_attr(
     feature = "schemars",
     derive(schemars::JsonSchema),
     schemars(with = "String")
 )]
-pub struct Name(compact_str::CompactString);
+pub struct Name(FrozenCompactString);
 
 impl Name {
+    /// The maximum number of UTF-8 bytes stored inline in a name.
+    pub const INLINE_CAPACITY: usize = crate::frozen_string::INLINE_CAPACITY;
+
     #[inline]
     pub fn empty() -> Self {
-        Self(compact_str::CompactString::default())
+        Self(FrozenCompactString::default())
     }
 
     #[inline]
     pub fn new(name: impl AsRef<str>) -> Self {
-        Self(compact_str::CompactString::new(name))
+        Self(FrozenCompactString::new(name))
     }
 
     #[inline]
     pub const fn new_static(name: &'static str) -> Self {
-        Self(compact_str::CompactString::const_new(name))
+        Self(FrozenCompactString::new_static(name))
     }
 
     pub fn shrink_to_fit(&mut self) {
-        self.0.shrink_to_fit();
+        // Inline storage has a fixed size and shared heap storage has no spare capacity.
     }
 
     pub fn as_str(&self) -> &str {
@@ -45,7 +45,11 @@ impl Name {
     }
 
     pub fn push_str(&mut self, s: &str) {
-        self.0.push_str(s);
+        if s.is_empty() {
+            return;
+        }
+
+        self.0 = FrozenCompactString::concat(self, s);
     }
 }
 
@@ -57,7 +61,7 @@ impl Debug for Name {
 
 impl std::fmt::Write for Name {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        self.0.push_str(s);
+        self.push_str(s);
         Ok(())
     }
 }
@@ -88,49 +92,49 @@ impl Borrow<str> for Name {
 impl<'a> From<&'a str> for Name {
     #[inline]
     fn from(s: &'a str) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
 impl From<String> for Name {
     #[inline]
     fn from(s: String) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
 impl<'a> From<&'a String> for Name {
     #[inline]
     fn from(s: &'a String) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
 impl<'a> From<Cow<'a, str>> for Name {
     #[inline]
     fn from(cow: Cow<'a, str>) -> Self {
-        Name(cow.into())
+        Name::new(cow)
     }
 }
 
 impl From<Box<str>> for Name {
     #[inline]
     fn from(b: Box<str>) -> Self {
-        Name(b.into())
+        Name::new(b)
     }
 }
 
 impl From<compact_str::CompactString> for Name {
     #[inline]
     fn from(value: compact_str::CompactString) -> Self {
-        Self(value)
+        Self::new(value)
     }
 }
 
 impl From<Name> for compact_str::CompactString {
     #[inline]
     fn from(name: Name) -> Self {
-        name.0
+        compact_str::CompactString::new(name.as_str())
     }
 }
 
@@ -138,7 +142,7 @@ impl From<Name> for compact_str::CompactString {
 impl salsa::Lookup<compact_str::CompactString> for Name {
     #[inline]
     fn into_owned(self) -> compact_str::CompactString {
-        self.0
+        self.into()
     }
 }
 
@@ -146,7 +150,7 @@ impl salsa::Lookup<compact_str::CompactString> for Name {
 impl salsa::Lookup<compact_str::CompactString> for &Name {
     #[inline]
     fn into_owned(self) -> compact_str::CompactString {
-        self.0.clone()
+        compact_str::CompactString::new(self.as_str())
     }
 }
 
@@ -185,7 +189,86 @@ impl From<Name> for String {
 
 impl FromIterator<char> for Name {
     fn from_iter<I: IntoIterator<Item = char>>(iter: I) -> Self {
-        Self(iter.into_iter().collect())
+        Self::from(iter.into_iter().collect::<String>())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Name {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_newtype_struct("Name", self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Name {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct NameVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for NameVisitor {
+            type Value = Name;
+
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a Python name")
+            }
+
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let value = <Cow<'de, str> as serde::Deserialize>::deserialize(deserializer)?;
+                Ok(Name::new(value))
+            }
+        }
+
+        deserializer.deserialize_newtype_struct("Name", NameVisitor)
+    }
+}
+
+#[cfg(feature = "cache")]
+impl ruff_cache::CacheKey for Name {
+    fn cache_key(&self, state: &mut ruff_cache::CacheKeyHasher) {
+        ruff_cache::CacheKey::cache_key(self.as_str(), state);
+    }
+}
+
+#[cfg(feature = "get-size")]
+impl get_size2::GetSize for Name {
+    fn get_heap_size_with_tracker<T: get_size2::GetSizeTracker>(
+        &self,
+        mut tracker: T,
+    ) -> (usize, T) {
+        let size = if self.0.is_heap_allocated() && tracker.track(self.as_ptr()) {
+            self.len()
+        } else {
+            0
+        };
+        (size, tracker)
+    }
+}
+
+#[cfg(feature = "salsa")]
+#[expect(
+    unsafe_code,
+    reason = "implements Salsa's unsafe update contract for an owned value"
+)]
+unsafe impl salsa::Update for Name {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        // SAFETY: `Update` guarantees that `old_pointer` is valid and uniquely available for the
+        // duration of this call. `Name` owns all of its data and has no borrowed state.
+        let old_value = unsafe { &mut *old_pointer };
+        if *old_value == new_value {
+            false
+        } else {
+            *old_value = new_value;
+            true
+        }
     }
 }
 
@@ -801,7 +884,57 @@ type SegmentsStack<'a> = ArrayVec<&'a str, SMALL_LEN>;
 
 #[cfg(test)]
 mod tests {
-    use crate::name::SegmentsVec;
+    #[cfg(feature = "get-size")]
+    use get_size2::{GetSize, StandardTracker};
+
+    use crate::Identifier;
+    use crate::name::{Name, SegmentsVec};
+
+    const STATIC_NAME: Name = Name::new_static("a_static_name_that_is_not_inline");
+
+    #[test]
+    fn inline_and_static_storage() {
+        assert!(
+            !Name::new("x".repeat(Name::INLINE_CAPACITY))
+                .0
+                .is_heap_allocated()
+        );
+        assert!(
+            Name::new("x".repeat(Name::INLINE_CAPACITY + 1))
+                .0
+                .is_heap_allocated()
+        );
+        assert_eq!(STATIC_NAME, "a_static_name_that_is_not_inline");
+        assert!(!STATIC_NAME.0.is_heap_allocated());
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn size() {
+        assert_eq!(std::mem::size_of::<Name>(), 24);
+        assert_eq!(std::mem::size_of::<Option<Name>>(), 24);
+        assert_eq!(std::mem::size_of::<Identifier>(), 40);
+    }
+
+    #[test]
+    #[cfg(all(feature = "serde", feature = "schemars"))]
+    fn serde_roundtrip() {
+        let name = Name::new("Python_🐍");
+        let serialized = serde_json::to_string(&name).unwrap();
+        assert_eq!(serde_json::from_str::<Name>(&serialized).unwrap(), name);
+    }
+
+    #[test]
+    #[cfg(feature = "get-size")]
+    fn heap_size_tracks_shared_storage_once() {
+        assert_eq!(Name::new("inline").get_heap_size(), 0);
+
+        let name = Name::new("a name too long for inline storage");
+        let expected = name.len();
+        let clone = name.clone();
+        let (size, _) = (name, clone).get_heap_size_with_tracker(StandardTracker::new());
+        assert_eq!(size, expected);
+    }
 
     #[test]
     fn empty_vec() {

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -21,6 +21,7 @@ bitflags = { workspace = true }
 bstr = { workspace = true }
 compact_str = { workspace = true }
 get-size2 = { workspace = true }
+hashbrown = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 static_assertions = { workspace = true }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -583,7 +583,8 @@ impl<'src> Parser<'src> {
         }
 
         if self.current_token_kind().is_soft_keyword() {
-            let id = Name::new(self.src_text(range));
+            let text = self.src_text(range);
+            let id = self.intern_name(text);
             self.bump_soft_keyword_as_name();
             return ast::Identifier {
                 id,
@@ -617,7 +618,8 @@ impl<'src> Parser<'src> {
                 range,
             );
 
-            let id = Name::new(self.src_text(range));
+            let text = self.src_text(range);
+            let id = self.intern_name(text);
             self.bump_any();
             ast::Identifier {
                 id,

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use std::str::FromStr;
 
 use bitflags::bitflags;
+use hashbrown::HashSet;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{
@@ -10,6 +11,7 @@ use ruff_python_ast::{
 };
 use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use rustc_hash::FxBuildHasher;
 use thin_vec::ThinVec;
 use unicode_normalization::UnicodeNormalization;
 
@@ -34,12 +36,42 @@ mod statement;
 #[cfg(test)]
 mod tests;
 
+#[derive(Debug, Default)]
+struct NameInterner {
+    names: HashSet<Name, FxBuildHasher>,
+}
+
+impl NameInterner {
+    /// Returns an inline name directly, or a shared clone of a heap-allocated name.
+    fn intern(&mut self, text: &str) -> Name {
+        if text.len() <= Name::INLINE_CAPACITY {
+            return Name::new(text);
+        }
+
+        self.names
+            .get_or_insert_with(text, |text| Name::new(text))
+            .clone()
+    }
+
+    /// Interns a name that has already been allocated, such as a normalized identifier.
+    fn intern_owned(&mut self, name: Name) -> Name {
+        if name.len() <= Name::INLINE_CAPACITY {
+            return name;
+        }
+
+        self.names.get_or_insert(name).clone()
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {
     source: &'src str,
 
     /// Token source for the parser that skips over any non-trivia token.
     tokens: TokenSource<'src>,
+
+    /// Deduplicates the backing allocations for repeated names that do not fit inline.
+    name_interner: NameInterner,
 
     /// Stores all the syntax errors found during the parsing.
     errors: Vec<ParseError>,
@@ -92,6 +124,7 @@ impl<'src> Parser<'src> {
             errors: Vec::new(),
             unsupported_syntax_errors: Vec::new(),
             tokens,
+            name_interner: NameInterner::default(),
             recovery_context: RecoveryContext::empty(),
             prev_token_end: TextSize::new(0),
             start_offset,
@@ -395,12 +428,21 @@ impl<'src> Parser<'src> {
     fn bump_name(&mut self) -> Name {
         let text = self.current_token_text();
         let name = if !self.tokens.current_flags().is_non_ascii_name() {
-            Name::new(text)
+            self.intern_name(text)
         } else {
-            normalize_name(text)
+            let normalized = normalize_name(text);
+            self.intern_owned_name(normalized)
         };
         self.bump(TokenKind::Name);
         name
+    }
+
+    fn intern_name(&mut self, text: &str) -> Name {
+        self.name_interner.intern(text)
+    }
+
+    fn intern_owned_name(&mut self, name: Name) -> Name {
+        self.name_interner.intern_owned(name)
     }
 
     fn bump_int(&mut self) -> Int {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -831,7 +831,12 @@ impl<'src> Parser<'src> {
     fn parse_dotted_name(&mut self) -> ast::Identifier {
         let start = self.node_start();
 
-        let mut dotted_name: CompactString = self.parse_identifier().id.into();
+        let first = self.parse_identifier();
+        if !self.at(TokenKind::Dot) {
+            return first;
+        }
+
+        let mut dotted_name: CompactString = first.id.into();
         let mut progress = ParserProgress::default();
 
         while self.eat(TokenKind::Dot) {
@@ -848,7 +853,7 @@ impl<'src> Parser<'src> {
         // import a.b.c
         // import a .  b  . c
         ast::Identifier {
-            id: Name::from(dotted_name),
+            id: self.intern_owned_name(Name::from(dotted_name)),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,5 +1,7 @@
+use ruff_python_ast::name::Name;
 use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, Stmt};
 
+use super::NameInterner;
 use crate::{Mode, ParseErrorType, ParseOptions, parse, parse_expression, parse_module};
 
 #[test]
@@ -69,6 +71,53 @@ fn nfkc_normalizes_names() {
     };
 
     assert_eq!(name.id.as_str(), "C");
+}
+
+#[test]
+fn repeated_long_names_share_storage() {
+    let long_name = "identifier_longer_than_inline_capacity";
+    let source = format!("{long_name} = {long_name}");
+    let parsed = parse_module(&source).unwrap();
+    let [Stmt::Assign(assign)] = parsed.suite().as_slice() else {
+        panic!("expected an assignment");
+    };
+    let [Expr::Name(target)] = assign.targets.as_slice() else {
+        panic!("expected a name target");
+    };
+    let Expr::Name(value) = assign.value.as_ref() else {
+        panic!("expected a name value");
+    };
+
+    assert!(std::ptr::eq(target.id.as_str(), value.id.as_str()));
+}
+
+#[test]
+fn only_heap_allocated_names_are_interned() {
+    let mut interner = NameInterner::default();
+    interner.intern(&"x".repeat(Name::INLINE_CAPACITY));
+    assert!(interner.names.is_empty());
+
+    interner.intern(&"x".repeat(Name::INLINE_CAPACITY + 1));
+    assert_eq!(interner.names.len(), 1);
+}
+
+#[test]
+fn normalized_long_names_share_storage() {
+    let normalized = "C".repeat(Name::INLINE_CAPACITY + 1);
+    let source = format!("{} = {normalized}", "𝒞".repeat(Name::INLINE_CAPACITY + 1));
+    let parsed = parse_module(&source).unwrap();
+    let [Stmt::Assign(assign)] = parsed.suite().as_slice() else {
+        panic!("expected an assignment");
+    };
+    let [Expr::Name(target)] = assign.targets.as_slice() else {
+        panic!("expected a name target");
+    };
+    let Expr::Name(value) = assign.value.as_ref() else {
+        panic!("expected a name value");
+    };
+
+    assert_eq!(target.id.as_str(), normalized);
+    assert!(std::ptr::eq(target.id.as_str(), value.id.as_str()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This draft is the 24-byte comparison for #26594. It keeps Python AST `Name` values at the same size and inline capacity as `CompactString`, while adding parser-local structural sharing only for names longer than 24 UTF-8 bytes. Short names bypass the interner, and repeated longer names retain one immutable `Arc<[u8]>` allocation per distinct identifier within a parser invocation.

The custom `FrozenCompactString` uses tagged 24-byte storage: short inline lengths are encoded with trailing byte patterns that cannot terminate valid UTF-8, full 24-byte names occupy the entire value, long runtime names use shared heap storage, and static names retain a borrowed pointer and length without allocating. `Option<Name>` remains 24 bytes, and mutation rebuilds an immutable value rather than exposing shared storage.

This keeps the parser behavior aligned with #26594 while changing the two variables we want CI to measure: `Name` is 24 rather than 16 bytes, and names from 17 through 24 bytes remain inline rather than entering the interner. #26562 used a custom 16-byte representation with 15 bytes of inline storage, so it did not answer this cutoff question.

The AST and parser suites, the `ty_python_semantic` suite, workspace Clippy, `cargo shear`, and the repository hooks pass locally. This implementation deliberately leaves the in-tree representation and unsafe-code maintenance cost visible so we can weigh it alongside the memory and timing results.
