### PR TITLE
[ty] Use purpose-specific types for completion and module text

### DIFF
--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -1,6 +1,6 @@
+use compact_str::CompactString;
 use rayon::prelude::*;
 use ruff_db::files::File;
-use ruff_python_ast::name::Name;
 use ty_module_resolver::{Module, ModuleName, all_modules, resolve_real_shadowable_module};
 use ty_project::{Db, parallel::ParallelIteratorExt};
 
@@ -99,7 +99,7 @@ pub struct AllSymbolInfo<'db> {
     /// When absent, this implies the symbol is the module itself.
     symbol: Option<SymbolInfo<'static>>,
     /// The fully qualified name of this symbol.
-    qualified: Name,
+    qualified: CompactString,
     /// The module containing the symbol.
     module: Module<'db>,
     /// The file containing the symbol.
@@ -116,11 +116,11 @@ impl<'db> AllSymbolInfo<'db> {
         module: Module<'db>,
         file: File,
     ) -> AllSymbolInfo<'db> {
-        let qualified = Name::from(compact_str::format_compact!(
+        let qualified = compact_str::format_compact!(
             "{module_name}.{name}",
             module_name = module.name(db),
             name = symbol.name,
-        ));
+        );
         AllSymbolInfo {
             symbol: Some(symbol),
             qualified,

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -764,7 +764,7 @@ impl<'m> Context<'m> {
                     // same scope (in which case the bases refer to the prior
                     // definition).
                     if !model.is_class_name_reassigned(class_def) {
-                        bases.insert(class_def.name.id.clone());
+                        bases.insert(CompactString::new(class_def.name.as_str()));
                     }
                     bases
                 });
@@ -1550,7 +1550,7 @@ struct CollectionContext<'db> {
     /// including the class being defined (unless its name was previously bound).
     /// Used to filter out duplicate and self-referential base class suggestions.
     /// This is only `Some` when we're in a class definition context.
-    existing_class_bases: Option<FxHashSet<Name>>,
+    existing_class_bases: Option<FxHashSet<CompactString>>,
     /// When set, the context dictates that only *these* keywords
     /// are acceptable in this context.
     valid_keywords: Option<FxHashSet<&'static str>>,
