### PR TITLE
[ty] Support type[Protocol]

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1856,7 +1856,7 @@ fn attrs(criterion: &mut Criterion) {
             max_dep_date: TY_ECOSYSTEM_PIN,
             python_version: SupportedPythonVersion::Py311,
         },
-        102,
+        103,
     );
 
     bench_project(&benchmark, criterion);

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1890,7 +1890,7 @@ fn datetype(criterion: &mut Criterion) {
             max_dep_date: TY_ECOSYSTEM_PIN,
             python_version: SupportedPythonVersion::Py311,
         },
-        18,
+        17,
     );
 
     bench_project(&benchmark, criterion);

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1890,7 +1890,7 @@ fn datetype(criterion: &mut Criterion) {
             max_dep_date: TY_ECOSYSTEM_PIN,
             python_version: SupportedPythonVersion::Py311,
         },
-        17,
+        18,
     );
 
     bench_project(&benchmark, criterion);

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -664,6 +664,16 @@ reveal_type(super(B, object))
 super(object, object()).__class__
 ```
 
+An inhabitant of `type[Protocol]` may be either a nominal subclass of the protocol or a structural
+implementation, so the protocol's presence in the class's MRO is unknown:
+
+```py
+class StructuralProtocol(typing.Protocol): ...
+
+def protocol_super(cls: type[StructuralProtocol]):
+    reveal_type(super(StructuralProtocol, cls))  # revealed: <super: <class 'StructuralProtocol'>, Unknown>
+```
+
 Not all objects valid in a class's bases list are valid as the first argument to `super()`. For
 example, it's valid to inherit from `typing.ChainMap`, but it's not valid as the first argument to
 `super()`.

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2453,6 +2453,8 @@ dataclass()(MyEnum)
 # error: [invalid-dataclass] "Cannot use `dataclass()` on a protocol class"
 dataclass(MyProtocol)
 
-# error: [invalid-dataclass] "Cannot use `dataclass()` on a protocol class"
+# A protocol class is rejected before `dataclass`-specific validation because it is not a concrete
+# inhabitant of the inferred `type[MyProtocol]` parameter.
+# error: [invalid-argument-type] "Expected `type[MyProtocol]`, found `<class 'MyProtocol'>`"
 dataclass()(MyProtocol)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2453,8 +2453,6 @@ dataclass()(MyEnum)
 # error: [invalid-dataclass] "Cannot use `dataclass()` on a protocol class"
 dataclass(MyProtocol)
 
-# A protocol class is rejected before `dataclass`-specific validation because it is not a concrete
-# inhabitant of the inferred `type[MyProtocol]` parameter.
-# error: [invalid-argument-type] "Expected `type[MyProtocol]`, found `<class 'MyProtocol'>`"
+# error: [invalid-dataclass] "Cannot use `dataclass()` on a protocol class"
 dataclass()(MyProtocol)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4971,6 +4971,29 @@ reveal_type(meta_protocol_identity(GenericFooImpl[int]))  # revealed: type[Gener
 def _(f: type[GenericFoo[int]]) -> None:
     reveal_type(infer_meta_protocol(f))  # revealed: int
 
+T_identity = TypeVar("T_identity")
+
+def class_identity(cls: type[T_identity]) -> type[T_identity]:
+    return cls
+
+def _(cls: type[Foo]) -> None:
+    preserved: type[Foo] = class_identity(cls)
+
+def _(cls: type[Foo] | type[int]) -> None:
+    preserved: type[Foo] | type[int] = class_identity(cls)
+
+# A protocol class is not a concrete inhabitant of structural `type[Foo]`.
+class_identity(Foo)  # error: [invalid-argument-type]
+
+def _(cls: type[GenericFoo[int]]) -> None:
+    preserved: type[GenericFoo[int]] = class_identity(cls)
+    wrong: type[GenericFoo[str]] = class_identity(cls)  # error: [invalid-assignment]
+
+def predicate(cls: type[Foo]) -> bool:
+    return True
+
+classmethod(predicate)
+
 T_runtime_co = TypeVar("T_runtime_co", covariant=True)
 
 @runtime_checkable

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4805,8 +4805,9 @@ class BadFactory(Baz, metaclass=BadFactoryMeta): ...
 static_assert(not is_assignable_to(TypeOf[BadFactory], type[Foo]))
 ```
 
-A property declaration requires a readable attribute on the constructed instance, but does not
-guarantee that the attribute exists on the class object.
+A `@property` declaration requires a readable attribute on the constructed instance, but does not
+require the implementation to use `@property` or guarantee that the attribute exists on the class
+object.
 
 ```py
 class PropertyProtocol(Protocol):
@@ -4818,6 +4819,10 @@ class PropertyImpl:
         self.value = 1
 
 static_assert(is_assignable_to(TypeOf[PropertyImpl], type[PropertyProtocol]))
+
+class MissingProperty: ...
+
+static_assert(not is_assignable_to(TypeOf[MissingProperty], type[PropertyProtocol]))
 
 def _(cls: type[PropertyProtocol]) -> None:
     cls.value  # error: [unresolved-attribute]

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5033,10 +5033,10 @@ def _(flag: bool) -> None:
     reveal_type(infer_producer(cls))  # revealed: int | str
 ```
 
-## Protocol definition objects as `type[Self]` receivers
+## Protocol definition objects as generic self receivers
 
 A protocol definition object is not a concrete inhabitant of `type[P]`, but it remains a valid
-receiver for classmethods defined on the protocol itself.
+receiver for classmethods defined on the protocol itself using either `type[Self]` or `type[T]`.
 
 ```toml
 [environment]
@@ -5044,7 +5044,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Protocol, Self, cast
+from typing import Protocol, Self, TypeVar, cast
 
 class SelfFactory(Protocol):
     @classmethod
@@ -5067,6 +5067,31 @@ class GenericSelfFactory[T](Protocol):
         return cast(Self, object())
 
 reveal_type(GenericSelfFactory[int].make(1))  # revealed: GenericSelfFactory[int]
+
+T_legacy = TypeVar("T_legacy", bound="LegacySelfFactory")
+
+class LegacySelfFactory(Protocol):
+    @classmethod
+    def make(cls: type[T_legacy]) -> T_legacy:
+        return cast(T_legacy, object())
+
+reveal_type(LegacySelfFactory.make())  # revealed: LegacySelfFactory
+
+class Pep695SelfFactory(Protocol):
+    @classmethod
+    def make[T: Pep695SelfFactory](cls: type[T]) -> T:
+        return cast(T, object())
+
+reveal_type(Pep695SelfFactory.make())  # revealed: Pep695SelfFactory
+
+T_unrelated = TypeVar("T_unrelated", bound=int)
+
+class UnrelatedBoundFactory(Protocol):
+    @classmethod
+    def make(cls: type[T_unrelated]) -> T_unrelated:
+        return cast(T_unrelated, object())
+
+UnrelatedBoundFactory.make()  # error: [invalid-argument-type]
 
 class GenericFactory[T](Protocol):
     @classmethod

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4824,7 +4824,7 @@ def _(cls: type[PropertyProtocol]) -> None:
 ```
 
 Even when construction returns a `Foo`, the class object itself must provide the required class
-variable and method.
+variable and method (the instance attribute is not required).
 
 ```py
 class MissingClassVar(metaclass=FactoryMeta):

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4917,8 +4917,8 @@ class SelfFactoryImpl:
 static_assert(is_assignable_to(TypeOf[SelfFactoryImpl], type[SelfFactory]))
 ```
 
-Protocol classes and abstract classes do not inhabit `type[Foo]` because they cannot be instantiated
-to produce a `Foo`.
+Protocol and abstract class objects are accepted as inhabitants of `type[Foo]`. This is
+intentionally more permissive than the typing spec, which requires a concrete class.
 
 ```py
 from abc import ABC, ABCMeta, abstractmethod
@@ -4929,8 +4929,8 @@ class AbstractFoo(ABC):
     @abstractmethod
     def method(self) -> bytes: ...
 
-static_assert(not is_assignable_to(TypeOf[Foo], type[Foo]))
-static_assert(not is_assignable_to(TypeOf[AbstractFoo], type[Foo]))
+static_assert(is_assignable_to(TypeOf[Foo], type[Foo]))
+static_assert(is_assignable_to(TypeOf[AbstractFoo], type[Foo]))
 ```
 
 A structural implementation can use any subclass of `type` as its metaclass, so `type[Foo]` is not
@@ -5078,10 +5078,10 @@ def _(cls: type[P] | type[int]) -> None:
     preserved: type[P] | type[int] = class_identity(cls)
 ```
 
-The protocol class object itself remains distinct from structural `type[P]`.
+The protocol class object is also accepted by the identity function as an inhabitant of `type[P]`.
 
 ```py
-class_identity(P)  # error: [invalid-argument-type]
+reveal_type(class_identity(P))  # revealed: type[P]
 ```
 
 Generic protocol arguments are also preserved through the identity function.
@@ -5142,73 +5142,6 @@ def _(
     if isinstance(condition, RuntimeProtocol):
         reveal_type(type(condition))  # revealed: type[RuntimeProtocol[int]] | (type[int] & type[RuntimeProtocol[object]])
         values[type(condition)] = condition
-```
-
-## Protocol class objects as generic self receivers
-
-A protocol class does not inhabit `type[P]`, but it can still receive a class method declared on the
-protocol itself. This exception applies only to the method's receiver.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from typing import Protocol, Self, TypeVar, cast
-
-class SelfFactory(Protocol):
-    @classmethod
-    def make(cls) -> Self:
-        return cast(Self, object())
-
-reveal_type(SelfFactory.make())  # revealed: SelfFactory
-not_concrete: type[SelfFactory] = SelfFactory  # error: [invalid-assignment]
-```
-
-The specialization of a generic protocol class is retained when binding `Self`.
-
-```py
-class GenericSelfFactory[T](Protocol):
-    @classmethod
-    def make(cls, value: T) -> Self:
-        return cast(Self, object())
-
-reveal_type(GenericSelfFactory[int].make(1))  # revealed: GenericSelfFactory[int]
-```
-
-Bound type variables are the pre-PEP 673 spelling of generic self. Both legacy syntax and PEP 695
-method type parameters are supported.
-
-```py
-T_legacy = TypeVar("T_legacy", bound="LegacySelfFactory")
-
-class LegacySelfFactory(Protocol):
-    @classmethod
-    def make(cls: type[T_legacy]) -> T_legacy:
-        return cast(T_legacy, object())
-
-reveal_type(LegacySelfFactory.make())  # revealed: LegacySelfFactory
-
-class Pep695SelfFactory(Protocol):
-    @classmethod
-    def make[T: Pep695SelfFactory](cls: type[T]) -> T:
-        return cast(T, object())
-
-reveal_type(Pep695SelfFactory.make())  # revealed: Pep695SelfFactory
-```
-
-The receiver exception does not bypass an unrelated type-variable bound.
-
-```py
-T_unrelated = TypeVar("T_unrelated", bound=int)
-
-class UnrelatedBoundFactory(Protocol):
-    @classmethod
-    def make(cls: type[T_unrelated]) -> T_unrelated:
-        return cast(T_unrelated, object())
-
-UnrelatedBoundFactory.make()  # error: [invalid-argument-type]
 ```
 
 ## Regression test for `ClassVar` members in stubs

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4778,9 +4778,11 @@ static_assert(is_subtype_of(type[Baz], type[Foo]))
 static_assert(is_subtype_of(TypeOf[Baz], type[Foo]))
 ```
 
-If a metaclass customizes construction, its return type determines whether the class object
-satisfies `type[Foo]`. `BadFactory` would normally construct a `Foo`, but its metaclass returns an
-`object` instead.
+As stated above, a class object must construct instances that satisfy `Foo` in order to inhabit
+`type[Foo]`. The type of instances a class is considered to construct respects the `__call__` of its
+metaclass. `Factory` constructs `Baz` instances (and itself has the necessary attributes to satisfy
+the classvar/method portion of `Foo`), so it inhabits `type[Foo]`. `BadFactory` constructs `object`,
+which does not satisfy `Foo`, so it cannot inhabit `type[Foo]`.
 
 ```py
 class FactoryMeta(type):

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -432,7 +432,7 @@ And as a corollary, `type[MyProtocol]` can also be called:
 
 ```py
 def f(x: type[MyProtocol]):
