### PR TITLE
[ty] Improve protocol attribute diagnostic context

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -799,7 +799,7 @@ info: └── protocol member `check` is not defined on type `SupportsSomethin
 Incompatible readable and writable protocol attributes:
 
 ```py
-from typing import Generic, Protocol, TypeVar
+from typing import Protocol
 
 class ReadableName(Protocol):
     @property
@@ -882,32 +882,6 @@ info: └── protocol member `name` is incompatible
 info:     └── the member does not accept writes of type `str`
 ```
 
-```py
-T = TypeVar("T", bound=WritableName)
-
-class NameBox(Generic[T]): ...
-
-class InvalidNameBox(NameBox[ReadOnlyName]):  # snapshot: invalid-type-arguments
-    pass
-```
-
-```snapshot
-error[invalid-type-arguments]: Type `ReadOnlyName` is not assignable to upper bound `WritableName` of type variable `T@NameBox`
-  --> src/mdtest_snippet.py:59:1
-   |
-59 | T = TypeVar("T", bound=WritableName)
-   | - Type variable defined here
-60 |
-61 | class NameBox(Generic[T]): ...
-62 |
-63 | class InvalidNameBox(NameBox[ReadOnlyName]):  # snapshot: invalid-type-arguments
-   |                              ^^^^^^^^^^^^
-   |
-info: type `ReadOnlyName` is not assignable to protocol `WritableName`
-info: └── protocol member `name` is incompatible
-info:     └── the member does not accept writes of type `str`
-```
-
 Incompatible readable and writable attributes when assigning one protocol to another:
 
 ```py
@@ -932,9 +906,9 @@ def _(source: ReadOnlyNameProtocol):
 
 ```snapshot
 error[invalid-assignment]: Object of type `ReadOnlyNameProtocol` is not assignable to `WritableName`
-  --> src/mdtest_snippet.py:78:13
+  --> src/mdtest_snippet.py:72:13
    |
-78 |     target: WritableName = source  # snapshot
+72 |     target: WritableName = source  # snapshot
    |             ------------   ^^^^^^ Incompatible value of type `ReadOnlyNameProtocol`
    |             |
    |             Declared type
@@ -951,9 +925,9 @@ def _(source: BytesNameProtocol):
 
 ```snapshot
 error[invalid-assignment]: Object of type `BytesNameProtocol` is not assignable to `WritableName`
-  --> src/mdtest_snippet.py:80:13
+  --> src/mdtest_snippet.py:74:13
    |
-80 |     target: WritableName = source  # snapshot
+74 |     target: WritableName = source  # snapshot
    |             ------------   ^^^^^^ Incompatible value of type `BytesNameProtocol`
    |             |
    |             Declared type
@@ -970,9 +944,9 @@ def _(source: BytesSetterNameProtocol):
 
 ```snapshot
 error[invalid-assignment]: Object of type `BytesSetterNameProtocol` is not assignable to `WritableName`
-  --> src/mdtest_snippet.py:82:13
+  --> src/mdtest_snippet.py:76:13
    |
-82 |     target: WritableName = source  # snapshot
+76 |     target: WritableName = source  # snapshot
    |             ------------   ^^^^^^ Incompatible value of type `BytesSetterNameProtocol`
    |             |
    |             Declared type
@@ -994,9 +968,9 @@ def _(source: SupportsCheckWithOtherSignature):
 
 ```snapshot
 error[invalid-assignment]: Object of type `SupportsCheckWithOtherSignature` is not assignable to `SupportsCheck`
-  --> src/mdtest_snippet.py:87:13
+  --> src/mdtest_snippet.py:81:13
    |
-87 |     target: SupportsCheck = source  # snapshot
+81 |     target: SupportsCheck = source  # snapshot
    |             -------------   ^^^^^^ Incompatible value of type `SupportsCheckWithOtherSignature`
    |             |
    |             Declared type

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -796,6 +796,192 @@ info: protocol `SupportsSomethingElse` is not assignable to protocol `SupportsCh
 info: └── protocol member `check` is not defined on type `SupportsSomethingElse`
 ```
 
