### PR TITLE
[ty] Pydantic: Support field metadata in `Annotated`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -625,6 +625,43 @@ Person3(age=20)
 Person3(age="20")  # error: [invalid-argument-type]
 ```
 
+Pydantic's strict aliases and `Strict()` metadata also enable strict validation for individual
+fields:
+
+```py
+from typing import Annotated
+from pydantic import Field, Strict, StrictInt
+
+class StrictFields(BaseModel):
+    strict_int: StrictInt
+    strict_str: Annotated[str, Strict()]
+
+StrictFields(strict_int=1, strict_str="foo")
+StrictFields(strict_int="1", strict_str="foo")  # error: [invalid-argument-type]
+StrictFields(strict_int=1, strict_str=b"foo")  # error: [invalid-argument-type]
+
+class StrictMetadataOrder(BaseModel):
+    field_then_lax: Annotated[int, Field(strict=True), Strict(False)]
+    lax_then_field: Annotated[int, Strict(False), Field(strict=True)]
+
+StrictMetadataOrder(field_then_lax="1", lax_then_field=1)
+StrictMetadataOrder(field_then_lax=1, lax_then_field="1")  # error: [invalid-argument-type]
+```
+
+A field with `Strict(False)` can opt out of strict validation, even in a model with `strict=True`:
+
+```py
+class LaxFieldInStrictModel(BaseModel):
+    model_config = ConfigDict(strict=True)
+
+    strict_int: int
+    lax_int: Annotated[int, Strict(False)]
+
+LaxFieldInStrictModel(strict_int=1, lax_int=1)
+LaxFieldInStrictModel(strict_int=1, lax_int="1")
+LaxFieldInStrictModel(strict_int="1", lax_int=1)  # error: [invalid-argument-type]
+```
+
 ## `validate_by_name`, `validate_by_alias`
 
 By default, Pydantic only allows a field to be initialized by its alias name, not by its field name:
@@ -794,15 +831,48 @@ class Person(BaseModel):
     id: Annotated[int, Field(default=0)]
 
 Person(name="Alice", id=1)
-# TODO: This should not be an error
-# error: [invalid-argument-type]
 Person(name=b"Alice", id=1)
-# TODO: This should not be an error
-# error: [missing-argument]
 Person(name="Alice")
 
 Person(name=None, id=1)  # error: [invalid-argument-type]
 Person(id=1)  # error: [missing-argument]
+```
+
+Multiple `Field(...)` calls in `Annotated[...]` are merged:
+
+```py
+class MultipleAnnotatedFields(BaseModel):
+    strict_then_default: Annotated[int, Field(strict=True), Field(default=0)]
+    default_then_strict: Annotated[int, Field(default=0), Field(strict=True)]
+
+MultipleAnnotatedFields()
+MultipleAnnotatedFields(strict_then_default=1, default_then_strict=1)
+MultipleAnnotatedFields(strict_then_default="1")  # error: [invalid-argument-type]
+MultipleAnnotatedFields(default_then_strict="1")  # error: [invalid-argument-type]
+```
+
+Field metadata in the annotation and on the right hand side is also merged:
+
+```py
+class AnnotatedAndAssignedFields(BaseModel):
+    strict_then_default: Annotated[int, Field(strict=True)] = Field(default=0)
+    default_then_strict: Annotated[int, Field(default=0)] = Field(strict=True)
+
+AnnotatedAndAssignedFields()
+AnnotatedAndAssignedFields(strict_then_default=1, default_then_strict=1)
+AnnotatedAndAssignedFields(strict_then_default="1")  # error: [invalid-argument-type]
+AnnotatedAndAssignedFields(default_then_strict="1")  # error: [invalid-argument-type]
+```
+
+Field metadata is also collected through aliases:
+
+```py
+AliasField = Annotated[int, Field(default=0)]
+
+class ModelWithAliasField(BaseModel):
+    value: AliasField
+
+ModelWithAliasField()
 ```
 
 ## Frozen models and fields

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -158,6 +158,7 @@ pub enum KnownClass {
     PydanticBaseSettings,
     PydanticConfigDict,
     PydanticRootModel,
+    PydanticStrict,
 }
 
 impl KnownClass {
@@ -288,7 +289,8 @@ impl KnownClass {
             | Self::PydanticBaseModel
             | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
-            | Self::PydanticRootModel => Some(Truthiness::Ambiguous),
+            | Self::PydanticRootModel
+            | Self::PydanticStrict => Some(Truthiness::Ambiguous),
 
             Self::Tuple => None,
         }
@@ -400,7 +402,8 @@ impl KnownClass {
             | KnownClass::PydanticBaseModel
             | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticConfigDict
-            | KnownClass::PydanticRootModel => false,
+            | KnownClass::PydanticRootModel
+            | KnownClass::PydanticStrict => false,
         }
     }
 
