### PR TITLE
[ty] Expose protocol instance attributes through `type[Protocol]`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -898,8 +898,8 @@ class ExplicitSubclass(HasXWithDefault): ...
 reveal_type(ExplicitSubclass.x)  # revealed: int
 
 def f(arg: HasXWithDefault):
-    # `arg` may be an implicit subtype that does not define `x` on its class object.
-    type(arg).x  # error: [unresolved-attribute]
+    # Compatibility lookup exposes the protocol's instance attribute on the meta-type.
+    reveal_type(type(arg).x)  # revealed: int
 ```
 
 Assignments in a class body of a protocol -- of any kind -- are not permitted by ty unless the
@@ -4723,9 +4723,9 @@ Where `P` is a protocol type, a class object `N` can be said to inhabit the type
 - All method members on `P` exist on the class object `N`
 - Instantiating `N` creates an object that would satisfy the protocol `P`
 
-Ordinary instance attributes are required only on the object constructed by `N`, so they are not
-available through a value of type `type[P]`. Class variables and methods are available because every
-inhabitant of `type[P]` must provide them on the class object itself.
+Properties and ordinary instance attributes are not required to exist on `N` itself. For
+compatibility with other type checkers, however, attribute lookup on a value of type `type[P]`
+exposes ordinary instance attributes even though they are not required on `N`.
 
 ```toml
 [environment]
@@ -4744,8 +4744,9 @@ class Foo(Protocol):
 
 def _(f: type[Foo]):
     reveal_type(f)  # revealed: type[Foo]
-    f.x  # error: [unresolved-attribute]
-    f.x = 1  # error: [invalid-assignment]
+    reveal_type(f.x)  # revealed: int
+    f.x = 1
+    f.x = "bad"  # error: [invalid-assignment]
     reveal_type(f.y)  # revealed: str
     f.y = "foo"  # fine
     f.y = b"bad"  # error: [invalid-assignment]
@@ -4970,7 +4971,8 @@ static_assert(is_assignable_to(type[Any], type[Foo]))
 static_assert(not is_subtype_of(type[Any], type[Foo]))
 ```
 
-An ordinary instance attribute does not satisfy a `ClassVar` requirement on another meta-protocol.
+The broad attribute lookup on `type[Protocol]` does not turn an instance attribute into a `ClassVar`
+requirement.
 
 ```py
 class InstanceAttributeProtocol(Protocol):
@@ -5034,6 +5036,7 @@ static_assert(is_assignable_to(type[IntFoo], type[GenericFoo[int]]))
 static_assert(not is_assignable_to(type[IntFoo], type[GenericFoo[str]]))
 
 def _(f: type[GenericFoo[int]]) -> None:
+    reveal_type(f.value)  # revealed: int
     reveal_type(f.get)  # revealed: (self, /) -> int
     reveal_type(f())  # revealed: GenericFoo[int]
 ```

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -320,10 +320,12 @@ impl<'db> ProtocolInterface<'db> {
         })
     }
 
-    /// Returns the write requirement exposed through `type[Protocol]` lookup.
+    /// Returns the effective write requirement exposed through `type[Protocol]` lookup.
     ///
-    /// Only members required on every class object that satisfies the meta-protocol are available.
-    /// Ordinary instance attributes are required on the constructed object instead.
+    /// Attribute lookup on `type[Protocol]` intentionally exposes ordinary instance members even
+    /// though those members are not required to exist on a class object that satisfies the
+    /// meta-protocol. Prefer a member's true class capability when it has one (`ClassVar`s and
+    /// methods), and otherwise use its instance capability for this compatibility behavior.
     pub(super) fn meta_write_requirement(
         self,
         db: &'db dyn Db,
@@ -381,11 +383,13 @@ impl<'db> ProtocolInterface<'db> {
             .unwrap_or_else(|| Type::object().member(db, name))
     }
 
-    /// Looks up a member guaranteed to exist on every inhabitant of `type[Protocol]`.
+    /// Looks up a member through the compatibility behavior of `type[Protocol]`.
     ///
-    /// Methods retain their unbound signatures and `ClassVar`s retain their class-side types.
-    /// Properties are only required on the constructed instance, so they are undefined even when
-    /// the nominal protocol origin provides a property descriptor.
+    /// True class capabilities take precedence so methods retain their unbound signatures and
+    /// `ClassVar`s retain their class-side types. Ordinary instance attributes fall back to their
+    /// instance read type, matching the behavior of other type checkers even though meta-protocol
+    /// assignability does not require those members on the class object. Properties are only
+    /// required on the constructed instance, so they remain undefined.
     pub(super) fn meta_member(
         self,
         db: &'db dyn Db,
@@ -1105,7 +1109,14 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         if self.has_todo_type() {
             return None;
         }
-        Some(self.capabilities(db).class)
+        let capabilities = self.capabilities(db);
+        if self.is_property() {
+            return Some(capabilities.class);
+        }
+        Some(ProtocolMemberAccess::new(
+            capabilities.class.read.or(capabilities.instance.read),
+            capabilities.class.write.or(capabilities.instance.write),
+        ))
     }
 
     fn has_todo_type(&self) -> bool {


### PR DESCRIPTION
## Summary

#26649 exposes only members that every inhabitant of `type[P]` must provide on the class object itself. This PR also exposes instance attributes from `P` through a value typed as `type[P]`:

```python
from typing import Protocol

class P(Protocol):
    value: int

class C:
    def __init__(self) -> None:
        self.value = 1

def read(cls: type[P]) -> int:
    return cls.value

read(C)  # accepted here, but raises AttributeError at runtime
```

This is intentionally unsound: `C()` satisfies `P`, but `C.value` does not exist. But the behavior is used by other type checkers and preserves the precise protocol member type for reads and writes, including generic protocol arguments.
