### PR TITLE
[ty] Preserve possible metaclass descriptors on reads

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -381,7 +381,7 @@ reveal_type(UnionC.attribute)  # revealed: Any | Literal["descriptor"]
 A `TypeForm` argument describes the instances produced by a type form, not the runtime type form
 value itself. A metaclass attribute typed as `TypeForm[Descriptor]` can therefore be a class whose
 own metaclass makes it a data descriptor, and must continue to take precedence over a class
-attribute with the same name when assigning to the attribute:
+attribute with the same name when reading or assigning to the attribute:
 
 ```py
 from typing_extensions import TypeForm
@@ -398,6 +398,7 @@ class Meta(type):
 class C(metaclass=Meta):
     attribute: int = 1
 
+reveal_type(C.attribute)  # revealed: TypeForm[Descriptor] | int
 C.attribute = 1  # error: [invalid-assignment]
 C.attribute = Descriptor  # error: [invalid-assignment]
 ```
@@ -406,7 +407,7 @@ C.attribute = Descriptor  # error: [invalid-assignment]
 
 An inexact `type[Base]` attribute can hold a subclass whose custom metaclass makes the class object
 a data descriptor. It must therefore continue to take precedence over a class attribute with the
-same name when assigning to the attribute:
+same name when reading or assigning to the attribute:
 
 ```py
 class Base: ...
@@ -423,6 +424,7 @@ class Meta(type):
 class C(metaclass=Meta):
     attribute: int = 1
 
+reveal_type(C.attribute)  # revealed: type[Base] | int
 C.attribute = 1  # error: [invalid-assignment]
 C.attribute = Descriptor  # error: [invalid-assignment]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -381,7 +381,7 @@ reveal_type(UnionC.attribute)  # revealed: Any | Literal["descriptor"]
 A `TypeForm` argument describes the instances produced by a type form, not the runtime type form
 value itself. A metaclass attribute typed as `TypeForm[Descriptor]` can therefore be a class whose
 own metaclass makes it a data descriptor, and must continue to take precedence over a class
-attribute with the same name when assigning to the attribute:
+attribute with the same name when reading or assigning to the attribute:
 
 ```py
 from typing_extensions import TypeForm
@@ -398,6 +398,7 @@ class Meta(type):
 class C(metaclass=Meta):
     attribute: int = 1
 
+reveal_type(C.attribute)  # revealed: TypeForm[Descriptor] | int
 C.attribute = 1  # error: [invalid-assignment]
 # error: [invalid-assignment]
 C.attribute = Descriptor  # error: [invalid-assignment]
@@ -440,7 +441,7 @@ UnionC.attribute = 1  # error: [invalid-assignment]
 
 An inexact `type[Base]` attribute can hold a subclass whose custom metaclass makes the class object
 a data descriptor. It must therefore continue to take precedence over a class attribute with the
