### PR TITLE
[ty] Preserve covariant generic bases during cycle recovery

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1215,6 +1215,44 @@ impl<'db> Type<'db> {
         .recursive_type_normalized(db, cycle)
     }
 
+    /// Widen two types in a covariant generic position during cycle recovery.
+    ///
+    /// When both types are instances of the same generic class, preserve that class identity and
+    /// recursively widen its covariant arguments. Otherwise, retain both types in a union.
+    pub(super) fn merge_covariant_cycle_recovery(self, db: &'db dyn Db, previous: Self) -> Self {
+        let merged = match (self, previous) {
+            (Type::GenericAlias(current), Type::GenericAlias(previous)) => current
+                .merge_cycle_recovery(db, previous)
+                .map(Type::GenericAlias),
+            (
+                current @ (Type::NominalInstance(_) | Type::ProtocolInstance(_)),
+                previous @ (Type::NominalInstance(_) | Type::ProtocolInstance(_)),
+            ) => Self::merge_generic_instance_cycle_recovery(db, current, previous),
+            _ => None,
+        };
+
+        merged.unwrap_or_else(|| UnionType::from_elements_cycle_recovery(db, [previous, self]))
+    }
+
+    fn merge_generic_instance_cycle_recovery(
+        db: &'db dyn Db,
+        current: Self,
+        previous: Self,
+    ) -> Option<Self> {
+        let (current_origin, current_specialization) = current.class_specialization(db)?;
+        let (previous_origin, previous_specialization) = previous.class_specialization(db)?;
+        if current_origin != previous_origin {
+            return None;
+        }
+
+        let specialization =
+            current_specialization.merge_cycle_recovery(db, previous_specialization)?;
+        Some(Type::instance(
+            db,
+            ClassType::Generic(GenericAlias::new(db, current_origin, specialization)),
+        ))
+    }
+
     pub fn is_none(&self, db: &'db dyn Db) -> bool {
         self.is_instance_of(db, KnownClass::NoneType)
     }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1114,10 +1114,10 @@ pub(super) fn walk_specialization<'db, V: TypeVisitor<'db> + ?Sized>(
 }
 
 impl<'db> Specialization<'db> {
-    /// Merge cycle iterations that differ only by gradual `Unknown` type arguments.
+    /// Merge two cycle iterations without losing their shared generic class identity.
     ///
-    /// Known argument mismatches are not merged because doing so would be unsound for invariant
-    /// type variables; the caller must retain the outer semantic union in that case.
+    /// Covariant type arguments can be widened in place. Mismatched invariant or contravariant
+    /// arguments cannot, so the caller must retain the outer semantic union in those cases.
     pub(super) fn merge_cycle_recovery(self, db: &'db dyn Db, previous: Self) -> Option<Self> {
         if self.generic_context(db) != previous.generic_context(db)
             || self.materialization_kind(db) != previous.materialization_kind(db)
@@ -1126,20 +1126,24 @@ impl<'db> Specialization<'db> {
             return None;
         }
 
-        let types: Box<[_]> = previous
-            .types(db)
-            .iter()
-            .zip(self.types(db))
-            .map(|(previous, current)| match (*previous, *current) {
-                (previous, current) if previous == current => Some(current),
-                (previous, current)
-                    if previous == Type::unknown() || current == Type::unknown() =>
-                {
-                    Some(Type::unknown())
+        let types: Box<[_]> = itertools::izip!(
+            self.generic_context(db).variables(db),
+            previous.types(db),
+            self.types(db)
+        )
+        .map(|(typevar, previous, current)| match (*previous, *current) {
+            (previous, current) if previous == current => Some(current),
+            (previous, current) if previous == Type::unknown() || current == Type::unknown() => {
+                Some(Type::unknown())
+            }
+            (previous, current) => match specialization_variance(db, typevar) {
+                TypeVarVariance::Bivariant | TypeVarVariance::Covariant => {
+                    Some(current.merge_covariant_cycle_recovery(db, previous))
                 }
-                _ => None,
-            })
-            .collect::<Option<Box<[_]>>>()?;
+                TypeVarVariance::Contravariant | TypeVarVariance::Invariant => None,
+            },
+        })
+        .collect::<Option<Box<[_]>>>()?;
 
         Some(Self::new(
             db,

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -50,6 +50,19 @@ fn list_alias<'db>(db: &'db dyn Db, argument: Type<'db>) -> GenericAlias<'db> {
         .expect("a specialized `list` should be a generic alias")
 }
 
+fn iterable_alias<'db>(db: &'db dyn Db, argument: Type<'db>) -> GenericAlias<'db> {
+    KnownClass::Iterable
+        .to_specialized_class_type(db, &[argument])
+        .expect("`Iterable` should accept one type argument")
+        .into_generic_alias()
+        .expect("a specialized `Iterable` should be a generic alias")
+}
+
+fn nested_iterable_alias<'db>(db: &'db dyn Db, argument: Type<'db>) -> GenericAlias<'db> {
+    let inner = Type::instance(db, ClassType::Generic(iterable_alias(db, argument)));
+    iterable_alias(db, inner)
+}
+
 fn oscillating_generic_alias_cycle_recover<'db>(
     db: &'db dyn Db,
     cycle: &salsa::Cycle,
@@ -76,6 +89,21 @@ fn oscillating_generic_alias(db: &dyn Db) -> Type<'_> {
     list_alias(db, argument).into()
 }
 
+#[salsa::tracked(
+    cycle_initial=|_, id| Type::divergent(id),
+    cycle_fn=oscillating_generic_alias_cycle_recover,
+)]
+fn oscillating_protocol_alias(db: &dyn Db) -> Type<'_> {
+    let previous = oscillating_protocol_alias(db);
+    let int: Type = nested_iterable_alias(db, KnownClass::Int.to_instance(db)).into();
+
+    if previous == int {
+        nested_iterable_alias(db, KnownClass::Str.to_instance(db)).into()
+    } else {
+        int
+    }
+}
+
 #[test]
 fn generic_alias_cycle_recovery_normalizes_same_origin_unknown_oscillation() {
     let db = setup_db();
@@ -99,6 +127,38 @@ fn generic_alias_cycle_recovery_rejects_unsafe_merges() {
         int.merge_cycle_recovery(&db, list_alias(&db, unknown_generic))
             .is_none()
     );
+}
+
+#[test]
+fn protocol_alias_cycle_recovery_recursively_widens_covariant_arguments() {
+    let db = setup_db();
+    let int = KnownClass::Int.to_instance(&db);
+    let str = KnownClass::Str.to_instance(&db);
+    let previous: Type = nested_iterable_alias(&db, int).into();
+    let current: Type = nested_iterable_alias(&db, str).into();
+
+    assert!(ClassBase::try_from_type(&db, previous, None).is_some());
+    assert!(ClassBase::try_from_type(&db, current, None).is_some());
+
+    let recovered = oscillating_protocol_alias(&db);
+    let Type::GenericAlias(outer) = recovered else {
+        panic!("cycle recovery should preserve the outer protocol alias");
+    };
+    let [inner] = outer.specialization(&db).types(&db) else {
+        panic!("`Iterable` should have one type argument");
+    };
+    let Some((inner_origin, inner_specialization)) = inner.class_specialization(&db) else {
+        panic!("cycle recovery should preserve the inner protocol instance");
+    };
+    assert_eq!(inner_origin, outer.origin(&db));
+
+    let [Type::Union(argument)] = inner_specialization.types(&db) else {
+        panic!("the innermost covariant arguments should be widened to a union");
+    };
+    assert_eq!(argument.elements(&db).len(), 2);
+    assert!(argument.elements(&db).contains(&int));
+    assert!(argument.elements(&db).contains(&str));
+    assert!(ClassBase::try_from_type(&db, recovered, None).is_some());
 }
 
 /// All other tests also make sure that `Type::Todo` works as expected. This particular


### PR DESCRIPTION
## Summary

During Salsa cycle recovery, differing specializations of the same generic class could be unioned as class objects, producing an invalid class base.

Recursively widen covariant arguments while preserving generic identity; invariant and contravariant mismatches retain the conservative fallback.

## Test Plan

Testing: Added deterministic cycle-recovery coverage and ran the full ty semantic suite plus repeated steam.py root-order checks.