@@ -508,7 +511,8 @@ impl KnownClass {
             | KnownClass::FunctoolsPartial
             | KnownClass::PydanticBaseModel
             | KnownClass::PydanticBaseSettings
-            | KnownClass::PydanticRootModel => false,
+            | KnownClass::PydanticRootModel
+            | KnownClass::PydanticStrict => false,
 
             KnownClass::PydanticConfigDict => true,
         }
@@ -618,7 +622,8 @@ impl KnownClass {
             | KnownClass::PydanticBaseModel
             | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticConfigDict
-            | KnownClass::PydanticRootModel => false,
+            | KnownClass::PydanticRootModel
+            | KnownClass::PydanticStrict => false,
         }
     }
 
@@ -739,7 +744,8 @@ impl KnownClass {
             | Self::PydanticBaseModel
             | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
-            | Self::PydanticRootModel => false,
+            | Self::PydanticRootModel
+            | Self::PydanticStrict => false,
         }
     }
 
@@ -849,7 +855,8 @@ impl KnownClass {
             | KnownClass::PydanticBaseModel
             | KnownClass::PydanticBaseSettings
             | KnownClass::PydanticConfigDict
-            | KnownClass::PydanticRootModel => false,
+            | KnownClass::PydanticRootModel
+            | KnownClass::PydanticStrict => false,
             KnownClass::NamedTupleFallback
             | KnownClass::TypedDictFallback
             | KnownClass::ExtensionTypedDictFallback => true,
@@ -973,6 +980,7 @@ impl KnownClass {
             Self::PydanticBaseSettings => "BaseSettings",
             Self::PydanticConfigDict => "ConfigDict",
             Self::PydanticRootModel => "RootModel",
+            Self::PydanticStrict => "Strict",
         }
     }
 
@@ -1359,6 +1367,7 @@ impl KnownClass {
             Self::PydanticBaseSettings => KnownModule::PydanticSettingsMain,
             Self::PydanticConfigDict => KnownModule::PydanticConfig,
             Self::PydanticRootModel => KnownModule::PydanticRootModel,
+            Self::PydanticStrict => KnownModule::PydanticTypes,
         }
     }
 
@@ -1469,7 +1478,8 @@ impl KnownClass {
             | Self::PydanticBaseModel
             | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
-            | Self::PydanticRootModel => Some(false),
+            | Self::PydanticRootModel
+            | Self::PydanticStrict => Some(false),
 
             Self::Tuple => None,
         }
@@ -1583,7 +1593,8 @@ impl KnownClass {
             | Self::PydanticBaseModel
             | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
-            | Self::PydanticRootModel => false,
+            | Self::PydanticRootModel
+            | Self::PydanticStrict => false,
         }
     }
 
@@ -1697,6 +1708,7 @@ impl KnownClass {
             "BaseSettings" => &[Self::PydanticBaseSettings],
             "ConfigDict" => &[Self::PydanticConfigDict],
             "RootModel" => &[Self::PydanticRootModel],
+            "Strict" => &[Self::PydanticStrict],
             _ => return None,
         };
 
