### PR TITLE
[ty] Handle class objects that may be descriptors

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -378,22 +378,22 @@ reveal_type(UnionC.attribute)  # revealed: Any | Literal["descriptor"]
 
 ### `TypeForm` metaclass attributes
 
-A metaclass attribute typed as `TypeForm[Any]` could be a class whose own metaclass makes it a data
-descriptor. It must therefore continue to take precedence over a class attribute with the same name
-when assigning to the attribute:
+A `TypeForm` argument describes the instances produced by a type form, not the runtime type form
+value itself. A metaclass attribute typed as `TypeForm[Descriptor]` can therefore be a class whose
+own metaclass makes it a data descriptor, and must continue to take precedence over a class
+attribute with the same name when assigning to the attribute:
 
 ```py
-from typing import Any
 from typing_extensions import TypeForm
 
 class DescriptorMeta(type):
-    def __set__(self, instance: object, value: object) -> None:
+    def __set__(self, instance: object, value: str) -> None:
         pass
 
 class Descriptor(metaclass=DescriptorMeta): ...
 
 class Meta(type):
-    attribute: TypeForm[Any] = Descriptor
+    attribute: TypeForm[Descriptor] = Descriptor
 
 class C(metaclass=Meta):
     attribute: int = 1

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -376,6 +376,31 @@ class UnionC(metaclass=UnionMeta):
 reveal_type(UnionC.attribute)  # revealed: Any | Literal["descriptor"]
 ```
 
+### `TypeForm` metaclass attributes
+
+A metaclass attribute typed as `TypeForm[Any]` could be a class whose own metaclass makes it a data
+descriptor. It must therefore continue to take precedence over a class attribute with the same name
+when assigning to the attribute:
+
+```py
+from typing import Any
+from typing_extensions import TypeForm
+
+class DescriptorMeta(type):
+    def __set__(self, instance: object, value: object) -> None:
+        pass
+
+class Descriptor(metaclass=DescriptorMeta): ...
+
+class Meta(type):
+    attribute: TypeForm[Any] = Descriptor
+
+class C(metaclass=Meta):
+    attribute: int = 1
+
+C.attribute = 1  # error: [invalid-assignment]
+```
+
 ### Class objects with unknown metaclasses
 
 A `type[Any]` value could contain a class whose metaclass implements the descriptor protocol. We

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -399,6 +399,7 @@ class C(metaclass=Meta):
     attribute: int = 1
 
 C.attribute = 1  # error: [invalid-assignment]
+C.attribute = Descriptor  # error: [invalid-assignment]
 ```
 
 ### Bounded class-object metaclass attributes
@@ -423,6 +424,7 @@ class C(metaclass=Meta):
     attribute: int = 1
 
 C.attribute = 1  # error: [invalid-assignment]
+C.attribute = Descriptor  # error: [invalid-assignment]
 ```
 
 ### Class objects with unknown metaclasses

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -401,6 +401,30 @@ class C(metaclass=Meta):
 C.attribute = 1  # error: [invalid-assignment]
 ```
 
+### Bounded class-object metaclass attributes
+
+An inexact `type[Base]` attribute can hold a subclass whose custom metaclass makes the class object
+a data descriptor. It must therefore continue to take precedence over a class attribute with the
+same name when assigning to the attribute:
+
+```py
+class Base: ...
+
+class DescriptorMeta(type):
+    def __set__(self, instance: object, value: str) -> None:
+        pass
+
+class Descriptor(Base, metaclass=DescriptorMeta): ...
+
+class Meta(type):
+    attribute: type[Base] = Descriptor
+
+class C(metaclass=Meta):
+    attribute: int = 1
+
+C.attribute = 1  # error: [invalid-assignment]
+```
+
 ### Class objects with unknown metaclasses
 
 A `type[Any]` value could contain a class whose metaclass implements the descriptor protocol. We

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -399,6 +399,7 @@ class C(metaclass=Meta):
     attribute: int = 1
 
 C.attribute = 1  # error: [invalid-assignment]
+# error: [invalid-assignment]
 C.attribute = Descriptor  # error: [invalid-assignment]
 ```
 
@@ -409,7 +410,18 @@ string:
 class StringC(metaclass=Meta):
     attribute: str = ""
 
+StringC.attribute = "valid"
 StringC.attribute = "Descriptor"