-same name when assigning to the attribute:
+same name when reading or assigning to the attribute:
 
 ```py
 class Base: ...
@@ -457,6 +458,7 @@ class Meta(type):
 class C(metaclass=Meta):
     attribute: int = 1
 
+reveal_type(C.attribute)  # revealed: type[Base] | int
 C.attribute = 1  # error: [invalid-assignment]
 # error: [invalid-assignment]
 C.attribute = Descriptor  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -431,18 +431,39 @@ impl AttributeKind {
     }
 }
 
-/// This enum is used to control the behavior of the descriptor protocol implementation.
-/// When invoked on a class object, the fallback type (a class attribute) can shadow a
-/// non-data descriptor of the meta-type (the class's metaclass). However, this is not
-/// true for instances. When invoked on an instance, the fallback type (an attribute on
-/// the instance) cannot completely shadow a non-data descriptor of the meta-type (the
-/// class), because we do not currently attempt to statically infer if an instance
-/// attribute is definitely defined (i.e. to check whether a particular method has been
-/// called).
+/// Whether a member on the receiver can shadow a non-data member on the receiver's type.
+///
+/// This is enabled for class objects, where an always-defined class member shadows a non-data
+/// descriptor on the metaclass. It is disabled for ordinary instances because we do not currently
+/// infer whether an instance attribute is definitely initialized.
 #[derive(Clone, Debug, Copy, PartialEq)]
-enum InstanceFallbackShadowsNonDataDescriptor {
+enum ReceiverMemberShadowsNonDataDescriptor {
     Yes,
     No,
+}
+
+/// Return whether `receiver_member` takes precedence over `type_member`.
+///
+/// Descriptor uncertainty is conservative: the receiver member only takes precedence when it is
+/// always defined and the type member is known not to be a data descriptor.
+fn receiver_member_shadows_type_member<'db>(
+    db: &'db dyn Db,
+    type_member: PlaceAndQualifiers<'db>,
+    receiver_member: PlaceAndQualifiers<'db>,
+    policy: ReceiverMemberShadowsNonDataDescriptor,
+) -> bool {
+    policy == ReceiverMemberShadowsNonDataDescriptor::Yes
+        && matches!(
+            receiver_member.place,
+            Place::Defined(DefinedPlace {
+                definedness: Definedness::AlwaysDefined,
+                ..
+            })
+        )
+        && type_member
+            .place
+            .ignore_possibly_undefined()
+            .is_some_and(|ty| ty.is_definitely_non_data_descriptor(db))
 }
 
 bitflags! {
@@ -3617,9 +3638,14 @@ impl<'db> Type<'db> {
         receiver: Type<'db>,
         name: &str,
         fallback: PlaceAndQualifiers<'db>,
-        policy: InstanceFallbackShadowsNonDataDescriptor,
+        policy: ReceiverMemberShadowsNonDataDescriptor,
         member_policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
+        let type_member =
+            self.instance_lookup_class_member_with_policy(db, name.into(), member_policy);
+        if receiver_member_shadows_type_member(db, type_member, fallback, policy) {
+            return fallback;
+        }
         let (
             PlaceAndQualifiers {
                 place: meta_attr,
@@ -3628,7 +3654,7 @@ impl<'db> Type<'db> {
             meta_attr_kind,
         ) = Self::try_call_dunder_get_on_attribute(
             db,
-            self.instance_lookup_class_member_with_policy(db, name.into(), member_policy),
+            type_member,
             Some(receiver),
             self.to_meta_type(db),
         );
@@ -3684,28 +3710,9 @@ impl<'db> Type<'db> {
             })
             .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers)),
 
-            // `meta_attr` is *not* a data descriptor. This means that the `fallback` type has
-            // now the highest priority. However, we only return the pure `fallback` type if the
-            // policy allows it. When invoked on class objects, the policy is set to `Yes`, which
-            // means that class-level attributes (the fallback) can shadow non-data descriptors
-            // on metaclasses. However, for instances, the policy is set to `No`, because we do
-            // allow instance-level attributes to shadow class-level non-data descriptors. This
-            // would require us to statically infer if an instance attribute is always set, which
-            // is something we currently don't attempt to do.
-            (
-                Place::Defined(_),
-                AttributeKind::NormalOrNonDataDescriptor,
-                fallback @ Place::Defined(DefinedPlace {
-                    definedness: Definedness::AlwaysDefined,
-                    ..
-                }),
-            ) if policy == InstanceFallbackShadowsNonDataDescriptor::Yes => {
-                fallback.with_qualifiers(fallback_qualifiers)
-            }
-
-            // `meta_attr` is *not* a data descriptor. The `fallback` symbol is either possibly
-            // unbound or the policy argument is `No`. In both cases, the `fallback` type does
-            // not completely shadow the non-data descriptor, so we build a union of the two.
+            // The fallback cannot completely shadow the type member when it is possibly unbound,
+            // the policy disables shadowing, or the raw type member's descriptor status is
+            // uncertain. Preserve both possibilities.
             (
                 Place::Defined(DefinedPlace {
                     ty: meta_attr_ty,
@@ -3840,7 +3847,7 @@ impl<'db> Type<'db> {
                     receiver,
                     name_str,
                     fallback,
-                    InstanceFallbackShadowsNonDataDescriptor::No,
+                    ReceiverMemberShadowsNonDataDescriptor::No,
                     policy,
                 );
 
@@ -4139,7 +4146,7 @@ impl<'db> Type<'db> {
                     receiver.unwrap_or(this),
                     name_str,
                     Place::Undefined.into(),
-                    InstanceFallbackShadowsNonDataDescriptor::No,
+                    ReceiverMemberShadowsNonDataDescriptor::No,
                     policy,
                 ),
 
@@ -4337,7 +4344,7 @@ impl<'db> Type<'db> {
                         receiver,
                         name_str,
                         class_attr_fallback,
-                        InstanceFallbackShadowsNonDataDescriptor::Yes,
+                        ReceiverMemberShadowsNonDataDescriptor::Yes,
                         policy,
                     );
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -433,9 +433,16 @@ impl AttributeKind {
 
 /// Whether a member on the receiver can shadow a non-data member on the receiver's type.
 ///
-/// This is enabled for class objects, where an always-defined class member shadows a non-data
-/// descriptor on the metaclass. It is disabled for ordinary instances because we do not currently
-/// infer whether an instance attribute is definitely initialized.
+/// This policy is shared by attribute reads and writes. For a class-object receiver `C`, the
+/// receiver member is a class attribute such as `C.x`, while the type member is an attribute on the
+/// metaclass, `type(C).x`. An always-defined class attribute can therefore shadow a non-data
+/// descriptor on the metaclass.
+///
+/// For an ordinary instance `obj`, the receiver member is an instance attribute such as `obj.x`,
+/// while the type member is a class attribute, `type(obj).x`. Shadowing is disabled in this case
+/// because we do not currently infer whether the instance attribute is definitely initialized at
+/// the point of access. Doing so would require tracking whether the relevant initializer path, or
+/// another method that assigns the attribute, has executed.
 #[derive(Clone, Debug, Copy, PartialEq)]
 enum ReceiverMemberShadowsNonDataDescriptor {
     Yes,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -800,18 +800,40 @@ impl<'db> From<Place<'db>> for MemberLookupResult<'db> {
     }
 }
 
-/// This enum is used to control the behavior of the descriptor protocol implementation.
-/// When invoked on a class object, the fallback type (a class attribute) can shadow a
-/// non-data descriptor of the meta-type (the class's metaclass). However, this is not
-/// true for instances. When invoked on an instance, the fallback type (an attribute on
-/// the instance) cannot completely shadow a non-data descriptor of the meta-type (the
-/// class), because we do not currently attempt to statically infer if an instance
-/// attribute is definitely defined (i.e. to check whether a particular method has been
-/// called).
+/// Whether a member on the receiver can shadow a non-data member on the receiver's type.
+///
+/// This is enabled for class objects, where an always-defined class member shadows a non-data
+/// descriptor on the metaclass. It is disabled for ordinary instances because we do not currently
+/// infer whether an instance attribute is definitely initialized.
 #[derive(Clone, Debug, Copy, PartialEq)]
-enum InstanceFallbackShadowsNonDataDescriptor {
+enum ReceiverMemberShadowsNonDataDescriptor {
     Yes,
     No,
+}
+
+/// Return whether `receiver_member` takes precedence over `type_member`.
+///
+/// Descriptor uncertainty is conservative: the receiver member only takes precedence when it is
+/// always defined and the type member is known not to be a data descriptor.
+fn receiver_member_shadows_type_member<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    type_member: PlaceAndQualifiers<'db>,
+    receiver_member: PlaceAndQualifiers<'db>,
+    policy: ReceiverMemberShadowsNonDataDescriptor,
+) -> bool {
+    policy == ReceiverMemberShadowsNonDataDescriptor::Yes
+        && matches!(
+            receiver_member.place,
+            Place::Defined(DefinedPlace {
+                definedness: Definedness::AlwaysDefined,
+                ..
+            })
+        )
+        && type_member
+            .place
+            .ignore_possibly_undefined()
+            .is_some_and(|ty| ty.is_definitely_non_data_descriptor(db, env))
 }
 
 bitflags! {
@@ -4292,9 +4314,18 @@ impl<'db> Type<'db> {
         key: MemberLookupKey<'db>,
         receiver: Type<'db>,
         fallback: MemberLookupResult<'db>,
-        policy: InstanceFallbackShadowsNonDataDescriptor,
+        policy: ReceiverMemberShadowsNonDataDescriptor,
     ) -> MemberLookupResult<'db> {
         let meta_attr_plain = Self::instance_lookup_class_member_with_policy(db, env, key);
+        if receiver_member_shadows_type_member(
+            db,
+            env,
+            meta_attr_plain,
+            fallback.unwrap_or_else(|error| error.fallback_member(db)),
+            policy,
+        ) {
+            return fallback;
+        }
         // A TypeVar retains its class identity when lookup is delegated to its bound, including
         // after narrowing. Narrowing can also add an unrelated class to a mixin's `Self`, in which
         // case the TypeVar alone is not a valid owner for descriptors from that class.
@@ -4381,30 +4412,9 @@ impl<'db> Type<'db> {
                 meta_attr_error.or(fallback_error),
             ),
 
-            // `meta_attr` is *not* a data descriptor. This means that the `fallback` type has
-            // now the highest priority. However, we only return the pure `fallback` type if the
-            // policy allows it. When invoked on class objects, the policy is set to `Yes`, which
-            // means that class-level attributes (the fallback) can shadow non-data descriptors
-            // on metaclasses. However, for instances, the policy is set to `No`, because we do
-            // allow instance-level attributes to shadow class-level non-data descriptors. This
-            // would require us to statically infer if an instance attribute is always set, which
-            // is something we currently don't attempt to do.
-            (
-                Place::Defined(_),
-                AttributeKind::NormalOrNonDataDescriptor,
-                fallback @ Place::Defined(DefinedPlace {
-                    definedness: Definedness::AlwaysDefined,
-                    ..
-                }),
-            ) if policy == InstanceFallbackShadowsNonDataDescriptor::Yes => member_lookup_result(
-                db,
-                fallback.with_qualifiers(fallback_qualifiers),
-                fallback_error,
-            ),
-
-            // `meta_attr` is *not* a data descriptor. The `fallback` symbol is either possibly
-            // unbound or the policy argument is `No`. In both cases, the `fallback` type does
-            // not completely shadow the non-data descriptor, so we build a union of the two.
+            // The fallback cannot completely shadow the type member when it is possibly unbound,
+            // the policy disables shadowing, or the raw type member's descriptor status is
+            // uncertain. Preserve both possibilities.
             (
                 Place::Defined(DefinedPlace {
                     ty: meta_attr_ty,
@@ -4596,7 +4606,7 @@ impl<'db> Type<'db> {
                     key,
                     receiver,
                     fallback.into(),
-                    InstanceFallbackShadowsNonDataDescriptor::No,
+                    ReceiverMemberShadowsNonDataDescriptor::No,
                 );
 
                 if result
@@ -4969,7 +4979,7 @@ impl<'db> Type<'db> {
                         key,
                         receiver,
                         Place::Undefined.into(),
-                        InstanceFallbackShadowsNonDataDescriptor::No,
+                        ReceiverMemberShadowsNonDataDescriptor::No,
                     );
                     map_member_lookup_type(db, result, |ty| {
                         ty.bind_self_typevars(db, env, receiver)
@@ -5175,7 +5185,7 @@ impl<'db> Type<'db> {
                             class_attr_fallback,
                             class_attr_error.map(MemberLookupErrorKind::DescriptorGet),
                         ),
-                        InstanceFallbackShadowsNonDataDescriptor::Yes,
+                        ReceiverMemberShadowsNonDataDescriptor::Yes,
                     );
 
                     // A class is an instance of its metaclass. If attribute lookup on the class

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -802,9 +802,16 @@ impl<'db> From<Place<'db>> for MemberLookupResult<'db> {
 
 /// Whether a member on the receiver can shadow a non-data member on the receiver's type.
 ///
-/// This is enabled for class objects, where an always-defined class member shadows a non-data
-/// descriptor on the metaclass. It is disabled for ordinary instances because we do not currently
-/// infer whether an instance attribute is definitely initialized.
+/// This policy is shared by attribute reads and writes. For a class-object receiver `C`, the
+/// receiver member is a class attribute such as `C.x`, while the type member is an attribute on the
+/// metaclass, `type(C).x`. An always-defined class attribute can therefore shadow a non-data
+/// descriptor on the metaclass.
+///
+/// For an ordinary instance `obj`, the receiver member is an instance attribute such as `obj.x`,
+/// while the type member is a class attribute, `type(obj).x`. Shadowing is disabled in this case
+/// because we do not currently infer whether the instance attribute is definitely initialized at
+/// the point of access. Doing so would require tracking whether the relevant initializer path, or
+/// another method that assigns the attribute, has executed.
 #[derive(Clone, Debug, Copy, PartialEq)]
 enum ReceiverMemberShadowsNonDataDescriptor {
     Yes,

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -12,7 +12,9 @@ use ty_module_resolver::KnownModule;
 use super::call::CallArguments;
 use super::callable::CallableTypeKind;
 use super::{
-    IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeQualifiers,
+    IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy,
+    ReceiverMemberShadowsNonDataDescriptor, Type, TypeQualifiers,
+    receiver_member_shadows_type_member,
 };
 use crate::Db;
 use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, builtins_symbol};
@@ -592,7 +594,7 @@ enum ClassObjectMemberPrecedence<'db> {
 ///     attribute = object()
 ///
 /// class C(metaclass=Meta):
-///     attribute: int
+///     attribute: int = 0
 ///
 /// C.attribute = 1
 /// ```
