### PR TITLE
[ty] Pydantic: Add support for `validate_by_{name,alias}`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -610,16 +610,14 @@ class AliasAndName(BaseModel):
     name: int = Field(alias="alias")
 
 AliasAndName(alias=1)
-# TODO: no errors here
-# error: [missing-argument]
 AliasAndName(name=1)
+AliasAndName(name=None)  # error: [invalid-argument-type]
 ```
 
 Passing none of these should be an error:
 
 ```py
-# Note: this might be hard to support once we implement the feature above?
-# error: [missing-argument]
+# This is a known limitation, it should ideally be an error.
 AliasAndName()
 ```
 
@@ -631,11 +629,21 @@ class OnlyName(BaseModel):
 
     name: int = Field(alias="alias")
 
-# TODO: this should be an error
-OnlyName(alias=1)
-# TODO: no errors here
-# error: [missing-argument]
+OnlyName(alias=1)  # error: [missing-argument]
 OnlyName(name=1)
+```
+
+If `validate_by_alias=False` is set without specifying `validate_by_name`, Pydantic implicitly
+enables validation by name:
+
+```py
+class ImplicitlyOnlyName(BaseModel):
+    model_config = ConfigDict(validate_by_alias=False)
+
+    name: int = Field(alias="alias")
+
+ImplicitlyOnlyName(alias=1)  # error: [missing-argument]
+ImplicitlyOnlyName(name=1)
 ```
 
 ## Extra fields

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -34,7 +34,7 @@ use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, PathBound, PathBounds, Solutions,
 };
