### PR TITLE
[ty] Track semantic type-expression contexts

### DIFF
--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -17,10 +17,11 @@ use crate::place::implicit_globals::all_implicit_module_globals;
 use crate::types::ide_support::{ImportAliasResolution, definition_for_name};
 use crate::types::list_members::{Member, all_members, all_reachable_members};
 use crate::types::{
-    CycleDetector, SpecialFormType, Type, TypeQualifiers, binding_type, infer_complete_scope_types,
-    inferred_declaration,
+    CycleDetector, SpecialFormType, Type, TypeExpressionFlags, TypeQualifiers, binding_type,
+    infer_complete_scope_types, inferred_declaration,
 };
 use ty_python_core::definition::{Definition, DefinitionKind};
+use ty_python_core::expression::ExpressionKind;
 use ty_python_core::place_table;
 use ty_python_core::scope::{FileScopeId, Scope};
 use ty_python_core::semantic_index;
@@ -470,6 +471,25 @@ impl<'db> SemanticModel<'db> {
         )
     }
 
+    /// Returns whether inference interprets `expression` as a normal or type expression.
+    pub fn expression_kind(&self, expression: ExprRef<'_>) -> ExpressionKind {
+        let index = semantic_index(self.db, self.file);
+        let Some(file_scope) = index.try_expression_scope_id(&self.expr_ref_in_ast(expression))
+        else {
+            return ExpressionKind::Normal;
+        };
+        let scope = file_scope.to_scope_id(self.db, self.file);
+
+        if infer_complete_scope_types(self.db, scope)
+            .type_expression_flags(expression)
+            .contains(TypeExpressionFlags::TYPE_EXPRESSION)
+        {
+            ExpressionKind::TypeExpression
+        } else {
+            ExpressionKind::Normal
+        }
+    }
+
     /// Returns whether `definition` defines a PEP 613 or PEP 695 type alias.
     pub fn is_type_alias_definition(&self, definition: Definition<'db>) -> bool {
         match definition.kind(self.db) {
@@ -493,19 +513,7 @@ impl<'db> SemanticModel<'db> {
                 else {
                     return TypeQualifiers::empty();
                 };
-                let definition_file = definition.file(self.db);
-                let module = parsed_module(self.db, definition_file).load(self.db);
-                if !definition
-                    .kind(self.db)
-                    .category(definition_file.is_stub(self.db), &module)
-                    .is_declaration()
-                {
-                    return TypeQualifiers::empty();
-                }
-                let Some(declared) = inferred_declaration(self.db, definition).declared() else {
-                    return TypeQualifiers::empty();
-                };
-                declared.qualifiers()
+                self.definition_type_qualifiers(definition)
             }
             ExprRef::Attribute(attr) => {
                 let Some(value_ty) = attr.value.inferred_type(self) else {
@@ -521,6 +529,22 @@ impl<'db> SemanticModel<'db> {
             }
             _ => TypeQualifiers::empty(),
         }
+    }
+
+    /// Returns the qualifiers declared by a definition.
+    pub fn definition_type_qualifiers(&self, definition: Definition<'db>) -> TypeQualifiers {
+        let definition_file = definition.file(self.db);
+        let module = parsed_module(self.db, definition_file).load(self.db);
+        if !definition
+            .kind(self.db)
+            .category(definition_file.is_stub(self.db), &module)
+            .is_declaration()
+        {
+            return TypeQualifiers::empty();
+        }
+        inferred_declaration(self.db, definition)
+            .declared()
+            .map_or_else(TypeQualifiers::empty, |declared| declared.qualifiers())
     }
 
     /// Returns completion candidates for a string-literal expression based on its expected type.
@@ -848,6 +872,8 @@ mod tests {
     use crate::{HasType, SemanticModel};
     use ruff_db::files::system_path_to_file;
     use ruff_db::parsed::parsed_module;
+    use ruff_python_ast::ExprRef;
+    use ty_python_core::expression::ExpressionKind;
 
     #[test]
     fn function_type() -> anyhow::Result<()> {
@@ -883,6 +909,469 @@ mod tests {
         let ty = class.inferred_type(&model).unwrap();
 
         assert!(ty.is_class_literal());
+
+        Ok(())
+    }
+
+    #[test]
+    fn expression_kinds_follow_inference_context() -> anyhow::Result<()> {
+        let db = TestDbBuilder::new()
+            .with_file(
+                "/src/foo.py",
+                r#"
+                from typing import Annotated, TypeAlias
+
+                normal = int
+                annotation: list[int]
+                metadata = 1
+                annotated: Annotated[int, metadata]
+                Alias: TypeAlias = list[int]
+
+                class Decorator[T]:
+                    def __init__(self, target): ...
+
+                @Decorator[int]
+                def decorated(): ...
+
+                @Decorator["int"]
+                def string_decorated(): ...
+
+                string_annotated: "Annotated[int, metadata]"
+                QuotedAlias: TypeAlias = "list[int]"
+                "#,
+            )
+            .build()?;
+
+        let foo = system_path_to_file(&db, "/src/foo.py").unwrap();
+        let module = parsed_module(&db, foo).load(&db);
+        let model = SemanticModel::new(&db, foo);
+
+        let normal = module.suite()[1].as_assign_stmt().unwrap();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(normal.value.as_ref())),
+            ExpressionKind::Normal
+        );
+
+        let annotation = module.suite()[2].as_ann_assign_stmt().unwrap();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(annotation.annotation.as_ref())),
+            ExpressionKind::TypeExpression
+        );
+
+        let annotated = module.suite()[4].as_ann_assign_stmt().unwrap();
+        let arguments = annotated
+            .annotation
+            .as_subscript_expr()
+            .unwrap()
+            .slice
+            .as_tuple_expr()
+            .unwrap();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(&arguments.elts[0])),
+            ExpressionKind::TypeExpression
+        );
+        assert_eq!(
+            model.expression_kind(ExprRef::from(&arguments.elts[1])),
+            ExpressionKind::Normal
+        );
+
+        let alias = module.suite()[5].as_ann_assign_stmt().unwrap();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(alias.value.as_deref().unwrap())),
+            ExpressionKind::TypeExpression
+        );
+
+        let decorated = module.suite()[7].as_function_def_stmt().unwrap();
+        let decorator_argument = decorated.decorator_list[0]
+            .expression
+            .as_subscript_expr()
+            .unwrap()
+            .slice
+            .as_ref();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(decorator_argument)),
+            ExpressionKind::TypeExpression
+        );
+
+        let string_decorated = module.suite()[8].as_function_def_stmt().unwrap();
+        let string_decorator_argument = string_decorated.decorator_list[0]
+            .expression
+            .as_subscript_expr()
+            .unwrap()
+            .slice
+            .as_string_literal_expr()
+            .unwrap();
+        let (parsed, string_model) = model
+            .enter_string_annotation(string_decorator_argument)
+            .unwrap();
+        assert_eq!(
+            string_model.expression_kind(ExprRef::from(&parsed.syntax().body)),
+            ExpressionKind::TypeExpression
+        );
+
+        let string_annotated = module.suite()[9].as_ann_assign_stmt().unwrap();
+        let string_annotation = string_annotated
+            .annotation
+            .as_string_literal_expr()
+            .unwrap();
+        let (parsed, string_model) = model.enter_string_annotation(string_annotation).unwrap();
+        let string_arguments = parsed
+            .syntax()
+            .body
+            .as_subscript_expr()
+            .unwrap()
+            .slice
+            .as_tuple_expr()
+            .unwrap();
+        assert_eq!(
+            string_model.expression_kind(ExprRef::from(&string_arguments.elts[0])),
+            ExpressionKind::TypeExpression
+        );
+        assert_eq!(
+            string_model.expression_kind(ExprRef::from(&string_arguments.elts[1])),
+            ExpressionKind::Normal
+        );
+
+        let quoted_alias = module.suite()[10]
+            .as_ann_assign_stmt()
+            .unwrap()
+            .value
+            .as_deref()
+            .unwrap()
+            .as_string_literal_expr()
+            .unwrap();
+        let (parsed, string_model) = model.enter_string_annotation(quoted_alias).unwrap();
+        assert!(parsed.syntax().body.inferred_type(&string_model).is_some());
+        assert_eq!(
+            string_model.expression_kind(ExprRef::from(&parsed.syntax().body)),
+            ExpressionKind::TypeExpression
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn expression_kinds_follow_compound_annotations_and_selected_overloads() -> anyhow::Result<()> {
+        let db = TestDbBuilder::new()
+            .with_file(
+                "/src/foo.py",
+                r#"
+                from typing import Any, TypeVar, overload
+                from typing_extensions import TypeForm
+
+                module: Any
+                qualified: module.Missing[int]
+                quoted: "module.Missing[int]"
+
+                T = TypeVar("T")
+
+                @overload
+                def accepts(value: TypeForm[Any], discriminator: int) -> None: ...
+                @overload
+                def accepts(value: int, discriminator: str) -> None: ...
+                def accepts(value, discriminator): ...
+
+                accepts(T, 1)
+                accepts(module, 1)
+                accepts("int", 1)
+                accepts(module.inner.Nested | int, 1)
+                "#,
+            )
+            .build()?;
+
+        let foo = system_path_to_file(&db, "/src/foo.py").unwrap();
+        let module = parsed_module(&db, foo).load(&db);
+        let model = SemanticModel::new(&db, foo);
+
+        let qualified = module.suite()[3]
+            .as_ann_assign_stmt()
+            .unwrap()
+            .annotation
+            .as_subscript_expr()
+            .unwrap();
+        let qualified_attribute = qualified.value.as_attribute_expr().unwrap();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(qualified)),
+            ExpressionKind::TypeExpression
+        );
+        assert_eq!(
+            model.expression_kind(ExprRef::from(qualified_attribute)),
+            ExpressionKind::TypeExpression
+        );
+        assert_eq!(
+            model.expression_kind(ExprRef::from(qualified_attribute.value.as_ref())),
+            ExpressionKind::TypeExpression
+        );
+
+        let quoted = module.suite()[4]
+            .as_ann_assign_stmt()
+            .unwrap()
+            .annotation
+            .as_string_literal_expr()
+            .unwrap();
+        let (parsed, string_model) = model.enter_string_annotation(quoted).unwrap();
+        let quoted_attribute = parsed
+            .syntax()
+            .body
+            .as_subscript_expr()
+            .unwrap()
+            .value
+            .as_attribute_expr()
+            .unwrap();
+        assert_eq!(
+            string_model.expression_kind(ExprRef::from(quoted_attribute)),
+            ExpressionKind::TypeExpression
+        );
+        assert_eq!(
+            string_model.expression_kind(ExprRef::from(quoted_attribute.value.as_ref())),
+            ExpressionKind::TypeExpression
+        );
+
+        let call = module.suite()[9]
+            .as_expr_stmt()
+            .unwrap()
+            .value
+            .as_call_expr()
+            .unwrap();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(&call.arguments.args[0])),
+            ExpressionKind::TypeExpression
+        );
+        assert_eq!(
+            model.expression_kind(ExprRef::from(&call.arguments.args[1])),
+            ExpressionKind::Normal
+        );
+
+        let ambiguous_call = module.suite()[10]
+            .as_expr_stmt()
+            .unwrap()
+            .value
+            .as_call_expr()
+            .unwrap();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(&ambiguous_call.arguments.args[0])),
+            ExpressionKind::Normal
+        );
+
+        let string_call = module.suite()[11]
+            .as_expr_stmt()
+            .unwrap()
+            .value
+            .as_call_expr()
+            .unwrap();
+        let string_argument = string_call.arguments.args[0]
+            .as_string_literal_expr()
+            .unwrap();
+        assert!(
+            string_argument
+                .inferred_type(&model)
+                .unwrap()
+                .is_string_literal()
+        );
+        let (parsed, string_model) = model.enter_string_annotation(string_argument).unwrap();
+        assert!(parsed.syntax().body.inferred_type(&string_model).is_some());
+        assert_eq!(
+            string_model.expression_kind(ExprRef::from(&parsed.syntax().body)),
+            ExpressionKind::TypeExpression
+        );
+
+        let compound_call = module.suite()[12]
+            .as_expr_stmt()
+            .unwrap()
+            .value
+            .as_call_expr()
+            .unwrap();
+        let compound_argument = &compound_call.arguments.args[0];
+        assert_eq!(
+            model.expression_kind(ExprRef::from(compound_argument)),
+            ExpressionKind::TypeExpression
+        );
+        let compound_attribute = compound_argument
+            .as_bin_op_expr()
+            .unwrap()
+            .left
+            .as_attribute_expr()
+            .unwrap();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(compound_attribute)),
+            ExpressionKind::TypeExpression
+        );
+        let compound_inner_attribute = compound_attribute.value.as_attribute_expr().unwrap();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(compound_inner_attribute)),
+            ExpressionKind::TypeExpression
+        );
+        let compound_base = compound_inner_attribute.value.as_ref();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(compound_base)),
+            ExpressionKind::TypeExpression
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn expression_kinds_preserve_fallback_value_positions() -> anyhow::Result<()> {
+        let db = TestDbBuilder::new()
+            .with_file(
+                "/src/foo.py",
+                r#"
+                def unreachable():
+                    literal_value = 1
+                    metadata = 1
+                    return
+                    from typing import Annotated, Literal
+                    literal: Literal[literal_value]
+                    annotated: Annotated[int, metadata]
+
+                from ty_extensions._internal import CallableTypeOf, RegularCallableTypeOf, TypeOf
+
+                first = 1
+                second = 2
+                type_of: TypeOf[first, second]
+                callable_type_of: CallableTypeOf[first, second]
+                regular_callable_type_of: RegularCallableTypeOf[first, second]
+                "#,
+            )
+            .build()?;
+
+        let foo = system_path_to_file(&db, "/src/foo.py").unwrap();
+        let module = parsed_module(&db, foo).load(&db);
+        let model = SemanticModel::new(&db, foo);
+
+        let function = module.suite()[0].as_function_def_stmt().unwrap();
+        let literal_value = function.body[4]
+            .as_ann_assign_stmt()
+            .unwrap()
+            .annotation
+            .as_subscript_expr()
+            .unwrap()
+            .slice
+            .as_ref();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(literal_value)),
+            ExpressionKind::Normal
+        );
+
+        let metadata = &function.body[5]
+            .as_ann_assign_stmt()
+            .unwrap()
+            .annotation
+            .as_subscript_expr()
+            .unwrap()
+            .slice
+            .as_tuple_expr()
+            .unwrap()
+            .elts[1];
+        assert_eq!(
+            model.expression_kind(ExprRef::from(metadata)),
+            ExpressionKind::Normal
+        );
+
+        for statement in &module.suite()[4..=6] {
+            let first_argument = &statement
+                .as_ann_assign_stmt()
+                .unwrap()
+                .annotation
+                .as_subscript_expr()
+                .unwrap()
+                .slice
+                .as_tuple_expr()
+                .unwrap()
+                .elts[0];
+            assert_eq!(
+                model.expression_kind(ExprRef::from(first_argument)),
+                ExpressionKind::Normal
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn expression_kinds_are_independent_of_inference_strategy() -> anyhow::Result<()> {
+        let db = TestDbBuilder::new()
+            .with_file(
+                "/src/foo.py",
+                r#"
+                from typing import Annotated, Generic, Literal, Protocol, TypeVar, Union
+                from typing_extensions import TypeAliasType
+
+                T = TypeVar("T")
+                metadata = 1
+                singleton = Union[T]
+                nested = Union[Annotated[T, metadata]]
+                literal: Literal[metadata]
+
+                class GenericClass(Generic[T]): ...
+                class ProtocolClass(Protocol[T]): ...
+
+                Manual = TypeAliasType("Manual", T, type_params=(T,))
+                specialized = Manual[T]
+                "#,
+            )
+            .build()?;
+
+        let foo = system_path_to_file(&db, "/src/foo.py").unwrap();
+        let module = parsed_module(&db, foo).load(&db);
+        let model = SemanticModel::new(&db, foo);
+
+        let singleton = module.suite()[4].as_assign_stmt().unwrap();
+        let singleton_argument = singleton.value.as_subscript_expr().unwrap().slice.as_ref();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(singleton_argument)),
+            ExpressionKind::TypeExpression
+        );
+
+        let nested = module.suite()[5].as_assign_stmt().unwrap();
+        let nested_annotated = nested.value.as_subscript_expr().unwrap().slice.as_ref();
+        let nested_arguments = nested_annotated
+            .as_subscript_expr()
+            .unwrap()
+            .slice
+            .as_tuple_expr()
+            .unwrap();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(&nested_arguments.elts[0])),
+            ExpressionKind::TypeExpression
+        );
+        assert_eq!(
+            model.expression_kind(ExprRef::from(&nested_arguments.elts[1])),
+            ExpressionKind::Normal
+        );
+
+        let literal = module.suite()[6].as_ann_assign_stmt().unwrap();
+        let literal_argument = literal
+            .annotation
+            .as_subscript_expr()
+            .unwrap()
+            .slice
+            .as_ref();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(literal_argument)),
+            ExpressionKind::Normal
+        );
+
+        for class in &module.suite()[7..=8] {
+            let class = class.as_class_def_stmt().unwrap();
+            let base_argument = class.bases()[0].as_subscript_expr().unwrap().slice.as_ref();
+            assert_eq!(
+                model.expression_kind(ExprRef::from(base_argument)),
+                ExpressionKind::TypeExpression
+            );
+        }
+
+        let specialized = module.suite()[10].as_assign_stmt().unwrap();
+        let specialized_argument = specialized
+            .value
+            .as_subscript_expr()
+            .unwrap()
+            .slice
+            .as_ref();
+        assert_eq!(
+            model.expression_kind(ExprRef::from(specialized_argument)),
+            ExpressionKind::TypeExpression
+        );
 
         Ok(())
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -28,8 +28,8 @@ pub(crate) use self::cyclic::{ActiveRecursionDetector, TypeTransformer};
 pub(crate) use self::diagnostic::register_lints;
 pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
 pub(crate) use self::infer::{
-    InferredDeclaration, TypeContext, infer_complete_scope_types, infer_deferred_types,
-    infer_definition_types, infer_expression_type, infer_expression_types,
+    InferredDeclaration, TypeContext, TypeExpressionFlags, infer_complete_scope_types,
+    infer_deferred_types, infer_definition_types, infer_expression_type, infer_expression_types,
     infer_same_file_expression_type, infer_scope_types, is_discarded_dict_key_assignment,
 };
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -82,6 +82,8 @@ bitflags::bitflags! {
     pub(crate) struct TypeExpressionFlags: u8 {
         /// The expression is syntactically an `Unpack[...]` type expression.
         const UNPACK = 1 << 0;
+        /// The expression is interpreted as a type expression.
+        const TYPE_EXPRESSION = 1 << 1;
     }
 }
 
