### PR TITLE
[ty] Avoid allocation for every stdout write

### DIFF
--- a/crates/ty/src/printer.rs
+++ b/crates/ty/src/printer.rs
@@ -147,10 +147,11 @@ impl Stdout {
         self
     }
 
-    fn handle(&mut self) -> Box<dyn std::io::Write + '_> {
+    #[inline]
+    fn with_handle<T>(&mut self, callback: impl FnOnce(&mut dyn std::io::Write) -> T) -> T {
         match self.lock.as_mut() {
-            Some(lock) => Box::new(lock),
-            None => Box::new(std::io::stdout()),
+            Some(lock) => callback(lock),
+            None => callback(&mut std::io::stdout()),
         }
     }
 
@@ -162,14 +163,14 @@ impl Stdout {
 impl std::io::Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self.status {
-            StreamStatus::Enabled => self.handle().write(buf),
+            StreamStatus::Enabled => self.with_handle(|handle| handle.write(buf)),
             StreamStatus::Disabled => Ok(buf.len()),
         }
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
         match self.status {
-            StreamStatus::Enabled => self.handle().flush(),
+            StreamStatus::Enabled => self.with_handle(|handle| handle.flush()),
             StreamStatus::Disabled => Ok(()),
         }
     }
@@ -179,7 +180,7 @@ impl std::fmt::Write for Stdout {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         match self.status {
             StreamStatus::Enabled => {
-                let _ = write!(self.handle(), "{s}");
+                let _ = self.with_handle(|handle| write!(handle, "{s}"));
                 Ok(())
             }
             StreamStatus::Disabled => Ok(()),


### PR DESCRIPTION
## Summary

We allocated a new `Box<dyn Write>` for every `Write` call (unless the compiler managed to remove it). This is rather expensive. 

This PR replaces the `handle() -> Box<dyn Write>` function with `with_handle` that takes a callback instead. This avoids the allocation entirely.

> On 50k diagnostics, concise improved from 497.1ms to 475.2ms—about 13.5% faster for rendering-only time.

Related to astral-sh/ty#3958.

## Test Plan

Testing: Passed the ty test suite and repository hooks.