+```
+
+The descriptor setter still rejects a class object even when the fallback attribute accepts that
+same class object:
+
+```py
+class TypeFormC(metaclass=Meta):
+    attribute: TypeForm[Descriptor] = Descriptor
+
+TypeFormC.attribute = Descriptor  # error: [invalid-assignment]
 ```
 
 The same contextual check applies when the metaclass attribute can also hold an ordinary string:
@@ -446,7 +458,73 @@ class C(metaclass=Meta):
     attribute: int = 1
 
 C.attribute = 1  # error: [invalid-assignment]
+# error: [invalid-assignment]
 C.attribute = Descriptor  # error: [invalid-assignment]
+```
+
+An assignment succeeds when both the possible descriptor setter and class attribute accept the
+assigned string:
+
+```py
+class StringC(metaclass=Meta):
+    attribute: str = ""
+
+StringC.attribute = "valid"
+```
+
+An assignment fails when the class attribute accepts the assigned class but the descriptor setter
+does not:
+
+```py
+class ClassC(metaclass=Meta):
+    attribute: type[Base] = Base
+
+ClassC.attribute = Base  # error: [invalid-assignment]
+```
+
+### Broad class-object metaclass attributes
+
+Both `type[object]` and bare `type` can contain a class whose metaclass implements `__set__`. Their
+possible descriptor setters must therefore be checked independently of the class-attribute fallback:
+
+```py
+class Base: ...
+
+class DescriptorMeta(type):
+    def __set__(self, instance: object, value: str) -> None:
+        pass
+
+class Descriptor(Base, metaclass=DescriptorMeta): ...
+
+class ObjectMeta(type):
+    attribute: type[object] = Descriptor
+
+class ObjectStringC(metaclass=ObjectMeta):
+    attribute: str = ""
+
+ObjectStringC.attribute = "valid"
+
+class ObjectClassC(metaclass=ObjectMeta):
+    attribute: type[Base] = Base
+
+ObjectClassC.attribute = Base  # error: [invalid-assignment]
+```
+
+The unparameterized spelling follows the same descriptor and class-attribute paths:
+
+```py
+class BareMeta(type):
+    attribute: type = Descriptor
+
+class BareStringC(metaclass=BareMeta):
+    attribute: str = ""
+
+BareStringC.attribute = "valid"
+
+class BareClassC(metaclass=BareMeta):
+    attribute: type[Base] = Base
+
+BareClassC.attribute = Base  # error: [invalid-assignment]
 ```
 
 ### Class objects with unknown metaclasses

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -402,6 +402,28 @@ C.attribute = 1  # error: [invalid-assignment]
 C.attribute = Descriptor  # error: [invalid-assignment]
 ```
 
+A quoted type expression remains valid when both possible write targets accept the same runtime
+string:
+
+```py
+class StringC(metaclass=Meta):
+    attribute: str = ""
+
+StringC.attribute = "Descriptor"
+```
+
+The same contextual check applies when the metaclass attribute can also hold an ordinary string:
+
+```py
+class UnionMeta(type):
+    attribute: TypeForm[Descriptor] | str = Descriptor
+
+class UnionC(metaclass=UnionMeta):
+    attribute: int = 1
+
+UnionC.attribute = 1  # error: [invalid-assignment]
+```
+
 ### Bounded class-object metaclass attributes
 
 An inexact `type[Base]` attribute can hold a subclass whose custom metaclass makes the class object

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3520,8 +3520,9 @@ impl<'db> Type<'db> {
 
     /// Returns whether this type is known not to be a data descriptor.
     ///
-    /// Descriptor uncertainty only propagates through outer unions, intersections, aliases, and
-    /// `TypeForm` arguments. Other type arguments do not affect the runtime descriptor class.
+    /// Descriptor uncertainty propagates through outer unions, intersections, and aliases.
+    /// `TypeForm` values are also uncertain because their arguments describe the represented
+    /// instance types, not the runtime values whose metaclasses determine descriptor behavior.
     pub(crate) fn is_definitely_non_data_descriptor(self, db: &'db dyn Db) -> bool {
         self.is_definitely_non_data_descriptor_impl(db, ())
     }
@@ -3544,9 +3545,7 @@ impl<'db> Type<'db> {
             Type::TypeAlias(alias) => alias
                 .value_type(db)
                 .is_definitely_non_data_descriptor_impl(db, ()),
-            Type::TypeForm(type_form) => type_form
-                .type_argument(db)
-                .is_definitely_non_data_descriptor_impl(db, ()),
+            Type::TypeForm(_) => false,
             _ => !self.may_be_data_descriptor(db),
         }
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3521,8 +3521,9 @@ impl<'db> Type<'db> {
     /// Returns whether this type is known not to be a data descriptor.
     ///
     /// Descriptor uncertainty propagates through outer unions, intersections, and aliases.
-    /// `TypeForm` values are also uncertain because their arguments describe the represented
-    /// instance types, not the runtime values whose metaclasses determine descriptor behavior.
+    /// `TypeForm` values and inexact `type[...]` values are also uncertain because their bounds
+    /// describe the represented instance types, not the runtime values whose metaclasses determine
+    /// descriptor behavior.
     pub(crate) fn is_definitely_non_data_descriptor(self, db: &'db dyn Db) -> bool {
         self.is_definitely_non_data_descriptor_impl(db, ())
     }
@@ -3545,7 +3546,7 @@ impl<'db> Type<'db> {
             Type::TypeAlias(alias) => alias
                 .value_type(db)
                 .is_definitely_non_data_descriptor_impl(db, ()),
-            Type::TypeForm(_) => false,
+            Type::TypeForm(_) | Type::SubclassOf(_) => false,
             _ => !self.may_be_data_descriptor(db),
         }
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3520,8 +3520,8 @@ impl<'db> Type<'db> {
 
     /// Returns whether this type is known not to be a data descriptor.
     ///
-    /// Descriptor uncertainty only propagates through outer unions, intersections, and aliases;
-    /// type arguments do not affect the runtime descriptor class.
+    /// Descriptor uncertainty only propagates through outer unions, intersections, aliases, and
+    /// `TypeForm` arguments. Other type arguments do not affect the runtime descriptor class.
     pub(crate) fn is_definitely_non_data_descriptor(self, db: &'db dyn Db) -> bool {
         self.is_definitely_non_data_descriptor_impl(db, ())
     }
@@ -3543,6 +3543,9 @@ impl<'db> Type<'db> {
                 .all(|ty| ty.is_definitely_non_data_descriptor_impl(db, ())),
             Type::TypeAlias(alias) => alias
                 .value_type(db)
+                .is_definitely_non_data_descriptor_impl(db, ()),
+            Type::TypeForm(type_form) => type_form
+                .type_argument(db)
                 .is_definitely_non_data_descriptor_impl(db, ()),
             _ => !self.may_be_data_descriptor(db),
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4182,6 +4182,9 @@ impl<'db> Type<'db> {
             Type::TypeAlias(alias) => alias
                 .value_type(db)
                 .is_definitely_non_data_descriptor_impl(db, program),
+            Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Type) => {
+                false
+            }
             Type::TypeForm(_) | Type::SubclassOf(_) => false,
             _ => !self.may_be_data_descriptor(db, env),
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4147,8 +4147,9 @@ impl<'db> Type<'db> {
     /// Returns whether this type is known not to be a data descriptor.
     ///
     /// Descriptor uncertainty propagates through outer unions, intersections, and aliases.
-    /// `TypeForm` values are also uncertain because their arguments describe the represented
-    /// instance types, not the runtime values whose metaclasses determine descriptor behavior.
+    /// `TypeForm` values and inexact `type[...]` values are also uncertain because their bounds
+    /// describe the represented instance types, not the runtime values whose metaclasses determine
+    /// descriptor behavior.
     fn is_definitely_non_data_descriptor(
         self,
         db: &'db dyn Db,
@@ -4181,7 +4182,7 @@ impl<'db> Type<'db> {
             Type::TypeAlias(alias) => alias
                 .value_type(db)
                 .is_definitely_non_data_descriptor_impl(db, program),
-            Type::TypeForm(_) => false,
+            Type::TypeForm(_) | Type::SubclassOf(_) => false,
             _ => !self.may_be_data_descriptor(db, env),
         }
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4146,8 +4146,9 @@ impl<'db> Type<'db> {
 
     /// Returns whether this type is known not to be a data descriptor.
     ///
-    /// Descriptor uncertainty only propagates through outer unions, intersections, aliases, and
-    /// `TypeForm` arguments. Other type arguments do not affect the runtime descriptor class.
+    /// Descriptor uncertainty propagates through outer unions, intersections, and aliases.
+    /// `TypeForm` values are also uncertain because their arguments describe the represented
+    /// instance types, not the runtime values whose metaclasses determine descriptor behavior.
     fn is_definitely_non_data_descriptor(
         self,
         db: &'db dyn Db,
@@ -4180,9 +4181,7 @@ impl<'db> Type<'db> {
             Type::TypeAlias(alias) => alias
                 .value_type(db)
                 .is_definitely_non_data_descriptor_impl(db, program),
-            Type::TypeForm(type_form) => type_form
-                .type_argument(db)
-                .is_definitely_non_data_descriptor_impl(db, program),
+            Type::TypeForm(_) => false,
             _ => !self.may_be_data_descriptor(db, env),
         }
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4146,8 +4146,8 @@ impl<'db> Type<'db> {
 
     /// Returns whether this type is known not to be a data descriptor.
     ///
-    /// Descriptor uncertainty only propagates through outer unions, intersections, and aliases;
-    /// type arguments do not affect the runtime descriptor class.
+    /// Descriptor uncertainty only propagates through outer unions, intersections, aliases, and
+    /// `TypeForm` arguments. Other type arguments do not affect the runtime descriptor class.
     fn is_definitely_non_data_descriptor(
         self,
         db: &'db dyn Db,
@@ -4179,6 +4179,9 @@ impl<'db> Type<'db> {
                 .all(|ty| ty.is_definitely_non_data_descriptor_impl(db, program)),
             Type::TypeAlias(alias) => alias
                 .value_type(db)
+                .is_definitely_non_data_descriptor_impl(db, program),
+            Type::TypeForm(type_form) => type_form
+                .type_argument(db)
                 .is_definitely_non_data_descriptor_impl(db, program),
             _ => !self.may_be_data_descriptor(db, env),
         }

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -88,7 +88,8 @@ pub(super) enum InstanceAttributeWriteMember<'db> {
 ///
 /// A data descriptor on the metaclass takes precedence over the class object's own attributes,
 /// which in turn take precedence over definitely non-data metaclass members. If the metaclass
-/// member is absent or possibly undefined, the class object's own attributes form the fallback.
+/// member is absent, possibly undefined, or could be a non-data descriptor, the class object's own
+/// attributes form the fallback.
 pub(super) enum ClassAttributeWriteMember<'db> {
     /// A metaclass member governs the write, optionally alongside a class-attribute fallback.
     Explicit {
@@ -132,7 +133,7 @@ impl ExplicitAttributeWriteRequirement<'_> {
     }
 }
 
-/// A write target found through a possibly absent fallback lookup.
+/// A receiver-level write target that can govern the write instead of the type member.
 pub(super) enum FallbackAttributeWriteRequirement<'db> {
     /// Check the value against `ty`, retaining whether the declaration may be absent at runtime.
     AssignableTo {
@@ -166,8 +167,8 @@ pub(super) enum FallbackAttributeWriteRequirement<'db> {
 /// ```
 pub(super) enum AssignmentAttributeMembers<'db> {
     /// The type member governs the write, as `Meta.data` does above because it is a data descriptor.
