### PR TITLE
[ty] Derive descriptor setter domains for protocols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2700,7 +2700,8 @@ def update_value(value: HasValue) -> None:
 ### Descriptor setters on union protocol receivers
 
 When assigning through a union of protocols, each descriptor setter is called with its matching
-union element as the receiver. The other elements of the union do not participate in that call.
+union element as the receiver. The other elements of the union do not participate in that call. The
+`a_only` and `b_only` methods keep the two protocol types distinct.
 
 ```py
 from __future__ import annotations
@@ -2724,64 +2725,26 @@ class BDescriptor:
 class A(Protocol):
     @ADescriptor
     def value(self) -> int: ...
-    def a(self) -> None: ...
+    def a_only(self) -> None: ...
 
 class B(Protocol):
     @BDescriptor
     def value(self) -> int: ...
-    def b(self) -> None: ...
+    def b_only(self) -> None: ...
 
 def update_union_value(value: A | B) -> None:
     value.value = 1
 ```
 
-### Bound descriptor setters
+### Static, class, and callable setters
 
-Descriptor invocation respects the binding mode of `__set__`. A static setter receives the instance
-and value directly, while a class setter also receives the descriptor class implicitly.
+The examples below use the same property implementations to check both assignment and protocol
+compatibility:
 
 ```py
 from typing import Protocol
 from ty_extensions import static_assert
 from ty_extensions._internal import is_subtype_of
-
-class StaticSetterDescriptor:
-    def __init__(self, getter: object) -> None: ...
-    def __get__(self, instance: object, owner: type | None = None) -> int:
-        return 1
-
-    @staticmethod
-    def __set__(instance: object, value: int) -> None: ...
-
-class ClassSetterDescriptor:
-    def __init__(self, getter: object) -> None: ...
-    def __get__(self, instance: object, owner: type | None = None) -> int:
-        return 1
-
-    @classmethod
-    def __set__(cls, instance: object, value: int) -> None: ...
-
-class IntSetter:
-    def __call__(self, instance: object, value: int) -> None: ...
-
-class CallableSetterDescriptor:
-    def __init__(self, getter: object) -> None: ...
-    def __get__(self, instance: object, owner: type | None = None) -> int:
-        return 1
-
-    __set__ = IntSetter()
-
-class HasStaticSetter(Protocol):
-    @StaticSetterDescriptor
-    def value(self) -> int: ...
-
-class HasClassSetter(Protocol):
-    @ClassSetterDescriptor
-    def value(self) -> int: ...
-
-class HasCallableSetter(Protocol):
-    @CallableSetterDescriptor
-    def value(self) -> int: ...
 
 class IntPropertySetter:
     @property
@@ -2798,26 +2761,77 @@ class StrPropertySetter:
 
     @value.setter
     def value(self, new_value: str) -> None: ...
+```
+
+A static `__set__` method receives the instance and assigned value directly:
+
+```py
+class StaticSetterDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    @staticmethod
+    def __set__(instance: object, value: int) -> None: ...
+
+class HasStaticSetter(Protocol):
+    @StaticSetterDescriptor
+    def value(self) -> int: ...
 
 static_assert(is_subtype_of(IntPropertySetter, HasStaticSetter))
-static_assert(is_subtype_of(IntPropertySetter, HasClassSetter))
-static_assert(is_subtype_of(IntPropertySetter, HasCallableSetter))
-
 static_assert(not is_subtype_of(StrPropertySetter, HasStaticSetter))
+
+def update_static_setter(value: HasStaticSetter) -> None:
+    value.value = 1
+    value.value = "bad"  # error: [invalid-assignment]
+```
+
+A class `__set__` method also receives the descriptor class implicitly:
+
+```py
+class ClassSetterDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    @classmethod
+    def __set__(cls, instance: object, value: int) -> None: ...
+
+class HasClassSetter(Protocol):
+    @ClassSetterDescriptor
+    def value(self) -> int: ...
+
+static_assert(is_subtype_of(IntPropertySetter, HasClassSetter))
 static_assert(not is_subtype_of(StrPropertySetter, HasClassSetter))
+
+def update_class_setter(value: HasClassSetter) -> None:
+    value.value = 1
+    value.value = "bad"  # error: [invalid-assignment]
+```
+
+An object stored in `__set__` is called with the instance and assigned value:
+
+```py
+class IntSetterCallable:
+    def __call__(self, instance: object, value: int) -> None: ...
+
+class CallableSetterDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    __set__ = IntSetterCallable()
+
+class HasCallableSetter(Protocol):
+    @CallableSetterDescriptor
+    def value(self) -> int: ...
+
+static_assert(is_subtype_of(IntPropertySetter, HasCallableSetter))
 static_assert(not is_subtype_of(StrPropertySetter, HasCallableSetter))
 
-def update_bound_setters(
-    static: HasStaticSetter,
-    class_: HasClassSetter,
-    callable_: HasCallableSetter,
-) -> None:
-    static.value = 1
-    static.value = "bad"  # error: [invalid-assignment]
-    class_.value = 1
-    class_.value = "bad"  # error: [invalid-assignment]
-    callable_.value = 1
-    callable_.value = "bad"  # error: [invalid-assignment]
+def update_callable_setter(value: HasCallableSetter) -> None:
+    value.value = 1
+    value.value = "bad"  # error: [invalid-assignment]
 ```
 
 ### Union descriptor types
@@ -2851,8 +2865,9 @@ def update_either_value(value: HasEitherValue) -> None:
 
 ### Aliased union descriptor types
 
-Top-level PEP 695 aliases do not change a descriptor union's write contract. As with the unaliased
-form above, only `str` is accepted by both possible descriptors, and the member remains writable.
+Top-level PEP 695 aliases do not change which assignments a descriptor union accepts. As with the
+unaliased form above, only `str` is accepted by both possible descriptors. The alias also does not
+make the protocol member read-only.
 
 ```toml
 [environment]
@@ -2891,11 +2906,11 @@ def update_aliased_value(value: HasAliasedValue) -> None:
     value.value = 1  # error: [invalid-assignment]
 ```
 
-### Descriptor intersections beyond the type budget
+### Large unions of descriptor types
 
-The write contract remains available when materializing its exact intersection type would exceed the
-set-theoretic expansion budget. Assignments are checked directly against every possible descriptor,
-and a read-only implementation still cannot satisfy the protocol.
+A value assigned through the protocol must be accepted by every possible descriptor. Here, `AX` is
+accepted by both descriptors, while `A` is accepted only by the first. Because the protocol member
+is writable, a read-only property cannot implement it.
 
 ```toml
 [environment]
@@ -2904,7 +2919,6 @@ python-version = "3.12"
 
 ```py
 from typing import Generic, Protocol, TypeVar
-from ty_extensions._internal import reveal_protocol_interface
 
 T = TypeVar("T")
 
@@ -2922,27 +2936,24 @@ class Descriptor(Generic[T]):
 
     def __set__(self, instance: object, value: T) -> None: ...
 