@@ -209,6 +211,7 @@ pub(crate) fn function_known_decorator_flags<'db>(
 #[derive(Debug, Eq, PartialEq, Default, salsa::Update, get_size2::GetSize)]
 pub(crate) struct FunctionDecoratorInference<'db> {
     expression_types: FrozenMap<ExpressionNodeKey, Type<'db>>,
+    extra: Option<Box<FunctionDecoratorInferenceExtra>>,
     bindings: Box<[(Definition<'db>, Type<'db>)]>,
     called_functions: Box<[FunctionType<'db>]>,
     known_decorators: FunctionDecorators,
@@ -229,6 +232,24 @@ impl<'db> FunctionDecoratorInference<'db> {
         self.expression_types.iter().copied()
     }
 
+    pub(crate) fn type_expression_flags(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (ExpressionNodeKey, TypeExpressionFlags)> + '_ {
+        match self.extra.as_deref() {
+            Some(extra) => Either::Left(extra.type_expression_flags.iter().copied()),
+            None => Either::Right(std::iter::empty()),
+        }
+    }
+
+    pub(crate) fn string_annotations(
+        &self,
+    ) -> impl ExactSizeIterator<Item = ExpressionNodeKey> + '_ {
+        match self.extra.as_deref() {
+            Some(extra) => Either::Left(extra.string_annotations.iter().copied()),
+            None => Either::Right(std::iter::empty()),
+        }
+    }
+
     pub(crate) fn bindings(
         &self,
     ) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> + '_ {