@@ -1796,7 +1808,8 @@ impl KnownClass {
             | Self::PydanticBaseModel
             | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
-            | Self::PydanticRootModel => module == self.canonical_module(db),
+            | Self::PydanticRootModel
+            | Self::PydanticStrict => module == self.canonical_module(db),
             Self::NoneType => matches!(module, KnownModule::Typeshed | KnownModule::Types),
             Self::SpecialForm
             | Self::TypeAliasType

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2185,13 +2185,21 @@ impl<'db> StaticClassLiteral<'db> {
                 let mut alias = None;
                 let mut converter = None;
                 let mut strict = pydantic::ConfigBoolean::Unspecified;
-                if let Some(Type::KnownInstance(KnownInstanceType::Field(field))) = default_ty {
+                if field_policy.is_pydantic() {
+                    let metadata =
+                        pydantic::field_metadata(db, first_declaration, default_ty, specialization);
+                    default_ty = metadata.default_ty;
+                    init = metadata.init;
+                    alias = metadata.alias;
+                    strict = metadata.strict;
+                } else if let Some(Type::KnownInstance(KnownInstanceType::Field(field))) =
+                    default_ty
+                {
                     default_ty = field.default_type(db);
                     init = field.init(db);
                     kw_only = field.kw_only(db);
                     alias.clone_from(field.alias(db));
                     converter = field.converter(db);
-                    strict = field.strict(db);
                 }
 
                 let kind = match field_policy {

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -94,6 +94,149 @@ impl Default for FieldMetadata<'_> {
 }
 
 impl<'db> FieldMetadata<'db> {
+    /// Collect Pydantic field metadata from the right-hand side of a field's assignment.
+    ///
+    /// For example, collect the default value and alias from the following field assignment:
+    /// ```py
+    /// field: int = Field(default=0, alias="field_alias")
+    /// ```
+    fn collect_from_rhs_type(
+        &mut self,
+        db: &'db dyn Db,
+        rhs_type: Option<Type<'db>>,
+        specialization: Option<Specialization<'db>>,
+    ) {
+        match rhs_type {
+            Some(Type::KnownInstance(KnownInstanceType::Field(field))) => {
+                self.merge_field(db, field, specialization);
+            }
+            Some(rhs_type) => self.default_ty = Some(rhs_type),
+            None => {}
+        }
+    }
+
+    /// Collect Pydantic field metadata from a field's annotation.
+    ///
+    /// For example, collect the strictness metadata from the following field annotation:
+    /// ```py
+    /// field: Annotated[int, Strict()]
+    /// ```
+    ///
+    /// This method also handles the case where the annotation is an alias to an `Annotated` type, such as:
+    /// ```py
+    /// field: StrictInt
+    /// ```
+    /// where `StrictInt` is defined as `StrictInt = Annotated[int, Strict()]`.
+    fn collect_from_annotation(
+        &mut self,
+        db: &'db dyn Db,
+        definition: Definition<'db>,
+        specialization: Option<Specialization<'db>>,
+    ) {
+        let module = parsed_module(db, definition.file(db)).load(db);
+        let DefinitionKind::AnnotatedAssignment(assignment) = definition.kind(db) else {
+            return;
+        };
+        let annotation = assignment.annotation(&module);
+
+        if self.collect_from_annotated(db, definition, annotation, specialization) {
+            return;
+        }
+
+        let Expr::Name(name) = annotation else {
+            return;
+        };
+
+        // The following part is unfortunate. Pydantic defines `StrictInt` and the other aliases
+        // using `StrictInt = Annotated[int, Strict()]`. Since we don't retain the `Annotated`
+        // metadata, we need to follow the alias back to its definition and parse the metadata
+        // from there.
+        let model = SemanticModel::new(db, definition.file(db));
+        let Some(alias_definition) = definitions_for_name(
+            &model,
+            name.id.as_str(),
+            name.into(),
+            ImportAliasResolution::ResolveAliases,
+        )
+        .into_iter()
+        .find_map(|resolved| resolved.definition()) else {
+            return;
+        };
+
+        let module = parsed_module(db, alias_definition.file(db)).load(db);
+        let kind = alias_definition.kind(db);
+        let value = match &kind {
+            DefinitionKind::Assignment(assignment) => assignment.value(&module),
+            DefinitionKind::AnnotatedAssignment(assignment) => {
+                let Some(value) = assignment.value(&module) else {
+                    return;
+                };
+                value
+            }
+            _ => return,
+        };
+
+        self.collect_from_annotated(db, alias_definition, value, specialization);
+    }
+
+    /// Collect Pydantic field metadata from the `Annotated` part of a field's annotation.
+    fn collect_from_annotated(
+        &mut self,
+        db: &'db dyn Db,
+        definition: Definition<'db>,
+        annotation: &Expr,
+        specialization: Option<Specialization<'db>>,
+    ) -> bool {
+        let Some(subscript) = annotation.as_subscript_expr() else {
+            return false;
+        };
+        if definition_expression_type(db, definition, &subscript.value)
+            != Type::SpecialForm(SpecialFormType::Annotated)
+        {
+            return false;
+        }
+        let Some(arguments) = subscript
+            .slice
+            .as_tuple_expr()
+            .and_then(|tuple| tuple.elts.get(1..))
+        else {
+            return false;
+        };
+
+        for metadata in arguments {
+            let Some(call) = metadata.as_call_expr() else {
+                continue;
+            };
+            let callee = definition_expression_type(db, definition, &call.func);
+
+            if callee
+                .as_class_literal()
+                .is_some_and(|class| class.is_known(db, KnownClass::PydanticStrict))
+            {
+                let strict = call.arguments.find_argument_value("strict", 0).map_or(
+                    ConfigBoolean::Enabled,
+                    |strict| {
+                        ConfigBoolean::from_type(definition_expression_type(db, definition, strict))
+                    },
+                );
+                self.merge_strict(strict);
+            } else if matches!(
+                callee,
+                Type::FunctionLiteral(function)
+                    if function.is_known(db, KnownFunction::PydanticField)
+            ) {
+                let field_type = definition_expression_type(db, definition, metadata);
+                if let Type::KnownInstance(KnownInstanceType::Field(field)) = field_type {
+                    self.merge_field(db, field, specialization);
+                } else {
+                    self.merge_field_call(db, definition, call, field_type, specialization);
+                }
+            }
+        }
+
+        true
+    }
+
     fn merge_strict(&mut self, strict: ConfigBoolean) {
         self.strict = strict;
     }
@@ -156,130 +299,6 @@ impl<'db> FieldMetadata<'db> {
             }
         }
     }
-
-    fn merge_rhs_type(
-        &mut self,
-        db: &'db dyn Db,
-        rhs_type: Option<Type<'db>>,
-        specialization: Option<Specialization<'db>>,
-    ) {
-        match rhs_type {
-            Some(Type::KnownInstance(KnownInstanceType::Field(field))) => {
-                self.merge_field(db, field, specialization);
-            }
-            Some(rhs_type) => self.default_ty = Some(rhs_type),
-            None => {}
-        }
-    }
-
-    fn collect_annotation(
-        &mut self,
-        db: &'db dyn Db,
-        definition: Definition<'db>,
-        specialization: Option<Specialization<'db>>,
-    ) {
-        let module = parsed_module(db, definition.file(db)).load(db);
-        let DefinitionKind::AnnotatedAssignment(assignment) = definition.kind(db) else {
-            return;
-        };
-        let annotation = assignment.annotation(&module);
-
-        if self.collect_from_annotated(db, definition, annotation, specialization) {
-            return;
-        }
-
-        let Expr::Name(name) = annotation else {
-            return;
-        };
-
-        // The following part is unfortunate. Pydantic defines `StrictInt` and the other aliases
-        // using `StrictInt = Annotated[int, Strict()]`. Since we don't retain the `Annotated`
-        // metadata, we need to follow the alias back to its definition and parse the metadata
-        // from there.
-        let model = SemanticModel::new(db, definition.file(db));
-        let Some(alias_definition) = definitions_for_name(
-            &model,
-            name.id.as_str(),
-            name.into(),
-            ImportAliasResolution::ResolveAliases,
-        )
-        .into_iter()
-        .find_map(|resolved| resolved.definition()) else {
-            return;
-        };
-
-        let module = parsed_module(db, alias_definition.file(db)).load(db);
-        let kind = alias_definition.kind(db);
-        let value = match &kind {
-            DefinitionKind::Assignment(assignment) => assignment.value(&module),
-            DefinitionKind::AnnotatedAssignment(assignment) => {
-                let Some(value) = assignment.value(&module) else {
-                    return;
-                };
-                value
-            }
-            _ => return,
-        };
-
-        self.collect_from_annotated(db, alias_definition, value, specialization);
-    }
-
-    fn collect_from_annotated(
-        &mut self,
-        db: &'db dyn Db,
-        definition: Definition<'db>,
-        annotation: &Expr,
-        specialization: Option<Specialization<'db>>,
-    ) -> bool {
-        let Some(subscript) = annotation.as_subscript_expr() else {
-            return false;
-        };
-        if definition_expression_type(db, definition, &subscript.value)
-            != Type::SpecialForm(SpecialFormType::Annotated)
-        {
-            return false;
-        }
-        let Some(arguments) = subscript
-            .slice
-            .as_tuple_expr()
-            .and_then(|tuple| tuple.elts.get(1..))
-        else {
-            return false;
-        };
-
-        for metadata in arguments {
-            let Some(call) = metadata.as_call_expr() else {
-                continue;
-            };
-            let callee = definition_expression_type(db, definition, &call.func);
-
-            if callee
-                .as_class_literal()
-                .is_some_and(|class| class.is_known(db, KnownClass::PydanticStrict))
-            {
-                let strict = call.arguments.find_argument_value("strict", 0).map_or(
-                    ConfigBoolean::Enabled,
-                    |strict| {
-                        ConfigBoolean::from_type(definition_expression_type(db, definition, strict))
-                    },
-                );
-                self.merge_strict(strict);
-            } else if matches!(
-                callee,
-                Type::FunctionLiteral(function)
-                    if function.is_known(db, KnownFunction::PydanticField)
-            ) {
-                let field_type = definition_expression_type(db, definition, metadata);
-                if let Type::KnownInstance(KnownInstanceType::Field(field)) = field_type {
-                    self.merge_field(db, field, specialization);
-                } else {
-                    self.merge_field_call(db, definition, call, field_type, specialization);
-                }
-            }
-        }
-
-        true
-    }
 }
 
 /// Resolve a Pydantic field's metadata from its annotation and right-hand side.
@@ -291,9 +310,9 @@ pub(in crate::types) fn field_metadata<'db>(
 ) -> FieldMetadata<'db> {
     let mut metadata = FieldMetadata::default();
     if let Some(definition) = definition {
-        metadata.collect_annotation(db, definition, specialization);
+        metadata.collect_from_annotation(db, definition, specialization);
     }
