### PR TITLE
[ty] Add assignability context to upper-bound diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -693,6 +693,36 @@ help: A TypedDict is not usually assignable to any `dict[..]` type; `dict` types
 help: Consider using `Mapping[..]` instead of `dict[..]`.
 ```
 
+## Type variable upper bounds
+
+Assignability context is included when an explicit type argument does not satisfy a type variable's
+upper bound:
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T", bound=tuple[int, bytes, bool])
+
+class Box(Generic[T]): ...
+
+bad: Box[tuple[int, str, bool]]  # snapshot: invalid-type-arguments
+```
+
+```snapshot
+error[invalid-type-arguments]: Type `tuple[int, str, bool]` is not assignable to upper bound `tuple[int, bytes, bool]` of type variable `T@Box`
+ --> src/mdtest_snippet.py:3:1
+  |
+3 | T = TypeVar("T", bound=tuple[int, bytes, bool])
+  | - Type variable defined here
+4 |
+5 | class Box(Generic[T]): ...
+6 |
+7 | bad: Box[tuple[int, str, bool]]  # snapshot: invalid-type-arguments
+  |          ^^^^^^^^^^^^^^^^^^^^^
+  |
+info: the second tuple element is not compatible: `str` is not assignable to `bytes`
+```
+
 ## Protocols
 
 Missing protocol members:

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___Leg…_-_Specializing_generic…_(5a066394f338af48).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___Leg…_-_Specializing_generic…_(5a066394f338af48).snap
@@ -139,6 +139,7 @@ error[invalid-type-arguments]: Type `int | str` is not assignable to upper bound
 14 | BoundedT = TypeVar("BoundedT", bound=int)
    | -------- Type variable defined here
    |
+info: element `str` of union `int | str` is not assignable to `int`
 
 ```
 

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -762,6 +762,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         typevar.identity(db).display(db),
                                     ));
                                     add_typevar_definition(db, &mut diagnostic, typevar);
+                                    provided_type
+                                        .assignability_error_context(db, bound)
+                                        .attach_to(db, &mut diagnostic);
                                 }
                                 error = Some(ExplicitSpecializationError::UnsatisfiedBound);
                                 specialization_types.push(Some(Type::unknown()));


### PR DESCRIPTION
## Summary

Attach existing assignability error context when an explicit type argument fails a TypeVar upper bound. 

Closes https://github.com/astral-sh/ty/issues/3940.

For the motivating case in that issue, this now clarifies why the concrete type is not assignable to the protocol.

## Validation

Added mdtest with inline diagnostic snapshot.