### PR TITLE
[ty] Rename type for Google docstring sections that do not participate in structural rendering.

### DIFF
--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -366,7 +366,7 @@ fn section_item_indent(header: SectionHeader, line: ParsedLine<'_>) -> Option<Te
             split_once_unbracketed_colon(trimmed).is_some_and(|(name, _)| !name.trim().is_empty())
         }
         HeaderKind::Structured(SectionKind::Returns | SectionKind::Yields) => !trimmed.is_empty(),
-        HeaderKind::Container => false,
+        HeaderKind::Opaque => false,
     };
     is_item.then_some(line.raw_indent)
 }
@@ -402,7 +402,7 @@ struct SectionHeader {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HeaderKind {
     Structured(SectionKind),
-    Container,
+    Opaque,
 }
 
 impl HeaderKind {
@@ -424,7 +424,7 @@ impl HeaderKind {
             "raise" | "raises" => Self::Structured(SectionKind::Raises),
             "attention" | "caution" | "danger" | "error" | "example" | "examples" | "hint"
             | "important" | "methods" | "note" | "notes" | "references" | "see also" | "tip"
-            | "todo" | "todos" | "warning" | "warnings" | "warns" => Self::Container,
+            | "todo" | "todos" | "warning" | "warnings" | "warns" => Self::Opaque,
             _ => return None,
         })
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This just picks a new name for a type that makes more sense with [upcoming markdown rendering for Google-style docstrings](https://github.com/astral-sh/ruff/pull/26599).

## Test Plan

Relies on existing test coverage.
<!-- How was it tested? -->