-    /// If the type member may be missing, the corresponding receiver member (`C.data`) is retained
-    /// as `receiver_fallback`.
+    /// If the type member may be missing or may be a non-data descriptor, the corresponding
+    /// receiver member (`C.data`) is retained as `receiver_fallback`.
     TypeMember {
         member: PlaceAndQualifiers<'db>,
         receiver_fallback: Option<PlaceAndQualifiers<'db>>,
@@ -573,7 +574,15 @@ pub(super) fn property_setter_returns_never<'db>(
     })
 }
 
-/// Return the class member that takes precedence over a definitely non-data metaclass member.
+enum ClassObjectMemberPrecedence<'db> {
+    /// The class-object member always shadows the metaclass member.
+    Receiver(PlaceAndQualifiers<'db>),
+    /// The metaclass member's descriptor status is uncertain, so either member can govern the
+    /// write.
+    TypeOrReceiver(PlaceAndQualifiers<'db>),
+}
+
+/// Classify the precedence between a metaclass member and a class-object member.
 ///
 /// For example, `C.attribute` governs the assignment below because `Meta.attribute` does not
 /// implement `__set__` or `__delete__`:
@@ -587,35 +596,41 @@ pub(super) fn property_setter_returns_never<'db>(
 ///
 /// C.attribute = 1
 /// ```
-fn class_member_preceding_non_data_metaclass_member<'db>(
+fn class_object_member_precedence<'db>(
     db: &'db dyn Db,
     object_ty: Type<'db>,
     attribute: &str,
     type_member: PlaceAndQualifiers<'db>,
-) -> Option<PlaceAndQualifiers<'db>> {
+) -> Option<ClassObjectMemberPrecedence<'db>> {
     if !matches!(
         object_ty,
         Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..)
