### PR TITLE
[ty] Bind Self in implicit dunder calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/dunder.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/dunder.md
@@ -143,7 +143,8 @@ after the `ParamSpec` is specialized:
 
 ```py
 from collections.abc import Callable
-from typing import ParamSpec, Protocol
+from typing import Generic, ParamSpec, Protocol
+from typing_extensions import Self
 
 P = ParamSpec("P")
 
@@ -153,6 +154,18 @@ class C(Protocol[P]):
 def check(value: C[[str]]) -> None:
     reveal_type(value.__call__)  # revealed: (str, /) -> int
     reveal_type(value("value"))  # revealed: int
+
+class Base(Generic[P]):
+    __getitem__: Callable[P, Self]
+
+class Child(Base[[int]]):
+    pass
+
+def check_self(value: Child) -> None:
+    reveal_type(value.__getitem__(0))  # revealed: Child
+    reveal_type(value[0])  # revealed: Child
+
+    result: Child = value[0]
 ```
 
 And of course the same is true if we have only an implicit assignment inside a method:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4131,14 +4131,18 @@ impl<'db> Type<'db> {
                     .value_type(db)
                     .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
 
-                _ if policy.no_instance_fallback() => this.invoke_descriptor_protocol(
-                    db,
-                    receiver.unwrap_or(this),
-                    name_str,
-                    Place::Undefined.into(),
-                    InstanceFallbackShadowsNonDataDescriptor::No,
-                    policy,
-                ),
+                _ if policy.no_instance_fallback() => {
+                    let receiver = receiver.unwrap_or(this);
+                    this.invoke_descriptor_protocol(
+                        db,
+                        receiver,
+                        name_str,
+                        Place::Undefined.into(),
+                        InstanceFallbackShadowsNonDataDescriptor::No,
+                        policy,
+                    )
+                    .map_type(|ty| ty.bind_self_typevars(db, receiver))
+                }
 
                 Type::LiteralValue(literal)
                     if matches!(name_str, "name" | "_name_" | "value" | "_value_")


### PR DESCRIPTION
## Summary

In #26696, we stopped treating `Callable[P, R]`-typed dunder members as function-like descriptors because binding the first parameter after specializing `P` would incorrectly remove a real argument. However, implicit dunder lookup uses a no-instance-fallback path that returned before the normal eager `Self` binding step. As a result, a ParamSpec dunder that returned `Self` preserved the declaring class's `Self` type instead of resolving it to the concrete receiver:

```python
class Base[**P]:
    __getitem__: Callable[P, Self]

class Child(Base[[int]]): ...

def check(value: Child) -> None:
    reveal_type(value[0])  # Self@Base, expected Child
```

We now apply the existing receiver-aware `Self` mapping to the result of no-instance-fallback descriptor lookup. Function-like callables continue to defer `Self` binding to their signature-binding path, while regular ParamSpec callables resolve `Self` without dropping any parameters.

The regression coverage verifies that explicit `value.__getitem__(0)` and implicit `value[0]` access both return `Child`.
