### PR TITLE
[ty] Render Google docstrings as structured Markdown

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -841,16 +841,17 @@ Summary.
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func...<HB>
-        <HB>
-        Returns:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;Some details<HB>
+        My cool func...
+
+        ## Returns
+        Some details
+
         `````python
-            x_y = thing_do();
-            ``` # this should't close the fence!
-            a_b = other_thing();
+        x_y = thing_do();
+        ``` # this should't close the fence!
+        a_b = other_thing();
         `````<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;And so on.
+        And so on.
         ");
     }
 
@@ -876,16 +877,17 @@ Summary.
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func...<HB>
-        <HB>
-        Returns:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;Some details<HB>
+        My cool func...
+
+        ## Returns
+        Some details
+
         ~~~~~~python
-            x_y = thing_do();
-            ~~~ # this should't close the fence!
-            a_b = other_thing();
+        x_y = thing_do();
+        ~~~ # this should't close the fence!
+        a_b = other_thing();
         ~~~~~~<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;And so on.
+        And so on.
         ");
     }
 
@@ -1284,16 +1286,21 @@ Summary.
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter description<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter description<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param3: A parameter without type annotation<HB>
-        <HB>
-        Returns:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;str: The return value description
+        This is a function description.
+
+        ## Arguments
+        **param1**: `str`<HB>
+        The first parameter description
+
+        **param2**: `int`<HB>
+        The second parameter description<HB>
+        This is a continuation of param2 description.
+
+        **param3**<HB>
+        A parameter without type annotation
+
+        ## Returns
+        str: The return value description
         ");
     }
 
@@ -1495,12 +1502,15 @@ Summary.
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Another Google-style parameter<HB>
-        <HB>
+        This is a function description.
+
+        ## Arguments
+        **param1**: `str`<HB>
+        Google-style parameter
+
+        **param2**: `int`<HB>
+        Another Google-style parameter
+
         Parameters<HB>
         ----------<HB>
         param3 : bool<HB>
@@ -1649,11 +1659,14 @@ Summary.
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Google-style duplicate parameter
+        This is a function description.
+
+        ## Arguments
+        **param1**: `str`<HB>
+        Google-style parameter
+
+        **param2**: `int`<HB>
+        Google-style duplicate parameter
 
         ## Parameters
         **param2**: `int`<HB>