-    ) || !type_member
-        .place
-        .ignore_possibly_undefined()?
-        .is_definitely_non_data_descriptor(db)
-    {
+    ) {
         return None;
     }
 
-    object_ty
+    let receiver_member = object_ty
         .find_name_in_mro_with_policy(db, attribute, MemberLookupPolicy::default())
-        .filter(|class_attr| !class_attr.place.is_undefined())
+        .filter(|class_attr| !class_attr.place.is_undefined())?;
+    let type_member_ty = type_member.place.ignore_possibly_undefined()?;
+
+    if type_member_ty.is_definitely_non_data_descriptor(db) {
+        Some(ClassObjectMemberPrecedence::Receiver(receiver_member))
+    } else if !type_member_ty.is_divergent() && !type_member_ty.is_data_descriptor(db) {
+        Some(ClassObjectMemberPrecedence::TypeOrReceiver(receiver_member))
+    } else {
+        None
+    }
 }
 
 /// Return the members considered by attribute assignment in lookup-precedence order.
 ///
 /// The type member comes from class-member lookup. A member found directly on the receiver is
 /// queried when the type member is absent or possibly undefined. For class objects, a class-MRO
-/// member instead takes precedence over a definitely non-data metaclass member. Composite and
-/// dynamic receiver types return `None`; their callers either decompose them before this point or
-/// handle them without member lookup.
+/// member instead takes precedence over a definitely non-data metaclass member and remains an
+/// alternative when the metaclass member's descriptor status is uncertain. Composite and dynamic
+/// receiver types return `None`; their callers either decompose them before this point or handle
+/// them without member lookup.
 ///
 /// This helper deliberately does not bind `Self` or interpret descriptors so that assignment,
 /// protocol compatibility, and `Final` validation share exactly the same lookup precedence.
@@ -635,11 +650,16 @@ pub(super) fn assignment_attribute_members<'db>(
     } else {
         object_ty.class_member(db, attribute.into())
     };
-    if let Some(receiver_member) =
-        class_member_preceding_non_data_metaclass_member(db, object_ty, attribute, type_member)
-    {
-        return Some(AssignmentAttributeMembers::ReceiverMember(receiver_member));
-    }
+    let receiver_alternative =
+        match class_object_member_precedence(db, object_ty, attribute, type_member) {
+            Some(ClassObjectMemberPrecedence::Receiver(receiver_member)) => {
+                return Some(AssignmentAttributeMembers::ReceiverMember(receiver_member));
+            }
+            Some(ClassObjectMemberPrecedence::TypeOrReceiver(receiver_member)) => {
+                Some(receiver_member)
+            }
+            None => None,
+        };
     let needs_receiver_fallback = matches!(
         type_member.place,
         Place::Defined(DefinedPlace {
@@ -647,7 +667,9 @@ pub(super) fn assignment_attribute_members<'db>(
             ..
         }) | Place::Undefined
     );
