### PR TITLE
[ty] Support cached properties in protocols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2472,6 +2472,37 @@ def update_name(value: HasName) -> None:
     value.name = 1  # error: [invalid-assignment]
 ```
 
+### Generic descriptor result types
+
+Applying a generic descriptor decorator to a generic protocol method currently loses the protocol's
+type variable and produces `cached_property[Unknown]`. The protocol must preserve that descriptor
+type instead of reducing it to a bare `Unknown`, which would allow an incompatible implementation.
+
+```py
+from functools import cached_property
+from typing import Protocol, TypeVar
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, reveal_protocol_interface
+
+T = TypeVar("T")
+
+class HasValue(Protocol[T]):
+    @cached_property
+    def value(self) -> T: ...
+
+class StrValue:
+    @cached_property
+    def value(self) -> str:
+        return "value"
+
+static_assert(not is_assignable_to(StrValue, HasValue[int]))
+
+# TODO: This should be a property with an `int` read type once decorator calls preserve enclosing
+# type variables.
+# revealed: {"value": AttributeMember(`cached_property[Unknown]`)}
+reveal_protocol_interface(HasValue[int])
+```
+
 ### Descriptor values in annotations
 
 Only a descriptor produced by decorating a protocol method changes how that member is read and

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2442,6 +2442,185 @@ static_assert(is_subtype_of(PropertyWithSelfSetter, HasConcretePropertySetter))
 static_assert(is_assignable_to(PropertyWithSelfSetter, HasConcretePropertySetter))
 ```
 
+## Protocol members defined using descriptor decorators
+
+### `cached_property`
+
+On an instance, a protocol member decorated with `cached_property` has the type returned by
+`cached_property.__get__`, not the type of the descriptor stored on the protocol class. The typeshed
+definition also includes a `__set__` method, whose value parameter determines which assignments are
+valid:
+
+```py
+from functools import cached_property
+from typing import Protocol
+
+class HasName(Protocol):
+    @cached_property
+    def name(self) -> str: ...
+
+class WithName:
+    @cached_property
+    def name(self) -> str:
+        return "example"
+
+has_name: HasName = WithName()
+
+def update_name(value: HasName) -> None:
+    reveal_type(value.name)  # revealed: str
+    value.name = "updated"
+    value.name = 1  # error: [invalid-assignment]
+```
+
+### Descriptor values in annotations
+
+Only a descriptor produced by decorating a protocol method changes how that member is read and
+written through an instance. An annotation whose type implements the descriptor protocol still
+declares an ordinary attribute whose protocol member type is the descriptor object. We reveal the
+protocol interface here because ordinary instance access would invoke `cached_property.__get__` and
+reveal `str` in both cases:
+
+```py
+from functools import cached_property
+from typing import Protocol
+from ty_extensions._internal import reveal_protocol_interface
+
+class StoresDescriptor(Protocol):
+    name: cached_property[str]
+
+# revealed: {"name": AttributeMember(`cached_property[str]`)}
+reveal_protocol_interface(StoresDescriptor)
+```
+
+### Overloaded setters selected by receiver type
+
+An overloaded `__set__` method can accept different values for different receiver types. For
+`HasValue`, the overloads with an `object` receiver accept `int` and `bytes`; the overload for
+`Other` does not apply.
+
+```py
+from typing import Protocol, final, overload
+
+@final
+class Other: ...
+
+class ReceiverSensitiveDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        raise NotImplementedError
+
+    @overload
+    def __set__(self, instance: object, value: int) -> None: ...
+    @overload
+    def __set__(self, instance: object, value: bytes) -> None: ...
+    @overload
+    def __set__(self, instance: Other, value: str) -> None: ...
+    def __set__(self, instance: object, value: int | bytes | str) -> None: ...
+
+class HasValue(Protocol):
+    @ReceiverSensitiveDescriptor
+    def value(self) -> int: ...
+
+def update_value(value: HasValue) -> None:
+    # TODO: These assignments should be accepted.
+    value.value = 1  # error: [invalid-assignment]
+    value.value = b"valid"  # error: [invalid-assignment]
+    value.value = "bad"  # error: [invalid-assignment]
+```
+
+### Union descriptor types
+
+If a decorator can return either of two descriptors, an assignment must be accepted by both possible
+descriptors. Here, only `str` is accepted by both.
+
+```py
+from typing import Generic, Protocol, TypeVar
+
+T = TypeVar("T")
+
+class Descriptor(Generic[T]):
+    def __get__(self, instance: object, owner: type | None = None) -> T:
+        raise NotImplementedError
+
+    def __set__(self, instance: object, value: T) -> None: ...
+
+def either_descriptor(getter: object) -> Descriptor[int | str] | Descriptor[str | bytes]:
+    raise NotImplementedError
+
+class HasEitherValue(Protocol):
+    @either_descriptor
+    def either_value(self) -> object: ...
+
+def update_either_value(value: HasEitherValue) -> None:
+    # TODO: This assignment should be accepted.
+    value.either_value = "valid"  # error: [invalid-assignment]
+    value.either_value = 1  # error: [invalid-assignment]
+```
+
+### Overloaded setters selected by descriptor type
+
+An overload can also restrict the type of the descriptor itself. The decorator below returns
+`SelfSensitiveDescriptor[int]`, so only the overload accepting an `int` value applies.
+
+```py
+from __future__ import annotations
+
+from typing import Generic, Protocol, TypeVar, overload
+
+T = TypeVar("T")
+
+class SelfSensitiveDescriptor(Generic[T]):
+    def __get__(self, instance: object, owner: type | None = None) -> T:
+        raise NotImplementedError
+
+    @overload
+    def __set__(self: SelfSensitiveDescriptor[int], instance: object, value: int) -> None: ...
+    @overload
+    def __set__(self: SelfSensitiveDescriptor[str], instance: object, value: str) -> None: ...
+    def __set__(self, instance: object, value: int | str) -> None: ...
+
+def int_descriptor(getter: object) -> SelfSensitiveDescriptor[int]:
+    raise NotImplementedError
+
+class HasIntValue(Protocol):
+    @int_descriptor
+    def int_value(self) -> int: ...
+
+def update_int_value(value: HasIntValue) -> None:
+    # TODO: This assignment should be accepted.
+    value.int_value = 1  # error: [invalid-assignment]
+    value.int_value = "bad"  # error: [invalid-assignment]
+```
+
+### Generic setter value types
+
+A setter that uses a method type variable directly as its value parameter accepts every value
+allowed by that type variable's upper bound.
+
+```py
+from typing import Protocol, TypeVar
+
+T = TypeVar("T", bound=int)
+
+class BoundedDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__(self, instance: object, value: T) -> None: ...
+
+def bounded_descriptor(getter: object) -> BoundedDescriptor:
+    raise NotImplementedError
+
+class HasBoundedValue(Protocol):
+    @bounded_descriptor
+    def bounded_value(self) -> int: ...
+
+def update_bounded_value(value: HasBoundedValue) -> None:
+    # TODO: This assignment should be accepted.
+    value.bounded_value = 1  # error: [invalid-assignment]
+    value.bounded_value = "bad"  # error: [invalid-assignment]
+```
+
 ## Variance of generic protocols with `Final` members
 
 A `Final` attribute is readable but not writable, so it constrains an inferred type parameter

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2548,7 +2548,8 @@ reveal_protocol_interface(StoresDescriptor)
 
 An overloaded `__set__` method can accept different values for different receiver types. For
 `HasValue`, the overloads with an `object` receiver accept `int` and `bytes`; the overload for