-    reveal_type(x())  # revealed: @Todo(type[T] for protocols)
+    reveal_type(x())  # revealed: MyProtocol
 ```
 
 ## Members of a protocol
@@ -2961,7 +2961,7 @@ class Foo(Protocol):
     def method(self) -> str: ...
 
 def f(x: Foo):
-    reveal_type(type(x).method)  # revealed: def method(self, /) -> str
+    reveal_type(type(x).method)  # revealed: (self, /) -> str
 
 class Bar:
     def __init__(self):
@@ -4368,7 +4368,7 @@ def _(r: Recursive):
     reveal_type(r.t)  # revealed: tuple[int, tuple[str, Recursive]]
     reveal_type(r.callable1)  # revealed: (int, /) -> Recursive
     reveal_type(r.callable2)  # revealed: (Recursive, /) -> int
-    reveal_type(r.subtype_of)  # revealed: @Todo(type[T] for protocols)
+    reveal_type(r.subtype_of)  # revealed: type[Recursive]
     reveal_type(r.generic)  # revealed: GenericC[Recursive]
     reveal_type(r.method(r))  # revealed: Recursive
     reveal_type(r.nested)  # revealed: Recursive | ((Recursive, tuple[Recursive, Recursive], /) -> Recursive)
@@ -4723,12 +4723,18 @@ Where `P` is a protocol type, a class object `N` can be said to inhabit the type
 - All method members on `P` exist on the class object `N`
 - Instantiating `N` creates an object that would satisfy the protocol `P`
 
-Currently meta-protocols are not fully supported by ty, but we try to keep false positives to a
-minimum in the meantime.
+Properties and ordinary instance attributes are not required to exist on `N` itself. For
+compatibility with other type checkers, however, attribute lookup on a value of type `type[P]`
+exposes ordinary instance attributes even though they are not required on `N`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
-from typing import Protocol, ClassVar
-from ty_extensions import static_assert
+from typing import Any, ClassVar, Protocol, Self
+from ty_extensions import Unknown, static_assert
 from ty_extensions._internal import TypeOf, is_assignable_to, is_subtype_of
 
 class Foo(Protocol):
@@ -4737,39 +4743,243 @@ class Foo(Protocol):
     def method(self) -> bytes: ...
 
 def _(f: type[Foo]):
-    reveal_type(f)  # revealed: type[@Todo(type[T] for protocols)]
-
-    # TODO: we should emit `unresolved-attribute` here: although we would accept this for a
-    # nominal class, we would see any class `N` as inhabiting `Foo` if it had an implicit
-    # instance attribute `x`, and implicit instance attributes are rarely bound on the class
-    # object.
-    reveal_type(f.x)  # revealed: @Todo(type[T] for protocols)
-
-    # TODO: should be `str`
-    reveal_type(f.y)  # revealed: @Todo(type[T] for protocols)
+    reveal_type(f)  # revealed: type[Foo]
+    reveal_type(f.x)  # revealed: int
+    f.x = 1
+    f.x = "bad"  # error: [invalid-assignment]
+    reveal_type(f.y)  # revealed: str
     f.y = "foo"  # fine
-
-    # TODO: should be `Callable[[Foo], bytes]`
-    reveal_type(f.method)  # revealed: @Todo(type[T] for protocols)
+    f.y = b"bad"  # error: [invalid-assignment]
+    reveal_type(f.method)  # revealed: (self, /) -> bytes
+    reveal_type(f())  # revealed: Foo
 
 class Bar: ...
 
-# TODO: these should pass
-static_assert(not is_assignable_to(type[Bar], type[Foo]))  # error: [static-assert-error]
-static_assert(not is_assignable_to(TypeOf[Bar], type[Foo]))  # error: [static-assert-error]
+static_assert(not is_assignable_to(type[Bar], type[Foo]))
+static_assert(not is_assignable_to(TypeOf[Bar], type[Foo]))
+static_assert(not is_subtype_of(type[Bar], type[Foo]))
+static_assert(not is_subtype_of(TypeOf[Bar], type[Foo]))
 
 class Baz:
-    x: int
     y: ClassVar[str] = "foo"
+    def __init__(self) -> None:
+        self.x = 1
     def method(self) -> bytes:
         return b"foo"
 
 static_assert(is_assignable_to(type[Baz], type[Foo]))
 static_assert(is_assignable_to(TypeOf[Baz], type[Foo]))
+static_assert(is_subtype_of(type[Baz], type[Foo]))
+static_assert(is_subtype_of(TypeOf[Baz], type[Foo]))
 
-# TODO: these should pass
-static_assert(is_subtype_of(type[Baz], type[Foo]))  # error: [static-assert-error]
-static_assert(is_subtype_of(TypeOf[Baz], type[Foo]))  # error: [static-assert-error]
+class FactoryMeta(type):
+    def __call__(self) -> Baz:
+        return Baz()
+
+class Factory(metaclass=FactoryMeta):
+    y: ClassVar[str] = "foo"
+    def method(self) -> bytes:
+        return b"foo"
+
+static_assert(is_assignable_to(TypeOf[Factory], type[Foo]))
+
+class BadFactoryMeta(type):
+    def __call__(self) -> object:
+        return object()
+
+class BadFactory(metaclass=BadFactoryMeta):
+    y: ClassVar[str] = "foo"
+    def method(self) -> bytes:
+        return b"foo"
+
+static_assert(not is_assignable_to(TypeOf[BadFactory], type[Foo]))
+
+class PropertyProtocol(Protocol):
+    @property
+    def value(self) -> int: ...
+
+class PropertyImpl:
+    @property
+    def value(self) -> int:
+        return 1
+
+static_assert(is_assignable_to(TypeOf[PropertyImpl], type[PropertyProtocol]))
+
+def _(cls: type[PropertyProtocol]) -> None:
+    # Properties are discarded from the class-object requirements and retain normal class lookup.
+    reveal_type(cls.value)  # revealed: property
+
+class MissingClassVar:
+    def __init__(self) -> None:
+        self.x = 1
+    def method(self) -> bytes:
+        return b"foo"
+
+static_assert(not is_assignable_to(type[MissingClassVar], type[Foo]))
+
+class MissingMethod:
+    y: ClassVar[str] = "foo"
+    def __init__(self) -> None:
+        self.x = 1
+
+static_assert(not is_assignable_to(type[MissingMethod], type[Foo]))
+
+class MissingInstanceAttribute:
+    y: ClassVar[str] = "foo"
+    def method(self) -> bytes:
+        return b"foo"
+
+static_assert(not is_assignable_to(type[MissingInstanceAttribute], type[Foo]))
+
+class StaticMethod:
+    y: ClassVar[str] = "foo"
+    def __init__(self) -> None:
+        self.x = 1
+    @staticmethod
+    def method() -> bytes:
+        return b"foo"
+
+# The instance-side call is compatible, but the method is not available on the class with the
+# unbound signature required by `type[Foo]`.
+static_assert(not is_assignable_to(type[StaticMethod], type[Foo]))
+
+class DecoratedMethods(Protocol):
+    @staticmethod
+    def static(value: int) -> str: ...
+    @classmethod
+    def class_(cls, value: int) -> str: ...
+
+class DecoratedMethodsImpl:
+    @staticmethod
+    def static(value: int) -> str:
+        return str(value)
+    @classmethod
+    def class_(cls, value: int) -> str:
+        return str(value)
+
+static_assert(is_assignable_to(TypeOf[DecoratedMethodsImpl], type[DecoratedMethods]))
+
+def decorated_method(value: int) -> str:
+    return str(value)
+
+class InstanceOnlyDecoratedMethods:
+    def __init__(self) -> None:
+        self.static = decorated_method
+        self.class_ = decorated_method
+
+# The constructed instance satisfies the protocol, but the methods are absent from the class.
+static_assert(not is_assignable_to(TypeOf[InstanceOnlyDecoratedMethods], type[DecoratedMethods]))
+
+def _(cls: type[DecoratedMethods]) -> None:
+    reveal_type(cls.static)  # revealed: (value: int) -> str
+    reveal_type(cls.class_)  # revealed: (value: int) -> str
+
+class SelfFactory(Protocol):
+    @classmethod
+    def make(cls) -> Self: ...
+
+class SelfFactoryImpl:
+    @classmethod
+    def make(cls) -> Self:
+        return cls()
+
+static_assert(is_assignable_to(TypeOf[SelfFactoryImpl], type[SelfFactory]))
+
+from abc import ABC, ABCMeta, abstractmethod
+
+class AbstractFoo(ABC):
+    x: int
+    y: ClassVar[str] = "foo"
+    @abstractmethod
+    def method(self) -> bytes: ...
+
+# `type[Foo]` describes concrete structural implementations, not the protocol class itself or an
+# abstract implementation.
+static_assert(not is_assignable_to(TypeOf[Foo], type[Foo]))
+static_assert(not is_assignable_to(TypeOf[AbstractFoo], type[Foo]))
+
+# Structural implementations are only guaranteed to use a subclass of `type`.
+static_assert(is_subtype_of(type[Foo], type))
+static_assert(not is_subtype_of(type[Foo], ABCMeta))
+
+static_assert(is_assignable_to(type[Any], type[Foo]))
+static_assert(is_assignable_to(type[Unknown], type[Foo]))
+static_assert(not is_subtype_of(type[Any], type[Foo]))
+static_assert(not is_subtype_of(type[Unknown], type[Foo]))
+
+class InstanceAttributeProtocol(Protocol):
+    value: int
+
+class ClassVariableProtocol(Protocol):
+    value: ClassVar[int]
+
+# The intentionally broad lookup on `type[InstanceAttributeProtocol]` must not turn an ordinary
+# instance attribute into a `ClassVar` requirement for assignability.
+static_assert(not is_assignable_to(type[InstanceAttributeProtocol], type[ClassVariableProtocol]))
+
+class HidingMeta(type):
+    @property
+    def method(cls) -> int:
+        return 1
+
+class HiddenMethod(metaclass=HidingMeta):
+    y: ClassVar[str] = "foo"
+    def __init__(self) -> None:
+        self.x = 1
+    def method(self) -> bytes:
+        return b"foo"
+
+# The metaclass data descriptor wins over the otherwise-compatible unbound instance method.
+static_assert(not is_assignable_to(TypeOf[HiddenMethod], type[Foo]))
+
+class GenericFoo[T](Protocol):
+    value: T
+    def get(self) -> T: ...
+
+class IntFoo:
+    def __init__(self) -> None:
+        self.value = 1
+    def get(self) -> int:
+        return self.value
+
+class GenericFooImpl[T]:
+    def __init__(self, value: T) -> None:
+        self.value = value
+    def get(self) -> T:
+        return self.value
+
+static_assert(is_assignable_to(type[IntFoo], type[GenericFoo[int]]))
+static_assert(not is_assignable_to(type[IntFoo], type[GenericFoo[str]]))
+
+def _(f: type[GenericFoo[int]]) -> None:
+    reveal_type(f)  # revealed: type[GenericFoo[int]]
+    reveal_type(f.value)  # revealed: int
+    reveal_type(f.get)  # revealed: (self, /) -> int
+    reveal_type(f())  # revealed: GenericFoo[int]
+
+def infer_meta_protocol[T](cls: type[GenericFoo[T]]) -> T:
+    raise NotImplementedError
+
+def meta_protocol_identity[T](cls: type[GenericFoo[T]]) -> type[GenericFoo[T]]:
+    return cls
+
+reveal_type(infer_meta_protocol(IntFoo))  # revealed: int
+reveal_type(meta_protocol_identity(IntFoo))  # revealed: type[GenericFoo[int]]
+reveal_type(infer_meta_protocol(GenericFooImpl[int]))  # revealed: int
+reveal_type(meta_protocol_identity(GenericFooImpl[int]))  # revealed: type[GenericFoo[int]]
+
+def _(f: type[GenericFoo[int]]) -> None:
+    reveal_type(infer_meta_protocol(f))  # revealed: int
+
+class Producer[T](Protocol):
+    def get(self) -> T: ...
+
+def infer_producer[T](cls: type[Producer[T]]) -> T:
+    raise NotImplementedError
+
+def _(flag: bool) -> None:
+    cls = GenericFooImpl[int] if flag else GenericFooImpl[str]
+    reveal_type(infer_producer(cls))  # revealed: int | str
 ```
 
 ## Regression test for `ClassVar` members in stubs

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4805,29 +4805,6 @@ class BadFactory(Baz, metaclass=BadFactoryMeta): ...
 static_assert(not is_assignable_to(TypeOf[BadFactory], type[Foo]))
 ```
 
-A `@property` declaration requires a readable attribute on the constructed instance, but does not
-require the implementation to use `@property` or guarantee that the attribute exists on the class
-object.
-
-```py
-class PropertyProtocol(Protocol):
-    @property
-    def value(self) -> int: ...
-
-class PropertyImpl:
-    def __init__(self) -> None:
-        self.value = 1
-
-static_assert(is_assignable_to(TypeOf[PropertyImpl], type[PropertyProtocol]))
-
-class MissingProperty: ...
-
-static_assert(not is_assignable_to(TypeOf[MissingProperty], type[PropertyProtocol]))
-
-def _(cls: type[PropertyProtocol]) -> None:
-    cls.value  # error: [unresolved-attribute]
-```
-
 Even when construction returns a `Foo`, the class object itself must provide the required class
 variable and method (the instance attribute is not required).
 
@@ -4871,9 +4848,8 @@ class StaticMethod:
 static_assert(not is_assignable_to(type[StaticMethod], type[Foo]))
 ```
 
-Static methods and class methods declared by a protocol are checked on the candidate class object,
-not on its metaclass. It is not enough for the constructed instance to acquire callables with
-matching signatures.
+Static methods and class methods declared by a protocol are checked on the candidate class object.
+They can be provided by the candidate's metaclass.
 
 ```py
 class DecoratedMethods(Protocol):
@@ -4892,6 +4868,24 @@ class DecoratedMethodsImpl:
 
 static_assert(is_assignable_to(TypeOf[DecoratedMethodsImpl], type[DecoratedMethods]))
 
+class DecoratedMethodsMeta(type):
+    @staticmethod
+    def static(value: int) -> str:
+        return str(value)
+    @classmethod
+    def class_(cls, value: int) -> str:
+        return str(value)
+    def __call__(self) -> DecoratedMethodsImpl:
+        return DecoratedMethodsImpl()
+
+class MetaclassOnlyDecoratedMethods(metaclass=DecoratedMethodsMeta): ...
+
+static_assert(is_assignable_to(TypeOf[MetaclassOnlyDecoratedMethods], type[DecoratedMethods]))
+```
+
+It is not enough for the constructed instance to acquire callables with matching signatures.
+
+```py
 def decorated_method(value: int) -> str:
     return str(value)
 
@@ -4920,6 +4914,29 @@ class SelfFactoryImpl:
         return cls()
 
 static_assert(is_assignable_to(TypeOf[SelfFactoryImpl], type[SelfFactory]))
+```
+
+A `@property` declaration requires a readable attribute on the constructed instance, but does not
+require the implementation to use `@property` or guarantee that the attribute exists on the class
+object.
+
+```py
+class PropertyProtocol(Protocol):
+    @property
+    def value(self) -> int: ...
+
+class PropertyImpl:
+    def __init__(self) -> None:
+        self.value = 1
+
+static_assert(is_assignable_to(TypeOf[PropertyImpl], type[PropertyProtocol]))
+
+class MissingProperty: ...
+
+static_assert(not is_assignable_to(TypeOf[MissingProperty], type[PropertyProtocol]))
+
+def _(cls: type[PropertyProtocol]) -> None:
+    cls.value  # error: [unresolved-attribute]
 ```
 
 Protocol and abstract class objects are accepted as inhabitants of `type[Foo]`. This is
@@ -5105,46 +5122,19 @@ def predicate(cls: type[P]) -> bool:
 classmethod(predicate)
 ```
 
-## Narrowing `type[Protocol]` with `issubclass`
+## Meta-types of protocol intersections
 
-Narrowing `type[ConstructorProtocol]` with `issubclass` currently loses the protocol's constructor
-signature. The reveal and diagnostic below document this known limitation.
+Calling `type()` on an intersection retains each positive class constraint.
 
 ```py
 from typing import Protocol
 
-class ConstructorProtocol(Protocol):
-    def __init__(self, *, value: int) -> None: ...
+class RuntimeProtocol(Protocol):
+    def get(self) -> object: ...
 