@@ -246,6 +267,12 @@ impl<'db> FunctionDecoratorInference<'db> {
     pub(crate) fn diagnostics(&self) -> &TypeCheckDiagnostics {
         &self.diagnostics
     }
+}
+
+#[derive(Debug, Eq, PartialEq, Default, salsa::Update, get_size2::GetSize)]
+struct FunctionDecoratorInferenceExtra {
+    type_expression_flags: FrozenMap<ExpressionNodeKey, TypeExpressionFlags>,
+    string_annotations: FrozenSet<ExpressionNodeKey>,
 }
 
 /// Infer types for all deferred type expressions in a [`Definition`].
@@ -1153,6 +1180,12 @@ enum DefinitionInferenceExtra<'db> {
 
     StringAnnotations(FrozenSet<ExpressionNodeKey>),
 
+    /// Type-expression metadata is the only extra data for most annotated definitions.
+    TypeExpressionFlags(FrozenMap<ExpressionNodeKey, TypeExpressionFlags>),
+
+    /// Annotation metadata fields commonly occur together.
+    AnnotationMetadata(Box<DefinitionAnnotationMetadata>),
+
     DiscardsDictKeyAssignments,
 
     Other(Box<OtherDefinitionInferenceExtra<'db>>),
@@ -1162,6 +1195,13 @@ enum DefinitionInferenceExtra<'db> {
 struct DeferredAndUndecorated<'db> {
     deferred: Box<[Definition<'db>]>,
     undecorated_type: Type<'db>,
+}
+
+#[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::Update, Default)]
+struct DefinitionAnnotationMetadata {
+    string_annotations: FrozenSet<ExpressionNodeKey>,
+    qualifiers: FrozenMap<ExpressionNodeKey, TypeQualifiers>,
+    type_expression_flags: FrozenMap<ExpressionNodeKey, TypeExpressionFlags>,
 }
 
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::Update, Default)]
@@ -1244,6 +1284,23 @@ impl<'db> DefinitionInferenceExtra<'db> {
                 string_annotations,
                 ..OtherDefinitionInferenceExtra::default()
             },
