### PR TITLE
[ty] Expose definition resolution to the language server

### DIFF
--- a/crates/ty_python_semantic/src/definition_resolution.rs
+++ b/crates/ty_python_semantic/src/definition_resolution.rs
@@ -1,12 +1,24 @@
 use smallvec::SmallVec;
 use ty_module_resolver::Module;
-use ty_python_core::definition::{Definition, DefinitionState};
+use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
+use ty_python_core::scope::ScopeId;
 use ty_python_core::{
-    BindingWithConstraintsIterator, Program, ProgramFile, global_scope, place_table, use_def_map,
+    BindingWithConstraintsIterator, BoundnessAnalysis, Program, ProgramFile, global_scope,
+    place_table, use_def_map,
 };
 
 use crate::Db;
+use crate::place::{
+    Place, RequiresExplicitReExport, builtins_module_scope, class_body_implicit_symbol,
+    implicit_builtins_symbol, implicit_builtins_symbol_scope, is_reexported,
+    loop_header_reachability, module_type_implicit_global_symbol,
+};
+use crate::place_load::{
+    ImplicitPlaceLoad, PlaceLoadResolution, PlaceLoadResolutionStep, PlaceLoadSource,
+    PlaceLoadSourceKind,
+};
 use crate::reachability::ReachabilityConstraintsExtension;
+use crate::types::ProgramEnvironment;
 
 /// Returns the definitions that may supply the value for a module global at the end of its scope.
 pub(crate) fn definitions_for_module_global<'db>(
@@ -22,27 +34,242 @@ pub(crate) fn definitions_for_module_global<'db>(
     Some(DefinitionResolution::from_bindings(
         db,
         use_def_map(db, scope).end_of_scope_symbol_bindings(symbol),
+        RequiresExplicitReExport::No,
     ))
 }
 
+/// Resolves the definitions for the ordered sources of a place load.
+pub(crate) fn definitions_for_place_load<'db>(
+    db: &'db dyn Db,
+    environment: &ProgramEnvironment<'db>,
+    scope: ScopeId<'db>,
+    place_load: &mut PlaceLoadResolution<'db, '_>,
+) -> DefinitionResolution<'db> {
+    let mut resolution = DefinitionResolution {
+        definitions: SmallVec::new(),
+        is_complete: true,
+        may_be_unbound: false,
+        may_be_deleted: false,
+        scope_declaration_crossing: ScopeDeclarationCrossing::None,
+    };
+    let mut may_be_unbound = true;
+
+    while may_be_unbound {
+        let Some(step) = place_load.next() else {
+            break;
+        };
+        match step {
+            PlaceLoadResolutionStep::Source(source) => {
+                let mut source_resolution =
+                    DefinitionResolution::from_place_load_source(db, environment, scope, &source);
+                if source.is_class_body_global_fallback() && source_resolution.has_value() {
+                    source_resolution.may_be_unbound = false;
+                }
+                may_be_unbound = source_resolution.may_be_unbound;
+                resolution.extend(source_resolution);
+            }
+            PlaceLoadResolutionStep::MemberResolutionCondition(_) => {
+                resolution.is_complete = false;
+                break;
+            }
+            PlaceLoadResolutionStep::Exhausted(_) => break,
+        }
+    }
+
+    resolution.may_be_unbound = may_be_unbound;
+    if place_load.crosses_scope_declaration() {
+        resolution.scope_declaration_crossing = ScopeDeclarationCrossing::Crosses;
+    }
+    resolution
+}
+
 /// A set of definitions found by name resolution along with facts about their availability.