-    metadata.merge_rhs_type(db, rhs_type, specialization);
+    metadata.collect_from_rhs_type(db, rhs_type, specialization);
     metadata
 }
 

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -1,18 +1,21 @@
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast::{ExprDict, Keyword, name::Name};
+use ruff_python_ast::{Expr, ExprCall, ExprDict, Keyword, name::Name};
 use rustc_hash::FxHashSet;
 use ty_module_resolver::{KnownModule, file_to_module};
 use ty_python_core::definition::{Definition, DefinitionKind};
 
-use crate::Db;
 use crate::place::{DefinedPlace, Definedness, Place, Provenance, known_module_symbol};
 use crate::types::class::CodeGeneratorKind;
+use crate::types::ide_support::{ImportAliasResolution, definitions_for_name};
+use crate::types::known_instance::FieldInstance;
 use crate::types::member::class_member;
+use crate::types::special_form::SpecialFormType;
 use crate::types::{
     ClassBase, DataclassTransformerParams, FunctionType, KnownClass, KnownFunction,
-    KnownInstanceType, KnownUnion, Parameter, StaticClassLiteral, Type, UnionType,
+    KnownInstanceType, KnownUnion, Parameter, Specialization, StaticClassLiteral, Type, UnionType,
     definition_expression_type,
 };
