### PR TITLE
[ty] Guard descriptor classification cycles

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3523,20 +3523,37 @@ impl<'db> Type<'db> {
     /// Descriptor uncertainty only propagates through outer unions, intersections, and aliases;
     /// type arguments do not affect the runtime descriptor class.
     pub(crate) fn is_definitely_non_data_descriptor(self, db: &'db dyn Db) -> bool {
+        self.is_definitely_non_data_descriptor_impl(db, ())
+    }
+
+    // Recursive aliases use `true`, the identity for the all-of classifications above.
+    #[salsa::tracked(
+        cycle_initial=|_, _, _, ()| true,
+        heap_size=ruff_memory_usage::heap_size
+    )]
+    fn is_definitely_non_data_descriptor_impl(self, db: &'db dyn Db, _: ()) -> bool {
         match self {
             Type::Dynamic(_) | Type::Divergent(_) | Type::TypeVar(_) => false,
             Type::Union(union) => union
                 .elements(db)
                 .iter()
-                .all(|ty| ty.is_definitely_non_data_descriptor(db)),
+                .all(|ty| ty.is_definitely_non_data_descriptor_impl(db, ())),
             Type::Intersection(intersection) => intersection
                 .iter_positive(db)
-                .all(|ty| ty.is_definitely_non_data_descriptor(db)),
-            Type::TypeAlias(alias) => alias.value_type(db).is_definitely_non_data_descriptor(db),
+                .all(|ty| ty.is_definitely_non_data_descriptor_impl(db, ())),
+            Type::TypeAlias(alias) => alias
+                .value_type(db)
+                .is_definitely_non_data_descriptor_impl(db, ()),
             _ => !self.may_be_data_descriptor(db),
         }
     }
 
+    // Definite data descriptors use an all-of union fold; possible data descriptors use any-of.
+    // Seed recursive aliases with the corresponding identity value.
+    #[salsa::tracked(
+        cycle_initial=|_, _, _, any_of_union: bool| !any_of_union,
+        heap_size=ruff_memory_usage::heap_size
+    )]
     fn is_data_descriptor_impl(self, db: &'db dyn Db, any_of_union: bool) -> bool {
         match self {
             Type::Dynamic(_) => !any_of_union,
@@ -3553,6 +3570,9 @@ impl<'db> Type<'db> {
             Type::Intersection(intersection) => intersection
                 .iter_positive(db)
                 .any(|ty| ty.is_data_descriptor_impl(db, any_of_union)),
+            Type::TypeAlias(alias) => alias
+                .value_type(db)
+                .is_data_descriptor_impl(db, any_of_union),
             _ => {
                 !self
                     .class_member_with_policy(

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3531,7 +3531,7 @@ impl<'db> Type<'db> {
         cycle_initial=|_, _, _, ()| true,
         heap_size=ruff_memory_usage::heap_size
     )]
-    fn is_definitely_non_data_descriptor_impl(self, db: &'db dyn Db, _: ()) -> bool {
+    fn is_definitely_non_data_descriptor_impl(self, db: &'db dyn Db, (): ()) -> bool {
         match self {
             Type::Dynamic(_) | Type::Divergent(_) | Type::TypeVar(_) => false,
             Type::Union(union) => union

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -341,47 +341,6 @@ fn divergent_type() {
 }
 
 #[test]
-fn data_descriptor_classification_recovers_recursive_aliases() {
-    use crate::db::tests::TestDb;
-    use crate::place::global_symbol;
-
-    fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> Type<'db> {
-        let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
-        let ty = global_symbol(db, module, name).place.expect_type();
-        let Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) = ty else {
-            panic!("Expected `{name}` to be a type alias");
-        };
-        Type::TypeAlias(type_alias)
-    }
-
-    let mut db = setup_db();
-    db.write_dedented(
-        "/src/a.py",
-        r#"
-class Descriptor:
-    def __set__(self, instance: object, value: object) -> None: ...
-
-type NonData = int | NonDataTail
-type NonDataTail = NonData
-
-type Data = Descriptor | DataTail
-type DataTail = Data
-"#,
-    )
-    .unwrap();
-
-    let non_data = get_type_alias(&db, "NonData");
-    assert!(!non_data.is_data_descriptor(&db));
-    assert!(!non_data.may_be_data_descriptor(&db));
-    assert!(non_data.is_definitely_non_data_descriptor(&db));
-
-    let data = get_type_alias(&db, "Data");
-    assert!(data.is_data_descriptor(&db));
-    assert!(data.may_be_data_descriptor(&db));
-    assert!(!data.is_definitely_non_data_descriptor(&db));
-}
-
-#[test]
 fn type_alias_variance() {
     use crate::db::tests::TestDb;
     use crate::place::global_symbol;

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -341,6 +341,47 @@ fn divergent_type() {
 }
 
 #[test]
+fn data_descriptor_classification_recovers_recursive_aliases() {
+    use crate::db::tests::TestDb;
+    use crate::place::global_symbol;
+
+    fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> Type<'db> {
+        let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
+        let ty = global_symbol(db, module, name).place.expect_type();
+        let Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) = ty else {
+            panic!("Expected `{name}` to be a type alias");
+        };
+        Type::TypeAlias(type_alias)
+    }
+
+    let mut db = setup_db();
+    db.write_dedented(
+        "/src/a.py",
+        r#"
+class Descriptor:
+    def __set__(self, instance: object, value: object) -> None: ...
+
+type NonData = int | NonDataTail
+type NonDataTail = NonData
+
+type Data = Descriptor | DataTail
+type DataTail = Data
+"#,
+    )
+    .unwrap();
+
+    let non_data = get_type_alias(&db, "NonData");
+    assert!(!non_data.is_data_descriptor(&db));
+    assert!(!non_data.may_be_data_descriptor(&db));
+    assert!(non_data.is_definitely_non_data_descriptor(&db));
+
+    let data = get_type_alias(&db, "Data");
+    assert!(data.is_data_descriptor(&db));
+    assert!(data.may_be_data_descriptor(&db));
+    assert!(!data.is_definitely_non_data_descriptor(&db));
+}
+
+#[test]
 fn type_alias_variance() {
     use crate::db::tests::TestDb;
     use crate::place::global_symbol;


### PR DESCRIPTION
## Summary

Our data-descriptor predicates recursively inspect outer unions, intersections, and type aliases. An unguarded recursive alias can therefore revisit the same classification:

```python
class Descriptor:
    def __set__(self, instance: object, value: object) -> None: ...

type NonData = int | NonDataTail
type NonDataTail = NonData

type Data = Descriptor | DataTail
type DataTail = Data
```

We now evaluate both descriptor classifiers as Salsa queries and route alias expansion back through those queries. Definite classifications use `true`, the identity for their all-of union folds, as cycle recovery; possible-data classification uses `false`, the identity for its any-of fold.

The regression test exercises `is_data_descriptor`, `may_be_data_descriptor`, and `is_definitely_non_data_descriptor` for recursive aliases with and without a reachable data descriptor.
