### PR TITLE
[ty] Enforce constructibility for type[Protocol]

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1894,7 +1894,7 @@ fn datetype(criterion: &mut Criterion) {
             max_dep_date: TY_ECOSYSTEM_PIN,
             python_version: SupportedPythonVersion::Py311,
         },
-        17,
+        18,
     );
 
     bench_project(&benchmark, criterion);

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2453,6 +2453,8 @@ dataclass()(MyEnum)
 # error: [invalid-dataclass] "Cannot use `dataclass()` on a protocol class"
 dataclass(MyProtocol)
 
-# error: [invalid-dataclass] "Cannot use `dataclass()` on a protocol class"
+# A protocol class is rejected before `dataclass`-specific validation because it is not a concrete
+# inhabitant of the inferred `type[MyProtocol]` parameter.
+# error: [invalid-argument-type] "Expected `type[MyProtocol]`, found `<class 'MyProtocol'>`"
 dataclass()(MyProtocol)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5289,8 +5289,8 @@ def _(cls: type[PropertyProtocol]) -> None:
     cls.value  # error: [unresolved-attribute]
 ```
 
-Protocol and abstract class objects are accepted as inhabitants of `type[Foo]`. This is
-intentionally more permissive than the typing spec, which requires a concrete class.
+Protocol classes and abstract classes do not inhabit `type[Foo]` because they cannot be instantiated
+to produce a `Foo`.
 
 ```py
 from abc import ABC, ABCMeta, abstractmethod
@@ -5301,8 +5301,8 @@ class AbstractFoo(ABC):
     @abstractmethod
     def method(self) -> bytes: ...
 
-static_assert(is_assignable_to(TypeOf[Foo], type[Foo]))
-static_assert(is_assignable_to(TypeOf[AbstractFoo], type[Foo]))
+static_assert(not is_assignable_to(TypeOf[Foo], type[Foo]))
+static_assert(not is_assignable_to(TypeOf[AbstractFoo], type[Foo]))
 ```
 
 A structural implementation can use any subclass of `type` as its metaclass, so `type[Foo]` is not
@@ -5557,10 +5557,10 @@ def _(cls: type[P] | type[int]) -> None:
     preserved: type[P] | type[int] = class_identity(cls)
 ```
 
-The protocol class object is also accepted by the identity function as an inhabitant of `type[P]`.
+The protocol class object itself remains distinct from structural `type[P]`.
 
 ```py
-reveal_type(class_identity(P))  # revealed: type[P]
+class_identity(P)  # error: [invalid-argument-type]
 ```
 
 Generic protocol arguments are also preserved through the identity function.
@@ -5594,6 +5594,73 @@ class RuntimeProtocol(Protocol):
 def _(value: RuntimeProtocol) -> None:
     if isinstance(value, int):
         reveal_type(type(value))  # revealed: type[RuntimeProtocol] & type[int]
