### PR TITLE
[ty] Retain raw `Options` by precedence

### DIFF
--- a/crates/ruff_benchmark/benches/module_resolution.rs
+++ b/crates/ruff_benchmark/benches/module_resolution.rs
@@ -62,7 +62,7 @@ fn setup_case(n: usize) -> Case {
     fs.write_file_all(&importing_path, "").unwrap();
 
     let mut metadata = ProjectMetadata::discover(SystemPath::new("/src"), &system).unwrap();
-    metadata.apply_options(Options {
+    metadata.apply_override_options(Options {
         environment: Some(EnvironmentOptions {
             python_version: Some(RangedValue::cli(SupportedPythonVersion::Py312)),
             extra_paths: Some(extra_paths),

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -85,7 +85,7 @@ fn setup_tomllib_case() -> Case {
 
     let src_root = SystemPath::new("/src");
     let mut metadata = ProjectMetadata::discover(src_root, &system).unwrap();
-    metadata.apply_options(Options {
+    metadata.apply_override_options(Options {
         environment: Some(EnvironmentOptions {
             python_version: Some(RangedValue::cli(SupportedPythonVersion::Py312)),
             ..EnvironmentOptions::default()
@@ -267,7 +267,7 @@ fn setup_micro_case_inner(code: &str, venv_path: Option<&Path>) -> Case {
 
     let src_root = SystemPath::new("/src");
     let mut metadata = ProjectMetadata::discover(src_root, &system).unwrap();
-    metadata.apply_options(Options {
+    metadata.apply_override_options(Options {
         environment: Some(EnvironmentOptions {
             python_version: Some(RangedValue::cli(SupportedPythonVersion::Py312)),
             python,
@@ -1725,7 +1725,7 @@ impl<'a> ProjectBenchmark<'a> {
         let src_root = SystemPath::new("/");
         let mut metadata = ProjectMetadata::discover(src_root, &system).unwrap();
 
-        metadata.apply_options(Options {
+        metadata.apply_override_options(Options {
             environment: Some(EnvironmentOptions {
                 python_version: Some(RangedValue::cli(self.project.config.python_version)),
                 python: Some(RelativePathBuf::cli(SystemPath::new(".venv"))),

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -163,13 +163,10 @@ fn benchmark_incremental(criterion: &mut Criterion) {
     fn incremental(case: &mut Case) {
         let Case { db, .. } = case;
 
-        db.apply_changes(
-            &[ChangeEvent::Changed {
-                path: case.file_path.clone(),
-                kind: ChangedKind::FileContent,
-            }],
-            None,
-        );
+        db.apply_changes(&[ChangeEvent::Changed {
+            path: case.file_path.clone(),
+            kind: ChangedKind::FileContent,
+        }]);
 
         let result = db.check();
 

--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -43,7 +43,7 @@ impl<'a> Benchmark<'a> {
 
         let mut metadata = ProjectMetadata::discover(&root, &system).unwrap();
 
-        metadata.apply_options(Options {
+        metadata.apply_override_options(Options {
             environment: Some(EnvironmentOptions {
                 python_version: Some(RangedValue::cli(installed_project.config.python_version)),
                 python: Some(RelativePathBuf::cli(SystemPath::new(".venv"))),

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -24,7 +24,6 @@ use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
 use ruff_db::{STACK_SIZE, max_parallelism};
 use ruff_diagnostics::Applicability;
 use salsa::Database;
-use ty_project::metadata::options::ProjectOptionsOverrides;
 use ty_project::metadata::settings::TerminalSettings;
 use ty_project::watch::ProjectWatcher;
 use ty_project::{CollectReporter, Db, watch};
@@ -162,8 +161,7 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
 
     project_metadata.apply_configuration_files(&system)?;
 
-    let project_options_overrides = ProjectOptionsOverrides::new(config_file, args.into_options());
-    project_metadata.apply_overrides(&project_options_overrides);
+    project_metadata.apply_override_options(args.into_options());
 
     let mut db = ProjectDatabase::fallible(project_metadata, system)?;
     let project = db.project();
@@ -189,8 +187,7 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
         db.freeze();
     }
 
-    let (main_loop, main_loop_cancellation_token) =
-        MainLoop::new(mode, project_options_overrides, printer);
+    let (main_loop, main_loop_cancellation_token) = MainLoop::new(mode, printer);
 
     // Listen to Ctrl+C and abort the watch mode.
     let main_loop_cancellation_token = Mutex::new(Some(main_loop_cancellation_token));
@@ -280,8 +277,6 @@ struct MainLoop {
     /// Interface for displaying information to the user.
     printer: Printer,
 
-    project_options_overrides: ProjectOptionsOverrides,
-
     /// Cancellation token that gets set by Ctrl+C.
     /// Used for long-running operations on the main thread. Operations on background threads
     /// use Salsa's cancellation mechanism.
@@ -289,11 +284,7 @@ struct MainLoop {
 }
 
 impl MainLoop {
-    fn new(
-        mode: MainLoopMode,
-        project_options_overrides: ProjectOptionsOverrides,
-        printer: Printer,
-    ) -> (Self, MainLoopCancellationToken) {
+    fn new(mode: MainLoopMode, printer: Printer) -> (Self, MainLoopCancellationToken) {
         let (sender, receiver) = crossbeam_channel::bounded(10);
 
         let cancellation_token_source = CancellationTokenSource::new();
@@ -305,7 +296,6 @@ impl MainLoop {
                 sender: sender.clone(),
                 receiver,
                 watcher: None,
-                project_options_overrides,
                 printer,
                 cancellation_token,
             },
@@ -476,7 +466,7 @@ impl MainLoop {
 
                     revision += 1;
                     // Automatically cancels any pending queries and waits for them to complete.
-                    db.apply_changes(&changes, Some(&self.project_options_overrides));
+                    db.apply_changes(&changes);
                     if let Some(watcher) = self.watcher.as_mut() {
                         watcher.update(db);
                     }

--- a/crates/ty/tests/cli/rule_selection.rs
+++ b/crates/ty/tests/cli/rule_selection.rs
@@ -410,6 +410,55 @@ fn overrides_precedence() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Multiple matching overrides inherit global options from higher-precedence layers.
+#[test]
+fn multiple_overrides_inherit_cli_rules() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "pyproject.toml",
+            r#"
+            [[tool.ty.overrides]]
+            include = ["test.py"]
+            [tool.ty.overrides.rules]
+            division-by-zero = "warn"
+
+            [[tool.ty.overrides]]
+            include = ["test.py"]
+            [tool.ty.overrides.rules]
+            possibly-unresolved-reference = "ignore"
+            "#,
+        ),
+        (
+            "test.py",
+            r#"
+            y = 4 / 0
+            prin(y)
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(
+        case.command().args(["--ignore", "unresolved-reference"]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
+     --> test.py:2:5
+      |
+    2 | y = 4 / 0
+      |     ^^^^^
+      |
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
 /// Override with exclude patterns
 #[test]
 fn overrides_exclude() -> anyhow::Result<()> {

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -10,11 +10,9 @@ use ruff_db::system::{
     file_time_now,
 };
 use ruff_python_ast::PythonVersion;
-use ruff_ranged_value::RangedValue;
+use ruff_ranged_value::{RangedValue, ValueSource};
 use ty_module_resolver::{Module, ModuleName, resolve_module_confident};
-use ty_project::metadata::options::{
-    EnvironmentOptions, Options, ProjectOptionsOverrides, SrcOptions,
-};
+use ty_project::metadata::options::{EnvironmentOptions, Options, SrcOptions};
 use ty_project::metadata::pyproject::{PyProject, Tool};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::{RelativeGlobPattern, RelativePathBuf};
@@ -179,12 +177,8 @@ impl TestCase {
         Ok(all_events)
     }
 
-    fn apply_changes(
-        &mut self,
-        changes: &[ChangeEvent],
-        project_options_overrides: Option<&ProjectOptionsOverrides>,
-    ) -> ChangeResult {
-        self.db.apply_changes(changes, project_options_overrides)
+    fn apply_changes(&mut self, changes: &[ChangeEvent]) -> ChangeResult {
+        self.db.apply_changes(changes)
     }
 
     fn update_options(&mut self, options: Options) -> anyhow::Result<()> {
@@ -199,7 +193,7 @@ impl TestCase {
         .context("Failed to write configuration")?;
 
         let changes = self.take_watch_changes(event_for_file("pyproject.toml"));
-        self.apply_changes(&changes, None);
+        self.apply_changes(&changes);
 
         if let Some(watcher) = &mut self.watcher {
             watcher.update(&self.db);
@@ -280,6 +274,9 @@ struct SetupContext<'a> {
     system: &'a OsSystem,
     root_path: &'a SystemPath,
     options: Option<Options>,
+    config_file_override: Option<SystemPathBuf>,
+    override_options: Option<Options>,
+    fallback_options: Option<Options>,
     included_paths: Option<Vec<SystemPathBuf>>,
 }
 
@@ -342,6 +339,18 @@ impl<'a> SetupContext<'a> {
 
     fn set_options(&mut self, options: Options) {
         self.options = Some(options);
+    }
+
+    fn set_config_file_override(&mut self, path: impl AsRef<SystemPath>) {
+        self.config_file_override = Some(self.join_project_path(path));
+    }
+
+    fn set_override_options(&mut self, options: Options) {
+        self.override_options = Some(options);
+    }
+
+    fn set_fallback_options(&mut self, options: Options) {
+        self.fallback_options = Some(options);
     }
 
     fn set_included_paths(&mut self, paths: Vec<SystemPathBuf>) {
@@ -408,6 +417,9 @@ where
         system: &os_system,
         root_path: &root_path,
         options: None,
+        config_file_override: None,
+        override_options: None,
+        fallback_options: None,
         included_paths: None,
     };
 
@@ -415,7 +427,16 @@ where
         .setup(&mut setup_context)
         .context("Failed to setup test files")?;
 
-    if let Some(options) = setup_context.options {
+    let SetupContext {
+        options,
+        config_file_override,
+        override_options,
+        fallback_options,
+        included_paths,
+        ..
+    } = setup_context;
+
+    if let Some(options) = options {
         std::fs::write(
             project_path.join("pyproject.toml").as_std_path(),
             toml::to_string(&PyProject {
@@ -427,13 +448,22 @@ where
         .context("Failed to write configuration")?;
     }
 
-    let included_paths = setup_context.included_paths;
-
-    let mut project = ProjectMetadata::discover(&project_path, &system)?;
+    let mut project = if let Some(config_file_override) = config_file_override {
+        ProjectMetadata::from_config_file(config_file_override, &project_path, &system)?
+    } else {
+        ProjectMetadata::discover(&project_path, &system)?
+    };
+    if let Some(fallback_options) = fallback_options {
+        project.apply_fallback_options(fallback_options);
+    }
     project.apply_configuration_files(&system)?;
+    if let Some(override_options) = override_options {
+        project.apply_override_options(override_options);
+    }
 
     // We need a chance to create the directories here.
-    if let Some(environment) = project.options().environment.as_ref() {
+    let merged_options = project.to_merged_options();
+    if let Some(environment) = merged_options.options().environment.as_ref() {
         for path in environment
             .extra_paths
             .as_deref()
@@ -545,7 +575,7 @@ fn new_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     let foo = case.system_file(&foo_path).expect("foo.py to exist.");
 
@@ -583,7 +613,7 @@ fn new_directory_with_python_files() -> anyhow::Result<()> {
         )
     });
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     let init = case.system_file(&init_path).expect("__init__.py to exist");
     let module = case.system_file(&module_path).expect("module.py to exist");
@@ -613,7 +643,7 @@ fn new_non_python_file_is_not_indexed() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("README.md"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(case.system_file(&readme_path).is_ok());
     case.assert_indexed_project_files([bar_file]);
@@ -635,7 +665,7 @@ fn new_ignored_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(case.system_file(&foo_path).is_ok());
     case.assert_indexed_project_files([bar_file]);
@@ -662,7 +692,7 @@ fn new_file_in_ignored_directory() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("bad.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(case.system_file(&bad_path).is_ok());
     case.assert_indexed_project_files([bar_file]);
@@ -688,7 +718,7 @@ fn new_file_in_parent_ignored_directory() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("bad.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(case.system_file(&bad_path).is_ok());
     case.assert_indexed_project_files([bar_file]);
@@ -713,7 +743,7 @@ fn new_ignore_file_in_ignored_directory() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file(".gitignore"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(case.system_file(&nested_ignore_path).is_ok());
     case.assert_indexed_project_files([bar_file]);
@@ -732,7 +762,7 @@ fn ignore_file_change_reloads_files_not_project_metadata() -> anyhow::Result<()>
     update_file(case.project_path(".ignore"), "")?;
 
     let changes = case.stop_watch(event_for_file(".ignore"));
-    let result = case.apply_changes(&changes, None);
+    let result = case.apply_changes(&changes);
 
     assert!(!result.project_changed());
     case.assert_indexed_project_files([bar, foo]);
@@ -796,7 +826,7 @@ fn new_non_project_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("black.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(case.system_file(&black_path).is_ok());
 
@@ -837,7 +867,7 @@ fn new_files_with_explicit_included_paths() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("test2.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     let sub_a_file = case.system_file(&sub_a_path).expect("sub/a.py to exist");
 
@@ -882,7 +912,7 @@ fn new_file_in_included_out_of_project_directory() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("script2.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     let src_a_file = case.system_file(&src_a).unwrap();
     let outside_b_file = case.system_file(&outside_b_path).unwrap();
@@ -909,7 +939,7 @@ fn changed_file() -> anyhow::Result<()> {
 
     assert!(!changes.is_empty());
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert_eq!(source_text(case.db(), foo).as_str(), "print('Version 2')");
     case.assert_indexed_project_files([foo]);
@@ -933,7 +963,7 @@ fn deleted_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(!foo.exists(case.db()));
     assert!(resolve_module_confident(case.db(), &ModuleName::new_static("foo").unwrap()).is_none());
@@ -966,7 +996,7 @@ fn move_file_to_trash() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(!foo.exists(case.db()));
     case.assert_indexed_project_files([]);
@@ -993,7 +1023,7 @@ fn move_file_to_project() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     let foo_in_project = case.system_file(&foo_in_project)?;
 
@@ -1018,7 +1048,7 @@ fn rename_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("bar.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(!foo.exists(case.db()));
 
@@ -1057,7 +1087,7 @@ fn directory_moved_to_project() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("sub"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     let init_file = case
         .system_file(sub_new_path.join("__init__.py"))
@@ -1106,7 +1136,7 @@ fn directory_moved_to_trash() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("sub"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     // `import sub.a` should no longer resolve
     assert!(
@@ -1157,7 +1187,7 @@ fn directory_renamed() -> anyhow::Result<()> {
     // Linux and windows only emit an event for the newly created root directory, but not for every new component.
     let changes = case.stop_watch(event_for_file("sub"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     // `import sub.a` should no longer resolve
     assert!(
@@ -1218,7 +1248,7 @@ fn directory_deleted() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("sub"));
 
-    let result = case.apply_changes(&changes, None);
+    let result = case.apply_changes(&changes);
     assert!(!result.project_changed());
 
     // `import sub.a` should no longer resolve
@@ -1261,7 +1291,7 @@ fn search_path() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("a.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(resolve_module_confident(case.db(), &ModuleName::new_static("a").unwrap()).is_some());
     case.assert_indexed_project_files([case.system_file(case.project_path("bar.py")).unwrap()]);
@@ -1292,7 +1322,7 @@ fn add_search_path() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("a.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(resolve_module_confident(case.db(), &ModuleName::new_static("a").unwrap()).is_some());
 
@@ -1496,7 +1526,7 @@ fn changed_versions_file() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("VERSIONS"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert!(resolve_module_confident(case.db(), &ModuleName::new_static("os").unwrap()).is_some());
 
@@ -1550,7 +1580,7 @@ fn hard_links_in_project() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("foo.py"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert_eq!(source_text(case.db(), foo).as_str(), "print('Version 2')");
 
@@ -1621,7 +1651,7 @@ fn hard_links_to_target_outside_project() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(ChangeEvent::is_changed);
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     assert_eq!(source_text(case.db(), bar).as_str(), "print('Version 2')");
 
@@ -1660,7 +1690,7 @@ mod unix {
 
         let changes = case.stop_watch(event_for_file("foo.py"));
 
-        case.apply_changes(&changes, None);
+        case.apply_changes(&changes);
 
         assert_eq!(
             foo.permissions(case.db()),
@@ -1740,7 +1770,7 @@ mod unix {
 
         let changes = case.take_watch_changes(event_for_file("baz.py"));
 
-        case.apply_changes(&changes, None);
+        case.apply_changes(&changes);
 
         assert_eq!(
             source_text(case.db(), baz_file).as_str(),
@@ -1753,7 +1783,7 @@ mod unix {
 
         let changes = case.stop_watch(event_for_file("baz.py"));
 
-        case.apply_changes(&changes, None);
+        case.apply_changes(&changes);
 
         assert_eq!(
             source_text(case.db(), baz_file).as_str(),
@@ -1821,7 +1851,7 @@ mod unix {
 
         let changes = case.stop_watch(event_for_file("baz.py"));
 
-        case.apply_changes(&changes, None);
+        case.apply_changes(&changes);
 
         // The file watcher is guaranteed to emit one event for the changed file, but it isn't specified
         // if the event is emitted for the "original" or linked path because both paths are watched.
@@ -1935,7 +1965,7 @@ mod unix {
 
         let changes = case.stop_watch(event_for_file("baz.py"));
 
-        case.apply_changes(&changes, None);
+        case.apply_changes(&changes);
 
         assert_eq!(
             source_text(case.db(), baz_original_file).as_str(),
@@ -1973,7 +2003,7 @@ fn active_project_config_change_reloads_project() -> anyhow::Result<()> {
     )?;
 
     let changes = case.stop_watch(event_for_file("pyproject.toml"));
-    let result = case.apply_changes(&changes, None);
+    let result = case.apply_changes(&changes);
 
     assert!(result.project_changed());
 
@@ -1993,7 +2023,7 @@ fn nested_project_config_change_is_cheap_if_active_project_unchanged() -> anyhow
     std::fs::write(nested_pyproject.as_std_path(), "[tool.ty]\n")?;
 
     let changes = case.stop_watch(event_for_file("pyproject.toml"));
-    let result = case.apply_changes(&changes, None);
+    let result = case.apply_changes(&changes);
 
     assert!(!result.project_changed());
     assert_eq!(case.db().project().root(case.db()), &*project_root);
@@ -2033,7 +2063,7 @@ fn nested_projects_delete_root() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(ChangeEvent::is_deleted);
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     // It should now pick up the outer project.
     assert_eq!(case.db().project().root(case.db()), case.root_path());
@@ -2097,15 +2127,102 @@ fn changes_to_user_configuration() -> anyhow::Result<()> {
         "#,
     )?;
 
-    let changes = case.stop_watch(event_for_file("ty.toml"));
+    let changes = case.take_watch_changes(event_for_file("ty.toml"));
 
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     let diagnostics = case.db().check_file(foo);
 
     assert!(
         diagnostics.len() == 1,
         "Expected exactly one diagnostic but got: {diagnostics:#?}"
+    );
+
+    // Removing the option from the user configuration must not retain the old warning level.
+    update_file(case.root_path().join("home/.config/ty/ty.toml"), "")?;
+
+    let changes = case.stop_watch(event_for_file("ty.toml"));
+    case.apply_changes(&changes);
+
+    let diagnostics = case.db().check_file(foo);
+    assert!(
+        diagnostics.is_empty(),
+        "Expected no diagnostics but got: {diagnostics:#?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn project_reload_preserves_override_options() -> anyhow::Result<()> {
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_project_file("foo.py", "prin('hello')")?;
+        context.set_options(Options::default());
+        context.set_override_options(Options::from_toml_str(
+            r#"
+            [rules]
+            unresolved-reference = "ignore"
+            "#,
+            ValueSource::Cli,
+        )?);
+        Ok(())
+    })?;
+
+    let foo = case
+        .system_file(case.project_path("foo.py"))
+        .expect("foo.py to exist");
+    assert!(case.db().check_file(foo).is_empty());
+
+    case.update_options(Options::from_toml_str(
+        r#"
+        [terminal]
+        error-on-warning = false
+        "#,
+        ValueSource::Cli,
+    )?)?;
+
+    let diagnostics = case.db().check_file(foo);
+    assert!(
+        diagnostics.is_empty(),
+        "Expected override options to survive reload but got: {diagnostics:#?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn project_reload_preserves_fallback_options() -> anyhow::Result<()> {
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_project_file("foo.py", "a = 10 / 0")?;
+        context.set_options(Options::default());
+        context.set_fallback_options(Options::from_toml_str(
+            r#"
+            [rules]
+            division-by-zero = "warn"
+            "#,
+            ValueSource::Editor,
+        )?);
+        Ok(())
+    })?;
+
+    let foo = case
+        .system_file(case.project_path("foo.py"))
+        .expect("foo.py to exist");
+    assert_eq!(case.db().check_file(foo).len(), 1);
+
+    case.update_options(Options::from_toml_str(
+        r#"
+        [terminal]
+        error-on-warning = false
+        "#,
+        ValueSource::Cli,
+    )?)?;
+
+    let diagnostics = case.db().check_file(foo);
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "Expected fallback options to survive reload but got: {diagnostics:#?}"
     );
 
     Ok(())
@@ -2134,6 +2251,7 @@ fn changes_to_config_file_override() -> anyhow::Result<()> {
             division-by-zero = "ignore"
             "#,
         )?;
+        context.set_config_file_override("ty-override.toml");
 
         Ok(())
     })?;
@@ -2159,13 +2277,7 @@ fn changes_to_config_file_override() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("ty-override.toml"));
 
-    case.apply_changes(
-        &changes,
-        Some(&ProjectOptionsOverrides::new(
-            Some(case.project_path("ty-override.toml")),
-            Options::default(),
-        )),
-    );
+    case.apply_changes(&changes);
 
     let diagnostics = case.db().check_file(foo);
 
@@ -2230,7 +2342,7 @@ fn rename_files_casing_only() -> anyhow::Result<()> {
     .context("Failed to rename `temp.py` to `Lib.py`")?;
 
     let changes = case.stop_watch(event_for_file("Lib.py"));
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     // Resolving `lib` should now fail but `Lib` should now succeed
     assert_eq!(
@@ -2260,7 +2372,7 @@ fn submodule_cache_invalidation_created() -> anyhow::Result<()> {
 
     std::fs::write(case.project_path("bar/wazoo.py").as_std_path(), "")?;
     let changes = case.stop_watch(event_for_file("wazoo.py"));
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     insta::assert_snapshot!(
         case.sorted_submodule_names("bar").join("\n"),
@@ -2294,7 +2406,7 @@ fn submodule_cache_invalidation_deleted() -> anyhow::Result<()> {
 
     std::fs::remove_file(case.project_path("bar/wazoo.py").as_std_path())?;
     let changes = case.stop_watch(event_for_file("wazoo.py"));
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     insta::assert_snapshot!(
         case.sorted_submodule_names("bar").join("\n"),
@@ -2317,11 +2429,11 @@ fn submodule_cache_invalidation_created_then_deleted() -> anyhow::Result<()> {
 
     std::fs::write(case.project_path("bar/wazoo.py").as_std_path(), "")?;
     let changes = case.take_watch_changes(event_for_file("wazoo.py"));
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     std::fs::remove_file(case.project_path("bar/wazoo.py").as_std_path())?;
     let changes = case.stop_watch(event_for_file("wazoo.py"));
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     insta::assert_snapshot!(
         case.sorted_submodule_names("bar").join("\n"),
@@ -2347,7 +2459,7 @@ fn submodule_cache_invalidation_after_pyproject_created() -> anyhow::Result<()> 
 
     std::fs::write(case.project_path("bar/wazoo.py").as_std_path(), "")?;
     let changes = case.take_watch_changes(event_for_file("wazoo.py"));
-    case.apply_changes(&changes, None);
+    case.apply_changes(&changes);
 
     insta::assert_snapshot!(
         case.sorted_submodule_names("bar").join("\n"),

--- a/crates/ty_completion_bench/src/main.rs
+++ b/crates/ty_completion_bench/src/main.rs
@@ -1,6 +1,6 @@
-/*!
-A simple command line tool for ad hoc completion benchmarking.
-*/
+//!
+//! A simple command line tool for ad hoc completion benchmarking.
+//!
 
 // This is a developer tool and is therefore fine to use `eprintln!`.
 #![allow(clippy::print_stderr)]
@@ -91,14 +91,13 @@ fn main() -> anyhow::Result<ExitCode> {
     let system = OsSystem::new(&project_dir);
     let mut project_metadata = ProjectMetadata::discover(&project_dir, &system)?;
     // Explicitly point ty to the .venv to avoid any set VIRTUAL_ENV variable to take precedence.
-    project_metadata.apply_options(Options {
+    project_metadata.apply_override_options(Options {
         environment: Some(EnvironmentOptions {
             python: Some(RelativePathBuf::cli(".venv")),
             ..EnvironmentOptions::default()
         }),
         ..Options::default()
     });
-    project_metadata.apply_configuration_files(&system)?;
     let db = ProjectDatabase::fallible(project_metadata, system)?;
 
     let start = std::time::Instant::now();

--- a/crates/ty_completion_eval/src/main.rs
+++ b/crates/ty_completion_eval/src/main.rs
@@ -1,8 +1,6 @@
-/*!
-A simple command line tool for running a completion evaluation.
-
-See `crates/ty_completion_eval/README.md` for examples and more docs.
-*/
+//! A simple command line tool for running a completion evaluation.
+//!
+//! See `crates/ty_completion_eval/README.md` for examples and more docs.
 
 use std::io::Write;
 use std::process::ExitCode;
@@ -282,14 +280,13 @@ impl Task {
         let system = OsSystem::new(project_path);
         let mut project_metadata = ProjectMetadata::discover(project_path, &system)?;
         // Explicitly point ty to the .venv to avoid any set VIRTUAL_ENV variable to take precedence.
-        project_metadata.apply_options(Options {
+        project_metadata.apply_override_options(Options {
             environment: Some(EnvironmentOptions {
                 python: Some(RelativePathBuf::cli(".venv")),
                 ..EnvironmentOptions::default()
             }),
             ..Options::default()
         });
-        project_metadata.apply_configuration_files(&system)?;
         let db = ProjectDatabase::fallible(project_metadata, system)?;
         Ok(Task {
             db,

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -124,10 +124,11 @@ impl ProjectDatabase {
         // cache key before loading the DB. Because of that, access to the `db` (other than system and vendored) is
         // strictly forbidden before resolving the `program_settings`.
 
+        let merged_options = project_metadata.to_merged_options();
+
         // Initialize the `Program` singleton
-        let (program_settings, program_settings_diagnostics) = strategy.to_anyhow(
-            project_metadata.to_program_settings(db.system(), db.vendored(), strategy),
-        )?;
+        let (program_settings, program_settings_diagnostics) = strategy
+            .to_anyhow(merged_options.to_program_settings(db.system(), db.vendored(), strategy))?;
 
         // This must be called before `from_settings`, or the `SearchPath` root
         // will take precedence over the `Project` root, resulting in
@@ -136,12 +137,10 @@ impl ProjectDatabase {
 
         Program::from_settings(&db, program_settings);
 
-        let (settings, settings_diagnostics) = strategy.map_err(
-            project_metadata
-                .options()
-                .to_settings(&db, project_metadata.root(), strategy),
-            |error| anyhow::anyhow!("{}", error.pretty(&db)),
-        )?;
+        let (settings, settings_diagnostics) = strategy
+            .map_err(merged_options.to_settings(&db, strategy), |error| {
+                anyhow::anyhow!("{}", error.pretty(&db))
+            })?;
 
         db.project = Some(Project::from_metadata(
             &db,
@@ -666,8 +665,8 @@ pub(crate) mod testing {
             };
 
             let (settings, settings_diagnostics) = project
-                .options()
-                .to_settings(&db, project.root(), &FallibleStrategy)
+                .to_merged_options()
+                .to_settings(&db, &FallibleStrategy)
                 .unwrap();
             let project =
                 Project::from_metadata(&db, project, settings, settings_diagnostics, Vec::new());

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -1,5 +1,4 @@
 use crate::db::{Db, ProjectDatabase};
-use crate::metadata::options::ProjectOptionsOverrides;
 use crate::watch::{ChangeEvent, CreatedKind, DeletedKind};
 use crate::{ProjectMetadata, ProjectReloadResult};
 use std::collections::BTreeSet;
@@ -31,17 +30,11 @@ impl ChangeResult {
 }
 
 impl ProjectDatabase {
-    #[tracing::instrument(level = "debug", skip(self, changes, project_options_overrides))]
-    pub fn apply_changes(
-        &mut self,
-        changes: &[ChangeEvent],
-        project_options_overrides: Option<&ProjectOptionsOverrides>,
-    ) -> ChangeResult {
+    #[tracing::instrument(level = "debug", skip(self, changes))]
+    pub fn apply_changes(&mut self, changes: &[ChangeEvent]) -> ChangeResult {
         let project = self.project();
         let project_root = project.root(self).to_path_buf();
-        let config_file_override =
-            project_options_overrides.and_then(|options| options.config_file_override.clone());
-        let extra_configuration_paths = project.metadata(self).extra_configuration_paths().to_vec();
+        let configuration_paths = ConfigurationPaths::from_metadata(project.metadata(self));
         let program = Program::get(self);
         let custom_stdlib_versions_path = program
             .custom_stdlib_search_path(self)
@@ -73,12 +66,7 @@ impl ProjectDatabase {
             tracing::debug!("Handling file watcher change event: {:?}", change);
 
             if let Some(path) = change.system_path() {
-                if is_project_configuration_path(
-                    path,
-                    &project_root,
-                    config_file_override.as_ref(),
-                    &extra_configuration_paths,
-                ) {
+                if configuration_paths.is_configuration(path, &project_root) {
                     File::sync_path(self, path);
                     reload_project = true;
 
@@ -211,12 +199,7 @@ impl ProjectDatabase {
                             result.custom_stdlib_changed = true;
                         }
 
-                        if directory_may_contain_project_configuration(
-                            path,
-                            &project_root,
-                            config_file_override.as_ref(),
-                            &extra_configuration_paths,
-                        ) {
+                        if configuration_paths.may_contain_configuration(path, &project_root) {
                             tracing::debug!(
                                 "Reload project because a configuration file may have been deleted."
                             );
@@ -249,18 +232,7 @@ impl ProjectDatabase {
         Files::sync_all_recursive(self, sync_recursively);
 
         if reload_project {
-            // The active project root may have been deleted. Start rediscovery from
-            // the closest existing ancestor so ty can fall back to an enclosing project.
-            let rediscovery_path = project_root
-                .ancestors()
-                .find(|path| self.system().is_directory(path))
-                .unwrap_or(&project_root);
-            let new_project_metadata = match config_file_override {
-                Some(config_file) => {
-                    ProjectMetadata::from_config_file(config_file, &project_root, self.system())
-                }
-                None => ProjectMetadata::discover(rediscovery_path, self.system()),
-            };
+            let new_project_metadata = project.metadata(self).rediscover(self.system());
             match new_project_metadata {
                 Ok(mut metadata) => {
                     if let Err(error) = metadata.apply_configuration_files(self.system()) {
@@ -270,13 +242,10 @@ impl ProjectDatabase {
                         );
                     }
 
-                    if let Some(overrides) = project_options_overrides {
-                        metadata.apply_overrides(overrides);
-                    }
-
                     metadata.try_add_project_root(self);
+                    let merged_options = metadata.to_merged_options();
 
-                    let program_settings_diagnostics = match metadata.to_program_settings(
+                    let program_settings_diagnostics = match merged_options.to_program_settings(
                         self.system(),
                         self.vendored(),
                         &FallibleStrategy,
@@ -294,11 +263,9 @@ impl ProjectDatabase {
                         }
                     };
 
-                    let (settings, settings_diagnostics) = match metadata.options().to_settings(
-                        self,
-                        metadata.root(),
-                        &FallibleStrategy,
-                    ) {
+                    let (settings, settings_diagnostics) = match merged_options
+                        .to_settings(self, &FallibleStrategy)
+                    {
                         Ok((settings, diagnostics)) => (Some(settings), diagnostics),
                         Err(error) => {
                             tracing::warn!(
@@ -348,21 +315,20 @@ impl ProjectDatabase {
         }
 
         if result.custom_stdlib_changed {
-            match project.metadata(self).to_program_settings(
+            let metadata = project.metadata(self);
+            let merged_options = metadata.to_merged_options();
+            match merged_options.to_program_settings(
                 self.system(),
                 self.vendored(),
                 &FallibleStrategy,
             ) {
                 Ok((program_settings, program_settings_diagnostics)) => {
+                    let settings_diagnostics =
+                        match merged_options.to_settings(self, &FallibleStrategy) {
+                            Ok((_, diagnostics)) => diagnostics,
+                            Err(error) => vec![error.into_diagnostic()],
+                        };
                     program.update_from_settings(self, program_settings);
-                    let settings_diagnostics = match project.metadata(self).options().to_settings(
-                        self,
-                        project.metadata(self).root(),
-                        &FallibleStrategy,
-                    ) {
-                        Ok((_, diagnostics)) => diagnostics,
-                        Err(error) => vec![error.into_diagnostic()],
-                    };
                     project.update_settings_diagnostics(
                         self,
                         settings_diagnostics,
@@ -402,54 +368,53 @@ impl ProjectDatabase {
     }
 }
 
-fn is_project_configuration_path(
-    path: &SystemPath,
-    project_root: &SystemPath,
-    config_file_override: Option<&SystemPathBuf>,
-    extra_configuration_paths: &[SystemPathBuf],
-) -> bool {
-    if extra_configuration_paths
-        .iter()
-        .any(|config_path| config_path.as_path() == path)
-    {
-        return true;
-    }
-
-    if let Some(config_path) = config_file_override {
-        config_path.as_path() == path
-    } else {
-        path.parent()
-            .is_some_and(|parent| project_root.starts_with(parent))
-            && is_project_config_file(path)
-    }
+struct ConfigurationPaths {
+    normal_discovery: bool,
+    extra: Box<[SystemPathBuf]>,
 }
 
-fn directory_may_contain_project_configuration(
-    directory: &SystemPath,
-    project_root: &SystemPath,
-    config_file_override: Option<&SystemPathBuf>,
-    extra_configuration_paths: &[SystemPathBuf],
-) -> bool {
-    if extra_configuration_paths
-        .iter()
-        .any(|config_path| config_path.starts_with(directory))
-    {
-        return true;
+impl ConfigurationPaths {
+    fn from_metadata(metadata: &ProjectMetadata) -> Self {
+        Self {
+            normal_discovery: metadata.config_file_override().is_none(),
+            extra: metadata
+                .extra_configuration_paths()
+                .map(SystemPath::to_path_buf)
+                .collect(),
+        }
     }
 
-    if let Some(config_path) = config_file_override {
-        config_path.starts_with(directory)
-    } else {
+    fn is_configuration(&self, path: &SystemPath, project_root: &SystemPath) -> bool {
+        if self
+            .extra
+            .iter()
+            .any(|config_path| config_path.as_path() == path)
+        {
+            return true;
+        }
+
+        self.normal_discovery
+            && path
+                .parent()
+                .is_some_and(|parent| project_root.starts_with(parent))
+            && matches!(path.file_name(), Some("ty.toml" | "pyproject.toml"))
+    }
+
+    fn may_contain_configuration(&self, directory: &SystemPath, project_root: &SystemPath) -> bool {
+        if self
+            .extra
+            .iter()
+            .any(|config_path| config_path.starts_with(directory))
+        {
+            return true;
+        }
+
         // Deleting the project root or one of its ancestors can change rediscovery:
         // ty may need to fall back to an enclosing configuration.
-        project_root.starts_with(directory)
+        self.normal_discovery && project_root.starts_with(directory)
     }
 }
 
 fn is_ignore_file(path: &SystemPath) -> bool {
     matches!(path.file_name(), Some(".gitignore" | ".ignore"))
-}
-
-fn is_project_config_file(path: &SystemPath) -> bool {
-    matches!(path.file_name(), Some("ty.toml" | "pyproject.toml"))
 }

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -10,7 +10,6 @@ use ty_combine::Combine;
 use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy, ProgramSettings};
 
 use crate::Db;
-use crate::metadata::options::ProjectOptionsOverrides;
 use crate::metadata::options::{OptionDiagnostic, ProgramSettingsDiagnostic, ToSettingsError};
 use crate::metadata::pyproject::{Project, PyProject, PyProjectError, ResolveRequiresPythonError};
 use crate::metadata::settings::Settings;
@@ -31,17 +30,33 @@ pub struct ProjectMetadata {
 
     pub(super) root: SystemPathBuf,
 
-    /// The raw options
+    /// The highest-precedence options, such as CLI flags or inline editor configuration.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
+    override_options: Option<Box<Options>>,
+
+    /// The raw (unmerged, unresolved) options from the project's configuration.
+    /// When [`Self::config_file_override`] is `None`, then these are the options from the
+    /// project's `ty.toml` or `pyproject.toml`. The options come from
+    /// the file specified by [`Self::config_file_override`] if it is `Some` (e.g. when using `--config-file <path>`).
     pub(super) options: Options,
 
-    /// Paths of configurations other than the project's configuration that were combined into [`Self::options`].
+    /// The user-level configuration path and its options.
     ///
-    /// This field stores the paths of the configuration files, mainly for
-    /// knowing which files to watch for changes.
+    /// Its options have lower precedence than [`Self::override_options`] and [`Self::options`],
+    /// but higher precedence than [`Self::fallback_options`].
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
+    user_configuration: Option<Box<(SystemPathBuf, Options)>>,
+
+    /// The lowest-precedence options, such as the editor-selected Python environment.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
+    fallback_options: Option<Box<Options>>,
+
+    /// The explicit configuration file that replaces normal project discovery.
     ///
-    /// The path ordering doesn't imply precedence.
-    #[cfg_attr(test, serde(skip_serializing_if = "Vec::is_empty"))]
-    pub(super) extra_configuration_paths: Vec<SystemPathBuf>,
+    /// Can be specified using `--config-file <path>`. When `Some`, [`Self::options`] were loaded from this file
+    /// instead of from the project's `pyproject.toml` or `ty.toml` file.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
+    config_file_override: Option<SystemPathBuf>,
 }
 
 impl ProjectMetadata {
@@ -50,8 +65,11 @@ impl ProjectMetadata {
         Self {
             name,
             root,
-            extra_configuration_paths: Vec::default(),
             options: Options::default(),
+            override_options: None,
+            user_configuration: None,
+            fallback_options: None,
+            config_file_override: None,
         }
     }
 
@@ -75,7 +93,10 @@ impl ProjectMetadata {
             name: Name::new(root.file_name().unwrap_or("root")),
             root: root.to_path_buf(),
             options,
-            extra_configuration_paths: vec![path],
+            override_options: None,
+            user_configuration: None,
+            fallback_options: None,
+            config_file_override: Some(path),
         })
     }
 
@@ -130,7 +151,10 @@ impl ProjectMetadata {
             name,
             root,
             options,
-            extra_configuration_paths: Vec::new(),
+            override_options: None,
+            user_configuration: None,
+            fallback_options: None,
+            config_file_override: None,
         })
     }
 
@@ -267,6 +291,27 @@ impl ProjectMetadata {
         Ok(metadata)
     }
 
+    /// Rediscovers the project, while preserving applied options.
+    pub(crate) fn rediscover(&self, system: &dyn System) -> Result<Self, ProjectMetadataError> {
+        let mut metadata = if let Some(config_file) = self.config_file_override() {
+            Self::from_config_file(config_file.to_path_buf(), self.root(), system)?
+        } else {
+            // The active project root may have been deleted. Start rediscovery from the closest
+            // existing ancestor so ty can fall back to an enclosing project.
+            let rediscovery_path = self
+                .root()
+                .ancestors()
+                .find(|path| system.is_directory(path))
+                .unwrap_or_else(|| self.root());
+            Self::discover(rediscovery_path, system)?
+        };
+
+        metadata.override_options.clone_from(&self.override_options);
+        metadata.fallback_options.clone_from(&self.fallback_options);
+
+        Ok(metadata)
+    }
+
     pub fn root(&self) -> &SystemPath {
         &self.root
     }
@@ -279,8 +324,18 @@ impl ProjectMetadata {
         &self.options
     }
 
-    pub fn extra_configuration_paths(&self) -> &[SystemPathBuf] {
-        &self.extra_configuration_paths
+    /// Returns the explicit configuration file that replaces normal project discovery, if any.
+    pub(crate) fn config_file_override(&self) -> Option<&SystemPath> {
+        self.config_file_override.as_deref()
+    }
+
+    /// Returns configuration paths outside normal project discovery that should be watched.
+    pub fn extra_configuration_paths(&self) -> impl Iterator<Item = &SystemPath> {
+        self.config_file_override().into_iter().chain(
+            self.user_configuration
+                .as_deref()
+                .map(|(path, _)| path.as_path()),
+        )
     }
 
     pub(crate) fn try_add_project_root(&self, db: &dyn Db) {
@@ -292,35 +347,59 @@ impl ProjectMetadata {
             .try_add_root(db, self.root(), FileRootKind::Project);
     }
 
-    pub fn to_program_settings<Strategy: MisconfigurationStrategy>(
-        &self,
-        system: &dyn System,
-        vendored: &VendoredFileSystem,
-        strategy: &Strategy,
-    ) -> Result<(ProgramSettings, Vec<ProgramSettingsDiagnostic>), Strategy::Error<anyhow::Error>>
-    {
-        self.options
-            .to_program_settings(self.root(), self.name(), system, vendored, strategy)
+    /// Applies higher-precedence options to this project.
+    ///
+    /// Options applied later take precedence over options applied earlier.
+    pub fn apply_override_options(&mut self, options: Options) {
+        if let Some(existing) = self.override_options.as_mut() {
+            let previous = std::mem::replace(existing.as_mut(), options);
+            existing.combine_with(previous);
+        } else {
+            self.override_options = Some(Box::new(options));
+        }
     }
 
-    pub fn to_settings<Strategy: MisconfigurationStrategy>(
-        &self,
-        db: &dyn Db,
-        strategy: &Strategy,
-    ) -> Result<(Settings, Vec<OptionDiagnostic>), Strategy::Error<ToSettingsError>> {
-        self.options.to_settings(db, self.root(), strategy)
+    /// Applies lower-precedence options to this project.
+    ///
+    /// Options applied later take precedence over options applied earlier, but all fallback options
+    /// have lower precedence than the raw and user-level options.
+    pub fn apply_fallback_options(&mut self, options: Options) {
+        if let Some(existing) = self.fallback_options.as_mut() {
+            let previous = std::mem::replace(existing.as_mut(), options);
+            existing.combine_with(previous);
+        } else {
+            self.fallback_options = Some(Box::new(options));
+        }
     }
 
-    pub fn apply_overrides(&mut self, overrides: &ProjectOptionsOverrides) {
-        self.options = overrides.apply_to(std::mem::take(&mut self.options));
+    /// Applies this project's option layers to another raw configuration.
+    pub fn apply_options_to(&self, options: &Options) -> Options {
+        let mut merged = Options::default();
+
+        for options in self.options_in_precedence_order(options) {
+            merged.combine_with(options.clone());
+        }
+
+        merged
     }
 
-    /// Combine the project options with the CLI options where the CLI options take precedence.
-    pub fn apply_options(&mut self, options: Options) {
-        self.options = options.combine(std::mem::take(&mut self.options));
+    pub(crate) fn options_in_precedence_order<'a>(
+        &'a self,
+        options: &'a Options,
+    ) -> impl Iterator<Item = &'a Options> {
+        self.override_options
+            .as_deref()
+            .into_iter()
+            .chain(std::iter::once(options))
+            .chain(
+                self.user_configuration
+                    .as_deref()
+                    .map(|(_, options)| options),
+            )
+            .chain(self.fallback_options.as_deref())
     }
 
-    /// Applies the options from the configuration files to the project's options.
+    /// Loads the lower-precedence options from configuration files.
     ///
     /// This includes:
     ///
@@ -329,22 +408,62 @@ impl ProjectMetadata {
         &mut self,
         system: &dyn System,
     ) -> Result<(), ConfigurationFileError> {
+        self.user_configuration = None;
+
         if let Some(user) = ConfigurationFile::user(system)? {
             tracing::debug!(
                 "Applying user-level configuration loaded from `{path}`.",
                 path = user.path()
             );
-            self.apply_configuration_file(user);
+            self.user_configuration = Some(Box::new((user.path().to_owned(), user.into_options())));
         }
 
         Ok(())
     }
 
-    /// Applies a lower-precedence configuration files to the project's options.
-    fn apply_configuration_file(&mut self, options: ConfigurationFile) {
-        self.extra_configuration_paths
-            .push(options.path().to_owned());
-        self.options.combine_with(options.into_options());
+    /// Returns all option layers merged according to their precedence.
+    pub fn to_merged_options(&self) -> MergedOptions<'_> {
+        MergedOptions {
+            metadata: self,
+            options: self.apply_options_to(&self.options),
+        }
+    }
+}
+
+/// The merged options for a project and the metadata needed to resolve them.
+pub struct MergedOptions<'a> {
+    metadata: &'a ProjectMetadata,
+    options: Options,
+}
+
+impl MergedOptions<'_> {
+    /// Returns the merged raw options.
+    pub fn options(&self) -> &Options {
+        &self.options
+    }
+
+    pub fn to_program_settings<Strategy: MisconfigurationStrategy>(
+        &self,
+        system: &dyn System,
+        vendored: &VendoredFileSystem,
+        strategy: &Strategy,
+    ) -> Result<(ProgramSettings, Vec<ProgramSettingsDiagnostic>), Strategy::Error<anyhow::Error>>
+    {
+        self.options.to_program_settings(
+            self.metadata.root(),
+            self.metadata.name(),
+            system,
+            vendored,
+            strategy,
+        )
+    }
+
+    pub fn to_settings<Strategy: MisconfigurationStrategy>(
+        &self,
+        db: &dyn Db,
+        strategy: &Strategy,
+    ) -> Result<(Settings, Vec<OptionDiagnostic>), Strategy::Error<ToSettingsError>> {
+        self.options.to_settings(db, self.metadata.root(), strategy)
     }
 }
 

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -372,17 +372,17 @@ impl ProjectMetadata {
         }
     }
 
-    /// Applies this project's option layers to another raw configuration.
-    pub fn apply_options_to(&self, options: &Options) -> Options {
-        let mut merged = Options::default();
-
-        for options in self.options_in_precedence_order(options) {
-            merged.combine_with(options.clone());
-        }
-
-        merged
-    }
-
+    /// Returns the project's option layers from highest to lowest precedence.
+    ///
+    /// `options` is used as the raw base layer between the override and user-level options.
+    /// Layers can be merged by passing them to [`Options::combine_with`] in iterator order:
+    ///
+    /// ```ignore
+    /// let mut merged = Options::default();
+    /// for layer in metadata.options_in_precedence_order(metadata.options()) {
+    ///     merged.combine_with(layer.clone());
+    /// }
+    /// ```
     pub(crate) fn options_in_precedence_order<'a>(
         &'a self,
         options: &'a Options,
@@ -423,9 +423,15 @@ impl ProjectMetadata {
 
     /// Returns all option layers merged according to their precedence.
     pub fn to_merged_options(&self) -> MergedOptions<'_> {
+        let mut options = Options::default();
+
+        for layer in self.options_in_precedence_order(&self.options) {
+            options.combine_with(layer.clone());
+        }
+
         MergedOptions {
             metadata: self,
-            options: self.apply_options_to(&self.options),
+            options,
         }
     }
 }

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -2194,40 +2194,6 @@ impl OptionDiagnostic {
     }
 }
 
-/// This is a wrapper for options that actually get loaded from configuration files
-/// and the CLI, which also includes a `config_file_override` option that overrides
-/// default configuration discovery with an explicitly-provided path to a configuration file
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
-pub struct ProjectOptionsOverrides {
-    pub config_file_override: Option<SystemPathBuf>,
-    pub fallback_python_version: Option<RangedValue<SupportedPythonVersion>>,
-    pub fallback_python: Option<RelativePathBuf>,
-    pub options: Options,
-}
-
-impl ProjectOptionsOverrides {
-    pub fn new(config_file_override: Option<SystemPathBuf>, options: Options) -> Self {
-        Self {
-            config_file_override,
-            options,
-            ..Self::default()
-        }
-    }
-
-    pub fn apply_to(&self, options: Options) -> Options {
-        let mut combined = self.options.clone().combine(options);
-
-        // Set the fallback python version and path if set
-        combined.environment.combine_with(Some(EnvironmentOptions {
-            python_version: self.fallback_python_version.clone(),
-            python: self.fallback_python.clone(),
-            ..EnvironmentOptions::default()
-        }));
-
-        combined
-    }
-}
-
 trait OrDefault {
     type Target: ToOwned;
 

--- a/crates/ty_project/src/metadata/settings.rs
+++ b/crates/ty_project/src/metadata/settings.rs
@@ -188,12 +188,14 @@ fn merge_overrides(db: &dyn Db, overrides: Vec<Arc<InnerOverrideOptions>>, _: ()
         merged.combine_with((*option).clone());
     }
 
-    let global_options = db.project().metadata(db).options();
+    let metadata = db.project().metadata(db);
 
-    merged.rules.combine_with(global_options.rules.clone());
-    merged
-        .analysis
-        .combine_with(global_options.analysis.clone());
+    // Merge with the project level options by replaying the individual options
+    // in the correct precedence order.
+    for options in metadata.options_in_precedence_order(metadata.options()) {
+        merged.rules.combine_with(options.rules.clone());
+        merged.analysis.combine_with(options.analysis.clone());
+    }
 
     if merged.rules.is_none() && merged.analysis.is_none() {
         return FileSettings::Global;

--- a/crates/ty_project/src/watch/project_watcher.rs
+++ b/crates/ty_project/src/watch/project_watcher.rs
@@ -69,12 +69,7 @@ impl ProjectWatcher {
 
         self.has_errored_paths = false;
 
-        let config_paths = db
-            .project()
-            .metadata(db)
-            .extra_configuration_paths()
-            .iter()
-            .map(SystemPathBuf::as_path);
+        let config_paths = db.project().metadata(db).extra_configuration_paths();
 
         // Watch both the project root and any paths provided by the user on the CLI (removing any redundant nested paths).
         // This is necessary to observe changes to files that are outside the project root.

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -413,18 +413,9 @@ impl Session {
         path: &AnySystemPath,
         changes: &[ChangeEvent],
     ) -> ChangeResult {
-        let overrides = path.as_system().and_then(|root| {
-            self.workspaces()
-                .for_path(root)?
-                .settings()
-                .project_options_overrides()
-                .cloned()
-        });
-
         self.bump_revision();
 
-        self.project_db_mut(path)
-            .apply_changes(changes, overrides.as_ref())
+        self.project_db_mut(path).apply_changes(changes)
     }
 
     /// Returns a mutable iterator over all project databases.
@@ -594,10 +585,7 @@ impl Session {
             self.native_system.clone(),
         );
 
-        let configuration_file = workspace
-            .settings
-            .project_options_overrides()
-            .and_then(|settings| settings.config_file_override.as_ref());
+        let configuration_file = workspace.settings.configuration_file();
 
         let metadata = if let Some(configuration_file) = configuration_file {
             ProjectMetadata::from_config_file(configuration_file.clone(), &root, &system)
@@ -608,12 +596,16 @@ impl Session {
         let project = metadata
             .context("Failed to discover project configuration")
             .and_then(|mut metadata| {
+                if let Some(fallback_options) = workspace.settings.fallback_options() {
+                    metadata.apply_fallback_options(fallback_options.clone());
+                }
+
                 metadata
                     .apply_configuration_files(&system)
                     .context("Failed to apply configuration files")?;
 
-                if let Some(overrides) = workspace.settings.project_options_overrides() {
-                    metadata.apply_overrides(overrides);
+                if let Some(override_options) = workspace.settings.override_options() {
+                    metadata.apply_override_options(override_options.clone());
                 }
 
                 ProjectDatabase::fallible(metadata, system.clone())

--- a/crates/ty_server/src/session/options.rs
+++ b/crates/ty_server/src/session/options.rs
@@ -12,7 +12,7 @@ use ty_combine::Combine;
 use ty_ide::{CompletionSettings, InlayHintSettings};
 use ty_project::CheckMode;
 use ty_project::metadata::Options as TyOptions;
-use ty_project::metadata::options::ProjectOptionsOverrides;
+use ty_project::metadata::options::EnvironmentOptions;
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::RelativePathBuf;
 
@@ -256,23 +256,25 @@ impl WorkspaceOptions {
                 }
             });
 
-        let mut overrides =
-            ProjectOptionsOverrides::new(configuration_file, options_overrides.unwrap_or_default());
+        let override_options = options_overrides
+            .filter(|options| options != &TyOptions::default())
+            .map(Box::new);
+        let mut fallback_environment = EnvironmentOptions::default();
 
         if let Some(extension) = self.python_extension
             && let Some(active_environment) = extension.active_environment
         {
-            overrides.fallback_python = Some(RelativePathBuf::python_extension(
+            fallback_environment.python = Some(RelativePathBuf::python_extension(
                 active_environment.executable.sys_prefix,
             ));
 
-            overrides.fallback_python_version = active_environment
+            fallback_environment.python_version = active_environment
                 .version
                 .as_ref()
                 .and_then(resolve_editor_python_version)
                 .map(RangedValue::python_extension);
 
-            if let Some(python) = &overrides.fallback_python {
+            if let Some(python) = &fallback_environment.python {
                 tracing::debug!(
                     "Using the Python environment selected in your editor \
                     in case the configuration doesn't specify a Python environment: {python}",
@@ -280,7 +282,7 @@ impl WorkspaceOptions {
                 );
             }
 
-            if let Some(version) = &overrides.fallback_python_version {
+            if let Some(version) = &fallback_environment.python_version {
                 tracing::debug!(
                     "Using the Python version selected in your editor: {version} \
                     in case the configuration doesn't specify a Python version",
@@ -288,10 +290,13 @@ impl WorkspaceOptions {
             }
         }
 
-        let overrides = if overrides == ProjectOptionsOverrides::default() {
+        let fallback_options = if fallback_environment == EnvironmentOptions::default() {
             None
         } else {
-            Some(overrides)
+            Some(Box::new(TyOptions {
+                environment: Some(fallback_environment),
+                ..TyOptions::default()
+            }))
         };
 
         WorkspaceSettings {
@@ -304,7 +309,9 @@ impl WorkspaceOptions {
                 .completions
                 .map(CompletionOptions::into_settings)
                 .unwrap_or_default(),
-            overrides,
+            configuration_file,
+            override_options,
+            fallback_options,
         }
     }
 }

--- a/crates/ty_server/src/session/settings.rs
+++ b/crates/ty_server/src/session/settings.rs
@@ -1,6 +1,8 @@
-use super::options::DiagnosticMode;
+use ruff_db::system::SystemPathBuf;
 use ty_ide::{CompletionSettings, InlayHintSettings};
-use ty_project::metadata::options::ProjectOptionsOverrides;
+use ty_project::metadata::Options;
+
+use super::options::DiagnosticMode;
 
 /// Resolved client settings that are shared across all workspaces.
 #[derive(Clone, Default, Debug, PartialEq)]
@@ -32,7 +34,9 @@ pub(crate) struct WorkspaceSettings {
     pub(super) disable_language_services: bool,
     pub(super) inlay_hints: InlayHintSettings,
     pub(super) completions: CompletionSettings,
-    pub(super) overrides: Option<ProjectOptionsOverrides>,
+    pub(super) configuration_file: Option<SystemPathBuf>,
+    pub(super) override_options: Option<Box<Options>>,
+    pub(super) fallback_options: Option<Box<Options>>,
 }
 
 impl WorkspaceSettings {
@@ -40,8 +44,16 @@ impl WorkspaceSettings {
         self.disable_language_services
     }
 
-    pub(crate) fn project_options_overrides(&self) -> Option<&ProjectOptionsOverrides> {
-        self.overrides.as_ref()
+    pub(crate) fn configuration_file(&self) -> Option<&SystemPathBuf> {
+        self.configuration_file.as_ref()
+    }
+
+    pub(crate) fn override_options(&self) -> Option<&Options> {
+        self.override_options.as_deref()
+    }
+
+    pub(crate) fn fallback_options(&self) -> Option<&Options> {
+        self.fallback_options.as_deref()
     }
 
     pub(crate) fn inlay_hints(&self) -> &InlayHintSettings {

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -24,7 +24,9 @@ Settings: WorkspaceSettings {
         auto_import: true,
         complete_function_parentheses: false,
     },
-    overrides: None,
+    configuration_file: None,
+    override_options: None,
+    fallback_options: None,
 }
 
 Project at XXX

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -165,12 +165,13 @@ impl Workspace {
         )
         .map_err(into_error)?;
 
-        let (program_settings, program_settings_diagnostics) = project
+        let merged_options = project.to_merged_options();
+        let (program_settings, program_settings_diagnostics) = merged_options
             .to_program_settings(&self.system, self.db.vendored(), &FallibleStrategy)
             .map_err(into_error)?;
         Program::get(&self.db).update_from_settings(&mut self.db, program_settings);
 
-        let (settings, settings_diagnostics) = project
+        let (settings, settings_diagnostics) = merged_options
             .to_settings(&self.db, &FallibleStrategy)
             .map_err(into_error)?;
 
@@ -194,13 +195,10 @@ impl Workspace {
             .write_file_all(&path, contents)
             .map_err(into_error)?;
 
-        self.db.apply_changes(
-            &[ChangeEvent::Created {
-                path: path.clone(),
-                kind: CreatedKind::File,
-            }],
-            None,
-        );
+        self.db.apply_changes(&[ChangeEvent::Created {
+            path: path.clone(),
+            kind: CreatedKind::File,
+        }]);
 
         let file = system_path_to_file(&self.db, &path).expect("File to exist");
 
@@ -227,19 +225,16 @@ impl Workspace {
             .write_file(system_path, contents)
             .map_err(into_error)?;
 
-        self.db.apply_changes(
-            &[
-                ChangeEvent::Changed {
-                    path: system_path.to_path_buf(),
-                    kind: ChangedKind::FileContent,
-                },
-                ChangeEvent::Changed {
-                    path: system_path.to_path_buf(),
-                    kind: ChangedKind::FileMetadata,
-                },
-            ],
-            None,
-        );
+        self.db.apply_changes(&[
+            ChangeEvent::Changed {
+                path: system_path.to_path_buf(),
+                kind: ChangedKind::FileContent,
+            },
+            ChangeEvent::Changed {
+                path: system_path.to_path_buf(),
+                kind: ChangedKind::FileMetadata,
+            },
+        ]);
 
         Ok(())
     }
@@ -261,13 +256,10 @@ impl Workspace {
                 .remove_file(system_path)
                 .map_err(into_error)?;
 
-            self.db.apply_changes(
-                &[ChangeEvent::Deleted {
-                    path: system_path.to_path_buf(),
-                    kind: DeletedKind::File,
-                }],
-                None,
-            );
+            self.db.apply_changes(&[ChangeEvent::Deleted {
+                path: system_path.to_path_buf(),
+                kind: DeletedKind::File,
+            }]);
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

This is a refactor in preparation for adding support for script-metadata blocks. That is, scripts will be able to enable/disable individual rules. 

Today, `ProjectMetadata` only stores the Options that were merged from the CLI arguments, project configuration, user configuration, and LSP fallbacks. This granularity is sufficient for `overrides`, because overrides are always based on the merged project options. Scripts, however, are different. They are independent of the project, but options provided on the CLI, in the LSP configuration, in user level configurations, or LSP fallbacks should still apply.

This PR refactors `ProjectMetadata` to store the unmerged `Options` grouped by precedence tier. This will allow us to replay the options when resolving the settings for a script.

## Test Plan

Testing: Added regression coverage and ran the affected ty tests, Clippy checks, and repository hooks.