-`Other` does not apply.
+`Other` does not apply. Until these overloads can be analyzed, `Unknown` is used as the write type.
+This preserves the writable requirement without rejecting assignments.
 
 ```py
 from typing import Protocol, final, overload
@@ -2573,11 +2574,18 @@ class HasValue(Protocol):
     @ReceiverSensitiveDescriptor
     def value(self) -> int: ...
 
+class ReadOnlyValue:
+    @property
+    def value(self) -> int:
+        return 1
+
+read_only: HasValue = ReadOnlyValue()  # error: [invalid-assignment]
+
 def update_value(value: HasValue) -> None:
-    # TODO: These assignments should be accepted.
-    value.value = 1  # error: [invalid-assignment]
-    value.value = b"valid"  # error: [invalid-assignment]
-    value.value = "bad"  # error: [invalid-assignment]
+    value.value = 1
+    value.value = b"valid"
+    # TODO: This assignment should be rejected.
+    value.value = "bad"
 ```
 
 ### Union descriptor types
@@ -2604,9 +2612,9 @@ class HasEitherValue(Protocol):
     def either_value(self) -> object: ...
 
 def update_either_value(value: HasEitherValue) -> None:
-    # TODO: This assignment should be accepted.
-    value.either_value = "valid"  # error: [invalid-assignment]
-    value.either_value = 1  # error: [invalid-assignment]
+    value.either_value = "valid"
+    # TODO: This assignment should be rejected.
+    value.either_value = 1
 ```
 
 ### Overloaded setters selected by descriptor type
@@ -2639,9 +2647,9 @@ class HasIntValue(Protocol):
     def int_value(self) -> int: ...
 
 def update_int_value(value: HasIntValue) -> None:
-    # TODO: This assignment should be accepted.
-    value.int_value = 1  # error: [invalid-assignment]
-    value.int_value = "bad"  # error: [invalid-assignment]
+    value.int_value = 1
+    # TODO: This assignment should be rejected.
+    value.int_value = "bad"
 ```
 
 ### Generic setter value types