-use crate::types::dedicated::pydantic::StrictMode;
+use crate::types::dedicated::pydantic::ConfigBoolean;
 use crate::types::diagnostic::{
     CALL_NON_CALLABLE, CALL_TOP_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_DATACLASS,
     MISSING_ARGUMENT, NO_MATCHING_OVERLOAD, PARAMETER_ALREADY_ASSIGNED,
@@ -1715,10 +1715,18 @@ impl<'db> Bindings<'db> {
                         let kw_only = get_argument_type("kw_only", true);
                         let alias = get_argument_type("alias", true);
                         let converter = get_argument_type("converter", true);
-                        let strict = get_argument_type("strict", false)
-                            .map_or(StrictMode::Unspecified, |strict| {
-                                StrictMode::from_field_type(db, strict)
-                            });
+                        // `Field(strict=None)` inherits the model-global strictness configuration,
+                        // so treat it like an unspecified field-level value.
+                        let strict = get_argument_type("strict", false).map_or(
+                            ConfigBoolean::Unspecified,
+                            |strict| {
+                                if strict.is_none(db) {
+                                    ConfigBoolean::Unspecified
+                                } else {
+                                    ConfigBoolean::from_type(strict)
+                                }
+                            },
+                        );
 
                         // `dataclasses.field` and field-specifier functions of commonly used
                         // libraries like `pydantic`, `attrs`, and `SQLAlchemy` all return

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2429,7 +2429,7 @@ pub(crate) enum FieldKind<'db> {
         /// The name for this field in the synthesized constructor signature, if specified.
         alias: Option<Box<str>>,
         /// The mode selected by Pydantic's `strict` argument.
-        strict: pydantic::StrictMode,
+        strict: pydantic::ConfigBoolean,
     },
     /// `TypedDict` field metadata
     TypedDict {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1370,7 +1370,7 @@ impl<'db> StaticClassLiteral<'db> {
                         None,
                         None,
                         None,
-                        pydantic::StrictMode::Unspecified,
+                        pydantic::ConfigBoolean::Unspecified,
                     ),
                     FieldKind::Dataclass {
                         init,
@@ -1385,7 +1385,7 @@ impl<'db> StaticClassLiteral<'db> {
                         *kw_only,
                         alias.as_ref(),
                         *converter,
-                        pydantic::StrictMode::Unspecified,
+                        pydantic::ConfigBoolean::Unspecified,
                     ),
                     FieldKind::Pydantic {
                         init,
@@ -1476,28 +1476,63 @@ impl<'db> StaticClassLiteral<'db> {
                     || pydantic_constructor_fields_are_keyword_only
                     || kw_only.unwrap_or(false);
 
-                // Use the alias name if provided, otherwise use the field name
-                let parameter_name =
-                    Name::new(alias.map(|alias| &**alias).unwrap_or(&**field_name));
+                let mut add_parameter_with_name = |parameter_name, default_ty| {
+                    let mut parameter = if is_kw_only {
+                        Parameter::keyword_only(parameter_name)
+                    } else {
+                        Parameter::positional_or_keyword(parameter_name)
+                    }
+                    .with_annotated_type(field_ty)
+                    .with_definition(field.first_declaration);
 
-                let mut parameter = if is_kw_only {
-                    Parameter::keyword_only(parameter_name)
-                } else {
-                    Parameter::positional_or_keyword(parameter_name)
-                }
-                .with_annotated_type(field_ty)
-                .with_definition(field.first_declaration);
+                    parameter = if matches!(name, "__replace__" | "_replace") {
+                        // When replacing, we know there is a default value for the field
+                        // (the value that is currently assigned to the field)
+                        // assume this to be the declared type of the field
+                        parameter.with_default_type(field_ty)
+                    } else {
+                        parameter.with_optional_default_type(default_ty)
+                    };
 
-                parameter = if matches!(name, "__replace__" | "_replace") {
-                    // When replacing, we know there is a default value for the field
-                    // (the value that is currently assigned to the field)
-                    // assume this to be the declared type of the field
-                    parameter.with_default_type(field_ty)
-                } else {
-                    parameter.with_optional_default_type(default_ty)
+                    parameters.push(parameter);
                 };
 
-                parameters.push(parameter);
+                if name == "__init__"
+                    && let Some(metadata) = field_policy.pydantic_metadata()
+                    && let Some(alias) = alias
+                {
+                    match (metadata.validates_by_alias(), metadata.validates_by_name()) {
+                        (true, true) => {
+                            let alias = Name::new(&**alias);
+                            if alias == *field_name {
+                                add_parameter_with_name(field_name.clone(), default_ty);
+                            } else {
+                                // A normal signature cannot express that at least one of two
+                                // differently named parameters is required. We could solve
+                                // this with overloads, but the number of overloads would grow
+                                // exponentially in the number of parameters. So for now, we
+                                // treat both the alias and the field name as optional
+                                // parameters, which leads to false negatives if none of them
+                                // is provided.
+                                let default_ty = Some(default_ty.unwrap_or_else(Type::unknown));
+                                add_parameter_with_name(alias, default_ty);
+                                add_parameter_with_name(field_name.clone(), default_ty);
+                            }
+                        }
+                        (true, false) => {
+                            add_parameter_with_name(Name::new(&**alias), default_ty);
+                        }
+                        (false, true) => {
+                            add_parameter_with_name(field_name.clone(), default_ty);
+                        }
+                        (false, false) => {}
+                    }
+                } else {
+                    // Use the alias name if provided, otherwise use the field name.
+                    let parameter_name =
+                        Name::new(alias.map(|alias| &**alias).unwrap_or(&**field_name));
+                    add_parameter_with_name(parameter_name, default_ty);
+                }
             }
 
             // In the event that we have a mix of keyword-only and positional parameters, we need to sort them
@@ -2140,7 +2175,7 @@ impl<'db> StaticClassLiteral<'db> {
                 let mut kw_only = None;
                 let mut alias = None;
                 let mut converter = None;
-                let mut strict = pydantic::StrictMode::Unspecified;
+                let mut strict = pydantic::ConfigBoolean::Unspecified;
                 if let Some(Type::KnownInstance(KnownInstanceType::Field(field))) = default_ty {
                     default_ty = field.default_type(db);
                     init = field.init(db);

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -1,8 +1,8 @@
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast::name::Name;
+use ruff_python_ast::{Keyword, name::Name};
 use rustc_hash::FxHashSet;
 use ty_module_resolver::{KnownModule, file_to_module};
-use ty_python_core::definition::DefinitionKind;
+use ty_python_core::definition::{Definition, DefinitionKind};
 
 use crate::Db;
 use crate::place::{DefinedPlace, Definedness, Place, Provenance, known_module_symbol};
@@ -42,6 +42,23 @@ impl<'db> ModelMetadata<'db> {
     const fn accepts_extra(self) -> bool {
         !matches!(self.config.extra, Some(ExtraBehavior::Forbid))
     }
+
+    pub(in crate::types) const fn validates_by_alias(self) -> bool {
+        self.config.validate_by_alias.enabled_or(true)
+    }
+
+    pub(in crate::types) const fn validates_by_name(self) -> bool {
+        let validate_by_name = self.config.validate_by_name;
+        // If `validate_by_alias=False` is set without specifying `validate_by_name`, Pydantic
+        // implicitly enables validation by name.
+        if matches!(validate_by_name, ConfigBoolean::Unspecified)
+            && matches!(self.config.validate_by_alias, ConfigBoolean::Disabled)
+        {
+            true
+        } else {
+            validate_by_name.enabled_or(false)
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -51,14 +68,20 @@ struct ModelConfig {
     extra: Option<ExtraBehavior>,
     /// The `strict` configuration controls whether constructor parameters accept values that
     /// Pydantic can coerce to the declared field type.
-    strict: StrictMode,
+    strict: ConfigBoolean,
+    /// Whether fields with aliases can be initialized by their alias.
+    validate_by_alias: ConfigBoolean,
+    /// Whether fields with aliases can be initialized by their field name.
+    validate_by_name: ConfigBoolean,
 }
 
 impl ModelConfig {
     const fn unknown() -> Self {
         Self {
             extra: Some(ExtraBehavior::Unknown),
-            strict: StrictMode::Unknown,
+            strict: ConfigBoolean::Unknown,
+            validate_by_alias: ConfigBoolean::Unknown,
+            validate_by_name: ConfigBoolean::Unknown,
         }
     }
 
@@ -66,6 +89,8 @@ impl ModelConfig {
     fn merge(&mut self, other: Self) {
         self.extra = other.extra.or(self.extra);
         self.strict = other.strict.or(self.strict);
+        self.validate_by_alias = other.validate_by_alias.or(self.validate_by_alias);
+        self.validate_by_name = other.validate_by_name.or(self.validate_by_name);
     }
 }
 
@@ -89,17 +114,19 @@ impl ExtraBehavior {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
-pub enum StrictMode {
+pub enum ConfigBoolean {
     /// No value was specified at this precedence level, so a lower-precedence value can apply.
     #[default]
     Unspecified,
-    Lax,
-    Strict,
+    /// The setting was explicitly disabled.
+    Disabled,
+    /// The setting was explicitly enabled.
+    Enabled,
     /// A value was specified, but it could not be resolved statically.
     Unknown,
 }
 
-impl StrictMode {
+impl ConfigBoolean {
     const fn or(self, other: Self) -> Self {
         if matches!(self, Self::Unspecified) {
             other
@@ -108,31 +135,37 @@ impl StrictMode {
         }
     }
 
-    /// Resolve a strictness value from the type inferred for the model-global `strict` configuration.
-    ///
-    /// `model_config = ConfigDict(strict=None)` means that the model overrides inherited strictness
-    /// configuration with `Unknown`, which is treated as `Lax`.
+    /// Resolve a boolean configuration value from its inferred type.
     pub(in crate::types) fn from_type(value: Type<'_>) -> Self {
         if value == Type::bool_literal(true) {
-            Self::Strict
+            Self::Enabled
         } else if value == Type::bool_literal(false) {
-            Self::Lax
+            Self::Disabled
         } else {
             Self::Unknown
         }
     }
 
-    /// Resolve a strictness value from the type inferred for the `strict` configuration on the field.
+    /// Resolve this value to a boolean, using `default` when it is unspecified.
     ///
-    /// `Field(strict=None)` means that the field should inherit the model-global strictness configuration,
-    /// so it is treated as `Unspecified`.
-    pub(in crate::types) fn from_field_type(db: &dyn Db, value: Type<'_>) -> Self {
-        if value.is_none(db) {
-            Self::Unspecified
-        } else {
-            Self::from_type(value)
+    /// An unknown value resolves to `true`.
+    const fn enabled_or(self, default: bool) -> bool {
+        match self {
+            Self::Unspecified => default,
+            Self::Disabled => false,
+            Self::Enabled | Self::Unknown => true,
         }
     }
+}
+
+fn config_boolean(
+    db: &dyn Db,
+    definition: Definition<'_>,
+    keyword: Option<&Keyword>,
+) -> ConfigBoolean {
+    keyword.map_or(ConfigBoolean::Unspecified, |keyword| {
+        ConfigBoolean::from_type(definition_expression_type(db, definition, &keyword.value))
+    })
 }
 
 pub(in crate::types) fn is_model(db: &dyn Db, class: StaticClassLiteral<'_>) -> bool {
@@ -186,9 +219,7 @@ fn model_config<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> ModelCo
     if let Some(own_config) = own_model_config(db, class) {
         config.merge(own_config);
     }
-    if let Some(class_keyword_config) = class_keyword_config(db, class) {
-        config.merge(class_keyword_config);
-    }
+    config.merge(class_keyword_config(db, class));
     config
 }
 
@@ -262,28 +293,43 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
             .map(|literal| literal.value(db));
         ExtraBehavior::from_value(extra)
     });
-    let strict = call
-        .arguments
-        .find_keyword("strict")
-        .map_or(StrictMode::Unspecified, |strict| {
-            StrictMode::from_type(definition_expression_type(db, definition, &strict.value))
-        });
+    let strict = config_boolean(db, definition, call.arguments.find_keyword("strict"));
+    let validate_by_alias = config_boolean(
+        db,
+        definition,
+        call.arguments.find_keyword("validate_by_alias"),
+    );
+    let validate_by_name = config_boolean(
+        db,
+        definition,
+        call.arguments.find_keyword("validate_by_name"),
+    );
 
-    Some(ModelConfig { extra, strict })
+    Some(ModelConfig {
+        extra,
+        strict,
+        validate_by_alias,
+        validate_by_name,
+    })
 }
 
-fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelConfig> {
+fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelConfig {
     let definition = class.definition(db);
     let module = parsed_module(db, class.file(db)).load(db);
     let kind = definition.kind(db);
-    let class_node = kind.as_class()?.node(&module);
-    let arguments = class_node.arguments.as_ref()?;
+    let Some(class) = kind.as_class() else {
+        return ModelConfig::default();
+    };
+    let class_node = class.node(&module);
+    let Some(arguments) = class_node.arguments.as_ref() else {
+        return ModelConfig::default();
+    };
     if arguments
         .keywords
         .iter()
         .any(|keyword| keyword.arg.is_none())
     {
-        return Some(ModelConfig::unknown());
+        return ModelConfig::unknown();
     }
     let extra = arguments.find_keyword("extra").map(|extra| {
         let extra = definition_expression_type(db, definition, &extra.value)
@@ -291,24 +337,28 @@ fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<Mo
             .map(|literal| literal.value(db));
         ExtraBehavior::from_value(extra)
     });
-    let strict = arguments
-        .find_keyword("strict")
-        .map_or(StrictMode::Unspecified, |strict| {
-            StrictMode::from_type(definition_expression_type(db, definition, &strict.value))
-        });
+    let strict = config_boolean(db, definition, arguments.find_keyword("strict"));
+    let validate_by_alias =
+        config_boolean(db, definition, arguments.find_keyword("validate_by_alias"));
+    let validate_by_name =
+        config_boolean(db, definition, arguments.find_keyword("validate_by_name"));
 
-    (extra.is_some() || !matches!(strict, StrictMode::Unspecified))
-        .then_some(ModelConfig { extra, strict })
+    ModelConfig {
+        extra,
+        strict,
+        validate_by_alias,
+        validate_by_name,
+    }
 }
 
 /// Return the input type accepted by a Pydantic field's synthesized constructor parameter.
 pub(in crate::types) fn constructor_parameter_type<'db>(
     db: &'db dyn Db,
     field_type: Type<'db>,
-    field_strict: StrictMode,
+    field_strict: ConfigBoolean,
     metadata: ModelMetadata<'db>,
 ) -> Type<'db> {
-    if field_strict.or(metadata.config.strict) == StrictMode::Strict {
+    if field_strict.or(metadata.config.strict) == ConfigBoolean::Enabled {
         return field_type;
     }
 

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -10,7 +10,7 @@ use crate::{
         TypeMapping, TypeVarNonce, TypeVarVariance, UnionBuilder,
         class::NamedTupleSpec,
         constraints::OwnedConstraintSet,
-        dedicated::pydantic::StrictMode,
+        dedicated::pydantic::ConfigBoolean,
         generics::{Specialization, walk_generic_context},
         newtype::NewType,
         typevar::TypeVarInstance,
@@ -496,7 +496,7 @@ pub struct FieldInstance<'db> {
     pub converter: Option<(Type<'db>, Type<'db>)>,
 
     /// The mode selected by Pydantic's `strict` argument.
-    pub strict: StrictMode,
+    pub strict: ConfigBoolean,
 }
 
 // The Salsa heap is tracked separately.


### PR DESCRIPTION
## Summary

Pydantic model fields are typically set using their alias name, not their field name (just like for dataclasses):

```py
class Person(BaseModel):
    name: str = Field(alias="full_name")

Person(full_name="Alice")  # okay
Person(name="Alice")  # error
```

However, both of these behaviors can be controlled by setting `validate_by_alias` and `validate_by_name`, which are `true` and `false` by default. So for example, when both of these are inverted, we get the opposite behavior:

```py
class Person(BaseModel):
    model_config = ConfigDict(validate_by_alias=False, validate_by_name=True)

    name: str = Field(alias="full_name")

Person(full_name="Alice")  # error
Person(name="Alice")  # okay
```

closes https://github.com/astral-sh/ty/issues/1438
towards https://github.com/astral-sh/ty/issues/2403

## Test Plan

Update Markdown tests.