-class ConstructorBase: ...
-
-def _(cls: type[ConstructorProtocol]) -> ConstructorProtocol:
-    assert issubclass(cls, ConstructorBase)
-    reveal_type(cls)  # revealed: type[ConstructorBase]
-    return cls(value=1)  # error: [unknown-argument]
-```
-
-## Meta-types of protocol intersections
-
-Calling `type()` on an intersection retains each positive class constraint. This matters after an
-`isinstance` check introduces a protocol constraint on one arm of a union.
-
-```py
-from typing import Protocol, TypeVar, runtime_checkable
-
-T_runtime_co = TypeVar("T_runtime_co", covariant=True)
-
-@runtime_checkable
-class RuntimeProtocol(Protocol[T_runtime_co]):
-    def get(self) -> T_runtime_co: ...
-
-def _(
-    condition: RuntimeProtocol[int] | int,
-    values: dict[type[RuntimeProtocol[object]], RuntimeProtocol[object]],
-) -> None:
-    if isinstance(condition, RuntimeProtocol):
-        reveal_type(type(condition))  # revealed: type[RuntimeProtocol[int]] | (type[int] & type[RuntimeProtocol[object]])
-        values[type(condition)] = condition
+def _(value: RuntimeProtocol) -> None:
+    if isinstance(value, int):
+        reveal_type(type(value))  # revealed: type[RuntimeProtocol] & type[int]
 ```
 
 ## Regression test for `ClassVar` members in stubs

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4803,8 +4803,8 @@ class BadFactory(Baz, metaclass=BadFactoryMeta): ...
 static_assert(not is_assignable_to(TypeOf[BadFactory], type[Foo]))
 ```
 
-A property is required on the constructed instance, but not on the class object itself. Looking up
-the property on `type[PropertyProtocol]` follows normal class lookup.
+A property declaration requires a readable attribute on the constructed instance, but does not
+guarantee that the attribute exists on the class object.
 
 ```py
 class PropertyProtocol(Protocol):
@@ -4812,14 +4812,13 @@ class PropertyProtocol(Protocol):
     def value(self) -> int: ...
 
 class PropertyImpl:
-    @property
-    def value(self) -> int:
-        return 1
+    def __init__(self) -> None:
+        self.value = 1
 
 static_assert(is_assignable_to(TypeOf[PropertyImpl], type[PropertyProtocol]))
 
 def _(cls: type[PropertyProtocol]) -> None:
-    reveal_type(cls.value)  # revealed: property
+    cls.value  # error: [unresolved-attribute]
 ```
 
 Even when construction returns a `Foo`, the class object itself must provide the required class

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4994,6 +4994,19 @@ def predicate(cls: type[Foo]) -> bool:
 
 classmethod(predicate)
 
+class ConstructorProtocol(Protocol):
+    def __init__(self, *, value: int) -> None: ...
+
+class ConstructorBase: ...
+
+def _(cls: type[ConstructorProtocol]) -> ConstructorProtocol:
+    assert issubclass(cls, ConstructorBase)
+    # TODO: Preserve the structural protocol meta-type through this narrowing. The redundancy
+    # relation currently eliminates it based on inhabitant subtyping, even though it carries a
+    # constructor signature that is not present on the nominal base.
+    reveal_type(cls)  # revealed: type[ConstructorBase]
+    return cls(value=1)  # error: [unknown-argument]
+
 T_runtime_co = TypeVar("T_runtime_co", covariant=True)
 
 @runtime_checkable

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4733,7 +4733,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Any, ClassVar, Protocol, Self
+from typing import Any, ClassVar, Protocol, Self, TypeVar, runtime_checkable
 from ty_extensions import Unknown, static_assert
 from ty_extensions._internal import TypeOf, is_assignable_to, is_subtype_of
 
@@ -4970,6 +4970,21 @@ reveal_type(meta_protocol_identity(GenericFooImpl[int]))  # revealed: type[Gener
 
 def _(f: type[GenericFoo[int]]) -> None:
     reveal_type(infer_meta_protocol(f))  # revealed: int
+
+T_runtime_co = TypeVar("T_runtime_co", covariant=True)
+
+@runtime_checkable
+class RuntimeProtocol(Protocol[T_runtime_co]):
+    def get(self) -> T_runtime_co: ...
+
+def _(
+    condition: RuntimeProtocol[int] | int,
+    values: dict[type[RuntimeProtocol[object]], RuntimeProtocol[object]],
+) -> None:
+    if isinstance(condition, RuntimeProtocol):
+        reveal_type(condition)  # revealed: RuntimeProtocol[int] | (int & RuntimeProtocol[object])
+        reveal_type(type(condition))  # revealed: type[RuntimeProtocol[int]] | (type[int] & type[RuntimeProtocol[object]])
+        values[type(condition)] = condition
 
 class Producer[T](Protocol):
     def get(self) -> T: ...

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -898,8 +898,8 @@ class ExplicitSubclass(HasXWithDefault): ...
 reveal_type(ExplicitSubclass.x)  # revealed: int
 
 def f(arg: HasXWithDefault):
-    # TODO: should emit `[unresolved-reference]` and reveal `Unknown`
-    reveal_type(type(arg).x)  # revealed: int
+    # `arg` may be an implicit subtype that does not define `x` on its class object.
+    type(arg).x  # error: [unresolved-attribute]
 ```
 
 Assignments in a class body of a protocol -- of any kind -- are not permitted by ty unless the
@@ -4723,9 +4723,9 @@ Where `P` is a protocol type, a class object `N` can be said to inhabit the type
 - All method members on `P` exist on the class object `N`
 - Instantiating `N` creates an object that would satisfy the protocol `P`
 
-Properties and ordinary instance attributes are not required to exist on `N` itself. For
-compatibility with other type checkers, however, attribute lookup on a value of type `type[P]`
-exposes ordinary instance attributes even though they are not required on `N`.
+Ordinary instance attributes are required only on the object constructed by `N`, so they are not
+available through a value of type `type[P]`. Class variables and methods are available because every
+inhabitant of `type[P]` must provide them on the class object itself.
 
 ```toml
 [environment]
@@ -4744,9 +4744,8 @@ class Foo(Protocol):
 
 def _(f: type[Foo]):
     reveal_type(f)  # revealed: type[Foo]
-    reveal_type(f.x)  # revealed: int
-    f.x = 1
-    f.x = "bad"  # error: [invalid-assignment]
+    f.x  # error: [unresolved-attribute]
+    f.x = 1  # error: [invalid-assignment]
     reveal_type(f.y)  # revealed: str
     f.y = "foo"  # fine
     f.y = b"bad"  # error: [invalid-assignment]
@@ -4948,8 +4947,7 @@ static_assert(is_assignable_to(type[Any], type[Foo]))
 static_assert(not is_subtype_of(type[Any], type[Foo]))
 ```
 
-The broad attribute lookup on `type[Protocol]` does not turn an instance attribute into a `ClassVar`
-requirement.
+An ordinary instance attribute does not satisfy a `ClassVar` requirement on another meta-protocol.
 
 ```py
 class InstanceAttributeProtocol(Protocol):
@@ -5013,7 +5011,6 @@ static_assert(is_assignable_to(type[IntFoo], type[GenericFoo[int]]))
 static_assert(not is_assignable_to(type[IntFoo], type[GenericFoo[str]]))
 
 def _(f: type[GenericFoo[int]]) -> None:
-    reveal_type(f.value)  # revealed: int
     reveal_type(f.get)  # revealed: (self, /) -> int
     reveal_type(f())  # revealed: GenericFoo[int]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5020,6 +5020,50 @@ def _(flag: bool) -> None:
     reveal_type(infer_producer(cls))  # revealed: int | str
 ```
 
+## Protocol definition objects as `type[Self]` receivers
+
+A protocol definition object is not a concrete inhabitant of `type[P]`, but it remains a valid
+receiver for classmethods defined on the protocol itself.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, Self, cast
+
+class SelfFactory(Protocol):
+    @classmethod
+    def make(cls) -> Self:
+        return cast(Self, object())
+
+reveal_type(SelfFactory.make())  # revealed: SelfFactory
+not_concrete: type[SelfFactory] = SelfFactory  # error: [invalid-assignment]
+
+class ExplicitSelfFactory(Protocol):
+    @classmethod
+    def make(cls: type[Self]) -> Self:
+        return cast(Self, object())
+
+reveal_type(ExplicitSelfFactory.make())  # revealed: ExplicitSelfFactory
+
+class GenericSelfFactory[T](Protocol):
+    @classmethod
+    def make(cls, value: T) -> Self:
+        return cast(Self, object())
+
+reveal_type(GenericSelfFactory[int].make(1))  # revealed: GenericSelfFactory[int]
+
+class GenericFactory[T](Protocol):
+    @classmethod
+    def make(cls) -> T:
+        return cast(T, object())
+
+def build[T](factory: GenericFactory[T]) -> T:
+    return factory.make()
+```
+
 ## Regression test for `ClassVar` members in stubs
 
 In an early version of our protocol implementation, we didn't retain the `ClassVar` qualifier for

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4733,8 +4733,8 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Any, ClassVar, Protocol, Self, TypeVar, runtime_checkable
-from ty_extensions import Unknown, static_assert
+from typing import Any, ClassVar, Protocol, Self
+from ty_extensions import static_assert
 from ty_extensions._internal import TypeOf, is_assignable_to, is_subtype_of
 
 class Foo(Protocol):
@@ -4752,7 +4752,13 @@ def _(f: type[Foo]):
     f.y = b"bad"  # error: [invalid-assignment]
     reveal_type(f.method)  # revealed: (self, /) -> bytes
     reveal_type(f())  # revealed: Foo
+```
 
+Both a particular class object, represented by `TypeOf[C]`, and an arbitrary subclass of `C`,
+represented by `type[C]`, are checked structurally. `Bar` fails the protocol requirements, while
+`Baz` satisfies them.
+
+```py
 class Bar: ...
 
 static_assert(not is_assignable_to(type[Bar], type[Foo]))
@@ -4771,7 +4777,13 @@ static_assert(is_assignable_to(type[Baz], type[Foo]))
 static_assert(is_assignable_to(TypeOf[Baz], type[Foo]))
 static_assert(is_subtype_of(type[Baz], type[Foo]))
 static_assert(is_subtype_of(TypeOf[Baz], type[Foo]))
+```
 
+If a metaclass customizes construction, its return type determines whether the class object
+satisfies `type[Foo]`. `BadFactory` would normally construct a `Foo`, but its metaclass returns an
+`object` instead.
+
+```py
 class FactoryMeta(type):
     def __call__(self) -> Baz:
         return Baz()
@@ -4787,13 +4799,15 @@ class BadFactoryMeta(type):
     def __call__(self) -> object:
         return object()
 
-class BadFactory(metaclass=BadFactoryMeta):
-    y: ClassVar[str] = "foo"
-    def method(self) -> bytes:
-        return b"foo"
+class BadFactory(Baz, metaclass=BadFactoryMeta): ...
 
 static_assert(not is_assignable_to(TypeOf[BadFactory], type[Foo]))
+```
 
+A property is required on the constructed instance, but not on the class object itself. Looking up
+the property on `type[PropertyProtocol]` follows normal class lookup.
+
+```py
 class PropertyProtocol(Protocol):
     @property
     def value(self) -> int: ...
@@ -4806,31 +4820,41 @@ class PropertyImpl:
 static_assert(is_assignable_to(TypeOf[PropertyImpl], type[PropertyProtocol]))
 
 def _(cls: type[PropertyProtocol]) -> None:
-    # Properties are discarded from the class-object requirements and retain normal class lookup.
     reveal_type(cls.value)  # revealed: property
+```
 
-class MissingClassVar:
-    def __init__(self) -> None:
-        self.x = 1
+Even when construction returns a `Foo`, the class object itself must provide the required class
+variable and method.
+
+```py
+class MissingClassVar(metaclass=FactoryMeta):
     def method(self) -> bytes:
         return b"foo"
 
 static_assert(not is_assignable_to(type[MissingClassVar], type[Foo]))
 
-class MissingMethod:
+class MissingMethod(metaclass=FactoryMeta):
     y: ClassVar[str] = "foo"
-    def __init__(self) -> None:
-        self.x = 1
 
 static_assert(not is_assignable_to(type[MissingMethod], type[Foo]))
+```
 
+Conversely, compatible class members are not enough if construction produces an object without the
+required instance attribute.
+
+```py
 class MissingInstanceAttribute:
     y: ClassVar[str] = "foo"
     def method(self) -> bytes:
         return b"foo"
 
 static_assert(not is_assignable_to(type[MissingInstanceAttribute], type[Foo]))
+```
 
+A static method can have the right signature on an instance while lacking the unbound signature
+required on the class object.
+
+```py
 class StaticMethod:
     y: ClassVar[str] = "foo"
     def __init__(self) -> None:
@@ -4839,10 +4863,14 @@ class StaticMethod:
     def method() -> bytes:
         return b"foo"
 
-# The instance-side call is compatible, but the method is not available on the class with the
-# unbound signature required by `type[Foo]`.
 static_assert(not is_assignable_to(type[StaticMethod], type[Foo]))
+```
 
+Static methods and class methods declared by a protocol are checked on the candidate class object,
+not on its metaclass. It is not enough for the constructed instance to acquire callables with
+matching signatures.
+
+```py
 class DecoratedMethods(Protocol):
     @staticmethod
     def static(value: int) -> str: ...
@@ -4867,13 +4895,16 @@ class InstanceOnlyDecoratedMethods:
         self.static = decorated_method
         self.class_ = decorated_method
 
-# The constructed instance satisfies the protocol, but the methods are absent from the class.
 static_assert(not is_assignable_to(TypeOf[InstanceOnlyDecoratedMethods], type[DecoratedMethods]))
 
 def _(cls: type[DecoratedMethods]) -> None:
     reveal_type(cls.static)  # revealed: (value: int) -> str
     reveal_type(cls.class_)  # revealed: (value: int) -> str
+```
 
+`Self` in a class method is bound to the class object being checked.
+
+```py
 class SelfFactory(Protocol):
     @classmethod
     def make(cls) -> Self: ...
@@ -4884,7 +4915,12 @@ class SelfFactoryImpl:
         return cls()
 
 static_assert(is_assignable_to(TypeOf[SelfFactoryImpl], type[SelfFactory]))
+```
 
+Protocol classes and abstract classes do not inhabit `type[Foo]` because they cannot be instantiated
+to produce a `Foo`.
+
+```py
 from abc import ABC, ABCMeta, abstractmethod
 
 class AbstractFoo(ABC):
@@ -4893,30 +4929,41 @@ class AbstractFoo(ABC):
     @abstractmethod
     def method(self) -> bytes: ...
 
-# `type[Foo]` describes concrete structural implementations, not the protocol class itself or an
-# abstract implementation.
 static_assert(not is_assignable_to(TypeOf[Foo], type[Foo]))
 static_assert(not is_assignable_to(TypeOf[AbstractFoo], type[Foo]))
