### PR TITLE
[ty] Pydantic: Add fields from mixin classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -1042,7 +1042,7 @@ Annotated attributes on mixin-classes that do not inherit from `BaseModel` also 
 model:
 
 ```py
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 class Mixin:
     mixin_field: bool
@@ -1050,9 +1050,9 @@ class Mixin:
 class MyModel(BaseModel, Mixin):
     model_field: bool
 
-# TODO: this should also include the field from the mixin
-# revealed: (self: MyModel, *, model_field: LaxBool, **extra: Any) -> None
+# revealed: (self: MyModel, *, mixin_field: LaxBool, model_field: LaxBool, **extra: Any) -> None
 reveal_type(MyModel.__init__)
+MyModel(model_field=True, mixin_field=False)
 ```
 
 ## Differences from dataclasses

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1957,7 +1957,11 @@ impl<'db> StaticClassLiteral<'db> {
                 let class = superclass.into_class()?;
 
                 if let Some((class_literal, specialization)) = class.static_class_literal(db) {
-                    if field_policy.matches(db, class_literal.into()) {
+                    // Pydantic collects annotated attributes from every class in the model's MRO,
+                    // including ordinary classes that are not themselves Pydantic models.
+                    if matches!(field_policy, CodeGeneratorKind::Pydantic(_))
+                        || field_policy.matches(db, class_literal.into())
+                    {
                         return Some(FieldSource::Static(class_literal, specialization));
                     }
                 }


### PR DESCRIPTION
## Summary

In contrast to dataclasses, Pydantic models collect annotated attributes from all base classes, including those that are not Pydantic models themselves:

```py
class Mixin:
    mixin_field: bool

class MyModel(BaseModel, Mixin):
    model_field: bool

# revealed: (self: MyModel, *, mixin_field: LaxBool, model_field: LaxBool, **extra: Any) -> None
reveal_type(MyModel.__init__)
````

closes https://github.com/astral-sh/ty/issues/3861
towards https://github.com/astral-sh/ty/issues/2403

## Test Plan

Updated Markdown tests