### PR TITLE
Fix relative submodule imports in init modules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35/__init__.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35/__init__.py
@@ -1,0 +1,5 @@
+from .foo import Bar
+from .pkg.bar import Baz
+
+print(foo.Bar, Bar)
+print(pkg.bar.Baz, Baz)

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35/foo.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35/foo.py
@@ -1,0 +1,2 @@
+class Bar:
+    pass

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35/pkg/__init__.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35/pkg/__init__.py
@@ -1,0 +1,1 @@
+# Intentionally empty.

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35/pkg/bar.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35/pkg/bar.py
@@ -1,0 +1,2 @@
+class Baz:
+    pass

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1127,7 +1127,8 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     self.importer.visit_import(stmt);
                 }
 
-                let module = module.as_deref();
+                let module_identifier = module.as_ref();
+                let module = module_identifier.map(ruff_python_ast::Identifier::as_str);
                 let level = *level;
                 let is_lazy = *is_lazy;
 
@@ -1135,6 +1136,40 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 if level == 0 {
                     if let Some(module) = module.and_then(|module| module.split('.').next()) {
                         self.semantic.add_module(module);
+                    }
+                }
+
+                if self.in_init_module() && level == 1 {
+                    if let Some(module_identifier) = module_identifier {
+                        let submodule = module_identifier.as_str().split('.').next().unwrap();
+                        let qualified_name = collect_import_from_member(level, None, submodule);
+                        let already_bound =
+                            self.semantic.current_scope().get(submodule).is_some_and(
+                                |binding_id| {
+                                    matches!(
+                                        &self.semantic.binding(binding_id).kind,
+                                        BindingKind::FromImport(FromImport {
+                                            qualified_name: existing,
+                                        }) if existing.as_ref() == &qualified_name
+                                    )
+                                },
+                            );
+
+                        if !already_bound {
+                            let binding_id = self.add_binding(
+                                submodule,
+                                TextRange::at(
+                                    module_identifier.start(),
+                                    TextSize::try_from(submodule.len()).unwrap(),
+                                ),
+                                BindingKind::FromImport(FromImport {
+                                    qualified_name: Box::new(qualified_name),
+                                }),
+                                BindingFlags::EXTERNAL,
+                            );
+                            // This binding is implicit, so don't report it as an unused import.
+                            self.semantic.bindings[binding_id].source = None;
+                        }
                     }
                 }
 

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -173,6 +173,7 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_33.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_34.pyi"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_34.py"))]
+    #[test_case(Rule::UndefinedName, Path::new("F821_35/__init__.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.pyi"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"))]

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_35____init__.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_35____init__.py.snap
@@ -1,0 +1,3 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---


### PR DESCRIPTION
## Summary

Fixes #23233.

This updates Pyflakes import handling so `from .foo import Bar` inside `__init__.py` also makes the implicit package-local `foo` name available for `foo.Bar`, matching Python runtime behavior.

The implicit binding is source-less, so it fixes the `F821` false positive without introducing `F401` or `F811` diagnostics.

## Test Plan

```sh
cargo +1.96.0 fmt --check
cargo +1.96.0 test -p ruff_linter --lib rules::pyflakes::tests::rules::rule_undefinedname_path_new_f821_35_init_py_expects -- --exact
./target/debug/ruff check crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35/__init__.py --select F401,F811,F821 --no-cache --isolated --output-format json --exit-zero