+Incompatible readable and writable protocol attributes:
+
+```py
+from typing import Generic, Protocol, TypeVar
+
+class ReadableName(Protocol):
+    @property
+    def name(self) -> str: ...
+
+class WritableName(Protocol):
+    name: str
+
+class BytesName:
+    name: bytes
+
+class ReadOnlyName:
+    @property
+    def name(self) -> str:
+        return ""
+
+class BytesSetterName:
+    @property
+    def name(self) -> str:
+        return ""
+
+    @name.setter
+    def name(self, value: bytes) -> None: ...
+```
+
+```py
+def _(source: BytesName):
+    target: ReadableName = source  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `BytesName` is not assignable to `ReadableName`
+  --> src/mdtest_snippet.py:54:13
+   |
+54 |     target: ReadableName = source  # snapshot
+   |             ------------   ^^^^^^ Incompatible value of type `BytesName`
+   |             |
+   |             Declared type
+   |
+info: type `BytesName` is not assignable to protocol `ReadableName`
+info: └── protocol member `name` is incompatible
+info:     └── read type `bytes` is not assignable to `str`
+```
+
+```py
+def _(source: ReadOnlyName):
+    target: WritableName = source  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `ReadOnlyName` is not assignable to `WritableName`
+  --> src/mdtest_snippet.py:56:13
+   |
+56 |     target: WritableName = source  # snapshot
+   |             ------------   ^^^^^^ Incompatible value of type `ReadOnlyName`
+   |             |
+   |             Declared type
+   |
+info: type `ReadOnlyName` is not assignable to protocol `WritableName`
+info: └── protocol member `name` is incompatible
+info:     └── the member does not accept writes of type `str`
+```
+
+```py
+def _(source: BytesSetterName):
+    target: WritableName = source  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `BytesSetterName` is not assignable to `WritableName`
+  --> src/mdtest_snippet.py:58:13
+   |
+58 |     target: WritableName = source  # snapshot
+   |             ------------   ^^^^^^ Incompatible value of type `BytesSetterName`
+   |             |
+   |             Declared type
+   |
+info: type `BytesSetterName` is not assignable to protocol `WritableName`
+info: └── protocol member `name` is incompatible
+info:     └── the member does not accept writes of type `str`
+```
+
+```py
+T = TypeVar("T", bound=WritableName)
+
+class NameBox(Generic[T]): ...
+
+class InvalidNameBox(NameBox[ReadOnlyName]):  # snapshot: invalid-type-arguments
+    pass
+```
+
+```snapshot
+error[invalid-type-arguments]: Type `ReadOnlyName` is not assignable to upper bound `WritableName` of type variable `T@NameBox`
+  --> src/mdtest_snippet.py:59:1
+   |
+59 | T = TypeVar("T", bound=WritableName)
+   | - Type variable defined here
+60 |
+61 | class NameBox(Generic[T]): ...
+62 |
+63 | class InvalidNameBox(NameBox[ReadOnlyName]):  # snapshot: invalid-type-arguments
+   |                              ^^^^^^^^^^^^
+   |
+info: type `ReadOnlyName` is not assignable to protocol `WritableName`
+info: └── protocol member `name` is incompatible
+info:     └── the member does not accept writes of type `str`
+```
+
+Incompatible readable and writable attributes when assigning one protocol to another:
+
+```py
+class ReadOnlyNameProtocol(Protocol):
+    @property
+    def name(self) -> str: ...
+
+class BytesNameProtocol(Protocol):
+    name: bytes
+
+class BytesSetterNameProtocol(Protocol):
+    @property
+    def name(self) -> str: ...
+    @name.setter
+    def name(self, value: bytes) -> None: ...
+```
+
+```py
+def _(source: ReadOnlyNameProtocol):
+    target: WritableName = source  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `ReadOnlyNameProtocol` is not assignable to `WritableName`
+  --> src/mdtest_snippet.py:78:13
+   |
+78 |     target: WritableName = source  # snapshot
+   |             ------------   ^^^^^^ Incompatible value of type `ReadOnlyNameProtocol`
+   |             |
+   |             Declared type
+   |
+info: protocol `ReadOnlyNameProtocol` is not assignable to protocol `WritableName`
+info: └── protocol member `name` is incompatible
+info:     └── the member is not writable
+```
+
+```py
+def _(source: BytesNameProtocol):
+    target: WritableName = source  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `BytesNameProtocol` is not assignable to `WritableName`
+  --> src/mdtest_snippet.py:80:13
+   |
+80 |     target: WritableName = source  # snapshot
+   |             ------------   ^^^^^^ Incompatible value of type `BytesNameProtocol`
+   |             |
+   |             Declared type
+   |
+info: protocol `BytesNameProtocol` is not assignable to protocol `WritableName`
+info: └── protocol member `name` is incompatible
+info:     └── read type `bytes` is not assignable to `str`
+```
+
+```py
+def _(source: BytesSetterNameProtocol):
+    target: WritableName = source  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `BytesSetterNameProtocol` is not assignable to `WritableName`
+  --> src/mdtest_snippet.py:82:13
+   |
+82 |     target: WritableName = source  # snapshot
+   |             ------------   ^^^^^^ Incompatible value of type `BytesSetterNameProtocol`
+   |             |
+   |             Declared type
+   |
+info: protocol `BytesSetterNameProtocol` is not assignable to protocol `WritableName`
+info: └── protocol member `name` is incompatible
+info:     └── the member does not accept writes of type `str`
+```
+
 Incompatible types for protocol members (protocol to protocol):
 
 ```py
@@ -808,9 +994,9 @@ def _(source: SupportsCheckWithOtherSignature):
 
 ```snapshot
 error[invalid-assignment]: Object of type `SupportsCheckWithOtherSignature` is not assignable to `SupportsCheck`
-  --> src/mdtest_snippet.py:33:13
+  --> src/mdtest_snippet.py:87:13
    |
-33 |     target: SupportsCheck = source  # snapshot
+87 |     target: SupportsCheck = source  # snapshot
    |             -------------   ^^^^^^ Incompatible value of type `SupportsCheckWithOtherSignature`
    |             |
    |             Declared type

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -762,6 +762,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         typevar.identity(db).display(db),
                                     ));
                                     add_typevar_definition(db, &mut diagnostic, typevar);
