### PR TITLE
[ty] Fix reflected binary dispatch for runtime classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/instances.md
@@ -250,6 +250,51 @@ def add_permission(permission: P) -> P:
     return 0 | permission
 ```
 
+## Runtime-class precedence ignores generic specializations
+
+Generic specializations do not exist at runtime, so they cannot affect whether the right operand's
+runtime class is a strict subclass of the left operand's runtime class:
+
+```py
+from typing import Generic, Literal, TypeVar
+
+T = TypeVar("T")
+
+class GenericBase(Generic[T]):
+    def __add__(self, other: object) -> Literal["left"]:
+        return "left"
+
+class GenericChild(GenericBase[T]):
+    def __radd__(self, other: object) -> Literal["right"]:
+        return "right"
+
+def add_generic(left: GenericBase[int], right: GenericChild[str]) -> Literal["left", "right"]:
+    reveal_type(left + right)  # revealed: Literal["right", "left"]
+    return left + right
+```
+
+## Class objects use their metaclasses for reflected precedence
+
+The runtime classes of class objects are their metaclasses. If the right operand's metaclass is a
+strict subclass of the left operand's metaclass, its reflected method takes precedence:
+
+```py
+from typing import Literal
+
+class LeftMeta(type):
+    def __add__(cls, other: object) -> Literal["left"]:
+        return "left"
+
+class RightMeta(LeftMeta):
+    def __radd__(cls, other: object) -> Literal["right"]:
+        return "right"
+
+class A(metaclass=LeftMeta): ...
+class B(metaclass=RightMeta): ...
+
+reveal_type(A + B)  # revealed: Literal["right"]
+```
+
 ## TypeVars and NewTypes do not have an exact runtime class
 
 The upper bound of a TypeVar is not necessarily its runtime class, so it cannot decide definitively

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -1,5 +1,5 @@
 use super::context::InferContext;
-use super::{Signature, Type, TypeContext, UnionType};
+use super::{ClassType, Signature, Type, TypeContext, UnionType};
 use crate::Db;
 use crate::place::Provenance;
 use crate::types::call::bind::BindingError;
@@ -29,10 +29,22 @@ enum ReflectedMethodPriority {
 /// while a false positive could discard a valid normal-method result.
 fn has_exact_runtime_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     match ty {
-        Type::LiteralValue(_) => true,
+        Type::ClassLiteral(_) | Type::LiteralValue(_) => true,
         Type::NominalInstance(instance) => instance.class(db).is_final(db),
         Type::TypeAlias(alias) => has_exact_runtime_class(db, alias.value_type(db)),
         _ => false,
+    }
+}
+
+/// Returns the nominal runtime class used to dispatch binary operators.
+///
+/// Instances dispatch through their nominal class, while class objects dispatch through their
+/// metaclass.
+fn nominal_runtime_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassType<'db>> {
+    match ty {
+        Type::ClassLiteral(class) => class.metaclass(db).to_class_type(db),
+        Type::TypeAlias(alias) => nominal_runtime_class(db, alias.value_type(db)),
+        _ => ty.nominal_class(db),
     }
 }
 
@@ -59,10 +71,11 @@ fn reflected_method_priority<'db>(
         return ReflectedMethodPriority::Never;
     }
 
-    if let (Some(left_class), Some(right_class)) =
-        (left_ty.nominal_class(db), right_ty.nominal_class(db))
-        && left_class.class_literal(db) != right_class.class_literal(db)
-        && right_class.is_subclass_of(db, left_class)
+    if let (Some(left_class), Some(right_class)) = (
+        nominal_runtime_class(db, left_ty),
+        nominal_runtime_class(db, right_ty),
+    ) && left_class.class_literal(db) != right_class.class_literal(db)
+        && right_class.is_subtype_of_class_literal(db, left_class.class_literal(db))
     {
         if has_exact_runtime_class(db, left_ty) {
             ReflectedMethodPriority::Definitely

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -43,7 +43,6 @@ fn has_exact_runtime_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
 fn nominal_runtime_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassType<'db>> {
     match ty {
         Type::ClassLiteral(class) => class.metaclass(db).to_class_type(db),
-        Type::TypeAlias(alias) => nominal_runtime_class(db, alias.value_type(db)),
         _ => ty.nominal_class(db),
     }
 }

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -40,7 +40,7 @@ fn has_exact_runtime_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
 ///
 /// Instances dispatch through their nominal class, while class objects dispatch through their
 /// metaclass.
-fn nominal_runtime_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassType<'db>> {
+fn operator_dispatch_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassType<'db>> {
     match ty {
         Type::ClassLiteral(class) => class.metaclass(db).to_class_type(db),
         _ => ty.nominal_class(db),
@@ -71,8 +71,8 @@ fn reflected_method_priority<'db>(
     }
 
     if let (Some(left_class), Some(right_class)) = (
-        nominal_runtime_class(db, left_ty),
-        nominal_runtime_class(db, right_ty),
+        operator_dispatch_class(db, left_ty),
+        operator_dispatch_class(db, right_ty),
     ) && left_class.class_literal(db) != right_class.class_literal(db)
         && right_class.is_subtype_of_class_literal(db, left_class.class_literal(db))
     {


### PR DESCRIPTION
## Summary

Fix a couple reflected-binary-operator-dispatch issues:
- class objects dispatch via their metaclasses.
- erase generic specializations; they are erased at runtime so they do not affect reflected dispatch order.

## Testing

Added mdtests.