+```
+
+## Protocol class objects as generic self receivers
+
+A protocol class does not inhabit `type[P]`, but it can still receive a class method declared on the
+protocol itself. This exception applies only to the method's receiver.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, Self, TypeVar, cast
+
+class SelfFactory(Protocol):
+    @classmethod
+    def make(cls) -> Self:
+        return cast(Self, object())
+
+reveal_type(SelfFactory.make())  # revealed: SelfFactory
+not_concrete: type[SelfFactory] = SelfFactory  # error: [invalid-assignment]
+```
+
+The specialization of a generic protocol class is retained when binding `Self`.
+
+```py
+class GenericSelfFactory[T](Protocol):
+    @classmethod
+    def make(cls, value: T) -> Self:
+        return cast(Self, object())
+
+reveal_type(GenericSelfFactory[int].make(1))  # revealed: GenericSelfFactory[int]
+```
+
+Bound type variables are the pre-PEP 673 spelling of generic self. Both legacy syntax and PEP 695
+method type parameters are supported.
+
+```py
+T_legacy = TypeVar("T_legacy", bound="LegacySelfFactory")
+
+class LegacySelfFactory(Protocol):
+    @classmethod
+    def make(cls: type[T_legacy]) -> T_legacy:
+        return cast(T_legacy, object())
+
+reveal_type(LegacySelfFactory.make())  # revealed: LegacySelfFactory
+
+class Pep695SelfFactory(Protocol):
+    @classmethod
+    def make[T: Pep695SelfFactory](cls: type[T]) -> T:
+        return cast(T, object())
+
+reveal_type(Pep695SelfFactory.make())  # revealed: Pep695SelfFactory
+```
+
+The receiver exception does not bypass an unrelated type-variable bound.
+
+```py
+T_unrelated = TypeVar("T_unrelated", bound=int)
+
+class UnrelatedBoundFactory(Protocol):
+    @classmethod
+    def make(cls: type[T_unrelated]) -> T_unrelated:
+        return cast(T_unrelated, object())
+
+UnrelatedBoundFactory.make()  # error: [invalid-argument-type]
 ```
 
 ## Regression test for `ClassVar` members in stubs

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5305,6 +5305,15 @@ static_assert(not is_assignable_to(TypeOf[Foo], type[Foo]))
 static_assert(not is_assignable_to(TypeOf[AbstractFoo], type[Foo]))
 ```
 
+By contrast, a value typed as `type[AbstractFoo]` may contain a concrete subclass. It can be
+forwarded to `type[Foo]` because every such subclass implements `Foo`.
+
+```py
+def accepts_foo(cls: type[Foo]) -> None: ...
+def forward_abstract_foo(cls: type[AbstractFoo]) -> None:
+    accepts_foo(cls)
+```
+
 A structural implementation can use any subclass of `type` as its metaclass, so `type[Foo]` is not
 limited to the protocol class's own metaclass.
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4939,35 +4939,6 @@ struct ArgumentTypeChecker<'a, 'db> {
     constraint_set_errors: Vec<bool>,
 }
 
-/// Use the structural meta-type of a protocol class when binding it to a generic `type[T]`
-/// receiver.
-///
-/// A protocol definition object is not generally an inhabitant of `type[P]`, because it cannot be
-/// instantiated to produce a `P`. It is nevertheless a valid receiver for classmethods defined on
-/// that protocol. This conversion is limited to the synthetic receiver argument so that ordinary
-/// `type[P]` parameters retain the concrete-inhabitant requirement.
-fn normalize_protocol_class_generic_self_receiver<'db>(
-    db: &'db dyn Db,
-    argument: Argument<'_>,
-    parameter: &Parameter<'db>,
-    argument_type: Type<'db>,
-) -> Type<'db> {
-    let Type::SubclassOf(subclass_of) = parameter.annotated_type() else {
-        return argument_type;
-    };
-    if subclass_of.into_type_var().is_none() {
-        return argument_type;
-    }
-    if !matches!(argument, Argument::Synthetic) {
-        return argument_type;
-    }
-
-    match argument_type.to_instance(db) {
-        Some(Type::ProtocolInstance(protocol)) => protocol.to_meta_type(db),
-        _ => argument_type,
-    }
-}
-
 /// Result of checking only the key type of a keyword-unpack argument.
 enum KeywordUnpackKeyTypeCheck<'db> {
     /// The argument type is handled by a more specific path, or does not expose mapping keys.
@@ -5344,7 +5315,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         specialization_errors: &mut Vec<BindingError<'db>>,
     ) -> bool {
         let parameters = self.signature.parameters();
-        for (argument_index, adjusted_argument_index, argument, argument_types) in
+        for (argument_index, adjusted_argument_index, _, argument_types) in
             self.enumerate_argument_types()
         {
             for matched_parameter in self.argument_matches[argument_index].iter() {
@@ -5357,12 +5328,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 let argument_type = matched_parameter
                     .argument_type
                     .unwrap_or_else(|| argument_types.get_for_declared_type(declared_type));
-                let argument_type = normalize_protocol_class_generic_self_receiver(
-                    self.db,
-                    argument,
-                    &parameters[parameter_index],
-                    argument_type,
-                );
                 let specialization_result = builder.infer(declared_type, argument_type);
 
                 if let Err(error) = specialization_result {
@@ -5398,12 +5363,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             return;
         }
 
-        argument_type = normalize_protocol_class_generic_self_receiver(
-            self.db,
-            argument,
-            parameter,
-            argument_type,
-        );
+        argument_type = matched_parameter.argument_type.unwrap_or(argument_type);
 
         let mut expected_ty = parameter.annotated_type();
         if let Some(specialization) = self.specialization() {
@@ -5840,10 +5800,11 @@ pub struct MatchedParameter<'db> {
     /// The index of the matched parameter.
     pub index: usize,
 
-    /// The type contributed by an unpacked positional or keyword argument.
+    /// A parameter-specific argument type.
     ///
-    /// This is `None` for non-splatted arguments because their type is not known when argument
-    /// matching runs.
+    /// This is used for values contributed by unpacking and for implicit receivers whose type is
+    /// normalized for the matched parameter. It is `None` for ordinary arguments because their
+    /// type is not known when argument matching runs.
     argument_type: Option<Type<'db>>,
 
     /// Why this parameter match exists.
@@ -6461,11 +6422,28 @@ impl<'db> Binding<'db> {
 
     fn match_parameters(&mut self, db: &'db dyn Db, arguments: &CallArguments<'_, 'db>) {
         let parameters = self.signature.parameters();
+        let normalized_bound_receiver_type = if let Type::BoundMethod(method) = self.signature_type
+            && let Some(parameter) = parameters.get_positional(0)
+            && let Some((Argument::Synthetic, argument_types)) = arguments.iter().next()
+            && let Some(argument_type) = argument_types.get_default()
+        {
+            method.normalized_receiver_argument_type(db, parameter, argument_type)
+        } else {
+            None
+        };
         let mut matcher = ArgumentMatcher::new(arguments, parameters, &mut self.errors);
         let mut keywords_arguments = vec![];
         for (argument_index, (argument, argument_types)) in arguments.iter().enumerate() {
             match argument {
-                Argument::Positional | Argument::Synthetic => {
+                Argument::Synthetic => {
+                    let _ = matcher.match_positional(
+                        argument_index,
+                        argument,
+                        normalized_bound_receiver_type,
+                        false,
+                    );
+                }
+                Argument::Positional => {
                     let _ = matcher.match_positional(argument_index, argument, None, false);
                 }
                 Argument::Keyword(name) => {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4939,6 +4939,35 @@ struct ArgumentTypeChecker<'a, 'db> {
     constraint_set_errors: Vec<bool>,
 }
 
+/// Use the structural meta-type of a protocol class when binding it to a generic `type[T]`
+/// receiver.
+///
+/// A protocol definition object is not generally an inhabitant of `type[P]`, because it cannot be
+/// instantiated to produce a `P`. It is nevertheless a valid receiver for classmethods defined on
+/// that protocol. This conversion is limited to the synthetic receiver argument so that ordinary
+/// `type[P]` parameters retain the concrete-inhabitant requirement.
+fn normalize_protocol_class_generic_self_receiver<'db>(
+    db: &'db dyn Db,
+    argument: Argument<'_>,
+    parameter: &Parameter<'db>,
+    argument_type: Type<'db>,
+) -> Type<'db> {
+    let Type::SubclassOf(subclass_of) = parameter.annotated_type() else {
+        return argument_type;
+    };
+    if subclass_of.into_type_var().is_none() {
+        return argument_type;
+    }
+    if !matches!(argument, Argument::Synthetic) {
+        return argument_type;
+    }
+
+    match argument_type.to_instance(db) {
+        Some(Type::ProtocolInstance(protocol)) => protocol.to_meta_type(db),
+        _ => argument_type,
+    }
+}
+
 /// Result of checking only the key type of a keyword-unpack argument.
 enum KeywordUnpackKeyTypeCheck<'db> {
     /// The argument type is handled by a more specific path, or does not expose mapping keys.
@@ -5315,7 +5344,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         specialization_errors: &mut Vec<BindingError<'db>>,
     ) -> bool {
         let parameters = self.signature.parameters();
-        for (argument_index, adjusted_argument_index, _, argument_types) in
+        for (argument_index, adjusted_argument_index, argument, argument_types) in
             self.enumerate_argument_types()
         {
             for matched_parameter in self.argument_matches[argument_index].iter() {
@@ -5325,11 +5354,16 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 }
 
                 let declared_type = parameters[parameter_index].annotated_type();
-                let argument_type = argument_types.get_for_declared_type(declared_type);
-                let specialization_result = builder.infer(
-                    declared_type,
-                    matched_parameter.argument_type.unwrap_or(argument_type),
+                let argument_type = matched_parameter
+                    .argument_type
+                    .unwrap_or_else(|| argument_types.get_for_declared_type(declared_type));
+                let argument_type = normalize_protocol_class_generic_self_receiver(
+                    self.db,
+                    argument,
+                    &parameters[parameter_index],
+                    argument_type,
                 );
+                let specialization_result = builder.infer(declared_type, argument_type);
 
                 if let Err(error) = specialization_result {
                     specialization_errors.push(BindingError::SpecializationError {
@@ -5363,6 +5397,13 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         if self.is_gradual_variadic_parameter(parameter_index) {
             return;
         }
+
+        argument_type = normalize_protocol_class_generic_self_receiver(
+            self.db,
+            argument,
+            parameter,
+            argument_type,
+        );
 
         let mut expected_ty = parameter.annotated_type();
         if let Some(specialization) = self.specialization() {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2249,6 +2249,13 @@ impl<'db> ClassType<'db> {
             .is_some_and(|(class, _)| class.is_protocol(db))
     }
 
+    /// Return whether this is a concrete class.
+    ///
+    /// Protocol classes are not concrete even when all of their members have implementations.
+    pub(super) fn is_concrete(self, db: &'db dyn Db) -> bool {
+        !self.is_protocol(db) && self.abstract_methods(db).is_empty()
+    }
+
     /// Returns a [`Span`] pointing to the definition of this class.
     ///
     /// For static classes, this is the class header (name and arguments).

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -9,7 +9,7 @@ use ty_module_resolver::{ModuleName, file_to_module};
 use super::protocol_class::ProtocolInterface;
 use super::{
     BoundTypeVarIdentity, BoundTypeVarInstance, ClassType, DivergentType, KnownClass,
-    MaterializationKind, SubclassOfInner, SubclassOfType, Type, TypeVarVariance,
+    MaterializationKind, SubclassOfType, Type, TypeVarVariance,
 };
 use crate::place::PlaceAndQualifiers;
 use crate::types::constraints::{
@@ -615,23 +615,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             meta_ty,
             Type::ClassLiteral(_) | Type::SubclassOf(_) | Type::GenericAlias(_)
         ));
-
-        let source_class = match meta_ty {
-            Type::ClassLiteral(class) => Some(class.default_specialization(db)),
-            Type::GenericAlias(alias) => Some(ClassType::Generic(alias)),
-            Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
-                SubclassOfInner::Class(class) => Some(class),
-                SubclassOfInner::Dynamic(_)
-                | SubclassOfInner::Protocol(_)
-                | SubclassOfInner::TypeVar(_) => None,
-            },
-            _ => None,
-        };
-        if source_class
-            .is_some_and(|class| class.is_protocol(db) || !class.abstract_methods(db).is_empty())
-        {
-            return self.never();
-        }
 
         let constructed_ty = meta_ty.bindings(db).return_type(db);
         self.check_type_pair(db, constructed_ty, Type::ProtocolInstance(protocol))

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -9,7 +9,7 @@ use ty_module_resolver::{ModuleName, file_to_module};
 use super::protocol_class::ProtocolInterface;
 use super::{
     BoundTypeVarIdentity, BoundTypeVarInstance, ClassType, DivergentType, KnownClass,
-    MaterializationKind, SubclassOfType, Type, TypeVarVariance,
+    MaterializationKind, SubclassOfInner, SubclassOfType, Type, TypeVarVariance,
 };
 use crate::place::PlaceAndQualifiers;
 use crate::types::constraints::{
@@ -615,6 +615,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             meta_ty,
             Type::ClassLiteral(_) | Type::SubclassOf(_) | Type::GenericAlias(_)
         ));
+
+        let source_class = match meta_ty {
+            Type::ClassLiteral(class) => Some(class.default_specialization(db)),
+            Type::GenericAlias(alias) => Some(ClassType::Generic(alias)),
+            Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
+                SubclassOfInner::Class(class) => Some(class),
+                SubclassOfInner::Dynamic(_)
+                | SubclassOfInner::Protocol(_)
+                | SubclassOfInner::TypeVar(_) => None,
+            },
+            _ => None,
+        };
+        if source_class
+            .is_some_and(|class| class.is_protocol(db) || !class.abstract_methods(db).is_empty())
+        {
+            return self.never();
+        }
 
         let constructed_ty = meta_ty.bindings(db).return_type(db);
         self.check_type_pair(db, constructed_ty, Type::ProtocolInstance(protocol))

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -65,6 +65,31 @@ impl<'db> BoundMethodType<'db> {
         Self::new(db, self.function(db), f(self.self_instance(db)))
     }
 
+    /// Normalize this method's implicit receiver for a parameter, if needed.
+    ///
+    /// A protocol class object does not generally inhabit `type[P]`, but it is a valid receiver
+    /// for a class method whose receiver is generic over `type[T]`.
+    pub(crate) fn normalized_receiver_argument_type(
+        self,
+        db: &'db dyn Db,
+        parameter: &Parameter<'db>,
+        argument_type: Type<'db>,
+    ) -> Option<Type<'db>> {
+        if !self.function(db).is_classmethod(db) {
+            return None;
+        }
+
+        let Type::SubclassOf(subclass_of) = parameter.annotated_type() else {
+            return None;
+        };
+        subclass_of.into_type_var()?;
+
+        match argument_type.to_instance(db) {
+            Some(Type::ProtocolInstance(protocol)) => Some(protocol.to_meta_type(db)),
+            _ => None,
+        }
+    }
+
     #[salsa::tracked(
         returns(copy),
         cycle_initial=|db, _, _| CallableType::bottom(db),

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1027,6 +1027,29 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             })
     }
 
+    /// Check an exact class object against a `type[...]` target, including the concrete-class
+    /// requirement for protocol meta-types.
+    fn check_class_object_against_subclass_of(
+        &self,
+        db: &'db dyn Db,
+        source_ty: Type<'db>,
+        source_class: ClassType<'db>,
+        target: SubclassOfType<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        match target.subclass_of() {
+            SubclassOfInner::Protocol(_) if !source_class.is_concrete(db) => self.never(),
+            SubclassOfInner::Protocol(target_protocol) => {
+                self.check_meta_type_satisfies_protocol(db, source_ty, target_protocol)
+            }
+            target => target
+                .into_class(db)
+                .map(|target_class| self.check_class_pair(db, source_class, target_class))
+                .unwrap_or_else(|| {
+                    ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
+                }),
+        }
+    }
+
     /// Return a constraint set indicating the conditions under which `self.relation` holds between `source` and `target`.
     pub(super) fn check_type_pair(
         &self,
@@ -2110,31 +2133,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // `Literal[<class 'C'>]` is a subtype of `type[B]` if `C` is a subclass of `B`,
             // since `type[B]` describes all possible runtime subclasses of the class object `B`.
-            (Type::ClassLiteral(source_cls), Type::SubclassOf(target_subclass_ty)) => {
-                match target_subclass_ty.subclass_of() {
-                    SubclassOfInner::Protocol(target_protocol) => self
-                        .check_meta_type_satisfies_protocol(
-                            db,
-                            Type::ClassLiteral(source_cls),
-                            target_protocol,
-                        ),
-                    target => target
-                        .into_class(db)
-                        .map(|target_cls| {
-                            self.check_class_pair(
-                                db,
-                                source_cls.default_specialization(db),
-                                target_cls,
-                            )
-                        })
-                        .unwrap_or_else(|| {
-                            ConstraintSet::from_bool(
-                                self.constraints,
-                                self.is_eager_assignability(),
-                            )
-                        }),
-                }
-            }
+            (source @ Type::ClassLiteral(source_cls), Type::SubclassOf(target)) => self
+                .check_class_object_against_subclass_of(
+                    db,
+                    source,
+                    source_cls.default_specialization(db),
+                    target,
+                ),
 
             // Similarly, `<class 'C'>` is assignable to `<class 'C[...]'>` (a generic-alias type)
             // if the default specialization of `C` is assignable to `C[...]`. This scenario occurs
@@ -2155,27 +2160,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     ClassType::Generic(target_alias),
                 ),
 
-            (Type::GenericAlias(source_alias), Type::SubclassOf(target_subclass_ty)) => {
-                match target_subclass_ty.subclass_of() {
-                    SubclassOfInner::Protocol(target_protocol) => self
-                        .check_meta_type_satisfies_protocol(
-                            db,
-                            Type::GenericAlias(source_alias),
-                            target_protocol,
-                        ),
-                    target => target
-                        .into_class(db)
-                        .map(|target_cls| {
-                            self.check_class_pair(db, ClassType::Generic(source_alias), target_cls)
-                        })
-                        .unwrap_or_else(|| {
-                            ConstraintSet::from_bool(
-                                self.constraints,
-                                self.is_eager_assignability(),
-                            )
-                        }),
-                }
-            }
+            (source @ Type::GenericAlias(source_alias), Type::SubclassOf(target)) => self
+                .check_class_object_against_subclass_of(
+                    db,
+                    source,
+                    ClassType::Generic(source_alias),
+                    target,
+                ),
 
             // This branch asks: given two types `type[T]` and `type[S]`, is `type[T]` a subtype of `type[S]`?
             (Type::SubclassOf(source), Type::SubclassOf(target)) => {


### PR DESCRIPTION
## Summary

A class object now fails `type[P]` if it is itself a protocol class or has abstract methods, even when its modeled constructor return type and class members otherwise satisfy `P`:

```python
from abc import ABC, abstractmethod
from typing import Protocol

class P(Protocol):
    def method(self) -> None: ...

class AbstractP(ABC):
    @abstractmethod
    def method(self) -> None: ...

def accepts(cls: type[P]) -> None: ...

accepts(P)          # error
accepts(AbstractP)  # error
```

This will let us measure the impact separately, as discussed in [review](https://github.com/astral-sh/ruff/pull/26649#discussion_r3549628613).