@@ -2668,9 +2676,9 @@ class HasBoundedValue(Protocol):
     def bounded_value(self) -> int: ...
 
 def update_bounded_value(value: HasBoundedValue) -> None:
-    # TODO: This assignment should be accepted.
-    value.bounded_value = 1  # error: [invalid-assignment]
-    value.bounded_value = "bad"  # error: [invalid-assignment]
+    value.bounded_value = 1
+    # TODO: This assignment should be rejected.
+    value.bounded_value = "bad"
 ```
 
 ## Variance of generic protocols with `Final` members

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2444,32 +2444,53 @@ static_assert(is_assignable_to(PropertyWithSelfSetter, HasConcretePropertySetter
 
 ## Protocol members defined using descriptor decorators
 
+### Descriptor reads and writes
+
+On an instance, a protocol member defined using a descriptor decorator has the type returned by
+`__get__`, not the type of the descriptor stored on the protocol class. If the descriptor defines
+`__set__`, its value parameter determines which assignments are valid:
+
+```py
+from typing import Protocol
+
+class StringDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> str:
+        return "example"
+
+    def __set__(self, instance: object, value: str) -> None: ...
+
+class HasName(Protocol):
+    @StringDescriptor
+    def name(self) -> object: ...
+
+class WithName:
+    name: str = "example"
+
+has_name: HasName = WithName()
+reveal_type(has_name.name)  # revealed: str
+has_name.name = "updated"
+has_name.name = 1  # error: [invalid-assignment]
+```
+
 ### `cached_property`
 
-On an instance, a protocol member decorated with `cached_property` has the type returned by
-`cached_property.__get__`, not the type of the descriptor stored on the protocol class. The typeshed
-definition also includes a `__set__` method, whose value parameter determines which assignments are
-valid:
+The standard-library `cached_property` descriptor uses the same behavior:
 
 ```py
 from functools import cached_property
 from typing import Protocol
 
-class HasName(Protocol):
+class HasCachedName(Protocol):
     @cached_property
     def name(self) -> str: ...
 
-class WithName:
+class WithCachedName:
     @cached_property
     def name(self) -> str:
         return "example"
 