-def large_intersection_descriptor(
+def large_union_descriptor(
     getter: object,
 ) -> Descriptor[A | B | C] | Descriptor[X | Y | Z]:
     raise NotImplementedError
 
-class HasLargeIntersectionValue(Protocol):
-    @large_intersection_descriptor
+class HasLargeUnionValue(Protocol):
+    @large_union_descriptor
     def value(self) -> object: ...
 
-# revealed: {"value": PropertyMember { read: `object`, write: `Unknown` }}
-reveal_protocol_interface(HasLargeIntersectionValue)
-
-class ReadOnlyLargeIntersectionValue:
+class ReadOnlyLargeUnionValue:
     @property
     def value(self) -> object:
         return "value"
 
-read_only: HasLargeIntersectionValue = ReadOnlyLargeIntersectionValue()  # error: [invalid-assignment]
+read_only: HasLargeUnionValue = ReadOnlyLargeUnionValue()  # error: [invalid-assignment]
 
-def update_large_intersection_value(
-    value: HasLargeIntersectionValue,
+def update_large_union_value(
+    value: HasLargeUnionValue,
     valid: AX,
     invalid: A,
 ) -> None:
@@ -3012,10 +3023,10 @@ def update_bounded_value(value: HasBoundedValue) -> None:
     value.bounded_value = "bad"  # error: [invalid-assignment]
 ```
 
-### Caller type variables in descriptor setters
+### Type variables from the surrounding function
 
-A type variable owned by the caller does not require setter-local inference. The generic protocol
-member remains writable just as it does after specialization to a concrete type.
+A type variable supplied by the surrounding function is still the descriptor's value type. Assigning
+a value of that type is valid.
 
 ```py
 from typing import Generic, Protocol, TypeVar
@@ -3034,18 +3045,14 @@ class HasGenericValue(Protocol[T]):
     @Descriptor[T]
     def value(self) -> T: ...
 
-def update_concrete_generic_value(value: HasGenericValue[int]) -> None:
-    value.value = 1
-
 def update_generic_value(value: HasGenericValue[U], new_value: U) -> None:
     value.value = new_value
 ```
 
-### Setter-local type variables inside aliases
+### Setter type variables inside aliases
 
-A setter-local type variable remains local when it appears through a PEP 695 alias. Domain
-derivation must defer rather than treating the receiver as inapplicable and the write domain as
-empty.
+A type alias does not hide that `T` belongs to `__set__`. The descriptor below still accepts `int`,
+so it remains writable with `int` but not with `str`.
 
 ```toml
 [environment]
@@ -3069,8 +3076,12 @@ class AliasedReceiverDescriptor:
 class HasAliasedReceiver(Protocol):
     @AliasedReceiverDescriptor
     def value(self) -> int: ...
+```
 
-class NeverAliasedReceiver:
+A property setter that accepts only `Never` cannot implement this protocol member:
+
+```py
+class NeverPropertySetter:
     @property
     def value(self) -> int:
         return 1
@@ -3078,18 +3089,21 @@ class NeverAliasedReceiver:
     @value.setter
     def value(self, new_value: Never) -> None: ...
 
-static_assert(not is_subtype_of(NeverAliasedReceiver, HasAliasedReceiver))
+static_assert(not is_subtype_of(NeverPropertySetter, HasAliasedReceiver))
+```
 
+Assignments through the protocol accept `int` but reject `str`:
+
+```py
 def update_aliased_receiver(value: HasAliasedReceiver) -> None:
     value.value = 1
     value.value = "bad"  # error: [invalid-assignment]
 ```
 
-### Constrained generic setter value types
+### Constrained generic setters
 
-A constrained method type variable cannot be flattened to the union of its constraints. A call must
-choose one constraint for the type variable, so a value whose type is the union of the constraints
-is not accepted.
+A setter with a constrained type variable must choose one constraint for each call. It accepts `int`
+and `str` separately, but not a value whose type is `int | str`.
 
 ```py
 from typing import Protocol, TypeVar
@@ -3108,24 +3122,32 @@ def constrained_descriptor(getter: object) -> ConstrainedDescriptor:
 class HasConstrainedValue(Protocol):
     @constrained_descriptor
     def constrained_value(self) -> int | str: ...
+```
 
+The setter is still present, so a read-only property cannot implement the protocol:
+
+```py
 class ReadOnlyConstrainedValue:
     @property
     def constrained_value(self) -> int | str:
         return "value"
 
 read_only: HasConstrainedValue = ReadOnlyConstrainedValue()  # error: [invalid-assignment]
+```
 
+Literal values select one constraint, while a union of the constraints does not:
+
+```py
 def update_constrained_value(value: HasConstrainedValue, new_value: int | str) -> None:
     value.constrained_value = 1
     value.constrained_value = "valid"
     value.constrained_value = new_value  # error: [invalid-assignment]
 ```
 
-### `Never` setter domains
+### Setters that accept `Never`
 
-A setter that accepts `Never` still makes the protocol member writable. An assignment whose value
-also has type `Never` is valid.
+A `Never` value cannot normally exist, but a `__set__` parameter of type `Never` still makes the
+protocol member writable. A read-only property therefore cannot implement it.
 
 ```py
 from typing import Protocol
@@ -3150,19 +3172,22 @@ class ReadOnlyNeverValue:
         return "value"
 
 read_only: HasNeverValue = ReadOnlyNeverValue()  # error: [invalid-assignment]
+```
 
+If the assigned expression itself has type `Never`, the assignment is valid:
+
+```py
 def update_never_value(value: HasNeverValue, new_value: Never) -> None:
     value.never_value = new_value
 ```
 
-### Optional trailing setter parameters
+### Optional parameters after the setter value
 
-A setter remains callable by the descriptor protocol when parameters after the assigned value can
-all be omitted. This includes a gradual `*args: Any, **kwargs: Any` tail. Required trailing
-parameters make the setter incompatible with attribute assignment.
+Attribute assignment calls `__set__` with the instance and assigned value. Any later parameters can
+be present if they can all be omitted.
 
 ```py
-from typing import Any, Protocol
+from typing import Protocol
 
 class OptionalTrailingDescriptor:
     def __init__(self, getter: object) -> None: ...
@@ -3186,6 +3211,15 @@ class HasOptionalTrailingValue(Protocol):
 def update_optional_trailing_value(value: HasOptionalTrailingValue) -> None:
     value.value = 1
     value.value = "bad"  # error: [invalid-assignment]
+```
+
+### Gradual variadic tails after the setter value
+
+A `*args: Any, **kwargs: Any` tail can also be omitted. It does not make the protocol member
+read-only or change the `int` value accepted by the setter.
+
+```py
+from typing import Any, Protocol
 
 class GradualTrailingDescriptor:
     def __init__(self, getter: object) -> None: ...
@@ -3208,6 +3242,15 @@ read_only: HasGradualTrailingValue = ReadOnlyGradualTrailingValue()  # error: [i
 def update_gradual_trailing_value(value: HasGradualTrailingValue) -> None:
     value.value = 1
     value.value = "bad"  # error: [invalid-assignment]
+```
+
+### Required parameters after the setter value
+
+If `__set__` requires another parameter after the assigned value, attribute assignment cannot call
+it because that argument is missing.
+
+```py
+from typing import Protocol
 
 class RequiredTrailingDescriptor:
     def __init__(self, getter: object) -> None: ...
@@ -3224,10 +3267,10 @@ def update_required_trailing_value(value: HasRequiredTrailingValue) -> None:
     value.value = 1  # error: [invalid-assignment]
 ```
 
-### Variadic setter value parameters
+### Setter values captured by `*args`
 
-A setter can receive the assigned value through a variadic positional parameter. Its write domain
-cannot be treated as empty when checking protocol compatibility.
+When `__set__` declares `(instance, *values: int)`, attribute assignment supplies the value as the
+first element of `values`. The descriptor therefore accepts `int` but not `str`.
 
 ```py
 from typing import Protocol
@@ -3244,8 +3287,12 @@ class VariadicValueDescriptor:
 class HasVariadicValue(Protocol):
     @VariadicValueDescriptor
     def value(self) -> int: ...
+```
 
-class StrVariadicValue:
+A property setter restricted to `str` cannot implement this protocol member:
+
+```py
+class StrPropertySetter:
     @property
     def value(self) -> int:
         return 1
@@ -3253,22 +3300,34 @@ class StrVariadicValue:
     @value.setter
     def value(self, new_value: str) -> None: ...
 
-static_assert(not is_subtype_of(StrVariadicValue, HasVariadicValue))
+static_assert(not is_subtype_of(StrPropertySetter, HasVariadicValue))
+```
 
+Assignments through the protocol follow the `int` annotation on `*values`:
+
+```py
 def update_variadic_value(value: HasVariadicValue) -> None:
     value.value = 1
     value.value = "bad"  # error: [invalid-assignment]
 ```
 
-### Gradual setter signatures
+### Gradually typed setter signatures
 
-A gradual `__set__` signature has an unknown write domain, not an empty one. Assignments remain
-valid, but a descriptor that only accepts `int` does not satisfy the broader gradual contract.
+When `__set__` is `Callable[..., None]`, ty cannot determine which values it accepts. Assignment is
+allowed, but a property setter limited to `int` is not guaranteed to implement the same member.
 
 ```py
 from typing import Any, Callable, Protocol
 from ty_extensions import static_assert
-from ty_extensions._internal import is_subtype_of, reveal_protocol_interface
+from ty_extensions._internal import is_subtype_of
+
+class IntPropertySetter:
+    @property
+    def value(self) -> int:
+        return 1
+
+    @value.setter
+    def value(self, new_value: int) -> None: ...
 
 class CallableSetterDescriptor:
     def __init__(self, getter: object) -> None: ...
@@ -3277,6 +3336,19 @@ class CallableSetterDescriptor:
 
     __set__: Callable[..., None]
 
+class HasCallableSetter(Protocol):
+    @CallableSetterDescriptor
+    def value(self) -> int: ...
+
+static_assert(not is_subtype_of(IntPropertySetter, HasCallableSetter))
+
+def update_callable_setter(value: HasCallableSetter) -> None:
+    value.value = object()
+```
+
+The same applies when the type of `__set__` is `Any`:
+
+```py
 class AnySetterDescriptor:
     def __init__(self, getter: object) -> None: ...
     def __get__(self, instance: object, owner: type | None = None) -> int:
@@ -3284,33 +3356,14 @@ class AnySetterDescriptor:
 
     __set__: Any
 
-class HasCallableSetter(Protocol):
-    @CallableSetterDescriptor
-    def value(self) -> int: ...
-
 class HasAnySetter(Protocol):
     @AnySetterDescriptor
     def value(self) -> int: ...
 
-class IntSetter:
-    @property
-    def value(self) -> int:
-        return 1
+static_assert(not is_subtype_of(IntPropertySetter, HasAnySetter))
 
-    @value.setter
-    def value(self, new_value: int) -> None: ...
-
-# revealed: {"value": PropertyMember { read: `int`, write: `Unknown` }}
-reveal_protocol_interface(HasCallableSetter)
-# revealed: {"value": PropertyMember { read: `int`, write: `Unknown` }}
-reveal_protocol_interface(HasAnySetter)
-
-static_assert(not is_subtype_of(IntSetter, HasCallableSetter))
-static_assert(not is_subtype_of(IntSetter, HasAnySetter))
-
-def update_gradual_setters(callable_: HasCallableSetter, any_: HasAnySetter) -> None:
-    callable_.value = object()
-    any_.value = object()
+def update_any_setter(value: HasAnySetter) -> None:
+    value.value = object()
 ```
 
 ## Variance of generic protocols with `Final` members

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2788,6 +2788,52 @@ def update_bounded_value(value: HasBoundedValue) -> None:
     value.bounded_value = "bad"  # error: [invalid-assignment]
 ```
 
+### Optional trailing setter parameters
+
+A setter remains callable by the descriptor protocol when parameters after the assigned value can
+all be omitted. Required trailing parameters make the setter incompatible with attribute assignment.
+
+```py
+from typing import Protocol
+
+class OptionalTrailingDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        raise NotImplementedError
+
+    def __set__(
+        self,
+        instance: object,
+        value: int,
+        notify: bool = False,
+        *metadata: str,
+        log: bool = False,
+        **named_metadata: str,
+    ) -> None: ...
+
+class HasOptionalTrailingValue(Protocol):
+    @OptionalTrailingDescriptor
+    def value(self) -> int: ...
+
+def update_optional_trailing_value(value: HasOptionalTrailingValue) -> None:
+    value.value = 1
+    value.value = "bad"  # error: [invalid-assignment]
+
+class RequiredTrailingDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        raise NotImplementedError
+
+    def __set__(self, instance: object, value: int, required: bool) -> None: ...
+
+class HasRequiredTrailingValue(Protocol):
+    @RequiredTrailingDescriptor
+    def value(self) -> int: ...
+
+def update_required_trailing_value(value: HasRequiredTrailingValue) -> None:
+    value.value = 1  # error: [invalid-assignment]
+```
+
 ## Variance of generic protocols with `Final` members
 
 A `Final` attribute is readable but not writable, so it constrains an inferred type parameter

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2726,6 +2726,107 @@ def update_either_value(value: HasEitherValue) -> None:
     value.either_value = 1  # error: [invalid-assignment]
 ```
 
+### Aliased union descriptor types
+
+Top-level PEP 695 aliases do not change a descriptor union's write contract. As with the unaliased
+form above, only `str` is accepted by both possible descriptors, and the member remains writable.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Generic, Protocol, TypeVar
+
+T = TypeVar("T")
+
+class Descriptor(Generic[T]):
+    def __get__(self, instance: object, owner: type | None = None) -> T:
+        raise NotImplementedError
+
+    def __set__(self, instance: object, value: T) -> None: ...
+
+type DescriptorAlias = Descriptor[int | str] | Descriptor[str | bytes]
+
+def aliased_descriptor(getter: object) -> DescriptorAlias:
+    raise NotImplementedError
+
+class HasAliasedValue(Protocol):
+    @aliased_descriptor
+    def value(self) -> object: ...
+
+class ReadOnlyAliasedValue:
+    @property
+    def value(self) -> object:
+        return "value"
+
+read_only: HasAliasedValue = ReadOnlyAliasedValue()  # error: [invalid-assignment]
+
+def update_aliased_value(value: HasAliasedValue) -> None:
+    value.value = "valid"
+    value.value = 1  # error: [invalid-assignment]
+```
+
+### Descriptor intersections beyond the type budget
+
+The write contract remains available when materializing its exact intersection type would exceed the
+set-theoretic expansion budget. Assignments are checked directly against every possible descriptor,
+and a read-only implementation still cannot satisfy the protocol.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Generic, Protocol, TypeVar
+from ty_extensions._internal import reveal_protocol_interface
+
+T = TypeVar("T")
+
+class A: ...
+class B: ...
+class C: ...
+class X: ...
+class Y: ...
+class Z: ...
+class AX(A, X): ...
+
+class Descriptor(Generic[T]):
+    def __get__(self, instance: object, owner: type | None = None) -> object:
+        raise NotImplementedError
+
+    def __set__(self, instance: object, value: T) -> None: ...
+
+def large_intersection_descriptor(
+    getter: object,
+) -> Descriptor[A | B | C] | Descriptor[X | Y | Z]:
+    raise NotImplementedError
+
+class HasLargeIntersectionValue(Protocol):
+    @large_intersection_descriptor
+    def value(self) -> object: ...
+
+# revealed: {"value": PropertyMember { read: `object`, write: `Unknown` }}
+reveal_protocol_interface(HasLargeIntersectionValue)
+
+class ReadOnlyLargeIntersectionValue:
+    @property
+    def value(self) -> object:
+        return "value"
+
+read_only: HasLargeIntersectionValue = ReadOnlyLargeIntersectionValue()  # error: [invalid-assignment]
+
+def update_large_intersection_value(
+    value: HasLargeIntersectionValue,
+    valid: AX,
+    invalid: A,
+) -> None:
+    value.value = valid
+    value.value = invalid  # error: [invalid-assignment]
+```
+
 ### Overloaded setters selected by descriptor type
 
 An overload can also restrict the type of the descriptor itself. The decorator below returns
@@ -2788,6 +2889,35 @@ def update_bounded_value(value: HasBoundedValue) -> None:
     value.bounded_value = "bad"  # error: [invalid-assignment]
 ```
 
+### Caller type variables in descriptor setters
+
+A type variable owned by the caller does not require setter-local inference. The generic protocol
+member remains writable just as it does after specialization to a concrete type.
+
+```py
+from typing import Generic, Protocol, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class Descriptor(Generic[T]):
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> T:
+        raise NotImplementedError
+
+    def __set__(self, instance: object, value: T) -> None: ...
+
+class HasGenericValue(Protocol[T]):
+    @Descriptor[T]
+    def value(self) -> T: ...
+
+def update_concrete_generic_value(value: HasGenericValue[int]) -> None:
+    value.value = 1
+
+def update_generic_value(value: HasGenericValue[U], new_value: U) -> None:
+    value.value = new_value
+```
+
 ### Constrained generic setter value types
 
 A constrained method type variable cannot be flattened to the union of its constraints. A call must
@@ -2812,7 +2942,16 @@ class HasConstrainedValue(Protocol):
     @constrained_descriptor
     def constrained_value(self) -> int | str: ...
 
+class ReadOnlyConstrainedValue:
+    @property
+    def constrained_value(self) -> int | str:
+        return "value"
+
+read_only: HasConstrainedValue = ReadOnlyConstrainedValue()  # error: [invalid-assignment]
+
 def update_constrained_value(value: HasConstrainedValue, new_value: int | str) -> None:
+    value.constrained_value = 1
+    value.constrained_value = "valid"
     value.constrained_value = new_value  # error: [invalid-assignment]
 ```
 
@@ -2837,6 +2976,13 @@ def never_descriptor(getter: object) -> NeverDescriptor:
 class HasNeverValue(Protocol):
     @never_descriptor
     def never_value(self) -> object: ...
+
+class ReadOnlyNeverValue:
+    @property
+    def never_value(self) -> object:
+        return "value"
+
+read_only: HasNeverValue = ReadOnlyNeverValue()  # error: [invalid-assignment]
 
 def update_never_value(value: HasNeverValue, new_value: Never) -> None:
     value.never_value = new_value
@@ -2884,6 +3030,13 @@ class GradualTrailingDescriptor:
 class HasGradualTrailingValue(Protocol):
     @GradualTrailingDescriptor
     def value(self) -> int: ...
+
+class ReadOnlyGradualTrailingValue:
+    @property
+    def value(self) -> int:
+        return 1
+
+read_only: HasGradualTrailingValue = ReadOnlyGradualTrailingValue()  # error: [invalid-assignment]
 
 def update_gradual_trailing_value(value: HasGradualTrailingValue) -> None:
     value.value = 1

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3134,6 +3134,59 @@ def update_required_trailing_value(value: HasRequiredTrailingValue) -> None:
     value.value = 1  # error: [invalid-assignment]
 ```
 
+### Gradual setter signatures
+
+A gradual `__set__` signature has an unknown write domain, not an empty one. Assignments remain
+valid, but a descriptor that only accepts `int` does not satisfy the broader gradual contract.
+
+```py
+from typing import Any, Callable, Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of, reveal_protocol_interface
+
+class CallableSetterDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    __set__: Callable[..., None]
+
+class AnySetterDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    __set__: Any
+
+class HasCallableSetter(Protocol):
+    @CallableSetterDescriptor
+    def value(self) -> int: ...
+
+class HasAnySetter(Protocol):
+    @AnySetterDescriptor
+    def value(self) -> int: ...
+
+class IntSetter:
+    @property
+    def value(self) -> int:
+        return 1
+
+    @value.setter
+    def value(self, new_value: int) -> None: ...
+
+# revealed: {"value": PropertyMember { read: `int`, write: `Unknown` }}
+reveal_protocol_interface(HasCallableSetter)
+# revealed: {"value": PropertyMember { read: `int`, write: `Unknown` }}
+reveal_protocol_interface(HasAnySetter)
+
+static_assert(not is_subtype_of(IntSetter, HasCallableSetter))
+static_assert(not is_subtype_of(IntSetter, HasAnySetter))
+
+def update_gradual_setters(callable_: HasCallableSetter, any_: HasAnySetter) -> None:
+    callable_.value = object()
+    any_.value = object()
+```
+
 ## Variance of generic protocols with `Final` members
 
 A `Final` attribute is readable but not writable, so it constrains an inferred type parameter

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3180,6 +3180,42 @@ def update_required_trailing_value(value: HasRequiredTrailingValue) -> None:
     value.value = 1  # error: [invalid-assignment]
 ```
 
+### Variadic setter value parameters
+
+A setter can receive the assigned value through a variadic positional parameter. Its write domain
+cannot be treated as empty when checking protocol compatibility.
+
+```py
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class VariadicValueDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__(self, instance: object, *values: int) -> None: ...
+
+class HasVariadicValue(Protocol):
+    @VariadicValueDescriptor
+    def value(self) -> int: ...
+
+class StrVariadicValue:
+    @property
+    def value(self) -> int:
+        return 1
+
+    @value.setter
+    def value(self, new_value: str) -> None: ...
+
+static_assert(not is_subtype_of(StrVariadicValue, HasVariadicValue))
+
+def update_variadic_value(value: HasVariadicValue) -> None:
+    value.value = 1
+    value.value = "bad"  # error: [invalid-assignment]
+```
+
 ### Gradual setter signatures
 
 A gradual `__set__` signature has an unknown write domain, not an empty one. Assignments remain

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2742,6 +2742,8 @@ and value directly, while a class setter also receives the descriptor class impl
 
 ```py
 from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
 
 class StaticSetterDescriptor:
     def __init__(self, getter: object) -> None: ...
@@ -2759,6 +2761,16 @@ class ClassSetterDescriptor:
     @classmethod
     def __set__(cls, instance: object, value: int) -> None: ...
 
+class IntSetter:
+    def __call__(self, instance: object, value: int) -> None: ...
+
+class CallableSetterDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    __set__ = IntSetter()
+
 class HasStaticSetter(Protocol):
     @StaticSetterDescriptor
     def value(self) -> int: ...
@@ -2767,11 +2779,45 @@ class HasClassSetter(Protocol):
     @ClassSetterDescriptor
     def value(self) -> int: ...
 
-def update_bound_setters(static: HasStaticSetter, class_: HasClassSetter) -> None:
+class HasCallableSetter(Protocol):
+    @CallableSetterDescriptor
+    def value(self) -> int: ...
+
+class IntPropertySetter:
+    @property
+    def value(self) -> int:
+        return 1
+
+    @value.setter
+    def value(self, new_value: int) -> None: ...
+
+class StrPropertySetter:
+    @property
+    def value(self) -> int:
+        return 1
+
+    @value.setter
+    def value(self, new_value: str) -> None: ...
+
+static_assert(is_subtype_of(IntPropertySetter, HasStaticSetter))
+static_assert(is_subtype_of(IntPropertySetter, HasClassSetter))
+static_assert(is_subtype_of(IntPropertySetter, HasCallableSetter))
+
+static_assert(not is_subtype_of(StrPropertySetter, HasStaticSetter))
+static_assert(not is_subtype_of(StrPropertySetter, HasClassSetter))
+static_assert(not is_subtype_of(StrPropertySetter, HasCallableSetter))
+
+def update_bound_setters(
+    static: HasStaticSetter,
+    class_: HasClassSetter,
+    callable_: HasCallableSetter,
+) -> None:
     static.value = 1
     static.value = "bad"  # error: [invalid-assignment]
     class_.value = 1
     class_.value = "bad"  # error: [invalid-assignment]
+    callable_.value = 1
+    callable_.value = "bad"  # error: [invalid-assignment]
 ```
 
 ### Union descriptor types

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2816,6 +2816,32 @@ def update_constrained_value(value: HasConstrainedValue, new_value: int | str) -
     value.constrained_value = new_value  # error: [invalid-assignment]
 ```
 
+### `Never` setter domains
+
+A setter that accepts `Never` still makes the protocol member writable. An assignment whose value
+also has type `Never` is valid.
+
+```py
+from typing import Protocol
+from typing_extensions import Never
+
+class NeverDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> object:
+        raise NotImplementedError
+
+    def __set__(self, instance: object, value: Never) -> None: ...
+
+def never_descriptor(getter: object) -> NeverDescriptor:
+    raise NotImplementedError
+
+class HasNeverValue(Protocol):
+    @never_descriptor
+    def never_value(self) -> object: ...
+
+def update_never_value(value: HasNeverValue, new_value: Never) -> None:
+    value.never_value = new_value
+```
+
 ### Optional trailing setter parameters
 
 A setter remains callable by the descriptor protocol when parameters after the assigned value can

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2697,6 +2697,44 @@ def update_value(value: HasValue) -> None:
     value.value = "bad"  # error: [invalid-assignment]
 ```
 
+### Descriptor setters on union protocol receivers
+
+When assigning through a union of protocols, each descriptor setter is called with its matching
+union element as the receiver. The other elements of the union do not participate in that call.
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class ADescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__(self, instance: A, value: int) -> None: ...
+
+class BDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__(self, instance: B, value: int) -> None: ...
+
+class A(Protocol):
+    @ADescriptor
+    def value(self) -> int: ...
+    def a(self) -> None: ...
+
+class B(Protocol):
+    @BDescriptor
+    def value(self) -> int: ...
+    def b(self) -> None: ...
+
+def update_union_value(value: A | B) -> None:
+    value.value = 1
+```
+
 ### Union descriptor types
 
 If a decorator can return either of two descriptors, an assignment must be accepted by both possible

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2735,6 +2735,45 @@ def update_union_value(value: A | B) -> None:
     value.value = 1
 ```
 
+### Bound descriptor setters
+
+Descriptor invocation respects the binding mode of `__set__`. A static setter receives the instance
+and value directly, while a class setter also receives the descriptor class implicitly.
+
+```py
+from typing import Protocol
+
+class StaticSetterDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    @staticmethod
+    def __set__(instance: object, value: int) -> None: ...
+
+class ClassSetterDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    @classmethod
+    def __set__(cls, instance: object, value: int) -> None: ...
+
+class HasStaticSetter(Protocol):
+    @StaticSetterDescriptor
+    def value(self) -> int: ...
+
+class HasClassSetter(Protocol):
+    @ClassSetterDescriptor
+    def value(self) -> int: ...
+
+def update_bound_setters(static: HasStaticSetter, class_: HasClassSetter) -> None:
+    static.value = 1
+    static.value = "bad"  # error: [invalid-assignment]
+    class_.value = 1
+    class_.value = "bad"  # error: [invalid-assignment]
+```
+
 ### Union descriptor types
 
 If a decorator can return either of two descriptors, an assignment must be accepted by both possible

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2788,6 +2788,34 @@ def update_bounded_value(value: HasBoundedValue) -> None:
     value.bounded_value = "bad"  # error: [invalid-assignment]
 ```
 
+### Constrained generic setter value types
+
+A constrained method type variable cannot be flattened to the union of its constraints. A call must
+choose one constraint for the type variable, so a value whose type is the union of the constraints
+is not accepted.
+
+```py
+from typing import Protocol, TypeVar
+
+T = TypeVar("T", int, str)
+
+class ConstrainedDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> int | str:
+        raise NotImplementedError
+
+    def __set__(self, instance: object, value: T) -> None: ...
+
+def constrained_descriptor(getter: object) -> ConstrainedDescriptor:
+    raise NotImplementedError
+
+class HasConstrainedValue(Protocol):
+    @constrained_descriptor
+    def constrained_value(self) -> int | str: ...
+
+def update_constrained_value(value: HasConstrainedValue, new_value: int | str) -> None:
+    value.constrained_value = new_value  # error: [invalid-assignment]
+```
+
 ### Optional trailing setter parameters
 
 A setter remains callable by the descriptor protocol when parameters after the assigned value can

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3041,6 +3041,50 @@ def update_generic_value(value: HasGenericValue[U], new_value: U) -> None:
     value.value = new_value
 ```
 
+### Setter-local type variables inside aliases
+
+A setter-local type variable remains local when it appears through a PEP 695 alias. Domain
+derivation must defer rather than treating the receiver as inapplicable and the write domain as
+empty.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Never, Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+type Alias[T] = T
+
+class AliasedReceiverDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__[T](self, instance: Alias[T], value: int) -> None: ...
+
+class HasAliasedReceiver(Protocol):
+    @AliasedReceiverDescriptor
+    def value(self) -> int: ...
+
+class NeverAliasedReceiver:
+    @property
+    def value(self) -> int:
+        return 1
+
+    @value.setter
+    def value(self, new_value: Never) -> None: ...
+
+static_assert(not is_subtype_of(NeverAliasedReceiver, HasAliasedReceiver))
+
+def update_aliased_receiver(value: HasAliasedReceiver) -> None:
+    value.value = 1
+    value.value = "bad"  # error: [invalid-assignment]
+```
+
 ### Constrained generic setter value types
 
 A constrained method type variable cannot be flattened to the union of its constraints. A call must

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2658,8 +2658,8 @@ reveal_protocol_interface(StoresDescriptor)
 
 An overloaded `__set__` method can accept different values for different receiver types. For
 `HasValue`, the overloads with an `object` receiver accept `int` and `bytes`; the overload for
-`Other` does not apply. Until these overloads can be analyzed, `Unknown` is used as the write type.
-This preserves the writable requirement without rejecting assignments.
+`Other` does not apply. Therefore, assignments of `int` and `bytes` are valid, but assignments of
+`str` are not.
 
 ```py
 from typing import Protocol, final, overload
@@ -2694,14 +2694,14 @@ read_only: HasValue = ReadOnlyValue()  # error: [invalid-assignment]
 def update_value(value: HasValue) -> None:
     value.value = 1
     value.value = b"valid"
-    # TODO: This assignment should be rejected.
-    value.value = "bad"
+    value.value = "bad"  # error: [invalid-assignment]
 ```
 
 ### Union descriptor types
 
 If a decorator can return either of two descriptors, an assignment must be accepted by both possible
-descriptors. Here, only `str` is accepted by both.
+descriptors. Here, only `str` is accepted by both, so an `int` assignment is invalid even though one
+of the descriptors accepts it.
 
 ```py
 from typing import Generic, Protocol, TypeVar
@@ -2723,8 +2723,7 @@ class HasEitherValue(Protocol):
 
 def update_either_value(value: HasEitherValue) -> None:
     value.either_value = "valid"
-    # TODO: This assignment should be rejected.
-    value.either_value = 1
+    value.either_value = 1  # error: [invalid-assignment]
 ```
 
 ### Overloaded setters selected by descriptor type
@@ -2758,14 +2757,13 @@ class HasIntValue(Protocol):
 
 def update_int_value(value: HasIntValue) -> None:
     value.int_value = 1
-    # TODO: This assignment should be rejected.
-    value.int_value = "bad"
+    value.int_value = "bad"  # error: [invalid-assignment]
 ```
 
 ### Generic setter value types
 
 A setter that uses a method type variable directly as its value parameter accepts every value
-allowed by that type variable's upper bound.
+allowed by that type variable's upper bound. The setter below therefore accepts `int` values.
 
 ```py
 from typing import Protocol, TypeVar
@@ -2787,8 +2785,7 @@ class HasBoundedValue(Protocol):
 
 def update_bounded_value(value: HasBoundedValue) -> None:
     value.bounded_value = 1
-    # TODO: This assignment should be rejected.
-    value.bounded_value = "bad"
+    value.bounded_value = "bad"  # error: [invalid-assignment]
 ```
 
 ## Variance of generic protocols with `Final` members

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2845,10 +2845,11 @@ def update_never_value(value: HasNeverValue, new_value: Never) -> None:
 ### Optional trailing setter parameters
 
 A setter remains callable by the descriptor protocol when parameters after the assigned value can
-all be omitted. Required trailing parameters make the setter incompatible with attribute assignment.
+all be omitted. This includes a gradual `*args: Any, **kwargs: Any` tail. Required trailing
+parameters make the setter incompatible with attribute assignment.
 
 ```py
-from typing import Protocol
+from typing import Any, Protocol
 
 class OptionalTrailingDescriptor:
     def __init__(self, getter: object) -> None: ...
@@ -2870,6 +2871,21 @@ class HasOptionalTrailingValue(Protocol):
     def value(self) -> int: ...
 
 def update_optional_trailing_value(value: HasOptionalTrailingValue) -> None:
+    value.value = 1
+    value.value = "bad"  # error: [invalid-assignment]
+
+class GradualTrailingDescriptor:
+    def __init__(self, getter: object) -> None: ...
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        raise NotImplementedError
+
+    def __set__(self, instance: object, value: int, *args: Any, **kwargs: Any) -> None: ...
+
+class HasGradualTrailingValue(Protocol):
+    @GradualTrailingDescriptor
+    def value(self) -> int: ...
+
+def update_gradual_trailing_value(value: HasGradualTrailingValue) -> None:
     value.value = 1
     value.value = "bad"  # error: [invalid-assignment]
 

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -42,13 +42,12 @@ pub(super) enum AttributeWriteRequirement<'db> {
     ///
     /// `None` represents an unresolved module attribute rather than an unconstrained write.
     Module(Option<Type<'db>>),
-    /// The effective instance-write type of a declared protocol member.
+    /// The effective instance-write requirement of a declared protocol member.
     ///
-    /// `write_ty` is `None` for a read-only member. Qualifiers are retained so assignment
-    /// inference can distinguish `Final` and `ClassVar` diagnostics from other non-writable
-    /// members.
+    /// `write` is `None` for a read-only member. Qualifiers are retained so assignment inference
+    /// can distinguish `Final` and `ClassVar` diagnostics from other non-writable members.
     ProtocolMember {
-        write_ty: Option<Type<'db>>,
+        write: Option<ProtocolMemberWriteRequirement<'db>>,
         qualifiers: TypeQualifiers,
     },
     /// A write through an instance, resolved against its class and instance attributes.
@@ -60,6 +59,22 @@ pub(super) enum AttributeWriteRequirement<'db> {
     Class {
         object_ty: Type<'db>,
         member: ClassAttributeWriteMember<'db>,
+    },
+}
+
+/// How a writable protocol member validates an assigned value.
+pub(super) enum ProtocolMemberWriteRequirement<'db> {
+    /// Check the assigned value against a directly representable write type.
+    AssignableTo(Type<'db>),
+    /// Invoke every possible descriptor setter with the assigned value.
+    ///
+    /// `domain` is the precisely derived write type when that domain fits in [`Type`]. It is used
+    /// for contextual inference and protocol compatibility, while descriptor calls remain the
+    /// authority for real assignments. `None` preserves a known write capability whose generic or
+    /// set-theoretic domain cannot be represented precisely.
+    Descriptor {
+        descriptor_ty: Type<'db>,
+        domain: Option<Type<'db>>,
     },
 }
 
@@ -243,8 +258,8 @@ pub(super) fn attribute_write_requirement<'db>(
             .instance_write_requirement(db, object_ty, attribute)
             .map_or_else(
                 || instance_attribute_write_requirement(db, object_ty, attribute),
-                |(write_ty, qualifiers)| AttributeWriteRequirement::ProtocolMember {
-                    write_ty,
+                |(write, qualifiers)| AttributeWriteRequirement::ProtocolMember {
+                    write,
                     qualifiers,
                 },
             ),
@@ -277,7 +292,7 @@ pub(super) fn attribute_write_requirement<'db>(
             .map_or_else(
                 || class_attribute_write_requirement(db, object_ty, attribute),
                 |(write_ty, qualifiers)| AttributeWriteRequirement::ProtocolMember {
-                    write_ty,
+                    write: write_ty.map(ProtocolMemberWriteRequirement::AssignableTo),
                     qualifiers,
                 },
             ),

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -74,6 +74,7 @@ pub(super) enum ProtocolMemberWriteRequirement<'db> {
     /// set-theoretic domain cannot be represented precisely.
     Descriptor {
         descriptor_ty: Type<'db>,
+        receiver_ty: Type<'db>,
         domain: Option<Type<'db>>,
     },
 }

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -7,9 +7,10 @@ use crate::{
     place::Place,
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassType, FindLegacyTypeVarsVisitor,
-        FunctionType, InternedType, KnownBoundMethodType, KnownClass, KnownInstanceType,
-        LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters, Signature,
-        SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints, UnionType,
+        FunctionType, InternedType, IntersectionType, KnownBoundMethodType, KnownClass,
+        KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters,
+        Signature, SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
+        UnionType,
         constraints::{ConstraintSet, IteratorConstraintsExtension},
         known_instance::FunctoolsPartialInstance,
         relation::{TypeRelation, TypeRelationChecker},
@@ -703,6 +704,38 @@ impl<'db> CallableTypes<'db> {
         }
     }
 
+    /// Return the values accepted by a positional parameter for the given preceding arguments.
+    ///
+    /// Overloads of one callable expand the accepted domain, while alternatives in a callable
+    /// union restrict it to values accepted by every possible runtime callable. Signatures with
+    /// correlated or nested function type variables are skipped conservatively.
+    pub(crate) fn positional_parameter_domain(
+        &self,
+        db: &'db dyn Db,
+        prefix_arguments: &[Type<'db>],
+        self_ty: Type<'db>,
+    ) -> Option<Type<'db>> {
+        let domains = self
+            .iter()
+            .map(|callable| {
+                let domain = UnionType::from_elements(
+                    db,
+                    callable.signatures(db).iter().filter_map(|signature| {
+                        signature_positional_parameter_domain(
+                            db,
+                            signature,
+                            prefix_arguments,
+                            self_ty,
+                        )
+                    }),
+                );
+                (!domain.is_never()).then_some(domain)
+            })
+            .collect::<Option<Vec<_>>>()?;
+        let domain = IntersectionType::bounded_from_elements(db, domains)?;
+        (!domain.is_never()).then_some(domain)
+    }
+
     pub(super) fn as_slice(&self) -> &[CallableType<'db>] {
         &self.0
     }
@@ -753,6 +786,58 @@ impl<'db> CallableTypes<'db> {
         )
         .into_precise_functools_partial_instance(db, wrapped)
     }
+}
+
+/// Return the values accepted by one signature after validating the preceding arguments.
+fn signature_positional_parameter_domain<'db>(
+    db: &'db dyn Db,
+    signature: &Signature<'db>,
+    prefix_arguments: &[Type<'db>],
+    self_ty: Type<'db>,
+) -> Option<Type<'db>> {
+    let parameters = signature.parameters();
+    if parameters.len() != prefix_arguments.len() + 1 {
+        return None;
+    }
+
+    for (index, argument) in prefix_arguments.iter().enumerate() {
+        let parameter_ty = parameters
+            .get_positional(index)?
+            .annotated_type()
+            .bind_self_typevars(db, self_ty);
+        if parameter_ty.has_typevar(db) || !argument.is_assignable_to(db, parameter_ty) {
+            return None;
+        }
+    }
+
+    let domain = parameters
+        .get_positional(prefix_arguments.len())?
+        .annotated_type()
+        .bind_self_typevars(db, self_ty);
+    if !domain.has_typevar(db) {
+        return Some(domain);
+    }
+
+    let Type::TypeVar(typevar) = domain else {
+        return None;
+    };
+    let generic_context = signature.generic_context?;
+    if !generic_context.contains(db, typevar.identity(db))
+        || !typevar
+            .binding_context(db)
+            .definition()
+            .is_some_and(|definition| definition.kind(db).is_function_def())
+    {
+        return None;
+    }
+
+    Some(
+        typevar
+            .typevar(db)
+            .bound_or_constraints(db)
+            .map_or(Type::object(), |bound| bound.as_type(db))
+            .bind_self_typevars(db, self_ty),
+    )
 }
 
 impl<'a, 'db> IntoIterator for &'a CallableTypes<'db> {

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -7,10 +7,9 @@ use crate::{
     place::Place,
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassType, FindLegacyTypeVarsVisitor,
-        FunctionType, InternedType, IntersectionType, KnownBoundMethodType, KnownClass,
-        KnownInstanceType, LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters,
-        Signature, SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
-        UnionType,
+        FunctionType, InternedType, KnownBoundMethodType, KnownClass, KnownInstanceType,
+        LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters, Signature,
+        SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints, UnionType,
         constraints::{ConstraintSet, IteratorConstraintsExtension},
         known_instance::FunctoolsPartialInstance,
         relation::{TypeRelation, TypeRelationChecker},
@@ -704,38 +703,6 @@ impl<'db> CallableTypes<'db> {
         }
     }
 
-    /// Return the values accepted by a positional parameter for the given preceding arguments.
-    ///
-    /// Overloads of one callable expand the accepted domain, while alternatives in a callable
-    /// union restrict it to values accepted by every possible runtime callable. Signatures with
-    /// correlated or nested function type variables are skipped conservatively.
-    pub(crate) fn positional_parameter_domain(
-        &self,
-        db: &'db dyn Db,
-        prefix_arguments: &[Type<'db>],
-        self_ty: Type<'db>,
-    ) -> Option<Type<'db>> {
-        let domains = self
-            .iter()
-            .map(|callable| {
-                let domain = UnionType::from_elements(
-                    db,
-                    callable.signatures(db).iter().filter_map(|signature| {
-                        signature_positional_parameter_domain(
-                            db,
-                            signature,
-                            prefix_arguments,
-                            self_ty,
-                        )
-                    }),
-                );
-                (!domain.is_never()).then_some(domain)
-            })
-            .collect::<Option<Vec<_>>>()?;
-        let domain = IntersectionType::bounded_from_elements(db, domains)?;
-        (!domain.is_never()).then_some(domain)
-    }
-
     pub(super) fn as_slice(&self) -> &[CallableType<'db>] {
         &self.0
     }
@@ -786,64 +753,6 @@ impl<'db> CallableTypes<'db> {
         )
         .into_precise_functools_partial_instance(db, wrapped)
     }
