### PR TITLE
[ty] Pydantic: Accept known extra keywords in BaseSettings models

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -995,8 +995,12 @@ Settings(port=8000)
 Settings(host="localhost", port=8000)
 Settings(host=None)  # error: [invalid-argument-type]
 
-# `BaseSettings` defines a specialized constructor and forbids extra values by default.
-Settings(host="localhost", port=8000, something_else=7)  # error: [unknown-argument]
+# `BaseSettings.__init__` accepts many additional known keyword arguments:
+Settings(host="localhost", port=8000, _cli_parse_args=False)
+
+# We currently accept this as a know limitation: if unrelated keyword arguments are passed,
+# they are silently ignored.
+Settings(host="localhost", port=8000, something_else=7)
 ```
 
 ## Root models

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -474,6 +474,10 @@ pub(in crate::types) fn constructor_fields_are_optional(
     db: &dyn Db,
     class: StaticClassLiteral<'_>,
 ) -> bool {
+    is_base_settings_model(db, class)
+}
+
+fn is_base_settings_model(db: &dyn Db, class: StaticClassLiteral<'_>) -> bool {
     class
         .iter_mro(db, None)
         .filter_map(ClassBase::into_class)
@@ -908,6 +912,12 @@ pub(in crate::types) fn model_init_accepts_extra(
     class: StaticClassLiteral<'_>,
     metadata: ModelMetadata<'_>,
 ) -> bool {
+    // `BaseSettings.__init__` accepts many additional known keyword arguments which we currently
+    // don't model precisely, so just accept any extra keyword arguments for now.
+    if is_base_settings_model(db, class) {
+        return true;
+    }
+
     if !metadata.accepts_extra(db) {
         return false;
     }


### PR DESCRIPTION
## Summary

Accept `BaseSettings` model constructor calls with keyword arguments like `_cli_parse_args=False`:

```py
class Settings(BaseSettings):
    host: str
    port: int

Settings(host="localhost", port=8000, _cli_parse_args=False)
```

towards https://github.com/astral-sh/ty/issues/2403

## Test Plan

Updated tests