+            Self::TypeExpressionFlags(type_expression_flags) => OtherDefinitionInferenceExtra {
+                type_expression_flags,
+                ..OtherDefinitionInferenceExtra::default()
+            },
+            Self::AnnotationMetadata(metadata) => {
+                let DefinitionAnnotationMetadata {
+                    string_annotations,
+                    qualifiers,
+                    type_expression_flags,
+                } = *metadata;
+                OtherDefinitionInferenceExtra {
+                    string_annotations,
+                    type_expression_flags,
+                    qualifiers,
+                    ..OtherDefinitionInferenceExtra::default()
+                }
+            }
             Self::DiscardsDictKeyAssignments => OtherDefinitionInferenceExtra {
                 discards_dict_key_assignments: true,
                 ..OtherDefinitionInferenceExtra::default()
@@ -1378,6 +1435,11 @@ impl<'db> DefinitionInference<'db> {
             Some(DefinitionInferenceExtra::Qualifiers(qualifiers)) => {
                 qualifiers.get(&expression).copied().unwrap_or_default()
             }
+            Some(DefinitionInferenceExtra::AnnotationMetadata(metadata)) => metadata
+                .qualifiers
+                .get(&expression)
+                .copied()
+                .unwrap_or_default(),
             Some(DefinitionInferenceExtra::Other(extra)) => extra
                 .qualifiers
                 .get(&expression)
@@ -1393,6 +1455,17 @@ impl<'db> DefinitionInference<'db> {
         expression: impl Into<ExpressionNodeKey>,
     ) -> TypeExpressionFlags {
         match self.extra.as_deref() {
+            Some(DefinitionInferenceExtra::TypeExpressionFlags(type_expression_flags)) => {
+                type_expression_flags
+                    .get(&expression.into())
+                    .copied()
+                    .unwrap_or_default()
+            }
+            Some(DefinitionInferenceExtra::AnnotationMetadata(metadata)) => metadata
+                .type_expression_flags
+                .get(&expression.into())
+                .copied()
+                .unwrap_or_default(),
             Some(DefinitionInferenceExtra::Other(extra)) => extra
                 .type_expression_flags
                 .get(&expression.into())
@@ -1862,6 +1935,13 @@ bitflags::bitflags! {
 
         /// Whether we're in a context where `Unpack` can be legal.
         const IN_VALID_UNPACK_CONTEXT = 1 << 10;
+
+        /// Whether value-expression inference is traversing a semantic type expression.
+        ///
+        /// Some typing forms deliberately use value-expression inference to preserve their
+        /// runtime result. This flag keeps that implementation detail separate from how IDE
+        /// consumers should interpret the expression.
+        const INHERITED_TYPE_EXPRESSION = 1 << 11;
 
         /// Whether the visitor is currently visiting a type expression.
         const IN_TYPE_EXPRESSION = 1 << 12;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -23,11 +23,12 @@ use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
 use super::{
-    DeferredAndUndecorated, DefinitionInference, DefinitionInferenceExtra, DefinitionTypes,
-    ExpressionInference, ExpressionInferenceExtra, FrozenMap, FrozenSet, FrozenValueMap,
-    FunctionDecoratorInference, InferenceRegion, OtherDefinitionInferenceExtra, ScopeInference,
-    ScopeInferenceExtra, infer_deferred_types, infer_definition_types, infer_expression_types,
-    infer_same_file_expression_type, infer_unpack_types,
+    DeferredAndUndecorated, DefinitionAnnotationMetadata, DefinitionInference,
+    DefinitionInferenceExtra, DefinitionTypes, ExpressionInference, ExpressionInferenceExtra,
+    FrozenMap, FrozenSet, FrozenValueMap, FunctionDecoratorInference,
+    FunctionDecoratorInferenceExtra, InferenceRegion, OtherDefinitionInferenceExtra,
+    ScopeInference, ScopeInferenceExtra, infer_deferred_types, infer_definition_types,
+    infer_expression_types, infer_same_file_expression_type, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -359,7 +360,94 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
 }
 
 /// An expression cache shared across builders during multi-inference.
+///
+/// Type-expression traversals bypass this cache because recording semantic metadata for every
+/// descendant is part of their result.
 type ExpressionCache<'db> = FxHashMap<(ExpressionNodeKey, TypeContext<'db>), Type<'db>>;
+
+/// Expression results produced by contextual inference that can be merged without replacing
+/// results from ordinary inference.
+#[derive(Debug, Clone, Default)]
+struct ContextualExpressionMetadata<'db> {
+    expression_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
+    type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
+    string_annotations: FxHashSet<ExpressionNodeKey>,
+}
+
+impl<'db> ContextualExpressionMetadata<'db> {
+    fn take_from_builder(builder: &mut TypeInferenceBuilder<'db, '_>) -> Self {
+        Self {
+            expression_types: std::mem::take(&mut builder.expressions),
+            type_expression_flags: std::mem::take(&mut builder.type_expression_flags),
+            string_annotations: std::mem::take(&mut builder.string_annotations),
+        }
+    }
+
+    fn intersect_with(&mut self, other: &Self) {
+        self.expression_types
+            .retain(|expression, ty| other.expression_types.get(expression) == Some(ty));
+        self.type_expression_flags.retain(|expression, flags| {
+            let Some(other_flags) = other.type_expression_flags.get(expression) else {
+                return false;
+            };
+            *flags &= *other_flags;
+            !flags.is_empty()
+        });
+        self.string_annotations
+            .retain(|expression| other.string_annotations.contains(expression));
+    }
+
+    fn extend_into(self, builder: &mut TypeInferenceBuilder<'db, '_>) {
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "types for distinct expressions are merged independently"
+        )]
+        for (expression, ty) in self.expression_types {
+            builder.expressions.entry(expression).or_insert(ty);
+        }
+
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "metadata for distinct expressions is merged independently"
+        )]
+        for (expression, flags) in self.type_expression_flags {
+            builder
+                .type_expression_flags
+                .entry(expression)
+                .or_default()
+                .insert(flags);
+        }
+        builder.string_annotations.extend(self.string_annotations);
+    }
+}
+
+/// Semantic metadata from speculative call-argument inference, keyed by argument and context.
+#[derive(Debug, Default)]
+struct CallArgumentInferenceMetadata<'db> {
+    by_context: FxHashMap<(usize, Type<'db>), ContextualExpressionMetadata<'db>>,
+}
+
+impl<'db> CallArgumentInferenceMetadata<'db> {
+    fn insert(
+        &mut self,
+        argument_index: usize,
+        inference_cache_key: Type<'db>,
+        builder: &mut TypeInferenceBuilder<'db, '_>,
+    ) {
+        self.by_context.insert(
+            (argument_index, inference_cache_key),
+            ContextualExpressionMetadata::take_from_builder(builder),
+        );
+    }
+
+    fn get(
+        &self,
+        argument_index: usize,
+        inference_cache_key: Type<'db>,
+    ) -> Option<&ContextualExpressionMetadata<'db>> {
+        self.by_context.get(&(argument_index, inference_cache_key))
+    }
+}
 
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// How big a string do we build before bailing?
@@ -495,6 +583,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 DefinitionInferenceExtra::StringAnnotations(string_annotations) => {
                     self.string_annotations
                         .extend(string_annotations.iter().copied());
+                }
+                DefinitionInferenceExtra::TypeExpressionFlags(type_expression_flags) => {
+                    self.type_expression_flags
+                        .extend(type_expression_flags.iter().copied());
+                }
+                DefinitionInferenceExtra::AnnotationMetadata(metadata) => {
+                    self.string_annotations
+                        .extend(metadata.string_annotations.iter().copied());
+                    self.qualifiers.extend(metadata.qualifiers.iter().copied());
+                    self.type_expression_flags
+                        .extend(metadata.type_expression_flags.iter().copied());
                 }
                 DefinitionInferenceExtra::Undecorated(_)
                 | DefinitionInferenceExtra::DiscardsDictKeyAssignments => {}