@@ -609,14 +611,20 @@ fn class_object_member_precedence<'db>(
         return None;
     }
 
-    let receiver_member = object_ty
-        .find_name_in_mro_with_policy(db, attribute, MemberLookupPolicy::default())
-        .filter(|class_attr| !class_attr.place.is_undefined())?;
-    let type_member_ty = type_member.place.ignore_possibly_undefined()?;
-
-    if type_member_ty.is_definitely_non_data_descriptor(db) {
+    let receiver_member =
+        object_ty.class_object_member(db, attribute, MemberLookupPolicy::default());
+    if receiver_member_shadows_type_member(
+        db,
+        type_member,
+        receiver_member,
+        ReceiverMemberShadowsNonDataDescriptor::Yes,
+    ) {
         Some(ClassObjectMemberPrecedence::Receiver(receiver_member))
-    } else if !type_member_ty.is_divergent() && !type_member_ty.is_data_descriptor(db) {
+    } else if !receiver_member.place.is_undefined()
+        && let Some(type_member_ty) = type_member.place.ignore_possibly_undefined()
+        && !type_member_ty.is_divergent()
+        && !type_member_ty.is_data_descriptor(db)
+    {
         Some(ClassObjectMemberPrecedence::TypeOrReceiver(receiver_member))
     } else {
         None
@@ -626,7 +634,7 @@ fn class_object_member_precedence<'db>(
 /// Return the members considered by attribute assignment in lookup-precedence order.
 ///
 /// The type member comes from class-member lookup. A member found directly on the receiver is
-/// queried when the type member is absent or possibly undefined. For class objects, a class-MRO
+/// queried when the type member is absent or possibly undefined. For class objects, a class-object
 /// member instead takes precedence over a definitely non-data metaclass member and remains an
 /// alternative when the metaclass member's descriptor status is uncertain. Composite and dynamic
 /// receiver types return `None`; their callers either decompose them before this point or handle

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -14,7 +14,9 @@ use ty_python_core::use_def_map;
 use super::call::CallArguments;
 use super::callable::CallableTypeKind;
 use super::{
-    IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeQualifiers,
+    IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy,
+    ReceiverMemberShadowsNonDataDescriptor, Type, TypeQualifiers,
+    receiver_member_shadows_type_member,
 };
 use crate::ProgramEnvironment;
 use crate::place::{
@@ -695,7 +697,7 @@ pub(super) fn property_setter_returns_never<'db>(
 ///     attribute = object()
 ///
 /// class C(metaclass=Meta):
-///     attribute: int
+///     attribute: int = 0
 ///
 /// C.attribute = 1
 /// ```
@@ -713,32 +715,34 @@ fn class_object_assignment_members<'db>(
         return None;
     }
 
-    let type_member_ty = type_member.place.ignore_possibly_undefined()?;
-    let definitely_non_data_descriptor = type_member_ty.is_definitely_non_data_descriptor(db, env);
-    if !definitely_non_data_descriptor
-        && (type_member_ty.is_divergent() || type_member_ty.is_data_descriptor(db, env))
+    let receiver_member =
+        object_ty.class_object_member(db, env, attribute, MemberLookupPolicy::default());
+    if receiver_member_shadows_type_member(
+        db,
+        env,
+        type_member,
+        receiver_member,
+        ReceiverMemberShadowsNonDataDescriptor::Yes,
+    ) {
+        Some(AssignmentAttributeMembers::ReceiverMember(receiver_member))
+    } else if !receiver_member.place.is_undefined()
+        && let Some(type_member_ty) = type_member.place.ignore_possibly_undefined()
+        && !type_member_ty.is_divergent()
+        && !type_member_ty.is_data_descriptor(db, env)
     {
-        return None;
-    }
-
-    let receiver_member = object_ty
-        .find_name_in_mro_with_policy(db, env, attribute, MemberLookupPolicy::default())
-        .filter(|class_attr| !class_attr.place.is_undefined())?;
-
-    Some(if definitely_non_data_descriptor {
-        AssignmentAttributeMembers::ReceiverMember(receiver_member)
-    } else {
-        AssignmentAttributeMembers::TypeMember {
+        Some(AssignmentAttributeMembers::TypeMember {
             member: type_member,
             receiver_fallback: Some(receiver_member),
-        }
-    })
+        })
+    } else {
+        None
+    }
 }
 
 /// Return the members considered by attribute assignment in lookup-precedence order.
 ///
 /// The type member comes from class-member lookup. A member found directly on the receiver is