-}
-
-/// Return the values accepted by one signature after validating the preceding arguments.
-fn signature_positional_parameter_domain<'db>(
-    db: &'db dyn Db,
-    signature: &Signature<'db>,
-    prefix_arguments: &[Type<'db>],
-    self_ty: Type<'db>,
-) -> Option<Type<'db>> {
-    let parameters = signature.parameters();
-    let domain_index = prefix_arguments.len();
-    let trailing_parameters = parameters.as_slice().get(domain_index + 1..)?;
-    if !trailing_parameters.iter().all(|parameter| {
-        parameter.default_type().is_some()
-            || (parameters.is_standard()
-                && (parameter.is_variadic() || parameter.is_keyword_variadic()))
-    }) {
-        return None;
-    }
-
-    for (index, argument) in prefix_arguments.iter().enumerate() {
-        let parameter_ty = parameters
-            .get_positional(index)?
-            .annotated_type()
-            .bind_self_typevars(db, self_ty);
-        if parameter_ty.has_typevar(db) || !argument.is_assignable_to(db, parameter_ty) {
-            return None;
-        }
-    }
-
-    let domain = parameters
-        .get_positional(domain_index)?
-        .annotated_type()
-        .bind_self_typevars(db, self_ty);
-    if !domain.has_typevar(db) {
-        return Some(domain);
-    }
-
-    let Type::TypeVar(typevar) = domain else {
-        return None;
-    };
-    let generic_context = signature.generic_context?;
-    if !generic_context.contains(db, typevar.identity(db))
-        || !typevar
-            .binding_context(db)
-            .definition()
-            .is_some_and(|definition| definition.kind(db).is_function_def())
-    {
-        return None;
-    }
-
-    Some(
-        typevar
-            .typevar(db)
-            .bound_or_constraints(db)
-            .map_or(Type::object(), |bound| bound.as_type(db))
-            .bind_self_typevars(db, self_ty),
-    )
 }
 
 impl<'a, 'db> IntoIterator for &'a CallableTypes<'db> {

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -796,7 +796,13 @@ fn signature_positional_parameter_domain<'db>(
     self_ty: Type<'db>,
 ) -> Option<Type<'db>> {
     let parameters = signature.parameters();