+```
 
-# Structural implementations are only guaranteed to use a subclass of `type`.
+A structural implementation can use any subclass of `type` as its metaclass, so `type[Foo]` is not
+limited to the protocol class's own metaclass.
+
+```py
 static_assert(is_subtype_of(type[Foo], type))
 static_assert(not is_subtype_of(type[Foo], ABCMeta))
+```
 
+`type[Any]` is assignable to `type[Foo]` but is not a subtype of it.
+
+```py
 static_assert(is_assignable_to(type[Any], type[Foo]))
-static_assert(is_assignable_to(type[Unknown], type[Foo]))
 static_assert(not is_subtype_of(type[Any], type[Foo]))
-static_assert(not is_subtype_of(type[Unknown], type[Foo]))
+```
 
+The broad attribute lookup on `type[Protocol]` does not turn an instance attribute into a `ClassVar`
+requirement.
+
+```py
 class InstanceAttributeProtocol(Protocol):
     value: int
 
 class ClassVariableProtocol(Protocol):
     value: ClassVar[int]
 
-# The intentionally broad lookup on `type[InstanceAttributeProtocol]` must not turn an ordinary
-# instance attribute into a `ClassVar` requirement for assignability.
 static_assert(not is_assignable_to(type[InstanceAttributeProtocol], type[ClassVariableProtocol]))
+```
 
+A metaclass data descriptor takes precedence over an otherwise compatible unbound instance method.
+
+```py
 class HidingMeta(type):
     @property
     def method(cls) -> int:
@@ -4929,8 +4976,22 @@ class HiddenMethod(metaclass=HidingMeta):
     def method(self) -> bytes:
         return b"foo"
 
-# The metaclass data descriptor wins over the otherwise-compatible unbound instance method.
 static_assert(not is_assignable_to(TypeOf[HiddenMethod], type[Foo]))
+```
+
+## Generic meta-protocols
+
+Generic protocol arguments are preserved by structural matching, member lookup, and construction.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to
 
 class GenericFoo[T](Protocol):
     value: T
@@ -4952,47 +5013,102 @@ static_assert(is_assignable_to(type[IntFoo], type[GenericFoo[int]]))
 static_assert(not is_assignable_to(type[IntFoo], type[GenericFoo[str]]))
 
 def _(f: type[GenericFoo[int]]) -> None:
-    reveal_type(f)  # revealed: type[GenericFoo[int]]
     reveal_type(f.value)  # revealed: int
     reveal_type(f.get)  # revealed: (self, /) -> int
     reveal_type(f())  # revealed: GenericFoo[int]
+```
 
+Inference derives the protocol argument from exact class objects, generic aliases, and parameters
+already annotated as `type[GenericFoo[T]]`.
+
+```py
 def infer_meta_protocol[T](cls: type[GenericFoo[T]]) -> T:
     raise NotImplementedError
 
-def meta_protocol_identity[T](cls: type[GenericFoo[T]]) -> type[GenericFoo[T]]:
-    return cls
-
 reveal_type(infer_meta_protocol(IntFoo))  # revealed: int
-reveal_type(meta_protocol_identity(IntFoo))  # revealed: type[GenericFoo[int]]
 reveal_type(infer_meta_protocol(GenericFooImpl[int]))  # revealed: int
-reveal_type(meta_protocol_identity(GenericFooImpl[int]))  # revealed: type[GenericFoo[int]]
 
 def _(f: type[GenericFoo[int]]) -> None:
     reveal_type(infer_meta_protocol(f))  # revealed: int
+```
+
+For a covariant protocol, inference combines the specializations contributed by each class object in
+a union.
+
+```py
+class Producer[T](Protocol):
+    def get(self) -> T: ...
+
+def infer_producer[T](cls: type[Producer[T]]) -> T:
+    raise NotImplementedError
+
+def _(flag: bool) -> None:
+    cls = GenericFooImpl[int] if flag else GenericFooImpl[str]
+    reveal_type(infer_producer(cls))  # revealed: int | str
+```
+
+## Generic substitution of `type[Protocol]`
+
+Passing `type[P]` through a generic identity function preserves its structural meaning, including
+inside a union.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, TypeVar
+
+class P(Protocol):
+    value: int
+
+class GenericP[T](Protocol):
+    value: T
 
 T_identity = TypeVar("T_identity")
 
 def class_identity(cls: type[T_identity]) -> type[T_identity]:
     return cls
 
-def _(cls: type[Foo]) -> None:
-    preserved: type[Foo] = class_identity(cls)
+def _(cls: type[P]) -> None:
+    preserved: type[P] = class_identity(cls)
 
-def _(cls: type[Foo] | type[int]) -> None:
-    preserved: type[Foo] | type[int] = class_identity(cls)
+def _(cls: type[P] | type[int]) -> None:
+    preserved: type[P] | type[int] = class_identity(cls)
+```
 
-# A protocol class is not a concrete inhabitant of structural `type[Foo]`.
-class_identity(Foo)  # error: [invalid-argument-type]
+The protocol class object itself remains distinct from structural `type[P]`.
 
-def _(cls: type[GenericFoo[int]]) -> None:
-    preserved: type[GenericFoo[int]] = class_identity(cls)
-    wrong: type[GenericFoo[str]] = class_identity(cls)  # error: [invalid-assignment]
+```py
+class_identity(P)  # error: [invalid-argument-type]
+```
 
-def predicate(cls: type[Foo]) -> bool:
+Generic protocol arguments are also preserved through the identity function.
+
+```py
+def _(cls: type[GenericP[int]]) -> None:
+    preserved: type[GenericP[int]] = class_identity(cls)
+    wrong: type[GenericP[str]] = class_identity(cls)  # error: [invalid-assignment]
+```
+
+The same substitution occurs when `type[P]` appears in a generic callable signature such as
+`classmethod`.
+
+```py
+def predicate(cls: type[P]) -> bool:
     return True
 
 classmethod(predicate)
+```
+
+## Narrowing `type[Protocol]` with `issubclass`
+
+Narrowing `type[ConstructorProtocol]` with `issubclass` currently loses the protocol's constructor
+signature. The reveal and diagnostic below document this known limitation.
+
+```py
+from typing import Protocol
 
 class ConstructorProtocol(Protocol):
     def __init__(self, *, value: int) -> None: ...
@@ -5001,11 +5117,17 @@ class ConstructorBase: ...
 
 def _(cls: type[ConstructorProtocol]) -> ConstructorProtocol:
     assert issubclass(cls, ConstructorBase)
-    # TODO: Preserve the structural protocol meta-type through this narrowing. The redundancy
-    # relation currently eliminates it based on inhabitant subtyping, even though it carries a
-    # constructor signature that is not present on the nominal base.
     reveal_type(cls)  # revealed: type[ConstructorBase]
     return cls(value=1)  # error: [unknown-argument]
+```
+
+## Meta-types of protocol intersections
+
+Calling `type()` on an intersection retains each positive class constraint. This matters after an
+`isinstance` check introduces a protocol constraint on one arm of a union.
+
+```py
+from typing import Protocol, TypeVar, runtime_checkable
 
 T_runtime_co = TypeVar("T_runtime_co", covariant=True)
 
@@ -5018,25 +5140,14 @@ def _(
     values: dict[type[RuntimeProtocol[object]], RuntimeProtocol[object]],
 ) -> None:
     if isinstance(condition, RuntimeProtocol):
-        reveal_type(condition)  # revealed: RuntimeProtocol[int] | (int & RuntimeProtocol[object])
         reveal_type(type(condition))  # revealed: type[RuntimeProtocol[int]] | (type[int] & type[RuntimeProtocol[object]])
         values[type(condition)] = condition
-
-class Producer[T](Protocol):
-    def get(self) -> T: ...
-
-def infer_producer[T](cls: type[Producer[T]]) -> T:
-    raise NotImplementedError
-
-def _(flag: bool) -> None:
-    cls = GenericFooImpl[int] if flag else GenericFooImpl[str]
-    reveal_type(infer_producer(cls))  # revealed: int | str
 ```
 
-## Protocol definition objects as generic self receivers
+## Protocol class objects as generic self receivers
 
-A protocol definition object is not a concrete inhabitant of `type[P]`, but it remains a valid
-receiver for classmethods defined on the protocol itself using either `type[Self]` or `type[T]`.
+A protocol class does not inhabit `type[P]`, but it can still receive a class method declared on the
+protocol itself. This exception applies only to the method's receiver.
 
 ```toml
 [environment]
@@ -5053,21 +5164,23 @@ class SelfFactory(Protocol):
 
 reveal_type(SelfFactory.make())  # revealed: SelfFactory
 not_concrete: type[SelfFactory] = SelfFactory  # error: [invalid-assignment]
+```
 
-class ExplicitSelfFactory(Protocol):
-    @classmethod
-    def make(cls: type[Self]) -> Self:
-        return cast(Self, object())
+The specialization of a generic protocol class is retained when binding `Self`.
 
-reveal_type(ExplicitSelfFactory.make())  # revealed: ExplicitSelfFactory
-
+```py
 class GenericSelfFactory[T](Protocol):
     @classmethod
     def make(cls, value: T) -> Self:
         return cast(Self, object())
 
 reveal_type(GenericSelfFactory[int].make(1))  # revealed: GenericSelfFactory[int]
+```
 
+Bound type variables are the pre-PEP 673 spelling of generic self. Both legacy syntax and PEP 695
+method type parameters are supported.
+
+```py
 T_legacy = TypeVar("T_legacy", bound="LegacySelfFactory")
 
 class LegacySelfFactory(Protocol):
@@ -5083,7 +5196,11 @@ class Pep695SelfFactory(Protocol):
         return cast(T, object())
 
 reveal_type(Pep695SelfFactory.make())  # revealed: Pep695SelfFactory
+```
 
+The receiver exception does not bypass an unrelated type-variable bound.
+
+```py
 T_unrelated = TypeVar("T_unrelated", bound=int)
 
 class UnrelatedBoundFactory(Protocol):
@@ -5092,14 +5209,6 @@ class UnrelatedBoundFactory(Protocol):
         return cast(T_unrelated, object())
 
 UnrelatedBoundFactory.make()  # error: [invalid-argument-type]
-
-class GenericFactory[T](Protocol):
-    @classmethod
-    def make(cls) -> T:
-        return cast(T, object())
-
-def build[T](factory: GenericFactory[T]) -> T:
-    return factory.make()
 ```
 
 ## Regression test for `ClassVar` members in stubs

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_cl…_(288988036f34ddcf).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/protocols.md_-_Protocols_-_Calls_to_protocol_cl…_(288988036f34ddcf).snap
@@ -37,7 +37,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/protocols.md
 22 | 
 23 | reveal_type(SubclassOfGenericProtocol[int]())  # revealed: SubclassOfGenericProtocol[int]
 24 | def f(x: type[MyProtocol]):
-25 |     reveal_type(x())  # revealed: @Todo(type[T] for protocols)
+25 |     reveal_type(x())  # revealed: MyProtocol
 ```
 
 # Diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -451,7 +451,7 @@ var: type[C[int]] = C[int]
 var: type[C[int]] = D[int]  # error: [invalid-assignment] "Object of type `<class 'D[int]'>` is not assignable to `type[C[int]]`"
 ```
 
-However, generic `Protocol` classes are still TODO:
+Generic protocol meta-types preserve their specialization and use structural assignability:
 
 ```py
 from typing import Protocol
@@ -459,11 +459,10 @@ from typing import Protocol
 class Proto[U](Protocol):
     def some_method(self): ...
 
-# TODO: should be error: [invalid-assignment]
-var: type[Proto[int]] = C[int]
+var: type[Proto[int]] = C[int]  # error: [invalid-assignment]
 
 def _(p: type[Proto[int]]):
