### PR TITLE
[ty] Add universal constraint quantification

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -861,6 +861,56 @@ def same_typevar[T]():
     static_assert(constraints == expected)
 ```
 
+## Universal quantification
+
+Universal quantification removes the listed typevars from a constraint set. Any constraints that do
+not involve those typevars must remain in the result, including constraints in an uncertain branch.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+def preserves_uncertain_disjunct[T, U]() -> None:
+    t_int = ConstraintSet.range(int, T, int)
+    u_str = ConstraintSet.range(str, U, str)
+    quantified = (t_int | u_str).for_all(tuple[U])
+    static_assert(quantified == t_int)
+
+def removes_multiple_typevars[T, U]() -> None:
+    t_int = ConstraintSet.range(int, T, int)
+    u_str = ConstraintSet.range(str, U, str)
+    quantified = (t_int | u_str).for_all(tuple[T, U])
+    static_assert(quantified == ConstraintSet.never())
+
+def no_typevars_is_identity[T]() -> None:
+    constraints = ConstraintSet.range(Never, T, int)
+    static_assert(constraints.for_all(tuple[()]) == constraints)
+```
+
+The order of existential and universal quantifiers matters. For each target truth assignment there
+is some matching source truth assignment, but no single source truth assignment matches every target
+truth assignment.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+def quantifier_order[S, T]() -> None:
+    source_is_int = ConstraintSet.range(int, S, int)
+    target_is_int = ConstraintSet.range(int, T, int)
+    equal = source_is_int.satisfies(target_is_int) & target_is_int.satisfies(source_is_int)
+
+    # ∀T.∃S.equal(S, T) = ∀T.¬∀S.¬equal(S, T)
+    forall_target_exists_source = (~((~equal).for_all(tuple[S]))).for_all(tuple[T])
+    static_assert(forall_target_exists_source == ConstraintSet.always())
+
+    # ∃S.∀T.equal(S, T) = ¬∀S.¬∀T.equal(S, T)
+    forall_target = equal.for_all(tuple[T])
+    exists_source_forall_target = ~((~forall_target).for_all(tuple[S]))
+    static_assert(exists_source_forall_target == ConstraintSet.never())
+```
+
 ## Displaying constraints
 
 The `with_detailed_display` method can be used to print out the boolean formula that a constraint

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3979,6 +3979,14 @@ impl<'db> Type<'db> {
                     .into()
                 }
                 Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
+                    if name == "for_all" =>
+                {
+                    Place::bound(Type::KnownBoundMethod(
+                        KnownBoundMethodType::ConstraintSetForAll(tracked),
+                    ))
+                    .into()
+                }
+                Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
                     if name == "satisfied_by_all_typevars" =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -6382,6 +6390,7 @@ impl<'db> Type<'db> {
                         | KnownBoundMethodType::ConstraintSetNever
                         | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                         | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                        | KnownBoundMethodType::ConstraintSetForAll(_)
                         | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                         | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_)
                 )
@@ -6751,6 +6760,7 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                | KnownBoundMethodType::ConstraintSetForAll(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_)
             )
@@ -7007,6 +7017,7 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                | KnownBoundMethodType::ConstraintSetForAll(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
             )

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -150,6 +150,21 @@ fn freshen_generic_contexts_in_type<'db>(
         })
 }
 
+fn inferable_typevars_from_tuple<'db>(
+    db: &'db dyn Db,
+    instance: &NominalInstanceType<'db>,
+) -> Option<InferableTypeVars<'db>> {
+    let typevars: Option<FxOrderSet<_>> = instance
+        .tuple_spec(db)?
+        .fixed_elements()
+        .map(|ty| {
+            ty.as_typevar()
+                .map(|bound_typevar| bound_typevar.identity(db))
+        })
+        .collect();
+    typevars.map(|typevars| InferableTypeVars::from_typevars(db, typevars))
+}
+
 /// Priority levels for call errors in intersection types.
 /// Higher values indicate more specific errors that should take precedence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -2658,6 +2673,31 @@ impl<'db> Bindings<'db> {
                         ));
                     }
 
+                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetForAll(tracked)) => {
+                        let [Some(typevars)] = overload.parameter_types() else {
+                            continue;
+                        };
+                        let Type::NominalInstance(instance) = typevars.project_type_form(db) else {
+                            continue;
+                        };
+                        let Some(typevars) = inferable_typevars_from_tuple(db, &instance) else {
+                            continue;
+                        };
+
+                        let constraints = ConstraintSetBuilder::new();
+                        let result = constraints.into_owned(|constraints| {
+                            constraints.load(db, tracked.constraints(db)).for_all(
+                                db,
+                                constraints,
+                                typevars,
+                            )
+                        });
+                        let tracked = InternedConstraintSet::new(db, result);
+                        overload.set_return_type(Type::KnownInstance(
+                            KnownInstanceType::ConstraintSet(tracked),
+                        ));
+                    }
+
                     Type::KnownBoundMethod(
                         KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(tracked),
                     ) => {
@@ -2666,15 +2706,7 @@ impl<'db> Bindings<'db> {
                                 // Caller explicitly passed None, so no typevars are inferable.
                                 return Some(InferableTypeVars::None);
                             }
-                            let typevars: Option<FxOrderSet<_>> = instance
-                                .tuple_spec(db)?
-                                .fixed_elements()
-                                .map(|ty| {
-                                    ty.as_typevar()
-                                        .map(|bound_typevar| bound_typevar.identity(db))
-                                })
-                                .collect();
-                            typevars.map(|typevars| InferableTypeVars::from_typevars(db, typevars))
+                            inferable_typevars_from_tuple(db, instance)
                         };
 
                         let inferable = match overload.parameter_types() {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -681,6 +681,46 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         )
     }
 
+    /// Universally abstracts constraints involving the given type variables from this TDD.
+    ///
+    /// This is the Boolean dual of [`Self::reduce_inferable`]. Declared type variable bounds and
+    /// constraints are not applied implicitly, and must be encoded as implications in the input
+    /// constraint set.
+    ///
+    /// # Preconditions
+    ///
+    /// An atomic constraint must not relate a removed type variable to one that remains in the
+    /// result. Callers that need type-level quantification must project those relationships before
+    /// calling this method.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "used by generic signature quantification in the stacked follow-up"
+        )
+    )]
+    pub(crate) fn for_all(
+        self,
+        db: &'db dyn Db,
+        builder: &'c ConstraintSetBuilder<'db>,
+        to_remove: InferableTypeVars<'db>,
+    ) -> Self {
+        self.verify_builder(builder);
+        if to_remove == InferableTypeVars::None {
+            return self;
+        }
+
+        // Universal and existential quantification are duals. Reusing existential abstraction
+        // also keeps this operation on its cached, single-pass implementation.
+        Self::from_node(
+            builder,
+            self.node
+                .negate(builder)
+                .exists(db, builder, to_remove)
+                .negate(builder),
+        )
+    }
+
     /// Computes solutions for each BDD path, using a caller-provided hook to select solutions.
     ///
     /// The `choose` hook is called for each typevar on each BDD path with the typevar's variance
@@ -7149,6 +7189,19 @@ mod tests {
         ConstraintSet::constrain_typevar(db, builder, bound_typevar, ty, ty)
     }
 
+    fn typevar_set<'db>(
+        db: &'db dyn Db,
+        typevars: impl IntoIterator<Item = BoundTypeVarInstance<'db>>,
+    ) -> InferableTypeVars<'db> {
+        InferableTypeVars::from_typevars(
+            db,
+            typevars
+                .into_iter()
+                .map(|typevar| typevar.identity(db))
+                .collect(),
+        )
+    }
+
     fn known_instance(db: &dyn Db, class: KnownClass) -> Type<'_> {
         class.to_instance(db)
     }
@@ -7651,6 +7704,79 @@ mod tests {
 
         // T ∨ ¬T == true
         assert!(tdd.or(&db, &builder, || negated).is_always_satisfied(&db));
+    }
+
+    #[test]
+    fn universal_quantification_preserves_uncertain_disjunct() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let builder = ConstraintSetBuilder::new();
+        let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
+        let u_str = create_constraint(&db, &builder, u, KnownClass::Str);
+
+        // `t_int` is stored in the uncertain branch below `u_str`. It is independent of `U`, so
+        // it must survive universal quantification of `U`.
+        let quantified =
+            t_int
+                .or(&db, &builder, || u_str)
+                .for_all(&db, &builder, typevar_set(&db, [u]));
+        assert!(
+            quantified
+                .iff(&db, &builder, t_int)
+                .is_always_satisfied(&db)
+        );
+    }
+
+    #[test]
+    fn universal_quantification_removes_multiple_typevars() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let builder = ConstraintSetBuilder::new();
+        let relation =
+            create_constraint(&db, &builder, t, KnownClass::Int).or(&db, &builder, || {
+                create_constraint(&db, &builder, u, KnownClass::Str)
+            });
+
+        let quantified = relation.for_all(&db, &builder, typevar_set(&db, [t, u]));
+        assert!(quantified.is_never_satisfied(&db));
+    }
+
+    #[test]
+    fn universal_quantification_of_no_typevars_is_identity() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let constraints = create_constraint(&db, &builder, t, KnownClass::Int);
+
+        let quantified = constraints.for_all(&db, &builder, InferableTypeVars::None);
+        assert_eq!(quantified.node, constraints.node);
+    }
+
+    #[test]
+    fn existential_and_universal_quantifier_order() {
+        let db = setup_db();
+        let source = create_typevar(&db, "S");
+        let target = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let source_is_int = create_constraint(&db, &builder, source, KnownClass::Int);
+        let target_is_int = create_constraint(&db, &builder, target, KnownClass::Int);
+        let equal = source_is_int.iff(&db, &builder, target_is_int);
+
+        // Every truth assignment for the target predicate has some matching truth assignment for
+        // the source predicate.
+        let forall_target_exists_source = equal
+            .reduce_inferable(&db, &builder, typevar_set(&db, [source]))
+            .for_all(&db, &builder, typevar_set(&db, [target]));
+        assert!(forall_target_exists_source.is_always_satisfied(&db));
+
+        // No single truth assignment for the source predicate matches every truth assignment for
+        // the target predicate.
+        let exists_source_forall_target = equal
+            .for_all(&db, &builder, typevar_set(&db, [target]))
+            .reduce_inferable(&db, &builder, typevar_set(&db, [source]));
+        assert!(exists_source_forall_target.is_never_satisfied(&db));
     }
 
     /// Double negation of a TDD with uncertain branches is semantically equivalent to the

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -692,13 +692,6 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// An atomic constraint must not relate a removed type variable to one that remains in the
     /// result. Callers that need type-level quantification must project those relationships before
     /// calling this method.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "used by generic signature quantification in the stacked follow-up"
-        )
-    )]
     pub(crate) fn for_all(
         self,
         db: &'db dyn Db,
@@ -7189,19 +7182,6 @@ mod tests {
         ConstraintSet::constrain_typevar(db, builder, bound_typevar, ty, ty)
     }
 
-    fn typevar_set<'db>(
-        db: &'db dyn Db,
-        typevars: impl IntoIterator<Item = BoundTypeVarInstance<'db>>,
-    ) -> InferableTypeVars<'db> {
-        InferableTypeVars::from_typevars(
-            db,
-            typevars
-                .into_iter()
-                .map(|typevar| typevar.identity(db))
-                .collect(),
-        )
-    }
-
     fn known_instance(db: &dyn Db, class: KnownClass) -> Type<'_> {
         class.to_instance(db)
     }
@@ -7704,79 +7684,6 @@ mod tests {
 
         // T ∨ ¬T == true
         assert!(tdd.or(&db, &builder, || negated).is_always_satisfied(&db));
-    }
-
-    #[test]
-    fn universal_quantification_preserves_uncertain_disjunct() {
-        let db = setup_db();
-        let t = create_typevar(&db, "T");
-        let u = create_typevar(&db, "U");
-        let builder = ConstraintSetBuilder::new();
-        let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
-        let u_str = create_constraint(&db, &builder, u, KnownClass::Str);
-
-        // `t_int` is stored in the uncertain branch below `u_str`. It is independent of `U`, so
-        // it must survive universal quantification of `U`.
-        let quantified =
-            t_int
-                .or(&db, &builder, || u_str)
-                .for_all(&db, &builder, typevar_set(&db, [u]));
-        assert!(
-            quantified
-                .iff(&db, &builder, t_int)
-                .is_always_satisfied(&db)
-        );
-    }
-
-    #[test]
-    fn universal_quantification_removes_multiple_typevars() {
-        let db = setup_db();
-        let t = create_typevar(&db, "T");
-        let u = create_typevar(&db, "U");
-        let builder = ConstraintSetBuilder::new();
-        let relation =
-            create_constraint(&db, &builder, t, KnownClass::Int).or(&db, &builder, || {
-                create_constraint(&db, &builder, u, KnownClass::Str)
-            });
-
-        let quantified = relation.for_all(&db, &builder, typevar_set(&db, [t, u]));
-        assert!(quantified.is_never_satisfied(&db));
-    }
-
-    #[test]
-    fn universal_quantification_of_no_typevars_is_identity() {
-        let db = setup_db();
-        let t = create_typevar(&db, "T");
-        let builder = ConstraintSetBuilder::new();
-        let constraints = create_constraint(&db, &builder, t, KnownClass::Int);
-
-        let quantified = constraints.for_all(&db, &builder, InferableTypeVars::None);
-        assert_eq!(quantified.node, constraints.node);
-    }
-
-    #[test]
-    fn existential_and_universal_quantifier_order() {
-        let db = setup_db();
-        let source = create_typevar(&db, "S");
-        let target = create_typevar(&db, "T");
-        let builder = ConstraintSetBuilder::new();
-        let source_is_int = create_constraint(&db, &builder, source, KnownClass::Int);
-        let target_is_int = create_constraint(&db, &builder, target, KnownClass::Int);
-        let equal = source_is_int.iff(&db, &builder, target_is_int);
-
-        // Every truth assignment for the target predicate has some matching truth assignment for
-        // the source predicate.
-        let forall_target_exists_source = equal
-            .reduce_inferable(&db, &builder, typevar_set(&db, [source]))
-            .for_all(&db, &builder, typevar_set(&db, [target]));
-        assert!(forall_target_exists_source.is_always_satisfied(&db));
-
-        // No single truth assignment for the source predicate matches every truth assignment for
-        // the target predicate.
-        let exists_source_forall_target = equal
-            .for_all(&db, &builder, typevar_set(&db, [target]))
-            .reduce_inferable(&db, &builder, typevar_set(&db, [source]));
-        assert!(exists_source_forall_target.is_never_satisfied(&db));
     }
 
     /// Double negation of a TDD with uncertain branches is semantically equivalent to the

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1210,6 +1210,9 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     KnownBoundMethodType::ConstraintSetSatisfies(_) => {
                         return f.write_str("bound method `ConstraintSet.satisfies`");
                     }
+                    KnownBoundMethodType::ConstraintSetForAll(_) => {
+                        return f.write_str("bound method `ConstraintSet.for_all`");
+                    }
                     KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_) => {
                         return f
                             .write_str("bound method `ConstraintSet.satisfied_by_all_typevars`");

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -178,6 +178,7 @@ pub enum KnownBoundMethodType<'db> {
     ConstraintSetNever,
     ConstraintSetImpliesSubtypeOf(InternedConstraintSet<'db>),
     ConstraintSetSatisfies(InternedConstraintSet<'db>),
+    ConstraintSetForAll(InternedConstraintSet<'db>),
     ConstraintSetSatisfiedByAllTypeVars(InternedConstraintSet<'db>),
     ConstraintSetWithDetailedDisplay(InternedConstraintSet<'db>),
 }
@@ -214,6 +215,7 @@ pub(super) fn walk_method_wrapper_type<'db, V: visitor::TypeVisitor<'db> + ?Size
         | KnownBoundMethodType::ConstraintSetNever
         | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
         | KnownBoundMethodType::ConstraintSetSatisfies(_)
+        | KnownBoundMethodType::ConstraintSetForAll(_)
         | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
         | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_) => {}
     }
@@ -258,6 +260,7 @@ impl<'db> KnownBoundMethodType<'db> {
             | KnownBoundMethodType::ConstraintSetNever
             | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
             | KnownBoundMethodType::ConstraintSetSatisfies(_)
+            | KnownBoundMethodType::ConstraintSetForAll(_)
             | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
             | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_) => Some(self),
         }
@@ -277,6 +280,7 @@ impl<'db> KnownBoundMethodType<'db> {
             | KnownBoundMethodType::ConstraintSetNever
             | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
             | KnownBoundMethodType::ConstraintSetSatisfies(_)
+            | KnownBoundMethodType::ConstraintSetForAll(_)
             | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
             | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_) => {
                 KnownClass::ConstraintSet
@@ -434,6 +438,19 @@ impl<'db> KnownBoundMethodType<'db> {
                 )))
             }
 
+            KnownBoundMethodType::ConstraintSetForAll(_) => {
+                Either::Right(std::iter::once(Signature::new(
+                    Parameters::standard([Parameter::positional_only(Some(Name::new_static(
+                        "typevars",
+                    )))
+                    .with_annotated_type(TypeFormType::from_type_expression(
+                        db,
+                        Type::homogeneous_tuple(db, Type::object()),
+                    ))]),
+                    KnownClass::ConstraintSet.to_instance(db),
+                )))
+            }
+
             KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_) => {
                 Either::Right(std::iter::once(Signature::new(
                     Parameters::standard([Parameter::keyword_only(Name::new_static("inferable"))
@@ -516,6 +533,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 KnownBoundMethodType::ConstraintSetSatisfies(_),
             )
             | (
+                KnownBoundMethodType::ConstraintSetForAll(_),
+                KnownBoundMethodType::ConstraintSetForAll(_),
+            )
+            | (
                 KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_),
                 KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_),
             )
@@ -536,6 +557,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                | KnownBoundMethodType::ConstraintSetForAll(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
                 KnownBoundMethodType::FunctionTypeDunderGet(_)
@@ -549,6 +571,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                | KnownBoundMethodType::ConstraintSetForAll(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
             ) => self.never(),

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -262,6 +262,7 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                | KnownBoundMethodType::ConstraintSetForAll(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
             )

--- a/crates/ty_vendored/ty_extensions/_internal.pyi
+++ b/crates/ty_vendored/ty_extensions/_internal.pyi
@@ -114,6 +114,11 @@ class ConstraintSet:
         `other`.
         """
 
+    def for_all(self, typevars: TypeForm[tuple[object, ...]]) -> Self:
+        """
+        Universally abstracts the given type variables from this constraint set.
+        """
+
     def satisfied_by_all_typevars(
         self, *, inferable: TypeForm[tuple[object, ...]] | None = None
     ) -> bool:


### PR DESCRIPTION
## Summary

`ConstraintSet` already supports existentially abstracting a set of inferable type variables. This adds the universal counterpart, `ConstraintSet::for_all`, using the Boolean dual `¬∃¬` so it reuses the cached, single-pass existential abstraction added in #26622.

The operation is intentionally low-level: declared type-variable bounds and constraints must be encoded as implications in the input, and callers must first project atomic constraints that relate removed variables to variables retained in the result.

The stacked receiver-constraint and signature-relation follow-ups culminate in #26695, which uses this operation when comparing generic signatures.