@@ -1594,14 +1594,17 @@ impl<'db> CollectionContext<'db> {
         // Exclude classes that are already listed as base classes in the class definition.
         if let Some(ref existing_class_bases) = self.existing_class_bases {
             // For in-scope completions, check if the simple name matches.
-            if builder.import.is_none() && existing_class_bases.contains(builder.name.as_str()) {
+            if builder.import.is_none()
+                && let SemanticCompletionName::Name(name) = &builder.name
+                && existing_class_bases.contains(name.as_str())
+            {
                 return true;
             }
             // For auto-import completions, check if the qualified name matches.
             // This handles cases like `class Foo(mod.Bar, ...)` where we want to
             // filter out auto-import suggestions for `Bar` from module `mod`.
             if let Some(ref qualified) = builder.qualified
-                && existing_class_bases.contains(qualified.as_str())
+                && existing_class_bases.contains(qualified)
             {
                 return true;
             }
@@ -1624,11 +1627,13 @@ impl<'db> CollectionContext<'db> {
 ///
 /// For simple name references (e.g., `Foo`), returns the name as-is.
 /// For attribute accesses (e.g., `mod.Foo`), returns the full dotted path.
-fn extract_base_class_names(class_def: &ast::StmtClassDef) -> FxHashSet<Name> {
+fn extract_base_class_names(class_def: &ast::StmtClassDef) -> FxHashSet<CompactString> {
     class_def
         .bases()
         .iter()
-        .filter_map(|expr| UnqualifiedName::from_expr(expr).map(|name| Name::new(name.to_string())))
+        .filter_map(|expr| {
+            UnqualifiedName::from_expr(expr).map(|name| compact_str::format_compact!("{name}"))
+        })
         .collect()
 }
 
@@ -1717,7 +1722,7 @@ impl Relevance {
             } else {
                 Sort::Even
             },
-            name_kind: NameKind::classify(c.name.as_str()),
+            name_kind: c.name.name_kind(),
             is_in_scope: if c.module_dependency_kind == Some(ModuleDependencyKind::Current) {
                 Sort::Higher
             } else {

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, binary_heap};
 
+use compact_str::CompactString;
 use ruff_db::files::File;
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_db::source::{SourceText, source_text};
@@ -286,16 +287,16 @@ pub struct Completion<'db> {
     /// The name used when matching the query and ranking this suggestion.
     pub name: Name,
     /// The label shown to the user for this suggestion.
-    pub label: Name,
+    pub label: CompactString,
     /// The fully qualified name, when available.
     ///
     /// This is only set when `module_name` is available.
-    pub qualified: Option<Name>,
+    pub qualified: Option<CompactString>,
     /// The text that should be inserted at the cursor
     /// when the completion is selected.
     ///
     /// When this is not set, [`Self::label`] is used.
-    pub insert: Option<Name>,
+    pub insert: Option<CompactString>,
     /// The format of [`Self::insert`].
     pub insert_text_format: CompletionInsertTextFormat,
     /// The type of this completion, if available.
@@ -362,8 +363,8 @@ impl<'db> Completion<'db> {
 struct CompletionBuilder<'db> {
     // See comments on `Completion` for the meaning of fields.
     name: Name,
-    qualified: Option<Name>,
-    insert: Option<Name>,
+    qualified: Option<CompactString>,
+    insert: Option<CompactString>,
     ty: Option<Type<'db>>,
     kind: Option<CompletionKind>,
     module_name: Option<&'db ModuleName>,
@@ -477,13 +478,16 @@ impl<'db> CompletionBuilder<'db> {
             .kind
             .or_else(|| self.ty.and_then(|ty| completion_kind_from_type(db, ty)));
         let relevance = Relevance::new(ctx, query, &self);
-        let label = self.insert.as_ref().unwrap_or(&self.name).clone();
+        let label = self
+            .insert
+            .clone()
+            .unwrap_or_else(|| CompactString::new(self.name.as_str()));
         let (insert, insert_text_format) = if ctx.should_complete_callable_parentheses(kind) {
             if ctx.capabilities.snippets {
-                let insert = Name::new(format!("{label}($0)"));
+                let insert = compact_str::format_compact!("{label}($0)");
                 (Some(insert), CompletionInsertTextFormat::Snippet)
             } else {
-                let insert = Name::new(format!("{label}()"));
+                let insert = compact_str::format_compact!("{label}()");
                 (Some(insert), CompletionInsertTextFormat::PlainText)
             }
         } else {
@@ -508,12 +512,12 @@ impl<'db> CompletionBuilder<'db> {
         }
     }
 
-    fn qualified(mut self, qualified: impl Into<Name>) -> CompletionBuilder<'db> {
+    fn qualified(mut self, qualified: impl Into<CompactString>) -> CompletionBuilder<'db> {
         self.qualified = Some(qualified.into());
         self
     }
 
-    fn insert(mut self, insert: impl Into<Name>) -> CompletionBuilder<'db> {
+    fn insert(mut self, insert: impl Into<CompactString>) -> CompletionBuilder<'db> {
         self.insert = Some(insert.into());
         self
     }
@@ -1592,7 +1596,7 @@ impl<'db> CollectionContext<'db> {
             // This handles cases like `class Foo(mod.Bar, ...)` where we want to
             // filter out auto-import suggestions for `Bar` from module `mod`.
             if let Some(ref qualified) = builder.qualified
-                && existing_class_bases.contains(qualified)
+                && existing_class_bases.contains(qualified.as_str())
             {
                 return true;
             }

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -19,8 +19,7 @@ use ty_module_resolver::{KnownModule, Module, ModuleName};
 use ty_python_semantic::HasType;
 use ty_python_semantic::types::{SpecialFormType, UnionType};
 use ty_python_semantic::{
-    Completion as SemanticCompletion, CompletionName as SemanticCompletionName, NameKind,
-    SemanticModel,
+    Completion as SemanticCompletion, NameKind, SemanticModel,
     types::{CycleDetector, KnownClass, Type},
 };
 
@@ -286,7 +285,7 @@ impl<'db> Extend<CompletionBuilder<'db>> for Completions<'db> {
 #[derive(Clone, Debug)]
 pub struct Completion<'db> {
     /// The name used when matching the query and ranking this suggestion.
-    pub name: SemanticCompletionName<'db>,
+    pub name: CompactString,
     /// The label shown to the user for this suggestion.
     pub label: CompactString,
     /// The fully qualified name, when available.
@@ -363,7 +362,7 @@ impl<'db> Completion<'db> {
 #[expect(clippy::struct_excessive_bools)]
 struct CompletionBuilder<'db> {
     // See comments on `Completion` for the meaning of fields.
-    name: SemanticCompletionName<'db>,
+    name: CompactString,
     qualified: Option<CompactString>,
     insert: Option<CompactString>,
     ty: Option<Type<'db>>,
@@ -385,10 +384,11 @@ impl<'db> CompletionBuilder<'db> {
     /// valid, but callers will generally want to fill in as much
     /// as is appropriate.
     fn new(name: impl Into<Name>) -> CompletionBuilder<'db> {
-        Self::from_name(SemanticCompletionName::Name(name.into()))
+        let name: Name = name.into();
+        Self::from_name(name.into())
     }
 
-    fn from_name(name: SemanticCompletionName<'db>) -> CompletionBuilder<'db> {
+    fn from_name(name: CompactString) -> CompletionBuilder<'db> {
         CompletionBuilder {
             name,
             qualified: None,
@@ -483,10 +483,7 @@ impl<'db> CompletionBuilder<'db> {
             .kind
             .or_else(|| self.ty.and_then(|ty| completion_kind_from_type(db, ty)));
         let relevance = Relevance::new(ctx, query, &self);
-        let label = self
-            .insert
-            .clone()
-            .unwrap_or_else(|| CompactString::new(self.name.as_str()));
+        let label = self.insert.clone().unwrap_or_else(|| self.name.clone());
         let (insert, insert_text_format) = if ctx.should_complete_callable_parentheses(kind) {
             if ctx.capabilities.snippets {
                 let insert = compact_str::format_compact!("{label}($0)");
@@ -1594,10 +1591,7 @@ impl<'db> CollectionContext<'db> {
         // Exclude classes that are already listed as base classes in the class definition.
         if let Some(ref existing_class_bases) = self.existing_class_bases {
             // For in-scope completions, check if the simple name matches.
-            if builder.import.is_none()
-                && let SemanticCompletionName::Name(name) = &builder.name
-                && existing_class_bases.contains(name.as_str())
-            {
+            if builder.import.is_none() && existing_class_bases.contains(&builder.name) {
                 return true;
             }
             // For auto-import completions, check if the qualified name matches.
@@ -1722,7 +1716,7 @@ impl Relevance {
             } else {
                 Sort::Even
             },
-            name_kind: c.name.name_kind(),
+            name_kind: NameKind::classify(c.name.as_str()),
             is_in_scope: if c.module_dependency_kind == Some(ModuleDependencyKind::Current) {
                 Sort::Higher
             } else {

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -352,7 +352,7 @@ pub struct Completion<'db> {
 }
 
 impl<'db> Completion<'db> {
-    fn builder(name: impl Into<Name>) -> CompletionBuilder<'db> {
+    fn builder(name: impl Into<CompactString>) -> CompletionBuilder<'db> {
         CompletionBuilder::new(name)
     }
 }
@@ -383,14 +383,9 @@ impl<'db> CompletionBuilder<'db> {
     /// All other values given to the completion by default are
     /// valid, but callers will generally want to fill in as much
     /// as is appropriate.
-    fn new(name: impl Into<Name>) -> CompletionBuilder<'db> {
-        let name: Name = name.into();
-        Self::from_name(name.into())
-    }
-
-    fn from_name(name: CompactString) -> CompletionBuilder<'db> {
+    fn new(name: impl Into<CompactString>) -> CompletionBuilder<'db> {
         CompletionBuilder {
-            name,
+            name: name.into(),
             qualified: None,
             insert: None,
             ty: None,
@@ -412,7 +407,7 @@ impl<'db> CompletionBuilder<'db> {
     ) -> CompletionBuilder<'db> {
         let definition = semantic.ty.and_then(|ty| Definitions::from_ty(db, ty));
         let documentation = definition.and_then(|def| def.docstring(db));
-        CompletionBuilder::from_name(semantic.name)
+        Completion::builder(semantic.name)
             .ty(semantic.ty)
             .builtin(semantic.builtin)
             .docstring(documentation)
@@ -422,7 +417,7 @@ impl<'db> CompletionBuilder<'db> {
     ///
     /// This is just like `CompletionBuilder::new`, but sets the kind
     /// to "keyword."
-    fn keyword(name: impl Into<Name>) -> CompletionBuilder<'db> {
+    fn keyword(name: impl Into<CompactString>) -> CompletionBuilder<'db> {
         Completion::builder(name).kind(CompletionKind::Keyword)
     }
 
@@ -483,7 +478,7 @@ impl<'db> CompletionBuilder<'db> {
             .kind
             .or_else(|| self.ty.and_then(|ty| completion_kind_from_type(db, ty)));
         let relevance = Relevance::new(ctx, query, &self);
-        let label = self.insert.clone().unwrap_or_else(|| self.name.clone());
+        let label = self.insert.as_ref().unwrap_or(&self.name).clone();
         let (insert, insert_text_format) = if ctx.should_complete_callable_parentheses(kind) {
             if ctx.capabilities.snippets {
                 let insert = compact_str::format_compact!("{label}($0)");
@@ -1625,9 +1620,8 @@ fn extract_base_class_names(class_def: &ast::StmtClassDef) -> FxHashSet<CompactS
     class_def
         .bases()
         .iter()
-        .filter_map(|expr| {
-            UnqualifiedName::from_expr(expr).map(|name| compact_str::format_compact!("{name}"))
-        })
+        .filter_map(UnqualifiedName::from_expr)
+        .map(|name| compact_str::format_compact!("{name}"))
         .collect()
 }
 
@@ -1716,7 +1710,7 @@ impl Relevance {
             } else {
                 Sort::Even
             },
-            name_kind: NameKind::classify(c.name.as_str()),
+            name_kind: NameKind::classify(&c.name),
             is_in_scope: if c.module_dependency_kind == Some(ModuleDependencyKind::Current) {
                 Sort::Higher
             } else {

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -19,7 +19,8 @@ use ty_module_resolver::{KnownModule, Module, ModuleName};
 use ty_python_semantic::HasType;
 use ty_python_semantic::types::{SpecialFormType, UnionType};
 use ty_python_semantic::{
-    Completion as SemanticCompletion, NameKind, SemanticModel,
+    Completion as SemanticCompletion, CompletionName as SemanticCompletionName, NameKind,
+    SemanticModel,
     types::{CycleDetector, KnownClass, Type},
 };
 
@@ -285,7 +286,7 @@ impl<'db> Extend<CompletionBuilder<'db>> for Completions<'db> {
 #[derive(Clone, Debug)]
 pub struct Completion<'db> {
     /// The name used when matching the query and ranking this suggestion.
-    pub name: Name,
+    pub name: SemanticCompletionName<'db>,
     /// The label shown to the user for this suggestion.
     pub label: CompactString,
     /// The fully qualified name, when available.
@@ -362,7 +363,7 @@ impl<'db> Completion<'db> {
 #[expect(clippy::struct_excessive_bools)]
 struct CompletionBuilder<'db> {
     // See comments on `Completion` for the meaning of fields.
-    name: Name,
+    name: SemanticCompletionName<'db>,
     qualified: Option<CompactString>,
     insert: Option<CompactString>,
     ty: Option<Type<'db>>,
@@ -384,8 +385,12 @@ impl<'db> CompletionBuilder<'db> {
     /// valid, but callers will generally want to fill in as much
     /// as is appropriate.
     fn new(name: impl Into<Name>) -> CompletionBuilder<'db> {
+        Self::from_name(SemanticCompletionName::Name(name.into()))
+    }
+
+    fn from_name(name: SemanticCompletionName<'db>) -> CompletionBuilder<'db> {
         CompletionBuilder {
-            name: name.into(),
+            name,
             qualified: None,
             insert: None,
             ty: None,
@@ -407,7 +412,7 @@ impl<'db> CompletionBuilder<'db> {
     ) -> CompletionBuilder<'db> {
         let definition = semantic.ty.and_then(|ty| Definitions::from_ty(db, ty));
         let documentation = definition.and_then(|def| def.docstring(db));
-        Completion::builder(semantic.name)
+        CompletionBuilder::from_name(semantic.name)
             .ty(semantic.ty)
             .builtin(semantic.builtin)
             .docstring(documentation)
@@ -1589,7 +1594,7 @@ impl<'db> CollectionContext<'db> {
         // Exclude classes that are already listed as base classes in the class definition.
         if let Some(ref existing_class_bases) = self.existing_class_bases {
             // For in-scope completions, check if the simple name matches.
-            if builder.import.is_none() && existing_class_bases.contains(&builder.name) {
+            if builder.import.is_none() && existing_class_bases.contains(builder.name.as_str()) {
                 return true;
             }
             // For auto-import completions, check if the qualified name matches.
@@ -1712,7 +1717,7 @@ impl Relevance {
             } else {
                 Sort::Even
             },
-            name_kind: NameKind::classify(&c.name),
+            name_kind: NameKind::classify(c.name.as_str()),
             is_in_scope: if c.module_dependency_kind == Some(ModuleDependencyKind::Current) {
                 Sort::Higher
             } else {

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -592,7 +592,7 @@ impl<'db> Imports<'db> {
         &self,
         db: &'db dyn Db,
         importing_file: File,
-        name: &Name,
+        name: &ModuleName,
     ) -> Option<&'db FlatSymbols> {
         let module_name = match self.module_names.get(name.as_str())? {
             ImportModuleKind::Definitive(name) | ImportModuleKind::Possible(name) => {
@@ -973,7 +973,10 @@ impl<'db> SymbolVisitor<'db> {
                 if attr != "__all__" {
                     return false;
                 }
-                let possible_module_name = Name::new(rest.join("."));
+                let Some(possible_module_name) = ModuleName::from_components(rest.iter().copied())
+                else {
+                    return false;
+                };
                 let Some(symbols) =
                     self.imports
                         .get_module_symbols(self.db, self.file, &possible_module_name)

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -19,8 +19,8 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::source::{SourceTextError, source_text};
 use rustc_hash::FxHasher;
 pub use semantic_model::{
-    Completion, CompletionName, ExpectedStringLiteralCompletion, HasDefinition,
-    HasOptionalDefinition, HasType, MemberDefinition, NameKind, SemanticModel,
+    Completion, ExpectedStringLiteralCompletion, HasDefinition, HasOptionalDefinition, HasType,
+    MemberDefinition, NameKind, SemanticModel,
 };
 use std::hash::BuildHasherDefault;
 pub use suppression::{

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -19,8 +19,8 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::source::{SourceTextError, source_text};
 use rustc_hash::FxHasher;
 pub use semantic_model::{
-    Completion, ExpectedStringLiteralCompletion, HasDefinition, HasOptionalDefinition, HasType,
-    MemberDefinition, NameKind, SemanticModel,
+    Completion, CompletionName, ExpectedStringLiteralCompletion, HasDefinition,
+    HasOptionalDefinition, HasType, MemberDefinition, NameKind, SemanticModel,
 };
 use std::hash::BuildHasherDefault;
 pub use suppression::{

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -619,7 +619,11 @@ pub enum NameKind {
 }
 
 impl NameKind {
-    pub fn classify(name: &str) -> NameKind {
+    pub fn classify(name: &Name) -> NameKind {
+        Self::classify_str(name.as_str())
+    }
+
+    fn classify_str(name: &str) -> NameKind {
         // Dunder needs a prefix and suffix double underscore.
         // When there's only a prefix double underscore, this
         // results in explicit name mangling. We let that be
@@ -671,6 +675,13 @@ impl CompletionName<'_> {
         match self {
             Self::Name(name) => name.as_str(),
             Self::Module(name) => name.as_str(),
+        }
+    }
+
+    pub fn name_kind(&self) -> NameKind {
+        match self {
+            Self::Name(name) => NameKind::classify(name),
+            Self::Module(name) => NameKind::classify_str(name.as_str()),
         }
     }
 }

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -206,7 +206,7 @@ impl<'db> SemanticModel<'db> {
             let ty = Type::module_literal(self.db, self.file, *submodule);
             let base = submodule.name(self.db).last_component();
             completions.push(Completion {
-                name: Name::new(base).into(),
+                name: CompactString::new(base),
                 ty: Some(ty),
                 builtin,
             });

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use ruff_db::files::{File, FilePath};
 use ruff_db::parsed::{parsed_module, parsed_string_annotation};
 use ruff_db::source::{line_index, source_text};
@@ -134,7 +135,7 @@ impl<'db> SemanticModel<'db> {
                 let builtin = module.is_known(self.db, KnownModule::Builtins);
                 let ty = Type::module_literal(self.db, self.file, module);
                 Completion {
-                    name: CompletionName::Module(module.name(self.db)),
+                    name: CompactString::new(module.name(self.db).as_str()),
                     ty: Some(ty),
                     builtin,
                 }
@@ -619,11 +620,7 @@ pub enum NameKind {
 }
 
 impl NameKind {
-    pub fn classify(name: &Name) -> NameKind {
-        Self::classify_str(name.as_str())
-    }
-
-    fn classify_str(name: &str) -> NameKind {
+    pub fn classify(name: &str) -> NameKind {
         // Dunder needs a prefix and suffix double underscore.
         // When there's only a prefix double underscore, this
         // results in explicit name mangling. We let that be
@@ -644,7 +641,7 @@ impl NameKind {
 #[derive(Clone, Debug)]
 pub struct Completion<'db> {
     /// The label shown to the user for this suggestion.
-    pub name: CompletionName<'db>,
+    pub name: CompactString,
     /// The type of this completion, if available.
     ///
     /// Generally speaking, this is always available
@@ -659,77 +656,6 @@ pub struct Completion<'db> {
     /// use it mainly in tests so that we can write less
     /// noisy tests.
     pub builtin: bool,
-}
-
-/// The name used to match and display a completion.
-#[derive(Clone, Debug)]
-pub enum CompletionName<'db> {
-    /// A Python identifier.
-    Name(Name),
-    /// An absolute, possibly dotted module name.
-    Module(&'db ModuleName),
-}
-
-impl CompletionName<'_> {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Name(name) => name.as_str(),
-            Self::Module(name) => name.as_str(),
-        }
-    }
-
-    pub fn name_kind(&self) -> NameKind {
-        match self {
-            Self::Name(name) => NameKind::classify(name),
-            Self::Module(name) => NameKind::classify_str(name.as_str()),
-        }
-    }
-}
-
-impl std::ops::Deref for CompletionName<'_> {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        self.as_str()
-    }
-}
-
-impl PartialEq for CompletionName<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_str() == other.as_str()
-    }
-}
-
-impl Eq for CompletionName<'_> {}
-
-impl PartialOrd for CompletionName<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for CompletionName<'_> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.as_str().cmp(other.as_str())
-    }
-}
-
-impl PartialEq<str> for CompletionName<'_> {
-    fn eq(&self, other: &str) -> bool {
-        self.as_str() == other
-    }
-}
-
-impl PartialEq<&str> for CompletionName<'_> {
-    fn eq(&self, other: &&str) -> bool {
-        self.as_str() == *other
-    }
-}
-
-impl From<Name> for CompletionName<'_> {
-    fn from(name: Name) -> Self {
-        Self::Name(name)
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -134,7 +134,7 @@ impl<'db> SemanticModel<'db> {
                 let builtin = module.is_known(self.db, KnownModule::Builtins);
                 let ty = Type::module_literal(self.db, self.file, module);
                 Completion {
-                    name: Name::new(module.name(self.db).as_str()),
+                    name: CompletionName::Module(module.name(self.db)),
                     ty: Some(ty),
                     builtin,
                 }
@@ -187,7 +187,7 @@ impl<'db> SemanticModel<'db> {
         )]
         for Member { name, ty } in all_members(self.db, ty) {
             completions.push(Completion {
-                name,
+                name: name.into(),
                 ty: Some(ty),
                 builtin,
             });
@@ -205,7 +205,7 @@ impl<'db> SemanticModel<'db> {
             let ty = Type::module_literal(self.db, self.file, *submodule);
             let base = submodule.name(self.db).last_component();
             completions.push(Completion {
-                name: Name::new(base),
+                name: Name::new(base).into(),
                 ty: Some(ty),
                 builtin,
             });
@@ -222,7 +222,7 @@ impl<'db> SemanticModel<'db> {
         all_members(self.db, ty)
             .into_iter()
             .map(|member| Completion {
-                name: member.name,
+                name: member.name.into(),
                 ty: Some(member.ty),
                 builtin: false,
             })
@@ -244,7 +244,7 @@ impl<'db> SemanticModel<'db> {
             completions.extend(
                 all_reachable_members(self.db, file_scope.to_scope_id(self.db, self.file)).map(
                     |memberdef| Completion {
-                        name: memberdef.member.name,
+                        name: memberdef.member.name.into(),
                         ty: Some(memberdef.member.ty),
                         builtin: false,
                     },
@@ -258,7 +258,7 @@ impl<'db> SemanticModel<'db> {
         // not `str | None`).
         completions.extend(
             all_implicit_module_globals(self.db, self.file).map(|(name, ty)| Completion {
-                name,
+                name: name.into(),
                 ty: Some(ty),
                 builtin: true,
             }),
@@ -619,7 +619,7 @@ pub enum NameKind {
 }
 
 impl NameKind {
-    pub fn classify(name: &Name) -> NameKind {
+    pub fn classify(name: &str) -> NameKind {
         // Dunder needs a prefix and suffix double underscore.
         // When there's only a prefix double underscore, this
         // results in explicit name mangling. We let that be
@@ -640,7 +640,7 @@ impl NameKind {
 #[derive(Clone, Debug)]
 pub struct Completion<'db> {
     /// The label shown to the user for this suggestion.
-    pub name: Name,
+    pub name: CompletionName<'db>,
     /// The type of this completion, if available.
     ///
     /// Generally speaking, this is always available
@@ -655,6 +655,70 @@ pub struct Completion<'db> {
     /// use it mainly in tests so that we can write less
     /// noisy tests.
     pub builtin: bool,
+}
+
+/// The name used to match and display a completion.
+#[derive(Clone, Debug)]
+pub enum CompletionName<'db> {
+    /// A Python identifier.
+    Name(Name),
+    /// An absolute, possibly dotted module name.
+    Module(&'db ModuleName),
+}
+
+impl CompletionName<'_> {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Name(name) => name.as_str(),
+            Self::Module(name) => name.as_str(),
+        }
+    }
+}
+
+impl std::ops::Deref for CompletionName<'_> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl PartialEq for CompletionName<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for CompletionName<'_> {}
+
+impl PartialOrd for CompletionName<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CompletionName<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialEq<str> for CompletionName<'_> {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<&str> for CompletionName<'_> {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl From<Name> for CompletionName<'_> {
+    fn from(name: Name) -> Self {
+        Self::Name(name)
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary

`Name` represents a Python identifier, but ty's IDE paths also used it for arbitrary text such as dotted module and qualified names, synthesized completion insertions, and dotted base-class references.

Use `CompactString` for completion matching, display, insertion, and fully qualified symbol text, and construct `ModuleName` directly for module references used in `__all__` resolution. This keeps dotted and generated text out of the AST identifier type, avoids intermediate `String` allocations when formatting completion text and module paths, and preserves the existing completion and symbol behavior.