-    if parameters.len() != prefix_arguments.len() + 1 {
+    let domain_index = prefix_arguments.len();
+    let trailing_parameters = parameters.as_slice().get(domain_index + 1..)?;
+    if !trailing_parameters.iter().all(|parameter| {
+        parameter.default_type().is_some()
+            || (parameters.is_standard()
+                && (parameter.is_variadic() || parameter.is_keyword_variadic()))
+    }) {
         return None;
     }
 
@@ -811,7 +817,7 @@ fn signature_positional_parameter_domain<'db>(
     }
 
     let domain = parameters
-        .get_positional(prefix_arguments.len())?
+        .get_positional(domain_index)?
         .annotated_type()
         .bind_self_typevars(db, self_ty);
     if !domain.has_typevar(db) {

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -193,6 +193,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 }
                 Some(ProtocolMemberWriteRequirement::Descriptor {
                     descriptor_ty,
+                    receiver_ty,
                     domain,
                 }) => {
                     let value_ty = self.infer_value(
@@ -201,6 +202,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     );
                     self.evaluate_protocol_descriptor_write(
                         *descriptor_ty,
+                        *receiver_ty,
                         value_ty,
                         emit_diagnostics,
                     )
@@ -449,6 +451,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
     fn evaluate_protocol_descriptor_write(
         &mut self,
         descriptor_ty: Type<'db>,
+        receiver_ty: Type<'db>,
         value_ty: Type<'db>,
         emit_diagnostics: bool,
     ) -> bool {
@@ -456,9 +459,19 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         let descriptor_ty = descriptor_ty.resolve_type_alias(db);
         if let Type::Union(union) = descriptor_ty {
             for descriptor_ty in union.elements(db) {
-                if !self.evaluate_protocol_descriptor_write(*descriptor_ty, value_ty, false) {
+                if !self.evaluate_protocol_descriptor_write(
+                    *descriptor_ty,
+                    receiver_ty,
+                    value_ty,
+                    false,
+                ) {
                     if emit_diagnostics {
-                        self.evaluate_protocol_descriptor_write(*descriptor_ty, value_ty, true);
+                        self.evaluate_protocol_descriptor_write(
+                            *descriptor_ty,
+                            receiver_ty,
+                            value_ty,
+                            true,
+                        );
                     }
                     return false;
                 }
@@ -483,7 +496,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         self.evaluate_descriptor_write(
             descriptor_ty,
             setter_ty,
-            self.object_ty,
+            receiver_ty,
             value_ty,
             emit_diagnostics,
         )

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -2,11 +2,11 @@ use ruff_python_ast as ast;
 use ruff_text_size::Ranged;
 
 use super::{MultiInferenceGuard, TypeInferenceBuilder};
-use crate::place::{DefinedPlace, Place, PlaceAndQualifiers};
+use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers};
 use crate::types::attribute_write::{
     AttributeWriteRequirement, ClassAttributeWriteMember, ExplicitAttributeWriteRequirement,
-    FallbackAttributeWriteRequirement, InstanceAttributeWriteMember, attribute_write_requirement,
-    property_setter_returns_never,
+    FallbackAttributeWriteRequirement, InstanceAttributeWriteMember,
+    ProtocolMemberWriteRequirement, attribute_write_requirement, property_setter_returns_never,
 };
 use crate::types::call::{CallArguments, CallError};
 use crate::types::diagnostic::{
@@ -185,15 +185,27 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     false
                 }
             }
-            AttributeWriteRequirement::ProtocolMember {
-                write_ty,
-                qualifiers,
-            } => {
-                if let Some(write_ty) = write_ty {
+            AttributeWriteRequirement::ProtocolMember { write, qualifiers } => match write {
+                Some(ProtocolMemberWriteRequirement::AssignableTo(write_ty)) => {
                     let value_ty =
                         self.infer_value(TypeContext::new(Some(*write_ty)), emit_diagnostics);
                     self.check_type_pair(value_ty, *write_ty, emit_diagnostics)
-                } else {
+                }
+                Some(ProtocolMemberWriteRequirement::Descriptor {
+                    descriptor_ty,
+                    domain,
+                }) => {
+                    let value_ty = self.infer_value(
+                        TypeContext::new(Some(domain.unwrap_or_else(Type::unknown))),
+                        emit_diagnostics,
+                    );
+                    self.evaluate_protocol_descriptor_write(
+                        *descriptor_ty,
+                        value_ty,
+                        emit_diagnostics,
+                    )
+                }
+                None => {
                     self.infer_value(TypeContext::default(), emit_diagnostics);
                     let reported_final = !qualifiers.contains(TypeQualifiers::CLASS_VAR)
                         && qualifiers.contains(TypeQualifiers::FINAL)
@@ -211,7 +223,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     }
                     false
                 }
-            }
+            },
             AttributeWriteRequirement::Instance { object_ty, member } => {
                 self.evaluate_instance(*object_ty, member, emit_diagnostics)
             }
@@ -420,34 +432,89 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 descriptor_ty,
                 setter_ty,
                 ..
-            } => {
-                let db = self.builder.db();
-                let result = setter_ty.try_call(
-                    db,
-                    &CallArguments::positional([*descriptor_ty, object_ty, value_ty]),
-                );
-                if property_setter_returns_never(db, *descriptor_ty, object_ty, value_ty) {
-                    if emit_diagnostics {
-                        self.report(AssignmentAttributeWriteDiagnostic::TerminalDescriptor);
-                    }
-                    false
-                } else {
-                    match result {
-                        Ok(_) => true,
-                        Err(error) => {
-                            if emit_diagnostics {
-                                self.report(AssignmentAttributeWriteDiagnostic::BadDunderSet(
-                                    error,
-                                ));
-                            }
-                            false
-                        }
-                    }
-                }
-            }
+            } => self.evaluate_descriptor_write(
+                *descriptor_ty,
+                *setter_ty,
+                object_ty,
+                value_ty,
+                emit_diagnostics,
+            ),
             ExplicitAttributeWriteRequirement::AssignableTo { ty, .. } => {
                 let value_ty = self.infer_value(TypeContext::new(Some(*ty)), false);
                 self.check_type_pair(value_ty, *ty, emit_diagnostics)
+            }
+        }
+    }
+
+    fn evaluate_protocol_descriptor_write(
+        &mut self,
+        descriptor_ty: Type<'db>,
+        value_ty: Type<'db>,
+        emit_diagnostics: bool,
+    ) -> bool {
+        let db = self.builder.db();
+        let descriptor_ty = descriptor_ty.resolve_type_alias(db);
+        if let Type::Union(union) = descriptor_ty {
+            for descriptor_ty in union.elements(db) {
+                if !self.evaluate_protocol_descriptor_write(*descriptor_ty, value_ty, false) {
+                    if emit_diagnostics {
+                        self.evaluate_protocol_descriptor_write(*descriptor_ty, value_ty, true);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        let Place::Defined(DefinedPlace {
+            ty: setter_ty,
+            definedness: Definedness::AlwaysDefined,
+            ..
+        }) = descriptor_ty
+            .class_member_with_policy(db, "__set__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
+            .place
+        else {
+            if emit_diagnostics {
+                self.report(AssignmentAttributeWriteDiagnostic::CannotAssign);
+            }
+            return false;
+        };
+
+        self.evaluate_descriptor_write(
+            descriptor_ty,
+            setter_ty,
+            self.object_ty,
+            value_ty,
+            emit_diagnostics,
+        )
+    }
+
+    fn evaluate_descriptor_write(
+        &mut self,
+        descriptor_ty: Type<'db>,
+        setter_ty: Type<'db>,
+        object_ty: Type<'db>,
+        value_ty: Type<'db>,
+        emit_diagnostics: bool,
+    ) -> bool {
+        let db = self.builder.db();
+        if property_setter_returns_never(db, descriptor_ty, object_ty, value_ty) {
+            if emit_diagnostics {
+                self.report(AssignmentAttributeWriteDiagnostic::TerminalDescriptor);
+            }
+            return false;
+        }
+
+        match setter_ty.try_call(
+            db,
+            &CallArguments::positional([descriptor_ty, object_ty, value_ty]),
+        ) {
+            Ok(_) => true,
+            Err(error) => {
+                if emit_diagnostics {
+                    self.report(AssignmentAttributeWriteDiagnostic::BadDunderSet(error));
+                }
+                false
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -2,7 +2,7 @@ use ruff_python_ast as ast;
 use ruff_text_size::Ranged;
 
 use super::{MultiInferenceGuard, TypeInferenceBuilder};
-use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers};
+use crate::place::{DefinedPlace, Place, PlaceAndQualifiers};
 use crate::types::attribute_write::{
     AttributeWriteRequirement, ClassAttributeWriteMember, ExplicitAttributeWriteRequirement,
     FallbackAttributeWriteRequirement, InstanceAttributeWriteMember,
@@ -479,27 +479,36 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             return true;
         }
 
-        let Place::Defined(DefinedPlace {
-            ty: setter_ty,
-            definedness: Definedness::AlwaysDefined,
-            ..
-        }) = descriptor_ty
-            .class_member_with_policy(db, "__set__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
-            .place
-        else {
+        if property_setter_returns_never(db, descriptor_ty, receiver_ty, value_ty) {
             if emit_diagnostics {
-                self.report(AssignmentAttributeWriteDiagnostic::CannotAssign);
+                self.report(AssignmentAttributeWriteDiagnostic::TerminalDescriptor);
             }
             return false;
-        };
+        }
 
-        self.evaluate_descriptor_write(
-            descriptor_ty,
-            setter_ty,
-            receiver_ty,
-            value_ty,
-            emit_diagnostics,
-        )
+        match descriptor_ty.try_call_dunder_with_policy(
+            db,
+            "__set__",
+            &mut CallArguments::positional([receiver_ty, value_ty]),
+            TypeContext::default(),
+            MemberLookupPolicy::REQUIRE_CONCRETE,
+        ) {
+            Ok(_) => true,
+            Err(CallDunderError::CallError(kind, bindings, _)) => {
+                if emit_diagnostics {
+                    self.report(AssignmentAttributeWriteDiagnostic::BadDunderSet(CallError(
+                        kind, bindings,
+                    )));
+                }
+                false
+            }
+            Err(CallDunderError::MethodNotAvailable | CallDunderError::PossiblyUnbound { .. }) => {
+                if emit_diagnostics {
+                    self.report(AssignmentAttributeWriteDiagnostic::CannotAssign);
+                }
+                false
+            }
+        }
     }
 
     fn evaluate_descriptor_write(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -24,9 +24,9 @@ use crate::{
         ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
         CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor,
         InstanceFallbackShadowsNonDataDescriptor, IntersectionType, KnownFunction,
-        MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SelfBinding, Signature,
-        StaticClassLiteral, Type, TypeMapping, TypeQualifiers, TypeVarBoundOrConstraints,
-        TypeVarVariance, UnionType, VarianceInferable,
+        MemberLookupPolicy, Parameter, PropertyInstanceType, ProtocolInstanceType, SelfBinding,
+        Signature, StaticClassLiteral, Type, TypeMapping, TypeQualifiers,
+        TypeVarBoundOrConstraints, TypeVarVariance, UnionType, VarianceInferable,
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
         diagnostic::report_undeclared_protocol_member,
@@ -1646,7 +1646,7 @@ fn descriptor_setter_signature_domain<'db>(
 ) -> DescriptorSetterSignatureDomain<'db> {
     let parameters = signature.parameters();
     let missing_required_parameter = || {
-        if parameters.is_gradual() {
+        if parameters.is_gradual() || parameters.as_slice().iter().any(Parameter::is_variadic) {
             DescriptorSetterSignatureDomain::Deferred
         } else {
             DescriptorSetterSignatureDomain::Inapplicable

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1598,7 +1598,11 @@ fn single_descriptor_setter_domain<'db>(
         definedness: Definedness::AlwaysDefined,
         ..
     }) = descriptor_ty
-        .class_member_with_policy(db, "__set__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
+        .member_lookup_with_policy(
+            db,
+            "__set__".into(),
+            MemberLookupPolicy::REQUIRE_CONCRETE | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+        )
         .place
     else {
         return DescriptorSetterDomain::Missing;
@@ -1641,12 +1645,15 @@ fn descriptor_setter_signature_domain<'db>(
     receiver_ty: Type<'db>,
 ) -> DescriptorSetterSignatureDomain<'db> {
     let parameters = signature.parameters();
-    let Some(trailing_parameters) = parameters.as_slice().get(3..) else {
-        return if parameters.is_gradual() {
+    let missing_required_parameter = || {
+        if parameters.is_gradual() {
             DescriptorSetterSignatureDomain::Deferred
         } else {
             DescriptorSetterSignatureDomain::Inapplicable
-        };
+        }
+    };
+    let Some(trailing_parameters) = parameters.as_slice().get(2..) else {
+        return missing_required_parameter();
     };
     if !trailing_parameters.iter().all(|parameter| {
         parameter.default_type().is_some()
@@ -1656,31 +1663,21 @@ fn descriptor_setter_signature_domain<'db>(
         return DescriptorSetterSignatureDomain::Inapplicable;
     }
 
-    let Some(descriptor_parameter) = parameters.get_positional(0) else {
-        return DescriptorSetterSignatureDomain::Inapplicable;
-    };
-    let descriptor_parameter = descriptor_parameter
-        .annotated_type()
-        .bind_self_typevars(db, descriptor_ty);
-    let Some(receiver_parameter) = parameters.get_positional(1) else {
-        return DescriptorSetterSignatureDomain::Inapplicable;
+    let Some(receiver_parameter) = parameters.get_positional(0) else {
+        return missing_required_parameter();
     };
     let receiver_parameter = receiver_parameter
         .annotated_type()
         .bind_self_typevars(db, descriptor_ty);
-    if contains_signature_typevar(db, signature, descriptor_parameter)
-        || contains_signature_typevar(db, signature, receiver_parameter)
-    {
+    if contains_signature_typevar(db, signature, receiver_parameter) {
         return DescriptorSetterSignatureDomain::Deferred;
     }
-    if !descriptor_ty.is_assignable_to(db, descriptor_parameter)
-        || !receiver_ty.is_assignable_to(db, receiver_parameter)
-    {
+    if !receiver_ty.is_assignable_to(db, receiver_parameter) {
         return DescriptorSetterSignatureDomain::Inapplicable;
     }
 
-    let Some(write_parameter) = parameters.get_positional(2) else {
-        return DescriptorSetterSignatureDomain::Inapplicable;
+    let Some(write_parameter) = parameters.get_positional(1) else {
+        return missing_required_parameter();
     };
     let write_ty = write_parameter
         .annotated_type()

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1365,7 +1365,7 @@ fn descriptor_setter_write_type<'db>(
     descriptor_ty: Type<'db>,
     receiver_ty: Type<'db>,
 ) -> Option<Type<'db>> {
-    let write_ty = match descriptor_ty {
+    match descriptor_ty {
         Type::Union(union) => {
             let write_types = union
                 .elements(db)
@@ -1374,11 +1374,10 @@ fn descriptor_setter_write_type<'db>(
                     descriptor_setter_write_type_for_alternative(db, *descriptor_ty, receiver_ty)
                 })
                 .collect::<Option<Vec<_>>>()?;
-            IntersectionType::bounded_from_elements(db, write_types)?
+            IntersectionType::bounded_from_elements(db, write_types)
         }
-        _ => descriptor_setter_write_type_for_alternative(db, descriptor_ty, receiver_ty)?,
-    };
-    (!write_ty.is_never()).then_some(write_ty)
+        _ => descriptor_setter_write_type_for_alternative(db, descriptor_ty, receiver_ty),
+    }
 }
 
 /// Derive the values accepted by one possible runtime descriptor.
@@ -1402,22 +1401,22 @@ fn descriptor_setter_write_type_for_alternative<'db>(
     let write_types = callables
         .iter()
         .map(|callable| {
-            let write_ty = UnionType::from_elements(
-                db,
-                callable.signatures(db).iter().filter_map(|signature| {
+            let write_types = callable
+                .signatures(db)
+                .iter()
+                .filter_map(|signature| {
                     descriptor_setter_signature_write_type(
                         db,
                         signature,
                         descriptor_ty,
                         receiver_ty,
                     )
-                }),
-            );
-            (!write_ty.is_never()).then_some(write_ty)
+                })
+                .collect::<Vec<_>>();
+            (!write_types.is_empty()).then(|| UnionType::from_elements(db, write_types))
         })
         .collect::<Option<Vec<_>>>()?;
-    let write_ty = IntersectionType::bounded_from_elements(db, write_types)?;
-    (!write_ty.is_never()).then_some(write_ty)
+    IntersectionType::bounded_from_elements(db, write_types)
 }
 
 /// Derive the values accepted by one applicable `__set__` overload.

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -23,7 +23,7 @@ use crate::{
         ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
         CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor,
         InstanceFallbackShadowsNonDataDescriptor, IntersectionType, KnownFunction,
-        MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SelfBinding,
+        MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SelfBinding, Signature,
         StaticClassLiteral, Type, TypeMapping, TypeQualifiers, TypeVarVariance, UnionType,
         VarianceInferable,
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
@@ -1399,7 +1399,88 @@ fn descriptor_setter_write_type_for_alternative<'db>(
     };
 
     let callables = setter_ty.try_upcast_to_callable(db)?;
-    callables.positional_parameter_domain(db, &[descriptor_ty, receiver_ty], descriptor_ty)
+    let write_types = callables
+        .iter()
+        .map(|callable| {
+            let write_ty = UnionType::from_elements(
+                db,
+                callable.signatures(db).iter().filter_map(|signature| {
+                    descriptor_setter_signature_write_type(
+                        db,
+                        signature,
+                        descriptor_ty,
+                        receiver_ty,
+                    )
+                }),
+            );
+            (!write_ty.is_never()).then_some(write_ty)
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let write_ty = IntersectionType::bounded_from_elements(db, write_types)?;
+    (!write_ty.is_never()).then_some(write_ty)
+}
+
+/// Derive the values accepted by one applicable `__set__` overload.
+fn descriptor_setter_signature_write_type<'db>(
+    db: &'db dyn Db,
+    signature: &Signature<'db>,
+    descriptor_ty: Type<'db>,
+    receiver_ty: Type<'db>,
+) -> Option<Type<'db>> {
+    let parameters = signature.parameters();
+    let trailing_parameters = parameters.as_slice().get(3..)?;
+    if !trailing_parameters.iter().all(|parameter| {
+        parameter.default_type().is_some()
+            || (parameters.is_standard()
+                && (parameter.is_variadic() || parameter.is_keyword_variadic()))
+    }) {
+        return None;
+    }
+
+    let descriptor_parameter = parameters
+        .get_positional(0)?
+        .annotated_type()
+        .bind_self_typevars(db, descriptor_ty);
+    let receiver_parameter = parameters
+        .get_positional(1)?
+        .annotated_type()
+        .bind_self_typevars(db, descriptor_ty);
+    if descriptor_parameter.has_typevar(db)
+        || receiver_parameter.has_typevar(db)
+        || !descriptor_ty.is_assignable_to(db, descriptor_parameter)
+        || !receiver_ty.is_assignable_to(db, receiver_parameter)
+    {
+        return None;
+    }
+
+    let write_ty = parameters
+        .get_positional(2)?
+        .annotated_type()
+        .bind_self_typevars(db, descriptor_ty);
+    if !write_ty.has_typevar(db) {
+        return Some(write_ty);
+    }
+
+    let Type::TypeVar(typevar) = write_ty else {
+        return None;
+    };
+    let generic_context = signature.generic_context?;
+    if !generic_context.contains(db, typevar.identity(db))
+        || !typevar
+            .binding_context(db)
+            .definition()
+            .is_some_and(|definition| definition.kind(db).is_function_def())
+    {
+        return None;
+    }
+
+    Some(
+        typevar
+            .typevar(db)
+            .bound_or_constraints(db)
+            .map_or(Type::object(), |bound| bound.as_type(db))
+            .bind_self_typevars(db, descriptor_ty),
+    )
 }
 
 fn property_set_type<'db>(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -24,8 +24,8 @@ use crate::{
         CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor,
         InstanceFallbackShadowsNonDataDescriptor, IntersectionType, KnownFunction,
         MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SelfBinding, Signature,
-        StaticClassLiteral, Type, TypeMapping, TypeQualifiers, TypeVarVariance, UnionType,
-        VarianceInferable,
+        StaticClassLiteral, Type, TypeMapping, TypeQualifiers, TypeVarBoundOrConstraints,
+        TypeVarVariance, UnionType, VarianceInferable,
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
         diagnostic::report_undeclared_protocol_member,
@@ -1475,11 +1475,12 @@ fn descriptor_setter_signature_write_type<'db>(
     }
 
     Some(
-        typevar
-            .typevar(db)
-            .bound_or_constraints(db)
-            .map_or(Type::object(), |bound| bound.as_type(db))
-            .bind_self_typevars(db, descriptor_ty),
+        match typevar.typevar(db).bound_or_constraints(db) {
+            None => Type::object(),
+            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound,
+            Some(TypeVarBoundOrConstraints::Constraints(_)) => return None,
+        }
+        .bind_self_typevars(db, descriptor_ty),
     )
 }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -8,7 +8,8 @@ use rustc_hash::FxHashMap;
 
 use crate::types::attribute_write::{
     AttributeWriteRequirement, ClassAttributeWriteMember, ExplicitAttributeWriteRequirement,
-    FallbackAttributeWriteRequirement, InstanceAttributeWriteMember, attribute_write_requirement,
+    FallbackAttributeWriteRequirement, InstanceAttributeWriteMember,
+    ProtocolMemberWriteRequirement, attribute_write_requirement,
 };
 use crate::types::call::{CallArguments, CallDunderError};
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
@@ -243,7 +244,14 @@ pub(super) fn walk_protocol_instance_interface<
                 }
             }
             ProtocolMemberKind::Property { read, write } => {
-                for member_type in [read, write].into_iter().flatten() {
+                for member_type in [
+                    read,
+                    write.and_then(ProtocolMemberWrite::domain),
+                    write.and_then(ProtocolMemberWrite::descriptor_type),
+                ]
+                .into_iter()
+                .flatten()
+                {
                     if let Some(ty) = member_type.bind_self(db, receiver_ty) {
                         visitor.visit_type(db, ty);
                     }
@@ -353,21 +361,21 @@ impl<'db> ProtocolInterface<'db> {
     /// Returns the declared instance-write requirement for a protocol member.
     ///
     /// `None` means that the protocol does not declare `name`; `Some((None, _))` means that the
-    /// member exists but is read-only. A writable member's type is bound to `receiver_ty` before
-    /// it is returned.
+    /// member exists but is read-only. A writable member's requirement is bound to `receiver_ty`
+    /// before it is returned.
     pub(super) fn instance_write_requirement(
         self,
         db: &'db dyn Db,
         receiver_ty: Type<'db>,
         name: &str,
-    ) -> Option<(Option<Type<'db>>, TypeQualifiers)> {
+    ) -> Option<(Option<ProtocolMemberWriteRequirement<'db>>, TypeQualifiers)> {
         self.member_by_name(db, name).map(|member| {
             let capabilities = member.capabilities(db);
             (
                 capabilities
                     .instance
                     .write
-                    .and_then(|write| write.bind_self(db, receiver_ty)),
+                    .and_then(|write| write.bind_requirement(db, receiver_ty)),
                 member.qualifiers(),
             )
         })
@@ -388,7 +396,7 @@ impl<'db> ProtocolInterface<'db> {
                 member
                     .meta_access(db)?
                     .write
-                    .and_then(|write| write.bind_self(db, receiver_ty)),
+                    .and_then(|write| write.bind_compatibility_type(db, receiver_ty)),
                 member.qualifiers(),
             ))
         })
@@ -532,6 +540,165 @@ impl<'db> ProtocolInterface<'db> {
         ProtocolInterfaceDisplay {
             db,
             interface: self,
+        }
+    }
+}
+
+/// A protocol member's write capability.
+///
+/// Descriptor setters retain their call contract even when their accepted values cannot be
+/// represented by a single [`Type`]. This keeps an unrepresentable domain distinct from an absent
+/// setter and lets real assignments use normal call binding.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+enum ProtocolMemberWrite<'db> {
+    Type(ProtocolMemberType<'db>),
+    Descriptor {
+        descriptor: ProtocolMemberType<'db>,
+        domain: Option<ProtocolMemberType<'db>>,
+    },
+}
+
+impl<'db> ProtocolMemberWrite<'db> {
+    const fn from_type(member: ProtocolMemberType<'db>) -> Self {
+        Self::Type(member)
+    }
+
+    fn descriptor(
+        descriptor_ty: Type<'db>,
+        domain: Option<Type<'db>>,
+        definition: Option<Definition<'db>>,
+    ) -> Self {
+        Self::Descriptor {
+            descriptor: ProtocolMemberType::with_definition(descriptor_ty, definition),
+            domain: domain.map(|ty| ProtocolMemberType::with_definition(ty, definition)),
+        }
+    }
+
+    const fn domain(self) -> Option<ProtocolMemberType<'db>> {
+        match self {
+            Self::Type(member) => Some(member),
+            Self::Descriptor { domain, .. } => domain,
+        }
+    }
+
+    const fn descriptor_type(self) -> Option<ProtocolMemberType<'db>> {
+        match self {
+            Self::Type(_) => None,
+            Self::Descriptor { descriptor, .. } => Some(descriptor),
+        }
+    }
+
+    fn display_type(self, db: &'db dyn Db) -> Option<ProtocolMemberType<'db>> {
+        match self {
+            Self::Type(member) => member.resolve(db),
+            Self::Descriptor {
+                domain: Some(domain),
+                ..
+            } => domain.resolve(db),
+            Self::Descriptor { domain: None, .. } => Some(ProtocolMemberType::new(Type::unknown())),
+        }
+    }
+
+    fn bind_requirement(
+        self,
+        db: &'db dyn Db,
+        self_type: Type<'db>,
+    ) -> Option<ProtocolMemberWriteRequirement<'db>> {
+        match self {
+            Self::Type(member) => Some(ProtocolMemberWriteRequirement::AssignableTo(
+                member.bind_self(db, self_type)?,
+            )),
+            Self::Descriptor { descriptor, domain } => {
+                Some(ProtocolMemberWriteRequirement::Descriptor {
+                    descriptor_ty: descriptor.bind_self(db, self_type)?,
+                    domain: domain.and_then(|domain| domain.bind_self(db, self_type)),
+                })
+            }
+        }
+    }
+
+    fn bind_compatibility_type(self, db: &'db dyn Db, self_type: Type<'db>) -> Option<Type<'db>> {
+        match self {
+            Self::Type(member) => member.bind_self(db, self_type),
+            Self::Descriptor { domain, .. } => Some(
+                domain
+                    .and_then(|domain| domain.bind_self(db, self_type))
+                    .unwrap_or_else(Type::unknown),
+            ),
+        }
+    }
+
+    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
+        match (self, previous) {
+            (Self::Type(current), Self::Type(previous)) => {
+                Self::Type(current.cycle_normalized(db, previous, cycle))
+            }
+            (
+                Self::Descriptor {
+                    descriptor: current_descriptor,
+                    domain: current_domain,
+                },
+                Self::Descriptor {
+                    descriptor: previous_descriptor,
+                    domain: previous_domain,
+                },
+            ) => Self::Descriptor {
+                descriptor: current_descriptor.cycle_normalized(db, previous_descriptor, cycle),
+                domain: cycle_normalized_optional_type(db, current_domain, previous_domain, cycle),
+            },
+            (current, _) => current,
+        }
+    }
+
+    fn cycle_normalized_without_previous(self, db: &'db dyn Db, cycle: &salsa::Cycle) -> Self {
+        let normalize = |member: ProtocolMemberType<'db>| {
+            member.with_ty(member.ty().recursive_type_normalized(db, cycle))
+        };
+        match self {
+            Self::Type(member) => Self::Type(normalize(member)),
+            Self::Descriptor { descriptor, domain } => Self::Descriptor {
+                descriptor: normalize(descriptor),
+                domain: domain.map(normalize),
+            },
+        }
+    }
+
+    fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        Some(match self {
+            Self::Type(member) => {
+                Self::Type(member.recursive_type_normalized_impl(db, div, nested)?)
+            }
+            Self::Descriptor { descriptor, domain } => Self::Descriptor {
+                descriptor: descriptor.recursive_type_normalized_impl(db, div, nested)?,
+                domain: match domain {
+                    Some(domain) => Some(domain.recursive_type_normalized_impl(db, div, nested)?),
+                    None => None,
+                },
+            },
+        })
+    }
+
+    fn apply_type_mapping_impl<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'a, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        match self {
+            Self::Type(member) => {
+                Self::Type(member.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+            }
+            Self::Descriptor { descriptor, domain } => Self::Descriptor {
+                descriptor: descriptor.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                domain: domain
+                    .map(|domain| domain.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
+            },
         }
     }
 }
@@ -685,7 +852,7 @@ impl<'db> ProtocolMemberType<'db> {
 /// an instance cannot write a `ClassVar`, while a normal instance attribute has no class access.
 struct ProtocolMemberAccess<'db> {
     read: Option<ProtocolMemberType<'db>>,
-    write: Option<ProtocolMemberType<'db>>,
+    write: Option<ProtocolMemberWrite<'db>>,
 }
 
 impl<'db> ProtocolMemberAccess<'db> {
@@ -696,7 +863,7 @@ impl<'db> ProtocolMemberAccess<'db> {
 
     const fn new(
         read: Option<ProtocolMemberType<'db>>,
-        write: Option<ProtocolMemberType<'db>>,
+        write: Option<ProtocolMemberWrite<'db>>,
     ) -> Self {
         Self { read, write }
     }
@@ -708,6 +875,7 @@ impl<'db> ProtocolMemberAccess<'db> {
             .into_iter()
             .chain(
                 self.write
+                    .and_then(ProtocolMemberWrite::domain)
                     .and_then(|member| member.resolve(db))
                     .map(|member| (member.ty(), TypeVarVariance::Contravariant)),
             )
@@ -782,7 +950,7 @@ impl<'db> ProtocolMemberData<'db> {
 
     fn property(
         read: Option<ProtocolMemberType<'db>>,
-        write: Option<ProtocolMemberType<'db>>,
+        write: Option<ProtocolMemberWrite<'db>>,
         definition: Option<Definition<'db>>,
     ) -> Self {
         Self {
@@ -837,12 +1005,14 @@ impl<'db> ProtocolMemberData<'db> {
                 ProtocolMemberCapabilities {
                     instance: ProtocolMemberAccess::new(
                         Some(member_ty),
-                        (!is_class_var && !is_final && !is_todo).then_some(member_ty),
+                        (!is_class_var && !is_final && !is_todo)
+                            .then_some(ProtocolMemberWrite::from_type(member_ty)),
                     ),
                     class: if is_class_var {
                         ProtocolMemberAccess::new(
                             Some(member_ty),
-                            (!is_final && !is_todo).then_some(member_ty),
+                            (!is_final && !is_todo)
+                                .then_some(ProtocolMemberWrite::from_type(member_ty)),
                         )
                     } else {
                         ProtocolMemberAccess::NONE
@@ -921,7 +1091,7 @@ impl<'db> ProtocolMemberData<'db> {
                         if let Some(read) = read.and_then(|read| read.resolve(self.db)) {
                             d.field("read", &format_args!("`{}`", read.ty().display(self.db)));
                         }
-                        if let Some(write) = write.and_then(|write| write.resolve(self.db)) {
+                        if let Some(write) = write.and_then(|write| write.display_type(self.db)) {
                             d.field("write", &format_args!("`{}`", write.ty().display(self.db)));
                         }
                         d.finish()
@@ -951,7 +1121,7 @@ enum ProtocolMemberKind<'db> {
     Method(ProtocolMemberType<'db>, ProtocolMethodKind),
     Property {
         read: Option<ProtocolMemberType<'db>>,
-        write: Option<ProtocolMemberType<'db>>,
+        write: Option<ProtocolMemberWrite<'db>>,
     },
     Attribute(ProtocolMemberType<'db>),
 }
@@ -966,9 +1136,13 @@ enum ProtocolMethodKind {
 impl<'db> ProtocolMemberKind<'db> {
     fn member_types(self) -> impl Iterator<Item = ProtocolMemberType<'db>> {
         match self {
-            Self::Method(member, _) => [Some(member), None],
-            Self::Property { read, write } => [read, write],
-            Self::Attribute(attribute) => [Some(attribute), None],
+            Self::Method(method, _) => [Some(method), None, None],
+            Self::Property { read, write } => [
+                read,
+                write.and_then(ProtocolMemberWrite::domain),
+                write.and_then(ProtocolMemberWrite::descriptor_type),
+            ],
+            Self::Attribute(attribute) => [Some(attribute), None, None],
         }
         .into_iter()
         .flatten()
@@ -1009,7 +1183,15 @@ impl<'db> ProtocolMemberKind<'db> {
                 },
             ) => Self::Property {
                 read: cycle_normalized_optional_type(db, current_read, previous_read, cycle),
-                write: cycle_normalized_optional_type(db, current_write, previous_write, cycle),
+                write: match (current_write, previous_write) {
+                    (Some(current), Some(previous)) => {
+                        Some(current.cycle_normalized(db, previous, cycle))
+                    }
+                    (Some(current), None) => {
+                        Some(current.cycle_normalized_without_previous(db, cycle))
+                    }
+                    (None, _) => None,
+                },
             },
             (Self::Attribute(current), Self::Attribute(previous)) => {
                 Self::Attribute(current.cycle_normalized(db, previous, cycle))
@@ -1330,6 +1512,8 @@ fn descriptor_decorated_protocol_member<'db>(
     protocol: ClassType<'db>,
     definition: Option<Definition<'db>>,
 ) -> Option<ProtocolMemberData<'db>> {
+    let descriptor_ty = descriptor_ty.resolve_type_alias(db);
+
     // Applying a generic descriptor decorator to a method that refers to an enclosing type
     // variable can currently materialize that variable as `Unknown`. Reducing the descriptor to
     // its `__get__` result would then erase the remaining descriptor structure and weaken the
@@ -1353,39 +1537,61 @@ fn descriptor_decorated_protocol_member<'db>(
         descriptor_ty.try_call_dunder_get(db, Some(receiver_ty), receiver_ty.to_meta_type(db))?;
     let read = Some(ProtocolMemberType::with_definition(read_ty, definition));
 
-    let write = descriptor_setter_write_type(db, descriptor_ty, receiver_ty)
-        .map(|write_ty| ProtocolMemberType::with_definition(write_ty, definition));
+    let write = match descriptor_setter_domain(db, descriptor_ty, receiver_ty) {
+        DescriptorSetterDomain::Missing => None,
+        DescriptorSetterDomain::Known(domain) => Some(ProtocolMemberWrite::descriptor(
+            descriptor_ty,
+            Some(domain),
+            definition,
+        )),
+        DescriptorSetterDomain::Deferred => Some(ProtocolMemberWrite::descriptor(
+            descriptor_ty,
+            None,
+            definition,
+        )),
+    };
 
     Some(ProtocolMemberData::property(read, write, definition))
 }
 
-/// Derive the values accepted by every possible descriptor setter.
-fn descriptor_setter_write_type<'db>(
+#[derive(Copy, Clone)]
+enum DescriptorSetterDomain<'db> {
+    Missing,
+    Known(Type<'db>),
+    Deferred,
+}
+
+/// Derive the values accepted by every possible descriptor setter when they fit in [`Type`].
+fn descriptor_setter_domain<'db>(
     db: &'db dyn Db,
     descriptor_ty: Type<'db>,
     receiver_ty: Type<'db>,
-) -> Option<Type<'db>> {
+) -> DescriptorSetterDomain<'db> {
     match descriptor_ty {
         Type::Union(union) => {
-            let write_types = union
-                .elements(db)
-                .iter()
-                .map(|descriptor_ty| {
-                    descriptor_setter_write_type_for_alternative(db, *descriptor_ty, receiver_ty)
-                })
-                .collect::<Option<Vec<_>>>()?;
-            IntersectionType::bounded_from_elements(db, write_types)
+            let mut write_types = Vec::with_capacity(union.elements(db).len());
+            for descriptor_ty in union.elements(db) {
+                match single_descriptor_setter_domain(db, *descriptor_ty, receiver_ty) {
+                    DescriptorSetterDomain::Missing => return DescriptorSetterDomain::Missing,
+                    DescriptorSetterDomain::Known(write_ty) => write_types.push(write_ty),
+                    DescriptorSetterDomain::Deferred => return DescriptorSetterDomain::Deferred,
+                }
+            }
+            IntersectionType::bounded_from_elements(db, write_types).map_or(
+                DescriptorSetterDomain::Deferred,
+                DescriptorSetterDomain::Known,
+            )
         }
-        _ => descriptor_setter_write_type_for_alternative(db, descriptor_ty, receiver_ty),
+        _ => single_descriptor_setter_domain(db, descriptor_ty, receiver_ty),
     }
 }
 
 /// Derive the values accepted by one possible runtime descriptor.
-fn descriptor_setter_write_type_for_alternative<'db>(
+fn single_descriptor_setter_domain<'db>(
     db: &'db dyn Db,
     descriptor_ty: Type<'db>,
     receiver_ty: Type<'db>,
-) -> Option<Type<'db>> {
+) -> DescriptorSetterDomain<'db> {
     let Place::Defined(DefinedPlace {
         ty: setter_ty,
         definedness: Definedness::AlwaysDefined,
@@ -1394,93 +1600,126 @@ fn descriptor_setter_write_type_for_alternative<'db>(
         .class_member_with_policy(db, "__set__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
         .place
     else {
-        return None;
+        return DescriptorSetterDomain::Missing;
     };
 
-    let callables = setter_ty.try_upcast_to_callable(db)?;
-    let write_types = callables
-        .iter()
-        .map(|callable| {
-            let write_types = callable
-                .signatures(db)
-                .iter()
-                .filter_map(|signature| {
-                    descriptor_setter_signature_write_type(
-                        db,
-                        signature,
-                        descriptor_ty,
-                        receiver_ty,
-                    )
-                })
-                .collect::<Vec<_>>();
-            (!write_types.is_empty()).then(|| UnionType::from_elements(db, write_types))
-        })
-        .collect::<Option<Vec<_>>>()?;
-    IntersectionType::bounded_from_elements(db, write_types)
+    let Some(callables) = setter_ty.try_upcast_to_callable(db) else {
+        return DescriptorSetterDomain::Deferred;
+    };
+    let mut callable_domains = Vec::with_capacity(callables.iter().len());
+    for callable in &callables {
+        let mut write_types = Vec::new();
+        for signature in callable.signatures(db) {
+            match descriptor_setter_signature_domain(db, signature, descriptor_ty, receiver_ty) {
+                DescriptorSetterSignatureDomain::Inapplicable => {}
+                DescriptorSetterSignatureDomain::Known(write_ty) => write_types.push(write_ty),
+                DescriptorSetterSignatureDomain::Deferred => {
+                    return DescriptorSetterDomain::Deferred;
+                }
+            }
+        }
+        callable_domains.push(UnionType::from_elements(db, write_types));
+    }
+    IntersectionType::bounded_from_elements(db, callable_domains).map_or(
+        DescriptorSetterDomain::Deferred,
+        DescriptorSetterDomain::Known,
+    )
 }
 
-/// Derive the values accepted by one applicable `__set__` overload.
-fn descriptor_setter_signature_write_type<'db>(
+enum DescriptorSetterSignatureDomain<'db> {
+    Inapplicable,
+    Known(Type<'db>),
+    Deferred,
+}
+
+/// Derive the values accepted by one `__set__` overload when they fit in [`Type`].
+fn descriptor_setter_signature_domain<'db>(
     db: &'db dyn Db,
     signature: &Signature<'db>,
     descriptor_ty: Type<'db>,
     receiver_ty: Type<'db>,
-) -> Option<Type<'db>> {
+) -> DescriptorSetterSignatureDomain<'db> {
     let parameters = signature.parameters();
-    let trailing_parameters = parameters.as_slice().get(3..)?;
+    let Some(trailing_parameters) = parameters.as_slice().get(3..) else {
+        return DescriptorSetterSignatureDomain::Inapplicable;
+    };
     if !trailing_parameters.iter().all(|parameter| {
         parameter.default_type().is_some()
             || ((parameters.is_standard() || parameters.is_gradual())
                 && (parameter.is_variadic() || parameter.is_keyword_variadic()))
     }) {
-        return None;
+        return DescriptorSetterSignatureDomain::Inapplicable;
     }
 
-    let descriptor_parameter = parameters
-        .get_positional(0)?
+    let Some(descriptor_parameter) = parameters.get_positional(0) else {
+        return DescriptorSetterSignatureDomain::Inapplicable;
+    };
+    let descriptor_parameter = descriptor_parameter
         .annotated_type()
         .bind_self_typevars(db, descriptor_ty);
-    let receiver_parameter = parameters
-        .get_positional(1)?
+    let Some(receiver_parameter) = parameters.get_positional(1) else {
+        return DescriptorSetterSignatureDomain::Inapplicable;
+    };
+    let receiver_parameter = receiver_parameter
         .annotated_type()
         .bind_self_typevars(db, descriptor_ty);
-    if descriptor_parameter.has_typevar(db)
-        || receiver_parameter.has_typevar(db)
-        || !descriptor_ty.is_assignable_to(db, descriptor_parameter)
+    if contains_signature_typevar(db, signature, descriptor_parameter)
+        || contains_signature_typevar(db, signature, receiver_parameter)
+    {
+        return DescriptorSetterSignatureDomain::Deferred;
+    }
+    if !descriptor_ty.is_assignable_to(db, descriptor_parameter)
         || !receiver_ty.is_assignable_to(db, receiver_parameter)
     {
-        return None;
+        return DescriptorSetterSignatureDomain::Inapplicable;
     }
 
-    let write_ty = parameters
-        .get_positional(2)?
+    let Some(write_parameter) = parameters.get_positional(2) else {
+        return DescriptorSetterSignatureDomain::Inapplicable;
+    };
+    let write_ty = write_parameter
         .annotated_type()
         .bind_self_typevars(db, descriptor_ty);
-    if !write_ty.has_typevar(db) {
-        return Some(write_ty);
+    if !contains_signature_typevar(db, signature, write_ty) {
+        return DescriptorSetterSignatureDomain::Known(write_ty);
     }
 
     let Type::TypeVar(typevar) = write_ty else {
-        return None;
+        return DescriptorSetterSignatureDomain::Deferred;
     };
-    let generic_context = signature.generic_context?;
+    let Some(generic_context) = signature.generic_context else {
+        return DescriptorSetterSignatureDomain::Deferred;
+    };
     if !generic_context.contains(db, typevar.identity(db))
         || !typevar
             .binding_context(db)
             .definition()
             .is_some_and(|definition| definition.kind(db).is_function_def())
     {
-        return None;
+        return DescriptorSetterSignatureDomain::Deferred;
     }
 
-    Some(
-        match typevar.typevar(db).bound_or_constraints(db) {
-            None => Type::object(),
-            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound,
-            Some(TypeVarBoundOrConstraints::Constraints(_)) => return None,
+    match typevar.typevar(db).bound_or_constraints(db) {
+        None => DescriptorSetterSignatureDomain::Known(Type::object()),
+        Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+            DescriptorSetterSignatureDomain::Known(bound.bind_self_typevars(db, descriptor_ty))
         }
-        .bind_self_typevars(db, descriptor_ty),
-    )
+        Some(TypeVarBoundOrConstraints::Constraints(_)) => {
+            DescriptorSetterSignatureDomain::Deferred
+        }
+    }
+}
+
+fn contains_signature_typevar<'db>(
+    db: &'db dyn Db,
+    signature: &Signature<'db>,
+    ty: Type<'db>,
+) -> bool {
+    signature.generic_context.is_some_and(|generic_context| {
+        super::visitor::any_over_type(db, ty, false, |ty| {
+            matches!(ty, Type::TypeVar(typevar) if generic_context.contains(db, typevar.identity(db)))
+        })
+    })
 }
 
 fn property_set_type<'db>(
@@ -1607,13 +1846,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
             AttributeWriteRequirement::Unconstrained => self.always(),
             AttributeWriteRequirement::CannotAssign => self.never(),
-            AttributeWriteRequirement::Module(Some(write_ty))
-            | AttributeWriteRequirement::ProtocolMember {
-                write_ty: Some(write_ty),
+            AttributeWriteRequirement::Module(Some(write_ty)) => {
+                self.check_type_pair(db, value_ty, *write_ty)
+            }
+            AttributeWriteRequirement::ProtocolMember {
+                write: Some(ProtocolMemberWriteRequirement::AssignableTo(write_ty)),
                 ..
             } => self.check_type_pair(db, value_ty, *write_ty),
+            AttributeWriteRequirement::ProtocolMember {
+                write: Some(ProtocolMemberWriteRequirement::Descriptor { domain, .. }),
+                ..
+            } => self.check_type_pair(db, value_ty, domain.unwrap_or_else(Type::unknown)),
             AttributeWriteRequirement::Module(None)
-            | AttributeWriteRequirement::ProtocolMember { write_ty: None, .. } => self.never(),
+            | AttributeWriteRequirement::ProtocolMember { write: None, .. } => self.never(),
             AttributeWriteRequirement::Instance { object_ty, member } => {
                 self.check_instance_property_write(db, *object_ty, member, member_name, value_ty)
             }
@@ -2022,7 +2267,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         read_result.and(db, self.constraints, || {
             required.write.map_or_else(
                 || self.always(),
-                |write_ty| {
+                |write| {
                     let fallback_ty = ty.literal_fallback_instance(db).unwrap_or(ty);
                     let receiver_ty = if access == ProtocolMemberAccessMode::Instance
                         && matches!(ty, Type::LiteralValue(_))
@@ -2031,10 +2276,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     } else {
                         receiver_ty
                     };
-                    write_ty.bind_self(db, fallback_ty).when_some_and(
-                        db,
-                        self.constraints,
-                        |write_ty| {
+                    write
+                        .bind_compatibility_type(db, fallback_ty)
+                        .when_some_and(db, self.constraints, |write_ty| {
                             let result =
                                 self.check_property_write(db, receiver_ty, member.name, write_ty);
                             if let Some(context) = self.report_context()
@@ -2045,8 +2289,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 });
                             }
                             result
-                        },
-                    )
+                        })
                 },
             )
         })
@@ -2263,8 +2506,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
                 (Some(source), Some(target)) => {
                     let (Some(target), Some(source)) = (
-                        target.bind_self(db, source_type),
-                        source.bind_self(db, source_type),
+                        target.bind_compatibility_type(db, source_type),
+                        source.bind_compatibility_type(db, source_type),
                     ) else {
                         return self.never();
                     };
@@ -2579,7 +2822,10 @@ fn cached_protocol_interface<'db>(
             let member = match ty {
                 Type::PropertyInstance(property) => ProtocolMemberData::property(
                     property.getter(db).map(ProtocolMemberType::property_getter),
-                    property.setter(db).map(ProtocolMemberType::property_setter),
+                    property
+                        .setter(db)
+                        .map(ProtocolMemberType::property_setter)
+                        .map(ProtocolMemberWrite::from_type),
                     definition,
                 ),
                 Type::Callable(callable)

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1430,7 +1430,7 @@ fn descriptor_setter_signature_write_type<'db>(
     let trailing_parameters = parameters.as_slice().get(3..)?;
     if !trailing_parameters.iter().all(|parameter| {
         parameter.default_type().is_some()
-            || (parameters.is_standard()
+            || ((parameters.is_standard() || parameters.is_gradual())
                 && (parameter.is_variadic() || parameter.is_keyword_variadic()))
     }) {
         return None;

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -611,6 +611,7 @@ impl<'db> ProtocolMemberWrite<'db> {
             Self::Descriptor { descriptor, domain } => {
                 Some(ProtocolMemberWriteRequirement::Descriptor {
                     descriptor_ty: descriptor.bind_self(db, self_type)?,
+                    receiver_ty: self_type,
                     domain: domain.and_then(|domain| domain.bind_self(db, self_type)),
                 })
             }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1642,7 +1642,11 @@ fn descriptor_setter_signature_domain<'db>(
 ) -> DescriptorSetterSignatureDomain<'db> {
     let parameters = signature.parameters();
     let Some(trailing_parameters) = parameters.as_slice().get(3..) else {
-        return DescriptorSetterSignatureDomain::Inapplicable;
+        return if parameters.is_gradual() {
+            DescriptorSetterSignatureDomain::Deferred
+        } else {
+            DescriptorSetterSignatureDomain::Inapplicable
+        };
     };
     if !trailing_parameters.iter().all(|parameter| {
         parameter.default_type().is_some()

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -22,9 +22,10 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
         CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor,
-        InstanceFallbackShadowsNonDataDescriptor, KnownFunction, MemberLookupPolicy,
-        PropertyInstanceType, ProtocolInstanceType, SelfBinding, StaticClassLiteral, Type,
-        TypeMapping, TypeQualifiers, TypeVarVariance, UnionType, VarianceInferable,
+        InstanceFallbackShadowsNonDataDescriptor, IntersectionType, KnownFunction,
+        MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SelfBinding,
+        StaticClassLiteral, Type, TypeMapping, TypeQualifiers, TypeVarVariance, UnionType,
+        VarianceInferable,
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
         diagnostic::report_undeclared_protocol_member,
@@ -1352,77 +1353,53 @@ fn descriptor_decorated_protocol_member<'db>(
         descriptor_ty.try_call_dunder_get(db, Some(receiver_ty), receiver_ty.to_meta_type(db))?;
     let read = Some(ProtocolMemberType::with_definition(read_ty, definition));
 
-    let write = if let Place::Defined(DefinedPlace {
+    let write = descriptor_setter_write_type(db, descriptor_ty, receiver_ty)
+        .map(|write_ty| ProtocolMemberType::with_definition(write_ty, definition));
+
+    Some(ProtocolMemberData::property(read, write, definition))
+}
+
+/// Derive the values accepted by every possible descriptor setter.
+fn descriptor_setter_write_type<'db>(
+    db: &'db dyn Db,
+    descriptor_ty: Type<'db>,
+    receiver_ty: Type<'db>,
+) -> Option<Type<'db>> {
+    let write_ty = match descriptor_ty {
+        Type::Union(union) => {
+            let write_types = union
+                .elements(db)
+                .iter()
+                .map(|descriptor_ty| {
+                    descriptor_setter_write_type_for_alternative(db, *descriptor_ty, receiver_ty)
+                })
+                .collect::<Option<Vec<_>>>()?;
+            IntersectionType::bounded_from_elements(db, write_types)?
+        }
+        _ => descriptor_setter_write_type_for_alternative(db, descriptor_ty, receiver_ty)?,
+    };
+    (!write_ty.is_never()).then_some(write_ty)
+}
+
+/// Derive the values accepted by one possible runtime descriptor.
+fn descriptor_setter_write_type_for_alternative<'db>(
+    db: &'db dyn Db,
+    descriptor_ty: Type<'db>,
+    receiver_ty: Type<'db>,
+) -> Option<Type<'db>> {
+    let Place::Defined(DefinedPlace {
         ty: setter_ty,
         definedness: Definedness::AlwaysDefined,
         ..
     }) = descriptor_ty
         .class_member_with_policy(db, "__set__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
         .place
-    {
-        Some(ProtocolMemberType::with_definition(
-            descriptor_setter_write_type(db, setter_ty, descriptor_ty, receiver_ty)
-                .unwrap_or_else(Type::unknown),
-            definition,
-        ))
-    } else {
-        None
-    };
-
-    Some(ProtocolMemberData::property(read, write, definition))
-}
-
-/// Derive a write type from a single ordinary setter signature.
-fn descriptor_setter_write_type<'db>(
-    db: &'db dyn Db,
-    setter_ty: Type<'db>,
-    descriptor_ty: Type<'db>,
-    receiver_ty: Type<'db>,
-) -> Option<Type<'db>> {
-    let callable = setter_ty.try_upcast_to_callable(db)?.exactly_one()?;
-    let signatures = callable.signatures(db);
-    let [signature] = signatures.overloads.as_ref() else {
+    else {
         return None;
     };
 
-    // A method type variable cannot be used as the write type directly: it is inferred separately
-    // for each call. Deriving its accepted values requires generic call analysis.
-    if signature.generic_context.is_some_and(|generic_context| {
-        generic_context.variables(db).any(|typevar| {
-            !typevar.typevar(db).is_self(db)
-                && typevar
-                    .binding_context(db)
-                    .definition()
-                    .is_some_and(|definition| definition.kind(db).is_function_def())
-        })
-    }) {
-        return None;
-    }
-
-    let parameters = signature.parameters();
-    if parameters.len() != 3 {
-        return None;
-    }
-    let descriptor_parameter = parameters
-        .get_positional(0)?
-        .annotated_type()
-        .bind_self_typevars(db, descriptor_ty);
-    let receiver_parameter = parameters
-        .get_positional(1)?
-        .annotated_type()
-        .bind_self_typevars(db, descriptor_ty);
-    if !descriptor_ty.is_assignable_to(db, descriptor_parameter)
-        || !receiver_ty.is_assignable_to(db, receiver_parameter)
-    {
-        return None;
-    }
-
-    Some(
-        parameters
-            .get_positional(2)?
-            .annotated_type()
-            .bind_self_typevars(db, descriptor_ty),
-    )
+    let callables = setter_ty.try_upcast_to_callable(db)?;
+    callables.positional_parameter_domain(db, &[descriptor_ty, receiver_ty], descriptor_ty)
 }
 
 fn property_set_type<'db>(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1718,7 +1718,7 @@ fn contains_signature_typevar<'db>(
     ty: Type<'db>,
 ) -> bool {
     signature.generic_context.is_some_and(|generic_context| {
-        super::visitor::any_over_type(db, ty, false, |ty| {
+        super::visitor::any_over_type(db, ty, true, |ty| {
             matches!(ty, Type::TypeVar(typevar) if generic_context.contains(db, typevar.identity(db)))
         })
     })


### PR DESCRIPTION
## Summary

This is a follow-up to #26681. That PR conservatively treats a descriptor-decorated protocol member as read-only unless its `__set__` method has one simple signature. This PR models descriptor write capability separately from the write domain we can represent as a `Type`, so writable protocols remain writable without inventing an unsound approximation.

For concrete setter signatures, we derive the accepted value domain after normal descriptor binding. Applicable overloads within one callable expand the domain, while callable alternatives and union-valued descriptors intersect their domains because every possible runtime setter must accept the assignment:

```python
def either_descriptor(getter: object) -> Descriptor[int | str] | Descriptor[str | bytes]:
    ...

class HasValue(Protocol):
    @either_descriptor
    def value(self) -> object: ...

def update(value: HasValue) -> None:
    value.value = "valid"
    value.value = 1  # error
```

Some valid setter contracts cannot be flattened into one exact type without losing information, including constrained or aliased method type variables, gradual and variadic signatures, and intersections that exceed the set-theoretic expansion budget. These cases now retain the descriptor call contract with an unknown domain instead of collapsing to `Never` or becoming read-only. Exact `Never` domains remain writable, and optional trailing parameters remain supported.

Real assignments invoke each possible descriptor's bound `__set__` method with the active receiver arm. This preserves receiver-sensitive overloads and the binding behavior of ordinary methods, static methods, class methods, and callable objects, while structural protocol compatibility continues to reject read-only or too-narrow implementations.