-    reveal_type(p)  # revealed: type[@Todo(type[T] for protocols)]
+    reveal_type(p)  # revealed: type[Proto[int]]
 ```
 
 ## Generic `@final` classes

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6331,19 +6331,19 @@ impl<'db> Type<'db> {
     /// Class-backed protocols return their structural `type[Protocol]` view.
     #[must_use]
     pub(crate) fn dunder_class(self, db: &'db dyn Db) -> Type<'db> {
-        if self.is_typed_dict() {
-            return KnownClass::Dict
+        match self {
+            Type::Union(union) => union.map(db, |element| element.dunder_class(db)),
+            Type::Intersection(intersection) => intersection
+                .try_dunder_class(db)
+                .unwrap_or_else(|| self.to_meta_type(db)),
+            Type::ProtocolInstance(protocol) => protocol.to_meta_type(db),
+            Type::TypedDict(_) => KnownClass::Dict
                 .to_specialized_class_type(db, &[KnownClass::Str.to_instance(db), Type::object()])
                 .map(Type::from)
                 // Guard against user-customized typesheds with a broken `dict` class
-                .unwrap_or_else(Type::unknown);
+                .unwrap_or_else(Type::unknown),
+            _ => self.to_meta_type(db),
         }
-
-        if let Type::ProtocolInstance(protocol) = self {
-            return protocol.to_meta_type(db);
-        }
-
-        self.to_meta_type(db)
     }
 
     #[must_use]

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2002,6 +2002,7 @@ impl<'db> Type<'db> {
 
             Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                 SubclassOfInner::Class(_) => true,
+                SubclassOfInner::Protocol(_) => true,
                 SubclassOfInner::Dynamic(dynamic) => Type::Dynamic(dynamic).is_hintable(db),
                 SubclassOfInner::TypeVar(tvar) => Type::TypeVar(tvar).is_hintable(db),
             },
@@ -2865,7 +2866,12 @@ impl<'db> Type<'db> {
         );
 
         let own_class = match self {
-            Type::SubclassOf(subclass_of) => subclass_of.subclass_of().into_class(db),
+            Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
+                SubclassOfInner::Protocol(protocol) => {
+                    protocol.class_origin().map(|origin| *origin)
+                }
+                subclass_of => subclass_of.into_class(db),
+            },
             _ => self.to_class_type(db),
         };
         let own_class_attr = own_class.map(|class| class.own_class_member(db, None, name).inner);
@@ -4777,6 +4783,10 @@ impl<'db> Type<'db> {
                     Binding::single(self, Signature::dynamic(Type::Dynamic(dynamic_type))).into()
                 }
                 SubclassOfInner::Class(class) => self.constructor_bindings(db, class),
+                SubclassOfInner::Protocol(protocol) => protocol.class_origin().map_or_else(
+                    || Binding::single(self, Signature::dynamic(Type::unknown())).into(),
+                    |origin| self.constructor_bindings(db, *origin),
+                ),
                 SubclassOfInner::TypeVar(tvar) => {
                     let constructor_instance_type = Type::TypeVar(tvar);
                     let bindings = match tvar.typevar(db).bound_or_constraints(db) {
@@ -6296,7 +6306,10 @@ impl<'db> Type<'db> {
             }
             Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db),
             Type::BoundSuper(_) => KnownClass::Super.to_class_literal(db),
-            Type::ProtocolInstance(protocol) => protocol.to_meta_type(db),
+            // Class-member lookup on a protocol instance must use the protocol's nominal class.
+            // The structural `type[Protocol]` view is exposed by `dunder_class` and explicit
+            // `type[Protocol]` annotations instead.
+            Type::ProtocolInstance(protocol) => protocol.to_nominal_meta_type(db),
             // `TypedDict` instances are instances of `dict` at runtime, but its important that we
             // understand a more specific meta type in order to correctly handle `__getitem__`.
             Type::TypedDict(typed_dict) => match typed_dict {
@@ -6313,9 +6326,9 @@ impl<'db> Type<'db> {
 
     /// Get the type of the `__class__` attribute of this type.
     ///
-    /// For most types, this is equivalent to the meta type of this type. For `TypedDict` types,
-    /// this returns `type[dict[str, object]]` instead, because inhabitants of a `TypedDict` are
-    /// instances of `dict` at runtime.
+    /// For most types, this is equivalent to the meta type of this type. `TypedDict` types return
+    /// `type[dict[str, object]]`, because their inhabitants are instances of `dict` at runtime.
+    /// Class-backed protocols return their structural `type[Protocol]` view.
     #[must_use]
     pub(crate) fn dunder_class(self, db: &'db dyn Db) -> Type<'db> {
         if self.is_typed_dict() {
@@ -6324,6 +6337,10 @@ impl<'db> Type<'db> {
                 .map(Type::from)
                 // Guard against user-customized typesheds with a broken `dict` class
                 .unwrap_or_else(Type::unknown);
+        }
+
+        if let Type::ProtocolInstance(protocol) = self {
+            return protocol.to_meta_type(db);
         }
 
         self.to_meta_type(db)
@@ -7185,6 +7202,7 @@ impl<'db> Type<'db> {
             Self::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Dynamic(_) => None,
                 SubclassOfInner::Class(class) => class.type_definition(db),
+                SubclassOfInner::Protocol(protocol) => protocol.class_origin()?.type_definition(db),
                 SubclassOfInner::TypeVar(bound_typevar) => Some(TypeDefinition::TypeVar(
                     bound_typevar.typevar(db).definition(db)?,
                 )),

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -272,7 +272,17 @@ pub(super) fn attribute_write_requirement<'db>(
             instance_attribute_write_requirement(db, object_ty, attribute)
         }
 
-        Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
+        Type::SubclassOf(subclass_of) => subclass_of
+            .meta_write_requirement(db, attribute)
+            .map_or_else(
+                || class_attribute_write_requirement(db, object_ty, attribute),
+                |(write_ty, qualifiers)| AttributeWriteRequirement::ProtocolMember {
+                    write_ty,
+                    qualifiers,
+                },
+            ),
+
+        Type::ClassLiteral(..) | Type::GenericAlias(..) => {
             class_attribute_write_requirement(db, object_ty, attribute)
         }
 

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -268,6 +268,7 @@ impl<'db> Type<'db> {
                     SubclassOfInner::Class(class) => {
                         Type::from(class).try_bool_impl(db, allow_short_circuit, visitor)?
                     }
+                    SubclassOfInner::Protocol(_) => Truthiness::Ambiguous,
                     SubclassOfInner::TypeVar(bound_typevar) => Type::TypeVar(bound_typevar)
                         .try_bool_impl(db, allow_short_circuit, visitor)?,
                 }

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -626,6 +626,9 @@ impl<'db> BoundSuperType<'db> {
                         None,
                     )?)
                 }
+                // `type[Protocol]` is structural: an inhabitant need not inherit from the protocol
+                // class, so its MRO cannot be recovered from the protocol's nominal origin.
+                SubclassOfInner::Protocol(_) => SuperOwnerKind::Dynamic(DynamicType::Unknown),
                 SubclassOfInner::Dynamic(dynamic) => SuperOwnerKind::Dynamic(dynamic),
                 SubclassOfInner::TypeVar(bound_typevar) => {
                     let typevar = bound_typevar.typevar(db);

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4817,13 +4817,14 @@ struct ArgumentTypeChecker<'a, 'db> {
     constraint_set_errors: Vec<bool>,
 }
 
-/// Use the structural meta-type of a protocol class when binding it to a `type[Self]` receiver.
+/// Use the structural meta-type of a protocol class when binding it to a generic `type[T]`
+/// receiver.
 ///
 /// A protocol definition object is not generally an inhabitant of `type[P]`, because it cannot be
 /// instantiated to produce a `P`. It is nevertheless a valid receiver for classmethods defined on
 /// that protocol. This conversion is limited to the synthetic receiver argument so that ordinary
 /// `type[P]` parameters retain the concrete-inhabitant requirement.
-fn normalize_protocol_class_self_receiver<'db>(
+fn normalize_protocol_class_generic_self_receiver<'db>(
     db: &'db dyn Db,
     argument: Argument<'_>,
     parameter: &Parameter<'db>,
@@ -4832,10 +4833,10 @@ fn normalize_protocol_class_self_receiver<'db>(
     let Type::SubclassOf(subclass_of) = parameter.annotated_type() else {
         return argument_type;
     };
-    let Some(typevar) = subclass_of.into_type_var() else {
+    if subclass_of.into_type_var().is_none() {
         return argument_type;
-    };
-    if !matches!(argument, Argument::Synthetic) || !typevar.typevar(db).is_self(db) {
+    }
+    if !matches!(argument, Argument::Synthetic) {
         return argument_type;
     }
 
@@ -5234,7 +5235,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 let argument_type = matched_parameter
                     .argument_type
                     .unwrap_or_else(|| argument_types.get_for_declared_type(declared_type));
-                let argument_type = normalize_protocol_class_self_receiver(
+                let argument_type = normalize_protocol_class_generic_self_receiver(
                     self.db,
                     argument,
                     &parameters[parameter_index],
@@ -5275,8 +5276,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             return;
         }
 
-        argument_type =
-            normalize_protocol_class_self_receiver(self.db, argument, parameter, argument_type);
+        argument_type = normalize_protocol_class_generic_self_receiver(
+            self.db,
+            argument,
+            parameter,
+            argument_type,
+        );
 
         let mut expected_ty = parameter.annotated_type();
         if let Some(specialization) = self.specialization() {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4817,6 +4817,34 @@ struct ArgumentTypeChecker<'a, 'db> {
     constraint_set_errors: Vec<bool>,
 }
 
+/// Use the structural meta-type of a protocol class when binding it to a `type[Self]` receiver.
+///
+/// A protocol definition object is not generally an inhabitant of `type[P]`, because it cannot be
+/// instantiated to produce a `P`. It is nevertheless a valid receiver for classmethods defined on
+/// that protocol. This conversion is limited to the synthetic receiver argument so that ordinary
+/// `type[P]` parameters retain the concrete-inhabitant requirement.
+fn normalize_protocol_class_self_receiver<'db>(
+    db: &'db dyn Db,
+    argument: Argument<'_>,
+    parameter: &Parameter<'db>,
+    argument_type: Type<'db>,
+) -> Type<'db> {
+    let Type::SubclassOf(subclass_of) = parameter.annotated_type() else {
+        return argument_type;
+    };
+    let Some(typevar) = subclass_of.into_type_var() else {
+        return argument_type;
+    };
+    if !matches!(argument, Argument::Synthetic) || !typevar.typevar(db).is_self(db) {
+        return argument_type;
+    }
+
+    match argument_type.to_instance(db) {
+        Some(Type::ProtocolInstance(protocol)) => protocol.to_meta_type(db),
+        _ => argument_type,
+    }
+}
+
 /// Result of checking only the key type of a keyword-unpack argument.
 enum KeywordUnpackKeyTypeCheck<'db> {
     /// The argument type is handled by a more specific path, or does not expose mapping keys.
@@ -5193,7 +5221,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         specialization_errors: &mut Vec<BindingError<'db>>,
     ) -> bool {
         let parameters = self.signature.parameters();
-        for (argument_index, adjusted_argument_index, _, argument_types) in
+        for (argument_index, adjusted_argument_index, argument, argument_types) in
             self.enumerate_argument_types()
         {
             for matched_parameter in self.argument_matches[argument_index].iter() {
@@ -5203,11 +5231,16 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 }
 
                 let declared_type = parameters[parameter_index].annotated_type();
-                let argument_type = argument_types.get_for_declared_type(declared_type);
-                let specialization_result = builder.infer(
-                    declared_type,
-                    matched_parameter.argument_type.unwrap_or(argument_type),
+                let argument_type = matched_parameter
+                    .argument_type
+                    .unwrap_or_else(|| argument_types.get_for_declared_type(declared_type));
+                let argument_type = normalize_protocol_class_self_receiver(
+                    self.db,
+                    argument,
+                    &parameters[parameter_index],
+                    argument_type,
                 );
+                let specialization_result = builder.infer(declared_type, argument_type);
 
                 if let Err(error) = specialization_result {
                     specialization_errors.push(BindingError::SpecializationError {
@@ -5241,6 +5274,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         if self.is_gradual_variadic_parameter(parameter_index) {
             return;
         }
+
+        argument_type =
+            normalize_protocol_class_self_receiver(self.db, argument, parameter, argument_type);
 
         let mut expected_ty = parameter.annotated_type();
         if let Some(specialization) = self.specialization() {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4817,35 +4817,6 @@ struct ArgumentTypeChecker<'a, 'db> {
     constraint_set_errors: Vec<bool>,
 }
 
-/// Use the structural meta-type of a protocol class when binding it to a generic `type[T]`
-/// receiver.
-///
-/// A protocol definition object is not generally an inhabitant of `type[P]`, because it cannot be
-/// instantiated to produce a `P`. It is nevertheless a valid receiver for classmethods defined on
-/// that protocol. This conversion is limited to the synthetic receiver argument so that ordinary
-/// `type[P]` parameters retain the concrete-inhabitant requirement.
-fn normalize_protocol_class_generic_self_receiver<'db>(
-    db: &'db dyn Db,
-    argument: Argument<'_>,
-    parameter: &Parameter<'db>,
-    argument_type: Type<'db>,
-) -> Type<'db> {
-    let Type::SubclassOf(subclass_of) = parameter.annotated_type() else {
-        return argument_type;
-    };
-    if subclass_of.into_type_var().is_none() {
-        return argument_type;
-    }
-    if !matches!(argument, Argument::Synthetic) {
-        return argument_type;
-    }
-
-    match argument_type.to_instance(db) {
-        Some(Type::ProtocolInstance(protocol)) => protocol.to_meta_type(db),
-        _ => argument_type,
-    }
-}
-
 /// Result of checking only the key type of a keyword-unpack argument.
 enum KeywordUnpackKeyTypeCheck<'db> {
     /// The argument type is handled by a more specific path, or does not expose mapping keys.
@@ -5222,7 +5193,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         specialization_errors: &mut Vec<BindingError<'db>>,
     ) -> bool {
         let parameters = self.signature.parameters();
-        for (argument_index, adjusted_argument_index, argument, argument_types) in
+        for (argument_index, adjusted_argument_index, _, argument_types) in
             self.enumerate_argument_types()
         {
             for matched_parameter in self.argument_matches[argument_index].iter() {
@@ -5232,16 +5203,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 }
 
                 let declared_type = parameters[parameter_index].annotated_type();
-                let argument_type = matched_parameter
-                    .argument_type
-                    .unwrap_or_else(|| argument_types.get_for_declared_type(declared_type));
-                let argument_type = normalize_protocol_class_generic_self_receiver(
-                    self.db,
-                    argument,
-                    &parameters[parameter_index],
-                    argument_type,
+                let argument_type = argument_types.get_for_declared_type(declared_type);
+                let specialization_result = builder.infer(
+                    declared_type,
+                    matched_parameter.argument_type.unwrap_or(argument_type),
                 );
-                let specialization_result = builder.infer(declared_type, argument_type);
 
                 if let Err(error) = specialization_result {
                     specialization_errors.push(BindingError::SpecializationError {
@@ -5275,13 +5241,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         if self.is_gradual_variadic_parameter(parameter_index) {
             return;
         }
-
-        argument_type = normalize_protocol_class_generic_self_receiver(
-            self.db,
-            argument,
-            parameter,
-            argument_type,
-        );
 
         let mut expected_ty = parameter.annotated_type();
         if let Some(specialization) = self.specialization() {

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -152,6 +152,9 @@ impl<'db> Type<'db> {
             // TODO: This is unsound so in future we can consider an opt-in option to disable it.
             Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
                 SubclassOfInner::Class(class) => Some(class.into_callable(db)),
+                SubclassOfInner::Protocol(protocol) => protocol
+                    .class_origin()
+                    .map(|origin| (*origin).into_callable(db)),
                 SubclassOfInner::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         let upcast_callables = bound

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2815,6 +2815,7 @@ pub(crate) fn report_undeclared_protocol_member(
             }) => return true,
             Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                 SubclassOfInner::Class(class) => class,
+                SubclassOfInner::Protocol(_) => return true,
                 SubclassOfInner::Dynamic(DynamicType::Any) => return true,
                 SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => return false,
             },

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1061,6 +1061,15 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     write!(f.with_type(Type::Dynamic(dynamic)), "{dynamic}")?;
                     f.write_char(']')
                 }
+                SubclassOfInner::Protocol(protocol) => {
+                    f.with_type(KnownClass::Type.to_class_literal(self.db))
+                        .write_str("type")?;
+                    f.write_char('[')?;
+                    Type::ProtocolInstance(protocol)
+                        .display_with(self.db, self.settings.clone())
+                        .fmt_detailed(f)?;
+                    f.write_char(']')
+                }
                 SubclassOfInner::TypeVar(bound_typevar) => {
                     f.set_invalid_type_annotation();
                     f.with_type(KnownClass::Type.to_class_literal(self.db))
@@ -2761,6 +2770,11 @@ impl<'db> FmtDetailed<'db> for DisplaySubclassOfGroup<'db> {
                 SubclassOfInner::Dynamic(dynamic) => {
                     let rep =
                         Type::Dynamic(dynamic).representation(self.db, self.settings.singleline());
+                    join.entry(&rep);
+                }
+                SubclassOfInner::Protocol(protocol) => {
+                    let rep = Type::ProtocolInstance(protocol)
+                        .representation(self.db, self.settings.singleline());
                     join.entry(&rep);
                 }
                 SubclassOfInner::TypeVar(bound_typevar) => {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -31,9 +31,9 @@ use crate::types::visitor::{
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, CallableTypes,
     ClassLiteral, FindLegacyTypeVarsVisitor, IntersectionType, KnownClass, KnownInstanceType,
-    MaterializationKind, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
-    TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType, binding_type,
-    infer_definition_types, inferred_declaration,
+    MaterializationKind, SubclassOfInner, Type, TypeAliasType, TypeContext, TypeMapping,
+    TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType,
+    binding_type, infer_definition_types, inferred_declaration,
 };
 use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -2995,6 +2995,36 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 if !found_matching_element && let Some(error) = first_error {
                     return Err(error);
                 }
+            }
+
+            (
+                Type::SubclassOf(formal_subclass),
+                actual @ (Type::ClassLiteral(_)
+                | Type::GenericAlias(_)
+                | Type::SubclassOf(_)
+                | Type::Union(_)),
+            ) if matches!(formal_subclass.subclass_of(), SubclassOfInner::Protocol(_)) => {
+                let SubclassOfInner::Protocol(protocol) = formal_subclass.subclass_of() else {
+                    return Ok(());
+                };
+                let formal_protocol = Type::ProtocolInstance(protocol);
+                if let Type::Union(union) = actual {
+                    for element in union.elements(self.db) {
+                        self.infer_map_impl(
+                            formal_protocol,
+                            element.bindings(self.db).return_type(self.db),
+                            polarity,
+                            seen,
+                        )?;
+                    }
+                    return Ok(());
+                }
+                return self.infer_map_impl(
+                    formal_protocol,
+                    actual.bindings(self.db).return_type(self.db),
+                    polarity,
+                    seen,
+                );
             }
 
             (Type::SubclassOf(subclass_of), ty) | (ty, Type::SubclassOf(subclass_of))

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -9,7 +9,7 @@ use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::signatures::{ParametersKind, Signature};
 use crate::types::{
     CallDunderError, CallableTypes, ClassBase, ClassLiteral, ClassType, KnownClass, KnownFunction,
-    KnownUnion, Type, TypeContext,
+    KnownUnion, SubclassOfInner, Type, TypeContext,
 };
 use crate::{Db, DisplaySettings, HasDefinition, HasType, SemanticModel};
 use itertools::Either;
@@ -214,6 +214,18 @@ pub fn definitions_for_attribute<'db>(
     let db = model.db();
     let name_str = attribute.attr.as_str();
 
+    // A structural protocol meta-type still uses its nominal protocol declaration as the source
+    // location for go-to-definition, even though the origin is not a nominal upper bound.
+    let subclass_origin = |subclass_of: SubclassOfInner<'db>| {
+        let class = match subclass_of {
+            SubclassOfInner::Protocol(protocol) => protocol.class_origin().map(|origin| *origin),
+            subclass_of => subclass_of.into_class(db),
+        }?;
+        class
+            .static_class_literal(db)
+            .map(|(literal, _)| ClassLiteral::Static(literal))
+    };
+
     let mut resolved = Vec::new();
 
     // Determine the type of the LHS
@@ -267,13 +279,12 @@ pub fn definitions_for_attribute<'db>(
 
         let class_literal = match lookup_type {
             Type::ClassLiteral(class_literal) => class_literal,
-            Type::SubclassOf(subclass) => match subclass.subclass_of().into_class(db) {
-                Some(cls) => match cls.static_class_literal(db) {
-                    Some((lit, _)) => ClassLiteral::Static(lit),
-                    None => continue,
-                },
-                None => continue,
-            },
+            Type::SubclassOf(subclass) => {
+                let Some(class_literal) = subclass_origin(subclass.subclass_of()) else {
+                    continue;
+                };
+                class_literal
+            }
             _ => continue,
         };
 
@@ -291,13 +302,12 @@ pub fn definitions_for_attribute<'db>(
         if resolved.is_empty() && meta_type != lookup_type {
             let class_literal = match meta_type {
                 Type::ClassLiteral(class_literal) => class_literal,
-                Type::SubclassOf(subclass) => match subclass.subclass_of().into_class(db) {
-                    Some(cls) => match cls.static_class_literal(db) {
-                        Some((lit, _)) => ClassLiteral::Static(lit),
-                        None => continue,
-                    },
-                    None => continue,
-                },
+                Type::SubclassOf(subclass) => {
+                    let Some(class_literal) = subclass_origin(subclass.subclass_of()) else {
+                        continue;
+                    };
+                    class_literal
+                }
                 _ => continue,
             };
 
@@ -2061,6 +2071,7 @@ fn extract_class_literal<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassLit
                     Some(class_type.class_literal(db))
                 }
                 crate::types::SubclassOfInner::Dynamic(_)
+                | crate::types::SubclassOfInner::Protocol(_)
                 | crate::types::SubclassOfInner::TypeVar(_) => None,
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9438,6 +9438,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     "Attribute lookup on a dynamic `SubclassOf` type \
                                     should always return a bound symbol"
                                 ),
+                                SubclassOfInner::Protocol(_) => false,
                                 SubclassOfInner::TypeVar(_) => false,
                             }
                         }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1226,12 +1226,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let infer_type_argument = |builder: &mut Self, slice: &ast::Expr| {
             let slice_ty = builder.infer_type_expression(slice);
-            if matches!(slice_ty, Type::ProtocolInstance(_)) {
-                return SubclassOfType::from(
-                    builder.db(),
-                    todo_type!("type[T] for protocols").expect_dynamic(),
-                );
-            }
             SubclassOfType::try_from_instance(builder.db(), slice_ty).unwrap_or_else(|| {
                 match slice_ty {
                     Type::Callable(_) => invalid_type_argument(builder, slice),
@@ -1282,12 +1276,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         _ => self.infer_subclass_of_type_expression(parameters),
                     },
                     value_ty @ Type::ClassLiteral(class_literal) => {
-                        if class_literal.is_protocol(self.db()) {
-                            SubclassOfType::from(
-                                self.db(),
-                                todo_type!("type[T] for protocols").expect_dynamic(),
-                            )
-                        } else if class_literal.is_tuple(self.db()) {
+                        if class_literal.is_tuple(self.db()) {
                             let class_type = self
                                 .infer_tuple_type_expression(subscript)
                                 .map(|tuple_type| tuple_type.to_class_type(self.db()))
@@ -1298,13 +1287,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 Some(generic_context) => {
                                     let db = self.db();
                                     let specialize = &|types: &[Option<Type<'db>>]| {
-                                        SubclassOfType::from(
-                                            db,
-                                            class_literal.apply_specialization(db, |_| {
-                                                generic_context
-                                                    .specialize_partial(db, types.iter().copied())
-                                            }),
-                                        )
+                                        let class = class_literal.apply_specialization(db, |_| {
+                                            generic_context
+                                                .specialize_partial(db, types.iter().copied())
+                                        });
+                                        if class_literal.is_protocol(db) {
+                                            match Type::instance(db, class) {
+                                                Type::ProtocolInstance(protocol) => {
+                                                    SubclassOfType::from_protocol(protocol)
+                                                }
+                                                _ => SubclassOfType::from(db, class),
+                                            }
+                                        } else {
+                                            SubclassOfType::from(db, class)
+                                        }
                                     };
                                     self.infer_explicit_callable_specialization(
                                         subscript,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -584,12 +584,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     /// The effective constructor return must satisfy the instance protocol, while the class object
     /// itself must provide the protocol's `ClassVar` and unbound method requirements. Ordinary
     /// instance attributes and properties are intentionally not required on the class object.
+    ///
+    /// `meta_ty` must be a class-object type represented by `ClassLiteral`, `SubclassOf`, or
+    /// `GenericAlias`. Other types are not necessarily subtypes of `type` or callable, and could
+    /// therefore incorrectly satisfy this check through an `Unknown` constructor return type.
     pub(super) fn check_meta_type_satisfies_protocol(
         &self,
         db: &'db dyn Db,
         meta_ty: Type<'db>,
         protocol: ProtocolInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        debug_assert!(matches!(
+            meta_ty,
+            Type::ClassLiteral(_) | Type::SubclassOf(_) | Type::GenericAlias(_)
+        ));
+
         let constructed_ty = meta_ty.bindings(db).return_type(db);
         self.check_type_pair(db, constructed_ty, Type::ProtocolInstance(protocol))
             .and(db, self.constraints, || {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -9,7 +9,7 @@ use ty_module_resolver::{ModuleName, file_to_module};
 use super::protocol_class::ProtocolInterface;
 use super::{
     BoundTypeVarIdentity, BoundTypeVarInstance, ClassType, DivergentType, KnownClass,
-    MaterializationKind, SubclassOfType, Type, TypeVarVariance,
+    MaterializationKind, SubclassOfInner, SubclassOfType, Type, TypeVarVariance,
 };
 use crate::place::PlaceAndQualifiers;
 use crate::types::constraints::{
@@ -579,6 +579,41 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         result.or(db, self.constraints, || structurally_satisfied)
     }
 
+    /// Return whether a class-object type inhabits `type[protocol]`.
+    ///
+    /// The effective constructor return must satisfy the instance protocol, while the class object
+    /// itself must provide the protocol's `ClassVar` and unbound method requirements. Ordinary
+    /// instance attributes and properties are intentionally not required on the class object.
+    pub(super) fn check_meta_type_satisfies_protocol(
+        &self,
+        db: &'db dyn Db,
+        meta_ty: Type<'db>,
+        protocol: ProtocolInstanceType<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        let source_class = match meta_ty {
+            Type::ClassLiteral(class) => Some(class.default_specialization(db)),
+            Type::GenericAlias(alias) => Some(ClassType::Generic(alias)),
+            Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
+                SubclassOfInner::Class(class) => Some(class),
+                SubclassOfInner::Dynamic(_)
+                | SubclassOfInner::Protocol(_)
+                | SubclassOfInner::TypeVar(_) => None,
+            },
+            _ => None,
+        };
+        if source_class
+            .is_some_and(|class| class.is_protocol(db) || !class.abstract_methods(db).is_empty())
+        {
+            return self.never();
+        }
+
+        let constructed_ty = meta_ty.bindings(db).return_type(db);
+        self.check_type_pair(db, constructed_ty, Type::ProtocolInstance(protocol))
+            .and(db, self.constraints, || {
+                self.check_meta_protocol_members(db, constructed_ty, meta_ty, protocol)
+            })
+    }
+
     pub(super) fn check_nominal_instance_pair(
         &self,
         db: &'db dyn Db,
@@ -809,10 +844,18 @@ impl<'db> ProtocolInstanceType<'db> {
         }
     }
 
-    /// Return the meta-type of this protocol-instance type.
+    /// Return the class that defines this protocol, if it is class-backed.
+    pub(super) const fn class_origin(self) -> Option<ProtocolClass<'db>> {
+        match self.inner {
+            Protocol::FromClass(class) => Some(class),
+            Protocol::Synthesized(_) => None,
+        }
+    }
+
+    /// Return the structural meta-type of this protocol-instance type.
     pub(super) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
         match self.inner {
-            Protocol::FromClass(class) => SubclassOfType::from(db, class),
+            Protocol::FromClass(_) => SubclassOfType::from_protocol(self),
 
             // TODO: we can and should do better here.
             //
@@ -828,6 +871,14 @@ impl<'db> ProtocolInstanceType<'db> {
             //     reveal_type(type(x).__call__)        # mypy: "def (*args: Any, **kwds: Any) -> Any"
             // ```
             Protocol::Synthesized(_) => KnownClass::Type.to_instance(db),
