### PR TITLE
Add `ruff_python_ast::name::Name::with_capacity` method

### DIFF
--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -36,6 +36,11 @@ impl Name {
         Self(compact_str::CompactString::const_new(name))
     }
 
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(compact_str::CompactString::with_capacity(capacity))
+    }
+
     pub fn shrink_to_fit(&mut self) {
         self.0.shrink_to_fit();
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

At [RustPython](https://github.com/RustPython/RustPython) we are using ruff to generate the symbol table. I'm currently working on optimizing it and decided to use [ruff_python_ast::name::Name](https://docs.rs/ruff_python_ast/latest/ruff_python_ast/name/struct.Name.html) for it.

There's a scenario where we know the exact size the string is going to be when calculating the mangled name, atm we do something this:

```rs
let mut ret = String::with_capacity(1 + class_name.len() + name.len());
ret.push('_');
ret.push_str(class_name);
ret.push_str(name);
```

[link to code](https://github.com/RustPython/RustPython/blob/9c064c1dcbc018bde16646a6caa7cc33fe66f862/crates/codegen/src/symboltable.rs#L3473-L3476)

It would be more ideal if we could do: `Name::with_capacity(...)`.


## Test Plan

---

Feel free to close this PR if it's not a good fit