### PR TITLE
[ty] Correct how we expand tabs in docstrings

### DIFF
--- a/crates/ruff_python_trivia/src/whitespace.rs
+++ b/crates/ruff_python_trivia/src/whitespace.rs
@@ -1,5 +1,39 @@
+use std::borrow::Cow;
+
 use ruff_source_file::LineRanges;
 use ruff_text_size::{TextRange, TextSize};
+
+/// Expands tabs to the next eight-column tab stop, matching Python's `str.expandtabs`.
+pub fn expand_tabs(source: &str) -> Cow<'_, str> {
+    const TAB_SIZE: usize = 8;
+
+    if !source.contains('\t') {
+        return Cow::Borrowed(source);
+    }
+
+    let mut expanded = String::with_capacity(source.len());
+    let mut column = 0;
+
+    for character in source.chars() {
+        match character {
+            '\t' => {
+                let spaces = TAB_SIZE - column % TAB_SIZE;
+                expanded.extend(std::iter::repeat_n(' ', spaces));
+                column += spaces;
+            }
+            '\r' | '\n' => {
+                expanded.push(character);
+                column = 0;
+            }
+            _ => {
+                expanded.push(character);
+                column += 1;
+            }
+        }
+    }
+
+    Cow::Owned(expanded)
+}
 
 /// Extract the leading indentation from a line.
 pub fn indentation_at_offset(offset: TextSize, source: &str) -> Option<&str> {
@@ -76,5 +110,25 @@ impl PythonWhitespace for str {
 
     fn trim_whitespace_end(&self) -> &Self {
         self.trim_end_matches(is_python_whitespace)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::expand_tabs;
+
+    #[test]
+    fn tab_expansion_borrows_unchanged_text() {
+        assert!(matches!(expand_tabs("unchanged"), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn tab_expansion_allocates_changed_text() {
+        let expanded = expand_tabs("  \tvalue");
+
+        assert!(matches!(&expanded, Cow::Owned(_)));
+        assert_eq!(expanded, "        value");
     }
 }

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -11,7 +11,7 @@ mod markdown;
 
 use indexmap::IndexMap;
 use regex::Regex;
-use ruff_python_trivia::{PythonWhitespace, leading_indentation};
+use ruff_python_trivia::{PythonWhitespace, expand_tabs, leading_indentation};
 use ruff_source_file::UniversalNewlines;
 use std::sync::LazyLock;
 
@@ -83,7 +83,7 @@ impl DocstringFragment {
 
 /// Normalizes an extracted docstring fragment without removing meaningful relative indentation.
 fn documentation_fragment_trim(docs: &str) -> String {
-    let expanded = docs.trim_end().replace('\t', "        ");
+    let expanded = expand_tabs(docs.trim_end());
     let mut output = String::with_capacity(expanded.len());
     for line in expanded.universal_newlines() {
         output.push_str(line.as_str().trim_whitespace_end());
@@ -96,13 +96,13 @@ fn documentation_fragment_trim(docs: &str) -> String {
 ///
 /// See: <https://peps.python.org/pep-0257/#handling-docstring-indentation>
 fn documentation_trim(docs: &str) -> String {
-    // First apply tab expansion as we don't want tabs in our output
-    // (python says tabs are equal to 8 spaces).
+    // First apply tab expansion as we don't want tabs in our output. Python advances tabs to the
+    // next eight-column tab stop.
     //
     // We also trim off all trailing whitespace here to eliminate trailing newlines so we
     // don't need to handle trailing blank lines later. We can't trim away leading
     // whitespace yet, because we need to identify the first line and handle it specially.
-    let expanded = docs.trim_end().replace('\t', "        ");
+    let expanded = expand_tabs(docs.trim_end());
 
     // Compute the minimum indention of all non-empty non-first lines
     // and statistics about leading blank lines to help trim them later.
@@ -346,6 +346,23 @@ mod tests {
         // so tests are stable and the expected output stays readable.
         settings.add_filter("  \n", "<HB>\n");
         settings.bind_to_scope()
+    }
+
+    #[test]
+    fn expands_tabs_to_tab_stops_when_trimming_documentation() {
+        assert_snapshot!(
+            documentation_trim(
+                "\
+Summary.
+    baseline
+  \tindented",
+            ),
+            @"
+        Summary.
+        baseline
+            indented
+        "
+        );
     }
 
     // A nice doctest that is surrounded by prose


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This corrects how we expand tabs as part of PEP-257 normalization of docstrings.

Previously, we incorrectly replaced each tab in the docstring with 8 spaces. However, as per [the reference implementation](https://peps.python.org/pep-0257/#handling-docstring-indentation) (and the [`str.expandtabs` docs](https://docs.python.org/3/library/stdtypes.html#str.expandtabs)), we should instead treat a tab as a directive to advance to the next tab stop (the next column at a multiple of 8).

This matters for Google-style parameter extraction when a tab follows spaces. For example, consider an `Args:` section whose first item is indented with two spaces followed by a tab, while the second uses eight spaces:

```python
def example(first: str, second: str):
    """Summary.

    Args:
      \tfirst: First parameter.
        second: Second parameter.
    """
```

The previous normalization produced this docstring. Because the parameter items have different indentation, `second` is treated as continuation text for `first` rather than as a separate parameter:

```text
Summary.

Args:
          first: First parameter.
    second: Second parameter.
```

Whereas the correct interpretation according to PEP 257 aligns the parameter items, allowing documentation to be extracted for both `first` and `second`:

```text
Summary.

Args:
    first: First parameter.
    second: Second parameter.
```

## Test Plan

See included tests.
<!-- How was it tested? -->
