### PR TITLE
[`ruff`] Clarify intentional async contexts for `unused-async` (`RUF029`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
@@ -18,7 +18,11 @@ use crate::rules::fastapi::rules::is_fastapi_route;
 /// ## Why is this bad?
 /// Declaring a function `async` when it's not is usually a mistake, and will artificially limit the
 /// contexts where that function may be called. In some cases, labeling a function `async` is
-/// semantically meaningful (e.g. with the trio library).
+/// semantically meaningful. For example, an async test or callback may need to run in an async
+/// execution context, even if it only uses a `ContextVar`.
+///
+/// If the async context is intentional, add an actual await expression, such as
+/// `await asyncio.sleep(0)`, or disable this rule for the function.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
## Summary

This updates the RUF029 documentation to mention that an async function can sometimes be intentional even when it does not directly await anything.

One example is an async test or callback that needs to run inside an async execution context, such as code that uses a ContextVar.

The docs now point users toward either adding a real await when appropriate or disabling the rule for that specific function when the async boundary is intentional.

Refs #23196.

## Test Plan

- `cargo dev generate-docs`
- `cargo fmt --check --all`
- `PATH="$PWD/target/debug:$PATH" uv run --only-group dev --locked python scripts/check_docs_formatted.py`
- `PATH="$PWD/target/debug:$PATH" uv run --only-group dev --locked prek run --files crates/ruff_linter/src/rules/ruff/rules/unused_async.rs`
- `cargo test -p ruff_linter rules::ruff::tests::rules::rule_unusedasync_path_new_ruf029_py_expects`
