### PR TITLE
[ty] Show error spans for errors originating in script metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,6 +3667,7 @@ version = "0.0.9"
 dependencies = [
  "get-size2",
  "ruff_db",
+ "ruff_python_ast",
  "ruff_text_size",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,6 +3667,7 @@ version = "0.0.7"
 dependencies = [
  "get-size2",
  "ruff_db",
+ "ruff_python_ast",
  "ruff_text_size",
  "schemars",
  "serde",

--- a/crates/ruff_python_ast/src/script.rs
+++ b/crates/ruff_python_ast/src/script.rs
@@ -1,6 +1,8 @@
 use std::sync::LazyLock;
 
 use memchr::memmem::Finder;
+use ruff_source_file::UniversalNewlineIterator;
+use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 static FINDER: LazyLock<Finder> = LazyLock::new(|| Finder::new(b"# /// script"));
 
@@ -11,12 +13,12 @@ static FINDER: LazyLock<Finder> = LazyLock::new(|| Finder::new(b"# /// script"))
 /// Vendored from: <https://github.com/astral-sh/uv/blob/debe67ffdb0cd7835734100e909b2d8f79613743/crates/uv-scripts/src/lib.rs#L283>
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ScriptTag {
-    /// The content of the script before the metadata block.
-    prelude: String,
     /// The metadata block.
     metadata: String,
-    /// The content of the script after the metadata block.
-    postlude: String,
+    /// The source range of the metadata block, including its opening and closing delimiters.
+    range: TextRange,
+    /// Maps offsets in the extracted metadata to offsets in the original Python script.
+    source_map: ScriptSourceMap,
 }
 
 impl ScriptTag {
@@ -25,9 +27,18 @@ impl ScriptTag {
         &self.metadata
     }
 
+    /// Returns the map from extracted TOML offsets to their original script offsets.
+    pub fn source_map(&self) -> &ScriptSourceMap {
+        &self.source_map
+    }
+
+    /// Consumes this tag and returns its TOML together with its original-source mapping.
+    pub fn into_metadata_and_source_map(self) -> (String, ScriptSourceMap) {
+        (self.metadata, self.source_map)
+    }
+
     /// Given the contents of a Python file, extract the `script` metadata block with leading
-    /// comment hashes removed, any preceding shebang or content (prelude), and the remaining Python
-    /// script.
+    /// comment hashes removed and map its offsets to the original Python script.
     ///
     /// Given the following input string representing the contents of a Python script:
     ///
@@ -46,11 +57,14 @@ impl ScriptTag {
     /// print("Hello, World!")
     /// ```
     ///
-    /// This function would return:
-    ///
-    /// - Preamble: `#!/usr/bin/env python3\n`
-    /// - Metadata: `requires-python = '>=3.11'\ndependencies = [\n  'requests<3',\n  'rich',\n]`
-    /// - Postlude: `import requests\n\nprint("Hello, World!")\n`
+    /// This function extracts the metadata:
+    /// ```toml
+    /// requires-python = '>=3.11'
+    /// dependencies = [
+    ///   'requests<3',
+    ///   'rich',
+    /// ]
+    /// ```
     ///
     /// See: <https://peps.python.org/pep-0723/>
     pub fn parse(contents: &[u8]) -> Option<Self> {
@@ -65,14 +79,11 @@ impl ScriptTag {
             return None;
         }
 
-        // Extract the preceding content.
-        let prelude = std::str::from_utf8(&contents[..index]).ok()?;
-
-        // Decode as UTF-8.
-        let contents = &contents[index..];
         let contents = std::str::from_utf8(contents).ok()?;
+        let contents = &contents[index..];
 
-        let mut lines = contents.lines();
+        let start = TextSize::try_from(index).ok()?;
+        let mut lines = UniversalNewlineIterator::with_offset(contents, start);
 
         // Ensure that the first line is exactly `# /// script`.
         if lines.next().is_none_or(|line| line != "# /// script") {
@@ -84,37 +95,36 @@ impl ScriptTag {
         // > embedded content is formed by taking away the first two characters of each line if the
         // > second character is a space, otherwise just the first character (which means the line
         // > consists of only a single #).
-        let mut toml = vec![];
+        let mut metadata = String::new();
+        let mut source_map = ScriptSourceMap::default();
+        let mut closing = None;
 
-        // Extract the content that follows the metadata block.
-        let mut python_script = vec![];
-
-        while let Some(line) = lines.next() {
+        for line in lines {
             // Remove the leading `#`.
-            let Some(line) = line.strip_prefix('#') else {
-                python_script.push(line);
-                python_script.extend(lines);
+            let Some(comment) = line.strip_prefix('#') else {
                 break;
             };
 
-            // If the line is empty, continue.
-            if line.is_empty() {
-                toml.push("");
-                continue;
+            let (content, indent_len) = if comment.is_empty() {
+                ("", TextSize::ZERO)
+            } else if let Some(content) = comment.strip_prefix(' ') {
+                (content, ' '.text_len())
+            } else {
+                break;
+            };
+
+            if content == "///" {
+                closing = Some((metadata.len(), source_map.markers.len(), line.range()));
             }
 
-            // Otherwise, the line _must_ start with ` `.
-            let Some(line) = line.strip_prefix(' ') else {
-                python_script.push(line);
-                python_script.extend(lines);
-                break;
-            };
+            let prefix_length = '#'.text_len() + indent_len;
 
-            toml.push(line);
+            source_map.push_marker(metadata.text_len(), line.start() + prefix_length);
+            metadata.push_str(content);
+            metadata.push('\n');
         }
 
-        // Find the closing `# ///`. The precedence is such that we need to identify the _last_ such
-        // line.
+        // The last closing `# ///` wins, so discard that delimiter and everything after it.
         //
         // For example, given:
         // ```python
@@ -126,32 +136,163 @@ impl ScriptTag {
         // ```
         //
         // The latter `///` is the closing pragma
-        let index = toml.iter().rev().position(|line| *line == "///")?;
-        let index = toml.len() - index;
+        let (metadata_end, marker_count, closing_range) = closing?;
+        metadata.truncate(metadata_end);
+        source_map.truncate(marker_count);
 
-        // Discard any lines after the closing `# ///`.
-        //
-        // For example, given:
-        // ```python
-        // # /// script
-        // #
-        // # ///
-        // #
-        // #
-        // ```
-        //
-        // We need to discard the last two lines.
-        toml.truncate(index - 1);
-
-        // Join the lines into a single string.
-        let prelude = prelude.to_string();
-        let metadata = toml.join("\n") + "\n";
-        let postlude = python_script.join("\n") + "\n";
+        if metadata.is_empty() {
+            metadata.push('\n');
+        } else {
+            source_map.push_marker(metadata.text_len(), closing_range.start());
+        }
 
         Some(Self {
-            prelude,
             metadata,
-            postlude,
+            range: TextRange::new(start, closing_range.end()),
+            source_map,
         })
+    }
+}
+
+impl Ranged for ScriptTag {
+    fn range(&self) -> TextRange {
+        self.range
+    }
+}
+
+/// Maps offsets in extracted script metadata to offsets in the original Python source.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ScriptSourceMap {
+    markers: Vec<ScriptSourceMarker>,
+}
+
+impl ScriptSourceMap {
+    /// Maps a metadata offset to the corresponding offset in the Python source.
+    pub fn map_offset(&self, offset: TextSize) -> TextSize {
+        let Some(index) = self
+            .markers
+            .partition_point(|marker| marker.metadata_offset <= offset)
+            .checked_sub(1)
+        else {
+            return offset;
+        };
+        let marker = &self.markers[index];
+
+        marker.source_offset + (offset - marker.metadata_offset)
+    }
+
+    /// Maps a metadata range to its corresponding range in the Python source.
+    pub fn map_range(&self, range: TextRange) -> TextRange {
+        TextRange::new(self.map_offset(range.start()), self.map_offset(range.end()))
+    }
+
+    fn push_marker(&mut self, metadata_offset: TextSize, source_offset: TextSize) {
+        self.markers.push(ScriptSourceMarker {
+            metadata_offset,
+            source_offset,
+        });
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.markers.truncate(len);
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ScriptSourceMarker {
+    metadata_offset: TextSize,
+    source_offset: TextSize,
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_text_size::{Ranged, TextLen, TextRange};
+
+    use super::ScriptTag;
+
+    #[test]
+    fn carriage_return_line_endings() -> Result<(), &'static str> {
+        let tag = ScriptTag::parse(b"# /// script\r# value = true\r# ///\r")
+            .ok_or("Expected script metadata with carriage-return line endings")?;
+
+        assert_eq!(tag.metadata(), "value = true\n");
+
+        Ok(())
+    }
+
+    #[test]
+    fn metadata_block_range_includes_both_delimiters() -> Result<(), &'static str> {
+        let prefix = "#!/usr/bin/env python3\n\n";
+        let metadata = "# /// script\n# dependencies = []\n# ///";
+        let source = format!("{prefix}{metadata}\n\nprint('hello')\n");
+        let tag = ScriptTag::parse(source.as_bytes()).ok_or("Expected valid script metadata")?;
+
+        assert_eq!(
+            tag.range(),
+            TextRange::at(prefix.text_len(), metadata.text_len())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn metadata_range_accounts_for_unicode_crlf_and_multiline_values() -> Result<(), &'static str> {
+        let metadata_value = r#""""
+first
+
+last
+""""#;
+        let source_value = r#""""
+# first
+#
+# last
+# """"#
+            .replace('\n', "\r\n");
+        let source = format!("π\r\n# /// script\r\n# value = {source_value}\r\n# ///\r\n");
+        let tag = ScriptTag::parse(source.as_bytes()).ok_or("Expected valid script metadata")?;
+
+        assert_eq!(tag.metadata(), format!("value = {metadata_value}\n"));
+
+        let metadata_range = TextRange::at("value = ".text_len(), metadata_value.text_len());
+        let source_range = TextRange::at(
+            "π\r\n# /// script\r\n# value = ".text_len(),
+            source_value.text_len(),
+        );
+
+        assert_eq!(tag.source_map().map_range(metadata_range), source_range);
+
+        Ok(())
+    }
+
+    #[test]
+    fn last_closing_delimiter_discards_following_comments() -> Result<(), &'static str> {
+        let source = r"# /// script
+# first = true
+# ///
+# last = true
+# ///
+# ignored = true
+";
+        let tag = ScriptTag::parse(source.as_bytes()).ok_or("Expected valid script metadata")?;
+
+        assert_eq!(
+            tag.metadata(),
+            r"first = true
+///
+last = true
+"
+        );
+
+        let closing_start = source
+            .rfind("# ///")
+            .map(|offset| source[..offset].text_len())
+            .ok_or("Expected the final closing delimiter")?;
+        assert_eq!(
+            tag.source_map().map_offset(tag.metadata().text_len()),
+            closing_start,
+        );
+        assert_eq!(tag.end(), closing_start + "# ///".text_len());
+
+        Ok(())
     }
 }

--- a/crates/ruff_python_ast/src/script.rs
+++ b/crates/ruff_python_ast/src/script.rs
@@ -1,6 +1,8 @@
 use std::sync::LazyLock;
 
 use memchr::memmem::Finder;
+use ruff_source_file::UniversalNewlineIterator;
+use ruff_text_size::{TextLen, TextRange, TextSize};
 
 static FINDER: LazyLock<Finder> = LazyLock::new(|| Finder::new(b"# /// script"));
 
@@ -11,12 +13,10 @@ static FINDER: LazyLock<Finder> = LazyLock::new(|| Finder::new(b"# /// script"))
 /// Vendored from: <https://github.com/astral-sh/uv/blob/debe67ffdb0cd7835734100e909b2d8f79613743/crates/uv-scripts/src/lib.rs#L283>
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ScriptTag {
-    /// The content of the script before the metadata block.
-    prelude: String,
     /// The metadata block.
     metadata: String,
-    /// The content of the script after the metadata block.
-    postlude: String,
+    /// Maps offsets in the extracted metadata to offsets in the original Python script.
+    source_map: ScriptSourceMap,
 }
 
 impl ScriptTag {
@@ -25,9 +25,18 @@ impl ScriptTag {
         &self.metadata
     }
 
+    /// Returns the map from extracted TOML offsets to their original script offsets.
+    pub fn source_map(&self) -> &ScriptSourceMap {
+        &self.source_map
+    }
+
+    /// Consumes this tag and returns its TOML together with its original-source mapping.
+    pub fn into_metadata_and_source_map(self) -> (String, ScriptSourceMap) {
+        (self.metadata, self.source_map)
+    }
+
     /// Given the contents of a Python file, extract the `script` metadata block with leading
-    /// comment hashes removed, any preceding shebang or content (prelude), and the remaining Python
-    /// script.
+    /// comment hashes removed and map its offsets to the original Python script.
     ///
     /// Given the following input string representing the contents of a Python script:
     ///
@@ -46,11 +55,14 @@ impl ScriptTag {
     /// print("Hello, World!")
     /// ```
     ///
-    /// This function would return:
-    ///
-    /// - Preamble: `#!/usr/bin/env python3\n`
-    /// - Metadata: `requires-python = '>=3.11'\ndependencies = [\n  'requests<3',\n  'rich',\n]`
-    /// - Postlude: `import requests\n\nprint("Hello, World!")\n`
+    /// This function extracts the metadata:
+    /// ```toml
+    /// requires-python = '>=3.11'
+    /// dependencies = [
+    ///   'requests<3',
+    ///   'rich',
+    /// ]
+    /// ```
     ///
     /// See: <https://peps.python.org/pep-0723/>
     pub fn parse(contents: &[u8]) -> Option<Self> {
@@ -65,14 +77,11 @@ impl ScriptTag {
             return None;
         }
 
-        // Extract the preceding content.
-        let prelude = std::str::from_utf8(&contents[..index]).ok()?;
-
-        // Decode as UTF-8.
-        let contents = &contents[index..];
         let contents = std::str::from_utf8(contents).ok()?;
+        let contents = &contents[index..];
 
-        let mut lines = contents.lines();
+        let mut lines =
+            UniversalNewlineIterator::with_offset(contents, TextSize::try_from(index).ok()?);
 
         // Ensure that the first line is exactly `# /// script`.
         if lines.next().is_none_or(|line| line != "# /// script") {
@@ -84,37 +93,36 @@ impl ScriptTag {
         // > embedded content is formed by taking away the first two characters of each line if the
         // > second character is a space, otherwise just the first character (which means the line
         // > consists of only a single #).
-        let mut toml = vec![];
+        let mut metadata = String::new();
+        let mut source_map = ScriptSourceMap::default();
+        let mut closing = None;
 
-        // Extract the content that follows the metadata block.
-        let mut python_script = vec![];
-
-        while let Some(line) = lines.next() {
+        for line in lines {
             // Remove the leading `#`.
-            let Some(line) = line.strip_prefix('#') else {
-                python_script.push(line);
-                python_script.extend(lines);
+            let Some(comment) = line.strip_prefix('#') else {
                 break;
             };
 
-            // If the line is empty, continue.
-            if line.is_empty() {
-                toml.push("");
-                continue;
+            let (content, indent_len) = if comment.is_empty() {
+                ("", TextSize::ZERO)
+            } else if let Some(content) = comment.strip_prefix(' ') {
+                (content, ' '.text_len())
+            } else {
+                break;
+            };
+
+            if content == "///" {
+                closing = Some((metadata.len(), source_map.markers.len(), line.start()));
             }
 
-            // Otherwise, the line _must_ start with ` `.
-            let Some(line) = line.strip_prefix(' ') else {
-                python_script.push(line);
-                python_script.extend(lines);
-                break;
-            };
+            let prefix_length = '#'.text_len() + indent_len;
 
-            toml.push(line);
+            source_map.push_marker(metadata.text_len(), line.start() + prefix_length);
+            metadata.push_str(content);
+            metadata.push('\n');
         }
 
-        // Find the closing `# ///`. The precedence is such that we need to identify the _last_ such
-        // line.
+        // The last closing `# ///` wins, so discard that delimiter and everything after it.
         //
         // For example, given:
         // ```python
@@ -126,32 +134,140 @@ impl ScriptTag {
         // ```
         //
         // The latter `///` is the closing pragma
-        let index = toml.iter().rev().position(|line| *line == "///")?;
-        let index = toml.len() - index;
+        let (metadata_end, marker_count, source_end) = closing?;
+        metadata.truncate(metadata_end);
+        source_map.truncate(marker_count);
 
-        // Discard any lines after the closing `# ///`.
-        //
-        // For example, given:
-        // ```python
-        // # /// script
-        // #
-        // # ///
-        // #
-        // #
-        // ```
-        //
-        // We need to discard the last two lines.
-        toml.truncate(index - 1);
-
-        // Join the lines into a single string.
-        let prelude = prelude.to_string();
-        let metadata = toml.join("\n") + "\n";
-        let postlude = python_script.join("\n") + "\n";
+        if metadata.is_empty() {
+            metadata.push('\n');
+        } else {
+            source_map.push_marker(metadata.text_len(), source_end);
+        }
 
         Some(Self {
-            prelude,
             metadata,
-            postlude,
+            source_map,
         })
+    }
+}
+
+/// Maps offsets in extracted script metadata to offsets in the original Python source.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ScriptSourceMap {
+    markers: Vec<ScriptSourceMarker>,
+}
+
+impl ScriptSourceMap {
+    /// Maps a metadata offset to the corresponding offset in the Python source.
+    pub fn map_offset(&self, offset: TextSize) -> TextSize {
+        let Some(index) = self
+            .markers
+            .partition_point(|marker| marker.metadata_offset <= offset)
+            .checked_sub(1)
+        else {
+            return offset;
+        };
+        let marker = &self.markers[index];
+
+        marker.source_offset + (offset - marker.metadata_offset)
+    }
+
+    /// Maps a metadata range to its corresponding range in the Python source.
+    pub fn map_range(&self, range: TextRange) -> TextRange {
+        TextRange::new(self.map_offset(range.start()), self.map_offset(range.end()))
+    }
+
+    fn push_marker(&mut self, metadata_offset: TextSize, source_offset: TextSize) {
+        self.markers.push(ScriptSourceMarker {
+            metadata_offset,
+            source_offset,
+        });
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.markers.truncate(len);
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ScriptSourceMarker {
+    metadata_offset: TextSize,
+    source_offset: TextSize,
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_text_size::{TextLen, TextRange};
+
+    use super::ScriptTag;
+
+    #[test]
+    fn carriage_return_line_endings() -> Result<(), &'static str> {
+        let tag = ScriptTag::parse(b"# /// script\r# value = true\r# ///\r")
+            .ok_or("Expected script metadata with carriage-return line endings")?;
+
+        assert_eq!(tag.metadata(), "value = true\n");
+
+        Ok(())
+    }
+
+    #[test]
+    fn metadata_range_accounts_for_unicode_crlf_and_multiline_values() -> Result<(), &'static str> {
+        let metadata_value = r#""""
+first
+
+last
+""""#;
+        let source_value = r#""""
+# first
+#
+# last
+# """"#
+            .replace('\n', "\r\n");
+        let source = format!("π\r\n# /// script\r\n# value = {source_value}\r\n# ///\r\n");
+        let tag = ScriptTag::parse(source.as_bytes()).ok_or("Expected valid script metadata")?;
+
+        assert_eq!(tag.metadata(), format!("value = {metadata_value}\n"));
+
+        let metadata_range = TextRange::at("value = ".text_len(), metadata_value.text_len());
+        let source_range = TextRange::at(
+            "π\r\n# /// script\r\n# value = ".text_len(),
+            source_value.text_len(),
+        );
+
+        assert_eq!(tag.source_map().map_range(metadata_range), source_range);
+
+        Ok(())
+    }
+
+    #[test]
+    fn last_closing_delimiter_discards_following_comments() -> Result<(), &'static str> {
+        let source = r"# /// script
+# first = true
+# ///
+# last = true
+# ///
+# ignored = true
+";
+        let tag = ScriptTag::parse(source.as_bytes()).ok_or("Expected valid script metadata")?;
+
+        assert_eq!(
+            tag.metadata(),
+            r"first = true
+///
+last = true
+"
+        );
+
+        let closing_start = source
+            .rfind("# ///")
+            .map(|offset| source[..offset].text_len())
+            .ok_or("Expected the final closing delimiter")?;
+        assert_eq!(
+            tag.source_map().map_offset(tag.metadata().text_len()),
+            closing_start,
+        );
+
+        Ok(())
     }
 }

--- a/crates/ruff_ranged_value/Cargo.toml
+++ b/crates/ruff_ranged_value/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 
 [dependencies]
 ruff_db = { workspace = true }
+ruff_python_ast = { workspace = true }
 ruff_text_size = { workspace = true }
 
 get-size2 = { workspace = true, optional = true }

--- a/crates/ruff_ranged_value/src/lib.rs
+++ b/crates/ruff_ranged_value/src/lib.rs
@@ -11,6 +11,7 @@ use toml::Spanned;
 use ruff_db::Db;
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::SystemPathBuf;
+use ruff_python_ast::script::ScriptSourceMap;
 use ruff_text_size::{TextRange, TextSize};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -63,19 +64,31 @@ thread_local! {
     /// Use the [`ValueSourceGuard`] to initialize the thread local before calling into any
     /// deserialization code. It ensures that the thread local variable gets cleaned up
     /// once deserialization is done (once the guard gets dropped).
-    static VALUE_SOURCE: RefCell<Option<(ValueSource, bool)>> = const { RefCell::new(None) };
+    static VALUE_SOURCE: RefCell<Option<ValueSourceContext>> = const { RefCell::new(None) };
 }
 
 /// Guard to safely change the [`ValueSource`] for the current thread.
 #[must_use]
 pub struct ValueSourceGuard {
-    prev_value: Option<(ValueSource, bool)>,
+    prev_value: Option<ValueSourceContext>,
 }
 
 impl ValueSourceGuard {
     pub fn new(source: ValueSource, is_toml: bool) -> Self {
-        let prev = VALUE_SOURCE.replace(Some((source, is_toml)));
-        Self { prev_value: prev }
+        Self::replace(ValueSourceContext {
+            source,
+            has_span: is_toml,
+            source_map: None,
+        })
+    }
+
+    /// Sets the source and maps deserialized TOML ranges into that source.
+    pub fn with_source_map(source: ValueSource, source_map: ScriptSourceMap) -> Self {
+        Self::replace(ValueSourceContext {
+            source,
+            has_span: true,
+            source_map: Some(source_map),
+        })
     }
 
     pub fn without_spans() -> Self {
@@ -83,10 +96,15 @@ impl ValueSourceGuard {
             current
                 .as_ref()
                 .expect("value source to be set before disabling spans")
-                .0
+                .source
                 .clone()
         });
         Self::new(source, false)
+    }
+
+    fn replace(context: ValueSourceContext) -> Self {
+        let prev = VALUE_SOURCE.replace(Some(context));
+        Self { prev_value: prev }
     }
 }
 
@@ -94,6 +112,12 @@ impl Drop for ValueSourceGuard {
     fn drop(&mut self) {
         VALUE_SOURCE.set(self.prev_value.take());
     }
+}
+
+struct ValueSourceContext {
+    source: ValueSource,
+    has_span: bool,
+    source_map: Option<ScriptSourceMap>,
 }
 
 /// A value that "remembers" where it comes from (source) and its range in source.
@@ -319,9 +343,12 @@ where
         D: Deserializer<'de>,
     {
         VALUE_SOURCE.with_borrow(|source| {
-            let (source, has_span) = source.clone().unwrap();
+            let context = source
+                .as_ref()
+                .expect("value source to be set before deserializing a ranged value");
+            let source = context.source.clone();
 
-            if has_span {
+            if context.has_span {
                 let spanned: Spanned<T> = Spanned::deserialize(deserializer)?;
                 let span = spanned.span();
                 let range = TextRange::new(
@@ -330,6 +357,10 @@ where
                     TextSize::try_from(span.end)
                         .expect("Configuration file to be smaller than 4GB"),
                 );
+                let range = context
+                    .source_map
+                    .as_ref()
+                    .map_or(range, |source_map| source_map.map_range(range));
 
                 Ok(Self::with_range(spanned.into_inner(), source, range))
             } else {

--- a/crates/ty/tests/cli/scripts.rs
+++ b/crates/ty/tests/cli/scripts.rs
@@ -84,6 +84,36 @@ fn verbose_rule_diagnostics_identify_script_metadata() -> anyhow::Result<()> {
 }
 
 #[test]
+fn unknown_rule_diagnostics_point_to_script_metadata() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "script.py",
+        r#"
+        # /// script
+        # [tool.ty.rules]
+        # unknown-script-rule = "warn"
+        # ///
+        "#,
+    )?;
+
+    assert_cmd_snapshot!(case.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning[unknown-rule]: Unknown rule `unknown-script-rule`
+     --> script.py:4:3
+      |
+    4 | # unknown-script-rule = "warn"
+      |   ^^^^^^^^^^^^^^^^^^^
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn python_version_diagnostics_identify_script_metadata() -> anyhow::Result<()> {
     let case = CliTest::with_file(
         "script.py",
@@ -96,7 +126,7 @@ fn python_version_diagnostics_identify_script_metadata() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command(), @"
+    assert_cmd_snapshot!(case.command(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -107,11 +137,15 @@ fn python_version_diagnostics_identify_script_metadata() -> anyhow::Result<()> {
       | ^^^^^^^^^^^^^^^^^^^^^^^
     info: `PythonFinalizationError` was added as a builtin in Python 3.13
     info: Python 3.12 was assumed when resolving types because it was specified in script metadata
+     --> script.py:3:21
+      |
+    3 | # requires-python = ">=3.12"
+      |                     ^^^^^^^^ Python version configured here
 
     Found 1 diagnostic
 
     ----- stderr -----
-    ");
+    "#);
     assert_cmd_snapshot!(case.command().arg("--output-format").arg("concise"), @"
     success: false
     exit_code: 1

--- a/crates/ty_project/src/metadata/script.rs
+++ b/crates/ty_project/src/metadata/script.rs
@@ -180,10 +180,10 @@ pub(crate) fn script_metadata(db: &dyn SourceDb, file: File) -> Option<Box<Scrip
         return None;
     }
 
-    let tag = ScriptTag::parse(source.as_bytes())?;
-    let _guard = ValueSourceGuard::new(ValueSource::ScriptMetadata(file), false);
+    let (content, source_map) = ScriptTag::parse(source.as_bytes())?.into_metadata_and_source_map();
+    let _guard = ValueSourceGuard::with_source_map(ValueSource::ScriptMetadata(file), source_map);
     // FIXME: Report invalid TOML in script metadata instead of silently ignoring it.
-    let mut metadata: ScriptMetadata = toml::from_str(tag.metadata()).ok()?;
+    let mut metadata: ScriptMetadata = toml::from_str(&content).ok()?;
 
     if let Some(options) = metadata.tool.as_mut().and_then(|tool| tool.ty.as_mut()) {
         options.prioritize_all_selectors();

--- a/crates/ty_project/src/script.rs
+++ b/crates/ty_project/src/script.rs
@@ -180,10 +180,10 @@ pub(crate) fn script_metadata(db: &dyn SourceDb, file: File) -> Option<Box<Scrip
         return None;
     }
 
-    let tag = ScriptTag::parse(source.as_bytes())?;
-    let _guard = ValueSourceGuard::new(ValueSource::ScriptMetadata(file), false);
+    let (content, source_map) = ScriptTag::parse(source.as_bytes())?.into_metadata_and_source_map();
+    let _guard = ValueSourceGuard::with_source_map(ValueSource::ScriptMetadata(file), source_map);
     // FIXME: Report invalid TOML in script metadata instead of silently ignoring it.
-    let mut metadata: ScriptMetadata = toml::from_str(tag.metadata()).ok()?;
+    let mut metadata: ScriptMetadata = toml::from_str(&content).ok()?;
 
     if let Some(options) = metadata.tool.as_mut().and_then(|tool| tool.ty.as_mut()) {
         options.prioritize_all_selectors();

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change_script_python_requirement.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_change_script_python_requirement.snap
@@ -62,7 +62,7 @@ PublishDiagnosticsParams {
                 "ty",
             ),
             message: String(
-                "Name `PythonFinalizationError` used when not defined\n\ninfo: `PythonFinalizationError` was added as a builtin in Python 3.13\ninfo: Python 3.12 was assumed when resolving types because it was specified in script metadata",
+                "Name `PythonFinalizationError` used when not defined\n\ninfo: `PythonFinalizationError` was added as a builtin in Python 3.13",
             ),
             tags: None,
             related_information: None,

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_virtual_script_reports_inline_configuration_diagnostics.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_open_virtual_script_reports_inline_configuration_diagnostics.snap
@@ -21,12 +21,12 @@ PublishDiagnosticsParams {
         Diagnostic {
             range: Range {
                 start: Position {
-                    line: 0,
-                    character: 0,
+                    line: 2,
+                    character: 2,
                 },
                 end: Position {
-                    line: 0,
-                    character: 0,
+                    line: 2,
+                    character: 14,
                 },
             },
             severity: Some(


### PR DESCRIPTION
## Summary

Preserve source ranges for PEP 723 script metadata by building a compact source map during extraction and applying it when deserializing ranged values. 

Closes https://github.com/astral-sh/ty/issues/4180

