### PR TITLE
[ty] Share canonical docstring section kinds.

### DIFF
--- a/crates/ty_ide/src/docstring/document.rs
+++ b/crates/ty_ide/src/docstring/document.rs
@@ -1,4 +1,5 @@
 use indexmap::IndexMap;
+use strum_macros::EnumIter;
 
 /// Google-style docstring parsing.
 mod google;
@@ -18,8 +19,8 @@ pub(super) fn parameter_documentation(
     parameters
 }
 
-/// Parameter sections shared by supported docstring formats.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Canonical docstring sections shared by supported formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
 pub(in crate::docstring) enum SectionKind {
     /// Function or method parameters.
     Parameters,
@@ -27,4 +28,27 @@ pub(in crate::docstring) enum SectionKind {
     KeywordArguments,
     /// Less commonly used parameters listed separately from the main parameter section.
     OtherParameters,
+    /// Class or module attributes.
+    Attributes,
+    /// A returned value.
+    Returns,
+    /// A yielded value.
+    Yields,
+    /// Exceptions raised by a callable.
+    Raises,
+}
+
+impl SectionKind {
+    /// Returns the canonical display heading for this section.
+    pub(super) const fn heading(self) -> &'static str {
+        match self {
+            SectionKind::Parameters => "Parameters",
+            SectionKind::KeywordArguments => "Keyword Arguments",
+            SectionKind::OtherParameters => "Other Parameters",
+            SectionKind::Attributes => "Attributes",
+            SectionKind::Returns => "Returns",
+            SectionKind::Yields => "Yields",
+            SectionKind::Raises => "Raises",
+        }
+    }
 }

--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -349,6 +349,7 @@ fn section_item_indent(header: SectionHeader, line: ParsedLine<'_>) -> Option<Te
         HeaderKind::Structured(
             SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters,
         ) => parse_parameter(trimmed).is_some(),
+        HeaderKind::Structured(_) => false,
         HeaderKind::Container => false,
     };
     is_item.then_some(line.raw_indent)

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
 
 use super::general;
+use crate::docstring::document::SectionKind;
 use crate::docstring::document::preformatted::MarkdownFence;
 use crate::docstring::document::syntax::starts_with_markdown_list_item;
 
@@ -249,32 +249,6 @@ impl SectionItem {
                     }
                 }
             }
-        }
-    }
-}
-
-/// Canonical docstring sections shared by supported formats.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
-enum SectionKind {
-    Parameters,
-    KeywordArguments,
-    OtherParameters,
-    Attributes,
-    Returns,
-    Yields,
-    Raises,
-}
-
-impl SectionKind {
-    const fn heading(self) -> &'static str {
-        match self {
-            SectionKind::Parameters => "Parameters",
-            SectionKind::KeywordArguments => "Keyword Arguments",
-            SectionKind::OtherParameters => "Other Parameters",
-            SectionKind::Attributes => "Attributes",
-            SectionKind::Returns => "Returns",
-            SectionKind::Yields => "Yields",
-            SectionKind::Raises => "Raises",
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This centralizes our enumeration of structured docstring sections so that we can share the enumeration across rendering formats.

## Test Plan

This is a simple refactor that relies on existing test coverage.
<!-- How was it tested? -->
