### PR TITLE
[ty] Avoid recursive protocol union redundancy checks

### DIFF
--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -21,7 +21,7 @@ use crate::types::protocol_class::{
     ProtocolClass, has_all_protocol_members_defined, walk_protocol_interface,
 };
 use crate::types::relation::{
-    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelationChecker,
+    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
 use crate::types::signatures::SignatureRelationVisitor;
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
@@ -526,6 +526,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .is_always_satisfied(db)
             {
                 return result;
+            }
+
+            // For union simplification, failing the nominal relation between two
+            // specializations of the same protocol class is enough to keep both union elements.
+            // Falling back to the structural relation can recursively compare every protocol
+            // member even though a failed redundancy check only means that we preserve a
+            // potentially redundant union arm.
+            if matches!(self.relation, TypeRelation::Redundancy { pure: false })
+                && ty
+                    .as_protocol_instance()
+                    .and_then(ProtocolInstanceType::to_nominal_instance)
+                    .is_some_and(|source_instance| {
+                        source_instance.class(db).class_literal(db)
+                            == nominal_instance.class(db).class_literal(db)
+                    })
+            {
+                return nominally_satisfied;
             }
         }
 


### PR DESCRIPTION
## Summary

When simplifying a union containing two specializations of the same class-based protocol, we currently fall back from the nominal specialization relation to a full structural protocol comparison if the nominal relation fails. For recursive protocols with overloaded members, that structural fallback can recursively expand the same protocol under ever-growing specializations, causing combinatorial growth on the motivating reproducer.

For non-pure redundancy, a failed nominal relation is enough to conservatively keep both union arms. We now stop there for same-origin class-based protocols instead of attempting the structural fallback. Pure redundancy is deliberately excluded so equivalence checking keeps the existing structural behavior.

Related: <https://github.com/astral-sh/ty/issues/3954>