### PR TITLE
[ty] Pydantic: Make `BaseSettings` fields optional by default

### DIFF
--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -345,6 +345,8 @@ pub enum KnownModule {
     PydanticMain,
     #[strum(serialize = "pydantic.root_model")]
     PydanticRootModel,
+    #[strum(serialize = "pydantic_settings.main")]
+    PydanticSettingsMain,
     #[strum(serialize = "pydantic.types")]
     PydanticTypes,
 }
@@ -387,6 +389,7 @@ impl KnownModule {
             Self::PydanticConfig => "pydantic.config",
             Self::PydanticMain => "pydantic.main",
             Self::PydanticRootModel => "pydantic.root_model",
+            Self::PydanticSettingsMain => "pydantic_settings.main",
             Self::PydanticTypes => "pydantic.types",
         }
     }
@@ -414,6 +417,7 @@ impl KnownModule {
             Self::PydanticConfig
             | Self::PydanticMain
             | Self::PydanticRootModel
+            | Self::PydanticSettingsMain
             | Self::PydanticTypes => true,
             Self::Builtins
             | Self::Enum

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -897,9 +897,11 @@ class Settings(BaseSettings):
     port: int
 
 # Would succeed at runtime if HOST and PORT environment variables are set
-# TODO: no error here
-# error: [missing-argument]
 Settings()
+Settings(host="localhost")
+Settings(port=8000)
+Settings(host="localhost", port=8000)
+Settings(host=None)  # error: [invalid-argument-type]
 
 # `BaseSettings` defines a specialized constructor and forbids extra values by default.
 Settings(host="localhost", port=8000, something_else=7)  # error: [unknown-argument]

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -155,6 +155,7 @@ pub enum KnownClass {
     TyExtensionsIterator,
     // Pydantic
     PydanticBaseModel,
+    PydanticBaseSettings,
     PydanticConfigDict,
     PydanticRootModel,
 }
@@ -285,6 +286,7 @@ impl KnownClass {
             | Self::ExtensionTypedDictFallback
             | Self::TypedDictFallback
             | Self::PydanticBaseModel
+            | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
             | Self::PydanticRootModel => Some(Truthiness::Ambiguous),
 
@@ -396,6 +398,7 @@ impl KnownClass {
             | KnownClass::Path
             | KnownClass::FunctoolsPartial
             | KnownClass::PydanticBaseModel
+            | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticConfigDict
             | KnownClass::PydanticRootModel => false,
         }
@@ -504,6 +507,7 @@ impl KnownClass {
             | KnownClass::Path
             | KnownClass::FunctoolsPartial
             | KnownClass::PydanticBaseModel
+            | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticRootModel => false,
 
             KnownClass::PydanticConfigDict => true,
@@ -612,6 +616,7 @@ impl KnownClass {
             | KnownClass::Path
             | KnownClass::FunctoolsPartial
             | KnownClass::PydanticBaseModel
+            | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticConfigDict
             | KnownClass::PydanticRootModel => false,
         }
@@ -732,6 +737,7 @@ impl KnownClass {
             | Self::Mapping
             | Self::Sequence
             | Self::PydanticBaseModel
+            | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
             | Self::PydanticRootModel => false,
         }
@@ -841,6 +847,7 @@ impl KnownClass {
             | KnownClass::GenericContext
             | KnownClass::Specialization
             | KnownClass::PydanticBaseModel
+            | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticConfigDict
             | KnownClass::PydanticRootModel => false,
             KnownClass::NamedTupleFallback
@@ -963,6 +970,7 @@ impl KnownClass {
             Self::FunctoolsPartial => "partial",
             Self::ProtocolMeta => "_ProtocolMeta",
             Self::PydanticBaseModel => "BaseModel",
+            Self::PydanticBaseSettings => "BaseSettings",
             Self::PydanticConfigDict => "ConfigDict",
             Self::PydanticRootModel => "RootModel",
         }
@@ -1348,6 +1356,7 @@ impl KnownClass {
             Self::Path => KnownModule::Pathlib,
             Self::FunctoolsPartial => KnownModule::Functools,
             Self::PydanticBaseModel => KnownModule::PydanticMain,
+            Self::PydanticBaseSettings => KnownModule::PydanticSettingsMain,
             Self::PydanticConfigDict => KnownModule::PydanticConfig,
             Self::PydanticRootModel => KnownModule::PydanticRootModel,
         }
@@ -1458,6 +1467,7 @@ impl KnownClass {
             | Self::UnionType
             | Self::FunctoolsPartial
             | Self::PydanticBaseModel
+            | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
             | Self::PydanticRootModel => Some(false),
 
@@ -1571,6 +1581,7 @@ impl KnownClass {
             | Self::Path
             | Self::FunctoolsPartial
             | Self::PydanticBaseModel
+            | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
             | Self::PydanticRootModel => false,
         }
@@ -1683,6 +1694,7 @@ impl KnownClass {
             "_ProtocolMeta" => &[Self::ProtocolMeta],
             "_TypedDict" => &[Self::ExtensionTypedDictFallback],
             "BaseModel" => &[Self::PydanticBaseModel],
+            "BaseSettings" => &[Self::PydanticBaseSettings],
             "ConfigDict" => &[Self::PydanticConfigDict],
             "RootModel" => &[Self::PydanticRootModel],
             _ => return None,
@@ -1782,6 +1794,7 @@ impl KnownClass {
             | Self::Path
             | Self::FunctoolsPartial
             | Self::PydanticBaseModel
+            | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
             | Self::PydanticRootModel => module == self.canonical_module(db),
             Self::NoneType => matches!(module, KnownModule::Typeshed | KnownModule::Types),

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1357,6 +1357,9 @@ impl<'db> StaticClassLiteral<'db> {
         let pydantic_constructor_fields_are_keyword_only =
             matches!(field_policy, CodeGeneratorKind::Pydantic(_))
                 && pydantic::constructor_fields_are_keyword_only(db, self);
+        let pydantic_constructor_fields_are_optional = name == "__init__"
+            && matches!(field_policy, CodeGeneratorKind::Pydantic(_))
+            && pydantic::constructor_fields_are_optional(db, self);
 
         let instance_ty =
             Type::instance(db, self.apply_optional_specialization(db, specialization));
@@ -1470,6 +1473,10 @@ impl<'db> StaticClassLiteral<'db> {
                     && let Some(metadata) = field_policy.pydantic_metadata()
                 {
                     field_ty = pydantic::constructor_parameter_type(db, field_ty, strict, metadata);
+                }
+
+                if pydantic_constructor_fields_are_optional && default_ty.is_none() {
+                    default_ty = Some(Type::unknown());
                 }
 
                 let is_kw_only = matches!(name, "__replace__" | "_replace")

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -189,6 +189,20 @@ pub(in crate::types) fn constructor_fields_are_keyword_only(
         .any(|base| base.is_known(db, KnownClass::PydanticRootModel))
 }
 
+/// Return `true` if fields are optional constructor parameters for `class`.
+///
+/// A settings model can populate any field from environment variables or another configured
+/// settings source, so no field value is necessarily required at the call site.
+pub(in crate::types) fn constructor_fields_are_optional(
+    db: &dyn Db,
+    class: StaticClassLiteral<'_>,
+) -> bool {
+    class
+        .iter_mro(db, None)
+        .filter_map(ClassBase::into_class)
+        .any(|base| base.is_known(db, KnownClass::PydanticBaseSettings))
+}
+
 #[salsa::tracked(
     cycle_initial=|_, _, _| ModelConfig::unknown(),
     heap_size=ruff_memory_usage::heap_size,


### PR DESCRIPTION
## Summary

`BaseSettings` fields can be supplied via environment variables. To support this use case, we make all fields on these models optional by default.

```py
from pydantic_settings import BaseSettings

class Settings(BaseSettings):
    host: str
    port: int

# Would succeed at runtime if HOST and PORT environment variables are set
Settings()
```

closes https://github.com/astral-sh/ty/issues/1070
towards https://github.com/astral-sh/ty/issues/2403

## Test Plan

Updated existing Markdown tests
