### PR TITLE
[ty] Use a dedicated member path type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4831,6 +4831,7 @@ dependencies = [
  "get-size2",
  "hashbrown 0.17.1",
  "itertools 0.15.0",
+ "lean_string",
  "ruff_db",
  "ruff_index",
  "ruff_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3606,7 +3606,6 @@ dependencies = [
  "anyhow",
  "bitflags 2.13.0",
  "bstr",
- "compact_str",
  "datatest-stable",
  "get-size2",
  "hashbrown 0.17.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,6 +1895,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lean_string"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9d7a64297827f9ef2cc8a111ca1d87bead398b7f9fe76ba0eb9f50d175e8d"
+dependencies = [
+ "castaway",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3479,6 +3491,7 @@ dependencies = [
  "compact_str",
  "get-size2",
  "is-macro",
+ "lean_string",
  "memchr",
  "ruff_cache",
  "ruff_macros",
@@ -3596,6 +3609,7 @@ dependencies = [
  "compact_str",
  "datatest-stable",
  "get-size2",
+ "hashbrown 0.17.1",
  "insta",
  "itertools 0.15.0",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,8 +1897,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean_string"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9d7a64297827f9ef2cc8a111ca1d87bead398b7f9fe76ba0eb9f50d175e8d"
+source = "git+https://github.com/astral-sh/lean_string?rev=1f2643ea47e97f6f67393caf734c0bc7795b4f0b#1f2643ea47e97f6f67393caf734c0bc7795b4f0b"
 dependencies = [
  "castaway",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ itertools = { version = "0.15.0" }
 jiff = { version = "0.2.0" }
 jod-thread = { version = "1.0.0" }
 js-sys = { version = "0.3.69" }
-lean_string = { git = "https://github.com/astral-sh/lean_string", rev = "1f2643ea47e97f6f67393caf734c0bc7795b4f0b" }
+lean_string = { version = "0.6.1", git = "https://github.com/astral-sh/lean_string", rev = "1f2643ea47e97f6f67393caf734c0bc7795b4f0b" }
 libc = { version = "0.2.153" }
 libcst = { version = "1.8.4", default-features = false }
 log = { version = "0.4.17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ itertools = { version = "0.15.0" }
 jiff = { version = "0.2.0" }
 jod-thread = { version = "1.0.0" }
 js-sys = { version = "0.3.69" }
-lean_string = "0.6.1"
+lean_string = { git = "https://github.com/astral-sh/lean_string", rev = "1f2643ea47e97f6f67393caf734c0bc7795b4f0b" }
 libc = { version = "0.2.153" }
 libcst = { version = "1.8.4", default-features = false }
 log = { version = "0.4.17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ itertools = { version = "0.15.0" }
 jiff = { version = "0.2.0" }
 jod-thread = { version = "1.0.0" }
 js-sys = { version = "0.3.69" }
+lean_string = "0.6.1"
 libc = { version = "0.2.153" }
 libcst = { version = "1.8.4", default-features = false }
 log = { version = "0.4.17" }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -10,10 +10,6 @@ documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 
-[package.metadata.cargo-shear]
-# Used via `CacheKey` macro expansion.
-ignored = ["ruff_cache"]
-
 [lib]
 
 [dependencies]
@@ -29,6 +25,7 @@ bitflags = { workspace = true }
 compact_str = { workspace = true }
 get-size2 = { workspace = true, optional = true }
 is-macro = { workspace = true }
+lean_string = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 salsa = { workspace = true, optional = true }
@@ -46,6 +43,7 @@ serde = [
     "ruff_text_size/serde",
     "dep:ruff_cache",
     "compact_str/serde",
+    "lean_string/serde",
     "thin-vec/serde",
 ]
 get-size = ["dep:get-size2", "ruff_text_size/get-size"]

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
 use arrayvec::ArrayVec;
-use lean_string::LeanString;
+use lean_string::LeanStr;
 
 use crate::Expr;
 use crate::generated::ExprName;
@@ -16,50 +16,35 @@ use crate::generated::ExprName;
     derive(schemars::JsonSchema),
     schemars(with = "String")
 )]
-pub struct Name(LeanString);
+pub struct Name(LeanStr);
 
 impl Name {
     /// The maximum number of UTF-8 bytes stored inline in a name.
-    pub const INLINE_CAPACITY: usize = std::mem::size_of::<LeanString>();
+    pub const INLINE_CAPACITY: usize = std::mem::size_of::<LeanStr>();
 
     #[inline]
     pub fn empty() -> Self {
-        Self(LeanString::new())
+        Self(LeanStr::new())
     }
 
     #[inline]
     pub fn new(name: impl AsRef<str>) -> Self {
-        Self(LeanString::from(name.as_ref()))
+        Self(LeanStr::from(name.as_ref()))
     }
 
     #[inline]
     pub const fn new_static(name: &'static str) -> Self {
-        Self(LeanString::from_static_str(name))
-    }
-
-    pub fn shrink_to_fit(&mut self) {
-        self.0.shrink_to_fit();
+        Self(LeanStr::from_static_str(name))
     }
 
     pub fn as_str(&self) -> &str {
         self.0.as_str()
-    }
-
-    pub fn push_str(&mut self, s: &str) {
-        self.0.push_str(s);
     }
 }
 
 impl Debug for Name {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "Name({:?})", self.as_str())
-    }
-}
-
-impl std::fmt::Write for Name {
-    fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        self.0.push_str(s);
-        Ok(())
     }
 }
 
@@ -148,7 +133,7 @@ impl get_size2::GetSize for Name {
         mut tracker: T,
     ) -> (usize, T) {
         let size = if self.0.is_heap_allocated() && tracker.track(self.as_ptr()) {
-            self.0.capacity()
+            self.0.len()
         } else {
             0
         };
@@ -833,7 +818,7 @@ mod tests {
         assert_eq!(Name::new("inline").get_heap_size(), 0);
 
         let name = Name::new("a name too long for inline storage");
-        let expected = name.0.capacity();
+        let expected = name.len();
         let clone = name.clone();
         let (size, _) = (name, clone).get_heap_size_with_tracker(StandardTracker::new());
         assert_eq!(size, expected);

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -29,7 +29,7 @@ impl Name {
 
     #[inline]
     pub fn new(name: impl AsRef<str>) -> Self {
-        Self(name.as_ref().into())
+        Self(LeanString::from(name.as_ref()))
     }
 
     #[inline]

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -121,62 +121,6 @@ impl From<Box<str>> for Name {
     }
 }
 
-impl From<compact_str::CompactString> for Name {
-    #[inline]
-    fn from(value: compact_str::CompactString) -> Self {
-        Self::new(value)
-    }
-}
-
-impl From<Name> for compact_str::CompactString {
-    #[inline]
-    fn from(name: Name) -> Self {
-        compact_str::CompactString::new(name.as_str())
-    }
-}
-
-#[cfg(feature = "salsa")]
-impl salsa::Lookup<compact_str::CompactString> for Name {
-    #[inline]
-    fn into_owned(self) -> compact_str::CompactString {
-        self.into()
-    }
-}
-
-#[cfg(feature = "salsa")]
-impl salsa::Lookup<compact_str::CompactString> for &Name {
-    #[inline]
-    fn into_owned(self) -> compact_str::CompactString {
-        compact_str::CompactString::new(self.as_str())
-    }
-}
-
-#[cfg(feature = "salsa")]
-impl salsa::HashEqLike<Name> for compact_str::CompactString {
-    #[inline]
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        std::hash::Hash::hash(self, state);
-    }
-
-    #[inline]
-    fn eq(&self, data: &Name) -> bool {
-        self == data.as_str()
-    }
-}
-
-#[cfg(feature = "salsa")]
-impl salsa::HashEqLike<&Name> for compact_str::CompactString {
-    #[inline]
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        std::hash::Hash::hash(self, state);
-    }
-
-    #[inline]
-    fn eq(&self, data: &&Name) -> bool {
-        self == data.as_str()
-    }
-}
-
 impl From<Name> for String {
     #[inline]
     fn from(name: Name) -> Self {

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -4,36 +4,37 @@ use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
 use arrayvec::ArrayVec;
+use lean_string::LeanString;
 
 use crate::Expr;
 use crate::generated::ExprName;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "cache", derive(ruff_macros::CacheKey))]
-#[cfg_attr(feature = "salsa", derive(salsa::Update))]
-#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 #[cfg_attr(
     feature = "schemars",
     derive(schemars::JsonSchema),
     schemars(with = "String")
 )]