-    let receiver_fallback = if needs_receiver_fallback {
+    let receiver_fallback = if let Some(receiver_alternative) = receiver_alternative {
+        Some(receiver_alternative)
+    } else if needs_receiver_fallback {
         Some(match object_ty {
             Type::NominalInstance(..)
             | Type::ProtocolInstance(_)

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -574,6 +574,19 @@ pub(super) fn property_setter_returns_never<'db>(
 }
 
 /// Return the class member that takes precedence over a definitely non-data metaclass member.
+///
+/// For example, `C.attribute` governs the assignment below because `Meta.attribute` does not
+/// implement `__set__` or `__delete__`:
+///
+/// ```python
+/// class Meta(type):
+///     attribute = object()
+///
+/// class C(metaclass=Meta):
+///     attribute: int
+///
+/// C.attribute = 1
+/// ```
 fn class_member_preceding_non_data_metaclass_member<'db>(
     db: &'db dyn Db,
     object_ty: Type<'db>,

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -9,6 +9,7 @@
 
 use crate::Db;
 use ty_module_resolver::KnownModule;
+use ty_python_core::use_def_map;
 
 use super::call::CallArguments;
 use super::callable::CallableTypeKind;
@@ -16,7 +17,9 @@ use super::{
     IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeQualifiers,
 };
 use crate::ProgramEnvironment;
-use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, builtins_symbol};
+use crate::place::{
+    DefinedPlace, Definedness, Place, PlaceAndQualifiers, builtins_symbol, place_from_bindings,
+};
 
 /// The operation required to write an attribute.
 ///
@@ -441,16 +444,32 @@ fn class_attribute_write_requirement<'db>(
 
     let member = match type_member {
         PlaceAndQualifiers {
-            place: Place::Defined(DefinedPlace { ty, .. }),
+            place: Place::Defined(place @ DefinedPlace { ty, .. }),
             qualifiers,
-        } => ClassAttributeWriteMember::Explicit {
-            member: explicit_attribute_write_requirement(
-                db, env, object_ty, attribute, ty, qualifiers,
-            ),
-            fallback: receiver_fallback.map(|fallback| {
-                class_fallback_write_requirement(db, env, object_ty, class_attr_self_ty, fallback)
-            }),
-        },
+        } => {
+            let descriptor_ty = receiver_fallback
+                .and_then(|_| possible_class_attribute_descriptor(db, env, place))
+                .unwrap_or(ty);
+            ClassAttributeWriteMember::Explicit {
+                member: explicit_attribute_write_requirement(
+                    db,
+                    env,
+                    object_ty,
+                    attribute,
+                    descriptor_ty,
+                    qualifiers,
+                ),
+                fallback: receiver_fallback.map(|fallback| {
+                    class_fallback_write_requirement(
+                        db,
+                        env,
+                        object_ty,
+                        class_attr_self_ty,
+                        fallback,
+                    )
+                }),
+            }
+        }
         PlaceAndQualifiers {
             place: Place::Undefined,
             ..
@@ -477,6 +496,36 @@ fn class_attribute_write_requirement<'db>(
     };
 
     AttributeWriteRequirement::Class { object_ty, member }
+}
+
+/// Recover the concrete descriptor hidden by an uncertain metaclass-member annotation.
+///
+/// For `attribute: type[Base] = Descriptor`, the annotation describes the class object itself,
+/// while the binding can reveal that `Descriptor` has a metaclass implementing `__set__`.
+fn possible_class_attribute_descriptor<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    member: DefinedPlace<'db>,
+) -> Option<Type<'db>> {
+    if member.ty.is_data_descriptor(db, env) || member.ty.is_definitely_non_data_descriptor(db, env)
+    {
+        return None;
+    }
+
+    let definition = member.provenance.definition()?;
+    let use_def = use_def_map(db, definition.scope(db));
+    let descriptor_ty =
+        place_from_bindings(db, env, use_def.end_of_scope_bindings(definition.place(db)))
+            .place
+            .ignore_possibly_undefined()?;
+    let descriptor_ty = match descriptor_ty.resolve_type_alias(db) {
+        Type::TypeForm(typeform) => typeform.type_argument(db).to_meta_type(db, env),
+        descriptor_ty => descriptor_ty,
+    };
+
+    descriptor_ty
+        .is_data_descriptor(db, env)
+        .then_some(descriptor_ty)
 }
 
 /// Convert an explicitly resolved member into either a descriptor call or a direct type check.
@@ -662,17 +711,22 @@ fn class_object_member_precedence<'db>(
         return None;
     }
 
+    let type_member_ty = type_member.place.ignore_possibly_undefined()?;
+    let definitely_non_data_descriptor = type_member_ty.is_definitely_non_data_descriptor(db, env);
+    if !definitely_non_data_descriptor
+        && (type_member_ty.is_divergent() || type_member_ty.is_data_descriptor(db, env))
+    {
+        return None;
+    }
+
     let receiver_member = object_ty
         .find_name_in_mro_with_policy(db, env, attribute, MemberLookupPolicy::default())
         .filter(|class_attr| !class_attr.place.is_undefined())?;
-    let type_member_ty = type_member.place.ignore_possibly_undefined()?;
 
