### PR TITLE
[ty] Resolve ambiguity in Google-style docstring parsing in favour of observations from popular projects

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -58,7 +58,8 @@ impl Docstring {
     /// Extract parameter documentation from popular docstring formats.
     /// Returns a map of parameter names to their documentation.
     pub fn parameter_documentation(&self) -> IndexMap<String, String> {
-        document::parameter_documentation(&self.0, extract_numpy_style_params(&self.0))
+        let normalized_source = documentation_trim(&self.0);
+        document::parameter_documentation(&normalized_source, extract_numpy_style_params(&self.0))
     }
 }
 

--- a/crates/ty_ide/src/docstring/document.rs
+++ b/crates/ty_ide/src/docstring/document.rs
@@ -9,13 +9,16 @@ pub(super) mod rst;
 pub(in crate::docstring) mod syntax;
 
 /// Returns docs for all parameters recognized in the given docstring.
+///
+/// `normalized_source` must have already undergone PEP-257 trimming and universal newline
+/// normalization.
 pub(super) fn parameter_documentation(
-    raw: &str,
+    normalized_source: &str,
     numpy_parameters: IndexMap<String, String>,
 ) -> IndexMap<String, String> {
-    let mut parameters = google::parameter_documentation(raw);
+    let mut parameters = google::parameter_documentation(normalized_source);
     parameters.extend(numpy_parameters);
-    parameters.extend(rst::parameter_documentation(raw));
+    parameters.extend(rst::parameter_documentation(normalized_source));
     parameters
 }
 

--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -42,8 +42,11 @@ use super::syntax::{
 };
 
 /// Returns parameter documentation from recognized Google-style parameter sections.
-pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
-    let lines = parsed_lines(raw);
+///
+/// `normalized_source` must have already undergone PEP-257 trimming and universal newline
+/// normalization.
+pub(super) fn parameter_documentation(normalized_source: &str) -> IndexMap<String, String> {
+    let lines = parsed_lines(normalized_source);
     let mut parameters = Parameters::default();
     for section in sections(&lines) {
         if matches!(
@@ -57,6 +60,9 @@ pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
 }
 
 /// Returns recognized Google-style sections in source order.
+///
+/// `lines` must come from source that has already undergone PEP-257 trimming and universal
+/// newline normalization (typically via `docstring::documentation_trim`).
 pub(in crate::docstring) fn sections<'a>(
     lines: &'a [ParsedLine<'a>],
 ) -> impl Iterator<Item = Section<'a>> + 'a {
@@ -121,13 +127,13 @@ fn extend_parameter_documentation(parameters: &mut Parameters, lines: &[ParsedLi
 
         // The first recognized item establishes the sibling indentation.
         // Each item at that indentation starts a new sibling and completes its predecessor.
-        if item_indent.is_none_or(|indent| line.raw_indent == indent)
+        if item_indent.is_none_or(|indent| line.indent == indent)
             && let Some((names, description)) = parse_parameter(trimmed)
         {
             parameters.insert_documentation(
                 current.replace((names.to_string(), description.to_string())),
             );
-            item_indent = Some(line.raw_indent);
+            item_indent = Some(line.indent);
             continue;
         }
 
@@ -201,8 +207,7 @@ fn parse_section_header(lines: &[ParsedLine<'_>], index: usize) -> Option<Sectio
 
     Some(SectionHeader {
         kind,
-        indent: line.raw_indent,
-        structural_indent: line.structural_indent,
+        indent: line.indent,
         body_start_line_index: index + 1,
         range: line.range,
     })
@@ -268,7 +273,7 @@ fn section_body_continuation<'a>(
     }
 
     if leading_blank_lines > 0
-        && next_line.structural_indent <= header.structural_indent
+        && next_line.indent <= header.indent
         && (parse_section_header(lines, leading_blank_lines).is_some()
             || is_inline_section_header(next_line.text))
     {
@@ -278,7 +283,7 @@ fn section_body_continuation<'a>(
     // Returns and yields have no item syntax that distinguishes an aligned body from prose
     // following an empty section.
     if leading_blank_lines > 0
-        && next_line.raw_indent <= header.indent
+        && next_line.indent <= header.indent
         && item_indent.is_none()
         && matches!(
             header.kind,
@@ -299,7 +304,7 @@ fn section_body_continuation<'a>(
                     | SectionKind::OtherParameters
             )
         )
-        && item_indent == Some(next_line.raw_indent)
+        && item_indent == Some(next_line.indent)
         && section_item_indent(header, *next_line).is_none()
     {
         return None;
@@ -314,12 +319,11 @@ fn section_header_ends_body(lines: &[ParsedLine<'_>], index: usize, header: Sect
     let Some(line) = lines.get(index) else {
         return false;
     };
-    if line.structural_indent <= header.structural_indent && is_inline_section_header(line.text) {
+    if line.indent <= header.indent && is_inline_section_header(line.text) {
         return true;
     }
 
-    parse_section_header(lines, index)
-        .is_some_and(|next| next.structural_indent <= header.structural_indent)
+    parse_section_header(lines, index).is_some_and(|next| next.indent <= header.indent)
 }
 
 /// Returns whether `line` belongs to `header` under Google-style indentation rules.
@@ -328,12 +332,11 @@ fn line_belongs_to_body(
     line: ParsedLine<'_>,
     item_indent: Option<TextSize>,
 ) -> bool {
-    match line.raw_indent.cmp(&header.indent) {
+    match line.indent.cmp(&header.indent) {
         Ordering::Less => false,
         Ordering::Greater => true,
         Ordering::Equal => {
-            let item_indent_matches_line =
-                item_indent.is_none_or(|indent| indent == line.raw_indent);
+            let item_indent_matches_line = item_indent.is_none_or(|indent| indent == line.indent);
             let is_parameter_section = matches!(
                 header.kind,
                 HeaderKind::Structured(
@@ -368,7 +371,7 @@ fn section_item_indent(header: SectionHeader, line: ParsedLine<'_>) -> Option<Te
         HeaderKind::Structured(SectionKind::Returns | SectionKind::Yields) => !trimmed.is_empty(),
         HeaderKind::Opaque => false,
     };
-    is_item.then_some(line.raw_indent)
+    is_item.then_some(line.indent)
 }
 
 /// Returns whether `line` is a recognized section header followed by inline content.
@@ -394,7 +397,6 @@ fn is_inline_section_header(line: &str) -> bool {
 struct SectionHeader {
     kind: HeaderKind,
     indent: TextSize,
-    structural_indent: TextSize,
     body_start_line_index: usize,
     range: TextRange,
 }
@@ -739,6 +741,28 @@ This line starts at column zero.
     }
 
     #[test]
+    fn finds_parameter_section_after_first_line_literal_block() {
+        // Regression for https://github.com/pytorch/pytorch/blob/e3f5bf0b18585511e6cd7d7a574ebf82f465e5ae/torch/_native/instrumentation.py#L365-L383
+        assert_parameter_documentation(
+            "\
+Instrument a single ``@triton.jit`` kernel, stacked above the jit::
+
+        @instrument_triton_kernel(\"aten::bmm\")
+        @triton.jit
+        def _bmm_kernel(...): ...
+
+    A Triton kernel compiles lazily and caches variants on the kernel object.
+
+    Args:
+        op: Operator symbol being compiled for, e.g. ``\"aten::bmm\"``.",
+            &[(
+                "op",
+                "Operator symbol being compiled for, e.g. ``\"aten::bmm\"``.",
+            )],
+        );
+    }
+
+    #[test]
     fn keeps_colon_prose_in_parameter_documentation() {
         assert_parameter_documentation(
             "\
@@ -807,6 +831,8 @@ Args:
     fn ignores_parameter_section_in_rest_directive() {
         assert_parameter_documentation(
             "\
+Summary.
+
 .. note::
     Args:
         nested: Not parameter documentation.",
@@ -818,6 +844,8 @@ Args:
     fn ignores_parameter_section_after_blank_line_in_rest_directive() {
         assert_parameter_documentation(
             "\
+Summary.
+
 .. note::
 
         Keyword Args:
@@ -830,6 +858,8 @@ Args:
     fn ignores_parameter_section_in_unordered_markdown_list_item() {
         assert_parameter_documentation(
             "\
+Summary.
+
 - Example:
     Args:
         nested: Not parameter documentation.",
@@ -841,6 +871,8 @@ Args:
     fn ignores_parameter_section_after_blank_line_in_markdown_list_item() {
         assert_parameter_documentation(
             "\
+Summary.
+
 - Example:
 
         Args:
@@ -853,6 +885,8 @@ Args:
     fn ignores_parameter_section_in_ordered_markdown_list_item() {
         assert_parameter_documentation(
             "\
+Summary.
+
 1. Example:
     Args:
         nested: Not parameter documentation.",
@@ -864,6 +898,8 @@ Args:
     fn ignores_parameter_section_in_rest_field_list() {
         assert_parameter_documentation(
             "\
+Summary.
+
 :param value: Example input.
     Args:
         nested: Not parameter documentation.",
@@ -875,6 +911,8 @@ Args:
     fn ignores_parameter_section_in_rest_literal_block() {
         assert_parameter_documentation(
             "\
+Summary.
+
 Example::
 
         Args:
@@ -1054,7 +1092,8 @@ Returns:
     }
 
     fn display_parameters(raw: &str) -> String {
-        parameter_documentation(raw)
+        let normalized_source = crate::docstring::documentation_trim(raw);
+        parameter_documentation(&normalized_source)
             .into_iter()
             .map(|(name, documentation)| {
                 let documentation = documentation
@@ -1071,7 +1110,8 @@ Returns:
 
     #[track_caller]
     fn assert_parameter_documentation(raw: &str, expected: &[(&str, &str)]) {
-        let parameters = parameter_documentation(raw);
+        let normalized_source = crate::docstring::documentation_trim(raw);
+        let parameters = parameter_documentation(&normalized_source);
         assert_eq!(parameters.len(), expected.len(), "{raw}");
 
         for &(name, documentation) in expected {

--- a/crates/ty_ide/src/docstring/document/rst.rs
+++ b/crates/ty_ide/src/docstring/document/rst.rs
@@ -32,11 +32,13 @@ pub(in crate::docstring) fn top_level_field_lists(
 }
 
 /// Returns the parameter documentation recognized in a reST docstring.
-pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
+///
+/// `normalized_source` must have already undergone PEP-257 trimming and universal newline
+/// normalization.
+pub(super) fn parameter_documentation(normalized_source: &str) -> IndexMap<String, String> {
     let mut parameters = IndexMap::new();
-    let source = crate::docstring::documentation_trim(raw);
 
-    for field_list in top_level_field_lists(&source) {
+    for field_list in top_level_field_lists(normalized_source) {
         for field in field_list.fields {
             let Field::Parameter {
                 lookup_name,
@@ -1147,7 +1149,8 @@ Section::
     }
 
     fn parameter_documentation(docstring: &str) -> String {
-        let parameters = super::parameter_documentation(docstring);
+        let normalized_source = crate::docstring::documentation_trim(docstring);
+        let parameters = super::parameter_documentation(&normalized_source);
         let mut rendered = String::new();
 
         for (name, description) in parameters {

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -8,33 +8,15 @@ use super::rst::is_field_list_marker;
 /// source ranges.
 ///
 /// For example, `first\r\nsecond` yields `first` at offset 0 and `second` at offset 7.
-pub(super) fn parsed_lines(raw: &str) -> Vec<ParsedLine<'_>> {
-    let mut lines = raw
+pub(super) fn parsed_lines(source: &str) -> Vec<ParsedLine<'_>> {
+    source
         .universal_newlines()
         .map(|line| ParsedLine {
             text: line.as_str(),
             range: line.range(),
-            raw_indent: indentation(line.as_str()),
-            structural_indent: TextSize::new(0),
+            indent: indentation(line.as_str()),
         })
-        .collect::<Vec<_>>();
-
-    // PEP 257 ignores indentation on the first physical line and removes the common margin from
-    // all later lines. Keep the raw indentation as well because item and block indentation can
-    // still disambiguate content within a section.
-    let continuation_margin = lines
-        .iter()
-        .skip(1)
-        .filter(|line| !line.text.trim().is_empty())
-        .map(|line| line.raw_indent)
-        .min()
-        .unwrap_or(TextSize::new(0));
-
-    for line in lines.iter_mut().skip(1) {
-        line.structural_indent = line.raw_indent.saturating_sub(continuation_margin);
-    }
-
-    lines
+        .collect()
 }
 
 /// A docstring line and its source range, excluding the newline terminator.
@@ -44,10 +26,8 @@ pub(super) struct ParsedLine<'a> {
     pub(super) text: &'a str,
     /// The byte range of `text` within the source document.
     pub(super) range: TextRange,
-    /// The indentation in the raw docstring text.
-    pub(super) raw_indent: TextSize,
-    /// The indentation after removing the PEP 257 continuation margin.
-    pub(super) structural_indent: TextSize,
+    /// The indentation in the source document.
+    pub(super) indent: TextSize,
 }
 
 /// Returns whether `line` starts with a `CommonMark` list-item marker.
@@ -80,13 +60,11 @@ pub(super) fn container_block_end(lines: &[ParsedLine<'_>], index: usize) -> Opt
         return None;
     }
 
-    // Container membership is determined before PEP 257 normalization. This keeps raw-indented
-    // section-like text inside lists, directives, and field-list entries.
     Some(
         (index + 1..lines.len())
             .find(|&end| {
                 let line = lines[end];
-                !line.text.trim().is_empty() && line.raw_indent <= marker.raw_indent
+                !line.text.trim().is_empty() && line.indent <= marker.indent
             })
             .unwrap_or(lines.len()),
     )


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This changes how we resolve an ambiguity in extracting parameter documentation from Google-style docstrings that being with a reStructuredText literal block. Here is an [example of such a docstring that occurs in the wild](https://github.com/pytorch/pytorch/blob/e3f5bf0b18585511e6cd7d7a574ebf82f465e5ae/torch/_native/instrumentation.py#L360-L384) (paraphrased below):

```py
def instrument_triton_kernel(op: str):
    """Instrument a Triton kernel, with the instrumentation decorator above the jit::

        @instrument_triton_kernel("aten::bmm")
        @triton.jit
        def kernel(...): ...

    The kernel compiles lazily and caches variants on the kernel object.

    Args:
        op: Operator symbol being compiled.
    """
```

Previously, the parser used the raw indentation of the docstring and incorrectly treated the entire remainder of the docstring as part of the literal block. As a result, we did not recognize any parameter documentation from the above block. After the fix, we instead parse the PEP-257-normalized docstring, and thus correct recognize the documentation for `op`.

The tradeoff is that if the entire remainder of a docstring beginning with a literal block were intended as literal content, and that content looked like a Google-style param section, we would instead interpret it as real parameter documentation:

```py
def example():
    """Example::

        Args:
            value: Literal text, not parameter documentation.
    """
```

Whereas the former example was actually observed in the wild in quick survey of popular Python repos, the latter was not.

As an added benefit, this simplifies our Google-style docstring parsing and aligns it with our reStructuredText parsing, thereby streamlining follow-up [document-model](https://github.com/astral-sh/ruff/pull/26670) and [Markdown-rendering](https://github.com/astral-sh/ruff/pull/26599) changes.

## Test Plan

Please see included tests.
<!-- How was it tested? -->
