### PR TITLE
[ty] Pydantic: Add support for `validation_alias`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -666,17 +666,12 @@ Pydantic models can also specify a `validation_alias` for a field, which takes p
 class ValidationAlias(BaseModel):
     name: int = Field(alias="alias", validation_alias="validation_alias")
 
-# TODO: no error here
-# error: [missing-argument]
 ValidationAlias(validation_alias=1)
-# TODO: this should be a `invalid-argument-type` error, not a `missing-argument` error
-# error: [missing-argument]
-ValidationAlias(validation_alias=None)
+ValidationAlias(validation_alias=None)  # error: [invalid-argument-type]
 
 ValidationAlias()  # error: [missing-argument]
 ValidationAlias(name=1)  # error: [missing-argument]
-# TODO: this should be a `missing-argument` error
-ValidationAlias(alias=1)
+ValidationAlias(alias=1)  # error: [missing-argument]
 ```
 
 ## Extra fields

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1715,6 +1715,7 @@ impl<'db> Bindings<'db> {
                         let init = get_argument_type("init", true);
                         let kw_only = get_argument_type("kw_only", true);
                         let alias = get_argument_type("alias", true);
+                        let validation_alias = get_argument_type("validation_alias", true);
                         let converter = get_argument_type("converter", true);
                         // `Field(strict=None)` inherits the model-global strictness configuration,
                         // so treat it like an unspecified field-level value.
@@ -1760,8 +1761,12 @@ impl<'db> Bindings<'db> {
                             None
                         };
 
-                        let alias = alias
+                        // A Pydantic validation alias takes precedence over the ordinary alias for
+                        // constructor input. `FieldInstance::alias` only models the constructor
+                        // parameter name, so the ordinary alias does not need to be retained here.
+                        let alias = validation_alias
                             .and_then(Type::as_string_literal)
+                            .or_else(|| alias.and_then(Type::as_string_literal))
                             .map(|literal| Box::from(literal.value(db)));
 
                         // Extract the first positional parameter type and the return type from the


### PR DESCRIPTION
## Summary

If `validation_alias` is specified, it[ takes precedence over `alias` ](https://pydantic.dev/docs/validation/latest/concepts/fields#field-aliases) for purposes of the constructor signature, so here, we implement this by simply overriding the `alias` attribute on the field.

towards https://github.com/astral-sh/ty/issues/2403

## Test Plan

Update Markdown tests.
