### PR TITLE
[ty] Buffer diagnostic output

### DIFF
--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -5,7 +5,7 @@ mod python_version;
 mod rule;
 mod version;
 
-use std::fmt::Write;
+use std::io::{BufWriter, Write};
 use std::process::{ExitCode, Termination};
 use std::sync::Mutex;
 
@@ -506,11 +506,12 @@ impl MainLoop {
             diagnostics => {
                 let diagnostics_count = diagnostics.len();
 
-                let mut stdout = self.printer.stream_for_details().lock();
+                let stdout = self.printer.stream_for_details().lock();
 
                 // Only render diagnostics if they're going to be displayed, since doing
                 // so is expensive.
                 if stdout.is_enabled() {
+                    let mut stdout = BufWriter::new(stdout);
                     let display_config = DisplayDiagnosticConfig::new("ty")
                         .format(terminal_settings.output_format.into())
                         .color(colored::control::SHOULD_COLORIZE.should_colorize())
@@ -523,6 +524,7 @@ impl MainLoop {
                         "{}",
                         DisplayDiagnostics::new(db, &display_config, diagnostics)
                     )?;
+                    stdout.flush()?;
                 }
 
                 if !self.cancellation_token.is_cancelled() && is_human_readable {

--- a/crates/ty/src/main.rs
+++ b/crates/ty/src/main.rs
@@ -22,6 +22,17 @@ pub fn main() -> ExitStatus {
     run().unwrap_or_else(|error| {
         use io::Write;
 
+        // Exit "gracefully" on broken pipe errors.
+        //
+        // See: https://github.com/BurntSushi/ripgrep/blob/bf63fe8f258afc09bae6caa48f0ae35eaf115005/crates/core/main.rs#L47C1-L61C14
+        if error.chain().any(|cause| {
+            cause
+                .downcast_ref::<io::Error>()
+                .is_some_and(|ioerr| ioerr.kind() == io::ErrorKind::BrokenPipe)
+        }) {
+            return ExitStatus::Success;
+        }
+
         // Use `writeln` instead of `eprintln` to avoid panicking when the stderr pipe is broken.
         let mut stderr = io::stderr().lock();
 
@@ -32,15 +43,6 @@ pub fn main() -> ExitStatus {
         // the configuration it is help to chain errors ("resolving configuration failed" ->
         // "failed to read file: subdir/pyproject.toml")
         for cause in error.chain() {
-            // Exit "gracefully" on broken pipe errors.
-            //
-            // See: https://github.com/BurntSushi/ripgrep/blob/bf63fe8f258afc09bae6caa48f0ae35eaf115005/crates/core/main.rs#L47C1-L61C14
-            if let Some(ioerr) = cause.downcast_ref::<io::Error>() {
-                if ioerr.kind() == io::ErrorKind::BrokenPipe {
-                    return ExitStatus::Success;
-                }
-            }
-
             writeln!(stderr, "  {} {cause}", "Cause:".bold()).ok();
         }
 

--- a/crates/ty/src/printer.rs
+++ b/crates/ty/src/printer.rs
@@ -175,15 +175,3 @@ impl std::io::Write for Stdout {
         }
     }
 }
-
-impl std::fmt::Write for Stdout {
-    fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        match self.status {
-            StreamStatus::Enabled => {
-                let _ = self.with_handle(|handle| write!(handle, "{s}"));
-                Ok(())
-            }
-            StreamStatus::Disabled => Ok(()),
-        }
-    }
-}


### PR DESCRIPTION
## Summary

By default, `stdout` flushes its output at the end of a line (https://doc.rust-lang.org/std/io/struct.Stdout.html). This can get expensive when rendering many diagnostics, because each flush requires a sys call. 

This PR buffers our writes to reduce the number of syscalls. It's the same as what we use in Ruff.

For 480,000 diagnostics, concise output improves from 4.092s to 2.565s (1.60× faster) and full output improves from 7.858s to 4.158s (1.89× faster).

Closes https://github.com/astral-sh/ty/issues/3958.