+        }
+    }
+
+    /// Return the nominal meta-type used for internal class-member lookup on a protocol instance.
+    pub(super) fn to_nominal_meta_type(self, db: &'db dyn Db) -> Type<'db> {
+        match self.inner {
+            Protocol::FromClass(class) => SubclassOfType::from(db, *class),
+            Protocol::Synthesized(_) => self.to_meta_type(db),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -9,7 +9,7 @@ use ty_module_resolver::{ModuleName, file_to_module};
 use super::protocol_class::ProtocolInterface;
 use super::{
     BoundTypeVarIdentity, BoundTypeVarInstance, ClassType, DivergentType, KnownClass,
-    MaterializationKind, SubclassOfInner, SubclassOfType, Type, TypeVarVariance,
+    MaterializationKind, SubclassOfType, Type, TypeVarVariance,
 };
 use crate::place::PlaceAndQualifiers;
 use crate::types::constraints::{
@@ -590,23 +590,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         meta_ty: Type<'db>,
         protocol: ProtocolInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let source_class = match meta_ty {
-            Type::ClassLiteral(class) => Some(class.default_specialization(db)),
-            Type::GenericAlias(alias) => Some(ClassType::Generic(alias)),
-            Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
-                SubclassOfInner::Class(class) => Some(class),
-                SubclassOfInner::Dynamic(_)
-                | SubclassOfInner::Protocol(_)
-                | SubclassOfInner::TypeVar(_) => None,
-            },
-            _ => None,
-        };
-        if source_class
-            .is_some_and(|class| class.is_protocol(db) || !class.abstract_methods(db).is_empty())
-        {
-            return self.never();
-        }
-
         let constructed_ty = meta_ty.bindings(db).return_type(db);
         self.check_type_pair(db, constructed_ty, Type::ProtocolInstance(protocol))
             .and(db, self.constraints, || {

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -249,6 +249,22 @@ impl<'db> AllMembers<'db> {
                 SubclassOfInner::Dynamic(_) => {
                     self.extend_with_type(db, KnownClass::Type.to_instance(db));
                 }
+                SubclassOfInner::Protocol(protocol) => {
+                    if let Some((class_literal, _)) = protocol
+                        .class_origin()
+                        .and_then(|origin| origin.static_class_literal(db))
+                    {
+                        self.extend_with_class_members(db, ty, ClassLiteral::Static(class_literal));
+                        self.extend_with_synthetic_members(
+                            db,
+                            ty,
+                            ClassLiteral::Static(class_literal),
+                        );
+                    }
+                    // A structural implementation can use any metaclass, so only members of
+                    // `type` itself are guaranteed in addition to the protocol interface.
+                    self.extend_with_type(db, KnownClass::Type.to_instance(db));
+                }
                 _ => {
                     if let Some(class_type) = subclass_of_type.subclass_of().into_class(db) {
                         if let Some((class_literal, _)) = class_type.static_class_literal(db) {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -466,6 +466,11 @@ impl ClassInfoConstraintFunction {
                     // e.g. `isinstance(x, list[int])` fails at runtime.
                     SubclassOfInner::Class(ClassType::Generic(_)) => None,
                     SubclassOfInner::Dynamic(dynamic) => Some(Type::Dynamic(dynamic)),
+                    // TODO: This narrowing is not fully sound:
+                    // - `type[protocol]` currently admits non-concrete classes, some of which are
+                    //   not valid runtime class-info arguments.
+                    // - A class can inhabit `type[protocol]` because its metaclass constructs
+                    //   protocol-conforming objects even if its nominal instances do not conform.
                     SubclassOfInner::Protocol(protocol) => match self {
                         ClassInfoConstraintFunction::IsInstance => {
                             Some(Type::ProtocolInstance(protocol))

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -466,6 +466,12 @@ impl ClassInfoConstraintFunction {
                     // e.g. `isinstance(x, list[int])` fails at runtime.
                     SubclassOfInner::Class(ClassType::Generic(_)) => None,
                     SubclassOfInner::Dynamic(dynamic) => Some(Type::Dynamic(dynamic)),
+                    SubclassOfInner::Protocol(protocol) => match self {
+                        ClassInfoConstraintFunction::IsInstance => {
+                            Some(Type::ProtocolInstance(protocol))
+                        }
+                        ClassInfoConstraintFunction::IsSubclass => Some(classinfo),
+                    },
                     SubclassOfInner::TypeVar(bound_typevar) => match self {
                         ClassInfoConstraintFunction::IsSubclass => Some(classinfo),
                         ClassInfoConstraintFunction::IsInstance => {
@@ -3079,7 +3085,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     match subclass_of.subclass_of().with_transposed_type_var(db) {
                         SubclassOfInner::Class(ClassType::NonGeneric(class)) => Some(class),
                         SubclassOfInner::Class(ClassType::Generic(_))
-                        | SubclassOfInner::Dynamic(_) => None,
+                        | SubclassOfInner::Dynamic(_)
+                        | SubclassOfInner::Protocol(_) => None,
                         SubclassOfInner::TypeVar(tvar) => {
                             find_underlying_class(db, tvar.typevar(db).upper_bound(db)?)
                         }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -320,12 +320,10 @@ impl<'db> ProtocolInterface<'db> {
         })
     }
 
-    /// Returns the effective write requirement exposed through `type[Protocol]` lookup.
+    /// Returns the write requirement exposed through `type[Protocol]` lookup.
     ///
-    /// Attribute lookup on `type[Protocol]` intentionally exposes ordinary instance members even
-    /// though those members are not required to exist on a class object that satisfies the
-    /// meta-protocol. Prefer a member's true class capability when it has one (`ClassVar`s and
-    /// methods), and otherwise use its instance capability for this compatibility behavior.
+    /// Only members required on every class object that satisfies the meta-protocol are available.
+    /// Ordinary instance attributes are required on the constructed object instead.
     pub(super) fn meta_write_requirement(
         self,
         db: &'db dyn Db,
@@ -383,23 +381,20 @@ impl<'db> ProtocolInterface<'db> {
             .unwrap_or_else(|| Type::object().member(db, name))
     }
 
-    /// Looks up a member through the compatibility behavior of `type[Protocol]`.
+    /// Looks up a member guaranteed to exist on every inhabitant of `type[Protocol]`.
     ///
-    /// True class capabilities take precedence so methods retain their unbound signatures and
-    /// `ClassVar`s retain their class-side types. Ordinary instance attributes fall back to their
-    /// instance read type, matching the behavior of other type checkers even though meta-protocol
-    /// assignability does not require those members on the class object. Properties retain normal
-    /// class-object lookup behavior through the protocol origin.
+    /// Methods retain their unbound signatures and `ClassVar`s retain their class-side types.
+    /// Properties retain normal class-object lookup behavior through the protocol origin.
     pub(super) fn meta_member(
         self,
         db: &'db dyn Db,
         name: &str,
     ) -> Option<PlaceAndQualifiers<'db>> {
         self.member_by_name(db, name).and_then(|member| {
-            let read = member.meta_access(db)?.read?;
+            let read = member.meta_access(db)?.read;
             Some(PlaceAndQualifiers {
                 place: read
-                    .resolve(db)
+                    .and_then(|read| read.resolve(db))
                     .map(|read| Place::bound(read.ty()))
                     .unwrap_or(Place::Undefined)
                     .with_provenance(Provenance::from_definition(member.definition())),
@@ -1109,11 +1104,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         if self.is_property() || self.has_todo_type() {
             return None;
         }
-        let capabilities = self.capabilities(db);
-        Some(ProtocolMemberAccess::new(
-            capabilities.class.read.or(capabilities.instance.read),
-            capabilities.class.write.or(capabilities.instance.write),
-        ))
+        Some(self.capabilities(db).class)
     }
 
     fn has_todo_type(&self) -> bool {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -320,6 +320,29 @@ impl<'db> ProtocolInterface<'db> {
         })
     }
 
+    /// Returns the effective write requirement exposed through `type[Protocol]` lookup.
+    ///
+    /// Attribute lookup on `type[Protocol]` intentionally exposes ordinary instance members even
+    /// though those members are not required to exist on a class object that satisfies the
+    /// meta-protocol. Prefer a member's true class capability when it has one (`ClassVar`s and
+    /// methods), and otherwise use its instance capability for this compatibility behavior.
+    pub(super) fn meta_write_requirement(
+        self,
+        db: &'db dyn Db,
+        receiver_ty: Type<'db>,
+        name: &str,
+    ) -> Option<(Option<Type<'db>>, TypeQualifiers)> {
+        self.member_by_name(db, name).and_then(|member| {
+            Some((
+                member
+                    .meta_access(db)?
+                    .write
+                    .and_then(|write| write.bind_self(db, receiver_ty)),
+                member.qualifiers(),
+            ))
+        })
+    }
+
     /// Returns the callable signature exposed by instance access to a protocol's `__call__`
     /// method.
     ///
@@ -358,6 +381,31 @@ impl<'db> ProtocolInterface<'db> {
                 }
             })
             .unwrap_or_else(|| Type::object().member(db, name))
+    }
+
+    /// Looks up a member through the compatibility behavior of `type[Protocol]`.
+    ///
+    /// True class capabilities take precedence so methods retain their unbound signatures and
+    /// `ClassVar`s retain their class-side types. Ordinary instance attributes fall back to their
+    /// instance read type, matching the behavior of other type checkers even though meta-protocol
+    /// assignability does not require those members on the class object. Properties retain normal
+    /// class-object lookup behavior through the protocol origin.
+    pub(super) fn meta_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+    ) -> Option<PlaceAndQualifiers<'db>> {
+        self.member_by_name(db, name).and_then(|member| {
+            let read = member.meta_access(db)?.read?;
+            Some(PlaceAndQualifiers {
+                place: read
+                    .resolve(db)
+                    .map(|read| Place::bound(read.ty()))
+                    .unwrap_or(Place::Undefined)
+                    .with_provenance(Provenance::from_definition(member.definition())),
+                qualifiers: member.qualifiers(),
+            })
+        })
     }
 
     pub(super) fn recursive_type_normalized_impl(
@@ -1055,6 +1103,17 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         } else {
             capabilities
         }
+    }
+
+    fn meta_access(&self, db: &'db dyn Db) -> Option<ProtocolMemberAccess<'db>> {
+        if self.is_property() || self.has_todo_type() {
+            return None;
+        }
+        let capabilities = self.capabilities(db);
+        Some(ProtocolMemberAccess::new(
+            capabilities.class.read.or(capabilities.instance.read),
+            capabilities.class.write.or(capabilities.instance.write),
+        ))
     }
 
     fn has_todo_type(&self) -> bool {
@@ -1804,6 +1863,64 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             });
         }
         result
+    }
+
+    /// Checks the members that a class object must provide to inhabit `type[Protocol]`.
+    ///
+    /// Ordinary instance attributes and properties are deliberately absent from this check. They
+    /// are requirements on the object produced by constructing the class, not on the class object
+    /// itself. `ClassVar`s and methods are checked through class access; unlike ordinary protocol
+    /// matching, method access compares the unbound signature instead of checking only presence.
+    pub(super) fn check_meta_protocol_members(
+        &self,
+        db: &'db dyn Db,
+        instance_ty: Type<'db>,
+        meta_ty: Type<'db>,
+        protocol: ProtocolInstanceType<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        protocol
+            .interface(db)
+            .members(db)
+            .when_all(db, self.constraints, |member| {
+                let required = member.capabilities(db).class;
+                if required.read.is_none() && required.write.is_none() {
+                    return self.always();
+                }
+
+                let result = if member.is_method() {
+                    required.read.map_or_else(
+                        || self.always(),
+                        |required_ty| {
+                            self.check_protocol_member_read(
+                                db,
+                                instance_ty,
+                                meta_ty,
+                                &member,
+                                required_ty,
+                                ProtocolMemberAccessMode::Class,
+                            )
+                        },
+                    )
+                } else {
+                    self.type_satisfies_protocol_member_access(
+                        db,
+                        instance_ty,
+                        meta_ty,
+                        &member,
+                        required,
+                        ProtocolMemberAccessMode::Class,
+                    )
+                };
+
+                if let Some(context) = self.report_context()
+                    && result.is_never_satisfied(db)
+                {
+                    context.push(ErrorContext::ProtocolMemberIncompatible {
+                        member_name: member.name.into(),
+                    });
+                }
+                result
+            })
     }
 
     /// Compares either instance access or class access when relating two protocol members.

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -384,7 +384,8 @@ impl<'db> ProtocolInterface<'db> {
     /// Looks up a member guaranteed to exist on every inhabitant of `type[Protocol]`.
     ///
     /// Methods retain their unbound signatures and `ClassVar`s retain their class-side types.
-    /// Properties retain normal class-object lookup behavior through the protocol origin.
+    /// Properties are only required on the constructed instance, so they are undefined even when
+    /// the nominal protocol origin provides a property descriptor.
     pub(super) fn meta_member(
         self,
         db: &'db dyn Db,
@@ -1101,7 +1102,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
     }
 
     fn meta_access(&self, db: &'db dyn Db) -> Option<ProtocolMemberAccess<'db>> {
-        if self.is_property() || self.has_todo_type() {
+        if self.has_todo_type() {
             return None;
         }
         Some(self.capabilities(db).class)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2129,15 +2129,29 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // `Literal[<class 'C'>]` is a subtype of `type[B]` if `C` is a subclass of `B`,
             // since `type[B]` describes all possible runtime subclasses of the class object `B`.
             (Type::ClassLiteral(source_cls), Type::SubclassOf(target_subclass_ty)) => {
-                target_subclass_ty
-                    .subclass_of()
-                    .into_class(db)
-                    .map(|target_cls| {
-                        self.check_class_pair(db, source_cls.default_specialization(db), target_cls)
-                    })
-                    .unwrap_or_else(|| {
-                        ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
-                    })
+                match target_subclass_ty.subclass_of() {
+                    SubclassOfInner::Protocol(target_protocol) => self
+                        .check_meta_type_satisfies_protocol(
+                            db,
+                            Type::ClassLiteral(source_cls),
+                            target_protocol,
+                        ),
+                    target => target
+                        .into_class(db)
+                        .map(|target_cls| {
+                            self.check_class_pair(
+                                db,
+                                source_cls.default_specialization(db),
+                                target_cls,
+                            )
+                        })
+                        .unwrap_or_else(|| {
+                            ConstraintSet::from_bool(
+                                self.constraints,
+                                self.is_eager_assignability(),
+                            )
+                        }),
+                }
             }
 
             // Similarly, `<class 'C'>` is assignable to `<class 'C[...]'>` (a generic-alias type)
@@ -2160,15 +2174,25 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 ),
 
             (Type::GenericAlias(source_alias), Type::SubclassOf(target_subclass_ty)) => {
-                target_subclass_ty
-                    .subclass_of()
-                    .into_class(db)
-                    .map(|target_cls| {
-                        self.check_class_pair(db, ClassType::Generic(source_alias), target_cls)
-                    })
-                    .unwrap_or_else(|| {
-                        ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
-                    })
+                match target_subclass_ty.subclass_of() {
+                    SubclassOfInner::Protocol(target_protocol) => self
+                        .check_meta_type_satisfies_protocol(
+                            db,
+                            Type::GenericAlias(source_alias),
+                            target_protocol,
+                        ),
+                    target => target
+                        .into_class(db)
+                        .map(|target_cls| {
+                            self.check_class_pair(db, ClassType::Generic(source_alias), target_cls)
+                        })
+                        .unwrap_or_else(|| {
+                            ConstraintSet::from_bool(
+                                self.constraints,
+                                self.is_eager_assignability(),
+                            )
+                        }),
+                }
             }
 
             // This branch asks: given two types `type[T]` and `type[S]`, is `type[T]` a subtype of `type[S]`?
@@ -2947,6 +2971,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             | (Type::ClassLiteral(class_b), Type::SubclassOf(subclass_of_ty)) => {
                 match subclass_of_ty.subclass_of() {
                     SubclassOfInner::Dynamic(_) => self.never(),
+                    SubclassOfInner::Protocol(_) => self.never(),
                     SubclassOfInner::Class(class_a) => ConstraintSet::from_bool(
                         self.constraints,
                         !class_a.could_exist_in_mro_of_with_disjointness_checker(
@@ -2963,6 +2988,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             | (Type::GenericAlias(alias_b), Type::SubclassOf(subclass_of_ty)) => {
                 match subclass_of_ty.subclass_of() {
                     SubclassOfInner::Dynamic(_) => self.never(),
+                    SubclassOfInner::Protocol(_) => self.never(),
                     SubclassOfInner::Class(class_a) => ConstraintSet::from_bool(
                         self.constraints,
                         !class_a.could_exist_in_mro_of_with_disjointness_checker(
@@ -2988,6 +3014,9 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 }
                 SubclassOfInner::Class(class) => {
                     self.check_type_pair(db, class.metaclass_instance_type(db), other)
+                }
+                SubclassOfInner::Protocol(_) => {
+                    self.check_type_pair(db, KnownClass::Type.to_instance(db), other)
                 }
                 SubclassOfInner::TypeVar(_) => unreachable!(),
             },

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -927,6 +927,30 @@ impl<'db> IntersectionType<'db> {
         builder.build()
     }
 
+    /// Compute the `__class__` type when this intersection contains a positive class-backed
+    /// protocol constraint.
+    ///
+    /// Negative instance constraints are not transferred: an object not satisfying `P` does not
+    /// imply that other instances of its class cannot satisfy `P`.
+    pub(crate) fn try_dunder_class(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        if !self.iter_positive(db).any(|positive| {
+            matches!(
+                positive,
+                Type::ProtocolInstance(protocol) if protocol.class_origin().is_some()
+            )
+        }) {
+            return None;
+        }
+
+        Some(
+            self.iter_positive(db)
+                .fold(IntersectionBuilder::new(db), |builder, positive| {
+                    builder.add_positive(positive.dunder_class(db))
+                })
+                .build(),
+        )
+    }
+
     pub(crate) fn map_with_boundness(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -1,14 +1,13 @@
 use crate::place::PlaceAndQualifiers;
 use crate::types::class::DynamicClassLiteral;
 use crate::types::constraints::ConstraintSet;
-use crate::types::protocol_class::ProtocolClass;
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
 use crate::types::variance::VarianceInferable;
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance, ClassLiteral, ClassType,
     DynamicType, FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind, MemberLookupPolicy,
-    SpecialFormType, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance,
-    TypedDictType, UnionType, todo_type,
+    ProtocolInstanceType, SpecialFormType, Type, TypeContext, TypeMapping, TypeQualifiers,
+    TypeVarBoundOrConstraints, TypeVarVariance, TypedDictType, UnionType, todo_type,
 };
 use crate::{Db, FxOrderSet};
 use ty_python_core::definition::Definition;
@@ -52,10 +51,17 @@ impl<'db> SubclassOfType<'db> {
                     Type::SubclassOf(Self { subclass_of })
                 }
             }
-            SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => {
-                Type::SubclassOf(Self { subclass_of })
-            }
+            SubclassOfInner::Dynamic(_)
+            | SubclassOfInner::Protocol(_)
+            | SubclassOfInner::TypeVar(_) => Type::SubclassOf(Self { subclass_of }),
         }
+    }
+
+    /// Construct the meta-type of a class-backed protocol.
+    pub(super) const fn from_protocol(protocol: ProtocolInstanceType<'db>) -> Type<'db> {
+        Type::SubclassOf(Self {
+            subclass_of: SubclassOfInner::Protocol(protocol),
+        })
     }
 
     /// Given the class object `T`, returns a [`Type`] instance representing `type[T]`.
@@ -120,6 +126,25 @@ impl<'db> SubclassOfType<'db> {
         self.subclass_of
     }
 
+    /// Returns the effective write requirement exposed by `type[Protocol]` attribute lookup.
+    pub(super) fn meta_write_requirement(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+    ) -> Option<(Option<Type<'db>>, TypeQualifiers)> {
+        let SubclassOfInner::Protocol(protocol) = self.subclass_of else {
+            return None;
+        };
+        protocol
+            .interface(db)
+            .meta_write_requirement(db, Type::ProtocolInstance(protocol), name)
+            .map(|(write_ty, mut qualifiers)| {
+                // `ClassVar` prohibits instance writes, not writes through the class object.
+                qualifiers.remove(TypeQualifiers::CLASS_VAR);
+                (write_ty, qualifiers)
+            })
+    }
+
     pub(crate) const fn is_dynamic(self) -> bool {
         // Unpack `self` so that we're forced to update this method if any more fields are added in the future.
         let Self { subclass_of } = self;
@@ -163,6 +188,9 @@ impl<'db> SubclassOfType<'db> {
                     visitor,
                 )),
             }),
+            SubclassOfInner::Protocol(protocol) => protocol
+                .apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                .to_meta_type(db),
             SubclassOfInner::Dynamic(_) => match type_mapping {
                 TypeMapping::Materialize(materialization_kind) => match materialization_kind {
                     MaterializationKind::Top => KnownClass::Type.to_instance(db),
@@ -189,6 +217,9 @@ impl<'db> SubclassOfType<'db> {
             SubclassOfInner::Class(class) => {
                 class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
+            SubclassOfInner::Protocol(protocol) => {
+                protocol.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            }
             SubclassOfInner::TypeVar(typevar) => {
                 Type::TypeVar(typevar).find_legacy_typevars_impl(
                     db,
@@ -206,9 +237,16 @@ impl<'db> SubclassOfType<'db> {
         name: &str,
         policy: MemberLookupPolicy,
     ) -> Option<PlaceAndQualifiers<'db>> {
+        if let SubclassOfInner::Protocol(protocol) = self.subclass_of
+            && let Some(member) = protocol.interface(db).meta_member(db, name)
+        {
+            return Some(member);
+        }
+
         let class_like = match self.subclass_of.with_transposed_type_var(db) {
             SubclassOfInner::Class(class) => Type::from(class),
             SubclassOfInner::Dynamic(dynamic) => Type::Dynamic(dynamic),
+            SubclassOfInner::Protocol(protocol) => Type::from(*protocol.class_origin()?),
             SubclassOfInner::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => unreachable!(),
@@ -240,6 +278,7 @@ impl<'db> SubclassOfType<'db> {
         match self.subclass_of {
             SubclassOfInner::Class(class) => Type::instance(db, class),
             SubclassOfInner::Dynamic(dynamic_type) => Type::Dynamic(dynamic_type),
+            SubclassOfInner::Protocol(protocol) => Type::ProtocolInstance(protocol),
             SubclassOfInner::TypeVar(bound_typevar) => Type::TypeVar(bound_typevar),
         }
     }
@@ -268,6 +307,9 @@ impl<'db> SubclassOfType<'db> {
             }
             SubclassOfInner::Class(class) => SubclassOfType::try_from_type(db, class.metaclass(db))
                 .unwrap_or(SubclassOfType::subclass_of_unknown()),
+            // Structural implementations of a protocol can have arbitrary metaclasses. The only
+            // guaranteed upper bound is therefore `type`, not the protocol origin's metaclass.
+            SubclassOfInner::Protocol(_) => KnownClass::Type.to_subclass_of(db),
             // For `type[T]` where `T` is a TypeVar, `with_transposed_type_var` transforms
             // the bounds from instance types to `type[]` types. For example, `type[T]` where
             // `T: A | B` becomes a TypeVar with bound `type[A] | type[B]`. The metatype is
@@ -296,6 +338,7 @@ impl<'db> VarianceInferable<'db> for SubclassOfType<'db> {
     fn variance_of(self, db: &dyn Db, typevar: BoundTypeVarIdentity<'_>) -> TypeVarVariance {
         match self.subclass_of {
             SubclassOfInner::Class(class) => class.variance_of(db, typevar),
+            SubclassOfInner::Protocol(protocol) => protocol.variance_of(db, typevar),
             SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => TypeVarVariance::Bivariant,
         }
     }
@@ -309,6 +352,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: SubclassOfType<'db>,
         target: SubclassOfType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        if let SubclassOfInner::Protocol(target_protocol) = target.subclass_of {
+            return self.check_meta_type_satisfies_protocol(
+                db,
+                Type::SubclassOf(source),
+                target_protocol,
+            );
+        }
+        if let SubclassOfInner::Protocol(source_protocol) = source.subclass_of {
+            return self.check_type_pair(
+                db,
+                Type::ProtocolInstance(source_protocol),
+                target.to_instance(db),
+            );
+        }
+
         match (source.subclass_of, target.subclass_of) {
             (SubclassOfInner::Dynamic(_), SubclassOfInner::Dynamic(_)) => {
                 ConstraintSet::from_bool(self.constraints, !self.relation.is_subtyping())
@@ -333,6 +391,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             (SubclassOfInner::TypeVar(_), _) | (_, SubclassOfInner::TypeVar(_)) => {
                 unreachable!()
             }
+            (SubclassOfInner::Protocol(_), _) | (_, SubclassOfInner::Protocol(_)) => {
+                unreachable!("protocol meta-types are handled above")
+            }
         }
     }
 }
@@ -347,6 +408,14 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         left: SubclassOfType<'db>,
         right: SubclassOfType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        if matches!(left.subclass_of, SubclassOfInner::Protocol(_))
+            || matches!(right.subclass_of, SubclassOfInner::Protocol(_))
+        {
+            // Protocols are open structural types, so their meta-types can generally overlap with
+            // concrete class-object types and with other protocol meta-types.
+            return ConstraintSet::from_bool(self.constraints, false);
+        }
+
         match (left.subclass_of, right.subclass_of) {
             (SubclassOfInner::Dynamic(_), _) | (_, SubclassOfInner::Dynamic(_)) => {
                 ConstraintSet::from_bool(self.constraints, false)
@@ -360,6 +429,9 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             (SubclassOfInner::TypeVar(_), _) | (_, SubclassOfInner::TypeVar(_)) => {
                 unreachable!()
             }
+            (SubclassOfInner::Protocol(_), _) | (_, SubclassOfInner::Protocol(_)) => {
+                unreachable!("protocol meta-types are handled above")
+            }
         }
     }
 }
@@ -368,7 +440,8 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 ///
 /// 1. A "subclass of a class": `type[C]` for any class object `C`
 /// 2. A "subclass of a dynamic type": `type[Any]`, `type[Unknown]` and `type[@Todo]`
-/// 3. A "subclass of a type variable": `type[T]` for any type variable `T`
+/// 3. A protocol meta-type: `type[P]` for a class-backed protocol `P`
+/// 4. A "subclass of a type variable": `type[T]` for any type variable `T`
 ///
 /// In the long term, we may want to implement <https://github.com/astral-sh/ruff/issues/15381>.
 /// Doing this would allow us to get rid of this enum,
@@ -376,13 +449,14 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 /// rather than using the [`Type::SubclassOf`] variant at all;
 /// [`SubclassOfType`] would then be a simple wrapper around [`ClassType`].
 ///
-/// Note that this enum is similar to the [`super::ClassBase`] enum,
-/// but does not include the `ClassBase::Protocol` and `ClassBase::Generic` variants
-/// (`type[Protocol]` and `type[Generic]` are not valid types).
+/// Note that this enum is similar to the [`super::ClassBase`] enum, but does not include the
+/// `ClassBase::Protocol` and `ClassBase::Generic` special-form variants (`type[Protocol]` and
+/// `type[Generic]` are not valid types).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) enum SubclassOfInner<'db> {
     Class(ClassType<'db>),
     Dynamic(DynamicType<'db>),
+    Protocol(ProtocolInstanceType<'db>),
     TypeVar(BoundTypeVarInstance<'db>),
 }
 
@@ -401,7 +475,7 @@ impl<'db> SubclassOfInner<'db> {
 
     pub(crate) fn into_class(self, db: &'db dyn Db) -> Option<ClassType<'db>> {
         match self {
-            Self::Dynamic(_) => None,
+            Self::Dynamic(_) | Self::Protocol(_) => None,
             Self::Class(class) => Some(class),
             Self::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
@@ -419,14 +493,14 @@ impl<'db> SubclassOfInner<'db> {
 
     pub(crate) const fn into_dynamic(self) -> Option<DynamicType<'db>> {
         match self {
-            Self::Class(_) | Self::TypeVar(_) => None,
+            Self::Class(_) | Self::Protocol(_) | Self::TypeVar(_) => None,
             Self::Dynamic(dynamic) => Some(dynamic),
         }
     }
 
     pub(crate) const fn into_type_var(self) -> Option<BoundTypeVarInstance<'db>> {
         match self {
-            Self::Class(_) | Self::Dynamic(_) => None,
+            Self::Class(_) | Self::Dynamic(_) | Self::Protocol(_) => None,
             Self::TypeVar(bound_typevar) => Some(bound_typevar),
         }
     }
@@ -499,6 +573,9 @@ impl<'db> SubclassOfInner<'db> {
                 class.recursive_type_normalized_impl(db, div, nested)?,
             )),
             Self::Dynamic(dynamic) => Some(Self::Dynamic(dynamic.recursive_type_normalized())),
+            Self::Protocol(protocol) => Some(Self::Protocol(
+                protocol.recursive_type_normalized_impl(db, div, nested)?,
+            )),
             Self::TypeVar(_) => Some(self),
         }
     }
@@ -516,12 +593,6 @@ impl<'db> From<DynamicType<'db>> for SubclassOfInner<'db> {
     }
 }
 
-impl<'db> From<ProtocolClass<'db>> for SubclassOfInner<'db> {
-    fn from(value: ProtocolClass<'db>) -> Self {
-        SubclassOfInner::Class(*value)
-    }
-}
-
 impl<'db> From<BoundTypeVarInstance<'db>> for SubclassOfInner<'db> {
     fn from(value: BoundTypeVarInstance<'db>) -> Self {
         SubclassOfInner::TypeVar(value)
@@ -533,6 +604,7 @@ impl<'db> From<SubclassOfType<'db>> for Type<'db> {
         match value.subclass_of {
             SubclassOfInner::Class(class) => class.into(),
             SubclassOfInner::Dynamic(dynamic) => Type::Dynamic(dynamic),
+            SubclassOfInner::Protocol(protocol) => Type::ProtocolInstance(protocol),
             SubclassOfInner::TypeVar(bound_typevar) => Type::TypeVar(bound_typevar),
         }
     }

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -200,7 +200,7 @@ impl<'db> SubclassOfType<'db> {
             },
             SubclassOfInner::TypeVar(typevar) => {
                 let mapped = typevar.apply_type_mapping_impl(db, type_mapping, visitor);
-                mapped.to_meta_type(db)
+                Self::try_from_instance(db, mapped).unwrap_or_else(|| mapped.to_meta_type(db))
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR adds general support for `type[P]`, where `P` is a class-backed protocol.

During review of #26566, we talked through two different questions.

1. Which class objects can inhabit `type[P]`?
2. Which attributes can be accessed through a value already typed as `type[P]`?

For the former, a class object `X` can satisfy `type[P]` when:

- `X` is a subtype of or assignable to `type`.
- The modeled instance type of `X` satisfies `P`.
- Every mutable `ClassVar` declared on `P` is available on `X` as an invariant read/write attribute.
- Every method declared on `P` is available on `X` as a covariant read-only attribute with its unbound signature.

For attribute lookup, we implement sound behavior in this PR, with a separate follow-up change (https://github.com/astral-sh/ruff/pull/26661) to prototype the unsound behavior used in other type checkers that exposes instance attributes declared on `P` through a value of type `type[P]` (even though a valid inhabitant is not required to define those attributes on the class object):

```python
from typing import Protocol

class P(Protocol):
    value: int

class C:
    def __init__(self) -> None:
        self.value = 1

cls: type[P] = C
reveal_type(cls())       # P
reveal_type(cls.value)   # int
```

The assignment is valid because `C()` satisfies `P`. The lookup of `cls.value` is intentionally unsound (`C.value` does not necessarily exist at runtime) but matches other type checkers.
