### PR TITLE
[ty] Pydantic: Recognize frozen models via config

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -802,8 +802,7 @@ class PersonFrozenName2(BaseModel):
     name: str
 
 person = PersonFrozenName2(name="Alice")
-# TODO: This should be an error
-person.name = "Bob"
+person.name = "Bob"  # error: [invalid-assignment]
 ```
 
 Finally, individual fields can also be made immutable on a non-frozen model:

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -236,7 +236,14 @@ impl<'db> CodeGeneratorKind<'db> {
     pub(super) fn dataclass_transformer_params(self) -> Option<DataclassTransformerParams<'db>> {
         match self {
             Self::DataclassLike(params) => params,
-            Self::Pydantic(metadata) => Some(metadata.transformer_params()),
+            Self::Pydantic(_) | Self::NamedTuple | Self::TypedDict => None,
+        }
+    }
+
+    pub(super) fn field_specifiers(self, db: &'db dyn Db) -> Option<&'db [Type<'db>]> {
+        match self {
+            Self::DataclassLike(params) => Some(params?.field_specifiers(db)),
+            Self::Pydantic(metadata) => Some(metadata.field_specifiers(db)),
             Self::NamedTuple | Self::TypedDict => None,
         }
     }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -859,14 +859,11 @@ impl<'db> StaticClassLiteral<'db> {
         }
     }
 
-    /// Return `true` if Pydantic's dataclass-transform metadata marks this model as frozen.
-    fn is_frozen_pydantic_model(
-        self,
-        db: &'db dyn Db,
-        field_policy: CodeGeneratorKind<'db>,
-    ) -> bool {
-        matches!(field_policy, CodeGeneratorKind::Pydantic(_))
-            && self.has_dataclass_param(db, field_policy, DataclassFlags::FROZEN)
+    /// Return `true` if Pydantic's effective model configuration marks this model as frozen.
+    fn is_frozen_pydantic_model(db: &'db dyn Db, field_policy: CodeGeneratorKind<'db>) -> bool {
+        field_policy
+            .pydantic_metadata()
+            .is_some_and(|metadata| metadata.is_frozen(db))
     }
 
     /// Checks if the given dataclass parameter flag is set for this class.
@@ -1508,7 +1505,10 @@ impl<'db> StaticClassLiteral<'db> {
                     && let Some(metadata) = field_policy.pydantic_metadata()
                     && let Some(alias) = alias
                 {
-                    match (metadata.validates_by_alias(), metadata.validates_by_name()) {
+                    match (
+                        metadata.validates_by_alias(db),
+                        metadata.validates_by_name(db),
+                    ) {
                         (true, true) => {
                             let alias = Name::new(&**alias);
                             if alias == *field_name {
@@ -1570,7 +1570,9 @@ impl<'db> StaticClassLiteral<'db> {
             (field_policy, "__init__")
                 if field_policy.synthesizes_constructor_signature_from_fields() =>
             {
-                if !self.has_dataclass_param(db, field_policy, DataclassFlags::INIT) {
+                if matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
+                    && !self.has_dataclass_param(db, field_policy, DataclassFlags::INIT)
+                {
                     return None;
                 }
 
@@ -1749,7 +1751,7 @@ impl<'db> StaticClassLiteral<'db> {
                 "__setattr__",
             ) => {
                 if self.is_frozen_dataclass(db) == Some(true)
-                    || self.is_frozen_pydantic_model(db, field_policy)
+                    || Self::is_frozen_pydantic_model(db, field_policy)
                 {
                     let signature = Signature::new(
                         Parameters::standard([

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -15,15 +15,14 @@ use crate::types::{
 };
 
 /// Metadata that controls Pydantic-specific model synthesis.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub(crate) struct ModelMetadata<'db> {
-    // TODO: We may want to remove this field and model Pydantic behavior more explicitly.
-    // (since this information is static and doesn't vary between Pydantic models). To do
-    // this, we could only retain field specifier information and expose it through a new
-    // `CodeGeneratorKind` method. Maybe we could even skip the field specifiers as well.
-    transformer_params: DataclassTransformerParams<'db>,
+    #[returns(deref)]
+    pub(in crate::types) field_specifiers: Box<[Type<'db>]>,
     config: ModelConfig,
 }
+
+impl get_size2::GetSize for ModelMetadata<'_> {}
 
 impl<'db> ModelMetadata<'db> {
     pub(in crate::types) fn from_class(
@@ -31,46 +30,50 @@ impl<'db> ModelMetadata<'db> {
         class: StaticClassLiteral<'db>,
         transformer_params: DataclassTransformerParams<'db>,
     ) -> Self {
-        Self {
-            transformer_params,
-            config: model_config(db, class),
-        }
+        Self::new(
+            db,
+            transformer_params.field_specifiers(db),
+            model_config(db, class),
+        )
     }
 
-    pub(in crate::types) const fn transformer_params(self) -> DataclassTransformerParams<'db> {
-        self.transformer_params
+    fn accepts_extra(self, db: &'db dyn Db) -> bool {
+        !matches!(self.config(db).extra, Some(ExtraBehavior::Forbid))
     }
 
-    const fn accepts_extra(self) -> bool {
-        !matches!(self.config.extra, Some(ExtraBehavior::Forbid))
+    pub(in crate::types) fn validates_by_alias(self, db: &'db dyn Db) -> bool {
+        self.config(db).validate_by_alias.enabled_or(true)
     }
 
-    pub(in crate::types) const fn validates_by_alias(self) -> bool {
-        self.config.validate_by_alias.enabled_or(true)
-    }
-
-    pub(in crate::types) const fn validates_by_name(self) -> bool {
-        let validate_by_name = self.config.validate_by_name;
+    pub(in crate::types) fn validates_by_name(self, db: &'db dyn Db) -> bool {
+        let config = self.config(db);
+        let validate_by_name = config.validate_by_name;
         // If `validate_by_alias=False` is set without specifying `validate_by_name`, Pydantic
         // implicitly enables validation by name.
         if matches!(validate_by_name, ConfigBoolean::Unspecified)
-            && matches!(self.config.validate_by_alias, ConfigBoolean::Disabled)
+            && matches!(config.validate_by_alias, ConfigBoolean::Disabled)
         {
             true
         } else {
             validate_by_name.enabled_or(false)
         }
     }
+
+    pub(in crate::types) fn is_frozen(self, db: &'db dyn Db) -> bool {
+        matches!(self.config(db).frozen, ConfigBoolean::Enabled)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
-struct ModelConfig {
+pub(crate) struct ModelConfig {
     /// The `extra` configuration controls whether the synthesized constructor accepts keyword
     /// arguments that do not correspond to declared model fields.
     extra: Option<ExtraBehavior>,
     /// The `strict` configuration controls whether constructor parameters accept values that
     /// Pydantic can coerce to the declared field type.
     strict: ConfigBoolean,
+    /// Whether assignments to fields on model instances are forbidden.
+    frozen: ConfigBoolean,
     /// Whether fields with aliases can be initialized by their alias.
     validate_by_alias: ConfigBoolean,
     /// Whether fields with aliases can be initialized by their field name.
@@ -82,6 +85,7 @@ impl ModelConfig {
         Self {
             extra: Some(ExtraBehavior::Unknown),
             strict: ConfigBoolean::Unknown,
+            frozen: ConfigBoolean::Unknown,
             validate_by_alias: ConfigBoolean::Unknown,
             validate_by_name: ConfigBoolean::Unknown,
         }
@@ -91,6 +95,7 @@ impl ModelConfig {
     fn merge(&mut self, other: Self) {
         self.extra = other.extra.or(self.extra);
         self.strict = other.strict.or(self.strict);
+        self.frozen = other.frozen.or(self.frozen);
         self.validate_by_alias = other.validate_by_alias.or(self.validate_by_alias);
         self.validate_by_name = other.validate_by_name.or(self.validate_by_name);
     }
@@ -333,6 +338,7 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
         ExtraBehavior::from_value(extra)
     });
     let strict = config_boolean(db, definition, call.arguments.find_keyword("strict"));
+    let frozen = config_boolean(db, definition, call.arguments.find_keyword("frozen"));
     let validate_by_alias = config_boolean(
         db,
         definition,
@@ -347,6 +353,7 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
     Some(ModelConfig {
         extra,
         strict,
+        frozen,
         validate_by_alias,
         validate_by_name,
     })
@@ -376,6 +383,7 @@ fn model_config_from_dict(db: &dyn Db, definition: Definition<'_>, dict: &ExprDi
                 ));
             }
             "strict" => config.strict = ConfigBoolean::from_type(value),
+            "frozen" => config.frozen = ConfigBoolean::from_type(value),
             "validate_by_alias" => config.validate_by_alias = ConfigBoolean::from_type(value),
             "validate_by_name" => config.validate_by_name = ConfigBoolean::from_type(value),
             _ => {}
@@ -412,6 +420,7 @@ fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelConf
         ExtraBehavior::from_value(extra)
     });
     let strict = config_boolean(db, definition, arguments.find_keyword("strict"));
+    let frozen = config_boolean(db, definition, arguments.find_keyword("frozen"));
     let validate_by_alias =
         config_boolean(db, definition, arguments.find_keyword("validate_by_alias"));
     let validate_by_name =
@@ -420,6 +429,7 @@ fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelConf
     ModelConfig {
         extra,
         strict,
+        frozen,
         validate_by_alias,
         validate_by_name,
     }
@@ -432,7 +442,7 @@ pub(in crate::types) fn constructor_parameter_type<'db>(
     field_strict: ConfigBoolean,
     metadata: ModelMetadata<'db>,
 ) -> Type<'db> {
-    if field_strict.or(metadata.config.strict) == ConfigBoolean::Enabled {
+    if field_strict.or(metadata.config(db).strict) == ConfigBoolean::Enabled {
         return field_type;
     }
 
@@ -645,7 +655,7 @@ pub(in crate::types) fn model_init_accepts_extra(
     class: StaticClassLiteral<'_>,
     metadata: ModelMetadata<'_>,
 ) -> bool {
-    if !metadata.accepts_extra() {
+    if !metadata.accepts_extra(db) {
         return false;
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -690,8 +690,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .or_else(|| {
                     Some(SmallVec::from(
                         CodeGeneratorKind::from_class(db, class_literal.into())?
-                            .dataclass_transformer_params()?
-                            .field_specifiers(db),
+                            .field_specifiers(db)?,
                     ))
                 })
         }


### PR DESCRIPTION
## Summary

Recognize frozen models that have `frozen=True` in their model config:

```py
class Person(BaseModel):
    model_config = ConfigDict(frozen=True)

    name: str

person = Person(name="Alice")
person.name = "Bob"  # error: [invalid-assignment]
```

With this change, we can now also get rid of the `DataclassTransformerParams` that were still stored in every Pydantic model's metadata.

towards https://github.com/astral-sh/ty/issues/2403

## Test Plan

Updated Markdown tests