-has_name: HasName = WithName()
-
-def update_name(value: HasName) -> None:
-    reveal_type(value.name)  # revealed: str
-    value.name = "updated"
-    value.name = 1  # error: [invalid-assignment]
+has_name: HasCachedName = WithCachedName()
 ```
 
 ### Generic descriptor result types

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1061,8 +1061,11 @@ fn descriptor_decorated_protocol_member<'db>(
         .class_member_with_policy(db, "__set__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
         .place
     {
-        descriptor_setter_write_type(db, setter_ty, descriptor_ty, receiver_ty)
-            .map(|write_ty| ProtocolMemberType::with_definition(write_ty, definition))
+        Some(ProtocolMemberType::with_definition(
+            descriptor_setter_write_type(db, setter_ty, descriptor_ty, receiver_ty)
+                .unwrap_or_else(Type::unknown),
+            definition,
+        ))
     } else {
         None
     };

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1023,6 +1023,99 @@ fn property_set_member_type<'db>(
     ))
 }
 
+/// Derive the observable instance capabilities of a descriptor-decorated protocol member.
+fn descriptor_decorated_protocol_member<'db>(
+    db: &'db dyn Db,
+    descriptor_ty: Type<'db>,
+    protocol: ClassType<'db>,
+    definition: Option<Definition<'db>>,
+) -> Option<ProtocolMemberData<'db>> {
+    let Place::Defined(DefinedPlace {
+        definedness: Definedness::AlwaysDefined,
+        ..
+    }) = descriptor_ty
+        .class_member_with_policy(db, "__get__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
+        .place
+    else {
+        return None;
+    };
+
+    let receiver_ty = Type::instance(db, protocol);
+    let (read_ty, _) =
+        descriptor_ty.try_call_dunder_get(db, Some(receiver_ty), receiver_ty.to_meta_type(db))?;
+    let read = Some(ProtocolMemberType::with_definition(read_ty, definition));
+
+    let write = if let Place::Defined(DefinedPlace {
+        ty: setter_ty,
+        definedness: Definedness::AlwaysDefined,
+        ..
+    }) = descriptor_ty
+        .class_member_with_policy(db, "__set__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
+        .place
+    {
+        descriptor_setter_write_type(db, setter_ty, descriptor_ty, receiver_ty)
+            .map(|write_ty| ProtocolMemberType::with_definition(write_ty, definition))
+    } else {
+        None
+    };
+
+    Some(ProtocolMemberData::property(read, write, definition))
+}
+
+/// Derive a write type from a single ordinary setter signature.
+fn descriptor_setter_write_type<'db>(
+    db: &'db dyn Db,
+    setter_ty: Type<'db>,
+    descriptor_ty: Type<'db>,
+    receiver_ty: Type<'db>,
+) -> Option<Type<'db>> {
+    let callable = setter_ty.try_upcast_to_callable(db)?.exactly_one()?;
+    let signatures = callable.signatures(db);
+    let [signature] = signatures.overloads.as_ref() else {
+        return None;
+    };
+
+    // Function-generic setters require quantifier-aware callable-domain analysis. Class type
+    // variables have already been specialized by member lookup; an implicit `Self` can be bound
+    // directly to the descriptor instance.
+    if signature.generic_context.is_some_and(|generic_context| {
+        generic_context.variables(db).any(|typevar| {
+            !typevar.typevar(db).is_self(db)
+                && typevar
+                    .binding_context(db)
+                    .definition()
+                    .is_some_and(|definition| definition.kind(db).is_function_def())
+        })
+    }) {
+        return None;
+    }
+
+    let parameters = signature.parameters();
+    if parameters.len() != 3 {
+        return None;
+    }
+    let descriptor_parameter = parameters
+        .get_positional(0)?
+        .annotated_type()
+        .bind_self_typevars(db, descriptor_ty);
+    let receiver_parameter = parameters
+        .get_positional(1)?
+        .annotated_type()
+        .bind_self_typevars(db, descriptor_ty);
+    if !descriptor_ty.is_assignable_to(db, descriptor_parameter)
+        || !receiver_ty.is_assignable_to(db, receiver_parameter)
+    {
+        return None;
+    }
+
+    Some(
+        parameters
+            .get_positional(2)?
+            .annotated_type()
+            .bind_self_typevars(db, descriptor_ty),
+    )
+}
+
 fn property_set_type<'db>(
     db: &'db dyn Db,
     property: PropertyInstanceType<'db>,
@@ -1982,6 +2075,18 @@ fn cached_protocol_interface<'db>(
                 }
                 Type::FunctionLiteral(function) if bound_on_class.is_yes() => {
                     ProtocolMemberData::method(function.into_callable_type(db), definition)
+                }
+                _ if bound_on_class.is_yes()
+                    && definition
+                        .is_some_and(|definition| definition.kind(db).is_function_def()) =>
+                {
+                    if let Some(descriptor) =
+                        descriptor_decorated_protocol_member(db, ty, class, definition)
+                    {
+                        descriptor
+                    } else {
+                        ProtocolMemberData::attribute(ty, qualifiers, definition)
+                    }
                 }
                 _ => ProtocolMemberData::attribute(ty, qualifiers, definition),
             };

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1030,6 +1030,14 @@ fn descriptor_decorated_protocol_member<'db>(
     protocol: ClassType<'db>,
     definition: Option<Definition<'db>>,
 ) -> Option<ProtocolMemberData<'db>> {
+    // Applying a generic descriptor decorator to a method that refers to an enclosing type
+    // variable can currently materialize that variable as `Unknown`. Reducing the descriptor to
+    // its `__get__` result would then erase the remaining descriptor structure and weaken the
+    // protocol member to a bare `Unknown`.
+    if super::visitor::any_over_type(db, descriptor_ty, false, |ty| ty.is_unknown()) {
+        return None;
+    }
+
     let Place::Defined(DefinedPlace {
         definedness: Definedness::AlwaysDefined,
         ..
@@ -1075,9 +1083,8 @@ fn descriptor_setter_write_type<'db>(
         return None;
     };
 
-    // Function-generic setters require quantifier-aware callable-domain analysis. Class type
-    // variables have already been specialized by member lookup; an implicit `Self` can be bound
-    // directly to the descriptor instance.
+    // A method type variable cannot be used as the write type directly: it is inferred separately
+    // for each call. Deriving its accepted values requires generic call analysis.
     if signature.generic_context.is_some_and(|generic_context| {
         generic_context.variables(db).any(|typevar| {
             !typevar.typevar(db).is_self(db)


### PR DESCRIPTION
## Summary

Prior to this change, we treated a protocol member produced by a descriptor decorator as the descriptor object itself. This caused a class using `cached_property` to fail an otherwise matching protocol because we compared the instance read type, `str`, with `cached_property[str]`:

```python
from functools import cached_property
from typing import Protocol

class HasName(Protocol):
    @cached_property
    def name(self) -> str: ...

class WithName:
    @cached_property
    def name(self) -> str:
        return "example"

has_name: HasName = WithName()
```

We now resolve descriptor-decorated protocol methods through their instance interface. The result of `__get__` determines the readable member type, and the value parameter of a single ordinary `__set__` signature determines the writable member type. This lets `cached_property` implementations satisfy the protocol and preserves the expected type when reading from or assigning through a protocol instance.

This PR is focused on the simple case and leaves others as TODOs (with our existing, conservative behavior).

Closes https://github.com/astral-sh/ty/issues/3953.