-    if type_member_ty.is_definitely_non_data_descriptor(db, env) {
+    if definitely_non_data_descriptor {
         Some(ClassObjectMemberPrecedence::Receiver(receiver_member))
-    } else if !type_member_ty.is_divergent() && !type_member_ty.is_data_descriptor(db, env) {
-        Some(ClassObjectMemberPrecedence::TypeOrReceiver(receiver_member))
     } else {
-        None
+        Some(ClassObjectMemberPrecedence::TypeOrReceiver(receiver_member))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -626,6 +626,19 @@ pub(super) fn property_setter_returns_never<'db>(
 }
 
 /// Return the class member that takes precedence over a definitely non-data metaclass member.
+///
+/// For example, `C.attribute` governs the assignment below because `Meta.attribute` does not
+/// implement `__set__` or `__delete__`:
+///
+/// ```python
+/// class Meta(type):
+///     attribute = object()
+///
+/// class C(metaclass=Meta):
+///     attribute: int
+///
+/// C.attribute = 1
+/// ```
 fn class_member_preceding_non_data_metaclass_member<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -106,7 +106,8 @@ pub(super) enum InstanceAttributeWriteMember<'db> {
 ///
 /// A data descriptor on the metaclass takes precedence over the class object's own attributes,
 /// which in turn take precedence over definitely non-data metaclass members. If the metaclass
-/// member is absent or possibly undefined, the class object's own attributes form the fallback.
+/// member is absent, possibly undefined, or could be a non-data descriptor, the class object's own
+/// attributes form the fallback.
 pub(super) enum ClassAttributeWriteMember<'db> {
     /// A metaclass member governs the write, optionally alongside a class-attribute fallback.
     Explicit {
@@ -150,7 +151,7 @@ impl ExplicitAttributeWriteRequirement<'_> {
     }
 }
 
-/// A write target found through a possibly absent fallback lookup.
+/// A receiver-level write target that can govern the write instead of the type member.
 pub(super) enum FallbackAttributeWriteRequirement<'db> {
     /// Check the value against `ty`, retaining whether the declaration may be absent at runtime.
     AssignableTo {
@@ -184,8 +185,8 @@ pub(super) enum FallbackAttributeWriteRequirement<'db> {
 /// ```
 pub(super) enum AssignmentAttributeMembers<'db> {
     /// The type member governs the write, as `Meta.data` does above because it is a data descriptor.
-    /// If the type member may be missing, the corresponding receiver member (`C.data`) is retained
-    /// as `receiver_fallback`.
+    /// If the type member may be missing or may be a non-data descriptor, the corresponding
+    /// receiver member (`C.data`) is retained as `receiver_fallback`.
     TypeMember {
         member: PlaceAndQualifiers<'db>,
         receiver_fallback: Option<PlaceAndQualifiers<'db>>,
@@ -625,7 +626,15 @@ pub(super) fn property_setter_returns_never<'db>(
     })
 }
 
-/// Return the class member that takes precedence over a definitely non-data metaclass member.
+enum ClassObjectMemberPrecedence<'db> {
+    /// The class-object member always shadows the metaclass member.
+    Receiver(PlaceAndQualifiers<'db>),
+    /// The metaclass member's descriptor status is uncertain, so either member can govern the
+    /// write.
+    TypeOrReceiver(PlaceAndQualifiers<'db>),
+}
+
+/// Classify the precedence between a metaclass member and a class-object member.
 ///
 /// For example, `C.attribute` governs the assignment below because `Meta.attribute` does not
 /// implement `__set__` or `__delete__`:
@@ -639,36 +648,42 @@ pub(super) fn property_setter_returns_never<'db>(
 ///
 /// C.attribute = 1
 /// ```
-fn class_member_preceding_non_data_metaclass_member<'db>(
+fn class_object_member_precedence<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     object_ty: Type<'db>,
     attribute: &str,
     type_member: PlaceAndQualifiers<'db>,
-) -> Option<PlaceAndQualifiers<'db>> {
+) -> Option<ClassObjectMemberPrecedence<'db>> {
     if !matches!(
         object_ty,
         Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..)
-    ) || !type_member
-        .place
-        .ignore_possibly_undefined()?
-        .is_definitely_non_data_descriptor(db, env)
-    {
+    ) {
         return None;
     }
 
-    object_ty
+    let receiver_member = object_ty
         .find_name_in_mro_with_policy(db, env, attribute, MemberLookupPolicy::default())
-        .filter(|class_attr| !class_attr.place.is_undefined())
+        .filter(|class_attr| !class_attr.place.is_undefined())?;
+    let type_member_ty = type_member.place.ignore_possibly_undefined()?;
+
+    if type_member_ty.is_definitely_non_data_descriptor(db, env) {
+        Some(ClassObjectMemberPrecedence::Receiver(receiver_member))
+    } else if !type_member_ty.is_divergent() && !type_member_ty.is_data_descriptor(db, env) {
+        Some(ClassObjectMemberPrecedence::TypeOrReceiver(receiver_member))
+    } else {
+        None
+    }
 }
 
 /// Return the members considered by attribute assignment in lookup-precedence order.
 ///
 /// The type member comes from class-member lookup. A member found directly on the receiver is
 /// queried when the type member is absent or possibly undefined. For class objects, a class-MRO
-/// member instead takes precedence over a definitely non-data metaclass member. Composite and
-/// dynamic receiver types return `None`; their callers either decompose them before this point or
-/// handle them without member lookup.
+/// member instead takes precedence over a definitely non-data metaclass member and remains an
+/// alternative when the metaclass member's descriptor status is uncertain. Composite and dynamic
+/// receiver types return `None`; their callers either decompose them before this point or handle
+/// them without member lookup.
 ///
 /// This helper deliberately does not bind `Self` or interpret descriptors so that assignment,
 /// protocol compatibility, and `Final` validation share exactly the same lookup precedence.
