### PR TITLE
[ty] Consolidate tab stop offset calculations

### DIFF
--- a/crates/ruff_linter/src/checkers/logical_lines.rs
+++ b/crates/ruff_linter/src/checkers/logical_lines.rs
@@ -1,6 +1,7 @@
 use ruff_python_ast::token::{TokenKind, Tokens};
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
+use ruff_python_trivia::tab_offset;
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -26,7 +27,7 @@ pub(crate) fn expand_indent(line: &str, indent_width: IndentWidth) -> usize {
     let tab_size = indent_width.as_usize();
     for c in line.bytes() {
         match c {
-            b'\t' => indent = (indent / tab_size) * tab_size + tab_size,
+            b'\t' => indent += tab_offset(indent, tab_size),
             b' ' => indent += 1,
             _ => break,
         }

--- a/crates/ruff_linter/src/line_width.rs
+++ b/crates/ruff_linter/src/line_width.rs
@@ -9,6 +9,7 @@ use unicode_width::UnicodeWidthChar;
 
 use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_macros::CacheKey;
+use ruff_python_trivia::tab_offset;
 use ruff_text_size::TextSize;
 
 /// The length of a line of text that is considered too long.
@@ -201,7 +202,7 @@ impl LineWidthBuilder {
         for c in chars {
             match c {
                 '\t' => {
-                    let tab_offset = tab_size - (self.column % tab_size);
+                    let tab_offset = tab_offset(self.column, tab_size);
                     self.width += tab_offset;
                     self.column += tab_offset;
                 }

--- a/crates/ruff_python_formatter/src/string/docstring.rs
+++ b/crates/ruff_python_formatter/src/string/docstring.rs
@@ -15,7 +15,7 @@ use ruff_python_parser::ParseOptions;
 use ruff_python_trivia::TriviaRanges;
 use {
     ruff_formatter::{FormatOptions, IndentStyle, LineWidth, Printed, write},
-    ruff_python_trivia::{PythonWhitespace, is_python_whitespace},
+    ruff_python_trivia::{PythonWhitespace, is_python_whitespace, tab_offset},
     ruff_text_size::{Ranged, TextLen, TextRange, TextSize},
 };
 
@@ -1693,7 +1693,7 @@ impl Indentation {
         for char in iter {
             if char == '\t' {
                 // Pad to the next multiple of tab_width
-                width += Self::TAB_INDENT_WIDTH - (width.rem_euclid(Self::TAB_INDENT_WIDTH));
+                width += tab_offset(width, Self::TAB_INDENT_WIDTH);
                 len += '\t'.text_len();
             } else if char.is_whitespace() {
                 width += char.len_utf8();
@@ -1720,7 +1720,7 @@ impl Indentation {
             Self::TabSpaces { tabs, spaces } => tabs * Self::TAB_INDENT_WIDTH + spaces,
             Self::SpacesTabs { spaces, tabs } => {
                 let mut indent = spaces;
-                indent += Self::TAB_INDENT_WIDTH - indent.rem_euclid(Self::TAB_INDENT_WIDTH);
+                indent += tab_offset(indent, Self::TAB_INDENT_WIDTH);
                 indent + (tabs - 1) * Self::TAB_INDENT_WIDTH
             }
             Self::Mixed { width, .. } => width,
@@ -1827,8 +1827,7 @@ impl Indentation {
             }
             if char == '\t' {
                 // Pad to the next multiple of tab_width
-                seen_indent_len +=
-                    Self::TAB_INDENT_WIDTH - (seen_indent_len.rem_euclid(Self::TAB_INDENT_WIDTH));
+                seen_indent_len += tab_offset(seen_indent_len, Self::TAB_INDENT_WIDTH);
                 trimmed = &trimmed[1..];
             } else if char.is_whitespace() {
                 seen_indent_len += char.len_utf8();

--- a/crates/ruff_python_parser/src/lexer/indentation.rs
+++ b/crates/ruff_python_parser/src/lexer/indentation.rs
@@ -2,6 +2,8 @@ use static_assertions::assert_eq_size;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 
+use ruff_python_trivia::tab_offset_u32;
+
 /// The column index of an indentation.
 ///
 /// A space increments the column by one. A tab adds up to 2 (if tab size is 2) indices, but just one
@@ -63,7 +65,7 @@ impl Indentation {
             // * Adds `TAB_SIZE` if `column` is a multiple of `TAB_SIZE`
             // * Rounds `column` up to the next multiple of `TAB_SIZE` otherwise.
             // https://github.com/python/cpython/blob/2cf99026d6320f38937257da1ab014fc873a11a6/Parser/tokenizer.c#L1818
-            column: Column((self.column.0 / Self::TAB_SIZE + 1) * Self::TAB_SIZE),
+            column: Column(self.column.0 + tab_offset_u32(self.column.0, Self::TAB_SIZE)),
         }
     }
 

--- a/crates/ruff_python_trivia/src/whitespace.rs
+++ b/crates/ruff_python_trivia/src/whitespace.rs
@@ -17,7 +17,7 @@ pub fn expand_tabs(source: &str) -> Cow<'_, str> {
     for character in source.chars() {
         match character {
             '\t' => {
-                let spaces = TAB_SIZE - column % TAB_SIZE;
+                let spaces = tab_offset(column, TAB_SIZE);
                 expanded.extend(std::iter::repeat_n(' ', spaces));
                 column += spaces;
             }
@@ -33,6 +33,16 @@ pub fn expand_tabs(source: &str) -> Cow<'_, str> {
     }
 
     Cow::Owned(expanded)
+}
+
+/// Returns the number of columns from `column` to the next tab stop.
+pub const fn tab_offset(column: usize, tab_size: usize) -> usize {
+    tab_size - column % tab_size
+}
+
+/// Returns the number of columns from `column` to the next tab stop using `u32` values.
+pub const fn tab_offset_u32(column: u32, tab_size: u32) -> u32 {
+    tab_size - column % tab_size
 }
 
 /// Extract the leading indentation from a line.
@@ -117,7 +127,7 @@ impl PythonWhitespace for str {
 mod tests {
     use std::borrow::Cow;
 
-    use super::expand_tabs;
+    use super::{expand_tabs, tab_offset, tab_offset_u32};
 
     #[test]
     fn tab_expansion_borrows_unchanged_text() {
@@ -130,5 +140,19 @@ mod tests {
 
         assert!(matches!(&expanded, Cow::Owned(_)));
         assert_eq!(expanded, "        value");
+    }
+
+    #[test]
+    fn tab_offset_advances_to_next_stop() {
+        assert_eq!(tab_offset(0, 8), 8);
+        assert_eq!(tab_offset(2, 8), 6);
+        assert_eq!(tab_offset(8, 8), 8);
+    }
+
+    #[test]
+    fn u32_tab_offset_advances_to_next_stop() {
+        assert_eq!(tab_offset_u32(0, 8), 8);
+        assert_eq!(tab_offset_u32(2, 8), 6);
+        assert_eq!(tab_offset_u32(8, 8), 8);
     }
 }

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -1,4 +1,4 @@
-use ruff_python_trivia::leading_indentation;
+use ruff_python_trivia::{leading_indentation, tab_offset_u32};
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{TextRange, TextSize};
 
@@ -205,7 +205,7 @@ pub(super) fn indentation(line: &str) -> TextSize {
         leading_indentation(line)
             .bytes()
             .fold(0u32, |column, byte| match byte {
-                b'\t' => (column / 8 + 1) * 8,
+                b'\t' => column + tab_offset_u32(column, 8),
                 _ => column + 1,
             }),
     )


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Following up on [prior review feedback](https://github.com/astral-sh/ruff/pull/26679#discussion_r3557123788), this introduces a shared helper (`ruff_python_trivia::tab_offset`) that we use to consolidate the calculation for advancing a column to the next tab stop.

## Test Plan

See included tests for the new helper. Otherwise, since this is a pure refactor, we rely on existing test coverage.
<!-- How was it tested? -->
