### PR TITLE
[ty] Fix protocol matching for class variables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -365,6 +365,7 @@ class C(metaclass=Meta):
     attribute: int = 1
 
 reveal_type(C.attribute)  # revealed: Any
+C.attribute = "could be accepted by the dynamic descriptor"
 
 class UnionMeta(type):
     attribute: Any | DataDescriptor = DataDescriptor()

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -546,6 +546,10 @@ reveal_type(C3.meta_attribute1)  # revealed: Literal["value on class"]
 reveal_type(C3.meta_attribute2)  # revealed: Literal["class level data descriptor"]
 reveal_type(C3.meta_non_data_descriptor1)  # revealed: Literal["value on class"]
 reveal_type(C3.meta_non_data_descriptor2)  # revealed: Literal["class level data descriptor"]
+
+C3.meta_non_data_descriptor1 = "value on class"
+# error: [invalid-assignment] "Object of type `Literal["invalid"]` is not assignable to attribute `meta_non_data_descriptor1` of type `Literal["value on class"]`"
+C3.meta_non_data_descriptor1 = "invalid"
 ```
 
 Finally, metaclass attributes and metaclass non-data descriptors are only accessible when they are

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1834,7 +1834,7 @@ the non-callable attribute must be readable with the same type through both an i
 `classvars.py`:
 
 ```py
-from typing import ClassVar, Protocol
+from typing import Any, ClassVar, Protocol
 from ty_extensions import static_assert
 from ty_extensions._internal import is_subtype_of, is_assignable_to
 
@@ -1876,6 +1876,15 @@ class ClassVarXWithConflictingMetaclass(metaclass=XMeta):
 
 static_assert(is_assignable_to(ClassVarXWithConflictingMetaclass, ClassVarXProto))
 static_assert(is_subtype_of(ClassVarXWithConflictingMetaclass, ClassVarXProto))
+
+class GenericMeta(type):
+    x: list[Any] = []
+
+class ClassVarXWithGenericMetaclass(metaclass=GenericMeta):
+    x: ClassVar[int] = 42
+
+static_assert(is_assignable_to(ClassVarXWithGenericMetaclass, ClassVarXProto))
+static_assert(is_subtype_of(ClassVarXWithGenericMetaclass, ClassVarXProto))
 
 # A class-level attribute shadows a non-data descriptor on the metaclass. In particular,
 # `NotHashable.__hash__` takes precedence over the non-data `type.__hash__` descriptor.

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1866,6 +1866,27 @@ class ClassVarX:
 
 static_assert(is_assignable_to(ClassVarX, ClassVarXProto))
 static_assert(is_subtype_of(ClassVarX, ClassVarXProto))