@@ -693,11 +708,16 @@ pub(super) fn assignment_attribute_members<'db>(
     } else {
         object_ty.class_member(db, env, attribute)
     };
-    if let Some(receiver_member) =
-        class_member_preceding_non_data_metaclass_member(db, env, object_ty, attribute, type_member)
-    {
-        return Some(AssignmentAttributeMembers::ReceiverMember(receiver_member));
-    }
+    let receiver_alternative =
+        match class_object_member_precedence(db, env, object_ty, attribute, type_member) {
+            Some(ClassObjectMemberPrecedence::Receiver(receiver_member)) => {
+                return Some(AssignmentAttributeMembers::ReceiverMember(receiver_member));
+            }
+            Some(ClassObjectMemberPrecedence::TypeOrReceiver(receiver_member)) => {
+                Some(receiver_member)
+            }
+            None => None,
+        };
     let needs_receiver_fallback = matches!(
         type_member.place,
         Place::Defined(DefinedPlace {
@@ -705,7 +725,9 @@ pub(super) fn assignment_attribute_members<'db>(
             ..
         }) | Place::Undefined
     );
-    let receiver_fallback = if needs_receiver_fallback {
+    let receiver_fallback = if let Some(receiver_alternative) = receiver_alternative {
+        Some(receiver_alternative)
+    } else if needs_receiver_fallback {
         Some(match object_ty {
             Type::NominalInstance(..)
             | Type::ProtocolInstance(_)

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -500,8 +500,18 @@ fn class_attribute_write_requirement<'db>(
 
 /// Recover the concrete descriptor hidden by an uncertain metaclass-member annotation.
 ///
-/// For `attribute: type[Base] = Descriptor`, the annotation describes the class object itself,
-/// while the binding can reveal that `Descriptor` has a metaclass implementing `__set__`.
+/// The declared type describes the descriptor object, not the values accepted by its setter.
+/// Inspecting the binding preserves the setter's actual value contract:
+///
+/// ```python
+/// class DescriptorMeta(type):
+///     def __set__(self, instance: object, value: str) -> None: ...
+///
+/// class Descriptor(metaclass=DescriptorMeta): ...
+///
+/// class Meta(type):
+///     attribute: type[object] = Descriptor
+/// ```
 fn possible_class_attribute_descriptor<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -675,18 +685,10 @@ pub(super) fn property_setter_returns_never<'db>(
     })
 }
 
-enum ClassObjectMemberPrecedence<'db> {
-    /// The class-object member always shadows the metaclass member.
-    Receiver(PlaceAndQualifiers<'db>),
-    /// The metaclass member's descriptor status is uncertain, so either member can govern the
-    /// write.
-    TypeOrReceiver(PlaceAndQualifiers<'db>),
-}
-
-/// Classify the precedence between a metaclass member and a class-object member.
+/// Resolve class-object members when a class attribute can shadow its metaclass member.
 ///
-/// For example, `C.attribute` governs the assignment below because `Meta.attribute` does not
-/// implement `__set__` or `__delete__`:
+/// A definitely non-data metaclass member is shadowed entirely. If the metaclass member's
+/// descriptor status is uncertain, both members remain possible write targets.
 ///
 /// ```python
 /// class Meta(type):
@@ -697,13 +699,13 @@ enum ClassObjectMemberPrecedence<'db> {
 ///
 /// C.attribute = 1
 /// ```
-fn class_object_member_precedence<'db>(
+fn class_object_assignment_members<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     object_ty: Type<'db>,
     attribute: &str,
     type_member: PlaceAndQualifiers<'db>,
-) -> Option<ClassObjectMemberPrecedence<'db>> {
+) -> Option<AssignmentAttributeMembers<'db>> {
     if !matches!(
         object_ty,
         Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..)
@@ -723,11 +725,14 @@ fn class_object_member_precedence<'db>(
         .find_name_in_mro_with_policy(db, env, attribute, MemberLookupPolicy::default())
         .filter(|class_attr| !class_attr.place.is_undefined())?;
 
-    if definitely_non_data_descriptor {
-        Some(ClassObjectMemberPrecedence::Receiver(receiver_member))
+    Some(if definitely_non_data_descriptor {
+        AssignmentAttributeMembers::ReceiverMember(receiver_member)
     } else {
-        Some(ClassObjectMemberPrecedence::TypeOrReceiver(receiver_member))
-    }
+        AssignmentAttributeMembers::TypeMember {
+            member: type_member,
+            receiver_fallback: Some(receiver_member),
+        }
+    })
 }
 
 /// Return the members considered by attribute assignment in lookup-precedence order.
@@ -762,16 +767,11 @@ pub(super) fn assignment_attribute_members<'db>(
     } else {
         object_ty.class_member(db, env, attribute)
     };
