### PR TITLE
[ty] Pydantic: Understand ellipsis as providing no default value

### DIFF
--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -341,6 +341,8 @@ pub enum KnownModule {
     // Third-party modules
     #[strum(serialize = "pydantic.config")]
     PydanticConfig,
+    #[strum(serialize = "pydantic.fields")]
+    PydanticFields,
     #[strum(serialize = "pydantic.main")]
     PydanticMain,
     #[strum(serialize = "pydantic.root_model")]
@@ -387,6 +389,7 @@ impl KnownModule {
             Self::Numbers => "numbers",
             Self::Struct => "struct",
             Self::PydanticConfig => "pydantic.config",
+            Self::PydanticFields => "pydantic.fields",
             Self::PydanticMain => "pydantic.main",
             Self::PydanticRootModel => "pydantic.root_model",
             Self::PydanticSettingsMain => "pydantic_settings.main",
@@ -415,6 +418,7 @@ impl KnownModule {
     pub const fn is_third_party(self) -> bool {
         match self {
             Self::PydanticConfig
+            | Self::PydanticFields
             | Self::PydanticMain
             | Self::PydanticRootModel
             | Self::PydanticSettingsMain

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -92,8 +92,7 @@ class Person(BaseModel):
     name: str = Field(..., max_length=255)
 
 Person(name="Alice")
-# TODO: this should be an error
-Person()
+Person()  # error: [missing-argument]
 ```
 
 ## Strict and lax mode

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -34,7 +34,7 @@ use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, PathBound, PathBounds, Solutions,
 };
-use crate::types::dedicated::pydantic::ConfigBoolean;
+use crate::types::dedicated::pydantic::{self, ConfigBoolean};
 use crate::types::diagnostic::{
     CALL_NON_CALLABLE, CALL_TOP_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_DATACLASS,
     MISSING_ARGUMENT, NO_MATCHING_OVERLOAD, PARAMETER_ALREADY_ASSIGNED,
@@ -1686,7 +1686,7 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    function @ Type::FunctionLiteral(_)
+                    function @ Type::FunctionLiteral(function_type)
                         if dataclass_field_specifiers.contains(&function) =>
                     {
                         // Helper to get the type of a keyword argument by name. We first try to get it from
@@ -1708,9 +1708,13 @@ impl<'db> Bindings<'db> {
                             })
                         };
 
-                        let has_default_value = get_argument_type("default", false).is_some()
-                            || get_argument_type("default_factory", false).is_some()
-                            || get_argument_type("factory", false).is_some();
+                        let default = get_argument_type("default", false);
+                        let has_default_value = get_argument_type("default_factory", false)
+                            .is_some()
+                            || get_argument_type("factory", false).is_some()
+                            || default.is_some_and(|default| {
+                                pydantic::field_provides_default(db, function_type, default)
+                            });
 
                         let init = get_argument_type("init", true);
                         let kw_only = get_argument_type("kw_only", true);

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -8,8 +8,9 @@ use crate::Db;
 use crate::place::{DefinedPlace, Definedness, Place, Provenance, known_module_symbol};
 use crate::types::member::class_member;
 use crate::types::{
-    ClassBase, DataclassTransformerParams, KnownClass, KnownInstanceType, KnownUnion, Parameter,
-    StaticClassLiteral, Type, UnionType, definition_expression_type,
+    ClassBase, DataclassTransformerParams, FunctionType, KnownClass, KnownFunction,
+    KnownInstanceType, KnownUnion, Parameter, StaticClassLiteral, Type, UnionType,
+    definition_expression_type,
 };
 
 /// Metadata that controls Pydantic-specific model synthesis.
@@ -173,6 +174,19 @@ pub(in crate::types) fn is_model(db: &dyn Db, class: StaticClassLiteral<'_>) -> 
         .iter_mro(db, None)
         .filter_map(ClassBase::into_class)
         .any(|base| base.is_known(db, KnownClass::PydanticBaseModel))
+}
+
+/// Return whether a field specifier's `default` argument provides a default value.
+///
+/// Pydantic's `Field(...)` uses the ellipsis as a required-field sentinel, so it does not provide
+/// a default value.
+pub(in crate::types) fn field_provides_default(
+    db: &dyn Db,
+    function: FunctionType<'_>,
+    default: Type<'_>,
+) -> bool {
+    !default.is_instance_of(db, KnownClass::EllipsisType)
+        || !function.is_known(db, KnownFunction::PydanticField)
 }
 
 /// Return `true` if fields in `class` are keyword-only constructor parameters.

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2023,6 +2023,10 @@ pub enum KnownFunction {
     /// `dataclasses.field`
     Field,
 
+    /// `pydantic.fields.Field`
+    #[strum(serialize = "Field")]
+    PydanticField,
+
     /// `functools.total_ordering`
     TotalOrdering,
 
@@ -2141,6 +2145,7 @@ impl KnownFunction {
             Self::Dataclass | Self::Field => {
                 matches!(module, KnownModule::Dataclasses)
             }
+            Self::PydanticField => matches!(module, KnownModule::PydanticFields),
             Self::TotalOrdering => module.is_functools(),
             Self::GetattrStatic => module.is_inspect(),
             Self::StaticAssert => module.is_ty_extensions(),
@@ -2671,6 +2676,8 @@ pub(crate) mod tests {
 
                 KnownFunction::Dataclass | KnownFunction::Field => KnownModule::Dataclasses,
 
+                KnownFunction::PydanticField => KnownModule::PydanticFields,
+
                 KnownFunction::GetattrStatic => KnownModule::Inspect,
 
                 KnownFunction::Cast
@@ -2714,6 +2721,10 @@ pub(crate) mod tests {
                 KnownFunction::Unpack => KnownModule::Struct,
                 KnownFunction::NewClass => KnownModule::Types,
             };
+
+            if module.is_third_party() {
+                continue;
+            }
 
             let function_definition = known_module_symbol(&db, module, function_name)
                 .place


### PR DESCRIPTION
## Summary

A Pydantic field which uses `...` (ellipsis) for the `default` argument is actually required and provides no default value.

```py
class Model(BaseModel):
    value: Any = Field(...)

Model()  # error
```

towards https://github.com/astral-sh/ty/issues/2403

## Ecosystem

The two new diagnostics are false positives due to missing support for `AliasChoices`. I think they are acceptable. They were missing previously because we were modeling something completely wrong, so it's hardly a regression (we only recently removed those diagnostics when adding support for `extra`).

## Test Plan

Updated Markdown tests
