### PR TITLE
[ty] Use a dedicated project name type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,6 +4770,7 @@ dependencies = [
  "bitvec",
  "camino",
  "colored",
+ "compact_str",
  "crossbeam",
  "get-size2",
  "globset",

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -780,10 +780,8 @@ mod tests {
 
     impl CodeActionTest {
         pub(super) fn with_source(source: &str) -> Self {
-            let mut db = ty_project::TestDb::new(ProjectMetadata::new(
-                "test".into(),
-                SystemPathBuf::from("/"),
-            ));
+            let mut db =
+                ty_project::TestDb::new(ProjectMetadata::new("test", SystemPathBuf::from("/")));
 
             db.init_program().unwrap();
 

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -809,10 +809,8 @@ mod tests {
         const START: &str = "<START>";
         const END: &str = "<END>";
 
-        let mut db = ty_project::TestDb::new(ProjectMetadata::new(
-            "test".into(),
-            SystemPathBuf::from("/"),
-        ));
+        let mut db =
+            ty_project::TestDb::new(ProjectMetadata::new("test", SystemPathBuf::from("/")));
 
         db.init_program().unwrap();
 

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -512,10 +512,8 @@ mod tests {
 
     impl CursorTestBuilder {
         pub(super) fn build(&self) -> CursorTest {
-            let mut db = ty_project::TestDb::new(ProjectMetadata::new(
-                "test".into(),
-                SystemPathBuf::from("/"),
-            ));
+            let mut db =
+                ty_project::TestDb::new(ProjectMetadata::new("test", SystemPathBuf::from("/")));
 
             db.init_program_with_python_version(
                 self.python_version.unwrap_or_else(PythonVersion::latest_ty),
@@ -640,7 +638,7 @@ mod tests {
             let site_packages_path = SystemPathBuf::from("/site-packages");
 
             let mut db =
-                ty_project::TestDb::new(ProjectMetadata::new("test".into(), project_root.clone()));
+                ty_project::TestDb::new(ProjectMetadata::new("test", project_root.clone()));
 
             // Write site-packages files first (before init)
             for Source {

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -4692,10 +4692,8 @@ from pathlib import Missing as Alias
 
     impl SemanticTokenTest {
         fn new(source: &str) -> Self {
-            let mut db = ty_project::TestDb::new(ProjectMetadata::new(
-                "test".into(),
-                SystemPathBuf::from("/"),
-            ));
+            let mut db =
+                ty_project::TestDb::new(ProjectMetadata::new("test", SystemPathBuf::from("/")));
 
             db.init_program().unwrap();
 

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -2970,7 +2970,7 @@ class C: ...
 
     impl PublicTestBuilder {
         pub(super) fn build(&self) -> PublicTest {
-            let metadata = ProjectMetadata::new("test".into(), SystemPathBuf::from("/"));
+            let metadata = ProjectMetadata::new("test", SystemPathBuf::from("/"));
             let mut db = TestDb::new(metadata);
 
             db.init_program_with_python_version(self.python_version.unwrap_or_default())

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = { workspace = true }
 bitvec = { workspace = true }
 camino = { workspace = true }
 colored = { workspace = true }
+compact_str = { workspace = true, features = ["serde"] }
 crossbeam = { workspace = true }
 get-size2 = { workspace = true, features = ["ordermap"] }
 globset = { workspace = true }

--- a/crates/ty_project/src/files.rs
+++ b/crates/ty_project/src/files.rs
@@ -276,11 +276,10 @@ mod tests {
     use crate::files::Index;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{DbWithWritableSystem as _, SystemPathBuf};
-    use ruff_python_ast::name::Name;
 
     #[test]
     fn re_entrance() -> anyhow::Result<()> {
-        let metadata = ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/test"));
+        let metadata = ProjectMetadata::new("test", SystemPathBuf::from("/test"));
         let mut db = TestDb::new(metadata);
 
         db.write_file("test.py", "")?;

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -889,12 +889,11 @@ mod tests {
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
-    use ruff_python_ast::name::Name;
     use ty_python_semantic::types::check_types;
 
     #[test]
     fn check_file_skips_type_checking_when_file_cant_be_read() -> ruff_db::system::Result<()> {
-        let project = ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/"));
+        let project = ProjectMetadata::new("test", SystemPathBuf::from("/"));
         let mut db = TestDb::new(project);
         db.init_program().unwrap();
         let path = SystemPath::new("test.py");
@@ -941,7 +940,7 @@ mod tests {
     fn explicit_nested_included_file_is_a_literal_match() {
         let root = SystemPathBuf::from("/project");
         let explicit_file = root.join("build/keep.txt");
-        let project = ProjectMetadata::new(Name::new_static("test"), root.clone());
+        let project = ProjectMetadata::new("test", root.clone());
         let mut db = TestDb::new(project);
         let project = db.project();
 

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -26,20 +26,6 @@ pub mod value;
 
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
 #[cfg_attr(test, derive(serde::Serialize))]
-struct ProjectName(CompactString);
-
-impl ProjectName {
-    fn new(name: impl AsRef<str>) -> Self {
-        Self(CompactString::new(name))
-    }
-
-    fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
-#[cfg_attr(test, derive(serde::Serialize))]
 pub struct ProjectMetadata {
     name: ProjectName,
 
@@ -356,6 +342,20 @@ impl ProjectMetadata {
         self.extra_configuration_paths
             .push(options.path().to_owned());
         self.options.combine_with(options.into_options());
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
+#[cfg_attr(test, derive(serde::Serialize))]
+struct ProjectName(CompactString);
+
+impl ProjectName {
+    fn new(name: impl AsRef<str>) -> Self {
+        Self(CompactString::new(name))
+    }
+
+    fn as_str(&self) -> &str {
+        self.0.as_str()
     }
 }
 

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -1,8 +1,8 @@
+use compact_str::CompactString;
 use configuration_file::{ConfigurationFile, ConfigurationFileError};
 use ruff_db::files::FileRootKind;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::VendoredFileSystem;
-use ruff_python_ast::name::Name;
 use ruff_ranged_value::ValueSource;
 use std::sync::Arc;
 use thiserror::Error;
@@ -26,8 +26,22 @@ pub mod value;
 
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
 #[cfg_attr(test, derive(serde::Serialize))]
+struct ProjectName(CompactString);
+
+impl ProjectName {
+    fn new(name: impl AsRef<str>) -> Self {
+        Self(CompactString::new(name))
+    }
+
+    fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct ProjectMetadata {
-    pub(super) name: Name,
+    name: ProjectName,
 
     pub(super) root: SystemPathBuf,
 
@@ -46,9 +60,9 @@ pub struct ProjectMetadata {
 
 impl ProjectMetadata {
     /// Creates a project with the given name and root that uses the default options.
-    pub fn new(name: Name, root: SystemPathBuf) -> Self {
+    pub fn new(name: impl AsRef<str>, root: SystemPathBuf) -> Self {
         Self {
-            name,
+            name: ProjectName::new(name),
             root,
             extra_configuration_paths: Vec::default(),
             options: Options::default(),
@@ -72,7 +86,7 @@ impl ProjectMetadata {
         let options = config_file.into_options();
 
         Ok(Self {
-            name: Name::new(root.file_name().unwrap_or("root")),
+            name: ProjectName::new(root.file_name().unwrap_or("root")),
             root: root.to_path_buf(),
             options,
             extra_configuration_paths: vec![path],
@@ -101,8 +115,8 @@ impl ProjectMetadata {
     ) -> Result<Self, Strategy::Error<ResolveRequiresPythonError>> {
         let name = project
             .and_then(|project| project.name.as_deref())
-            .map(|name| Name::new(&**name))
-            .unwrap_or_else(|| Name::new(root.file_name().unwrap_or("root")));
+            .map(|name| ProjectName::new(&**name))
+            .unwrap_or_else(|| ProjectName::new(root.file_name().unwrap_or("root")));
 
         // If the `options` don't specify a python version but the `project.requires-python` field is set,
         // use that as a lower bound instead.
@@ -258,10 +272,7 @@ impl ProjectMetadata {
             );
 
             // Create a project with a default configuration
-            Self::new(
-                path.file_name().unwrap_or("root").into(),
-                path.to_path_buf(),
-            )
+            Self::new(path.file_name().unwrap_or("root"), path.to_path_buf())
         };
 
         Ok(metadata)
@@ -272,7 +283,7 @@ impl ProjectMetadata {
     }
 
     pub fn name(&self) -> &str {
-        &self.name
+        self.name.as_str()
     }
 
     pub fn options(&self) -> &Options {
@@ -407,7 +418,7 @@ mod tests {
         with_escaped_paths(|| {
             assert_ron_snapshot!(&project, @r#"
             ProjectMetadata(
-              name: Name("app"),
+              name: ProjectName("app"),
               root: "/app",
               options: Options(),
             )
@@ -445,7 +456,7 @@ mod tests {
         with_escaped_paths(|| {
             assert_ron_snapshot!(&project, @r#"
             ProjectMetadata(
-              name: Name("backend"),
+              name: ProjectName("backend"),
               root: "/app",
               options: Options(),
             )
@@ -537,7 +548,7 @@ unclosed table, expected `]`
         with_escaped_paths(|| {
             assert_ron_snapshot!(sub_project, @r#"
             ProjectMetadata(
-              name: Name("nested-project"),
+              name: ProjectName("nested-project"),
               root: "/app/packages/a",
               options: Options(
                 src: Some(SrcOptions(
@@ -587,7 +598,7 @@ unclosed table, expected `]`
         with_escaped_paths(|| {
             assert_ron_snapshot!(root, @r#"
             ProjectMetadata(
-              name: Name("project-root"),
+              name: ProjectName("project-root"),
               root: "/app",
               options: Options(
                 src: Some(SrcOptions(
@@ -631,7 +642,7 @@ unclosed table, expected `]`
         with_escaped_paths(|| {
             assert_ron_snapshot!(sub_project, @r#"
             ProjectMetadata(
-              name: Name("nested-project"),
+              name: ProjectName("nested-project"),
               root: "/app/packages/a",
               options: Options(),
             )
@@ -674,7 +685,7 @@ unclosed table, expected `]`
         with_escaped_paths(|| {
             assert_ron_snapshot!(root, @r#"
             ProjectMetadata(
-              name: Name("project-root"),
+              name: ProjectName("project-root"),
               root: "/app",
               options: Options(
                 environment: Some(EnvironmentOptions(
@@ -726,7 +737,7 @@ unclosed table, expected `]`
         with_escaped_paths(|| {
             assert_ron_snapshot!(root, @r#"
             ProjectMetadata(
-              name: Name("super-app"),
+              name: ProjectName("super-app"),
               root: "/app",
               options: Options(
                 environment: Some(EnvironmentOptions(


### PR DESCRIPTION
## Summary

This replaces the AST `Name` used by `ProjectMetadata` with a private `ProjectName` backed by `CompactString`.

Project names can come from distribution metadata or directory names and are not necessarily Python identifiers. Keeping them in a dedicated type makes that distinction explicit while preserving compact storage and the existing string accessor.