-    let receiver_alternative =
-        match class_object_member_precedence(db, env, object_ty, attribute, type_member) {
-            Some(ClassObjectMemberPrecedence::Receiver(receiver_member)) => {
-                return Some(AssignmentAttributeMembers::ReceiverMember(receiver_member));
-            }
-            Some(ClassObjectMemberPrecedence::TypeOrReceiver(receiver_member)) => {
-                Some(receiver_member)
-            }
-            None => None,
-        };
+    if let Some(members) =
+        class_object_assignment_members(db, env, object_ty, attribute, type_member)
+    {
+        return Some(members);
+    }
     let needs_receiver_fallback = matches!(
         type_member.place,
         Place::Defined(DefinedPlace {
@@ -779,9 +779,7 @@ pub(super) fn assignment_attribute_members<'db>(
             ..
         }) | Place::Undefined
     );
-    let receiver_fallback = if let Some(receiver_alternative) = receiver_alternative {
-        Some(receiver_alternative)
-    } else if needs_receiver_fallback {
+    let receiver_fallback = if needs_receiver_fallback {
         Some(match object_ty {
             Type::NominalInstance(..)
             | Type::ProtocolInstance(_)

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -529,8 +529,36 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     return false;
                 }
                 let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
-                let member_valid =
-                    self.evaluate_explicit_member(object_ty, member, value_ty, emit_diagnostics);
+                let member_valid = match member {
+                    ExplicitAttributeWriteRequirement::AssignableTo { ty, .. }
+                        if fallback.is_some()
+                            && match ty.resolve_type_alias(db) {
+                                Type::TypeForm(_) => true,
+                                Type::Union(union) => union.elements(db).iter().any(|element| {
+                                    matches!(element.resolve_type_alias(db), Type::TypeForm(_))
+                                }),
+                                _ => false,
+                            } =>
+                    {
+                        // Both possible write targets must receive the same runtime value.
+                        // In particular, invalid type expressions must not silently become
+                        // `TypeForm[Unknown]` while checking the metaclass alternative.
+                        let mut speculative_builder = self.builder.speculate();
+                        let contextual_value_ty = (self.infer_value_ty.infer_expr)(
+                            &mut speculative_builder,
+                            TypeContext::new(Some(*ty)),
+                        );
+                        let checked_value_ty = if speculative_builder.context.has_diagnostics() {
+                            value_ty
+                        } else {
+                            contextual_value_ty
+                        };
+                        self.check_type_pair(checked_value_ty, *ty, emit_diagnostics)
+                    }
+                    _ => {
+                        self.evaluate_explicit_member(object_ty, member, value_ty, emit_diagnostics)
+                    }
+                };
                 if let Some(fallback) = fallback {
                     let fallback_valid = self.evaluate_class_fallback(
                         object_ty,

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -529,36 +529,8 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     return false;
                 }
                 let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
-                let member_valid = match member {
-                    ExplicitAttributeWriteRequirement::AssignableTo { ty, .. }
-                        if fallback.is_some()
-                            && match ty.resolve_type_alias(db) {
-                                Type::TypeForm(_) => true,
-                                Type::Union(union) => union.elements(db).iter().any(|element| {
-                                    matches!(element.resolve_type_alias(db), Type::TypeForm(_))
-                                }),
-                                _ => false,
-                            } =>
-                    {
-                        // Both possible write targets must receive the same runtime value.
-                        // In particular, invalid type expressions must not silently become
-                        // `TypeForm[Unknown]` while checking the metaclass alternative.
-                        let mut speculative_builder = self.builder.speculate();
-                        let contextual_value_ty = (self.infer_value_ty.infer_expr)(
-                            &mut speculative_builder,
-                            TypeContext::new(Some(*ty)),
-                        );
-                        let checked_value_ty = if speculative_builder.context.has_diagnostics() {
-                            value_ty
-                        } else {
-                            contextual_value_ty
-                        };
-                        self.check_type_pair(checked_value_ty, *ty, emit_diagnostics)
-                    }
-                    _ => {
-                        self.evaluate_explicit_member(object_ty, member, value_ty, emit_diagnostics)
-                    }
-                };
+                let member_valid =
+                    self.evaluate_explicit_member(object_ty, member, value_ty, emit_diagnostics);
                 if let Some(fallback) = fallback {
                     let fallback_valid = self.evaluate_class_fallback(
                         object_ty,


### PR DESCRIPTION
## Summary

When assigning to `C.attribute`, a data descriptor on the metaclass takes precedence over `C`'s class attribute. If the metaclass member is definitely non-data, the class attribute shadows it.

For attributes annotated as `TypeForm[...]` or an inexact `type[Base]`, the annotation describes the instances produced by the represented class, but not the metaclass of the runtime class object. So the metaclass member could be _either_ a data descriptor or a non-data value, which means assignment has to be valid under both possible  paths...

```python
from typing_extensions import TypeForm

class DescriptorMeta(type):
    def __set__(self, instance: object, value: str) -> None: ...

class Descriptor(metaclass=DescriptorMeta): ...

class Meta(type):
    attribute: TypeForm[Descriptor] = Descriptor

class C(metaclass=Meta):
    attribute: int = 1

# Invalid under both possible runtime paths:
# - If Meta.attribute is a data descriptor, DescriptorMeta.__set__ expects str.
# - If Meta.attribute is non-data, C.attribute shadows it and expects int.
C.attribute = Descriptor  # error: [invalid-assignment]
```

Prior to this change, we treated these class-object types as definitely non-data descriptors. We now preserve their descriptor uncertainty and retain the class member as an alternative write target even when the metaclass member is always defined. Definitely data and definitely non-data members continue to use their single governing write path.