-pub(crate) struct DefinitionResolution<'db> {
+pub struct DefinitionResolution<'db> {
     definitions: SmallVec<[Definition<'db>; 2]>,
+    is_complete: bool,
+    may_be_unbound: bool,
+    may_be_deleted: bool,
+    scope_declaration_crossing: ScopeDeclarationCrossing,
 }
 
 impl<'db> DefinitionResolution<'db> {
     /// Returns the definitions found by name resolution.
-    pub(crate) fn definitions(&self) -> &[Definition<'db>] {
+    pub fn definitions(&self) -> &[Definition<'db>] {
         &self.definitions
+    }
+
+    /// Returns whether every possible result is represented by a definition.
+    pub fn is_complete(&self) -> bool {
+        self.is_complete
+    }
+
+    /// Returns whether the value is bound on every reachable control-flow path.
+    pub fn is_definitely_bound(&self) -> bool {
+        !self.may_be_unbound
+    }
+
+    /// Returns whether a reachable deletion may leave the value unbound.
+    pub fn may_be_deleted(&self) -> bool {
+        self.may_be_deleted
+    }
+
+    /// Returns whether resolution crosses a `global` or `nonlocal` declaration.
+    pub fn crosses_scope_declaration(&self) -> bool {
+        matches!(
+            self.scope_declaration_crossing,
+            ScopeDeclarationCrossing::Crosses
+        )
+    }
+
+    /// Replaces each definition with its projected definitions.
+    ///
+    /// The result is incomplete if any definition has no projection.
+    pub(crate) fn project_definitions<I>(
+        mut self,
+        mut project: impl FnMut(Definition<'db>) -> I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = Definition<'db>>,
+    {
+        let definitions = std::mem::take(&mut self.definitions);
+
+        for definition in definitions {
+            let mut has_projection = false;
+            for projected in project(definition) {
+                has_projection = true;
+                self.push_definition(projected);
+            }
+            self.is_complete &= has_projection;
+        }
+
+        self
+    }
+
+    fn from_place_load_source(
+        db: &'db dyn Db,
+        environment: &ProgramEnvironment<'db>,
+        scope: ScopeId<'db>,
+        source: &PlaceLoadSource<'db>,
+    ) -> Self {
+        match &source.kind {
+            PlaceLoadSourceKind::Bindings(bindings) => {
+                Self::from_bindings(db, bindings.clone(), RequiresExplicitReExport::No)
+            }
+            PlaceLoadSourceKind::DefinitionsFromOwningScope { scope, id } => Self::from_bindings(
+                db,
+                use_def_map(db, *scope).reachable_bindings(*id),
+                RequiresExplicitReExport::No,
+            ),
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ExplicitGlobalSymbol {
+                file,
+                name,
+            }) => {
+                let scope = global_scope(db, *file);
+                let Some(symbol) = place_table(db, scope).symbol_id(name) else {
+                    return Self {
+                        definitions: SmallVec::new(),
+                        is_complete: true,
+                        may_be_unbound: true,
+                        may_be_deleted: false,
+                        scope_declaration_crossing: ScopeDeclarationCrossing::None,
+                    };
+                };
+                Self::from_bindings(
+                    db,
+                    use_def_map(db, scope).reachable_symbol_bindings(symbol),
+                    RequiresExplicitReExport::No,
+                )
+            }
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::DunderClass(class_def)) => {
+                let mut resolution = Self {
+                    definitions: SmallVec::new(),
+                    is_complete: true,
+                    may_be_unbound: false,
+                    may_be_deleted: false,
+                    scope_declaration_crossing: ScopeDeclarationCrossing::None,
+                };
+                resolution.push_definition(*class_def);
+                resolution
+            }
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ClassBodySymbol(name)) => {
+                Self::from_place_without_definition(
+                    class_body_implicit_symbol(db, environment, name).place,
+                )
+            }
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ModuleImplicitGlobal {
+                file,
+                name,
+            }) => Self::from_place_without_definition(
+                module_type_implicit_global_symbol(db, *file, name).place,
+            ),
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::Builtin(name)) => {
+                Self::from_builtin(db, environment, scope, name)
+            }
+        }
+    }
+
+    fn from_builtin(
+        db: &'db dyn Db,
+        environment: &ProgramEnvironment<'db>,
+        scope: ScopeId<'db>,
+        name: &str,
+    ) -> Self {
+        if Some(scope) == builtins_module_scope(db, environment) {
+            // A missing name in `builtins` cannot fall back to the module that is currently being
+            // resolved. Treating it as undefined also avoids a recursive semantic query.
+            return Self::from_place_without_definition(Place::Undefined);
+        }
+
+        let Some(builtins_scope) = implicit_builtins_symbol_scope(db, environment, name) else {
+            // No runtime-visible builtin supplies this name.
+            return Self::from_place_without_definition(Place::Undefined);
+        };
+
+        if builtins_scope == scope {
+            // End-of-scope lookup in a project-level `__builtins__` module can select a binding
+            // that occurs after this load. Keep its inferred value unrepresented instead of
+            // exposing that later binding as the load's source definition.
+            return Self::from_place_without_definition(
+                implicit_builtins_symbol(db, environment, name).place,
+            );
+        }
+
+        let Some(symbol) = place_table(db, builtins_scope).symbol_id(name) else {
+            // The module supplies this name through a synthetic module attribute rather than an
+            // explicit symbol, so there is no source definition to expose.
+            return Self::from_place_without_definition(
+                implicit_builtins_symbol(db, environment, name).place,
+            );
+        };
+
+        let mut resolution = Self::from_bindings(
+            db,
+            use_def_map(db, builtins_scope).end_of_scope_symbol_bindings(symbol),
+            RequiresExplicitReExport::Yes,
+        );
+
+        // The target definitions are useful for navigation, but the implicit fallback that
+        // connects this load to them has no source representation that a refactor can safely
+        // rewrite.
+        resolution.is_complete = false;
+
+        resolution
     }
 
     fn from_bindings(
         db: &'db dyn Db,
         mut bindings: BindingWithConstraintsIterator<'db, 'db>,
+        requires_explicit_reexport: RequiresExplicitReExport,
     ) -> Self {
         let mut resolution = Self {
             definitions: SmallVec::new(),
+            is_complete: true,
+            may_be_unbound: false,
+            may_be_deleted: false,
+            scope_declaration_crossing: ScopeDeclarationCrossing::None,
         };
+        let boundness = bindings.boundness_analysis();
+        let mut has_defined_binding = false;
 
         while let Some(binding) = bindings.next() {
             let reachability = bindings.reachability_constraints().evaluate(
@@ -55,11 +282,39 @@ impl<'db> DefinitionResolution<'db> {
             }
 
             match binding.binding {
+                DefinitionState::Defined(definition)
+                    if matches!(requires_explicit_reexport, RequiresExplicitReExport::Yes)
+                        && !is_reexported(db, definition) =>
+                {
+                    resolution.may_be_unbound |= reachability.may_be_true();
+                }
                 DefinitionState::Defined(definition) => {
+                    if matches!(definition.kind(db), DefinitionKind::LoopHeader(_)) {
+                        let deleted_reachability =
+                            loop_header_reachability(db, definition).deleted_reachability;
+                        let may_be_deleted = !deleted_reachability.is_always_false();
+                        resolution.may_be_unbound |= may_be_deleted;
+                        resolution.may_be_deleted |= may_be_deleted;
+                    }
+                    has_defined_binding = true;
                     resolution.push_definition(definition);
                 }
-                DefinitionState::Deleted | DefinitionState::Undefined => {}
+                DefinitionState::Deleted => {
+                    let may_be_deleted = reachability.may_be_true();
+                    resolution.may_be_unbound |= may_be_deleted;
+                    resolution.may_be_deleted |= may_be_deleted;
+                }
+                DefinitionState::Undefined
+                    if boundness == BoundnessAnalysis::BasedOnUnboundVisibility =>
+                {
+                    resolution.may_be_unbound |= reachability.may_be_true();
+                }
+                DefinitionState::Undefined => {}
             }
+        }
+
+        if !has_defined_binding {
+            resolution.may_be_unbound = true;
         }
 
         resolution
@@ -70,6 +325,43 @@ impl<'db> DefinitionResolution<'db> {
             self.definitions.push(definition);
         }
     }
+
+    fn from_place_without_definition(place: Place<'db>) -> Self {
+        Self {
+            definitions: SmallVec::new(),
+            is_complete: place.is_undefined(),
+            may_be_unbound: !place.is_definitely_bound(),
+            may_be_deleted: false,
+            scope_declaration_crossing: ScopeDeclarationCrossing::None,
+        }
+    }
+
+    /// Returns whether resolution found a value, including one without a source definition.
+    fn has_value(&self) -> bool {
+        !self.definitions.is_empty() || !self.is_complete
+    }
+
+    fn extend(&mut self, other: Self) {
+        for definition in other.definitions {
+            if !self.definitions.contains(&definition) {
+                self.definitions.push(definition);
+            }
+        }
+        self.is_complete &= other.is_complete;
+        self.may_be_deleted |= other.may_be_deleted;
+        if matches!(
+            other.scope_declaration_crossing,
+            ScopeDeclarationCrossing::Crosses
+        ) {
+            self.scope_declaration_crossing = ScopeDeclarationCrossing::Crosses;
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ScopeDeclarationCrossing {
+    None,
+    Crosses,
 }
 
 #[cfg(test)]
@@ -109,5 +401,7 @@ else:
             .expect("module global should exist");
 
         assert_eq!(resolution.definitions().len(), 2);
+        assert!(resolution.is_complete());
+        assert!(resolution.is_definitely_bound());
     }
 }

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -41,8 +41,8 @@ pub use ty_site_packages::{
     SitePackagesPaths, SysPrefixPathOrigin,
 };
 pub use types::ide_support::{
-    ImplementationsFinder, ImportAliasResolution, ResolvedDefinition, TypeHierarchyClass,
-    contains_identifier, definitions_for_attribute, definitions_for_bin_op,
+    ImplementationsFinder, ImportAliasResolution, LiveBindings, ResolvedDefinition,
+    TypeHierarchyClass, contains_identifier, definitions_for_attribute, definitions_for_bin_op,
     definitions_for_imported_symbol, definitions_for_name, definitions_for_unary_op,
     map_stub_definition, type_hierarchy_prepare, type_hierarchy_subtypes,
     type_hierarchy_supertypes,

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -9,6 +9,7 @@ use crate::suppression::{
 };
 use crate::types::check_types;
 pub use db::Db;
+pub use definition_resolution::DefinitionResolution;
 pub(crate) use diagnostic::add_inferred_python_version_hint_to_diagnostic;
 pub use diagnostic::inferred_python_version_source_annotation;
 pub use fixes::{fix_all_diagnostics, suppress_all_diagnostics};
@@ -49,7 +50,7 @@ pub use types::ide_support::{
     type_hierarchy_supertypes,
 };
 pub use types::{
-    DisplaySettings, FixtureBinding, ProgramEnvironment, TypeQualifiers,
+    DisplaySettings, FixtureBinding, ProgramEnvironment, TypeQualifiers, binding_type,
     fixture_bindings_for_parameter,
 };
 

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -2119,12 +2119,11 @@ fn is_non_exported<'db>(
     requires_explicit_reexport.is_yes() && !is_reexported(db, declaration)
 }
 
-// Returns `true` if the `definition` is re-exported.
-//
-// This will first check if the definition is using the "redundant alias" pattern like `import foo
-// as foo` or `from foo import bar as bar`. If it's not, it will check whether the symbol is being
-// exported via `__all__`.
-fn is_reexported(db: &dyn Db, definition: Definition<'_>) -> bool {
+/// Returns `true` if the `definition` is re-exported.
+///
+/// This first checks for a redundant alias such as `import foo as foo` or
+/// `from foo import bar as bar`, then checks whether `__all__` exports the symbol.
+pub(crate) fn is_reexported(db: &dyn Db, definition: Definition<'_>) -> bool {
     // This information is computed by the semantic index builder.
     if definition.is_reexported(db) {
         return true;

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -585,6 +585,10 @@ impl<'db, 'ast> PlaceLoadResolution<'db, 'ast> {
         }
     }
 
+    pub(crate) fn crosses_scope_declaration(&self) -> bool {
+        self.crosses_scope_declaration
+    }
+
     pub(crate) fn narrowing_constraints_for(
         &self,
         source: &PlaceLoadSource<'_>,

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -63,6 +63,11 @@ impl<'db> SemanticModel<'db> {
         self.file
     }
 
+    /// Returns whether this model is analyzing a string annotation.
+    pub(crate) fn is_in_string_annotation(&self) -> bool {
+        self.in_string_annotation_expr.is_some()
+    }
+
     pub fn file_path(&self) -> &FilePath {
         self.file.path(self.db)
     }

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -81,6 +81,10 @@ impl<'db> SemanticModel<'db> {
         ProgramEnvironment::from_file(self.program_file())
     }
 
+    pub(crate) fn is_in_string_annotation(&self) -> bool {
+        self.in_string_annotation_expr.is_some()
+    }
+
     pub fn file_path(&self) -> &FilePath {
         self.file().path(self.db)
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -224,7 +224,7 @@ pub fn check_types(db: &dyn Db, file: ProgramFile<'_>) -> Vec<Diagnostic> {
 }
 
 /// Infer the type of a binding.
-pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
+pub fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     let inference = infer_definition_types(db, definition);
     inference.binding_type(definition)
 }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -25,6 +25,7 @@ use ty_module_resolver::{ImportingFile, Module, ResolverFile};
 use ty_python_core::definition::{Definition, DefinitionKind, NestedBindingExecution};
 use ty_python_core::{ProgramFile, attribute_scopes, global_scope, semantic_index, use_def_map};
 
+mod name_resolution;
 mod unreachable_code;
 #[path = "ide_support/unused_bindings.rs"]
 mod unused_binding_support;
@@ -93,7 +94,7 @@ pub fn definitions_for_name<'db>(
         if is_global || is_nonlocal {
             // Assignments in a forwarding scope remain valid navigation targets, including eager
             // walrus bindings exported from comprehensions.
-            all_definitions.extend(user_visible_definitions(
+            all_definitions.extend(source_backed_definitions(
                 db,
                 use_def_map
                     .reachable_symbol_bindings(symbol_id)
@@ -121,7 +122,7 @@ pub fn definitions_for_name<'db>(
 
             if let Some(global_symbol_id) = global_place_table.symbol_id(name_str) {
                 let global_use_def_map = ty_python_core::use_def_map(db, global_scope_id);
-                all_definitions.extend(user_visible_definitions(
+                all_definitions.extend(source_backed_definitions(
                     db,
                     global_use_def_map
                         .reachable_symbol_bindings(global_symbol_id)
@@ -143,7 +144,7 @@ pub fn definitions_for_name<'db>(
         }
 
         // Get all definitions (both bindings and declarations) for this place
-        all_definitions.extend(user_visible_definitions(
+        all_definitions.extend(source_backed_definitions(
             db,
             use_def_map
                 .reachable_symbol_bindings(symbol_id)
@@ -1053,9 +1054,13 @@ fn collect_implementation_root_classes<'db>(
     }
 }
 
-/// Returns the user-visible definitions represented by a use-def binding.
+/// Returns definitions that correspond to concrete locations in source code.
 ///
-/// Comprehension walruses are represented in the containing scope by synthetic eager bindings:
+/// This result excludes synthetic definitions such as loop headers and nested
+/// bindings.
+///
+/// For an eager synthetic definition like a comprehension walrus, the concrete
+/// definition it represents is returned instead:
 ///
 /// ```python
 /// [(last := item) for item in items]
@@ -1066,7 +1071,7 @@ fn collect_implementation_root_classes<'db>(
 /// end-of-scope bindings. Nested comprehensions can produce a chain of these proxies. Only
 /// follow sources that resolve to the same variable, so `global` and `nonlocal` writes do not
 /// become definitions of each other.
-fn user_visible_definitions<'db>(
+fn source_backed_definitions<'db>(
     db: &'db dyn Db,
     definitions: impl IntoIterator<Item = Definition<'db>>,
 ) -> FxIndexSet<Definition<'db>> {
@@ -1164,7 +1169,7 @@ fn resolve_reachable_definitions<'db>(
     symbol_name: &str,
     definitions: impl IntoIterator<Item = Definition<'db>>,
 ) -> Vec<ResolvedDefinition<'db>> {
-    user_visible_definitions(db, definitions)
+    source_backed_definitions(db, definitions)
         .into_iter()
         .flat_map(|definition| {
             resolve_definition(
@@ -2471,7 +2476,7 @@ mod resolve_definition {
             }
         }
 
-        super::user_visible_definitions(db, definitions)
+        super::source_backed_definitions(db, definitions)
             .into_iter()
             .collect()
     }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::FxIndexSet;
 use crate::place::builtins_module_scope;
-use crate::reachability::is_range_reachable;
+use crate::reachability::{binding_reachability, is_range_reachable};
 use crate::types::call::bind::CheckTypesMode;
 use crate::types::call::{CallArguments, CallError, MatchedArgument};
 use crate::types::class::{DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor};
@@ -22,8 +22,13 @@ use ruff_python_ast::{self as ast, AnyNodeRef, name::Name};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 use ty_module_resolver::Module;
-use ty_python_core::definition::{Definition, DefinitionKind};
-use ty_python_core::{attribute_scopes, global_scope, semantic_index, use_def_map};
+use ty_python_core::ast_ids::HasScopedUseId;
+use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
+use ty_python_core::{
+    BindingWithConstraintsIterator, EnclosingSnapshotResult, FileScopeId, PlaceExprRef,
+    SemanticIndex, UseDefMap, attribute_scopes, global_scope, place_table, semantic_index,
+    use_def_map,
+};
 
 mod unreachable_code;
 #[path = "ide_support/unused_bindings.rs"]
@@ -33,6 +38,256 @@ pub use resolve_definition::{ImportAliasResolution, ResolvedDefinition, map_stub
 use resolve_definition::{find_symbol_in_scope, resolve_definition};
 pub use unreachable_code::{UnreachableKind, UnreachableRange, unreachable_ranges};
 pub use unused_binding_support::{UnusedBinding, unused_bindings};
+
+impl<'db> SemanticModel<'db> {
+    /// Returns user-visible bindings for conservative IDE refactoring.
+    ///
+    /// This best-effort lookup does not cover every Python name-resolution case. Results may be
+    /// incomplete when a class-local name falls back to a surrounding scope, when an eagerly
+    /// evaluated reference appears before its binding, or when a name is read or reassigned
+    /// through `global` or `nonlocal`.
+    ///
+    /// Refactoring consumers must leave an occurrence unchanged if it uses `global` or
+    /// `nonlocal`, or if its bindings do not establish one unambiguous replacement.
+    ///
+    /// String annotations and lazy locals use reachable bindings as a fallback.
+    ///
+    /// For `pkg.member`, calling this with `pkg` returns the bindings for the local name `pkg`,
+    /// such as `import pkg`. Use [`Self::module_attribute_bindings`] to find the bindings for
+    /// `member` inside `pkg`.
+    ///
+    /// Returns `None` if the lookup cannot be represented completely as user-visible definitions.
+    pub fn name_use_bindings(&self, name: &ast::ExprName) -> Option<LiveBindings<'db>> {
+        let scope = self.scope(name.into())?;
+        let index = semantic_index(self.db(), self.file());
+
+        match self.bindings_in_use_scope(index, scope, name) {
+            UseScopeLookup::Resolved(bindings) => Some(bindings),
+            UseScopeLookup::Unrepresentable => None,
+            UseScopeLookup::SearchEnclosing {
+                depends_on_global_or_nonlocal,
+            } => self.bindings_in_visible_ancestors(
+                index,
+                scope,
+                name.id.as_str(),
+                depends_on_global_or_nonlocal,
+            ),
+        }
+    }
+
+    /// Returns the bindings live at the end of the module that defines an attribute.
+    ///
+    /// For `pkg.member`, this returns the bindings for `member` at the end of `pkg`. Use
+    /// [`Self::name_use_bindings`] to inspect the local binding of `pkg` at the access site.
+    ///
+    /// Returns `None` if the attribute has no source-backed module or if the lookup cannot be
+    /// represented completely as user-visible definitions.
+    pub fn module_attribute_bindings(
+        &self,
+        attribute: &ast::ExprAttribute,
+    ) -> Option<LiveBindings<'db>> {
+        let Type::ModuleLiteral(module) = attribute.value.inferred_type(self)? else {
+            return None;
+        };
+
+        let file = module.module(self.db()).file(self.db())?;
+        let scope = global_scope(self.db(), file);
+        let symbol = place_table(self.db(), scope).symbol_id(attribute.attr.as_str())?;
+        let use_def = use_def_map(self.db(), scope);
+        self.collect_live_bindings(use_def, use_def.end_of_scope_symbol_bindings(symbol), false)
+    }
+
+    /// Returns the inferred value type supplied by a definition.
+    ///
+    /// Definitions in [`LiveBindings`] may belong to a different file from this model. For
+    /// example, [`Self::module_attribute_bindings`] for `pkg.member` in a file named `use.py` can
+    /// return the definition of `member` from `pkg/__init__.py`; this method evaluates that
+    /// definition in its own file.
+    pub fn binding_type(&self, definition: Definition<'db>) -> Type<'db> {
+        crate::types::binding_type(self.db(), definition)
+    }
+
+    fn bindings_in_use_scope(
+        &self,
+        index: &'db SemanticIndex<'db>,
+        scope: FileScopeId,
+        name: &ast::ExprName,
+    ) -> UseScopeLookup<'db> {
+        let table = index.place_table(scope);
+        let Some(symbol_id) = table.symbol_id(name.id.as_str()) else {
+            return UseScopeLookup::SearchEnclosing {
+                depends_on_global_or_nonlocal: false,
+            };
+        };
+
+        let symbol = table.symbol(symbol_id);
+        let use_def = index.use_def_map(scope);
+        let depends_on_global_or_nonlocal =
+            !scope.is_global() && (symbol.is_global() || symbol.is_nonlocal());
+
+        if self.is_in_string_annotation() {
+            // A parsed string annotation has no use ID in the semantic index and may refer to a
+            // definition that appears later, so consider every reachable binding instead.
+
+            if symbol.is_local() || scope.is_global() {
+                return UseScopeLookup::from_bindings(self.collect_live_bindings(
+                    use_def,
+                    use_def.reachable_symbol_bindings(symbol_id),
+                    depends_on_global_or_nonlocal,
+                ));
+            }
+
+            return UseScopeLookup::SearchEnclosing {
+                depends_on_global_or_nonlocal,
+            };
+        }
+
+        // Ordinary source names have a precise control-flow position, so prefer the bindings live
+        // at that position.
+        let Some(bindings) = self.collect_live_bindings(
+            use_def,
+            use_def.bindings_at_use(name.scoped_use_id(self.db(), self.file())),
+            depends_on_global_or_nonlocal,
+        ) else {
+            return UseScopeLookup::Unrepresentable;
+        };
+        if !bindings.definitions.is_empty() || bindings.may_be_deleted {
+            return UseScopeLookup::Resolved(bindings);
+        }
+
+        // A local in a function-like scope owns the name throughout that scope, even before its
+        // first binding. Recover those later bindings for that otherwise-empty result; class and
+        // module scopes retain the point-in-time result.
+        let kind = index.scope(scope).kind();
+        if symbol.is_local() {
+            return if kind.is_class() || scope.is_global() {
+                UseScopeLookup::Resolved(bindings)
+            } else {
+                UseScopeLookup::from_bindings(self.collect_live_bindings(
+                    use_def,
+                    use_def.reachable_symbol_bindings(symbol_id),
+                    depends_on_global_or_nonlocal,
+                ))
+            };
+        }
+
+        UseScopeLookup::SearchEnclosing {
+            depends_on_global_or_nonlocal,
+        }
+    }
+
+    fn bindings_in_visible_ancestors(
+        &self,
+        index: &'db SemanticIndex<'db>,
+        scope: FileScopeId,
+        name: &str,
+        mut depends_on_global_or_nonlocal: bool,
+    ) -> Option<LiveBindings<'db>> {
+        // Walk outward until finding the visible scope that owns the name. Redirecting or unbound
+        // symbols do not end that search.
+        for (ancestor, _) in index.visible_ancestor_scopes(scope).skip(1) {
+            let table = index.place_table(ancestor);
+            let Some(symbol_id) = table.symbol_id(name) else {
+                continue;
+            };
+            let symbol = table.symbol(symbol_id);
+            depends_on_global_or_nonlocal |=
+                !ancestor.is_global() && (symbol.is_global() || symbol.is_nonlocal());
+
+            if symbol.is_nonlocal() || !symbol.is_local() && !ancestor.is_global() {
+                // Keep walking through scopes that forward the name with `global` or `nonlocal`,
+                // or use it without defining it.
+                continue;
+            }
+
+            // Prefer source bindings captured for the nested scope. If lookup produces only a
+            // constraint, finds no snapshot, or crosses out of an eager context, fall back to
+            // every binding reachable in the owning scope.
+            let use_def = index.use_def_map(ancestor);
+            let bindings =
+                match index.enclosing_snapshot(ancestor, PlaceExprRef::Symbol(symbol), scope) {
+                    EnclosingSnapshotResult::FoundBindings(bindings) => bindings,
+                    EnclosingSnapshotResult::FoundConstraint(_)
+                    | EnclosingSnapshotResult::NotFound
+                    | EnclosingSnapshotResult::NoLongerInEagerContext => {
+                        use_def.reachable_symbol_bindings(symbol_id)
+                    }
+                };
+            return self.collect_live_bindings(use_def, bindings, depends_on_global_or_nonlocal);
+        }
+
+        // This is a known empty result, unlike `None`, which means that a complete user-visible
+        // result could not be produced.
+        Some(LiveBindings {
+            depends_on_global_or_nonlocal,
+            ..LiveBindings::default()
+        })
+    }
+
+    fn collect_live_bindings(
+        &self,
+        use_def: &'db UseDefMap<'db>,
+        bindings: BindingWithConstraintsIterator<'_, 'db>,
+        depends_on_global_or_nonlocal: bool,
+    ) -> Option<LiveBindings<'db>> {
+        let db = self.db();
+        let mut result = LiveBindings {
+            depends_on_global_or_nonlocal,
+            ..LiveBindings::default()
+        };
+        let mut definitions = Vec::new();
+
+        for binding in bindings {
+            if binding_reachability(db, use_def, &binding).is_always_false() {
+                continue;
+            }
+
+            match binding.binding {
+                DefinitionState::Defined(definition) if definition.kind(db).is_user_visible() => {
+                    definitions.push(definition);
+                }
+                // Synthetic definitions can represent additional live bindings. Omitting one
+                // would make `definitions` incomplete, so this lookup cannot be represented as
+                // `LiveBindings`.
+                DefinitionState::Defined(_) => return None,
+                DefinitionState::Deleted => result.may_be_deleted = true,
+                DefinitionState::Undefined => {}
+            }
+        }
+
+        result.definitions = definitions.into_boxed_slice();
+        Some(result)
+    }
+}
+
+/// User-visible bindings associated with a semantic lookup point.
+///
+/// These are normally the bindings live at that point. [`SemanticModel::name_use_bindings`] can
+/// instead use reachable bindings as a fallback for deferred contexts.
+#[derive(Default)]
+pub struct LiveBindings<'db> {
+    /// User-visible definitions that can supply the binding.
+    pub definitions: Box<[Definition<'db>]>,
+    /// Whether a deleted path can also reach the use.
+    pub may_be_deleted: bool,
+    /// Whether lookup crossed an explicit `global` or `nonlocal` in a non-module scope.
+    pub depends_on_global_or_nonlocal: bool,
+}
+
+enum UseScopeLookup<'db> {
+    Resolved(LiveBindings<'db>),
+    Unrepresentable,
+    SearchEnclosing { depends_on_global_or_nonlocal: bool },
+}
+
+impl<'db> UseScopeLookup<'db> {
+    fn from_bindings(bindings: Option<LiveBindings<'db>>) -> Self {
+        match bindings {
+            Some(bindings) => Self::Resolved(bindings),
+            None => Self::Unrepresentable,
+        }
+    }
+}
 
 /// Get the primary definition kind for a name expression within a specific file.
 /// Returns the first definition kind that is reachable for this name in its scope.
@@ -2923,11 +3178,21 @@ pub fn constructor_signature(model: &SemanticModel, call_expr: &ast::ExprCall) -
 
 #[cfg(test)]
 mod tests {
-    use super::{CallArgumentForm, call_argument_forms, contains_identifier};
+    use std::fmt::Write as _;
+
+    use super::{CallArgumentForm, LiveBindings, call_argument_forms, contains_identifier};
     use crate::SemanticModel;
-    use crate::db::tests::TestDbBuilder;
-    use ruff_db::files::system_path_to_file;
+    use crate::db::tests::{TestDb, TestDbBuilder};
+    use crate::types::Type;
+    use anyhow::{Context, anyhow, bail, ensure};
+    use insta::assert_snapshot;
+    use ruff_db::diagnostic::{
+        Annotation, Diagnostic, DiagnosticId, DisplayDiagnosticConfig, DisplayDiagnostics, Severity,
+    };
+    use ruff_db::files::{FileRange, system_path_to_file};
     use ruff_db::parsed::parsed_module;
+    use ruff_python_ast::{self as ast, AnyNodeRef, find_node::covering_node};
+    use ruff_text_size::{TextRange, TextSize};
 
     #[test]
     fn source_candidate_prefilters_use_identifier_boundaries() {
@@ -2938,6 +3203,220 @@ mod tests {
         for (source, name) in [("exclude = 10", "x"), ("Database", "Base"), ("", "x")] {
             assert!(!contains_identifier(source, name));
         }
+    }
+
+    #[test]
+    fn name_use_bindings_ignore_later_conditional_bindings() -> anyhow::Result<()> {
+        let source = r#"
+import first as value
+before = value<CURSOR>
+if flag:
+    import second as value
+"#;
+
+        assert_snapshot!(
+            render_name_use_bindings_at_cursor(source)?,
+            @"
+        info[live-binding]: Candidate definition
+         --> src/foo.py:2:8
+          |
+        2 | import first as value
+          |        ^^^^^^^^^^^^^^
+          |
+
+        may_be_deleted: false
+        depends_on_global_or_nonlocal: false
+        "
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn name_use_bindings_track_end_of_control_flow() -> anyhow::Result<()> {
+        let source = r#"
+import sys
+import first as value
+if flag:
+    import second as value
+elif remove:
+    del value
+elif sys.version_info < (3, 0):
+    import never as value
+after = value<CURSOR>
+"#;
+
+        assert_snapshot!(
+            render_name_use_bindings_at_cursor(source)?,
+            @"
+        info[live-binding]: Candidate definition
+         --> src/foo.py:3:8
+          |
+        3 | import first as value
+          |        ^^^^^^^^^^^^^^
+          |
+
+        info[live-binding]: Candidate definition
+         --> src/foo.py:5:12
+          |
+        5 |     import second as value
+          |            ^^^^^^^^^^^^^^^
+          |
+
+        may_be_deleted: true
+        depends_on_global_or_nonlocal: false
+        "
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn name_use_bindings_follow_global_declarations() -> anyhow::Result<()> {
+        let source = r#"
+import other
+
+def declared():
+    global other
+    return other<CURSOR>
+"#;
+
+        assert_snapshot!(
+            render_name_use_bindings_at_cursor(source)?,
+            @"
+        info[live-binding]: Candidate definition
+         --> src/foo.py:2:8
+          |
+        2 | import other
+          |        ^^^^^
+          |
+
+        may_be_deleted: false
+        depends_on_global_or_nonlocal: true
+        "
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn name_use_bindings_fall_back_for_lazy_locals() -> anyhow::Result<()> {
+        let source = r#"
+import other
+
+def lazy():
+    before = value<CURSOR>
+    value = other
+"#;
+
+        assert_snapshot!(
+            render_name_use_bindings_at_cursor(source)?,
+            @"
+        info[live-binding]: Candidate definition
+         --> src/foo.py:6:5
+          |
+        6 |     value = other
+          |     ^^^^^^^^^^^^^
+          |
+
+        may_be_deleted: false
+        depends_on_global_or_nonlocal: false
+        "
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn name_use_bindings_fall_back_in_string_annotations() -> anyhow::Result<()> {
+        let source = r#"
+import other
+
+def annotated():
+    value: "other<CURSOR>.C"
+"#;
+
+        assert_snapshot!(
+            render_name_use_bindings_at_cursor(source)?,
+            @"
+        info[live-binding]: Candidate definition
+         --> src/foo.py:2:8
+          |
+        2 | import other
+          |        ^^^^^
+          |
+
+        may_be_deleted: false
+        depends_on_global_or_nonlocal: false
+        "
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn module_attribute_bindings_report_end_state() -> anyhow::Result<()> {
+        let use_source = "import pkg\nresult = pkg.current<CURSOR>\n";
+        let package_source = r#"
+from . import stale as current
+if bool(input()):
+    from . import first as current
+else:
+    from . import second as current
+"#;
+
+        assert_snapshot!(
+            render_module_attribute_bindings_at_cursor(use_source, package_source)?,
+            @"
+        info[live-binding]: Candidate definition
+         --> src/pkg/__init__.py:4:19
+          |
+        4 |     from . import first as current
+          |                   ^^^^^^^^^^^^^^^^
+          |
+
+        info[live-binding]: Candidate definition
+         --> src/pkg/__init__.py:6:19
+          |
+        6 |     from . import second as current
+          |                   ^^^^^^^^^^^^^^^^^
+          |
+
+        may_be_deleted: false
+        depends_on_global_or_nonlocal: false
+        "
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn binding_type_evaluates_cross_file_definitions() -> anyhow::Result<()> {
+        let use_source = r#"
+import pkg
+result = pkg.current<CURSOR>"
+"#;
+        let package_source = "from . import target as current\n";
+
+        let (use_source, cursor) = extract_cursor(use_source)?;
+        let db = TestDbBuilder::new()
+            .with_file("/src/pkg/__init__.py", package_source)
+            .with_file("/src/pkg/target.py", "")
+            .with_file("/src/use.py", &use_source)
+            .build()?;
+        let (model, bindings) = module_attribute_bindings_at_cursor(&db, cursor)?;
+        let [definition] = bindings.definitions.as_ref() else {
+            bail!(
+                "expected one definition for `pkg.current`, got {}",
+                bindings.definitions.len()
+            );
+        };
+        assert_ne!(definition.file(model.db()), model.file());
+
+        let Type::ModuleLiteral(module) = model.binding_type(*definition) else {
+            bail!("expected `pkg.current` to be bound to a module");
+        };
+        assert_eq!(
+            module.module(model.db()).name(model.db()).as_str(),
+            "pkg.target"
+        );
+
+        Ok(())
     }
 
     #[test]
@@ -3214,5 +3693,156 @@ cast(*args)
         );
 
         Ok(())
+    }
+
+    fn render_bindings<'db>(
+        model: &SemanticModel<'db>,
+        bindings: &LiveBindings<'db>,
+    ) -> anyhow::Result<String> {
+        let db = model.db();
+        let mut definitions = bindings
+            .definitions
+            .iter()
+            .map(|definition| {
+                let definition = *definition;
+                let file = definition.file(db);
+                let parsed = parsed_module(db, file).load(db);
+                let range = definition.kind(db).full_range(&parsed);
+                (file.path(db).to_string(), range, file)
+            })
+            .collect::<Vec<_>>();
+        definitions.sort_by(|(left_path, left_range, _), (right_path, right_range, _)| {
+            left_path
+                .cmp(right_path)
+                .then_with(|| left_range.start().cmp(&right_range.start()))
+        });
+
+        let diagnostics = definitions
+            .into_iter()
+            .map(|(_, range, file)| {
+                let mut diagnostic = Diagnostic::new(
+                    DiagnosticId::lint("live-binding"),
+                    Severity::Info,
+                    "Candidate definition",
+                );
+                diagnostic.annotate(Annotation::primary(FileRange::new(file, range).into()));
+                diagnostic
+            })
+            .collect::<Vec<_>>();
+        let resolver: &dyn ruff_db::Db = db;
+        let mut rendered = DisplayDiagnostics::new(
+            &resolver,
+            &DisplayDiagnosticConfig::new("ty").context(0),
+            &diagnostics,
+        )
+        .to_string();
+        write!(
+            &mut rendered,
+            "may_be_deleted: {}\ndepends_on_global_or_nonlocal: {}\n",
+            bindings.may_be_deleted, bindings.depends_on_global_or_nonlocal
+        )
+        .context("writing binding metadata should succeed")?;
+
+        Ok(rendered.replace('\\', "/"))
+    }
+
+    fn render_name_use_bindings_at_cursor(source: &str) -> anyhow::Result<String> {
+        let (source, cursor) = extract_cursor(source)?;
+        let db = TestDbBuilder::new()
+            .with_file("/src/foo.py", &source)
+            .build()?;
+
+        let file = system_path_to_file(&db, "/src/foo.py").context("test file should exist")?;
+        let parsed = parsed_module(&db, file).load(&db);
+        let model = SemanticModel::new(&db, file);
+        let expression = expression_at_cursor(parsed.syntax().into(), cursor)?;
+
+        match expression {
+            ast::ExprRef::Name(name) => {
+                let bindings = model
+                    .name_use_bindings(name)
+                    .context("name bindings should be representable")?;
+                render_bindings(&model, &bindings)
+            }
+            ast::ExprRef::StringLiteral(annotation) => {
+                let (annotation, annotation_model) = model
+                    .enter_string_annotation(annotation)
+                    .context("cursor should be inside a string annotation")?;
+                let ast::ExprRef::Name(name) =
+                    expression_at_cursor(annotation.syntax().into(), cursor)?
+                else {
+                    bail!("expected the cursor to select a name inside the string annotation");
+                };
+                let bindings = annotation_model
+                    .name_use_bindings(name)
+                    .context("name bindings should be representable")?;
+                render_bindings(&annotation_model, &bindings)
+            }
+            expression => bail!("expected the cursor to select a name, got {expression:?}"),
+        }
+    }
+
+    fn render_module_attribute_bindings_at_cursor(
+        use_source: &str,
+        package_source: &str,
+    ) -> anyhow::Result<String> {
+        let (use_source, cursor) = extract_cursor(use_source)?;
+        let db = TestDbBuilder::new()
+            .with_file("/src/pkg/__init__.py", package_source)
+            .with_file("/src/use.py", &use_source)
+            .build()?;
+        let (model, bindings) = module_attribute_bindings_at_cursor(&db, cursor)?;
+        render_bindings(&model, &bindings)
+    }
+
+    fn module_attribute_bindings_at_cursor(
+        db: &TestDb,
+        cursor: TextSize,
+    ) -> anyhow::Result<(SemanticModel<'_>, LiveBindings<'_>)> {
+        let file = system_path_to_file(db, "/src/use.py").context("test use file should exist")?;
+        let parsed = parsed_module(db, file).load(db);
+        let model = SemanticModel::new(db, file);
+        let ast::ExprRef::Attribute(attribute) =
+            expression_at_cursor(parsed.syntax().into(), cursor)?
+        else {
+            bail!("expected the cursor to select an attribute expression");
+        };
+        let bindings = model
+            .module_attribute_bindings(attribute)
+            .context("module attribute bindings should be representable")?;
+
+        Ok((model, bindings))
+    }
+
+    fn expression_at_cursor(
+        root: AnyNodeRef<'_>,
+        offset: TextSize,
+    ) -> anyhow::Result<ast::ExprRef<'_>> {
+        covering_node(root, TextRange::empty(offset))
+            .find_first(AnyNodeRef::is_expression)
+            .map_err(|node| {
+                anyhow!(
+                    "expected an expression at the cursor, got {:?}",
+                    node.node()
+                )
+            })?
+            .node()
+            .as_expr_ref()
+            .context("covering node should be an expression")
+    }
+
+    fn extract_cursor(source: &str) -> anyhow::Result<(String, TextSize)> {
+        const MARKER: &str = "<CURSOR>";
+
+        let Some((before, after)) = source.split_once(MARKER) else {
+            bail!("cursor source should contain a `{MARKER}` marker");
+        };
+        ensure!(
+            !after.contains(MARKER),
+            "cursor source should contain exactly one `{MARKER}` marker"
+        );
+
+        let offset = TextSize::try_from(before.len()).context("test source is too large")?;
+        Ok(([before, after].concat(), offset))
     }
 }

--- a/crates/ty_python_semantic/src/types/ide_support/name_resolution.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/name_resolution.rs
@@ -1,0 +1,558 @@
+//! This module exposes name resolution and reaching-definition analysis to the language server
+//! without requiring it to run type inference.
+//!
+//! It provides two entry points on [`SemanticModel`]:
+//!
+//! - [`SemanticModel::name_load`] resolves a name load in the model's file. It selects the
+//!   appropriate point-in-time, deferred, or string-annotation binding state. It returns `None`
+//!   when selecting that state requires type inference.
+//! - [`SemanticModel::definitions_for_module_global`] resolves an explicit module global using the
+//!   bindings available at the end of the module.
+//!
+//! Both entry points return a [`DefinitionResolution`], which exposes the definitions found by
+//! name resolution and whether the result is complete, may be unbound, may be deleted, or crosses
+//! a `global` or `nonlocal` declaration.
+//!
+//! ## Example
+//!
+//! ```py
+//! if use_fallback:
+//!     from .fallback import handler  # definition A
+//! else:
+//!     from .primary import handler  # definition B
+//!
+//! handler(request)  # load U
+//! ```
+//!
+//! Calling [`SemanticModel::name_load`] for `U` returns a [`DefinitionResolution`] containing
+//! definitions A and B. Because every branch defines `handler`,
+//! [`DefinitionResolution::is_definitely_bound`] returns `true`. If the `else` branch were absent,
+//! the resolution would still contain definition A, but `is_definitely_bound` would return
+//! `false`.
+
+use ruff_python_ast as ast;
+use ty_module_resolver::Module;
+use ty_python_core::place::PlaceExpr;
+use ty_python_core::semantic_index;
+
+use crate::SemanticModel;
+use crate::definition_resolution::DefinitionResolution;
+use crate::definition_resolution::{definitions_for_module_global, definitions_for_place_load};
+use crate::place_load::{PlaceLoadMode, resolve_place_load};
+
+use super::source_backed_definitions;
+
+impl<'db> SemanticModel<'db> {
+    /// Resolves the definitions for a name load.
+    ///
+    /// Returns `None` when choosing the correct binding state would require type inference.
+    pub fn name_load(&self, name: &ast::ExprName) -> Option<DefinitionResolution<'db>> {
+        let environment = self.program_environment();
+        let index = semantic_index(self.db(), self.program_file());
+        let scope = self
+            .scope(name.into())?
+            .to_scope_id(self.db(), self.program_file());
+        let mode = if self.is_in_string_annotation() {
+            PlaceLoadMode::StringAnnotation
+        } else if index.place_load_is_deferred(ast::ExprRef::Name(name))? {
+            PlaceLoadMode::Deferred
+        } else {
+            PlaceLoadMode::AtExpression(name.into())
+        };
+
+        let mut place_load_resolution = resolve_place_load(
+            self.db(),
+            index,
+            scope,
+            PlaceExpr::from_expr_name(name),
+            mode,
+        );
+
+        let resolution =
+            definitions_for_place_load(self.db(), &environment, scope, &mut place_load_resolution);
+
+        Some(source_backed_resolution(self.db(), resolution))
+    }
+
+    /// Resolves the definitions for an explicit module global.
+    pub fn definitions_for_module_global(
+        &self,
+        module: Module<'db>,
+        name: &str,
+    ) -> Option<DefinitionResolution<'db>> {
+        definitions_for_module_global(self.db(), self.program(), module, name)
+            .map(|resolution| source_backed_resolution(self.db(), resolution))
+    }
+}
+
+fn source_backed_resolution<'db>(
+    db: &'db dyn crate::Db,
+    resolution: DefinitionResolution<'db>,
+) -> DefinitionResolution<'db> {
+    resolution.project_definitions(|definition| source_backed_definitions(db, [definition]))
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::parsed::{ParsedModuleRef, parsed_module};
+    use ruff_db::source::{SourceText, source_text};
+    use ruff_python_ast::visitor::{Visitor, walk_expr};
+    use ruff_python_ast::{self as ast, PythonVersion};
+    use ruff_text_size::Ranged;
+    use ty_python_core::ProgramFile;
+
+    use super::DefinitionResolution;
+    use crate::SemanticModel;
+    use crate::db::tests::{TestDb, TestDbBuilder};
+
+    #[test]
+    fn name_load_uses_point_in_time_bindings() {
+        let db = test_db(
+            r#"
+import first as value
+before = value
+import second as value
+"#,
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let load = test.name_load("value");
+
+        assert_eq!(test.definition_texts(&load), ["first as value"]);
+    }
+
+    #[test]
+    fn name_load_uses_end_of_scope_bindings_for_deferred_annotations() {
+        let db = stub_test_db(
+            r#"
+import first as value
+before: value.C
+import second as value
+"#,
+        );
+        let test = NameResolutionTest::new(&db, STUB_FILE);
+        let load = test.name_load("value");
+
+        assert_eq!(
+            test.definition_texts(&load),
+            ["first as value", "second as value"]
+        );
+    }
+
+    #[test]
+    fn name_load_uses_end_of_scope_bindings_with_future_annotations() {
+        let db = build_test_db(
+            TestDbBuilder::new()
+                .with_python_version(PythonVersion::PY313)
+                .with_file(
+                    PYTHON_FILE,
+                    r#"
+from __future__ import annotations
+import first as value
+before: value.C
+import second as value
+"#,
+                ),
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let load = test.name_load("value");
+
+        assert_eq!(
+            test.definition_texts(&load),
+            ["first as value", "second as value"]
+        );
+    }
+
+    #[test]
+    fn name_load_uses_end_of_scope_bindings_for_python_314_annotations() {
+        let db = build_test_db(
+            TestDbBuilder::new()
+                .with_python_version(PythonVersion::PY314)
+                .with_file(
+                    PYTHON_FILE,
+                    r#"
+import first as value
+before: value.C
+import second as value
+"#,
+                ),
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let load = test.name_load("value");
+
+        assert_eq!(
+            test.definition_texts(&load),
+            ["first as value", "second as value"]
+        );
+    }
+
+    #[test]
+    fn name_load_returns_none_when_deferredness_requires_inference() {
+        let db = stub_test_db(
+            r#"
+import first as value
+before = value
+"#,
+        );
+        let test = NameResolutionTest::new(&db, STUB_FILE);
+
+        assert!(test.try_name_load("value").is_none());
+    }
+
+    #[test]
+    fn name_load_uses_end_of_scope_bindings_in_other_deferred_contexts() {
+        let db = stub_test_db(
+            r#"
+import first as value
+def function[T: value.C](arg=value): ...
+class Class(value.C): ...
+type Alias = value.C
+callback = lambda arg=value: None
+import second as value
+"#,
+        );
+        let test = NameResolutionTest::new(&db, STUB_FILE);
+        let loads = test.name_loads("value");
+
+        assert_eq!(loads.len(), 5);
+        for load in loads {
+            assert_eq!(
+                test.definition_texts(&load),
+                ["first as value", "second as value"]
+            );
+        }
+    }
+
+    #[test]
+    fn name_load_excludes_bindings_that_do_not_reach_the_use() {
+        let db = test_db(
+            r#"
+def test(flag: bool):
+    if flag:
+        x: int = 1
+        return
+    x = 2
+    print(x)
+"#,
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let load = test.name_load("x");
+
+        assert_eq!(test.definition_texts(&load), ["x = 2"]);
+    }
+
+    #[test]
+    fn name_load_respects_redeclarations() {
+        let db = test_db(
+            r#"
+def test(flag: bool):
+    if flag:
+        x: int = 10
+    else:
+        x: str = 'test'
+    print(x)
+    x: int = 30
+    print(x)
+"#,
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let loads = test.name_loads("x");
+        let [first_load, second_load] = loads.as_slice() else {
+            panic!("expected two loads of `x`");
+        };
+
+        assert_eq!(
+            test.definition_texts(first_load),
+            ["x: int = 10", "x: str = 'test'"]
+        );
+        assert_eq!(test.definition_texts(second_load), ["x: int = 30"]);
+    }
+
+    #[test]
+    fn name_load_reports_possible_unboundness() {
+        let db = build_test_db(
+            TestDbBuilder::new()
+                .with_file(
+                    PYTHON_FILE,
+                    r#"
+def test(flag: bool):
+    if flag:
+        import other as value
+    return value
+"#,
+                )
+                .with_file(
+                    "/src/other.py",
+                    r#"
+"#,
+                ),
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let load = test.name_load("value");
+
+        assert_eq!(test.definition_texts(&load), ["other as value"]);
+        assert!(!load.is_definitely_bound());
+        assert!(!load.may_be_deleted());
+    }
+
+    #[test]
+    fn name_load_reports_reachable_deletions() {
+        let db = build_test_db(
+            TestDbBuilder::new()
+                .with_file(
+                    PYTHON_FILE,
+                    r#"
+def test(flag: bool):
+    import other as value
+    if flag:
+        del value
+    return value
+"#,
+                )
+                .with_file(
+                    "/src/other.py",
+                    r#"
+"#,
+                ),
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let load = test.name_load("value");
+
+        assert_eq!(test.definition_texts(&load), ["other as value"]);
+        assert!(!load.is_definitely_bound());
+        assert!(load.may_be_deleted());
+    }
+
+    #[test]
+    fn name_load_reports_deletions_from_previous_loop_iterations() {
+        let db = test_db(
+            r#"
+def random() -> bool:
+    return False
+
+x = 0
+while random():
+    print(x)
+    x = 42
+    del x
+"#,
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let load = test.name_load("x");
+
+        assert!(!load.is_definitely_bound());
+        assert!(load.may_be_deleted());
+    }
+
+    #[test]
+    fn name_load_distinguishes_implicit_values_from_missing_names() {
+        let db = test_db(
+            r#"
+def test():
+    return int, missing_name
+"#,
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let builtin = test.name_load("int");
+        let missing = test.name_load("missing_name");
+
+        let [builtin_definition] = builtin.definitions() else {
+            panic!("expected exactly one definition for `int`");
+        };
+        assert_eq!(builtin_definition.name(&db).as_deref(), Some("int"));
+        assert!(!builtin.is_complete());
+        assert!(builtin.is_definitely_bound());
+        assert!(missing.is_complete());
+        assert!(!missing.is_definitely_bound());
+    }
+
+    #[test]
+    fn implicit_builtin_definitions_require_explicit_reexports() {
+        let db = build_test_db(
+            TestDbBuilder::new()
+                .with_file(
+                    "/src/__builtins__.pyi",
+                    r#"
+flag: bool
+if flag:
+    from first import value as value
+else:
+    from second import value
+"#,
+                )
+                .with_file(
+                    "/src/first.py",
+                    r#"
+value = 1
+"#,
+                )
+                .with_file(
+                    "/src/second.py",
+                    r#"
+value = 2
+"#,
+                )
+                .with_file(
+                    PYTHON_FILE,
+                    r#"
+result = value
+"#,
+                ),
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let load = test.name_load("value");
+
+        assert_eq!(load.definitions().len(), 1);
+        assert!(!load.is_complete());
+        assert!(!load.is_definitely_bound());
+    }
+
+    #[test]
+    fn implicit_builtin_definitions_do_not_use_later_bindings_from_the_same_scope() {
+        let db = build_test_db(
+            TestDbBuilder::new()
+                .with_file(
+                    "/src/__builtins__.py",
+                    r#"
+before = value
+from first import value as value
+"#,
+                )
+                .with_file(
+                    "/src/first.py",
+                    r#"
+value = 1
+"#,
+                ),
+        );
+        let test = NameResolutionTest::new(&db, "/src/__builtins__.py");
+        let load = test.name_load("value");
+
+        assert!(load.definitions().is_empty());
+        assert!(!load.is_complete());
+    }
+
+    #[test]
+    fn name_load_reports_scope_declarations() {
+        let db = test_db(
+            r#"
+value = 1
+def test():
+    global value
+    return value
+"#,
+        );
+        let test = NameResolutionTest::new(&db, PYTHON_FILE);
+        let load = test.name_load("value");
+
+        assert_eq!(test.definition_texts(&load), ["value = 1"]);
+        assert!(load.crosses_scope_declaration());
+    }
+
+    const PYTHON_FILE: &str = "/src/foo.py";
+    const STUB_FILE: &str = "/src/foo.pyi";
+
+    fn test_db(source: &str) -> TestDb {
+        build_test_db(TestDbBuilder::new().with_file(PYTHON_FILE, source))
+    }
+
+    fn stub_test_db(source: &str) -> TestDb {
+        build_test_db(TestDbBuilder::new().with_file(STUB_FILE, source))
+    }
+
+    fn build_test_db(builder: TestDbBuilder<'_>) -> TestDb {
+        builder.build().expect("valid TestDb setup")
+    }
+
+    struct NameResolutionTest<'db> {
+        db: &'db TestDb,
+        model: SemanticModel<'db>,
+        module: ParsedModuleRef,
+        source: SourceText,
+    }
+
+    impl<'db> NameResolutionTest<'db> {
+        fn new(db: &'db TestDb, path: &str) -> Self {
+            let Ok(file) = system_path_to_file(db, path) else {
+                panic!("test file `{path}` should exist");
+            };
+            let file = ProgramFile::new(db, file, db.program_environment().program(db));
+            let module = parsed_module(db, file.python_file(db)).load(db);
+            let source = source_text(db, file.file(db));
+            let model = SemanticModel::new(db, file);
+            Self {
+                db,
+                model,
+                module,
+                source,
+            }
+        }
+
+        fn try_name_load(&self, search: &str) -> Option<DefinitionResolution<'db>> {
+            let names = loaded_names(self.module.syntax(), search);
+            let &[name] = names.as_slice() else {
+                panic!(
+                    "expected exactly one load of `{search}`, found {}",
+                    names.len()
+                );
+            };
+            self.model.name_load(name)
+        }
+
+        fn name_load(&self, search: &str) -> DefinitionResolution<'db> {
+            self.try_name_load(search)
+                .unwrap_or_else(|| panic!("expected `{search}` load to be supported"))
+        }
+
+        fn name_loads(&self, searches: &str) -> Vec<DefinitionResolution<'db>> {
+            loaded_names(self.module.syntax(), searches)
+                .into_iter()
+                .map(|name| {
+                    self.model.name_load(name).unwrap_or_else(|| {
+                        panic!("expected every `{searches}` load to be supported")
+                    })
+                })
+                .collect()
+        }
+
+        fn definition_texts<'a>(&'a self, load: &DefinitionResolution<'db>) -> Vec<&'a str> {
+            load.definitions()
+                .iter()
+                .copied()
+                .map(|definition| {
+                    let range = definition.full_range(self.db, &self.module).range();
+                    &self.source[range]
+                })
+                .collect()
+        }
+    }
+
+    fn loaded_names<'ast>(
+        module: &'ast ast::ModModule,
+        searched: &str,
+    ) -> Vec<&'ast ast::ExprName> {
+        struct Collector<'ast, 'name> {
+            searched: &'name str,
+            names: Vec<&'ast ast::ExprName>,
+        }
+
+        impl<'ast> Visitor<'ast> for Collector<'ast, '_> {
+            fn visit_expr(&mut self, expression: &'ast ast::Expr) {
+                if let ast::Expr::Name(name) = expression
+                    && name.ctx.is_load()
+                    && name.id == self.searched
+                {
+                    self.names.push(name);
+                }
+                walk_expr(self, expression);
+            }
+        }
+
+        let mut collector = Collector {
+            searched,
+            names: Vec::new(),
+        };
+        collector.visit_body(&module.body);
+        collector.names
+    }
+}

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -115,7 +115,7 @@ pub fn unused_bindings(db: &dyn Db, file: ProgramFile<'_>) -> Box<[UnusedBinding
             .definitions_with_usage()
             .filter_map(|(_, definition, is_used)| is_used.then_some(definition))
     });
-    let used_user_visible_definitions = super::user_visible_definitions(db, used_definitions);
+    let used_user_visible_definitions = super::source_backed_definitions(db, used_definitions);
 
     for scope_id in index.scope_ids() {
         let file_scope_id = scope_id.file_scope_id(db);


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This exposes direct value-provider information from the semantic model for source-based IDE features.

`SemanticModel::name_load` returns the user-visible definitions that may provide a name's value at a source occurrence. It selects the appropriate point-in-time, deferred, or string-annotation binding state and reports when the value may instead be unbound, deleted, or supplied by a provider without a source definition. It also reports whether resolution crosses a `global` or `nonlocal` declaration. `SemanticModel::module_global_providers` exposes the same provider information for an explicit module global.

Unlike the existing navigation APIs, these interfaces preserve direct source definitions instead of following import aliases to their eventual targets. This lets features relate a use to only the bindings that may provide its value, without also selecting other uses of those bindings. The change also exposes `binding_type` so consumers can inspect a provider's inferred type.

This is shared infrastructure for reaching-definition-aware find references and [file and folder rename support](https://github.com/astral-sh/ruff/pull/26467).

## Test Plan

See included tests.
<!-- How was it tested? -->