@@ -1854,11 +1867,14 @@ Summary.
 
         let markdown = docstring_windows.render_markdown();
         assert_snapshot!(markdown.as_str(), @"
-        This is a function description.<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter
+        This is a function description.
+
+        ## Arguments
+        **param1**: `str`<HB>
+        The first parameter
+
+        **param2**: `int`<HB>
+        The second parameter
         ");
         assert_eq!(docstring_mac.render_markdown(), markdown);
         assert_eq!(docstring_unix.render_markdown(), markdown);

--- a/crates/ty_ide/src/docstring/document.rs
+++ b/crates/ty_ide/src/docstring/document.rs
@@ -1,11 +1,9 @@
 use indexmap::IndexMap;
 use strum_macros::EnumIter;
 
-/// Google-style docstring parsing.
-mod google;
+pub(super) mod google;
 pub(super) mod preformatted;
 pub(super) mod rst;
-/// Syntax utilities shared by docstring format parsers and renderers.
 pub(in crate::docstring) mod syntax;
 
 /// Returns docs for all parameters recognized in the given docstring.

--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -50,7 +50,7 @@ pub(super) fn parameter_documentation(normalized_source: &str) -> IndexMap<Strin
     for section in sections(normalized_source) {
         let Section {
             kind,
-            fragments,
+            body: SectionBody { fragments, .. },
             range: _,
         } = section;
         if matches!(
@@ -76,12 +76,42 @@ pub(in crate::docstring) fn sections(source: &str) -> impl Iterator<Item = Secti
 pub(in crate::docstring) struct Section {
     kind: SectionKind,
     range: TextRange,
+    body: SectionBody,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SectionBody {
     fragments: Vec<BodyFragment>,
+    /// Whether the structured Markdown renderer can represent the body without changing its
+    /// meaning.
+    is_renderable: bool,
+}
+
+impl SectionBody {
+    /// Creates a renderable body containing the description as a single prose fragment.
+    fn from_prose(description: String) -> Self {
+        let fragments = (!description.is_empty())
+            .then_some(BodyFragment::Prose(description))
+            .into_iter()
+            .collect();
+        Self {
+            fragments,
+            is_renderable: true,
+        }
+    }
+
+    /// Creates an unrenderable body for a section whose contents remain opaque.
+    fn opaque() -> Self {
+        Self {
+            fragments: Vec::new(),
+            is_renderable: false,
+        }
+    }
 }
 
 /// One parsed fragment in a Google section body.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum BodyFragment {
+pub(in crate::docstring) enum BodyFragment {
     /// Section-level prose that is not attached to a named item.
     Prose(String),
     /// A named item and its description.
@@ -90,7 +120,7 @@ enum BodyFragment {
 
 /// A named item in a Google section.
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct Item {
+pub(in crate::docstring) struct Item {
     display_name: String,
     ty: Option<String>,
     description: String,
@@ -327,7 +357,18 @@ impl<'a> SectionBuilder<'a> {
 
         // Third, classify a nonblank line and stop if it begins content outside
         // this section.
-        let item_line = ItemLine::classify(self.section_header.kind, line);
+        let also_parses_as_section_header = line_header.is_some()
+            && line
+                .text
+                .trim()
+                .chars()
+                .next()
+                .is_some_and(char::is_uppercase);
+        let item_line = ItemLine::classify(
+            self.section_header.kind,
+            line,
+            also_parses_as_section_header,
+        );
         let has_leading_blank_lines = !self.pending_blank_lines.is_empty();
         if self.should_end_before(
             line,
@@ -411,18 +452,18 @@ impl<'a> SectionBuilder<'a> {
 
     fn push_content_line(&mut self, line: ParsedLine<'a>, item_line: ItemLine<'a>) {
         self.range = self.range.cover(line.range);
-        self.body.push_line(line, item_line);
+        self.body.push_line(self.section_header, line, item_line);
     }
 
     fn finish(self) -> Option<Section> {
         let HeaderKind::Structured(kind) = self.section_header.kind else {
             return None;
         };
-        let fragments = self.body.finish();
+
         Some(Section {
             kind,
             range: self.range,
-            fragments,
+            body: self.body.finish(),
         })
     }
 }
@@ -517,30 +558,23 @@ impl<'a> BodyBuilder<'a> {
         }
     }
 
-    fn push_line(&mut self, line: ParsedLine<'a>, item_line: ItemLine<'a>) {
+    fn push_line(&mut self, section_header: Header, line: ParsedLine<'a>, item_line: ItemLine<'a>) {
         match self {
-            Self::ItemList(body) => body.push_line(line, item_line),
+            Self::ItemList(builder) => builder.push_line(section_header, line, item_line),
             Self::Prose(builder) => builder.push_line(line.text),
             Self::Opaque => {}
         }
     }
 
-    fn finish(self) -> Vec<BodyFragment> {
+    fn finish(self) -> SectionBody {
         match self {
-            Self::ItemList(body) => body.finish(),
-            Self::Prose(description) => {
-                let prose = description.finish();
-                (!prose.is_empty())
-                    .then_some(BodyFragment::Prose(prose))
-                    .into_iter()
-                    .collect()
-            }
-            Self::Opaque => Vec::new(),
+            Self::ItemList(builder) => builder.finish(),
+            Self::Prose(builder) => SectionBody::from_prose(builder.finish()),
+            Self::Opaque => SectionBody::opaque(),
         }
     }
 }
 
-#[derive(Default)]
 struct ItemListBuilder<'a> {
     fragments: Vec<BodyFragment>,
     current_item: Option<ItemBuilder<'a>>,
@@ -548,6 +582,23 @@ struct ItemListBuilder<'a> {
     leading_prose: DescriptionBuilder<'a>,
     /// Indentation established by the first renderable item.
     item_indent: Option<TextSize>,
+    /// Whether every line seen so far can be rendered faithfully as Markdown.
+    is_renderable: bool,
+}
+
+impl Default for ItemListBuilder<'_> {
+    /// Creates an empty builder that is renderable by default (meaning that we
+    /// must actually encounter an unrenderable line in order to prevent
+    /// rendering an item list as Markdown).
+    fn default() -> Self {
+        Self {
+            fragments: Vec::new(),
+            current_item: None,
+            leading_prose: DescriptionBuilder::default(),
+            item_indent: None,
+            is_renderable: true,
+        }
+    }
 }
 
 impl<'a> ItemListBuilder<'a> {
@@ -559,7 +610,7 @@ impl<'a> ItemListBuilder<'a> {
         }
     }
 
-    fn push_line(&mut self, line: ParsedLine<'a>, item_line: ItemLine<'a>) {
+    fn push_line(&mut self, section_header: Header, line: ParsedLine<'a>, item_line: ItemLine<'a>) {
         let line_indent = indentation(line.text);
         if self
             .item_indent
@@ -570,12 +621,21 @@ impl<'a> ItemListBuilder<'a> {
             self.finish_current_item();
             self.current_item = Some(ItemBuilder::new(&item_header));
             self.item_indent.get_or_insert(line_indent);
+            self.is_renderable &=
+                !item_line.also_parses_as_section_header && !item_header.type_was_discarded;
             return;
+        }
+
+        if let Some(item_indent) = self.item_indent
+            && !item_line.can_render_as_continuation(section_header.kind, line_indent, item_indent)
+        {
+            self.is_renderable = false;
         }
 
         if let Some(item) = &mut self.current_item {
             item.description.push_continuation(line.text);
         } else {
+            self.is_renderable = false;
             self.leading_prose.push_line(line.text);
         }
     }
@@ -593,10 +653,13 @@ impl<'a> ItemListBuilder<'a> {
         }
     }
 
-    fn finish(mut self) -> Vec<BodyFragment> {
+    fn finish(mut self) -> SectionBody {
         self.finish_leading_prose();
         self.finish_current_item();
-        self.fragments
+        SectionBody {
+            fragments: self.fragments,
+            is_renderable: self.is_renderable,
+        }
     }
 }
 
@@ -692,10 +755,33 @@ struct ItemLine<'a> {
     /// Whether this line establishes item indentation for section-boundary detection.
     boundary_item: bool,
     item_header: Option<ItemHeader<'a>>,
+    /// Whether this line resembles an item but is actually a URL or path continuation.
+    is_item_like_continuation: bool,
+    /// Whether this item could instead introduce a new section.
+    also_parses_as_section_header: bool,
 }
 
 impl<'a> ItemLine<'a> {
-    fn classify(section_kind: HeaderKind, line: ParsedLine<'a>) -> Self {
+    fn can_render_as_continuation(
+        &self,
+        section_kind: HeaderKind,
+        line_indent: TextSize,
+        item_indent: TextSize,
+    ) -> bool {
+        // More deeply indented lines are unambiguously part of the current item.
+        line_indent > item_indent
+            // Although the style guide suggests indenting continuation lines,
+            // aligned parameter prose is common in practice.
+            || (line_indent == item_indent && section_kind.is_parameter_section())
+            // Aligned URLs and paths are continuations despite resembling item headers.
+            || (line_indent == item_indent && self.is_item_like_continuation)
+    }
+
+    fn classify(
+        section_kind: HeaderKind,
+        line: ParsedLine<'a>,
+        also_parses_as_section_header: bool,
+    ) -> Self {
         let HeaderKind::Structured(kind) = section_kind else {
             return Self::default();
         };
@@ -707,26 +793,38 @@ impl<'a> ItemLine<'a> {
         }
 
         let line_text = line.text.trim();
-        let split = split_once_at_field_delimiter(line_text).or_else(|| {
-            if matches!(
-                kind,
-                SectionKind::Parameters
-                    | SectionKind::KeywordArguments
-                    | SectionKind::OtherParameters
-            ) {
-                // If malformed type syntax hides the delimiter, recover the conventional field
-                // shape and discard the type.
-                recover_parameter_without_type(line_text)
-            } else {
-                None
-            }
-        });
-        split
-            .map(|split| Self::from_split(kind, split))
-            .unwrap_or_default()
+        let (split, type_was_discarded) = if let Some(split) =
+            split_once_at_field_delimiter(line_text)
+        {
+            (split, false)
+        } else if matches!(
+            kind,
+            SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters
+        ) {
+            // If malformed type syntax hides the delimiter, recover the conventional field shape
+            // and discard the type. The section remains opaque to the structured renderer.
+            let Some(split) = recover_parameter_without_type(line_text) else {
+                return Self::default();
+            };
+            (split, true)
+        } else {
+            return Self::default();
+        };
+
+        Self::from_split(
+            kind,
+            split,
+            also_parses_as_section_header,
+            type_was_discarded,
+        )
     }
 
-    fn from_split(kind: SectionKind, (raw_name, inline_description): (&'a str, &'a str)) -> Self {
+    fn from_split(
+        kind: SectionKind,
+        (raw_name, inline_description): (&'a str, &'a str),
+        also_parses_as_section_header: bool,
+        type_was_discarded: bool,
+    ) -> Self {
         let name = raw_name.trim();
         if name.is_empty() {
             return Self::default();
@@ -764,13 +862,31 @@ impl<'a> ItemLine<'a> {
             SectionKind::Returns | SectionKind::Yields => return Self::default(),
         };
 
+        // URLs (`https://...`), Windows paths (`C:\\...`), and reST literal-block introductions
+        // (`Example::`) are description continuations rather than item headers.
+        //
+        // This was configured from a survey of such continuations in popular public projects that
+        // use Google-style docstrings; it may need to be reconfigured in the future.
+        if matches!(
+            inline_description.as_bytes().first(),
+            Some(b'/' | b'\\' | b':')
+        ) {
+            return Self {
+                is_item_like_continuation: true,
+                ..Self::default()
+            };
+        }
+
         Self {
             boundary_item: true,
             item_header: Some(ItemHeader {
                 display_name,
                 ty,
                 inline_description,
+                type_was_discarded,
             }),
+            is_item_like_continuation: false,
+            also_parses_as_section_header,
         }
     }
 }
@@ -779,6 +895,8 @@ struct ItemHeader<'a> {
     display_name: &'a str,
     ty: Option<&'a str>,
     inline_description: &'a str,
+    /// Whether malformed type syntax was discarded when parsing this header.
+    type_was_discarded: bool,
 }
 
 /// Splits at the field delimiter, skipping top-level colons in reST roles.
@@ -1530,7 +1648,7 @@ Returns:
 Methods:
     helper: Method documentation.";
         let sections = sections(raw)
-            .map(|section| (section.kind, section.fragments, &raw[section.range]))
+            .map(|section| (section.kind, section.body.fragments, &raw[section.range]))
             .collect::<Vec<_>>();
 
         assert_eq!(

--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -8,8 +8,9 @@
 //! - `Keyword Args` and `Keyword Arguments`
 //! - `Other Args`, `Other Arguments`, and `Other Parameters`
 //!
-//! It accepts comma-separated Python names with optional parenthesized types, preserves
-//! continuation text, and skips section-like text inside preformatted or container blocks.
+//! It accepts comma-separated Python names with optional parenthesized types, recovers common
+//! conjunction-separated names, preserves continuation text, and skips section-like text inside
+//! preformatted or container blocks.
 //! Supported section bodies are parsed into prose and named-item fragments; other known headings
 //! only delimit sections.
 //!
@@ -38,7 +39,7 @@ use super::SectionKind;
 use super::preformatted::PreformattedBlockScanner;
 use super::syntax::{
     ParsedLine, consume_quoted_string, container_block_end, indentation, parsed_lines,
-    split_once_at_top_level_colon, split_trailing_parenthetical,
+    split_once_at_top_level_colon, split_trailing_parenthetical, starts_with_markdown_list_item,
 };
 
 /// Returns parameter documentation from recognized Google-style parameter sections.
@@ -50,14 +51,14 @@ pub(super) fn parameter_documentation(normalized_source: &str) -> IndexMap<Strin
     for section in sections(normalized_source) {
         let Section {
             kind,
-            body: SectionBody { fragments, .. },
+            body,
             range: _,
         } = section;
         if matches!(
             kind,
             SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters
         ) {
-            parameters.extend_fragments(fragments);
+            parameters.extend_fragments(body.into_fragments());
         }
     }
     parameters.into_inner()
@@ -79,32 +80,59 @@ pub(in crate::docstring) struct Section {
     body: SectionBody,
 }
 
+impl Section {
+    /// Returns the section kind.
+    pub(in crate::docstring) const fn kind(&self) -> SectionKind {
+        self.kind
+    }
+
+    /// Returns the section's source range.
+    pub(in crate::docstring) const fn range(&self) -> TextRange {
+        self.range
+    }
+
+    /// Consumes this section and returns its fragments when it can be rendered structurally.
+    pub(in crate::docstring) fn into_renderable_fragments(self) -> Option<Vec<BodyFragment>> {
+        let SectionBody::Parsed {
+            fragments,
+            has_structural_ambiguity,
+        } = self.body
+        else {
+            return None;
+        };
+        (!has_structural_ambiguity).then_some(fragments)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct SectionBody {
-    fragments: Vec<BodyFragment>,
-    /// Whether the structured Markdown renderer can represent the body without changing its
-    /// meaning.
-    is_renderable: bool,
+enum SectionBody {
+    /// A body parsed into semantic fragments.
+    Parsed {
+        fragments: Vec<BodyFragment>,
+        /// Whether the body's structure is ambiguous.
+        has_structural_ambiguity: bool,
+    },
+    /// A body whose contents were not parsed.
+    Opaque,
 }
 
 impl SectionBody {
-    /// Creates a renderable body containing the description as a single prose fragment.
+    /// Creates an unambiguous body containing the description as a single prose fragment.
     fn from_prose(description: String) -> Self {
         let fragments = (!description.is_empty())
             .then_some(BodyFragment::Prose(description))
             .into_iter()
             .collect();
-        Self {
+        Self::Parsed {
             fragments,
-            is_renderable: true,
+            has_structural_ambiguity: false,
         }
     }
 
-    /// Creates an unrenderable body for a section whose contents remain opaque.
-    fn opaque() -> Self {
-        Self {
-            fragments: Vec::new(),
-            is_renderable: false,
+    fn into_fragments(self) -> Vec<BodyFragment> {
+        match self {
+            Self::Parsed { fragments, .. } => fragments,
+            Self::Opaque => Vec::new(),
         }
     }
 }
@@ -124,6 +152,15 @@ pub(in crate::docstring) struct Item {
     display_name: String,
     ty: Option<String>,
     description: String,
+}
+
+impl Item {
+    /// Consumes this item and returns its display parts.
+    pub(in crate::docstring) fn into_display_name_type_and_description(
+        self,
+    ) -> (String, Option<String>, String) {
+        (self.display_name, self.ty, self.description)
+    }
 }
 
 /// Splits a display name from a trailing parenthesized type.
@@ -177,6 +214,55 @@ fn is_parameter_name(name: &str) -> bool {
     is_identifier(identifier)
 }
 
+/// A parameter name that has been parsed into comma- and conjunction- separated parts.
+#[derive(Clone, Copy)]
+struct ParameterDisplayName<'a> {
+    comma_separated_names: &'a str,
+    final_name: Option<&'a str>,
+}
+
+impl<'a> ParameterDisplayName<'a> {
+    /// Parses comma-separated parameter names, optionally joined by a final conjunction.
+    ///
+    /// For example, `"stdin, stdout and stderr"` yields the three individual names.
+    fn parse(display_name: &'a str) -> Option<Self> {
+        let comma_separated = Self {
+            comma_separated_names: display_name,
+            final_name: None,
+        };
+        if comma_separated.names().all(is_parameter_name) {
+            return Some(comma_separated);
+        }
+
+        for conjunction in [" and ", " or "] {
+            let Some((comma_separated_names, final_name)) = display_name.rsplit_once(conjunction)
+            else {
+                continue;
+            };
+            let conjunction_separated = Self {
+                comma_separated_names,
+                final_name: Some(final_name),
+            };
+            if conjunction_separated.names().all(is_parameter_name) {
+                return Some(conjunction_separated);
+            }
+        }
+
+        None
+    }
+
+    fn names(self) -> impl Iterator<Item = &'a str> {
+        self.comma_separated_names
+            .split(',')
+            .chain(self.final_name)
+            .map(str::trim)
+    }
+
+    const fn is_conjunction_separated(self) -> bool {
+        self.final_name.is_some()
+    }
+}
+
 #[derive(Default)]
 struct Parameters(IndexMap<String, String>);
 
@@ -194,7 +280,10 @@ impl Parameters {
             if description.is_empty() {
                 continue;
             }
-            for name in display_name.split(',').map(str::trim) {
+            let Some(display_name) = ParameterDisplayName::parse(&display_name) else {
+                continue;
+            };
+            for name in display_name.names() {
                 self.0.insert(name.to_string(), description.clone());
             }
         }
@@ -357,13 +446,8 @@ impl<'a> SectionBuilder<'a> {
 
         // Third, classify a nonblank line and stop if it begins content outside
         // this section.
-        let also_parses_as_section_header = line_header.is_some()
-            && line
-                .text
-                .trim()
-                .chars()
-                .next()
-                .is_some_and(char::is_uppercase);
+        let also_parses_as_section_header =
+            line_header.is_some() && line.text.trim().starts_with(char::is_uppercase);
         let item_line = ItemLine::classify(
             self.section_header.kind,
             line,
@@ -570,11 +654,12 @@ impl<'a> BodyBuilder<'a> {
         match self {
             Self::ItemList(builder) => builder.finish(),
             Self::Prose(builder) => SectionBody::from_prose(builder.finish()),
-            Self::Opaque => SectionBody::opaque(),
+            Self::Opaque => SectionBody::Opaque,
         }
     }
 }
 
+#[derive(Default)]
 struct ItemListBuilder<'a> {
     fragments: Vec<BodyFragment>,
     current_item: Option<ItemBuilder<'a>>,
@@ -582,23 +667,8 @@ struct ItemListBuilder<'a> {
     leading_prose: DescriptionBuilder<'a>,
     /// Indentation established by the first renderable item.
     item_indent: Option<TextSize>,
-    /// Whether every line seen so far can be rendered faithfully as Markdown.
-    is_renderable: bool,
-}
-
-impl Default for ItemListBuilder<'_> {
-    /// Creates an empty builder that is renderable by default (meaning that we
-    /// must actually encounter an unrenderable line in order to prevent
-    /// rendering an item list as Markdown).
-    fn default() -> Self {
-        Self {
-            fragments: Vec::new(),
-            current_item: None,
-            leading_prose: DescriptionBuilder::default(),
-            item_indent: None,
-            is_renderable: true,
-        }
-    }
+    /// Whether the body's structure is ambiguous.
+    has_structural_ambiguity: bool,
 }
 
 impl<'a> ItemListBuilder<'a> {
@@ -621,21 +691,21 @@ impl<'a> ItemListBuilder<'a> {
             self.finish_current_item();
             self.current_item = Some(ItemBuilder::new(&item_header));
             self.item_indent.get_or_insert(line_indent);
-            self.is_renderable &=
-                !item_line.also_parses_as_section_header && !item_header.type_was_discarded;
+            self.has_structural_ambiguity |=
+                item_line.also_parses_as_section_header || item_header.has_structural_ambiguity;
             return;
         }
 
         if let Some(item_indent) = self.item_indent
             && !item_line.can_render_as_continuation(section_header.kind, line_indent, item_indent)
         {
-            self.is_renderable = false;
+            self.has_structural_ambiguity = true;
         }
 
         if let Some(item) = &mut self.current_item {
             item.description.push_continuation(line.text);
         } else {
-            self.is_renderable = false;
+            self.has_structural_ambiguity = true;
             self.leading_prose.push_line(line.text);
         }
     }
@@ -656,9 +726,9 @@ impl<'a> ItemListBuilder<'a> {
     fn finish(mut self) -> SectionBody {
         self.finish_leading_prose();
         self.finish_current_item();
-        SectionBody {
+        SectionBody::Parsed {
             fragments: self.fragments,
-            is_renderable: self.is_renderable,
+            has_structural_ambiguity: self.has_structural_ambiguity,
         }
     }
 }
@@ -703,7 +773,12 @@ impl<'a> DescriptionBuilder<'a> {
     }
 
     fn push_line(&mut self, line: &'a str) {
-        if self.inline.is_none() && self.continuation_lines.is_empty() {
+        // Keep a leading list item with the block so that its indentation establishes the baseline
+        // for nested items. Ordinary first lines use the allocation-free inline representation.
+        if self.inline.is_none()
+            && self.continuation_lines.is_empty()
+            && !starts_with_markdown_list_item(line.trim_start())
+        {
             self.inline = Some(line.trim());
         } else {
             self.push_continuation(line);
@@ -830,15 +905,19 @@ impl<'a> ItemLine<'a> {
             return Self::default();
         }
 
-        let (display_name, ty) = match kind {
+        let (display_name, ty, display_name_has_structural_ambiguity) = match kind {
             SectionKind::Parameters
             | SectionKind::KeywordArguments
             | SectionKind::OtherParameters => {
                 let (display_name, ty) = split_name_and_type(name);
-                if !is_parameter_display_name(display_name) {
+                let Some(parsed_display_name) = ParameterDisplayName::parse(display_name) else {
                     return Self::default();
-                }
-                (display_name, ty)
+                };
+                (
+                    display_name,
+                    ty,
+                    parsed_display_name.is_conjunction_separated(),
+                )
             }
             SectionKind::Attributes => {
                 let (display_name, ty) = split_name_and_type(name);
@@ -848,7 +927,7 @@ impl<'a> ItemLine<'a> {
                         ..Self::default()
                     };
                 }
-                (display_name, ty)
+                (display_name, ty, false)
             }
             SectionKind::Raises => {
                 if !is_dotted_identifier(name) {
@@ -857,7 +936,7 @@ impl<'a> ItemLine<'a> {
                         ..Self::default()
                     };
                 }
-                (name, None)
+                (name, None, false)
             }
             SectionKind::Returns | SectionKind::Yields => return Self::default(),
         };
@@ -883,7 +962,8 @@ impl<'a> ItemLine<'a> {
                 display_name,
                 ty,
                 inline_description,
-                type_was_discarded,
+                has_structural_ambiguity: type_was_discarded
+                    || display_name_has_structural_ambiguity,
             }),
             is_item_like_continuation: false,
             also_parses_as_section_header,
@@ -895,8 +975,8 @@ struct ItemHeader<'a> {
     display_name: &'a str,
     ty: Option<&'a str>,
     inline_description: &'a str,
-    /// Whether malformed type syntax was discarded when parsing this header.
-    type_was_discarded: bool,
+    /// Whether this header's noncanonical syntax makes its structure ambiguous.
+    has_structural_ambiguity: bool,
 }
 
 /// Splits at the field delimiter, skipping top-level colons in reST roles.
@@ -963,12 +1043,6 @@ fn consume_rest_prefix_role(cursor: &mut Cursor<'_>) -> bool {
 
     *cursor = role;
     true
-}
-
-fn is_parameter_display_name(display_name: &str) -> bool {
-    display_name
-        .split(',')
-        .all(|name| is_parameter_name(name.trim()))
 }
 
 fn is_attribute_display_name(display_name: &str) -> bool {
@@ -1067,6 +1141,27 @@ Args:
           │ Coordinates.
         y:
           │ Coordinates.
+        ");
+    }
+
+    #[test]
+    fn extracts_conjunction_separated_parameter_names() {
+        let raw = "\
+Args:
+    stdin, stdout and stderr: Standard streams.
+    encoding or errors: Text settings.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        stdin:
+          │ Standard streams.
+        stdout:
+          │ Standard streams.
+        stderr:
+          │ Standard streams.
+        encoding:
+          │ Text settings.
+        errors:
+          │ Text settings.
         ");
     }
 
@@ -1648,7 +1743,13 @@ Returns:
 Methods:
     helper: Method documentation.";
         let sections = sections(raw)
-            .map(|section| (section.kind, section.body.fragments, &raw[section.range]))
+            .map(|section| {
+                (
+                    section.kind,
+                    section.body.into_fragments(),
+                    &raw[section.range],
+                )
+            })
             .collect::<Vec<_>>();
 
         assert_eq!(

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -8,6 +8,7 @@ use crate::docstring::document::SectionKind;
 use crate::docstring::document::preformatted::MarkdownFence;
 use crate::docstring::document::syntax::{is_markdown_code_span, starts_with_markdown_list_item};
 
+mod google;
 mod rst;
 
 /// Renders a docstring as Markdown.
@@ -15,7 +16,9 @@ mod rst;
 /// `source` must have already undergone PEP-257 trimming and universal newline
 /// normalization (typically via `docstring::documentation_trim`).
 pub(super) fn render_into(output: &mut String, source: &str) {
-    render_sections_into(output, source, rst::structured_sections(source));
+    let mut sections = rst::structured_sections(source);
+    sections.extend(google::structured_sections(source));
+    render_sections_into(output, source, sections);
 }
 
 /// Renders a docstring from non-overlapping structured sections and general source fragments.
@@ -116,6 +119,21 @@ fn ensure_blank_line(output: &mut String) {
     output.push('\n');
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParameterHeading {
+    Parameters,
+    Arguments,
+}
+
+impl ParameterHeading {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Parameters => "Parameters",
+            Self::Arguments => "Arguments",
+        }
+    }
+}
+
 /// A parsed section ready for Markdown rendering.
 ///
 /// Parser modules create one of these for each supported source section or
@@ -127,16 +145,29 @@ struct Section {
     range: TextRange,
     /// The list of semantically-meaningful items to render to Markdown.
     items: Vec<SectionItem>,
+    parameter_heading: ParameterHeading,
 }
 
 impl Section {
     /// Creates a structured replacement from the items parsed out of one source section.
     fn new(range: TextRange, items: Vec<SectionItem>) -> Option<Self> {
+        Self::new_with_parameter_heading(range, items, ParameterHeading::Parameters)
+    }
+
+    fn new_with_parameter_heading(
+        range: TextRange,
+        items: Vec<SectionItem>,
+        parameter_heading: ParameterHeading,
+    ) -> Option<Self> {
         if range.is_empty() || items.iter().any(SectionItem::is_empty) {
             return None;
         }
 
-        Some(Self { range, items })
+        Some(Self {
+            range,
+            items,
+            parameter_heading,
+        })
     }
 
     fn is_empty(&self) -> bool {
@@ -147,9 +178,13 @@ impl Section {
     fn render_markdown(&self, output: &mut String) {
         let mut rendered_section = false;
         for kind in SectionKind::iter() {
+            let heading = match kind {
+                SectionKind::Parameters => self.parameter_heading.as_str(),
+                _ => kind.heading(),
+            };
             if render_markdown_section(
                 output,
-                kind.heading(),
+                heading,
                 self.items.iter().filter(move |item| item.kind == kind),
                 rendered_section,
             ) {
@@ -187,6 +222,20 @@ impl SectionItem {
             display_name: display_name.map(str::to_string),
             ty: ty.filter(|ty| !ty.is_empty()).map(str::to_string),
             description_source: description_source.into(),
+        }
+    }
+
+    fn from_owned_parts(
+        kind: SectionKind,
+        display_name: Option<String>,
+        ty: Option<String>,
+        description_source: String,
+    ) -> Self {
+        Self {
+            kind,
+            display_name,
+            ty: ty.filter(|ty| !ty.is_empty()),
+            description_source,
         }
     }
 

--- a/crates/ty_ide/src/docstring/markdown/structured/google.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/google.rs
@@ -1,0 +1,344 @@
+use crate::docstring::document::google;
+
+use super::{ParameterHeading, Section, SectionItem, SectionKind};
+
+/// Returns Google-style sections that can be rendered structurally.
+pub(super) fn structured_sections(normalized_source: &str) -> Vec<Section> {
+    google::sections(normalized_source)
+        .filter_map(section)
+        .collect()
+}
+
+fn section(parsed: google::Section) -> Option<Section> {
+    let kind = parsed.kind();
+    let range = parsed.range();
+    let fragments = parsed.into_renderable_fragments()?;
+    if fragments.is_empty() {
+        return None;
+    }
+    let items = fragments
+        .into_iter()
+        .map(|fragment| section_item(kind, fragment))
+        .collect();
+    Section::new_with_parameter_heading(range, items, ParameterHeading::Arguments)
+}
+
+fn section_item(kind: SectionKind, fragment: google::BodyFragment) -> SectionItem {
+    match fragment {
+        google::BodyFragment::Prose(description) => {
+            SectionItem::from_owned_parts(kind, None, None, description)
+        }
+        google::BodyFragment::Item(item) => {
+            let (display_name, ty, description) = item.into_display_name_type_and_description();
+            SectionItem::from_owned_parts(kind, Some(display_name), ty, description)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::{Settings, assert_snapshot};
+
+    use super::super::render_sections_into;
+    use super::structured_sections;
+
+    #[test]
+    fn renders_supported_sections() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Summary.
+
+Keyword Args:
+    optional (`int`): Optional value.
+
+Other Parameters:
+    timeout (float): Maximum wait.
+
+Attributes:
+    name (str): Display name.
+
+Yields:
+    The next `int` value.
+
+Raises:
+    ValueError: If invalid.
+";
+
+        assert_snapshot!(render_google(docstring), @"
+        Summary.
+
+        ## Keyword Arguments
+        **optional**: `int`<HB>
+        Optional value.
+
+        ## Other Parameters
+        **timeout**: `float`<HB>
+        Maximum wait.
+
+        ## Attributes
+        **name**: `str`<HB>
+        Display name.
+
+        ## Yields
+        The next `int` value.
+
+        ## Raises
+        `ValueError`<HB>
+        If invalid.
+        ");
+    }
+
+    #[test]
+    fn renders_aligned_parameter_continuation() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Args:
+    value: The value.
+    For example: pass an absolute path.
+";
+
+        assert_snapshot!(render_google(docstring), @"
+        ## Arguments
+        **value**<HB>
+        The value.<HB>
+        For example: pass an absolute path.
+        ");
+    }
+
+    #[test]
+    fn renders_parameter_url_continuation() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Args:
+    endpoint: Service endpoint, for example:
+    https://example.com/api
+";
+
+        assert_snapshot!(render_google(docstring), @"
+        ## Arguments
+        **endpoint**<HB>
+        Service endpoint, for example:<HB>
+        https://example.com/api
+        ");
+    }
+
+    #[test]
+    fn renders_parameter_windows_path_continuation() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Args:
+    output: Output path, for example:
+    C:\\temp\\result.txt
+";
+
+        assert_snapshot!(render_google(docstring), @r"
+        ## Arguments
+        **output**<HB>
+        Output path, for example:<HB>
+        C:\temp\result.txt
+        ");
+    }
+
+    #[test]
+    fn renders_preformatted_parameter_descriptions() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Args:
+    value: Description.
+        ```python
+        Args:
+            nested: Still code.
+        Returns:
+            Still code.
+        ```
+    url (Literal[\"http://\"]): URL.
+";
+
+        assert_snapshot!(render_google(docstring), @r#"
+        ## Arguments
+        **value**<HB>
+        Description.
+
+        ```python
+        Args:
+            nested: Still code.
+        Returns:
+            Still code.
+        ```
+
+        **url**: `Literal["http://"]`<HB>
+        URL.
+        "#);
+    }
+
+    #[test]
+    fn renders_return_body_as_prose() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Returns:
+    int: The **count**.
+    str: The `name`.
+";
+
+        assert_snapshot!(render_google(docstring), @"
+        ## Returns
+        int: The **count**.<HB>
+        str: The `name`.
+        ");
+    }
+
+    #[test]
+    fn renders_nested_list_in_return_prose() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Returns:
+    - first
+      - nested
+";
+
+        assert_snapshot!(render_google(docstring), @"
+        ## Returns
+        - first<HB>
+          - nested
+        ");
+    }
+
+    #[test]
+    fn renders_fenced_block_in_return_prose() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Returns:
+    str: Example output.
+        ```python
+        Args:
+            still code.
+        ```
+";
+
+        assert_snapshot!(render_google(docstring), @"
+        ## Returns
+        str: Example output.
+
+        ```python
+        Args:
+            still code.
+        ```
+        ");
+    }
+
+    #[test]
+    fn renders_nested_heading_in_return_prose() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Returns:
+    The result.
+
+    Examples:
+    This heading is part of the description.
+";
+
+        assert_snapshot!(render_google(docstring), @"
+        ## Returns
+        The result.
+
+        Examples:<HB>
+        This heading is part of the description.
+        ");
+    }
+
+    #[test]
+    fn declines_to_render_inline_section_heading_in_parameter_body() {
+        let docstring = "\
+Summary.
+
+Args:
+    value: The value.
+    Examples: Try it.
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    #[test]
+    fn declines_to_render_unclosed_parameter_fence() {
+        let docstring = "\
+Summary.
+
+Args:
+    value: Example.
+        ```python
+
+Args:
+    nested = 1
+        ```
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    #[test]
+    fn declines_to_render_parameter_section_with_unrecognized_leading_content() {
+        let docstring = "\
+Args:
+    (data, indices) : data and indices in batched COO format.
+    shape : shape of sparse array.
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    #[test]
+    fn declines_to_render_conjunction_separated_parameter_names() {
+        let docstring = "\
+Arguments:
+    args: Program arguments.
+
+    stdin, stdout and stderr: Standard stream handles.
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    #[test]
+    fn declines_to_render_parameter_section_with_unbalanced_type_brackets() {
+        let docstring = "\
+Args:
+    query_embeddings (`Union[torch.Tensor, list[torch.Tensor]`): Query embeddings.
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    #[test]
+    fn declines_to_render_empty_return_section() {
+        let docstring = "\
+Summary.
+
+Returns:
+
+After.
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    fn render_google(normalized_source: &str) -> String {
+        let mut output = String::new();
+        render_sections_into(
+            &mut output,
+            normalized_source,
+            parsed_sections(normalized_source),
+        );
+        output
+    }
+
+    fn parsed_sections(normalized_source: &str) -> Vec<super::Section> {
+        structured_sections(normalized_source)
+    }
+
+    fn bind_markdown_snapshot_filters() -> impl Drop {
+        let mut settings = Settings::clone_current();
+        settings.add_filter("  \n", "<HB>\n");
+        settings.bind_to_scope()
+    }
+}

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -494,11 +494,14 @@ mod tests {
         ) -> Unknown
         ```
         ---
-        This is such a great func!!<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
+        This is such a great func!!
+
+        ## Arguments
+        **a**<HB>
+        first for a reason
+
+        **b**<HB>
+        coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
           --> main.py:11:1
@@ -547,11 +550,14 @@ mod tests {
         ) -> Unknown
         ```
         ---
-        This is such a great func!!<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
+        This is such a great func!!
+
+        ## Arguments
+        **a**<HB>
+        first for a reason
+
+        **b**<HB>
+        coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
          --> main.py:2:5
@@ -1577,11 +1583,14 @@ mod tests {
         ) -> Unknown
         ```
         ---
-        This is such a great func!!<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
+        This is such a great func!!
+
+        ## Arguments
+        **a**<HB>
+        first for a reason
+
+        **b**<HB>
+        coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
           --> main.py:25:3


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This introduces Markdown rendering for Google-style sections in docstrings. Supported sections are rendered with canonical Markdown headings, bold item names, inline code spans for types and raised exceptions, and descriptions passed through the existing general Markdown renderer. Here's what it looks like in VSCode:

| Before | After |
| :--- | :--- |
| <img width="990" height="296" alt="before-1" src="https://github.com/user-attachments/assets/0f6beaf5-c86c-411e-ad0b-a8ff4d060563" /> <img width="988" height="272" alt="before-2" src="https://github.com/user-attachments/assets/2371d097-dd34-47c4-acac-8135b8caf01e" /> <img width="992" height="262" alt="before-3" src="https://github.com/user-attachments/assets/69867ee1-2689-42c7-8b76-eac26097231a" /> | <img width="852" height="410" alt="after-1" src="https://github.com/user-attachments/assets/6859cbe3-5e41-41f8-9201-d99f84d50774" /> <img width="850" height="430" alt="after-2" src="https://github.com/user-attachments/assets/290be4c4-0e6a-431a-a997-3328150f85a6" /> <img width="850" height="386" alt="after-3" src="https://github.com/user-attachments/assets/4d4fb1bd-7d75-4825-9bc7-e5507cd5afa3" /> |

The implementation includes the following judgement calls that I think are acceptable, but that we may want to revisit based on user feedback:

- We only render Markdown headings for a fixed subset of Google sections that map cleanly to a shared document model: parameters, attributes, returns, yields, and raises. That list can be expanded in the future.
- Return and yield bodies are rendered as prose rather than split into type and description. Google-style docstrings do not require a single unambiguous shape for these sections, so preserving their content avoids guessing.
- We carry forward a few of the rendering policies that were [established for the reStructuredText format](https://github.com/astral-sh/ruff/pull/25903):
  - Malformed, unsupported, or ambiguous content still causes us to leave an entire section raw (i.e. source content, not structured Markdown). Other well-formed sections in the same docstring are rendered as usual.
  - Types are rendered with inline code spans, and so do not receive syntax highlighting.
  - Physical line breaks in descriptions are preserved as Markdown hard breaks rather than being reflowed.

I recommend reviewing this diff commit-by-commit.

/xref https://github.com/astral-sh/ty/issues/1667

## Test Plan

See included tests.
<!-- How was it tested? -->