@@ -810,6 +909,35 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .insert(flags);
     }
 
+    /// Runs inference while recording whether value-inferred expressions are semantic type
+    /// expressions.
+    fn with_expression_kind<T>(
+        &mut self,
+        kind: ExpressionKind,
+        infer: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        let previous = self.context.inference_flags.replace(
+            InferenceFlags::INHERITED_TYPE_EXPRESSION,
+            kind == ExpressionKind::TypeExpression,
+        );
+        let result = infer(self);
+        self.context
+            .inference_flags
+            .set(InferenceFlags::INHERITED_TYPE_EXPRESSION, previous);
+        result
+    }
+
+    fn current_expression_kind(&self) -> ExpressionKind {
+        if self
+            .inference_flags()
+            .contains(InferenceFlags::INHERITED_TYPE_EXPRESSION)
+        {
+            ExpressionKind::TypeExpression
+        } else {
+            ExpressionKind::Normal
+        }
+    }
+
     /// Get metadata for a type expression from the current inference result.
     fn type_expression_flags(&self, expr: impl Into<ExpressionNodeKey>) -> TypeExpressionFlags {
         self.type_expression_flags
@@ -930,7 +1058,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             "Inferring deferred types should not add more deferred definitions"
         );
 
-        if self.db().should_check_file(self.file()) {
+        let should_check_file = self.db().should_check_file(self.file());
+        let annotated_assignments = self
+            .declarations
+            .iter()
+            .filter_map(|(definition, _)| match definition.kind(self.db()) {
+                DefinitionKind::AnnotatedAssignment(assignment) => Some((assignment, *definition)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        for (assignment, definition) in annotated_assignments {
+            post_inference::pep_613_alias::analyze_pep_613_alias(
+                assignment,
+                definition,
+                self,
+                should_check_file,
+            );
+        }
+
+        if should_check_file {
             let mut seen_overloaded_places = FxHashSet::default();
             let mut seen_public_functions = FxHashSet::default();
 
@@ -973,15 +1119,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             self.index,
                             &|expr| self.file_expression_type(expr),
                         );
-                    }
-                    DefinitionKind::AnnotatedAssignment(assignment) => {
-                        if let Some(diagnostics) =
-                            post_inference::pep_613_alias::check_pep_613_alias(
-                                assignment, definition, self,
-                            )
-                        {
-                            self.context.extend(&diagnostics);
-                        }
                     }
                     _ => {}
                 }
@@ -4948,7 +5085,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mut speculative_builder = self.speculate();
 
             // Attempt to infer the argument types using the narrowed type context.
-            speculative_builder.infer_all_argument_types(
+            let argument_metadata = speculative_builder.infer_all_argument_types(
                 ast_arguments.clone(),
                 argument_types,
                 infer_argument_ty,
@@ -4969,6 +5106,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             {
                 return None;
             }
+
+            speculative_builder.extend_selected_call_argument_metadata(
+                &speculative_bindings,
+                argument_types,
+                &argument_metadata,
+                narrowed_tcx,
+                &constraints,
+            );
 
             // Ensure the inferred return type is assignable to the narrowed declared type.
             //
@@ -5018,7 +5163,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         //
         // TODO: We could also attempt an inference without type context, but this
         // leads to similar performance issues.
-        self.infer_all_argument_types(
+        let argument_metadata = self.infer_all_argument_types(
             ast_arguments,
             argument_types,
             infer_argument_ty,
@@ -5026,13 +5171,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             call_expression_tcx,
         );
 
-        bindings.check_types_impl(
+        let result = bindings.check_types_impl(
             db,
             &constraints,
             argument_types,
             call_expression_tcx,
             &self.dataclass_field_specifiers,
-        )
+        );
+        if result.is_ok() {
+            self.extend_selected_call_argument_metadata(
+                bindings,
+                argument_types,
+                &argument_metadata,
+                call_expression_tcx,
+                &constraints,
+            );
+        }
+        result
     }
 
     /// Infer the argument types for all bindings.
@@ -5047,7 +5202,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
         bindings: &'bindings Bindings<'db>,
         call_expression_tcx: TypeContext<'db>,
-    ) {
+    ) -> CallArgumentInferenceMetadata<'db> {
         fn add_overloads_from_binding<'a, 'db>(
             overloads_with_binding: &mut Vec<(&'a Binding<'db>, &'a CallableBinding<'db>)>,
             binding: &'a CallableBinding<'db>,
@@ -5073,6 +5228,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
+        let mut argument_metadata = CallArgumentInferenceMetadata::default();
 
         let mut overloads_with_binding: Vec<(&Binding<'db>, &CallableBinding<'db>)> = Vec::new();
 
@@ -5215,6 +5371,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ),
                     );
 
+                    argument_metadata.insert(
+                        argument_index,
+                        inference_cache_key,
+                        &mut speculative_builder,
+                    );
                     inferred_by_cache_key.insert(inference_cache_key, inferred_ty);
                     self.union_expected_types(&speculative_builder.expected_types);
                     parameter_context.insert_inferred_type(
@@ -5228,6 +5389,54 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     self.teardown_expression_cache();
                 }
             }
+        }
+
+        argument_metadata
+    }
+
+    /// Retains metadata only when every selected overload interprets an argument the same way.
+    fn extend_selected_call_argument_metadata(
+        &mut self,
+        bindings: &Bindings<'db>,
+        arguments_types: &CallArguments<'_, 'db>,
+        metadata: &CallArgumentInferenceMetadata<'db>,
+        call_expression_tcx: TypeContext<'db>,
+        constraints: &ConstraintSetBuilder<'db>,
+    ) {
+        let db = self.db();
+
+        for argument_index in 0..arguments_types.len() {
+            let mut candidates = Vec::new();
+            for binding in bindings.iter_flat() {
+                for (_, overload) in binding.matching_overloads() {
+                    let candidate = overload
+                        .argument_type_context(
+                            db,
+                            constraints,
+                            binding,
+                            arguments_types,
+                            argument_index,
+                            call_expression_tcx,
+                        )
+                        .and_then(|context| {
+                            metadata.get(argument_index, context.inference_cache_key())
+                        });
+                    candidates.push(candidate);
+                }
+            }
+
+            let Some(Some(first)) = candidates.first() else {
+                continue;
+            };
+            let mut common = (*first).clone();
+            for candidate in &candidates[1..] {
+                let Some(candidate) = candidate else {
+                    common = ContextualExpressionMetadata::default();
+                    break;
+                };
+                common.intersect_with(candidate);
+            }
+            common.extend_into(self);
         }
     }
 