+
+class XMeta(type):
+    def x(cls) -> str:
+        return ""
+
+class ClassVarXWithConflictingMetaclass(metaclass=XMeta):
+    x: ClassVar[int] = 42
+
+static_assert(is_assignable_to(ClassVarXWithConflictingMetaclass, ClassVarXProto))
+static_assert(is_subtype_of(ClassVarXWithConflictingMetaclass, ClassVarXProto))
+
+# A class-level attribute shadows a non-data descriptor on the metaclass. In particular,
+# `NotHashable.__hash__` takes precedence over the non-data `type.__hash__` descriptor.
+class NotHashableProto(Protocol):
+    __hash__: ClassVar[None]
+
+class NotHashable:
+    __hash__: ClassVar[None] = None
+
+static_assert(is_assignable_to(NotHashable, NotHashableProto))
+static_assert(is_subtype_of(NotHashable, NotHashableProto))
 ```
 
 This is mentioned by the

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -259,9 +259,13 @@ class Meta(type):
     META_FINAL_A: Final[int] = 1
     META_FINAL_B: Final = 1
 
+    def CLASS_FINAL_SHADOWING_NON_DATA_DESCRIPTOR(cls) -> int:
+        return 1
+
 class C(metaclass=Meta):
     CLASS_FINAL_A: Final[int] = 1
     CLASS_FINAL_B: Final = 1
+    CLASS_FINAL_SHADOWING_NON_DATA_DESCRIPTOR: Final[int] = 1
 
     def __init__(self):
         self.INSTANCE_FINAL_A: Final[int] = 1
@@ -282,6 +286,8 @@ C.CLASS_FINAL_A = 2
 C.CLASS_FINAL_B = 2
 # error: [invalid-assignment] "Cannot assign to final attribute `CLASS_FINAL_A` on type `<class 'C'>`"
 C.CLASS_FINAL_A += 1
+# error: [invalid-assignment] "Cannot assign to final attribute `CLASS_FINAL_SHADOWING_NON_DATA_DESCRIPTOR` on type `<class 'C'>`"
+C.CLASS_FINAL_SHADOWING_NON_DATA_DESCRIPTOR = 2
 
 c = C()
 # error: [invalid-assignment] "Cannot assign to final attribute `CLASS_FINAL_A` on type `C`"

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3518,6 +3518,16 @@ impl<'db> Type<'db> {
         self.is_data_descriptor_impl(d, true)
     }
 
+    /// Returns whether this type is known not to be a data descriptor.
+    ///
+    /// Gradual types and type variables remain uncertain even though
+    /// [`Type::may_be_data_descriptor`] deliberately excludes them for narrowing.
+    pub(crate) fn is_definitely_non_data_descriptor(self, db: &'db dyn Db) -> bool {
+        !self.has_dynamic(db)
+            && !self.has_typevar_or_typevar_instance(db)
+            && !self.may_be_data_descriptor(db)
+    }
+
     fn is_data_descriptor_impl(self, db: &'db dyn Db, any_of_union: bool) -> bool {
         match self {
             Type::Dynamic(_) => !any_of_union,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3520,12 +3520,21 @@ impl<'db> Type<'db> {
 
     /// Returns whether this type is known not to be a data descriptor.
     ///
-    /// Gradual types and type variables remain uncertain even though
-    /// [`Type::may_be_data_descriptor`] deliberately excludes them for narrowing.
+    /// Descriptor uncertainty only propagates through outer unions, intersections, and aliases;
+    /// type arguments do not affect the runtime descriptor class.
     pub(crate) fn is_definitely_non_data_descriptor(self, db: &'db dyn Db) -> bool {
-        !self.has_dynamic(db)
-            && !self.has_typevar_or_typevar_instance(db)
-            && !self.may_be_data_descriptor(db)
+        match self {
+            Type::Dynamic(_) | Type::Divergent(_) | Type::TypeVar(_) => false,
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .all(|ty| ty.is_definitely_non_data_descriptor(db)),
+            Type::Intersection(intersection) => intersection
+                .iter_positive(db)
+                .all(|ty| ty.is_definitely_non_data_descriptor(db)),
+            Type::TypeAlias(alias) => alias.value_type(db).is_definitely_non_data_descriptor(db),
+            _ => !self.may_be_data_descriptor(db),
+        }
     }
 
     fn is_data_descriptor_impl(self, db: &'db dyn Db, any_of_union: bool) -> bool {

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -143,6 +143,35 @@ pub(super) enum FallbackAttributeWriteRequirement<'db> {
     PossiblyMissing,
 }
 
+/// The members that can govern an attribute write.
+pub(super) enum AssignmentAttributeMembers<'db> {
+    /// The primary lookup result governs the write, together with a fallback when it may be
+    /// missing.
+    Primary {
+        member: PlaceAndQualifiers<'db>,
+        fallback: Option<PlaceAndQualifiers<'db>>,
+    },
+    /// A class member shadows a metaclass member that is definitely non-data.
+    ShadowingClassMember(PlaceAndQualifiers<'db>),
+}
+
+impl<'db> AssignmentAttributeMembers<'db> {
+    pub(super) fn primary(self) -> Option<PlaceAndQualifiers<'db>> {
+        match self {
+            Self::Primary { member, .. } => Some(member),
+            Self::ShadowingClassMember(_) => None,
+        }
+    }
+
+    pub(super) fn effective_members(self) -> impl Iterator<Item = PlaceAndQualifiers<'db>> {
+        let members = match self {
+            Self::Primary { member, fallback } => [Some(member), fallback],
+            Self::ShadowingClassMember(member) => [Some(member), None],
+        };
+        members.into_iter().flatten()
+    }
+}
+
 /// Resolve the receiver-level requirements for writing `object_ty.attribute`.
 ///
 /// This expands aliases, preserves the all-arms rule for unions and the any-positive-arm rule for
@@ -259,9 +288,16 @@ fn instance_attribute_write_member_requirement<'db>(
     object_ty: Type<'db>,
     attribute: &str,
 ) -> InstanceAttributeWriteMember<'db> {
-    let Some((meta_attr, fallback_attr)) = assignment_attribute_members(db, object_ty, attribute)
-    else {
+    let Some(members) = assignment_attribute_members(db, object_ty, attribute) else {
         return InstanceAttributeWriteMember::SetAttr;
+    };
+    let (meta_attr, fallback_attr) = match members {
+        AssignmentAttributeMembers::Primary { member, fallback } => (member, fallback),
+        AssignmentAttributeMembers::ShadowingClassMember(fallback) => {
+            return InstanceAttributeWriteMember::Instance(instance_fallback_write_requirement(
+                db, object_ty, attribute, fallback,
+            ));
+        }
     };
 
     match meta_attr {
@@ -307,12 +343,22 @@ fn class_attribute_write_requirement<'db>(
     object_ty: Type<'db>,
     attribute: &str,
 ) -> AttributeWriteRequirement<'db> {
-    let Some((meta_attr, fallback_attr)) = assignment_attribute_members(db, object_ty, attribute)
-    else {
+    let Some(members) = assignment_attribute_members(db, object_ty, attribute) else {
         return AttributeWriteRequirement::Unconstrained;
     };
     let Some(class_attr_self_ty) = object_ty.to_instance(db) else {
         return AttributeWriteRequirement::Unconstrained;
+    };
+    let (meta_attr, fallback_attr) = match members {
+        AssignmentAttributeMembers::Primary { member, fallback } => (member, fallback),
+        AssignmentAttributeMembers::ShadowingClassMember(fallback) => {
+            return AttributeWriteRequirement::Class {
+                object_ty,
+                member: ClassAttributeWriteMember::ClassAttribute(
+                    class_fallback_write_requirement(db, object_ty, class_attr_self_ty, fallback),
+                ),
+            };
+        }
     };
 
     let member = match meta_attr {
@@ -494,11 +540,34 @@ pub(super) fn property_setter_returns_never<'db>(
     })
 }
 
-/// Return the primary and optional fallback members considered by attribute assignment.
+/// Return the class member that shadows a definitely non-data metaclass member, if any.
+fn shadowing_class_member<'db>(
+    db: &'db dyn Db,
+    object_ty: Type<'db>,
+    attribute: &str,
+    meta_attr: PlaceAndQualifiers<'db>,
+) -> Option<PlaceAndQualifiers<'db>> {
+    if !matches!(
+        object_ty,
+        Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..)
+    ) || !meta_attr
+        .place
+        .ignore_possibly_undefined()?
+        .is_definitely_non_data_descriptor(db)
+    {
+        return None;
+    }
+
+    object_ty
+        .find_name_in_mro_with_policy(db, attribute, MemberLookupPolicy::default())
+        .filter(|class_attr| !class_attr.place.is_undefined())
+}
+
+/// Return the members considered by attribute assignment in lookup-precedence order.
 ///
-/// The primary member comes from class-member lookup. The fallback is queried only when that
-/// member is absent or possibly undefined, and is an instance member for ordinary receivers or a
-/// class-object member for class receivers. Composite and dynamic receiver types return `None`;
+/// The primary member comes from class-member lookup. Its fallback is queried when that member is
+/// absent or possibly undefined. For class objects, a class-MRO member instead shadows a
+/// definitely non-data metaclass member. Composite and dynamic receiver types return `None`;
 /// their callers either decompose them before this point or handle them without member lookup.
 ///
 /// This helper deliberately does not bind `Self` or interpret descriptors so that assignment,
@@ -507,7 +576,7 @@ pub(super) fn assignment_attribute_members<'db>(
     db: &'db dyn Db,
     object_ty: Type<'db>,
     attribute: &str,
-) -> Option<(PlaceAndQualifiers<'db>, Option<PlaceAndQualifiers<'db>>)> {
+) -> Option<AssignmentAttributeMembers<'db>> {
     // Precise `functools.partial` instances synthesize a refined `__call__` member instead of
     // using the broad signature from typeshed.
     let meta_attr = if attribute == "__call__"
@@ -519,6 +588,9 @@ pub(super) fn assignment_attribute_members<'db>(
     } else {
         object_ty.class_member(db, attribute.into())
     };
+    if let Some(class_attr) = shadowing_class_member(db, object_ty, attribute, meta_attr) {
+        return Some(AssignmentAttributeMembers::ShadowingClassMember(class_attr));
+    }
     let needs_fallback = matches!(
         meta_attr.place,
         Place::Defined(DefinedPlace {
@@ -565,5 +637,8 @@ pub(super) fn assignment_attribute_members<'db>(
     } else {
         None
     };
-    Some((meta_attr, fallback_attr))
+    Some(AssignmentAttributeMembers::Primary {
+        member: meta_attr,
+        fallback: fallback_attr,
+    })
 }

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -144,14 +144,35 @@ pub(super) enum FallbackAttributeWriteRequirement<'db> {
 }
 
 /// The members that can govern an attribute write.
+///
+/// For a class-object receiver, the type member is found on the metaclass while the receiver member
+/// is found on the class's own MRO:
+///
+/// ```python
+/// class Descriptor:
+///     def __set__(self, instance: object, value: object) -> None: ...
+///
+/// class Meta(type):
+///     data = Descriptor()  # Type member: Meta.data
+///     plain = object()  # Type member: Meta.plain
+///
+/// class C(metaclass=Meta):
+///     data: int  # Receiver member: C.data
+///     plain: int  # Receiver member: C.plain
+///
+/// C.data = 1
+/// C.plain = 1
+/// ```
 pub(super) enum AssignmentAttributeMembers<'db> {
