### PR TITLE
[ty] Pydantic: Fix float conversion in unions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -543,6 +543,33 @@ LaxNestedList(value=1)  # error: [invalid-argument-type]
 LaxNestedList(value=[1, [2, None]])
 ```
 
+We support validation of `JsonValue` fields in lax mode:
+
+```py
+from pydantic import JsonValue
+
+class JsonValueModel(BaseModel):
+    value: JsonValue
+
+JsonValueModel(value=[1, 2])
+JsonValueModel(value={"key": 1})
+JsonValueModel(value="value")
+JsonValueModel(value=1)
+JsonValueModel(value=1.0)
+JsonValueModel(value=True)
+JsonValueModel(value=None)
+JsonValueModel(value={"outer": [1, {"inner": "value"}]})
+
+class SomethingElse: ...
+
+JsonValueModel(value=object())  # error: [invalid-argument-type]
+JsonValueModel(value=...)  # error: [invalid-argument-type]
+JsonValueModel(value=SomethingElse())  # error: [invalid-argument-type]
+
+# TODO: this should be an error once we support recursive types
+JsonValueModel(value={"outer": [1, {"inner": SomethingElse()}]})
+```
+
 ### Changing a specific field
 
 Strict mode can also be activated for a specific field only:

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -530,6 +530,7 @@ fn lax_input_type_impl<'db>(
     let builtin_alias = match known_class {
         Some(KnownClass::Bool) => Some("LaxBool"),
         Some(KnownClass::Bytes) => Some("LaxBytes"),
+        Some(KnownClass::Float) => Some("LaxFloat"),
         Some(KnownClass::Int) => Some("LaxInt"),
         Some(KnownClass::Str) => Some("LaxStr"),
         Some(KnownClass::Path) => Some("LaxPath"),


### PR DESCRIPTION
## Summary

`float`s that were embedded in unions were not recognized by our lax mode mapping (since we were only looking for the expanded `float | int`), so they were mapped to `Any` instead of `LaxFloat`, which lead to overly permissive lax types.

closes https://github.com/astral-sh/ty/issues/3946

## Test Plan

Added a regression test