-/// queried when the type member is absent or possibly undefined. For class objects, a class-MRO
+/// queried when the type member is absent or possibly undefined. For class objects, a class-object
 /// member instead takes precedence over a definitely non-data metaclass member and remains an
 /// alternative when the metaclass member's descriptor status is uncertain. Composite and dynamic
 /// receiver types return `None`; their callers either decompose them before this point or handle

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -22,10 +22,10 @@ use crate::{
     },
     types::{
         ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
-        CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor,
-        InstanceFallbackShadowsNonDataDescriptor, KnownFunction, MemberLookupPolicy,
-        PropertyInstanceType, ProtocolInstanceType, SelfBinding, StaticClassLiteral, Type,
-        TypeMapping, TypeQualifiers, TypeVarVariance, UnionType, VarianceInferable,
+        CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor, KnownFunction,
+        MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType,
+        ReceiverMemberShadowsNonDataDescriptor, SelfBinding, StaticClassLiteral, Type, TypeMapping,
+        TypeQualifiers, TypeVarVariance, UnionType, VarianceInferable,
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
         diagnostic::report_undeclared_protocol_member,
@@ -1154,7 +1154,7 @@ fn protocol_member_read_type<'db>(
             ty,
             member.name,
             Place::Undefined.into(),
-            InstanceFallbackShadowsNonDataDescriptor::No,
+            ReceiverMemberShadowsNonDataDescriptor::No,
             // The undefined fallback excludes instance members. Keep the class
             // member lookup from reintroducing dynamic instance fallbacks.
             MemberLookupPolicy::NO_INSTANCE_FALLBACK,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -26,10 +26,11 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
         CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor, GenericAlias,
-        GenericContext, InstanceFallbackShadowsNonDataDescriptor, IntersectionType, KnownFunction,
-        MaterializationKind, MemberLookupKey, MemberLookupPolicy, Parameter, PropertyInstanceType,
-        ProtocolInstanceType, SelfBinding, Signature, StaticClassLiteral, Type, TypeMapping,
-        TypeQualifiers, TypeVarBoundOrConstraints, TypeVarVariance, UnionType, VarianceInferable,
+        GenericContext, IntersectionType, KnownFunction, MaterializationKind, MemberLookupKey,
+        MemberLookupPolicy, Parameter, PropertyInstanceType, ProtocolInstanceType,
+        ReceiverMemberShadowsNonDataDescriptor, SelfBinding, Signature, StaticClassLiteral, Type,
+        TypeMapping, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarVariance, UnionType,
+        VarianceInferable,
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
         diagnostic::report_undeclared_protocol_member,
@@ -2522,7 +2523,7 @@ fn protocol_member_read_type<'db>(
             ),
             ty,
             Place::Undefined.into(),
-            InstanceFallbackShadowsNonDataDescriptor::No,
+            ReceiverMemberShadowsNonDataDescriptor::No,
         )
         .unwrap_or_else(|error| error.fallback_member(db))
         .place


### PR DESCRIPTION
## Summary

Building on #26687, we use the raw metaclass member type to decide whether a class attribute can shadow it when assigning. Class-object reads still made that decision after applying the descriptor protocol, which could erase the uncertainty that the metaclass member might be a data descriptor.

For example, a `TypeForm[Descriptor]` metaclass attribute could hold a class whose own metaclass implements `__set__`:

```python
from typing_extensions import TypeForm

class DescriptorMeta(type):
    def __set__(self, instance: object, value: str) -> None: ...

class Descriptor(metaclass=DescriptorMeta): ...

class Meta(type):
    attribute: TypeForm[Descriptor] = Descriptor

class C(metaclass=Meta):
    attribute: int = 1

# Before: int
# After: TypeForm[Descriptor] | int
reveal_type(C.attribute)
```

We now use the same receiver-versus-type precedence helper for class-object reads and writes. Reads preserve both possibilities when the raw metaclass member is not definitely a non-data descriptor, while ordinary instance reads retain their existing conservative shadowing policy.