@@ -5259,7 +5468,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             "Calling `self.infer_expression` on a standalone-expression is not allowed because it can lead to double-inference. Use `self.infer_standalone_expression` instead."
         );
 
+        if self
+            .inference_flags()
+            .contains(InferenceFlags::INHERITED_TYPE_EXPRESSION)
+        {
+            self.store_type_expression_flags(expression, TypeExpressionFlags::TYPE_EXPRESSION);
+        }
+
         self.infer_expression_impl(expression, tcx)
+    }
+
+    /// Infers an expression as a value even during a type-expression traversal.
+    fn infer_normal_expression(
+        &mut self,
+        expression: &ast::Expr,
+        tcx: TypeContext<'db>,
+    ) -> Type<'db> {
+        self.with_expression_kind(ExpressionKind::Normal, |builder| {
+            builder.infer_expression(expression, tcx)
+        })
     }
 
     fn infer_expression_with_state(
@@ -5386,12 +5613,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expression: &ast::Expr,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        if let Some(ty) = self.expression_cache.as_ref().and_then(|expression_cache| {
-            expression_cache
-                .borrow()
-                .get(&(expression.into(), tcx))
-                .copied()
-        }) {
+        let use_expression_cache = self.current_expression_kind() == ExpressionKind::Normal;
+        if use_expression_cache
+            && let Some(ty) = self.expression_cache.as_ref().and_then(|expression_cache| {
+                expression_cache
+                    .borrow()
+                    .get(&(expression.into(), tcx))
+                    .copied()
+            })
+        {
             self.store_expression_type(expression, ty);
             return ty;
         }
@@ -5401,7 +5631,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         {
             self.store_expression_type(expression, ty);
 
-            if let Some(expression_cache) = &self.expression_cache {
+            if use_expression_cache && let Some(expression_cache) = &self.expression_cache {
                 expression_cache
                     .borrow_mut()
                     .insert((expression.into(), tcx), ty);
@@ -5476,7 +5706,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ty = self.apply_type_context(expression, ty, tcx);
         self.store_expression_type(expression, ty);
 
-        if let Some(expression_cache) = &self.expression_cache {
+        if self.current_expression_kind() == ExpressionKind::Normal
+            && let Some(expression_cache) = &self.expression_cache
+        {
             expression_cache
                 .borrow_mut()
                 .insert((expression.into(), tcx), ty);
@@ -10332,7 +10564,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             declarations: _,
             deferred: _,
             scope: _,
-            string_annotations: _,
+            string_annotations,
             expected_types: _,
             return_types_and_ranges: _,
             collection_use_constraints: _,
@@ -10345,12 +10577,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             region: _,
             cycle_recovery: _,
             qualifiers: _,
-            type_expression_flags: _,
+            type_expression_flags,
         } = self;
         let diagnostics = context.finish();
+        let extra =
+            (!type_expression_flags.is_empty() || !string_annotations.is_empty()).then(|| {
+                Box::new(FunctionDecoratorInferenceExtra {
+                    type_expression_flags: FrozenMap::from(type_expression_flags),
+                    string_annotations: FrozenSet::from(string_annotations),
+                })
+            });
 
         FunctionDecoratorInference {
             expression_types: FrozenMap::from(expressions),
+            extra,
             bindings: bindings.into_boxed_slice(),
             called_functions: called_functions
                 .into_iter()
@@ -10398,19 +10638,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let _ = scope;
         let diagnostics = context.finish();
 
-        let non_undecorated_extra_field_count = usize::from(!string_annotations.is_empty())
+        let annotation_metadata_field_count = usize::from(!string_annotations.is_empty())
+            + usize::from(!type_expression_flags.is_empty())
+            + usize::from(!qualifiers.is_empty());
+        let non_undecorated_extra_field_count = usize::from(annotation_metadata_field_count > 0)
             + usize::from(!expected_types.is_empty())
             + usize::from(!collection_use_constraints.is_empty())
             + usize::from(!called_functions.is_empty())
-            + usize::from(!type_expression_flags.is_empty())
             + usize::from(cycle_recovery.is_some())
             + usize::from(!deferred.is_empty())
             + usize::from(!diagnostics.is_empty())
-            + usize::from(discards_dict_key_assignments)
-            + usize::from(!qualifiers.is_empty());
+            + usize::from(discards_dict_key_assignments);
 
         let extra = match (non_undecorated_extra_field_count, undecorated_type) {
             (0, None) => None,
+            (1, None) if annotation_metadata_field_count > 1 => {
+                Some(Box::new(DefinitionInferenceExtra::AnnotationMetadata(
+                    Box::new(DefinitionAnnotationMetadata {
+                        string_annotations: FrozenSet::from(string_annotations),
+                        qualifiers: FrozenMap::from(qualifiers),
+                        type_expression_flags: FrozenMap::from(type_expression_flags),
+                    }),
+                )))
+            }
             (1, None) if !qualifiers.is_empty() => Some(Box::new(
                 DefinitionInferenceExtra::Qualifiers(FrozenMap::from(qualifiers)),
             )),
@@ -10434,6 +10684,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (1, None) if !string_annotations.is_empty() => Some(Box::new(
                 DefinitionInferenceExtra::StringAnnotations(FrozenSet::from(string_annotations)),
             )),
+            (1, None) if !type_expression_flags.is_empty() => {
+                Some(Box::new(DefinitionInferenceExtra::TypeExpressionFlags(
+                    FrozenMap::from(type_expression_flags),
+                )))
+            }
             (1, None) if discards_dict_key_assignments => Some(Box::new(
                 DefinitionInferenceExtra::DiscardsDictKeyAssignments,
             )),

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -1,9 +1,11 @@
 use ruff_python_ast as ast;
 use ruff_python_ast::helpers::is_dotted_name;
+use ty_python_core::expression::ExpressionKind;
 
 use super::{DeferredExpressionState, TypeInferenceBuilder};
 use crate::place::TypeOrigin;
 use crate::types::diagnostic::{INVALID_TYPE_FORM, REDUNDANT_FINAL_CLASSVAR};
+use crate::types::infer::TypeExpressionFlags;
 use crate::types::infer::builder::InferenceFlags;
 use crate::types::infer::builder::subscript::AnnotatedExprContext;
 use crate::types::infer::nearest_enclosing_class;
@@ -88,7 +90,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .context
             .inference_flags
             .replace(InferenceFlags::CHECK_UNBOUND_TYPEVARS, true);
-        let annotation_ty = self.infer_annotation_expression_impl(annotation, pep_613_policy);
+        let annotation_ty = self.with_expression_kind(ExpressionKind::TypeExpression, |builder| {
+            builder.infer_annotation_expression_impl(annotation, pep_613_policy)
+        });
         self.context.inference_flags.set(
             InferenceFlags::CHECK_UNBOUND_TYPEVARS,
             previous_check_unbound_typevars,
@@ -175,6 +179,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 AnnotationExpressionInference::new(annotation_ty)
             }
         }
+
+        self.store_type_expression_flags(annotation, TypeExpressionFlags::TYPE_EXPRESSION);
 
         // https://typing.python.org/en/latest/spec/annotations.html#grammar-token-expression-grammar-annotation_expression
         let inferred = match annotation {

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -316,6 +316,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.context.extend(decorator_inference.diagnostics());
             self.expressions
                 .extend(decorator_inference.expression_types());
+            self.type_expression_flags
+                .extend(decorator_inference.type_expression_flags());
+            self.string_annotations
+                .extend(decorator_inference.string_annotations());
             self.bindings.extend(decorator_inference.bindings());
             self.called_functions
                 .extend(decorator_inference.called_functions().iter().copied());

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/pep_613_alias.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/pep_613_alias.rs
@@ -1,30 +1,39 @@
-use crate::types::{
-    TypeCheckDiagnostics,
-    infer::{InferenceFlags, TypeInferenceBuilder},
-};
+use crate::types::infer::builder::ContextualExpressionMetadata;
+use crate::types::infer::{InferenceFlags, TypeInferenceBuilder};
 use ty_python_core::definition::{AnnotatedAssignmentDefinitionKind, Definition};
 
-pub(crate) fn check_pep_613_alias<'db>(
+pub(crate) fn analyze_pep_613_alias<'db>(
     assignment: &AnnotatedAssignmentDefinitionKind,
     definition: Definition<'db>,
-    builder: &TypeInferenceBuilder<'db, '_>,
-) -> Option<TypeCheckDiagnostics> {
+    builder: &mut TypeInferenceBuilder<'db, '_>,
+    report_diagnostics: bool,
+) {
     let context = &builder.context;
 
-    let value = assignment.value(context.module())?;
+    let Some(value) = assignment.value(context.module()) else {
+        return;
+    };
 
     let annotation = assignment.annotation(context.module());
     if !builder
         .file_expression_type(annotation)
         .is_typealias_special_form()
     {
-        return None;
+        return;
     }
 
     let mut speculative = builder.speculate();
+    if !report_diagnostics {
+        speculative.context.suppress_diagnostics();
+    }
 
     speculative.typevar_binding_context = Some(definition);
     speculative.context.inference_flags |= InferenceFlags::IN_TYPE_ALIAS;
     speculative.infer_type_expression(value);
-    Some(speculative.context.finish())
+
+    ContextualExpressionMetadata::take_from_builder(&mut speculative).extend_into(builder);
+    let diagnostics = speculative.context.finish();
+    if report_diagnostics {
+        builder.context.extend(&diagnostics);
+    }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -34,6 +34,7 @@ use crate::types::{
 use crate::{Db, FxOrderSet};
 use ty_python_core::SemanticIndex;
 use ty_python_core::definition::Definition;
+use ty_python_core::expression::ExpressionKind;
 use ty_python_core::place::{PlaceExpr, PlaceExprRef};
 use ty_python_core::scope::FileScopeId;
 
@@ -243,7 +244,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::ManualPEP695(
                 _,
             ))) => {
-                let slice_ty = self.infer_expression(slice, TypeContext::default());
+                let slice_ty = self
+                    .with_expression_kind(ExpressionKind::TypeExpression, |builder| {
+                        builder.infer_expression(slice, TypeContext::default())
+                    });
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
                     db,
@@ -344,7 +348,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         return union_type;
                     }
                     _ => {
-                        return self.infer_expression(slice, TypeContext::default());
+                        return self
+                            .with_expression_kind(ExpressionKind::TypeExpression, |builder| {
+                                builder.infer_expression(slice, TypeContext::default())
+                            });
                     }
                 },
                 SpecialFormType::Type => {
@@ -426,7 +433,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             _ => {}
         }
 
-        let slice_ty = self.infer_expression(slice, TypeContext::default());
+        let slice_ty = if matches!(
+            value_ty,
+            Type::SpecialForm(SpecialFormType::Generic | SpecialFormType::Protocol)
+        ) {
+            self.with_expression_kind(ExpressionKind::TypeExpression, |builder| {
+                builder.infer_expression(slice, TypeContext::default())
+            })
+        } else {
+            self.infer_expression(slice, TypeContext::default())
+        };
         let result_ty = self.infer_subscript_expression_types(subscript, value_ty, slice_ty, *ctx);
         self.narrow_expr_with_applicable_constraints(subscript, result_ty, &constraint_keys)
     }
@@ -2011,9 +2027,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .context
             .inference_flags
             .replace(InferenceFlags::IN_TYPE_ALIAS, false);
-        for metadata_element in &arguments[1..] {
-            self.infer_expression(metadata_element, TypeContext::default());
-        }
+        self.with_expression_kind(ExpressionKind::Normal, |builder| {
+            for metadata_element in &arguments[1..] {
+                builder.infer_expression(metadata_element, TypeContext::default());
+            }
+        });
         self.context
             .inference_flags
             .set(InferenceFlags::IN_TYPE_ALIAS, previous_in_type_alias);

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -17,6 +17,7 @@ use crate::types::signatures::{ConcatenateTail, Signature};
 use crate::types::special_form::{AliasSpec, LegacyStdlibAlias};
 use crate::types::string_annotation::parse_string_annotation;
 use crate::types::tuple::{TupleSpecBuilder, TupleType};
+use ty_python_core::expression::ExpressionKind;
 use ty_python_core::scope::ScopeKind;
 
 use crate::types::{
@@ -132,6 +133,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
     /// Infer the type of a type expression without storing the result.
     pub(super) fn infer_type_expression_no_store(&mut self, expression: &ast::Expr) -> Type<'db> {
+        self.with_expression_kind(ExpressionKind::TypeExpression, |builder| {
+            builder.infer_type_expression_no_store_impl(expression)
+        })
+    }
+
+    fn infer_type_expression_no_store_impl(&mut self, expression: &ast::Expr) -> Type<'db> {
+        self.store_type_expression_flags(expression, TypeExpressionFlags::TYPE_EXPRESSION);
+
         let ignore_runtime_errors = |builder: &Self| {
             builder.deferred_state.is_deferred()
                 || builder.in_stub()
@@ -1427,12 +1436,25 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
 
-        self.infer_explicit_callable_specialization(
-            subscript,
-            value_ty,
-            generic_context,
-            specialize,
-        )
+        let expression_kind = if in_type_expression
+            || matches!(
+                value_ty,
+                Type::KnownInstance(KnownInstanceType::TypeAliasType(
+                    TypeAliasType::ManualPEP695(_)
+                ))
+            ) {
+            ExpressionKind::TypeExpression
+        } else {
+            ExpressionKind::Normal
+        };
+        self.with_expression_kind(expression_kind, |builder| {
+            builder.infer_explicit_callable_specialization(
+                subscript,
+                value_ty,
+                generic_context,
+                specialize,
+            )
+        })
     }
 
     pub(super) fn infer_subscript_type_expression(
@@ -1456,7 +1478,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 // false-positive `invalid-type-form` diagnostics (`1` is not a valid type
                 // expression).
                 if !self.in_string_annotation() {
-                    self.infer_expression(slice, TypeContext::default());
+                    self.infer_normal_expression(slice, TypeContext::default());
                 }
                 Type::unknown()
             }
@@ -2121,12 +2143,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 };
                 let num_arguments = arguments.len();
                 let type_of_type = if num_arguments == 1 {
-                    // N.B. This uses `infer_expression` rather than `infer_type_expression`
-                    self.infer_expression(&arguments[0], TypeContext::default())
+                    self.infer_normal_expression(&arguments[0], TypeContext::default())
                 } else {
                     if !self.in_string_annotation() {
                         for argument in arguments {
-                            self.infer_expression(argument, TypeContext::default());
+                            self.infer_normal_expression(argument, TypeContext::default());
                         }
                     }
                     report_invalid_argument_number_to_special_form(
@@ -2186,7 +2207,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 if num_arguments != 1 {
                     if !self.in_string_annotation() {
                         for argument in arguments {
-                            self.infer_expression(argument, TypeContext::default());
+                            self.infer_normal_expression(argument, TypeContext::default());
                         }
                     }
                     report_invalid_argument_number_to_special_form(
@@ -2202,7 +2223,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return Type::unknown();
                 }
 
-                let argument_type = self.infer_expression(&arguments[0], TypeContext::default());
+                let argument_type =
+                    self.infer_normal_expression(&arguments[0], TypeContext::default());
 
                 let Some(callable_type) = argument_type
                     .try_upcast_to_callable_with_recursive_fallback(
@@ -2551,6 +2573,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     }
 
     pub(crate) fn infer_literal_parameter_type<'param>(
+        &mut self,
+        parameters: &'param ast::Expr,
+    ) -> Result<Type<'db>, Vec<&'param ast::Expr>> {
+        self.with_expression_kind(ExpressionKind::Normal, |builder| {
+            builder.infer_literal_parameter_type_impl(parameters)
+        })
+    }
+
+    fn infer_literal_parameter_type_impl<'param>(
         &mut self,
         parameters: &'param ast::Expr,
     ) -> Result<Type<'db>, Vec<&'param ast::Expr>> {

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -4,7 +4,7 @@ use crate::place::symbol;
 use crate::place::{ConsideredDefinitions, Place, global_symbol};
 use crate::types::{KnownClass, KnownInstanceType, check_types};
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId};
-use ruff_db::files::{File, system_path_to_file};
+use ruff_db::files::{File, system_path_to_file, vendored_path_to_file};
 use ruff_db::system::DbWithWritableSystem as _;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
 use ty_python_core::definition::Definition;
@@ -110,6 +110,98 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
     assert_eq!(
         non_owner.bindings(first).collect::<Vec<_>>(),
         [(second, owner_type)]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn type_expression_metadata_uses_compact_definition_extra() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented("/src/annotation.py", "value: list[int]")?;
+
+    let file = system_path_to_file(&db, "/src/annotation.py")?;
+    let module = parsed_module(&db, file).load(&db);
+    let assignment = module.syntax().body[0].as_ann_assign_stmt().unwrap();
+    let definition = semantic_index(&db, file).expect_single_definition(assignment);
+    let inference = infer_definition_types(&db, definition);
+
+    assert!(matches!(
+        inference.extra.as_deref(),
+        Some(DefinitionInferenceExtra::TypeExpressionFlags(_))
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn combined_annotation_metadata_uses_compact_definition_extra() -> anyhow::Result<()> {
+    assert!(
+        std::mem::size_of::<DefinitionAnnotationMetadata>()
+            < std::mem::size_of::<OtherDefinitionInferenceExtra>()
+    );
+
+    let mut db = setup_db();
+    db.write_dedented(
+        "/src/annotations.py",
+        r#"
+        from typing import Final
+
+        string_value: "list[int]"
+        final_value: Final[int]
+        "#,
+    )?;
+
+    let file = system_path_to_file(&db, "/src/annotations.py")?;
+    let module = parsed_module(&db, file).load(&db);
+    for statement in &module.syntax().body[1..] {
+        let assignment = statement.as_ann_assign_stmt().unwrap();
+        let definition = semantic_index(&db, file).expect_single_definition(assignment);
+        let inference = infer_definition_types(&db, definition);
+
+        assert!(matches!(
+            inference.extra.as_deref(),
+            Some(DefinitionInferenceExtra::AnnotationMetadata(_))
+        ));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn function_decorator_metadata_is_allocated_on_demand() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented(
+        "/src/decorated.py",
+        r#"
+        @staticmethod
+        def decorated(): ...
+        "#,
+    )?;
+
+    let file = system_path_to_file(&db, "/src/decorated.py")?;
+    let module = parsed_module(&db, file).load(&db);
+    let function = module.syntax().body[0].as_function_def_stmt().unwrap();
+    let definition = semantic_index(&db, file).expect_single_definition(function);
+    let inference = function_known_decorators(&db, definition);
+
+    assert!(inference.extra.is_none());
+
+    Ok(())
+}
+
+#[test]
+fn type_expression_metadata_is_inferred_for_unchecked_file() -> anyhow::Result<()> {
+    let db = setup_db();
+    let file = vendored_path_to_file(&db, "stdlib/_remote_debugging.pyi")?;
+    let module = parsed_module(&db, file).load(&db);
+    let assignment = module.syntax().body[4].as_ann_assign_stmt().unwrap();
+    let inference = infer_complete_scope_types(&db, global_scope(&db, file));
+
+    assert!(
+        inference
+            .type_expression_flags(assignment.value.as_deref().unwrap())
+            .contains(TypeExpressionFlags::TYPE_EXPRESSION)
     );
 
     Ok(())


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This teaches ty's semantic model to report whether an expression was inferred as a type expression or as a value expression. We record that context during inference—including for quoted annotations and arguments whose role depends on overload resolution—so IDE features do not have to reconstruct it later from syntax or the inferred type.

This is an internal prerequisite for [the stacked hover change](https://github.com/astral-sh/ruff/pull/26706); it does not otherwise change type-checking behavior.

## Test Plan

<!-- How was it tested? -->