-pub struct Name(compact_str::CompactString);
+pub struct Name(LeanString);
 
 impl Name {
+    /// The maximum number of UTF-8 bytes stored inline in a name.
+    pub const INLINE_CAPACITY: usize = std::mem::size_of::<LeanString>();
+
     #[inline]
     pub fn empty() -> Self {
-        Self(compact_str::CompactString::default())
+        Self(LeanString::new())
     }
 
     #[inline]
     pub fn new(name: impl AsRef<str>) -> Self {
-        Self(compact_str::CompactString::new(name))
+        Self(name.as_ref().into())
     }
 
     #[inline]
     pub const fn new_static(name: &'static str) -> Self {
-        Self(compact_str::CompactString::const_new(name))
+        Self(LeanString::from_static_str(name))
     }
 
     pub fn shrink_to_fit(&mut self) {
@@ -88,7 +89,7 @@ impl Borrow<str> for Name {
 impl<'a> From<&'a str> for Name {
     #[inline]
     fn from(s: &'a str) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
@@ -102,7 +103,7 @@ impl From<String> for Name {
 impl<'a> From<&'a String> for Name {
     #[inline]
     fn from(s: &'a String) -> Self {
-        Name(s.into())
+        Name::new(s)
     }
 }
 
@@ -123,14 +124,14 @@ impl From<Box<str>> for Name {
 impl From<compact_str::CompactString> for Name {
     #[inline]
     fn from(value: compact_str::CompactString) -> Self {
-        Self(value)
+        Self::new(value)
     }
 }
 
 impl From<Name> for compact_str::CompactString {
     #[inline]
     fn from(name: Name) -> Self {
-        name.0
+        compact_str::CompactString::new(name.as_str())
     }
 }
 
@@ -138,7 +139,7 @@ impl From<Name> for compact_str::CompactString {
 impl salsa::Lookup<compact_str::CompactString> for Name {
     #[inline]
     fn into_owned(self) -> compact_str::CompactString {
-        self.0
+        self.into()
     }
 }
 
@@ -146,7 +147,7 @@ impl salsa::Lookup<compact_str::CompactString> for Name {
 impl salsa::Lookup<compact_str::CompactString> for &Name {
     #[inline]
     fn into_owned(self) -> compact_str::CompactString {
-        self.0.clone()
+        compact_str::CompactString::new(self.as_str())
     }
 }
 
@@ -179,13 +180,54 @@ impl salsa::HashEqLike<&Name> for compact_str::CompactString {
 impl From<Name> for String {
     #[inline]
     fn from(name: Name) -> Self {
-        name.as_str().into()
+        name.0.into()
     }
 }
 
 impl FromIterator<char> for Name {
     fn from_iter<I: IntoIterator<Item = char>>(iter: I) -> Self {
         Self(iter.into_iter().collect())
+    }
+}
+
+#[cfg(feature = "cache")]
+impl ruff_cache::CacheKey for Name {
+    fn cache_key(&self, state: &mut ruff_cache::CacheKeyHasher) {
+        ruff_cache::CacheKey::cache_key(self.as_str(), state);
+    }
+}
+
+#[cfg(feature = "get-size")]
+impl get_size2::GetSize for Name {
+    fn get_heap_size_with_tracker<T: get_size2::GetSizeTracker>(
+        &self,
+        mut tracker: T,
+    ) -> (usize, T) {
+        let size = if self.0.is_heap_allocated() && tracker.track(self.as_ptr()) {
+            self.0.capacity()
+        } else {
+            0
+        };
+        (size, tracker)
+    }
+}
+
+#[cfg(feature = "salsa")]
+#[expect(
+    unsafe_code,
+    reason = "implements Salsa's unsafe update contract for an owned value"
+)]
+unsafe impl salsa::Update for Name {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        // SAFETY: `Update` guarantees that `old_pointer` is valid and uniquely available for the
+        // duration of this call. `Name` owns all of its data and has no borrowed state.
+        let old_value = unsafe { &mut *old_pointer };
+        if *old_value == new_value {
+            false
+        } else {
+            *old_value = new_value;
+            true
+        }
     }
 }
 
@@ -801,7 +843,57 @@ type SegmentsStack<'a> = ArrayVec<&'a str, SMALL_LEN>;
 
 #[cfg(test)]
 mod tests {
-    use crate::name::SegmentsVec;
+    #[cfg(feature = "get-size")]
+    use get_size2::{GetSize, StandardTracker};
+
+    use crate::Identifier;
+    use crate::name::{Name, SegmentsVec};
+
+    const STATIC_NAME: Name = Name::new_static("a_static_name_that_is_not_inline");
+
+    #[test]
+    fn inline_and_static_storage() {
+        assert!(
+            !Name::new("x".repeat(Name::INLINE_CAPACITY))
+                .0
+                .is_heap_allocated()
+        );
+        assert!(
+            Name::new("x".repeat(Name::INLINE_CAPACITY + 1))
+                .0
+                .is_heap_allocated()
+        );
+        assert_eq!(STATIC_NAME, "a_static_name_that_is_not_inline");
+        assert!(!STATIC_NAME.0.is_heap_allocated());
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn size() {
+        assert_eq!(std::mem::size_of::<Name>(), 16);
+        assert_eq!(std::mem::size_of::<Option<Name>>(), 16);
+        assert_eq!(std::mem::size_of::<Identifier>(), 32);
+    }
+
+    #[test]
+    #[cfg(all(feature = "serde", feature = "schemars"))]
+    fn serde_roundtrip() {
+        let name = Name::new("Python_🐍");
+        let serialized = serde_json::to_string(&name).unwrap();
+        assert_eq!(serde_json::from_str::<Name>(&serialized).unwrap(), name);
+    }
+
+    #[test]
+    #[cfg(feature = "get-size")]
+    fn heap_size_tracks_shared_storage_once() {
+        assert_eq!(Name::new("inline").get_heap_size(), 0);
+
+        let name = Name::new("a name too long for inline storage");
+        let expected = name.0.capacity();
+        let clone = name.clone();
+        let (size, _) = (name, clone).get_heap_size_with_tracker(StandardTracker::new());
+        assert_eq!(size, expected);
+    }
 
     #[test]
     fn empty_vec() {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3916,16 +3916,16 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size() {
-        assert_eq!(std::mem::size_of::<Stmt>(), 96);
-        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 96);
-        assert_eq!(std::mem::size_of::<StmtClassDef>(), 88);
+        assert_eq!(std::mem::size_of::<Stmt>(), 88);
+        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 88);
+        assert_eq!(std::mem::size_of::<StmtClassDef>(), 80);
         assert_eq!(std::mem::size_of::<StmtTry>(), 64);
         assert_eq!(std::mem::size_of::<Mod>(), 32);
-        assert_eq!(std::mem::size_of::<Pattern>(), 80);
+        assert_eq!(std::mem::size_of::<Pattern>(), 72);
         assert_eq!(std::mem::size_of::<Parameters>(), 56);
         assert_eq!(std::mem::size_of::<Arguments>(), 40);
         assert_eq!(std::mem::size_of::<Expr>(), 72);
-        assert_eq!(std::mem::size_of::<ExprAttribute>(), 64);
+        assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 24);
         assert_eq!(std::mem::size_of::<ExprBinOp>(), 32);
         assert_eq!(std::mem::size_of::<ExprBoolOp>(), 40);
@@ -3943,7 +3943,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprLambda>(), 32);
         assert_eq!(std::mem::size_of::<ExprList>(), 40);
         assert_eq!(std::mem::size_of::<ExprListComp>(), 48);
-        assert_eq!(std::mem::size_of::<ExprName>(), 40);
+        assert_eq!(std::mem::size_of::<ExprName>(), 32);
         assert_eq!(std::mem::size_of::<ExprNamed>(), 32);
         assert_eq!(std::mem::size_of::<ExprNoneLiteral>(), 12);
         assert_eq!(std::mem::size_of::<ExprNumberLiteral>(), 40);

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -21,6 +21,7 @@ bitflags = { workspace = true }
 bstr = { workspace = true }
 compact_str = { workspace = true }
 get-size2 = { workspace = true }
+hashbrown = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 static_assertions = { workspace = true }

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -19,7 +19,6 @@ ruff_text_size = { workspace = true, features = ["get-size"] }
 
 bitflags = { workspace = true }
 bstr = { workspace = true }
-compact_str = { workspace = true }
 get-size2 = { workspace = true }
 hashbrown = { workspace = true }
 memchr = { workspace = true }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -583,7 +583,8 @@ impl<'src> Parser<'src> {
         }
 
         if self.current_token_kind().is_soft_keyword() {
-            let id = Name::new(self.src_text(range));
+            let text = self.src_text(range);
+            let id = self.intern_name(text);
             self.bump_soft_keyword_as_name();
             return ast::Identifier {
                 id,
@@ -617,7 +618,8 @@ impl<'src> Parser<'src> {
                 range,
             );
 
-            let id = Name::new(self.src_text(range));
+            let text = self.src_text(range);
+            let id = self.intern_name(text);
             self.bump_any();
             ast::Identifier {
                 id,

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use std::str::FromStr;
 
 use bitflags::bitflags;
+use hashbrown::HashSet;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{
@@ -10,6 +11,7 @@ use ruff_python_ast::{
 };
 use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use rustc_hash::FxBuildHasher;
 use thin_vec::ThinVec;
 use unicode_normalization::UnicodeNormalization;
 
@@ -34,12 +36,42 @@ mod statement;
 #[cfg(test)]
 mod tests;
 
+#[derive(Debug, Default)]
+struct NameInterner {
+    names: HashSet<Name, FxBuildHasher>,
+}
+
+impl NameInterner {
+    /// Returns an inline name directly, or a shared clone of a heap-allocated name.
+    fn intern(&mut self, text: &str) -> Name {
+        if text.len() <= Name::INLINE_CAPACITY {
+            return Name::new(text);
+        }
+
+        self.names
+            .get_or_insert_with(text, |text| Name::new(text))
+            .clone()
+    }
+
+    /// Interns a name that has already been allocated, such as a normalized identifier.
+    fn intern_owned(&mut self, name: Name) -> Name {
+        if name.len() <= Name::INLINE_CAPACITY {
+            return name;
+        }
+
+        self.names.get_or_insert(name).clone()
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {
     source: &'src str,
 
     /// Token source for the parser that skips over any non-trivia token.
     tokens: TokenSource<'src>,
+
+    /// Deduplicates the backing allocations for repeated names that do not fit inline.
+    name_interner: NameInterner,
 
     /// Stores all the syntax errors found during the parsing.
     errors: Vec<ParseError>,
@@ -92,6 +124,7 @@ impl<'src> Parser<'src> {
             errors: Vec::new(),
             unsupported_syntax_errors: Vec::new(),
             tokens,
+            name_interner: NameInterner::default(),
             recovery_context: RecoveryContext::empty(),
             prev_token_end: TextSize::new(0),
             start_offset,
@@ -395,12 +428,21 @@ impl<'src> Parser<'src> {
     fn bump_name(&mut self) -> Name {
         let text = self.current_token_text();
         let name = if !self.tokens.current_flags().is_non_ascii_name() {
-            Name::new(text)
+            self.intern_name(text)
         } else {
-            normalize_name(text)
+            let normalized = normalize_name(text);
+            self.intern_owned_name(normalized)
         };
         self.bump(TokenKind::Name);
         name
+    }
+
+    fn intern_name(&mut self, text: &str) -> Name {
+        self.name_interner.intern(text)
+    }
+
+    fn intern_owned_name(&mut self, name: Name) -> Name {
+        self.name_interner.intern_owned(name)
     }
 
     fn bump_int(&mut self) -> Int {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -835,7 +835,7 @@ impl<'src> Parser<'src> {
             return first;
         }
 
-        let mut dotted_name = first.id;
+        let mut dotted_name = first.id.as_str().to_owned();
         let mut progress = ParserProgress::default();
 
         while self.eat(TokenKind::Dot) {
@@ -844,15 +844,15 @@ impl<'src> Parser<'src> {
             // test_err dotted_name_multiple_dots
             // import a..b
             // import a...b
-            dotted_name.push_str(".");
-            dotted_name.push_str(&self.parse_identifier());
+            dotted_name.push('.');
+            dotted_name.push_str(self.parse_identifier().as_str());
         }
 
         // test_ok dotted_name_normalized_spaces
         // import a.b.c
         // import a .  b  . c
         ast::Identifier {
-            id: self.intern_owned_name(dotted_name),
+            id: self.intern_owned_name(Name::from(dotted_name)),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -1,4 +1,3 @@
-use compact_str::CompactString;
 use std::fmt::{Display, Write};
 
 use ruff_python_ast::name::Name;
@@ -836,7 +835,7 @@ impl<'src> Parser<'src> {
             return first;
         }
 
-        let mut dotted_name: CompactString = first.id.into();
+        let mut dotted_name = first.id;
         let mut progress = ParserProgress::default();
 
         while self.eat(TokenKind::Dot) {
@@ -845,7 +844,7 @@ impl<'src> Parser<'src> {
             // test_err dotted_name_multiple_dots
             // import a..b
             // import a...b
-            dotted_name.push('.');
+            dotted_name.push_str(".");
             dotted_name.push_str(&self.parse_identifier());
         }
 
@@ -853,7 +852,7 @@ impl<'src> Parser<'src> {
         // import a.b.c
         // import a .  b  . c
         ast::Identifier {
-            id: self.intern_owned_name(Name::from(dotted_name)),
+            id: self.intern_owned_name(dotted_name),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -831,7 +831,12 @@ impl<'src> Parser<'src> {
     fn parse_dotted_name(&mut self) -> ast::Identifier {
         let start = self.node_start();
 
-        let mut dotted_name: CompactString = self.parse_identifier().id.into();
+        let first = self.parse_identifier();
+        if !self.at(TokenKind::Dot) {
+            return first;
+        }
+
+        let mut dotted_name: CompactString = first.id.into();
         let mut progress = ParserProgress::default();
 
         while self.eat(TokenKind::Dot) {
@@ -848,7 +853,7 @@ impl<'src> Parser<'src> {
         // import a.b.c
         // import a .  b  . c
         ast::Identifier {
-            id: Name::from(dotted_name),
+            id: self.intern_owned_name(Name::from(dotted_name)),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,5 +1,7 @@
+use ruff_python_ast::name::Name;
 use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, Stmt};
 
+use super::NameInterner;
 use crate::{Mode, ParseErrorType, ParseOptions, parse, parse_expression, parse_module};
 
 #[test]
@@ -69,6 +71,53 @@ fn nfkc_normalizes_names() {
     };
 
     assert_eq!(name.id.as_str(), "C");
+}
+
+#[test]
+fn repeated_long_names_share_storage() {
+    let long_name = "identifier_longer_than_inline_capacity";
+    let source = format!("{long_name} = {long_name}");
+    let parsed = parse_module(&source).unwrap();
+    let [Stmt::Assign(assign)] = parsed.suite().as_slice() else {
+        panic!("expected an assignment");
+    };
+    let [Expr::Name(target)] = assign.targets.as_slice() else {
+        panic!("expected a name target");
+    };
+    let Expr::Name(value) = assign.value.as_ref() else {
+        panic!("expected a name value");
+    };
+
+    assert!(std::ptr::eq(target.id.as_str(), value.id.as_str()));
+}
+
+#[test]
+fn only_heap_allocated_names_are_interned() {
+    let mut interner = NameInterner::default();
+    interner.intern(&"x".repeat(Name::INLINE_CAPACITY));
+    assert!(interner.names.is_empty());
+
+    interner.intern(&"x".repeat(Name::INLINE_CAPACITY + 1));
+    assert_eq!(interner.names.len(), 1);
+}
+
+#[test]
+fn normalized_long_names_share_storage() {
+    let normalized = "C".repeat(Name::INLINE_CAPACITY + 1);
+    let source = format!("{} = {normalized}", "𝒞".repeat(Name::INLINE_CAPACITY + 1));
+    let parsed = parse_module(&source).unwrap();
+    let [Stmt::Assign(assign)] = parsed.suite().as_slice() else {
+        panic!("expected an assignment");
+    };
+    let [Expr::Name(target)] = assign.targets.as_slice() else {
+        panic!("expected a name target");
+    };
+    let Expr::Name(value) = assign.value.as_ref() else {
+        panic!("expected a name value");
+    };
+
+    assert_eq!(target.id.as_str(), normalized);
+    assert!(std::ptr::eq(target.id.as_str(), value.id.as_str()));
 }
 
 #[test]

--- a/crates/ty_python_core/Cargo.toml
+++ b/crates/ty_python_core/Cargo.toml
@@ -27,6 +27,7 @@ bitvec = { workspace = true }
 get-size2 = { workspace = true, features = ["indexmap", "ordermap", "thin-vec"] }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
+lean_string = { workspace = true }
 ruff_macros = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 salsa = { workspace = true, features = ["compact_str", "ordermap"] }

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -173,7 +173,7 @@ impl MemberExpr {
             None
         } else {
             Some(Self {
-                path: builder.path,
+                path: Name::from(builder.path),
                 segments: Segments::from_vec(builder.segments),
             })
         }
@@ -185,10 +185,6 @@ impl MemberExpr {
 
     fn segments(&self) -> impl Iterator<Item = Segment<'_>> + '_ {
         SegmentsIterator::new(self.path.as_str(), self.segment_infos())
-    }
-
-    fn shrink_to_fit(&mut self) {
-        self.path.shrink_to_fit();
     }
 
     /// Returns the left most part of the member expression, e.g. `x` in `x.y.z`.
@@ -213,7 +209,7 @@ impl MemberExpr {
 /// A builder for a [`MemberExpr`].
 #[derive(Clone, Debug, PartialEq, Eq, get_size2::GetSize)]
 pub(super) struct MemberExprBuilder {
-    path: Name,
+    path: String,
     segments: SmallVec<[SegmentInfo; 8]>,
 }
 
@@ -221,7 +217,7 @@ impl MemberExprBuilder {
     pub(super) fn visit_expr(expr: ast::ExprRef) -> Option<MemberExprBuilder> {
         match expr {
             ast::ExprRef::Name(name) => Some(MemberExprBuilder {
-                path: name.id.clone(),
+                path: name.id.as_str().to_owned(),
                 segments: smallvec::SmallVec::new_const(),
             }),
             ast::ExprRef::Named(named) if named.target.is_name_expr() => {
@@ -552,7 +548,7 @@ impl MemberTableBuilder {
     /// Adds a member to the table or updates the flags of an existing member if it already exists.
     ///
     /// Members are identified by their expression, which is hashed to find the entry in the table.
-    pub(super) fn add(&mut self, mut member: Member) -> (ScopedMemberId, bool) {
+    pub(super) fn add(&mut self, member: Member) -> (ScopedMemberId, bool) {
         let entry = self.reverse.entry(&self.table.members, &member);
 
         match entry {
@@ -566,8 +562,6 @@ impl MemberTableBuilder {
                 (id, false)
             }
             Entry::Vacant(entry) => {
-                member.expression.shrink_to_fit();
-
                 let id = self.table.members.push(member);
                 entry.insert(id);
                 (id, true)

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -1,9 +1,10 @@
 use ruff_index::{IndexVec, newtype_index};
-use ruff_python_ast::{self as ast, name::Name};
+use ruff_python_ast as ast;
 use ruff_text_size::{TextLen as _, TextRange, TextSize};
 
 use bitflags::bitflags;
 use hashbrown::hash_table::Entry;
+use lean_string::LeanStr;
 use rustc_hash::FxHasher;
 use smallvec::SmallVec;
 
@@ -15,6 +16,35 @@ use std::ops::{Deref, DerefMut};
 // Member-expression equality is relatively expensive, and raising the cutoff to 16 regressed
 // performance for comparatively little additional memory savings.
 const LINEAR_SEARCH_THRESHOLD: usize = 8;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MemberPath(LeanStr);
+
+impl MemberPath {
+    fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<String> for MemberPath {
+    fn from(path: String) -> Self {
+        Self(LeanStr::from(path))
+    }
+}
+
+impl get_size2::GetSize for MemberPath {
+    fn get_heap_size_with_tracker<T: get_size2::GetSizeTracker>(
+        &self,
+        mut tracker: T,
+    ) -> (usize, T) {
+        let size = if self.0.is_heap_allocated() && tracker.track(self.0.as_ptr()) {
+            self.0.len()
+        } else {
+            0
+        };
+        (size, tracker)
+    }
+}
 
 /// A member access, e.g. `x.y` or `x[1]` or `x["foo"]`.
 #[derive(Clone, Debug, PartialEq, Eq, get_size2::GetSize)]
@@ -156,8 +186,8 @@ impl get_size2::GetSize for MemberFlags {}
 /// The symbol name can be extracted from the path by taking the text up to the first segment's start offset.
 #[derive(Clone, Debug, PartialEq, Eq, get_size2::GetSize)]
 pub(crate) struct MemberExpr {
-    /// The entire path as a single Name
-    path: Name,
+    /// The entire path as a single immutable string.
+    path: MemberPath,
     /// Metadata for each segment (in forward order)
     segments: Segments,
 }
@@ -173,7 +203,7 @@ impl MemberExpr {
             None
         } else {
             Some(Self {
-                path: Name::from(builder.path),
+                path: MemberPath::from(builder.path),
                 segments: Segments::from_vec(builder.segments),
             })
         }

--- a/crates/ty_python_core/src/symbol.rs
+++ b/crates/ty_python_core/src/symbol.rs
@@ -273,7 +273,7 @@ impl SymbolTableBuilder {
     }
 
     /// Add a new symbol to this scope or update the flags if a symbol with the same name already exists.
-    pub(super) fn add(&mut self, mut symbol: Symbol) -> (ScopedSymbolId, bool) {
+    pub(super) fn add(&mut self, symbol: Symbol) -> (ScopedSymbolId, bool) {
         let entry = self.reverse.entry(&self.table.symbols, &symbol);
 
         match entry {
@@ -287,7 +287,6 @@ impl SymbolTableBuilder {
                 (id, false)
             }
             Entry::Vacant(entry) => {
-                symbol.name.shrink_to_fit();
                 let id = self.table.symbols.push(symbol);
                 entry.insert(id);
                 (id, true)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5393,7 +5393,7 @@ impl<'db> Type<'db> {
             self.try_call_dunder(
                 db,
                 "__getattr__",
-                CallArguments::positional([Type::string_literal(db, name)]),
+                CallArguments::positional([Type::string_literal(db, name.as_str())]),
                 TypeContext::default(),
             )
             .map(|outcome| Place::bound(outcome.return_type(db)))
@@ -5412,7 +5412,7 @@ impl<'db> Type<'db> {
             self.try_call_dunder_with_policy(
                 db,
                 "__getattribute__",
-                &mut CallArguments::positional([Type::string_literal(db, name)]),
+                &mut CallArguments::positional([Type::string_literal(db, name.as_str())]),
                 TypeContext::default(),
                 MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
             )

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -824,7 +824,7 @@ impl<'db> BoundSuperType<'db> {
                 let mut key_builder = UnionBuilder::new(db);
                 let mut value_builder = UnionBuilder::new(db);
                 for (name, field) in td.items(db) {
-                    key_builder = key_builder.add(Type::string_literal(db, name));
+                    key_builder = key_builder.add(Type::string_literal(db, name.as_str()));
                     value_builder = value_builder.add(field.declared_ty);
                 }
                 return delegate_to(

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1373,7 +1373,7 @@ impl<'db> Bindings<'db> {
                                     Some("__name__") => {
                                         overload.set_return_type(Type::string_literal(
                                             db,
-                                            typevar.name(db),
+                                            typevar.name(db).as_str(),
                                         ));
                                     }
                                     Some("__bound__") => {
@@ -2074,7 +2074,7 @@ impl<'db> Bindings<'db> {
                                                 Type::heterogeneous_tuple(
                                                     db,
                                                     names.iter().map(|name| {
-                                                        Type::string_literal(db, *name)
+                                                        Type::string_literal(db, name.as_str())
                                                     }),
                                                 )
                                             }
@@ -2095,10 +2095,9 @@ impl<'db> Bindings<'db> {
                                         {
                                             Type::heterogeneous_tuple(
                                                 db,
-                                                metadata
-                                                    .members
-                                                    .keys()
-                                                    .map(|member| Type::string_literal(db, member)),
+                                                metadata.members.keys().map(|member| {
+                                                    Type::string_literal(db, member.as_str())
+                                                }),
                                             )
                                         } else {
                                             Type::unknown()
@@ -2115,10 +2114,9 @@ impl<'db> Bindings<'db> {
                             if let [Some(ty)] = overload.parameter_types() {
                                 overload.set_return_type(Type::heterogeneous_tuple(
                                     db,
-                                    list_members::all_members(db, *ty)
-                                        .into_iter()
-                                        .sorted()
-                                        .map(|member| Type::string_literal(db, &member.name)),
+                                    list_members::all_members(db, *ty).into_iter().sorted().map(
+                                        |member| Type::string_literal(db, member.name.as_str()),
+                                    ),
                                 ));
                             }
                         }

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -68,12 +68,12 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
             }
 
             // __match_args__: tuple[Literal["field1"], Literal["field2"], ...]
-            let field_types = fields.map(|field| Type::string_literal(db, &field.name));
+            let field_types = fields.map(|field| Type::string_literal(db, field.name.as_str()));
             Some(Type::heterogeneous_tuple(db, field_types))
         }
         "_fields" => {
             // _fields: tuple[Literal["field1"], Literal["field2"], ...]
-            let field_types = fields.map(|field| Type::string_literal(db, &field.name));
+            let field_types = fields.map(|field| Type::string_literal(db, field.name.as_str()));
             Some(Type::heterogeneous_tuple(db, field_types))
         }
         "__slots__" => {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -998,7 +998,7 @@ impl<'db> StaticClassLiteral<'db> {
                     explicit_metaclass_of: class_metaclass_was_from,
                 }
             } else {
-                let name = Type::string_literal(db, class.name(db));
+                let name = Type::string_literal(db, class.name(db).as_str());
                 let bases = Type::heterogeneous_tuple(db, class.explicit_bases(db));
                 let namespace = KnownClass::Dict
                     .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
@@ -1689,7 +1689,7 @@ impl<'db> StaticClassLiteral<'db> {
                             false
                         }
                     })
-                    .map(|(name, _)| Type::string_literal(db, name));
+                    .map(|(name, _)| Type::string_literal(db, name.as_str()));
                 Some(Type::heterogeneous_tuple(db, match_args))
             }
             (field_policy @ CodeGeneratorKind::DataclassLike(_), "__weakref__")
@@ -1769,7 +1769,9 @@ impl<'db> StaticClassLiteral<'db> {
                 self.has_dataclass_param(db, field_policy, DataclassFlags::SLOTS)
                     .then(|| {
                         let fields = self.fields(db, specialization, field_policy);
-                        let slots = fields.keys().map(|name| Type::string_literal(db, name));
+                        let slots = fields
+                            .keys()
+                            .map(|name| Type::string_literal(db, name.as_str()));
                         Type::heterogeneous_tuple(db, slots)
                     })
             }
@@ -1819,7 +1821,7 @@ impl<'db> StaticClassLiteral<'db> {
 
         let overloads = frozen_base_fields
             .keys()
-            .map(|field| setattr_signature(Type::string_literal(db, field), Type::Never))
+            .map(|field| setattr_signature(Type::string_literal(db, field.as_str()), Type::Never))
             .chain([setattr_signature(
                 KnownClass::Str.to_instance(db),
                 Type::none(db),

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -206,7 +206,7 @@ fn synthesize_typed_dict_getitem<'db>(
     let overloads = fields
         .iter()
         .map(|(field_name, field)| {
-            let key_type = Type::string_literal(db, field_name);
+            let key_type = Type::string_literal(db, field_name.as_str());
             let parameters = [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
@@ -265,7 +265,7 @@ fn synthesize_typed_dict_setitem<'db>(
 
     let overloads = writable_fields
         .map(|(field_name, field)| {
-            let key_type = Type::string_literal(db, field_name);
+            let key_type = Type::string_literal(db, field_name.as_str());
             let parameters = [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
@@ -322,7 +322,7 @@ fn synthesize_typed_dict_delitem<'db>(
 
     let overloads = deletable_fields
         .map(|(field_name, _)| {
-            let key_type = Type::string_literal(db, field_name);
+            let key_type = Type::string_literal(db, field_name.as_str());
             let parameters = [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
@@ -364,7 +364,7 @@ fn synthesize_typed_dict_get<'db>(
     let overloads = fields
         .iter()
         .flat_map(|(field_name, field)| {
-            let key_type = Type::string_literal(db, field_name);
+            let key_type = Type::string_literal(db, field_name.as_str());
 
             let get_sig_params = [
                 Parameter::positional_only(Some(Name::new_static("self")))
@@ -580,7 +580,10 @@ fn synthesize_typed_dict_pop<'db>(
         .iter()
         .filter(|(_, field)| !field.is_required() && !field.is_read_only())
         .flat_map(|(field_name, field)| {
-            pop_overloads(Type::string_literal(db, field_name), field.declared_ty)
+            pop_overloads(
+                Type::string_literal(db, field_name.as_str()),
+                field.declared_ty,
+            )
         })
         .chain(
             typed_dict
@@ -609,7 +612,7 @@ fn synthesize_typed_dict_setdefault<'db>(
         .iter()
         .filter(|(_, field)| !field.is_read_only())
         .map(|(field_name, field)| {
-            let key_type = Type::string_literal(db, field_name);
+            let key_type = Type::string_literal(db, field_name.as_str());
             let parameters = [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -384,7 +384,7 @@ impl<'db> EnumClassLiteral<'db> {
     /// canonical, even though custom enum construction could make it an alias of another member.
     pub(crate) fn name_type(self, db: &'db dyn Db, name: &Name) -> Option<Type<'db>> {
         self.resolve_member(db, name)
-            .map(|name| Type::string_literal(db, name))
+            .map(|name| Type::string_literal(db, name.as_str()))
     }
 
     pub(crate) fn value_type(self, db: &'db dyn Db, name: &Name) -> Option<Type<'db>> {
@@ -612,7 +612,7 @@ impl<'db> EnumMetadata<'db> {
         let union = self
             .members
             .keys()
-            .map(|name| Type::string_literal(db, name))
+            .map(|name| Type::string_literal(db, name.as_str()))
             .fold(UnionBuilder::new(db), UnionBuilder::add)
             .build();
         Some(union)

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -102,7 +102,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let key = keyword_names
                     .get(&elt.node_index().load())
                     .expect("keyword-only dict() fast-path requires named keywords");
-                Type::string_literal(builder.db(), key)
+                Type::string_literal(builder.db(), key.as_str())
             } else {
                 builder.infer_expression(elt, tcx)
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -79,7 +79,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let keys = typed_dict
                         .items(db)
                         .keys()
-                        .map(|key| Type::string_literal(db, key))
+                        .map(|key| Type::string_literal(db, key.as_str()))
                         .collect_vec();
                     (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
                 }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -346,7 +346,7 @@ impl<'db> TypedDictType<'db> {
             .iter()
             .filter(|(_, field)| field.may_be_present(db))
             .fold(UnionBuilder::new(db), |builder, (name, _)| {
-                builder.add(Type::string_literal(db, name))
+                builder.add(Type::string_literal(db, name.as_str()))
             })
             .build()
     }


### PR DESCRIPTION
## Summary

This stores encoded member-expression paths in a dedicated `MemberPath` backed by `LeanStr` instead of representing values such as `foobar0baz` as Python identifiers.

Member paths retain the same compact, structurally shared storage introduced by #26594 while making the composite-path invariant explicit and keeping parser `Name` focused on actual identifiers.
