### PR TITLE
[ty] Compare overloaded protocol method returns pairwise

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1683,6 +1683,86 @@ static_assert(is_assignable_to(AliasedNeverLength, HasLengthTwo))
 static_assert(not is_disjoint_from(AliasedNeverLength, HasLengthTwo))
 ```
 
+For overloaded methods, every possible return type on one side must be disjoint from every possible
+return type on the other. A `Never` return in either overload set prevents the method from
+establishing disjointness.
+
+```py
+from typing import Literal, Protocol, overload
+from typing_extensions import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+class ReturnsOneOrTwo(Protocol):
+    @overload
+    def value(self, flag: Literal[True], /) -> Literal[1]: ...
+    @overload
+    def value(self, flag: Literal[False], /) -> Literal[2]: ...
+
+class ReturnsThreeOrFour:
+    @overload
+    def value(self, flag: Literal[True], /) -> Literal[3]: ...
+    @overload
+    def value(self, flag: Literal[False], /) -> Literal[4]: ...
+    def value(self, flag: bool, /) -> Literal[3, 4]:
+        return 3 if flag else 4
+
+class ReturnsTwoOrThree:
+    @overload
+    def value(self, flag: Literal[True], /) -> Literal[2]: ...
+    @overload
+    def value(self, flag: Literal[False], /) -> Literal[3]: ...
+    def value(self, flag: bool, /) -> Literal[2, 3]:
+        return 2 if flag else 3
+
+static_assert(is_disjoint_from(ReturnsOneOrTwo, ReturnsThreeOrFour))
+static_assert(not is_disjoint_from(ReturnsOneOrTwo, ReturnsTwoOrThree))
+
+class ReturnsOneOrNever(Protocol):
+    @overload
+    def value(self, flag: Literal[True], /) -> Literal[1]: ...
+    @overload
+    def value(self, flag: Literal[False], /) -> Never: ...
+
+class ReturnsThreeOrNever:
+    @overload
+    def value(self, flag: Literal[True], /) -> Literal[3]: ...
+    @overload
+    def value(self, flag: Literal[False], /) -> Never: ...
+    def value(self, flag: bool, /) -> Literal[3]:
+        return 3
+
+static_assert(not is_disjoint_from(ReturnsOneOrNever, ReturnsThreeOrFour))
+static_assert(not is_disjoint_from(ReturnsOneOrTwo, ReturnsThreeOrNever))
+
+type BottomReturn = Never
+
+class ReturnsThreeOrBottom:
+    @overload
+    def value(self, flag: Literal[True], /) -> Literal[3]: ...
+    @overload
+    def value(self, flag: Literal[False], /) -> BottomReturn: ...
+    def value(self, flag: bool, /) -> Literal[3]:
+        return 3
+
+static_assert(not is_disjoint_from(ReturnsOneOrTwo, ReturnsThreeOrBottom))
+
+class ReceiverFiltered[T]:
+    payload: T
+
+    @overload
+    def value(self: "ReceiverFiltered[bytes]", flag: bool, /) -> bytes: ...
+    @overload
+    def value(self: "ReceiverFiltered[str]", flag: bool, /) -> str: ...
+    def value(self, flag: bool, /) -> str | bytes:
+        return ""
+
+def empty_overloads(receiver: ReceiverFiltered[int]) -> None:
+    reveal_type(receiver.value)  # revealed: Overload[]
+
+static_assert(not is_disjoint_from(ReturnsOneOrTwo, ReceiverFiltered[int]))
+```
+
 ## Intersections of protocols with types that have possibly unbound attributes
 
 Note that if a `@final` class has a possibly unbound attribute corresponding to the protocol member,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1908,17 +1908,36 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             else {
                 return self.never();
             };
-            let Some(method_return_type) = non_never_callable_return_type(db, method) else {
+            if !callable_has_only_non_never_returns(db, method) {
                 return self.never();
-            };
+            }
 
             ty.try_upcast_to_callable_with_policy(db, UpcastPolicy::Sound)
                 .when_some_and(db, self.constraints, |callables| {
                     callables.iter().when_all(db, self.constraints, |callable| {
-                        non_never_callable_return_type(db, *callable).when_some_and(
+                        if !callable_has_only_non_never_returns(db, *callable) {
+                            return self.never();
+                        }
+
+                        // Disjointness distributes over unions. Compare the overload return arms
+                        // directly so that recursive return types do not require canonicalizing an
+                        // intermediate union merely to distribute it again.
+                        method.signatures(db).iter().when_all(
                             db,
                             self.constraints,
-                            |return_type| self.check_type_pair(db, method_return_type, return_type),
+                            |method_signature| {
+                                callable.signatures(db).iter().when_all(
+                                    db,
+                                    self.constraints,
+                                    |callable_signature| {
+                                        self.check_type_pair(
+                                            db,
+                                            method_signature.return_ty,
+                                            callable_signature.return_ty,
+                                        )
+                                    },
+                                )
+                            },
                         )
                     })
                 })
@@ -2132,19 +2151,19 @@ fn protocol_bind_self<'db>(
     callable.bind_self(db, self_type).into_regular(db)
 }
 
-/// Return the possible output type of a callable unless any overload returns `Never`.
+/// Return `true` if a callable has at least one overload and none return `Never`.
 ///
 /// Return-type disjointness is a pragmatic approximation for method members: a callable returning
 /// `Never` could satisfy otherwise-incompatible signatures, so it must not establish disjointness.
-fn non_never_callable_return_type<'db>(
-    db: &'db dyn Db,
-    callable: CallableType<'db>,
-) -> Option<Type<'db>> {
-    callable
-        .signatures(db)
-        .iter()
-        .all(|signature| !signature.return_ty.resolve_type_alias(db).is_never())
-        .then(|| callable.signatures(db).overload_return_type_or_unknown(db))
+fn callable_has_only_non_never_returns<'db>(db: &'db dyn Db, callable: CallableType<'db>) -> bool {
+    let mut signatures = callable.signatures(db).iter();
+    let Some(first) = signatures.next() else {
+        // An empty signature previously produced `Unknown`, which cannot establish disjointness.
+        return false;
+    };
+
+    !first.return_ty.resolve_type_alias(db).is_never()
+        && signatures.all(|signature| !signature.return_ty.resolve_type_alias(db).is_never())
 }
 
 /// Protocol compatibility can only succeed if every required member is present.


### PR DESCRIPTION
## Summary

When checking whether a protocol method is disjoint from another method, we currently combine each callable's overloaded return types into a union before comparing them. Building those unions performs redundancy checks between recursive protocol specializations; each redundancy check compares the overloaded protocol again.

Disjointness distributes over unions, so this PR instead compares every return arm on one side with every return arm on the other directly, to avoid constructing and simplifying an intermediate union.

This PR improves check time on a large internal file from 6.62s to 2.51s.
