### PR TITLE
[ty] Precompute parser name hashes

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::name::Name;
+use ruff_python_ast::name::NameHashMap;
 use ruff_python_ast::{self as ast, Expr, Stmt};
 use ruff_python_trivia::indentation_at_offset;
 use ruff_text_size::{Ranged, TextRange};
@@ -104,7 +102,7 @@ fn get_undecorated_methods(checker: &Checker, class_stmt: &Stmt, method_type: &M
         return;
     };
 
-    let mut explicit_decorator_calls: HashMap<Name, &Stmt> = HashMap::default();
+    let mut explicit_decorator_calls: NameHashMap<&Stmt> = NameHashMap::default();
 
     let method_name = match method_type {
         MethodType::Classmethod => "classmethod",

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -1,6 +1,7 @@
 use std::borrow::{Borrow, Cow};
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter, Write};
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher};
 use std::ops::Deref;
 
 use arrayvec::ArrayVec;
@@ -9,14 +10,125 @@ use char_str::CharStr;
 use crate::Expr;
 use crate::generated::ExprName;
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone)]
 #[cfg_attr(
     feature = "schemars",
     derive(schemars::JsonSchema),
     schemars(with = "String")
 )]
-pub struct Name(CharStr);
+pub struct Name {
+    text: CharStr,
+    hash: u64,
+}
+
+/// A hash map keyed directly by [`Name`] that reuses each name's precomputed hash.
+pub type NameHashMap<V> = HashMap<Name, V, NameBuildHasher>;
+
+/// A hash set keyed directly by [`Name`] that reuses each name's precomputed hash.
+pub type NameHashSet = HashSet<Name, NameBuildHasher>;
+
+/// A hash map keyed by borrowed [`Name`] values that reuses each name's precomputed hash.
+pub type NameRefHashMap<'a, V> = HashMap<&'a Name, V, NameBuildHasher>;
+
+/// A hash set keyed by borrowed [`Name`] values that reuses each name's precomputed hash.
+pub type NameRefHashSet<'a> = HashSet<&'a Name, NameBuildHasher>;
+
+/// Build hasher for collections keyed directly by [`Name`].
+///
+/// This hasher also hashes borrowed `str` keys compatibly with `Name`, preserving zero-allocation
+/// lookups through [`Borrow<str>`]. It must not be used for composite keys.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NameBuildHasher;
+
+impl BuildHasher for NameBuildHasher {
+    type Hasher = NameHasher;
+
+    #[inline]
+    fn build_hasher(&self) -> Self::Hasher {
+        NameHasher::default()
+    }
+}
+
+/// Hasher used by [`NameBuildHasher`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NameHasher {
+    state: u64,
+}
+
+impl Hasher for NameHasher {
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        self.state = name_hash(bytes);
+    }
+
+    #[inline]
+    fn write_u8(&mut self, _: u8) {}
+
+    #[inline]
+    fn write_u64(&mut self, hash: u64) {
+        self.state = hash;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.state
+    }
+}
+
+#[inline]
+const fn read_u32(bytes: &[u8], index: usize) -> u32 {
+    (bytes[index] as u32)
+        | ((bytes[index + 1] as u32) << 8)
+        | ((bytes[index + 2] as u32) << 16)
+        | ((bytes[index + 3] as u32) << 24)
+}
+
+#[inline]
+const fn mix(a: u32, b: u32) -> u32 {
+    let mixed = (a as u64).wrapping_mul(b as u64);
+    let bytes = mixed.to_le_bytes();
+    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+        ^ u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]])
+}
+
+/// Computes the hash stored in a [`Name`].
+///
+/// This follows Oxc's identifier hash: short names read all bytes, while longer names sample four
+/// positions. Full string equality still resolves hash collisions.
+#[inline]
+const fn name_hash(bytes: &[u8]) -> u64 {
+    const SEED1: u32 = 0x9E37_79B9;
+    const SEED2: u32 = 0x85EB_CA6B;
+
+    let len = bytes.len();
+    assert!(len <= u32::MAX as usize, "name is too long");
+
+    let hash = if len == 0 {
+        0
+    } else if len < 4 {
+        let packed =
+            ((bytes[0] as u32) << 16) | ((bytes[len >> 1] as u32) << 8) | bytes[len - 1] as u32;
+        mix(packed ^ SEED1, packed ^ SEED2)
+    } else if len <= 8 {
+        mix(read_u32(bytes, 0) ^ SEED1, read_u32(bytes, len - 4) ^ SEED2)
+    } else if len <= 16 {
+        let head = read_u32(bytes, 0);
+        let middle = read_u32(bytes, (len >> 1) - 2);
+        let tail = read_u32(bytes, len - 4);
+        mix(head ^ middle ^ SEED1, tail ^ SEED2)
+    } else {
+        let head = read_u32(bytes, 0);
+        let middle1 = read_u32(bytes, len / 3);
+        let middle2 = read_u32(bytes, 2 * len / 3);
+        let tail = read_u32(bytes, len - 4);
+        mix(head ^ middle1 ^ SEED1, middle2 ^ tail ^ SEED2)
+    };
+
+    let len_bytes = len.to_le_bytes();
+    let len = u32::from_le_bytes([len_bytes[0], len_bytes[1], len_bytes[2], len_bytes[3]]);
+    let low = hash ^ len.rotate_left(16);
+    (low as u64) | ((hash as u64) << 32)
+}
 
 impl Name {
     /// The maximum number of UTF-8 bytes stored inline in a name.
@@ -24,21 +136,71 @@ impl Name {
 
     #[inline]
     pub fn empty() -> Self {
-        Self(CharStr::new())
+        Self {
+            text: CharStr::new(),
+            hash: name_hash(b""),
+        }
     }
 
     #[inline]
     pub fn new(name: impl AsRef<str>) -> Self {
-        Self(CharStr::from(name.as_ref()))
+        Self::from_text(CharStr::from(name.as_ref()))
     }
 
     #[inline]
     pub const fn new_static(name: &'static str) -> Self {
-        Self(CharStr::from_static_str(name))
+        Self {
+            text: CharStr::from_static_str(name),
+            hash: name_hash(name.as_bytes()),
+        }
     }
 
+    #[inline]
     pub fn as_str(&self) -> &str {
-        self.0.as_str()
+        self.text.as_str()
+    }
+
+    #[inline]
+    fn from_text(text: CharStr) -> Self {
+        let hash = name_hash(text.as_bytes());
+        Self { text, hash }
+    }
+}
+
+impl Default for Name {
+    #[inline]
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl PartialEq for Name {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.hash == other.hash && self.text == other.text
+    }
+}
+
+impl Eq for Name {}
+
+impl PartialOrd for Name {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Name {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl Hash for Name {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash);
     }
 }
 
@@ -81,7 +243,7 @@ impl<'a> From<&'a str> for Name {
 impl From<String> for Name {
     #[inline]
     fn from(s: String) -> Self {
-        Name(s.into())
+        Self::from_text(s.into())
     }
 }
 
@@ -95,27 +257,41 @@ impl<'a> From<&'a String> for Name {
 impl<'a> From<Cow<'a, str>> for Name {
     #[inline]
     fn from(cow: Cow<'a, str>) -> Self {
-        Name(cow.into())
+        Self::from_text(cow.into())
     }
 }
 
 impl From<Box<str>> for Name {
     #[inline]
     fn from(b: Box<str>) -> Self {
-        Name(b.into())
+        Self::from_text(b.into())
     }
 }
 
 impl From<Name> for String {
     #[inline]
     fn from(name: Name) -> Self {
-        name.0.into()
+        name.text.into()
     }
 }
 
 impl FromIterator<char> for Name {
     fn from_iter<I: IntoIterator<Item = char>>(iter: I) -> Self {
-        Self(iter.into_iter().collect())
+        Self::from_text(iter.into_iter().collect())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Name {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serde::Serialize::serialize(self.as_str(), serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Name {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        <String as serde::Deserialize>::deserialize(deserializer).map(Self::from)
     }
 }
 
@@ -132,8 +308,8 @@ impl get_size2::GetSize for Name {
         &self,
         mut tracker: T,
     ) -> (usize, T) {
-        let size = if self.0.is_heap_allocated() && tracker.track(self.as_ptr()) {
-            self.0.len()
+        let size = if self.text.is_heap_allocated() && tracker.track(self.as_ptr()) {
+            self.text.len()
         } else {
             0
         };
@@ -772,11 +948,13 @@ type SegmentsStack<'a> = ArrayVec<&'a str, SMALL_LEN>;
 
 #[cfg(test)]
 mod tests {
+    use std::hash::BuildHasher;
+
     #[cfg(feature = "get-size")]
     use get_size2::{GetSize, StandardTracker};
 
     use crate::Identifier;
-    use crate::name::{Name, SegmentsVec};
+    use crate::name::{Name, NameBuildHasher, NameHashSet, SegmentsVec};
 
     const STATIC_NAME: Name = Name::new_static("a_static_name_that_is_not_inline");
 
@@ -784,24 +962,56 @@ mod tests {
     fn inline_and_static_storage() {
         assert!(
             !Name::new("x".repeat(Name::INLINE_CAPACITY))
-                .0
+                .text
                 .is_heap_allocated()
         );
         assert!(
             Name::new("x".repeat(Name::INLINE_CAPACITY + 1))
-                .0
+                .text
                 .is_heap_allocated()
         );
         assert_eq!(STATIC_NAME, "a_static_name_that_is_not_inline");
-        assert!(!STATIC_NAME.0.is_heap_allocated());
+        assert!(!STATIC_NAME.text.is_heap_allocated());
     }
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size() {
-        assert_eq!(std::mem::size_of::<Name>(), 16);
-        assert_eq!(std::mem::size_of::<Option<Name>>(), 16);
-        assert_eq!(std::mem::size_of::<Identifier>(), 32);
+        assert_eq!(std::mem::size_of::<Name>(), 24);
+        assert_eq!(std::mem::size_of::<Option<Name>>(), 24);
+        assert_eq!(std::mem::size_of::<Identifier>(), 40);
+    }
+
+    #[test]
+    fn precomputed_hash_matches_borrowed_string() {
+        for text in [
+            "",
+            "x",
+            "name",
+            "eight888",
+            "sixteen-bytes!!!",
+            "identifier_longer_than_inline_capacity",
+        ] {
+            let name = Name::new(text);
+            assert_eq!(
+                NameBuildHasher.hash_one(&name),
+                NameBuildHasher.hash_one(text)
+            );
+        }
+
+        assert_eq!(
+            NameBuildHasher.hash_one(&STATIC_NAME),
+            NameBuildHasher.hash_one(STATIC_NAME.as_str())
+        );
+    }
+
+    #[test]
+    fn name_hash_set_supports_borrowed_lookup() {
+        let mut names = NameHashSet::default();
+        names.insert(Name::new("identifier"));
+
+        assert!(names.contains("identifier"));
+        assert!(!names.contains("different"));
     }
 
     #[test]

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3916,16 +3916,16 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size() {
-        assert_eq!(std::mem::size_of::<Stmt>(), 88);
-        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 88);
-        assert_eq!(std::mem::size_of::<StmtClassDef>(), 80);
+        assert_eq!(std::mem::size_of::<Stmt>(), 96);
+        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 96);
+        assert_eq!(std::mem::size_of::<StmtClassDef>(), 88);
         assert_eq!(std::mem::size_of::<StmtTry>(), 64);
         assert_eq!(std::mem::size_of::<Mod>(), 32);
-        assert_eq!(std::mem::size_of::<Pattern>(), 72);
+        assert_eq!(std::mem::size_of::<Pattern>(), 80);
         assert_eq!(std::mem::size_of::<Parameters>(), 56);
         assert_eq!(std::mem::size_of::<Arguments>(), 40);
         assert_eq!(std::mem::size_of::<Expr>(), 72);
-        assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
+        assert_eq!(std::mem::size_of::<ExprAttribute>(), 64);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 24);
         assert_eq!(std::mem::size_of::<ExprBinOp>(), 32);
         assert_eq!(std::mem::size_of::<ExprBoolOp>(), 40);
@@ -3943,7 +3943,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprLambda>(), 32);
         assert_eq!(std::mem::size_of::<ExprList>(), 40);
         assert_eq!(std::mem::size_of::<ExprListComp>(), 48);
-        assert_eq!(std::mem::size_of::<ExprName>(), 32);
+        assert_eq!(std::mem::size_of::<ExprName>(), 40);
         assert_eq!(std::mem::size_of::<ExprNamed>(), 32);
         assert_eq!(std::mem::size_of::<ExprNoneLiteral>(), 12);
         assert_eq!(std::mem::size_of::<ExprNumberLiteral>(), 40);

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -4,14 +4,13 @@ use std::str::FromStr;
 
 use bitflags::bitflags;
 use hashbrown::HashSet;
-use ruff_python_ast::name::Name;
+use ruff_python_ast::name::{Name, NameBuildHasher};
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{
     AtomicNodeIndex, Int, IpyEscapeKind, Mod, ModExpression, ModModule, StringFlags,
 };
 use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use rustc_hash::FxBuildHasher;
 use thin_vec::ThinVec;
 use unicode_normalization::UnicodeNormalization;
 
@@ -38,7 +37,7 @@ mod tests;
 
 #[derive(Debug, Default)]
 struct NameInterner {
-    names: HashSet<Name, FxBuildHasher>,
+    names: HashSet<Name, NameBuildHasher>,
 }
 
 impl NameInterner {

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -102,6 +102,21 @@ fn only_heap_allocated_names_are_interned() {
 }
 
 #[test]
+fn prehashed_interner_survives_growth() {
+    let mut interner = NameInterner::default();
+    let texts: Vec<_> = (0..256)
+        .map(|index| format!("identifier_longer_than_inline_capacity_{index}"))
+        .collect();
+    let names: Vec<_> = texts.iter().map(|text| interner.intern(text)).collect();
+
+    assert_eq!(interner.names.len(), texts.len());
+    for (text, name) in texts.iter().zip(names) {
+        let interned = interner.intern(text);
+        assert!(std::ptr::eq(name.as_str(), interned.as_str()));
+    }
+}
+
+#[test]
 fn normalized_long_names_share_storage() {
     let normalized = "C".repeat(Name::INLINE_CAPACITY + 1);
     let source = format!("{} = {normalized}", "𝒞".repeat(Name::INLINE_CAPACITY + 1));

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -9,6 +9,7 @@ use ruff_python_ast::{
     StmtFunctionDef, StmtImportFrom,
     comparable::HashableExpr,
     helpers,
+    name::NameRefHashSet,
     visitor::{Visitor, walk_expr, walk_stmt},
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -198,7 +199,7 @@ impl SemanticSyntaxChecker {
                 Self::irrefutable_match_case(match_stmt, ctx);
                 for case in &match_stmt.cases {
                     let mut visitor = MatchPatternVisitor {
-                        names: FxHashSet::default(),
+                        names: NameRefHashSet::default(),
                         ctx,
                     };
                     visitor.visit_pattern(&case.pattern);
@@ -1107,7 +1108,7 @@ impl SemanticSyntaxChecker {
         Self::check_rebound_variables(
             expr,
             comprehension_target_names(comprehensions),
-            FxHashSet::default(),
+            NameRefHashSet::default(),
             ctx,
         );
         Self::check_class_body_expr(expr, ctx);
@@ -1149,8 +1150,8 @@ impl SemanticSyntaxChecker {
 
     fn check_rebound_variables<'a, Ctx: SemanticSyntaxContext>(
         expr: &Expr,
-        targets: FxHashSet<&'a ast::name::Name>,
-        direct_targets: FxHashSet<&'a ast::name::Name>,
+        targets: NameRefHashSet<'a>,
+        direct_targets: NameRefHashSet<'a>,
         ctx: &Ctx,
     ) {
         let mut visitor = ReboundComprehensionVisitor {
@@ -1985,9 +1986,7 @@ pub enum WriteToDebugKind {
     Delete(PythonVersion),
 }
 
-fn comprehension_target_names(
-    comprehensions: &[ast::Comprehension],
-) -> FxHashSet<&ast::name::Name> {
+fn comprehension_target_names(comprehensions: &[ast::Comprehension]) -> NameRefHashSet<'_> {
     let mut visitor = helpers::StoredNameFinder::default();
     for comprehension in comprehensions {
         visitor.visit_expr(&comprehension.target);
@@ -2043,9 +2042,9 @@ impl Visitor<'_> for ClassBodyNamedExpressionVisitor {
 /// iteration variables.
 struct ReboundComprehensionVisitor<'a> {
     /// Targets that apply inside nested comprehensions.
-    targets: FxHashSet<&'a ast::name::Name>,
+    targets: NameRefHashSet<'a>,
     /// Targets from later filter clauses, which do not apply inside nested comprehensions.
-    direct_targets: FxHashSet<&'a ast::name::Name>,
+    direct_targets: NameRefHashSet<'a>,
     ranges: Vec<TextRange>,
 }
 
@@ -2114,7 +2113,7 @@ impl Visitor<'_> for ReturnVisitor {
 }
 
 struct MatchPatternVisitor<'a, Ctx> {
-    names: FxHashSet<&'a ast::name::Name>,
+    names: NameRefHashSet<'a>,
     ctx: &'a Ctx,
 }
 
@@ -2272,10 +2271,10 @@ impl<'a, Ctx: SemanticSyntaxContext> MatchPatternVisitor<'a, Ctx> {
                 // match 2:
                 //     case Class(x) | [x] | x: ...
 
-                let mut previous_names: Option<FxHashSet<&ast::name::Name>> = None;
+                let mut previous_names: Option<NameRefHashSet<'_>> = None;
                 for pattern in patterns {
                     let mut visitor = Self {
-                        names: FxHashSet::default(),
+                        names: NameRefHashSet::default(),
                         ctx: self.ctx,
                     };
                     visitor.visit_pattern(pattern);

--- a/crates/ty_ide/src/importer.rs
+++ b/crates/ty_ide/src/importer.rs
@@ -16,14 +16,12 @@ The main differences here are:
 3. It doesn't have as many facilities as `ruff_linter`'s importer.
 */
 
-use rustc_hash::FxHashMap;
-
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
 use ruff_diagnostics::Edit;
 use ruff_python_ast as ast;
-use ruff_python_ast::name::Name;
+use ruff_python_ast::name::{Name, NameHashMap};
 use ruff_python_ast::token::Tokens;
 use ruff_python_ast::visitor::source_order::{SourceOrderVisitor, TraversalSignal, walk_stmt};
 use ruff_python_codegen::Stylist;
@@ -324,7 +322,7 @@ impl<'a> Importer<'a> {
 #[derive(Debug)]
 pub struct MembersInScope<'ast> {
     at: TextSize,
-    map: FxHashMap<Name, MemberInScope<'ast>>,
+    map: NameHashMap<MemberInScope<'ast>>,
 }
 
 impl<'ast> MembersInScope<'ast> {

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -10,7 +10,7 @@ use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_index::{IndexVec, newtype_index};
 use ruff_python_ast as ast;
-use ruff_python_ast::name::{Name, UnqualifiedName};
+use ruff_python_ast::name::{Name, NameHashSet, UnqualifiedName};
 use ruff_python_ast::visitor::source_order::{self, SourceOrderVisitor};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -119,7 +119,7 @@ pub struct FlatSymbols {
     ///
     /// This is `None` if the module has no `__all__` at module
     /// scope.
-    all_names: Option<FxHashSet<Name>>,
+    all_names: Option<NameHashSet>,
 }
 
 impl FlatSymbols {
@@ -706,7 +706,7 @@ struct SymbolVisitor<'db> {
     /// The origin of an `__all__` variable, if found.
     all_origin: Option<DunderAllOrigin>,
     /// A set of names extracted from `__all__`.
-    all_names: FxHashSet<Name>,
+    all_names: NameHashSet,
     /// A flag indicating whether the module uses unrecognized
     /// `__all__` idioms or there are any invalid elements in
     /// `__all__`.
@@ -729,7 +729,7 @@ impl<'db> SymbolVisitor<'db> {
             in_class: false,
             exports_only: false,
             all_origin: None,
-            all_names: FxHashSet::default(),
+            all_names: NameHashSet::default(),
             all_invalid: false,
             imports: Imports::default(),
         }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -10,7 +10,7 @@ use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::{SourceText, source_text};
 use ruff_index::IndexVec;
-use ruff_python_ast::name::Name;
+use ruff_python_ast::name::{Name, NameHashMap};
 use ruff_python_ast::visitor::{Visitor, walk_expr, walk_keyword, walk_pattern, walk_stmt};
 use ruff_python_ast::{self as ast, AtomicNodeIndex, NodeIndex, PySourceType, PythonVersion};
 use ruff_python_parser::semantic_errors::{
@@ -110,7 +110,7 @@ struct ScopeInfo<'ast> {
     /// Current loop state; None if we are not currently visiting a loop
     current_loop: Option<Loop>,
     /// Saved narrowing aliases from the enclosing scope, restored on `pop_scope`.
-    narrowing_aliases: FxHashMap<Name, NarrowingAlias<'ast>>,
+    narrowing_aliases: NameHashMap<NarrowingAlias<'ast>>,
     /// `global` and `nonlocal` declarations from scopes nested under this one. This is used for:
     ///
     /// 1. Visibility of nested writes. A nested function that binds a variable might affect the
@@ -133,12 +133,12 @@ struct ScopeInfo<'ast> {
     nested_global_or_nonlocal_declarations: NestedGlobalOrNonlocalDeclarations,
     /// Text ranges for `global` and `nonlocal` declarations in this scope, which we use to
     /// populate `nested_global_or_nonlocal_declarations` when we reach end of scope.
-    this_scope_global_or_nonlocal_declarations: FxHashMap<Name, TextRange>,
+    this_scope_global_or_nonlocal_declarations: NameHashMap<TextRange>,
     /// Free symbol uses from nested scopes that may resolve to this scope.
     pending_captures: PendingCaptures,
 }
 
-type NestedGlobalOrNonlocalDeclarations = FxHashMap<Name, SmallVec<[NestedDeclaration; 1]>>;
+type NestedGlobalOrNonlocalDeclarations = NameHashMap<SmallVec<[NestedDeclaration; 1]>>;
 
 /// Captures cannot be resolved until the enclosing scope is complete because a later binding can
 /// make the name local. For example, `inner` captures `outer`'s local `value`, even though the
@@ -154,7 +154,7 @@ type NestedGlobalOrNonlocalDeclarations = FxHashMap<Name, SmallVec<[NestedDeclar
 ///
 /// Each pending capture remembers the bindings visible when the nested scope was created and, for
 /// lazy scopes, any bindings added afterward.
-type PendingCaptures = FxHashMap<Name, SmallVec<[PendingCapture; 1]>>;
+type PendingCaptures = NameHashMap<SmallVec<[PendingCapture; 1]>>;
 
 #[derive(Debug)]
 struct PendingCapture {
@@ -294,7 +294,7 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
 
     /// Maps alias variable names to their narrowing expressions (same-scope only).
     /// TODO: cross-scope alias narrowing support
-    narrowing_aliases: FxHashMap<Name, NarrowingAlias<'ast>>,
+    narrowing_aliases: NameHashMap<NarrowingAlias<'ast>>,
 
     /// Alias metadata for predicate leaf names in the current file.
     alias_predicates: FxHashMap<ExpressionNodeKey, NarrowingAliasPredicate<'db>>,
@@ -346,7 +346,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             semantic_checker: SemanticSyntaxChecker::default(),
             in_try: false,
             semantic_syntax_errors: RefCell::default(),
-            narrowing_aliases: FxHashMap::default(),
+            narrowing_aliases: NameHashMap::default(),
             alias_predicates: FxHashMap::default(),
         };
 
@@ -527,9 +527,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             file_scope_id,
             current_loop: None,
             narrowing_aliases: saved_aliases,
-            nested_global_or_nonlocal_declarations: FxHashMap::default(),
-            this_scope_global_or_nonlocal_declarations: FxHashMap::default(),
-            pending_captures: FxHashMap::default(),
+            nested_global_or_nonlocal_declarations: NestedGlobalOrNonlocalDeclarations::default(),
+            this_scope_global_or_nonlocal_declarations: NameHashMap::default(),
+            pending_captures: PendingCaptures::default(),
         });
     }
 
@@ -934,7 +934,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // bindings. Short-circuit here and return an empty map.
         if popped_scope_kind.is_module() {
             debug_assert!(self.scope_stack.is_empty());
-            return FxHashMap::default();
+            return NestedGlobalOrNonlocalDeclarations::default();
         }
 
         // In the common case where we don't have any nested `global` or `nonlocal` declarations at
@@ -942,7 +942,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         if nested_global_or_nonlocal_declarations.is_empty()
             && this_scope_global_or_nonlocal_declarations.is_empty()
         {
-            return FxHashMap::default();
+            return NestedGlobalOrNonlocalDeclarations::default();
         }
 
         // For each symbol in the (non-module) scope we just popped:

--- a/crates/ty_python_core/src/re_exports.rs
+++ b/crates/ty_python_core/src/re_exports.rs
@@ -23,10 +23,9 @@
 use ruff_db::{files::File, parsed::parsed_module};
 use ruff_python_ast::{
     self as ast,
-    name::Name,
+    name::{Name, NameRefHashMap},
     visitor::{Visitor, walk_expr, walk_pattern, walk_stmt},
 };
-use rustc_hash::FxHashMap;
 use ty_module_resolver::{ModuleName, resolve_module};
 
 use crate::Db;
@@ -53,7 +52,7 @@ struct ExportFinder<'db> {
     db: &'db dyn Db,
     file: File,
     visiting_stub_file: bool,
-    exports: FxHashMap<&'db Name, PossibleExportKind>,
+    exports: NameRefHashMap<'db, PossibleExportKind>,
     dunder_all: DunderAll,
 }
 
@@ -63,7 +62,7 @@ impl<'db> ExportFinder<'db> {
             db,
             file,
             visiting_stub_file: file.is_stub(db),
-            exports: FxHashMap::default(),
+            exports: NameRefHashMap::default(),
             dunder_all: DunderAll::NotPresent,
         }
     }

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -1,9 +1,8 @@
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast::name::Name;
+use ruff_python_ast::name::{Name, NameHashSet};
 use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{self as ast};
-use rustc_hash::FxHashSet;
 use ty_module_resolver::{ModuleName, resolve_module};
 
 use crate::Db;
@@ -13,7 +12,7 @@ use ty_python_core::{SemanticIndex, Truthiness, semantic_index};
 /// Returns a set of names in the `__all__` variable for `file`, [`None`] if it is not defined or
 /// if it contains invalid elements.
 #[salsa::tracked(returns(as_ref), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<FxHashSet<Name>> {
+pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<NameHashSet> {
     let _span = tracing::trace_span!("dunder_all_names", file=?file.path(db)).entered();
 
     let module = parsed_module(db, file).load(db);
@@ -39,7 +38,7 @@ struct DunderAllNamesCollector<'db> {
     invalid: bool,
 
     /// A set of names found in `__all__` for the current module.
-    names: FxHashSet<Name>,
+    names: NameHashSet,
 }
 
 impl<'db> DunderAllNamesCollector<'db> {
@@ -50,7 +49,7 @@ impl<'db> DunderAllNamesCollector<'db> {
             index,
             origin: None,
             invalid: false,
-            names: FxHashSet::default(),
+            names: NameHashSet::default(),
         }
     }
 
@@ -155,7 +154,7 @@ impl<'db> DunderAllNamesCollector<'db> {
     fn dunder_all_names_for_import_from(
         &self,
         import_from: &ast::StmtImportFrom,
-    ) -> Option<&'db FxHashSet<Name>> {
+    ) -> Option<&'db NameHashSet> {
         let module_name =
             ModuleName::from_import_statement(self.db, self.file, import_from).ok()?;
         let module = resolve_module(self.db, self.file, &module_name)?;
@@ -196,7 +195,7 @@ impl<'db> DunderAllNamesCollector<'db> {
     ///
     /// Returns [`None`] if `__all__` is not defined in the current module or if it contains
     /// invalid elements.
-    fn into_names(mut self) -> Option<FxHashSet<Name>> {
+    fn into_names(mut self) -> Option<NameHashSet> {
         if self.origin.is_none() {
             None
         } else if self.invalid {

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -67,6 +67,8 @@ type FxOrderMap<K, V> = ordermap::map::OrderMap<K, V, BuildHasherDefault<FxHashe
 type FxOrderSet<V> = ordermap::set::OrderSet<V, BuildHasherDefault<FxHasher>>;
 type FxIndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 type FxIndexSet<V> = indexmap::IndexSet<V, BuildHasherDefault<FxHasher>>;
+type NameIndexMap<V> =
+    indexmap::IndexMap<ruff_python_ast::name::Name, V, ruff_python_ast::name::NameBuildHasher>;
 
 /// Returns the default registry with all known semantic lints.
 pub fn default_lint_registry() -> &'static LintRegistry {

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -209,9 +209,9 @@ use crate::{
     },
 };
 use ruff_index::{Idx, IndexSlice};
-use ruff_python_ast::name::Name;
+use ruff_python_ast::name::{Name, NameHashSet};
 use ruff_text_size::TextRange;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use salsa::plumbing::AsId;
 use smallvec::SmallVec;
 use ty_python_core::{
@@ -287,11 +287,11 @@ fn type_narrowed_by_pattern<'db>(
 fn enum_literal_subject_names<'db>(
     db: &'db dyn Db,
     subject_ty: Type<'db>,
-) -> Option<(EnumClassLiteral<'db>, FxHashSet<Name>)> {
+) -> Option<(EnumClassLiteral<'db>, NameHashSet)> {
     fn add_enum_literal<'db>(
         db: &'db dyn Db,
         enum_class: &mut Option<EnumClassLiteral<'db>>,
-        names: &mut FxHashSet<Name>,
+        names: &mut NameHashSet,
         ty: Type<'db>,
     ) -> Option<()> {
         let enum_literal = ty.as_enum_literal()?;
@@ -312,7 +312,7 @@ fn enum_literal_subject_names<'db>(
     }
 
     let mut enum_class = None;
-    let mut names = FxHashSet::default();
+    let mut names = NameHashSet::default();
 
     match subject_ty {
         Type::LiteralValue(_) => {
@@ -353,7 +353,7 @@ fn enum_member_pattern_name<'db>(
 
 struct EnumMemberPatternCoverage {
     /// Enum members that this pattern definitely matches.
-    definitely_matched: FxHashSet<Name>,
+    definitely_matched: NameHashSet,
     /// Whether the collected coverage is known to represent every possible matching enum member.
     is_exact: bool,
 }
@@ -370,7 +370,7 @@ fn enum_member_pattern_coverage<'db>(
     kind: &PatternPredicateKind<'db>,
 ) -> EnumMemberPatternCoverage {
     let mut coverage = EnumMemberPatternCoverage {
-        definitely_matched: FxHashSet::default(),
+        definitely_matched: NameHashSet::default(),
         is_exact: true,
     };
     match kind {

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -4,11 +4,10 @@ use ruff_db::parsed::{parsed_module, parsed_string_annotation};
 use ruff_db::source::{line_index, source_text};
 use ruff_python_ast::find_node::CoveringNode;
 use ruff_python_ast::{self as ast, ExprStringLiteral, ModExpression};
-use ruff_python_ast::{Expr, ExprRef, name::Name};
+use ruff_python_ast::{Expr, ExprRef, name::NameHashMap};
 use ruff_python_parser::Parsed;
 use ruff_source_file::LineIndex;
 use ruff_text_size::Ranged;
-use rustc_hash::FxHashMap;
 use ty_module_resolver::{
     KnownModule, Module, ModuleName, list_modules, resolve_module, resolve_real_shadowable_module,
 };
@@ -79,8 +78,8 @@ impl<'db> SemanticModel<'db> {
     pub fn members_in_scope_at(
         &self,
         node: ast::AnyNodeRef<'_>,
-    ) -> FxHashMap<Name, MemberDefinition<'db>> {
-        let mut members = FxHashMap::default();
+    ) -> NameHashMap<MemberDefinition<'db>> {
+        let mut members = NameHashMap::default();
         let index = semantic_index(self.db, self.file);
         let Some(file_scope) = self.scope(node) else {
             return members;

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -44,7 +44,7 @@ use crate::types::{
     UnionBuilder, VarianceInferable,
 };
 use crate::{
-    Db, FxIndexMap, FxOrderSet,
+    Db, FxIndexMap, FxOrderSet, NameIndexMap,
     place::{
         Definedness, LookupError, LookupResult, Place, PlaceAndQualifiers, PublicTypePolicy,
         place_from_bindings, place_from_declarations,
@@ -1248,7 +1248,7 @@ impl<'db> ClassType<'db> {
     ///
     /// The value of the map is a struct containing information about the abstract method.
     #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
-    pub(crate) fn abstract_methods(self, db: &'db dyn Db) -> FxIndexMap<Name, AbstractMethod<'db>> {
+    pub(crate) fn abstract_methods(self, db: &'db dyn Db) -> NameIndexMap<AbstractMethod<'db>> {
         fn type_as_abstract_method<'db>(
             db: &'db dyn Db,
             ty: Type<'db>,
@@ -1279,7 +1279,7 @@ impl<'db> ClassType<'db> {
             }
         }
 
-        let mut abstract_methods: FxIndexMap<Name, _> = FxIndexMap::default();
+        let mut abstract_methods = NameIndexMap::default();
 
         // Iterate through the MRO in reverse order,
         // skipping `object` (we know it doesn't define any abstract methods)

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -11,7 +11,7 @@ use ruff_text_size::{Ranged, TextRange};
 use std::cell::RefCell;
 
 use crate::{
-    Db, FxIndexMap, FxIndexSet, Program, TypeQualifiers,
+    Db, FxIndexSet, NameIndexMap, Program, TypeQualifiers,
     place::{
         DefinedPlace, Definedness, Place, PlaceAndQualifiers, Provenance, PublicTypePolicy,
         TypeOrigin, place_from_bindings, place_from_declarations,
@@ -1841,7 +1841,7 @@ impl<'db> StaticClassLiteral<'db> {
         self,
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
-    ) -> Option<&'db FxIndexMap<Name, Field<'db>>> {
+    ) -> Option<&'db NameIndexMap<Field<'db>>> {
         for base in self.iter_mro(db, specialization).skip(1) {
             let (base_class, base_specialization) = base.into_class()?.static_class_literal(db)?;
 
@@ -1918,7 +1918,7 @@ impl<'db> StaticClassLiteral<'db> {
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
         field_policy: CodeGeneratorKind<'db>,
-    ) -> &'db FxIndexMap<Name, Field<'db>> {
+    ) -> &'db NameIndexMap<Field<'db>> {
         if field_policy == CodeGeneratorKind::NamedTuple {
             // NamedTuples do not allow multiple inheritance, so it is sufficient to enumerate the
             // fields of this class only.
@@ -1930,7 +1930,7 @@ impl<'db> StaticClassLiteral<'db> {
 
     #[salsa::tracked(
         returns(ref),
-        cycle_initial=|_, _, _, _, _| FxIndexMap::default(),
+        cycle_initial=|_, _, _, _, _| NameIndexMap::default(),
         heap_size=get_size2::GetSize::get_heap_size
     )]
     fn fields_inner(
@@ -1938,7 +1938,7 @@ impl<'db> StaticClassLiteral<'db> {
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
         field_policy: CodeGeneratorKind<'db>,
-    ) -> FxIndexMap<Name, Field<'db>> {
+    ) -> NameIndexMap<Field<'db>> {
         enum FieldSource<'db> {
             Static(StaticClassLiteral<'db>, Option<Specialization<'db>>),
             DynamicTypedDict(DynamicTypedDictLiteral<'db>),
@@ -1950,7 +1950,7 @@ impl<'db> StaticClassLiteral<'db> {
             "Collecting `fields` for NamedTuples should short-circuit in `fields()`"
         );
 
-        let mut map: FxIndexMap<_, _> = self
+        let mut map: NameIndexMap<_> = self
             .iter_mro(db, specialization)
             .rev()
             .filter_map(|superclass| {
@@ -2087,7 +2087,7 @@ impl<'db> StaticClassLiteral<'db> {
     /// only what is explicitly specified in each field definition.
     #[salsa::tracked(
         returns(ref),
-        cycle_initial=|_, _, _, _, _| FxIndexMap::default(),
+        cycle_initial=|_, _, _, _, _| NameIndexMap::default(),
         heap_size=get_size2::GetSize::get_heap_size
     )]
     pub(crate) fn own_fields(
@@ -2095,7 +2095,7 @@ impl<'db> StaticClassLiteral<'db> {
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
         field_policy: CodeGeneratorKind<'db>,
-    ) -> FxIndexMap<Name, Field<'db>> {
+    ) -> NameIndexMap<Field<'db>> {
         let class_body_scope = self.body_scope(db);
         let table = place_table(db, class_body_scope);
 
@@ -2160,7 +2160,7 @@ impl<'db> StaticClassLiteral<'db> {
         field_declarations
             .sort_unstable_by_key(|(first_declaration_order, _, _)| *first_declaration_order);
 
-        let mut attributes = FxIndexMap::default();
+        let mut attributes = NameIndexMap::default();
         for (_, symbol_id, result) in field_declarations {
             let symbol = table.symbol(symbol_id);
             let first_declaration = result.first_declaration;

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -26,7 +26,7 @@ use crate::types::{
     MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictModule,
     TypedDictType, UnionType, determine_upper_bound,
 };
-use crate::{Db, FxIndexMap};
+use crate::{Db, NameIndexMap};
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::ScopeId;
 
@@ -85,7 +85,7 @@ pub(super) fn synthesize_typed_dict_method<'db>(
 #[derive(Debug, Copy, Clone)]
 pub(super) enum TypedDictFields<'db> {
     Dynamic(&'db TypedDictSchema<'db>),
-    Static(&'db FxIndexMap<Name, super::Field<'db>>),
+    Static(&'db NameIndexMap<super::Field<'db>>),
 }
 
 impl<'db> TypedDictFields<'db> {

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1,12 +1,11 @@
 use compact_str::ToCompactString;
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast::name::Name;
-use rustc_hash::{FxHashMap, FxHashSet};
+use ruff_python_ast::name::{Name, NameHashMap, NameHashSet};
+use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
-use crate::FxOrderSet;
 use crate::{
-    Db, FxIndexMap,
+    Db,
     place::{
         DefinedPlace, Place, PlaceAndQualifiers, place_from_bindings, place_from_declarations,
     },
@@ -22,6 +21,7 @@ use crate::{
         },
     },
 };
+use crate::{FxOrderSet, NameIndexMap};
 use ty_python_core::{definition::DefinitionKind, place_table, scope::ScopeId, use_def_map};
 
 /// A resolved enum method, retaining both whether it is analyzable and who defines it.
@@ -223,14 +223,14 @@ impl<'db> EnumValueAnnotation<'db> {
 
 #[derive(Debug, PartialEq, Eq, salsa::Update)]
 pub(crate) struct EnumMetadata<'db> {
-    pub(crate) members: FxIndexMap<Name, Type<'db>>,
-    pub(crate) aliases: FxHashMap<Name, Name>,
+    pub(crate) members: NameIndexMap<Type<'db>>,
+    pub(crate) aliases: NameHashMap<Name>,
 
     /// Whether alias detection was precise for every member declaration.
     pub(super) aliases_are_known: bool,
 
     /// Members whose values were defined using `auto()`.
-    pub(crate) auto_members: FxHashSet<Name>,
+    pub(crate) auto_members: NameHashSet,
 
     /// The effective `_value_` annotation, including where it was defined.
     value_annotation: Option<EnumValueAnnotation<'db>>,
@@ -497,10 +497,10 @@ fn value_has_exact_known_class<'db>(
 impl<'db> EnumMetadata<'db> {
     fn empty() -> Self {
         EnumMetadata {
-            members: FxIndexMap::default(),
-            aliases: FxHashMap::default(),
+            members: NameIndexMap::default(),
+            aliases: NameHashMap::default(),
             aliases_are_known: false,
-            auto_members: FxHashSet::default(),
+            auto_members: NameHashSet::default(),
             value_annotation: None,
             value_construction: EnumValueConstruction::default(),
         }
@@ -684,7 +684,7 @@ impl<'db> EnumComplementType<'db> {
         if !enum_class_literal.members_are_exhaustive(db) {
             return None;
         }
-        let mut excluded_names = FxHashSet::default();
+        let mut excluded_names = NameHashSet::default();
         for negative in negative {
             let enum_literal = negative.as_enum_literal()?;
             if enum_literal.enum_class_literal(db) != enum_class_literal {
@@ -859,12 +859,12 @@ impl<'db> EnumComplementType<'db> {
 
 /// Returns the set of names listed in an enum's `_ignore_` attribute.
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn enum_ignored_names<'db>(db: &'db dyn Db, scope_id: ScopeId<'db>) -> FxHashSet<Name> {
+pub(crate) fn enum_ignored_names<'db>(db: &'db dyn Db, scope_id: ScopeId<'db>) -> NameHashSet {
     let use_def_map = use_def_map(db, scope_id);
     let table = place_table(db, scope_id);
 
     let Some(ignore) = table.symbol_id("_ignore_") else {
-        return FxHashSet::default();
+        return NameHashSet::default();
     };
 
     let ignore_bindings = use_def_map.reachable_symbol_bindings(ignore);
@@ -883,7 +883,7 @@ pub(crate) fn enum_ignored_names<'db>(db: &'db dyn Db, scope_id: ScopeId<'db>) -
             .unwrap_or_default(),
 
         // TODO: support the list-variant of `_ignore_`.
-        Place::Undefined => FxHashSet::default(),
+        Place::Undefined => NameHashSet::default(),
     }
 }
 
@@ -895,7 +895,7 @@ fn try_register_alias<'db>(
     value_ty: Type<'db>,
     name: &Name,
     enum_values: &mut FxHashMap<LiteralValueTypeKind<'db>, Name>,
-    aliases: &mut FxHashMap<Name, Name>,
+    aliases: &mut NameHashMap<Name>,
 ) -> Option<bool> {
     let value = value_ty.as_literal_value_kind()?;
     if !matches!(
@@ -945,8 +945,8 @@ pub(crate) fn enum_metadata<'db>(
                 data_type: inherited_enum_data_type(db, ClassLiteral::DynamicEnum(enum_lit)),
                 ..EnumValueConstruction::default()
             };
-            let mut members = FxIndexMap::default();
-            let mut aliases = FxHashMap::default();
+            let mut members = NameIndexMap::default();
+            let mut aliases = NameHashMap::default();
             let mut enum_values: FxHashMap<LiteralValueTypeKind<'db>, Name> = FxHashMap::default();
             for (name, ty) in spec.members(db) {
                 if value_construction
@@ -970,7 +970,7 @@ pub(crate) fn enum_metadata<'db>(
                 members,
                 aliases,
                 aliases_are_known: true,
-                auto_members: FxHashSet::default(),
+                auto_members: NameHashSet::default(),
                 value_annotation: None,
                 value_construction,
             });
@@ -995,7 +995,7 @@ pub(crate) fn enum_metadata<'db>(
 
     let mut enum_values: FxHashMap<LiteralValueTypeKind<'db>, Name> = FxHashMap::default();
     let mut auto_counter = 0;
-    let mut auto_members = FxHashSet::default();
+    let mut auto_members = NameHashSet::default();
     let mut aliases_are_known = true;
     let mut prev_value_was_non_literal_int = false;
     let mut prev_bool_literal = None;
@@ -1032,7 +1032,7 @@ pub(crate) fn enum_metadata<'db>(
         metaclass_may_transform_values,
     };
 
-    let mut aliases = FxHashMap::default();
+    let mut aliases = NameHashMap::default();
 
     let mut members = use_def_map
         .all_end_of_scope_symbol_bindings()
@@ -1214,7 +1214,7 @@ pub(crate) fn enum_metadata<'db>(
 
             Some((name.clone(), value_ty))
         })
-        .collect::<FxIndexMap<_, _>>();
+        .collect::<NameIndexMap<_>>();
 
     if members.is_empty() {
         // Enum subclasses without members are not considered enums.

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1127,7 +1127,7 @@ fn check_class_namespace_against_metaclass_members<'db>(
 
         // A declaration on the metaclass constrains class-object access, but does not itself
         // populate a replacement value into the constructed class's namespace.
-        if !metaclass_assigned_members.contains(name.as_str()) {
+        if !metaclass_assigned_members.contains(&name) {
             continue;
         }
 


### PR DESCRIPTION
## Summary

This PR is stacked on #26594.

This explores storing an [Oxc-style precomputed identifier hash](https://github.com/oxc-project/oxc/blob/main/crates/oxc_str/src/ident.rs) alongside each parser `Name`. Constructing a name computes the hash once, while hashing an existing `Name` reuses the cached value instead of reading the identifier bytes again.

Direct `Name` maps and sets use a purpose-built hasher that accepts either the cached hash or a borrowed `str` with compatible results. This lets Name-to-Name lookups throughout ty and the linter reuse the cached hash while preserving allocation-free borrowed lookups. Parser interner lookups still start from token text and therefore still hash that input; there, the cached value primarily avoids rehashing stored keys during insertion and table growth.

## Tradeoff

The cached hash grows `Name` from 16 to 24 bytes while retaining the same 16-byte inline string capacity. This gives back the handle-size reduction from #26594: `Identifier` and `ExprName` grow from 32 to 40 bytes, and several other name-bearing AST nodes grow by eight bytes.

The affected suite passes all 6,069 tests, all-target/all-feature Clippy, and the repository hooks. Benchmark timings were inconclusive because the host remained under sustained high load, so this draft does not claim a runtime improvement.