-    /// A member found on the receiver's type governs the write, together with a receiver member
-    /// when the type member may be missing.
+    /// The type member governs the write, as `Meta.data` does above because it is a data descriptor.
+    /// If the type member may be missing, the corresponding receiver member (`C.data`) is retained
+    /// as `receiver_fallback`.
     TypeMember {
         member: PlaceAndQualifiers<'db>,
         receiver_fallback: Option<PlaceAndQualifiers<'db>>,
     },
-    /// A receiver-level member governs the write.
+    /// The receiver member governs the write, as `C.plain` does above because `Meta.plain` is
+    /// definitely not a data descriptor.
     ReceiverMember(PlaceAndQualifiers<'db>),
 }
 

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -145,28 +145,33 @@ pub(super) enum FallbackAttributeWriteRequirement<'db> {
 
 /// The members that can govern an attribute write.
 pub(super) enum AssignmentAttributeMembers<'db> {
-    /// The primary lookup result governs the write, together with a fallback when it may be
-    /// missing.
-    Primary {
+    /// A member found on the receiver's type governs the write, together with a receiver member
+    /// when the type member may be missing.
+    TypeMember {
         member: PlaceAndQualifiers<'db>,
-        fallback: Option<PlaceAndQualifiers<'db>>,
+        receiver_fallback: Option<PlaceAndQualifiers<'db>>,
     },
-    /// A class member shadows a metaclass member that is definitely non-data.
-    ShadowingClassMember(PlaceAndQualifiers<'db>),
+    /// A receiver-level member governs the write.
+    ReceiverMember(PlaceAndQualifiers<'db>),
 }
 
 impl<'db> AssignmentAttributeMembers<'db> {
-    pub(super) fn primary(self) -> Option<PlaceAndQualifiers<'db>> {
+    /// Return the member whose descriptor protocol applies to the receiver, if any.
+    pub(super) fn type_member(self) -> Option<PlaceAndQualifiers<'db>> {
         match self {
-            Self::Primary { member, .. } => Some(member),
-            Self::ShadowingClassMember(_) => None,
+            Self::TypeMember { member, .. } => Some(member),
+            Self::ReceiverMember(_) => None,
         }
     }
 
+    /// Iterate over every member that can govern the write at runtime.
     pub(super) fn effective_members(self) -> impl Iterator<Item = PlaceAndQualifiers<'db>> {
         let members = match self {
-            Self::Primary { member, fallback } => [Some(member), fallback],
-            Self::ShadowingClassMember(member) => [Some(member), None],
+            Self::TypeMember {
+                member,
+                receiver_fallback,
+            } => [Some(member), receiver_fallback],
+            Self::ReceiverMember(member) => [Some(member), None],
         };
         members.into_iter().flatten()
     }
@@ -291,17 +296,20 @@ fn instance_attribute_write_member_requirement<'db>(
     let Some(members) = assignment_attribute_members(db, object_ty, attribute) else {
         return InstanceAttributeWriteMember::SetAttr;
     };
-    let (meta_attr, fallback_attr) = match members {
-        AssignmentAttributeMembers::Primary { member, fallback } => (member, fallback),
-        AssignmentAttributeMembers::ShadowingClassMember(fallback) => {
+    let (type_member, receiver_fallback) = match members {
+        AssignmentAttributeMembers::TypeMember {
+            member,
+            receiver_fallback,
+        } => (member, receiver_fallback),
+        AssignmentAttributeMembers::ReceiverMember(member) => {
             return InstanceAttributeWriteMember::Instance(instance_fallback_write_requirement(
-                db, object_ty, attribute, fallback,
+                db, object_ty, attribute, member,
             ));
         }
     };
 
-    match meta_attr {
-        meta_attr if meta_attr.is_class_var() => InstanceAttributeWriteMember::ClassVar,
+    match type_member {
+        type_member if type_member.is_class_var() => InstanceAttributeWriteMember::ClassVar,
         PlaceAndQualifiers {
             place: Place::Defined(DefinedPlace { ty, .. }),
             qualifiers,
@@ -313,14 +321,14 @@ fn instance_attribute_write_member_requirement<'db>(
                 ty.bind_self_typevars(db, object_ty),
                 qualifiers,
             ),
-            fallback: fallback_attr.map(|fallback| {
+            fallback: receiver_fallback.map(|fallback| {
                 instance_fallback_write_requirement(db, object_ty, attribute, fallback)
             }),
         },
         PlaceAndQualifiers {
             place: Place::Undefined,
             ..
-        } => match fallback_attr {
+        } => match receiver_fallback {
             Some(
                 fallback @ PlaceAndQualifiers {
                     place: Place::Defined(_),
@@ -349,32 +357,35 @@ fn class_attribute_write_requirement<'db>(
     let Some(class_attr_self_ty) = object_ty.to_instance(db) else {
         return AttributeWriteRequirement::Unconstrained;
     };
-    let (meta_attr, fallback_attr) = match members {
-        AssignmentAttributeMembers::Primary { member, fallback } => (member, fallback),
-        AssignmentAttributeMembers::ShadowingClassMember(fallback) => {
+    let (type_member, receiver_fallback) = match members {
+        AssignmentAttributeMembers::TypeMember {
+            member,
+            receiver_fallback,
+        } => (member, receiver_fallback),
+        AssignmentAttributeMembers::ReceiverMember(member) => {
             return AttributeWriteRequirement::Class {
                 object_ty,
                 member: ClassAttributeWriteMember::ClassAttribute(
-                    class_fallback_write_requirement(db, object_ty, class_attr_self_ty, fallback),
+                    class_fallback_write_requirement(db, object_ty, class_attr_self_ty, member),
                 ),
             };
         }
     };
 
-    let member = match meta_attr {
+    let member = match type_member {
         PlaceAndQualifiers {
             place: Place::Defined(DefinedPlace { ty, .. }),
             qualifiers,
         } => ClassAttributeWriteMember::Explicit {
             member: explicit_attribute_write_requirement(db, object_ty, attribute, ty, qualifiers),
-            fallback: fallback_attr.map(|fallback| {
+            fallback: receiver_fallback.map(|fallback| {
                 class_fallback_write_requirement(db, object_ty, class_attr_self_ty, fallback)
             }),
         },
         PlaceAndQualifiers {
             place: Place::Undefined,
             ..
-        } => match fallback_attr {
+        } => match receiver_fallback {
             Some(
                 fallback @ PlaceAndQualifiers {
                     place: Place::Defined(_),
@@ -540,17 +551,17 @@ pub(super) fn property_setter_returns_never<'db>(
     })
 }
 
-/// Return the class member that shadows a definitely non-data metaclass member, if any.
-fn shadowing_class_member<'db>(
+/// Return the class member that takes precedence over a definitely non-data metaclass member.
+fn class_member_preceding_non_data_metaclass_member<'db>(
     db: &'db dyn Db,
     object_ty: Type<'db>,
     attribute: &str,
-    meta_attr: PlaceAndQualifiers<'db>,
+    type_member: PlaceAndQualifiers<'db>,
 ) -> Option<PlaceAndQualifiers<'db>> {
     if !matches!(
         object_ty,
         Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..)
-    ) || !meta_attr
+    ) || !type_member
         .place
         .ignore_possibly_undefined()?
         .is_definitely_non_data_descriptor(db)
@@ -565,10 +576,11 @@ fn shadowing_class_member<'db>(
 
 /// Return the members considered by attribute assignment in lookup-precedence order.
 ///
-/// The primary member comes from class-member lookup. Its fallback is queried when that member is
-/// absent or possibly undefined. For class objects, a class-MRO member instead shadows a
-/// definitely non-data metaclass member. Composite and dynamic receiver types return `None`;
-/// their callers either decompose them before this point or handle them without member lookup.
+/// The type member comes from class-member lookup. A member found directly on the receiver is
+/// queried when the type member is absent or possibly undefined. For class objects, a class-MRO
+/// member instead takes precedence over a definitely non-data metaclass member. Composite and
+/// dynamic receiver types return `None`; their callers either decompose them before this point or
+/// handle them without member lookup.
 ///
 /// This helper deliberately does not bind `Self` or interpret descriptors so that assignment,
 /// protocol compatibility, and `Final` validation share exactly the same lookup precedence.
@@ -579,7 +591,7 @@ pub(super) fn assignment_attribute_members<'db>(
 ) -> Option<AssignmentAttributeMembers<'db>> {
     // Precise `functools.partial` instances synthesize a refined `__call__` member instead of
     // using the broad signature from typeshed.
-    let meta_attr = if attribute == "__call__"
+    let type_member = if attribute == "__call__"
         && matches!(
             object_ty,
             Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
@@ -588,17 +600,19 @@ pub(super) fn assignment_attribute_members<'db>(
     } else {
         object_ty.class_member(db, attribute.into())
     };
-    if let Some(class_attr) = shadowing_class_member(db, object_ty, attribute, meta_attr) {
-        return Some(AssignmentAttributeMembers::ShadowingClassMember(class_attr));
+    if let Some(receiver_member) =
+        class_member_preceding_non_data_metaclass_member(db, object_ty, attribute, type_member)
+    {
+        return Some(AssignmentAttributeMembers::ReceiverMember(receiver_member));
     }
-    let needs_fallback = matches!(
-        meta_attr.place,
+    let needs_receiver_fallback = matches!(
+        type_member.place,
         Place::Defined(DefinedPlace {
             definedness: Definedness::PossiblyUndefined,
             ..
         }) | Place::Undefined
     );
-    let fallback_attr = if needs_fallback {
+    let receiver_fallback = if needs_receiver_fallback {
         Some(match object_ty {
             Type::NominalInstance(..)
             | Type::ProtocolInstance(_)
@@ -637,8 +651,8 @@ pub(super) fn assignment_attribute_members<'db>(
     } else {
         None
     };
-    Some(AssignmentAttributeMembers::Primary {
-        member: meta_attr,
-        fallback: fallback_attr,
+    Some(AssignmentAttributeMembers::TypeMember {
+        member: type_member,
+        receiver_fallback,
     })
 }

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -86,8 +86,9 @@ pub(super) enum InstanceAttributeWriteMember<'db> {
 
 /// The member that governs a write through a class object.
 ///
-/// The primary lookup is on the metaclass. If that lookup is absent or possibly undefined, the
-/// class object's own attributes form the fallback.
+/// A data descriptor on the metaclass takes precedence over the class object's own attributes,
+/// which in turn take precedence over definitely non-data metaclass members. If the metaclass
+/// member is absent or possibly undefined, the class object's own attributes form the fallback.
 pub(super) enum ClassAttributeWriteMember<'db> {
     /// A metaclass member governs the write, optionally alongside a class-attribute fallback.
     Explicit {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2857,7 +2857,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }),
                     ..
                 }) = assignment_attribute_members(db, object_ty, attribute)
-                    .map(|(meta_attr, _)| meta_attr)
+                    .and_then(|members| members.primary())
                 {
                     let attr_ty = attr_ty.bind_self_typevars(db, object_ty);
                     let delete_dunder_call_result = attr_ty.try_call_dunder(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -40,7 +40,7 @@ use crate::place::{
 };
 use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
-use crate::types::attribute_write::assignment_attribute_members;
+use crate::types::attribute_write::{AssignmentAttributeMembers, assignment_attribute_members};
 use crate::types::call::bind::MatchingOverloadIndex;
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
@@ -2857,7 +2857,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }),
                     ..
                 }) = assignment_attribute_members(db, object_ty, attribute)
-                    .and_then(|members| members.primary())
+                    .and_then(AssignmentAttributeMembers::type_member)
                 {
                     let attr_ty = attr_ty.bind_self_typevars(db, object_ty);
                     let delete_dunder_call_result = attr_ty.try_call_dunder(

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -317,25 +317,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         object_ty: Type<'db>,
         attribute: &str,
     ) {
-        let Some((meta_attr, fallback_attr)) =
-            assignment_attribute_members(self.db(), object_ty, attribute)
-        else {
+        let Some(members) = assignment_attribute_members(self.db(), object_ty, attribute) else {
             return;
         };
 
-        if !self.invalid_assignment_to_final_attribute(
-            object_ty,
-            target,
-            attribute,
-            meta_attr.qualifiers,
-        ) && let Some(fallback_attr) = fallback_attr
-        {
-            self.invalid_assignment_to_final_attribute(
+        for member in members.effective_members() {
+            if self.invalid_assignment_to_final_attribute(
                 object_ty,
                 target,
                 attribute,
-                fallback_attr.qualifiers,
-            );
+                member.qualifiers,
+            ) {
+                break;
+            }
         }
     }
 
@@ -346,24 +340,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         attribute: &str,
         emit_diagnostics: bool,
     ) -> bool {
-        let Some((meta_attr, fallback_attr)) =
-            assignment_attribute_members(self.db(), object_ty, attribute)
-        else {
+        let Some(members) = assignment_attribute_members(self.db(), object_ty, attribute) else {
             return false;
         };
 
-        self.invalid_deletion_of_final_attribute(
-            object_ty,
-            target,
-            attribute,
-            meta_attr.qualifiers,
-            emit_diagnostics,
-        ) || fallback_attr.is_some_and(|fallback_attr| {
+        members.effective_members().any(|member| {
             self.invalid_deletion_of_final_attribute(
                 object_ty,
                 target,
                 attribute,
-                fallback_attr.qualifiers,
+                member.qualifiers,
                 emit_diagnostics,
             )
         })


### PR DESCRIPTION
## Summary

Prior to this change, we rejected an unhashable class even though its `__hash__` matched the protocol:

```python
from typing import ClassVar, Protocol

class NotHashableProto(Protocol):
    __hash__: ClassVar[None]

class NotHashable:
    __hash__: ClassVar[None] = None

def accepts(value: NotHashableProto) -> None: ...

# Before: rejected
# After: accepted
accepts(NotHashable())
```

The problem is that we were checking the inherited `type.__hash__` instead of the class's own `__hash__ = None`.

For this case, class-object reads already used the correct precedence: metaclass data descriptor, then class attribute, then metaclass non-data descriptor. For writes, though, we treated _any_ metaclass member as the primary and only consulted the class attribute as a fallback. We now let an always-defined class member take precedence over an ordinary metaclass member that is known not to be a data descriptor, while preserving uncertainty for gradual metaclass members.

Closes https://github.com/astral-sh/ty/issues/3951.