+                                    if bound.as_protocol_instance().is_some() {
+                                        provided_type
+                                            .assignability_error_context(db, bound)
+                                            .attach_to(db, &mut diagnostic);
+                                    }
                                 }
                                 error = Some(ExplicitSpecializationError::UnsatisfiedBound);
                                 specialization_types.push(Some(Type::unknown()));

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -762,11 +762,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         typevar.identity(db).display(db),
                                     ));
                                     add_typevar_definition(db, &mut diagnostic, typevar);
-                                    if bound.as_protocol_instance().is_some() {
-                                        provided_type
-                                            .assignability_error_context(db, bound)
-                                            .attach_to(db, &mut diagnostic);
-                                    }
                                 }
                                 error = Some(ExplicitSpecializationError::UnsatisfiedBound);
                                 specialization_types.push(Some(Type::unknown()));

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1437,7 +1437,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             required_ty.bind_self(db, fallback_ty).when_some_and(
                 db,
                 self.constraints,
-                |required_ty| self.check_type_pair(db, attribute_type, required_ty),
+                |required_ty| {
+                    let result = self.check_type_pair(db, attribute_type, required_ty);
+                    if let Some(context) = self.report_context()
+                        && result.is_never_satisfied(db)
+                    {
+                        context.push(ErrorContext::ProtocolMemberReadTypeIncompatible {
+                            source: attribute_type,
+                            target: required_ty,
+                        });
+                    }
+                    result
+                },
             )
         }
     }
@@ -1497,7 +1508,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         db,
                         self.constraints,
                         |write_ty| {
-                            self.check_property_write(db, receiver_ty, member.name, write_ty)
+                            let result =
+                                self.check_property_write(db, receiver_ty, member.name, write_ty);
+                            if let Some(context) = self.report_context()
+                                && result.is_never_satisfied(db)
+                            {
+                                context.push(ErrorContext::ProtocolMemberWriteTypeIncompatible {
+                                    target: write_ty,
+                                });
+                            }
+                            result
                         },
                     )
                 },
@@ -1623,14 +1643,27 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 ) else {
                     return self.never();
                 };
-                self.check_type_pair(db, source, target)
+                let result = self.check_type_pair(db, source, target);
+                if let Some(context) = self.report_context()
+                    && !target_member.is_method()
+                    && result.is_never_satisfied(db)
+                {
+                    context
+                        .push(ErrorContext::ProtocolMemberReadTypeIncompatible { source, target });
+                }
+                result
             }
         };
 
         read_result.and(db, self.constraints, || {
             match (source.write, target.write) {
                 (_, None) => self.always(),
-                (None, Some(_)) => self.never(),
+                (None, Some(_)) => {
+                    if let Some(context) = self.report_context() {
+                        context.push(ErrorContext::ProtocolMemberNotWritable);
+                    }
+                    self.never()
+                }
                 (Some(source), Some(target)) => {
                     let (Some(target), Some(source)) = (
                         target.bind_self(db, source_type),
@@ -1638,7 +1671,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ) else {
                         return self.never();
                     };
-                    self.check_type_pair(db, target, source)
+                    let result = self.check_type_pair(db, target, source);
+                    if let Some(context) = self.report_context()
+                        && result.is_never_satisfied(db)
+                    {
+                        context.push(ErrorContext::ProtocolMemberWriteTypeIncompatible { target });
+                    }
+                    result
                 }
             }
         })

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -139,6 +139,14 @@ pub(crate) enum ErrorContext<'db> {
     ProtocolMemberIncompatible {
         member_name: Name,
     },
+    ProtocolMemberReadTypeIncompatible {
+        source: Type<'db>,
+        target: Type<'db>,
+    },
+    ProtocolMemberNotWritable,
+    ProtocolMemberWriteTypeIncompatible {
+        target: Type<'db>,
+    },
 }
 
 impl<'db> ErrorContext<'db> {
@@ -350,6 +358,16 @@ impl<'db> ErrorContext<'db> {
             Self::ProtocolMemberIncompatible { member_name } => {
                 format!("protocol member `{member_name}` is incompatible")
             }
+            Self::ProtocolMemberReadTypeIncompatible { source, target } => format!(
+                "read type `{source}` is not assignable to `{target}`",
+                source = source.display(db),
+                target = target.display(db),
+            ),
+            Self::ProtocolMemberNotWritable => "the member is not writable".to_string(),
+            Self::ProtocolMemberWriteTypeIncompatible { target } => format!(
+                "the member does not accept writes of type `{}`",
+                target.display(db),
+            ),
         })
     }
 }


### PR DESCRIPTION
## Summary

Report the actual and required read types for incompatible protocol attributes, distinguishing missing writable capabilities from members that reject the required write type.

For the motivating case, the diagnostic now explains:

```text
info: type `C` is not assignable to protocol `WithValue`
info: └── protocol member `value` is incompatible
info:     └── the member does not accept writes of type `str | None`
```

Related to astral-sh/ty#3940.

## Testing

Added mdtests with inline diagnostic snapshots.
