### PR TITLE
[`flake8-datetimez`] Clarify naming guidance for `datetime.today` (`DTZ002`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
@@ -18,13 +18,13 @@ use crate::rules::flake8_datetimez::helpers;
 /// some aspects of reality, which can lead to subtle bugs. Timezone-aware
 /// `datetime` objects are preferred, as they represent a specific moment in
 /// time, unlike "naive" objects.
-
-/// The name `today()` can be misleading, because it suggests a calendar date,
-/// but it actually returns the current local date and time as a `datetime`.
-/// That can make intent harder to infer when reading code.
 ///
 /// `datetime.datetime.today()` creates a "naive" object; instead, use
 /// `datetime.datetime.now(tz=...)` to create a timezone-aware object.
+///
+/// The name `today()` can be misleading, because it suggests a calendar date,
+/// but it actually returns the current local date and time as a `datetime`.
+/// That can make intent harder to infer when reading code.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
@@ -18,6 +18,10 @@ use crate::rules::flake8_datetimez::helpers;
 /// some aspects of reality, which can lead to subtle bugs. Timezone-aware
 /// `datetime` objects are preferred, as they represent a specific moment in
 /// time, unlike "naive" objects.
+
+/// The name `today()` can be misleading, because it suggests a calendar date,
+/// but it actually returns the current local date and time as a `datetime`.
+/// That can make intent harder to infer when reading code.
 ///
 /// `datetime.datetime.today()` creates a "naive" object; instead, use
 /// `datetime.datetime.now(tz=...)` to create a timezone-aware object.


### PR DESCRIPTION
## Summary

This updates the DTZ002 documentation to clarify the `datetime.today()` naming confusion raised in #23392.

- Notes that `datetime.datetime.today()` is named like a date helper, but it returns a local `datetime`.
- Keeps the existing guidance to use timezone-aware `datetime.now(...)` when you need an aware timestamp.

## Why this changed

The code behavior is already correct; this is a docs-only improvement to make the rule intent easier to understand.

## Test Plan

- `cargo dev generate-docs`
- `cargo fmt --check --all`
- `PATH="$PWD/target/debug:$PATH" uv run --only-group dev --locked python scripts/check_docs_formatted.py`