+use crate::{Db, SemanticModel};
 
 /// Metadata that controls Pydantic-specific model synthesis.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
@@ -62,6 +65,236 @@ impl<'db> ModelMetadata<'db> {
     pub(in crate::types) fn is_frozen(self, db: &'db dyn Db) -> bool {
         matches!(self.config(db).frozen, ConfigBoolean::Enabled)
     }
+}
+
+/// Pydantic-specific metadata resolved from a field's annotation (via `Annotation`)
+/// and right-hand side `Field(...)` specifier.
+///
+/// For example:
+/// ```py
+/// class Model(BaseModel):
+///     value: Annotated[int, Strict()] = Field(default=0)
+/// ```
+pub(in crate::types) struct FieldMetadata<'db> {
+    pub(in crate::types) default_ty: Option<Type<'db>>,
+    pub(in crate::types) init: bool,
+    pub(in crate::types) alias: Option<Box<str>>,
+    pub(in crate::types) strict: ConfigBoolean,
+}
+
+impl Default for FieldMetadata<'_> {
+    fn default() -> Self {
+        Self {
+            default_ty: None,
+            init: true,
+            alias: None,
+            strict: ConfigBoolean::Unspecified,
+        }
+    }
+}
+
+impl<'db> FieldMetadata<'db> {
+    fn merge_strict(&mut self, strict: ConfigBoolean) {
+        self.strict = strict;
+    }
+
+    fn merge_field(
+        &mut self,
+        db: &'db dyn Db,
+        field: FieldInstance<'db>,
+        specialization: Option<Specialization<'db>>,
+    ) {
+        if let Some(default_type) = field.default_type(db) {
+            self.default_ty = Some(default_type.apply_optional_specialization(db, specialization));
+        }
+        self.init &= field.init(db);
+        if let Some(alias) = field.alias(db) {
+            self.alias = Some(alias.clone());
+        }
+        if !matches!(field.strict(db), ConfigBoolean::Unspecified) {
+            self.strict = field.strict(db);
+        }
+    }
+
+    fn merge_field_call(
+        &mut self,
+        db: &'db dyn Db,
+        definition: Definition<'db>,
+        call: &ExprCall,
+        call_type: Type<'db>,
+        specialization: Option<Specialization<'db>>,
+    ) {
+        if let Some(default) = call.arguments.find_argument_value("default", 0) {
+            let default_type = definition_expression_type(db, definition, default);
+            if !default_type.is_instance_of(db, KnownClass::EllipsisType) {
+                self.default_ty =
+                    Some(default_type.apply_optional_specialization(db, specialization));
+            }
+        } else if call.arguments.find_keyword("default_factory").is_some() {
+            self.default_ty = Some(call_type.apply_optional_specialization(db, specialization));
+        }
+
+        if let Some(init) = call.arguments.find_keyword("init") {
+            let init = definition_expression_type(db, definition, &init.value);
+            self.init &= !init.bool(db).is_always_false();
+        }
+
+        if let Some(alias) = call
+            .arguments
+            .find_keyword("validation_alias")
+            .or_else(|| call.arguments.find_keyword("alias"))
+        {
+            self.alias = definition_expression_type(db, definition, &alias.value)
+                .as_string_literal()
+                .map(|literal| Box::from(literal.value(db)));
+        }
+
+        if let Some(strict) = call.arguments.find_keyword("strict") {
+            let strict = definition_expression_type(db, definition, &strict.value);
+            if !strict.is_none(db) {
+                self.merge_strict(ConfigBoolean::from_type(strict));
+            }
+        }
+    }
+
+    fn merge_rhs_type(
+        &mut self,
+        db: &'db dyn Db,
+        rhs_type: Option<Type<'db>>,
+        specialization: Option<Specialization<'db>>,
+    ) {
+        match rhs_type {
+            Some(Type::KnownInstance(KnownInstanceType::Field(field))) => {
+                self.merge_field(db, field, specialization);
+            }
+            Some(rhs_type) => self.default_ty = Some(rhs_type),
+            None => {}
+        }
+    }
+
+    fn collect_annotation(
+        &mut self,
+        db: &'db dyn Db,
+        definition: Definition<'db>,
+        specialization: Option<Specialization<'db>>,
+    ) {
+        let module = parsed_module(db, definition.file(db)).load(db);
+        let DefinitionKind::AnnotatedAssignment(assignment) = definition.kind(db) else {
+            return;
+        };
+        let annotation = assignment.annotation(&module);
+
+        if self.collect_from_annotated(db, definition, annotation, specialization) {
+            return;
+        }
+
+        let Expr::Name(name) = annotation else {
+            return;
+        };
+
+        // The following part is unfortunate. Pydantic defines `StrictInt` and the other aliases
+        // using `StrictInt = Annotated[int, Strict()]`. Since we don't retain the `Annotated`
+        // metadata, we need to follow the alias back to its definition and parse the metadata
+        // from there.
+        let model = SemanticModel::new(db, definition.file(db));
+        let Some(alias_definition) = definitions_for_name(
+            &model,
+            name.id.as_str(),
+            name.into(),
+            ImportAliasResolution::ResolveAliases,
+        )
+        .into_iter()
+        .find_map(|resolved| resolved.definition()) else {
+            return;
+        };
+
+        let module = parsed_module(db, alias_definition.file(db)).load(db);
+        let kind = alias_definition.kind(db);
+        let value = match &kind {
+            DefinitionKind::Assignment(assignment) => assignment.value(&module),
+            DefinitionKind::AnnotatedAssignment(assignment) => {
+                let Some(value) = assignment.value(&module) else {
+                    return;
+                };
+                value
+            }
+            _ => return,
+        };
+
+        self.collect_from_annotated(db, alias_definition, value, specialization);
+    }
+
+    fn collect_from_annotated(
+        &mut self,
+        db: &'db dyn Db,
+        definition: Definition<'db>,
+        annotation: &Expr,
+        specialization: Option<Specialization<'db>>,
+    ) -> bool {
+        let Some(subscript) = annotation.as_subscript_expr() else {
+            return false;
+        };
+        if definition_expression_type(db, definition, &subscript.value)
+            != Type::SpecialForm(SpecialFormType::Annotated)
+        {
+            return false;
+        }
+        let Some(arguments) = subscript
+            .slice
+            .as_tuple_expr()
+            .and_then(|tuple| tuple.elts.get(1..))
+        else {
+            return false;
+        };
+
+        for metadata in arguments {
+            let Some(call) = metadata.as_call_expr() else {
+                continue;
+            };
+            let callee = definition_expression_type(db, definition, &call.func);
+
+            if callee
+                .as_class_literal()
+                .is_some_and(|class| class.is_known(db, KnownClass::PydanticStrict))
+            {
+                let strict = call.arguments.find_argument_value("strict", 0).map_or(
+                    ConfigBoolean::Enabled,
+                    |strict| {
+                        ConfigBoolean::from_type(definition_expression_type(db, definition, strict))
+                    },
+                );
+                self.merge_strict(strict);
+            } else if matches!(
+                callee,
+                Type::FunctionLiteral(function)
+                    if function.is_known(db, KnownFunction::PydanticField)
+            ) {
+                let field_type = definition_expression_type(db, definition, metadata);
+                if let Type::KnownInstance(KnownInstanceType::Field(field)) = field_type {
+                    self.merge_field(db, field, specialization);
+                } else {
+                    self.merge_field_call(db, definition, call, field_type, specialization);
+                }
+            }
+        }
+
+        true
+    }
+}
+
+/// Resolve a Pydantic field's metadata from its annotation and right-hand side.
+pub(in crate::types) fn field_metadata<'db>(
+    db: &'db dyn Db,
+    definition: Option<Definition<'db>>,
+    rhs_type: Option<Type<'db>>,
+    specialization: Option<Specialization<'db>>,
+) -> FieldMetadata<'db> {
+    let mut metadata = FieldMetadata::default();
+    if let Some(definition) = definition {
+        metadata.collect_annotation(db, definition, specialization);
+    }
+    metadata.merge_rhs_type(db, rhs_type, specialization);
+    metadata
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3853,10 +3853,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let annotation = assignment.annotation(self.module());
+        // Pydantic supports field specifiers in annotations via `Annotated[T, Field(...)]`.
+        self.setup_dataclass_field_specifiers();
         let mut declared = self.infer_annotation_expression_allow_pep_613(
             annotation,
             DeferredExpressionState::from(self.defer_annotations()),
         );
+        self.dataclass_field_specifiers.clear();
 
         // P.args and P.kwargs are only valid as annotations on *args and **kwargs,
         // not as variable annotations. Check both resolved type and AST form.


### PR DESCRIPTION
## Summary

Add support for `Annotated[T, Field(...)]`, `Strict(..)` and (transitively) also support for aliases like `StrictInt`.

One challenge here is that aliases like `StrictInt` are defined as `StrictInt = Annotated[int, Strict()]`. When we see `StrictInt` in a field annotation, we have already lost the `Annotated` metadata. For now, we simply resolve this by following the alias back to it's original definition, since it seems wrong to store `Annotated` metadata (or a link back to its definition) inside the type for this specific use-case only.

closes https://github.com/astral-sh/ty/issues/2130
closes https://github.com/astral-sh/ty/issues/3948
towards https://github.com/astral-sh/ty/issues/2403

## Test Plan

New and updated Markdown tests.