### PR TITLE
[ty] Pydantic: Support custom `__init__` methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -777,6 +777,41 @@ class PersonAllowingExtras(BaseModel):
 PersonAllowingExtras(name="Alice", something_else=7)
 ```
 
+## Custom initializers and extra fields
+
+A custom initializer that accepts arbitrary keyword arguments does not prevent a subclass from
+accepting extra data:
+
+```py
+from typing import Any
+
+from pydantic import BaseModel
+
+class FrameworkBase(BaseModel):
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+
+class User(FrameworkBase):
+    name: str
+
+reveal_type(User.__init__)  # revealed: (self: User, *, name: LaxStr, **extra: Any) -> None
+User(name="Alice", city="Berlin")
+```
+
+A fixed custom initializer continues to control the accepted arguments:
+
+```py
+class RestrictiveBase(BaseModel):
+    def __init__(self, name: str) -> None:
+        super().__init__(name=name)
+
+class RestrictiveUser(RestrictiveBase):
+    name: str
+
+RestrictiveUser(name="Alice")
+RestrictiveUser(name="Alice", city="Berlin")  # error: [unknown-argument]
+```
+
 ## Field named `extra`
 
 The variadic keyword parameter uses a collision-free name when the model already has a field named

--- a/crates/ty_python_semantic/resources/mdtest/external/sqlmodel.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/sqlmodel.md
@@ -23,7 +23,7 @@ user = User(id=1, name="John Doe")
 reveal_type(user.id)  # revealed: int
 reveal_type(user.name)  # revealed: str
 
-reveal_type(User.__init__)  # revealed: (self: User, *, id: LaxInt, name: LaxStr) -> None
+reveal_type(User.__init__)  # revealed: (self: User, *, id: LaxInt, name: LaxStr, **extra: Any) -> None
 
 User()  # error: [missing-argument]
 ```

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -923,8 +923,23 @@ pub(in crate::types) fn model_init_accepts_extra(
             return true;
         }
 
-        if !class_member(db, base.body_scope(db), "__init__").is_undefined() {
+        // These constructors use variadic keywords for specialized inputs, not arbitrary extras.
+        if base.is_known(db, KnownClass::PydanticRootModel)
+            || base.is_known(db, KnownClass::PydanticBaseSettings)
+        {
             return false;
+        }
+
+        let init = class_member(db, base.body_scope(db), "__init__");
+        if !init.is_undefined() {
+            return init
+                .ignore_possibly_undefined()
+                .and_then(Type::as_function_literal)
+                .is_some_and(|init| {
+                    init.signature(db)
+                        .iter()
+                        .any(|signature| signature.parameters().keyword_variadic().is_some())
+                });
         }
     }
 


### PR DESCRIPTION
## Summary

A Pydantic model with a base class with a custom `__init__` method previously prevented us from adding `extra: **Unknown` to the models constructor.

towards https://github.com/astral-sh/ty/issues/2403

## Test Plan

Added Markdown tests
