### PR TITLE
[ty] Restrict callable dunder binding to implicit calls

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -4679,7 +4679,7 @@ C.<CURSOR>
             builder.skip_keywords().skip_builtins().type_signatures().build().snapshot(), @"
         meta_attr :: int
         mro :: bound method <class 'C'>.mro() -> list[type]
-        __annotate__ :: (() -> dict[str, Any]) | None
+        __annotate__ :: ((Format, /) -> dict[str, Any]) | None
         __annotations__ :: dict[str, Any]
         __base__ :: type | None
         __bases__ :: tuple[type, ...]
@@ -4878,7 +4878,7 @@ Quux.<CURSOR>
         some_method :: def some_method(self) -> int
         some_property :: property
         some_static_method :: def some_static_method(self) -> int
-        __annotate__ :: (() -> dict[str, Any]) | None
+        __annotate__ :: ((Format, /) -> dict[str, Any]) | None
         __annotations__ :: dict[str, Any]
         __base__ :: type | None
         __bases__ :: tuple[type, ...]

--- a/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
@@ -43,6 +43,15 @@ class C:
 x = C()
 x += "Hello"
 reveal_type(x)  # revealed: int
+
+from typing import Callable
+
+class CallableIAdd:
+    __iadd__: Callable[["CallableIAdd", int], str]
+
+callable_iadd = CallableIAdd()
+callable_iadd += 1
+reveal_type(callable_iadd)  # revealed: str
 ```
 
 ## Unsupported types

--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -296,6 +296,24 @@ class Wrapper:
         self.__antidote_wrapped__.__get__
 ```
 
+The receiver heuristic applies to the class member before descriptor resolution. A callable returned
+by a custom descriptor has already been resolved and is not bound again:
+
+```py
+class Descriptor:
+    def __get__(self, instance: C | None, owner: type[C]) -> Callable[[C, int], C]:
+        return implementation
+
+def implementation(instance: C, value: int) -> C:
+    return instance
+
+class C:
+    __pow__ = Descriptor()
+
+# error: [unsupported-operator]
+C() ** 1
+```
+
 A callable with no arguments cannot accept a receiver, so it remains unbound during both ordinary
 attribute access and implicit calls:
 

--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -250,11 +250,11 @@ def check(path: Path) -> None:
     reveal_type(path.write_bytes(b""))  # revealed: int
 ```
 
-## Use case: Treating dunder methods as bound-method descriptors
+## Use case: Binding callable dunders during implicit calls
 
 pytorch defines a `__pow__` dunder attribute on [`TensorBase`] in a similar way to the following
-example. We generally treat dunder attributes as bound-method descriptors since they all take a
-`self` argument. This allows us to type-check the following code correctly:
+example. For implicit special-method calls, we bind the first parameter of a `Callable`-typed dunder
+if it can accept the instance. This allows us to type-check the following code correctly:
 
 ```py
 from typing import Callable
@@ -266,11 +266,12 @@ class Tensor:
     __pow__: Callable[[Tensor, int], Tensor] = pow_impl
 
 Tensor() ** 2
+reveal_type(Tensor().__pow__)  # revealed: (Tensor, int, /) -> Tensor
 ```
 
 The following example is also taken from a real world project. Here, the `__lt__` dunder attribute
-is not declared. The attribute type is inferred as `Callable[…]`, but we still treat it as a
-bound-method descriptor:
+is not declared. The attribute type is inferred as `Callable[…]`, but we still bind its compatible
+receiver for the implicit comparison:
 
 ```py
 def make_comparison_operator(name: str) -> Callable[[Matrix, Matrix], bool]:
@@ -282,8 +283,21 @@ class Matrix:
 Matrix() < Matrix()
 ```
 
-The dunder-name heuristic does not apply when the callable takes no arguments, because it cannot
-accept a receiver:
+This is an implicit-call heuristic, not a claim that every `Callable`-typed dunder is a function
+descriptor. Ordinary attribute access preserves the declared callable type. In particular, it does
+not expose attributes that exist on function objects but not on arbitrary callable objects:
+
+```py
+class Wrapper:
+    __antidote_wrapped__: Callable[..., object]
+
+    def descriptor(self) -> None:
+        # error: [unresolved-attribute]
+        self.__antidote_wrapped__.__get__
+```
+
+A callable with no arguments cannot accept a receiver, so it remains unbound during both ordinary
+attribute access and implicit calls:
 
 ```py
 class Thunk:
@@ -293,23 +307,26 @@ class Thunk:
         self.__value_thunk__ = other.__value_thunk__
 
 reveal_type(Thunk().__value_thunk__)  # revealed: () -> int
+
+class Nullary:
+    __call__: Callable[[], int]
+
+reveal_type(Nullary()())  # revealed: int
 ```
 
-For other concrete signatures, the heuristic does not check whether the first parameter can accept
-the instance:
+The implicit-call heuristic does not bind a concrete first parameter that cannot accept the
+instance:
 
 ```py
-def descriptor_candidate(value: str) -> int:
-    return len(value)
-
 class DescriptorCandidate:
-    __value__: Callable[[str], int] = descriptor_candidate
+    __call__: Callable[[str], int]
 
-reveal_type(DescriptorCandidate().__value__)  # revealed: () -> int
+reveal_type(DescriptorCandidate().__call__)  # revealed: (str, /) -> int
+reveal_type(DescriptorCandidate()("value"))  # revealed: int
 ```
 
-A gradual callable signature might accept the receiver, so we preserve the function-descriptor
-heuristic. This also preserves function attributes on class access:
+A gradual callable signature might accept the receiver, so implicit calls can still bind it. It
+nevertheless remains an ordinary callable under explicit attribute access:
 
 ```py
 from typing import Any
@@ -317,6 +334,9 @@ from typing import Any
 class Method:
     __call__: Callable[..., Any]
 
+Method()()
+
+# error: [unresolved-attribute]
 Method.__call__.__code__
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -1380,6 +1380,30 @@ def _(flag: bool) -> None:
     reveal_type(Foo(1, 2))  # revealed: Foo
 ```
 
+## Callable-typed constructor dunders
+
+Callable-typed `__init__` attributes use the same receiver heuristic as other implicit dunder calls:
+
+```py
+from typing import Callable
+
+class CallableInit:
+    __init__: Callable[["CallableInit", int], None]
+
+reveal_type(CallableInit(1))  # revealed: CallableInit
+```
+
+The same is true for a callable-typed `__call__` on the metaclass:
+
+```py
+class Meta(type):
+    __call__: Callable[[type, int], object]
+
+class WithMeta(metaclass=Meta): ...
+
+reveal_type(WithMeta(1))  # revealed: object
+```
+
 ## A descriptor in place of `__init__`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/call/dunder.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/dunder.md
@@ -155,6 +155,22 @@ def check(value: C[[str]]) -> None:
     reveal_type(value("value"))  # revealed: int
 ```
 
+The same receiver check applies to concrete callable attributes. These annotations describe regular
+callable objects rather than methods, so the implementation satisfies the protocol without binding
+away the `str` parameter:
+
+```py
+class CallableProtocol(Protocol):
+    __call__: Callable[[str], int]
+
+class CallableImplementation:
+    __call__: Callable[[str], int]
+
+def accepts_callable_protocol(value: CallableProtocol) -> None: ...
+
+accepts_callable_protocol(CallableImplementation())
+```
+
 And of course the same is true if we have only an implicit assignment inside a method:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2840,6 +2840,37 @@ class Foo:
 static_assert(not is_assignable_to(Foo, Iterable[Any]))
 ```
 
+A callable-typed dunder class attribute can satisfy a protocol method if its first parameter can
+accept the receiver. The receiver heuristic applies only while checking the implicit dunder
+operation; ordinary attribute access still preserves the full callable signature.
+
+```py
+from typing import Callable, ContextManager, Iterable, Iterator, SupportsIndex
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to
+
+class CallableIterable:
+    __iter__: Callable[["CallableIterable"], Iterator[int]]
+
+class CallableContextManager:
+    __enter__: Callable[["CallableContextManager"], "CallableContextManager"]
+
+    def __exit__(self, *args: object) -> None: ...
+
+class CallableSupportsIndex:
+    __index__: Callable[["CallableSupportsIndex"], int]
+
+class WrongReceiver:
+    __iter__: Callable[[str], Iterator[int]]
+
+static_assert(is_assignable_to(CallableIterable, Iterable[int]))
+static_assert(is_assignable_to(CallableContextManager, ContextManager[CallableContextManager]))
+static_assert(is_assignable_to(CallableSupportsIndex, SupportsIndex))
+static_assert(not is_assignable_to(WrongReceiver, Iterable[int]))
+
+reveal_type(CallableIterable().__iter__)  # revealed: (CallableIterable, /) -> Iterator[int]
+```
+
 Because method members are always looked up on the meta-type of an object when testing assignability
 and subtyping, we understand that `IterableClass` here is a subtype of `Iterable[int]` even though
 `IterableClass.__iter__` has the wrong signature:

--- a/crates/ty_python_semantic/resources/mdtest/subscript/instance.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/instance.md
@@ -197,6 +197,13 @@ class Identity:
 
 a = Identity()
 a[0] = 0
+
+from typing import Callable
+
+class CallableSetItem:
+    __setitem__: Callable[["CallableSetItem", int, str], None]
+
+CallableSetItem()[0] = "value"
 ```
 
 ## `__setitem__` with invalid index argument

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -487,6 +487,10 @@ bitflags! {
         /// Bind a compatible receiver on a regular `Callable` class member before applying the
         /// descriptor protocol. This is used for implicit dunder calls only.
         const BIND_DUNDER_CALLABLE_RECEIVER = 1 << 6;
+
+        /// The standard policy for an implicit dunder call on an instance.
+        const IMPLICIT_DUNDER_CALL =
+            Self::NO_INSTANCE_FALLBACK.bits() | Self::BIND_DUNDER_CALLABLE_RECEIVER.bits();
     }
 }
 
@@ -4483,7 +4487,7 @@ impl<'db> Type<'db> {
             .member_lookup_with_policy(
                 db,
                 Name::new_static("__getitem__"),
-                MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                MemberLookupPolicy::IMPLICIT_DUNDER_CALL,
             )
             .place
         {
@@ -4806,8 +4810,7 @@ impl<'db> Type<'db> {
                     .member_lookup_with_policy(
                         db,
                         Name::new_static("__call__"),
-                        MemberLookupPolicy::NO_INSTANCE_FALLBACK
-                            | MemberLookupPolicy::BIND_DUNDER_CALLABLE_RECEIVER,
+                        MemberLookupPolicy::IMPLICIT_DUNDER_CALL,
                     )
                     .place
                 {
@@ -5338,7 +5341,7 @@ impl<'db> Type<'db> {
         let metaclass_dunder_call = self_type.member_lookup_with_policy(
             db,
             "__call__".into(),
-            MemberLookupPolicy::NO_INSTANCE_FALLBACK
+            MemberLookupPolicy::IMPLICIT_DUNDER_CALL
                 | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
         );
 
@@ -5351,7 +5354,7 @@ impl<'db> Type<'db> {
         let init_method_no_object = constructor_instance_ty.member_lookup_with_policy(
             db,
             "__init__".into(),
-            MemberLookupPolicy::NO_INSTANCE_FALLBACK | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+            MemberLookupPolicy::IMPLICIT_DUNDER_CALL | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
 
         let (new_bindings, has_any_new) = match new_method.as_ref().map(|method| method.place) {
@@ -5400,7 +5403,7 @@ impl<'db> Type<'db> {
                 let init_method_with_object = constructor_instance_ty.member_lookup_with_policy(
                     db,
                     "__init__".into(),
-                    MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                    MemberLookupPolicy::IMPLICIT_DUNDER_CALL,
                 );
                 match init_method_with_object.place {
                     Place::Defined(DefinedPlace {
@@ -5578,9 +5581,7 @@ impl<'db> Type<'db> {
 
         // Implicit calls to dunder methods never access instance members, so we pass
         // `NO_INSTANCE_FALLBACK` here in addition to other policies:
-        let policy = policy
-            | MemberLookupPolicy::NO_INSTANCE_FALLBACK
-            | MemberLookupPolicy::BIND_DUNDER_CALLABLE_RECEIVER;
+        let policy = policy | MemberLookupPolicy::IMPLICIT_DUNDER_CALL;
         match self
             .member_lookup_with_policy(db, name.into(), policy)
             .place
@@ -7489,9 +7490,7 @@ impl<'db> UnionType<'db> {
                 .member_lookup_with_policy(
                     db,
                     name.into(),
-                    policy
-                        | MemberLookupPolicy::NO_INSTANCE_FALLBACK
-                        | MemberLookupPolicy::BIND_DUNDER_CALLABLE_RECEIVER,
+                    policy | MemberLookupPolicy::IMPLICIT_DUNDER_CALL,
                 )
                 .place
             {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4792,6 +4792,8 @@ impl<'db> Type<'db> {
                         definedness: boundness,
                         ..
                     }) => {
+                        let dunder_callable =
+                            dunder_callable.bind_callable_dunder_for_implicit_call(db, self);
                         let mut bindings = dunder_callable.bindings(db);
                         bindings.replace_callable_type(dunder_callable, self);
                         if boundness == Definedness::PossiblyUndefined {
@@ -5503,6 +5505,32 @@ impl<'db> Type<'db> {
         )
     }
 
+    /// Bind a regular `Callable`-typed dunder for an implicit special-method call if its first
+    /// parameter can accept the receiver.
+    ///
+    /// Unlike descriptor lookup, this preserves the callable as a regular `Callable`: a dunder
+    /// name is enough evidence to bind a compatible receiver for implicit dispatch, but it is not
+    /// enough evidence that ordinary attribute access should expose function descriptor members.
+    pub(super) fn bind_callable_dunder_for_implicit_call(
+        self,
+        db: &'db dyn Db,
+        receiver: Type<'db>,
+    ) -> Type<'db> {
+        match self {
+            Type::Callable(callable) => callable
+                .try_bind_dunder_self(db, receiver)
+                .map(Type::Callable)
+                .unwrap_or(self),
+            Type::Union(union) => union.map(db, |element| {
+                element.bind_callable_dunder_for_implicit_call(db, receiver)
+            }),
+            Type::Intersection(intersection) => intersection.map_positive(db, |element| {
+                element.bind_callable_dunder_for_implicit_call(db, receiver)
+            }),
+            _ => self,
+        }
+    }
+
     /// Same as `try_call_dunder`, but allows specifying a policy for the member lookup. In
     /// particular, this allows to specify `MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK` to avoid
     /// looking up dunder methods on `object`, which is needed for functions like `__init__`,
@@ -5539,6 +5567,8 @@ impl<'db> Type<'db> {
                 provenance,
                 ..
             }) => {
+                let dunder_callable =
+                    dunder_callable.bind_callable_dunder_for_implicit_call(db, self);
                 let constraints = ConstraintSetBuilder::new();
                 let bindings = dunder_callable
                     .bindings(db)
@@ -5585,6 +5615,8 @@ impl<'db> Type<'db> {
                 provenance,
                 ..
             }) => {
+                let dunder_callable =
+                    dunder_callable.bind_callable_dunder_for_implicit_call(db, self);
                 let constraints = ConstraintSetBuilder::new();
                 let bindings = dunder_callable
                     .bindings(db)
@@ -7440,7 +7472,7 @@ impl<'db> UnionType<'db> {
                     provenance: member_provenance,
                     ..
                 }) => {
-                    builder = builder.add(ty);
+                    builder = builder.add(ty.bind_callable_dunder_for_implicit_call(db, *element));
                     any_defined = true;
                     possibly_undefined = true;
                     provenance = provenance.or(member_provenance);
@@ -7450,7 +7482,7 @@ impl<'db> UnionType<'db> {
                     provenance: member_provenance,
                     ..
                 }) => {
-                    builder = builder.add(ty);
+                    builder = builder.add(ty.bind_callable_dunder_for_implicit_call(db, *element));
                     any_defined = true;
                     provenance = provenance.or(member_provenance);
                 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -483,6 +483,10 @@ bitflags! {
         /// This is used when detecting descriptors. An `Any` or `Unknown` base can provide any
         /// member, but that does not mean that every subclass should be treated as a descriptor.
         const REQUIRE_CONCRETE = 1 << 5;
+
+        /// Bind a compatible receiver on a regular `Callable` class member before applying the
+        /// descriptor protocol. This is used for implicit dunder calls only.
+        const BIND_DUNDER_CALLABLE_RECEIVER = 1 << 6;
     }
 }
 
@@ -519,6 +523,11 @@ impl MemberLookupPolicy {
     /// Ignore members that are only available through a dynamic type.
     pub(crate) const fn require_concrete(self) -> bool {
         self.contains(Self::REQUIRE_CONCRETE)
+    }
+
+    /// Bind a compatible receiver on a regular `Callable` before descriptor resolution.
+    pub(crate) const fn bind_dunder_callable_receiver(self) -> bool {
+        self.contains(Self::BIND_DUNDER_CALLABLE_RECEIVER)
     }
 }
 
@@ -3617,6 +3626,14 @@ impl<'db> Type<'db> {
         policy: InstanceFallbackShadowsNonDataDescriptor,
         member_policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
+        let class_member =
+            self.instance_lookup_class_member_with_policy(db, name.into(), member_policy);
+        let class_member = if member_policy.bind_dunder_callable_receiver() {
+            class_member.map_type(|ty| ty.bind_callable_dunder_for_implicit_call(db, receiver))
+        } else {
+            class_member
+        };
+
         let (
             PlaceAndQualifiers {
                 place: meta_attr,
@@ -3625,7 +3642,7 @@ impl<'db> Type<'db> {
             meta_attr_kind,
         ) = Self::try_call_dunder_get_on_attribute(
             db,
-            self.instance_lookup_class_member_with_policy(db, name.into(), member_policy),
+            class_member,
             Some(receiver),
             self.to_meta_type(db),
         );
@@ -4320,6 +4337,12 @@ impl<'db> Type<'db> {
                     );
                     let class_attr_plain =
                         class_attr_plain.map_type(|ty| ty.bind_self_typevars(db, self_instance));
+                    let class_attr_plain = if policy.bind_dunder_callable_receiver() {
+                        class_attr_plain
+                            .map_type(|ty| ty.bind_callable_dunder_for_implicit_call(db, receiver))
+                    } else {
+                        class_attr_plain
+                    };
 
                     let class_attr_fallback = Type::try_call_dunder_get_on_attribute(
                         db,
@@ -4783,7 +4806,8 @@ impl<'db> Type<'db> {
                     .member_lookup_with_policy(
                         db,
                         Name::new_static("__call__"),
-                        MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                        MemberLookupPolicy::NO_INSTANCE_FALLBACK
+                            | MemberLookupPolicy::BIND_DUNDER_CALLABLE_RECEIVER,
                     )
                     .place
                 {
@@ -4792,8 +4816,6 @@ impl<'db> Type<'db> {
                         definedness: boundness,
                         ..
                     }) => {
-                        let dunder_callable =
-                            dunder_callable.bind_callable_dunder_for_implicit_call(db, self);
                         let mut bindings = dunder_callable.bindings(db);
                         bindings.replace_callable_type(dunder_callable, self);
                         if boundness == Definedness::PossiblyUndefined {
@@ -5505,8 +5527,8 @@ impl<'db> Type<'db> {
         )
     }
 
-    /// Bind a regular `Callable`-typed dunder for an implicit special-method call if its first
-    /// parameter can accept the receiver.
+    /// Bind a regular `Callable`-typed class member for an implicit special-method call if its
+    /// first parameter can accept the receiver.
     ///
     /// Unlike descriptor lookup, this preserves the callable as a regular `Callable`: a dunder
     /// name is enough evidence to bind a compatible receiver for implicit dispatch, but it is not
@@ -5556,7 +5578,9 @@ impl<'db> Type<'db> {
 
         // Implicit calls to dunder methods never access instance members, so we pass
         // `NO_INSTANCE_FALLBACK` here in addition to other policies:
-        let policy = policy | MemberLookupPolicy::NO_INSTANCE_FALLBACK;
+        let policy = policy
+            | MemberLookupPolicy::NO_INSTANCE_FALLBACK
+            | MemberLookupPolicy::BIND_DUNDER_CALLABLE_RECEIVER;
         match self
             .member_lookup_with_policy(db, name.into(), policy)
             .place
@@ -5567,8 +5591,6 @@ impl<'db> Type<'db> {
                 provenance,
                 ..
             }) => {
-                let dunder_callable =
-                    dunder_callable.bind_callable_dunder_for_implicit_call(db, self);
                 let constraints = ConstraintSetBuilder::new();
                 let bindings = dunder_callable
                     .bindings(db)
@@ -5608,15 +5630,20 @@ impl<'db> Type<'db> {
         argument_types: &CallArguments<'_, 'db>,
         tcx: TypeContext<'db>,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
-        match self.member(db, name).place {
+        match self
+            .member_lookup_with_policy(
+                db,
+                name.into(),
+                MemberLookupPolicy::BIND_DUNDER_CALLABLE_RECEIVER,
+            )
+            .place
+        {
             Place::Defined(DefinedPlace {
                 ty: dunder_callable,
                 definedness: boundness,
                 provenance,
                 ..
             }) => {
-                let dunder_callable =
-                    dunder_callable.bind_callable_dunder_for_implicit_call(db, self);
                 let constraints = ConstraintSetBuilder::new();
                 let bindings = dunder_callable
                     .bindings(db)
@@ -7462,7 +7489,9 @@ impl<'db> UnionType<'db> {
                 .member_lookup_with_policy(
                     db,
                     name.into(),
-                    policy | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                    policy
+                        | MemberLookupPolicy::NO_INSTANCE_FALLBACK
+                        | MemberLookupPolicy::BIND_DUNDER_CALLABLE_RECEIVER,
                 )
                 .place
             {
@@ -7472,7 +7501,7 @@ impl<'db> UnionType<'db> {
                     provenance: member_provenance,
                     ..
                 }) => {
-                    builder = builder.add(ty.bind_callable_dunder_for_implicit_call(db, *element));
+                    builder = builder.add(ty);
                     any_defined = true;
                     possibly_undefined = true;
                     provenance = provenance.or(member_provenance);
@@ -7482,7 +7511,7 @@ impl<'db> UnionType<'db> {
                     provenance: member_provenance,
                     ..
                 }) => {
-                    builder = builder.add(ty.bind_callable_dunder_for_implicit_call(db, *element));
+                    builder = builder.add(ty);
                     any_defined = true;
                     provenance = provenance.or(member_provenance);
                 }

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -124,6 +124,7 @@ impl<'db> Type<'db> {
                 {
                     place
                         .ty
+                        .bind_callable_dunder_for_implicit_call(db, self)
                         .try_upcast_to_callable_with_policy_and_context(db, policy, context)
                         // The callable instance itself doesn't inherit the descriptor behavior of
                         // its `__call__` method.
@@ -568,15 +569,6 @@ impl<'db> CallableType<'db> {
         )
     }
 
-    pub(crate) fn into_function_like(self, db: &'db dyn Db) -> CallableType<'db> {
-        CallableType::new(
-            db,
-            self.signatures(db),
-            CallableTypeKind::FunctionLike,
-            self.provenance(db),
-        )
-    }
-
     pub(crate) fn into_dunder_paramspec(self, db: &'db dyn Db) -> CallableType<'db> {
         CallableType::new(
             db,
@@ -584,6 +576,23 @@ impl<'db> CallableType<'db> {
             CallableTypeKind::DunderParamSpec,
             self.provenance(db),
         )
+    }
+
+    pub(crate) fn try_bind_dunder_self(
+        self,
+        db: &'db dyn Db,
+        self_type: Type<'db>,
+    ) -> Option<CallableType<'db>> {
+        if !self.is_regular(db) {
+            return None;
+        }
+
+        Some(CallableType::new(
+            db,
+            self.signatures(db).try_bind_dunder_self(db, self_type)?,
+            CallableTypeKind::Regular,
+            self.provenance(db),
+        ))
     }
 
     pub(crate) fn apply_self(self, db: &'db dyn Db, self_type: Type<'db>) -> CallableType<'db> {

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -115,8 +115,7 @@ impl<'db> Type<'db> {
                     .member_lookup_with_policy(
                         db,
                         Name::new_static("__call__"),
-                        MemberLookupPolicy::NO_INSTANCE_FALLBACK
-                            | MemberLookupPolicy::BIND_DUNDER_CALLABLE_RECEIVER,
+                        MemberLookupPolicy::IMPLICIT_DUNDER_CALL,
                     )
                     .place;
 

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -115,7 +115,8 @@ impl<'db> Type<'db> {
                     .member_lookup_with_policy(
                         db,
                         Name::new_static("__call__"),
-                        MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                        MemberLookupPolicy::NO_INSTANCE_FALLBACK
+                            | MemberLookupPolicy::BIND_DUNDER_CALLABLE_RECEIVER,
                     )
                     .place;
 
@@ -124,7 +125,6 @@ impl<'db> Type<'db> {
                 {
                     place
                         .ty
-                        .bind_callable_dunder_for_implicit_call(db, self)
                         .try_upcast_to_callable_with_policy_and_context(db, policy, context)
                         // The callable instance itself doesn't inherit the descriptor behavior of
                         // its `__call__` method.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2049,7 +2049,7 @@ impl<'db> ClassType<'db> {
             .member_lookup_with_policy(
                 db,
                 "__call__".into(),
-                MemberLookupPolicy::NO_INSTANCE_FALLBACK
+                MemberLookupPolicy::IMPLICIT_DUNDER_CALL
                     | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
             )
             .place;

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1115,23 +1115,6 @@ impl<'db> StaticClassLiteral<'db> {
         policy: MemberLookupPolicy,
         mro_iter: impl Iterator<Item = ClassBase<'db>>,
     ) -> PlaceAndQualifiers<'db> {
-        fn into_function_like_callable<'d>(db: &'d dyn Db, ty: Type<'d>) -> Type<'d> {
-            match ty {
-                Type::Callable(callable_ty)
-                    if callable_ty.is_regular(db)
-                        && callable_ty.signatures(db).has_parameters() =>
-                {
-                    Type::Callable(callable_ty.into_function_like(db))
-                }
-                Type::Union(union) => {
-                    union.map(db, |element| into_function_like_callable(db, *element))
-                }
-                Type::Intersection(intersection) => intersection
-                    .map_positive(db, |element| into_function_like_callable(db, *element)),
-                _ => ty,
-            }
-        }
-
         let result = MroLookup::new(db, mro_iter).class_member(
             name,
             policy,
@@ -1139,20 +1122,12 @@ impl<'db> StaticClassLiteral<'db> {
             self.is_known(db, KnownClass::Object),
         );
 
-        let mut member = match result {
+        match result {
             ClassMemberResult::Done(result) => result.finalize(db),
             ClassMemberResult::TypedDict(module) => {
                 typed_dict_class_member(db, self.identity_specialization(db), module, policy, name)
             }
-        };
-
-        // We generally treat dunder attributes with `Callable` types as function-like callables.
-        // See `callables_as_descriptors.md` for more details.
-        if name.starts_with("__") && name.ends_with("__") {
-            member = member.map_type(|ty| into_function_like_callable(db, ty));
         }
-
-        member
     }
 
     /// Returns the inferred type of the class member named `name`. Only bound members

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4865,7 +4865,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         call_expression_tcx: TypeContext<'db>,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
         match object
-            .member_lookup_with_policy(db, name.into(), MemberLookupPolicy::NO_INSTANCE_FALLBACK)
+            .member_lookup_with_policy(db, name.into(), MemberLookupPolicy::IMPLICIT_DUNDER_CALL)
             .place
         {
             Place::Defined(DefinedPlace {

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -665,7 +665,7 @@ impl ClassDecoratorUnknownResultPolicy {
                     .member_lookup_with_policy(
                         db,
                         Name::new_static("__call__"),
-                        MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                        MemberLookupPolicy::IMPLICIT_DUNDER_CALL,
                     )
                     .place;
 

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1279,7 +1279,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .member_lookup_with_policy(
                     db,
                     "__setitem__".into(),
-                    MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                    MemberLookupPolicy::IMPLICIT_DUNDER_CALL,
                 )
                 .place
             {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1148,6 +1148,11 @@ fn protocol_member_read_type<'db>(
     }
 
     let place = if access == ProtocolMemberAccessMode::Instance && member.is_method() {
+        let policy = if member.name.starts_with("__") && member.name.ends_with("__") {
+            MemberLookupPolicy::IMPLICIT_DUNDER_CALL
+        } else {
+            MemberLookupPolicy::NO_INSTANCE_FALLBACK
+        };
         ty.invoke_descriptor_protocol(
             db,
             ty,
@@ -1156,7 +1161,7 @@ fn protocol_member_read_type<'db>(
             InstanceFallbackShadowsNonDataDescriptor::No,
             // The undefined fallback excludes instance members. Keep the class
             // member lookup from reintroducing dynamic instance fallbacks.
-            MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+            policy,
         )
         .place
     } else {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1396,7 +1396,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 db,
                 "__setattr__".into(),
                 MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
-                    | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                    | MemberLookupPolicy::IMPLICIT_DUNDER_CALL,
             )
             .place
         else {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3168,7 +3168,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 .member_lookup_with_policy(
                     db,
                     Name::new_static("__call__"),
-                    MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                    MemberLookupPolicy::IMPLICIT_DUNDER_CALL,
                 )
                 .place
                 .ignore_possibly_undefined()

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -398,10 +398,20 @@ impl<'db> CallableSignature<'db> {
         }
     }
 
-    pub(crate) fn has_parameters(&self) -> bool {
-        self.overloads
+    pub(crate) fn try_bind_dunder_self(
+        &self,
+        db: &'db dyn Db,
+        self_type: Type<'db>,
+    ) -> Option<Self> {
+        let overloads = self
+            .overloads
             .iter()
-            .any(|signature| !signature.parameters().as_slice().is_empty())
+            .filter(|signature| {
+                signature.has_potential_receiver() && signature.can_bind_self_to(db, self_type)
+            })
+            .map(|signature| signature.bind_self(db, Some(self_type)));
+        let bound = Self::from_overloads(overloads);
+        (!bound.overloads.is_empty()).then_some(bound)
     }
 
     /// Replaces any occurrences of `typing.Self` in the parameter and return annotations with the
@@ -617,6 +627,15 @@ impl<'db> PartialApplication<'db> {
 }
 
 impl<'db> Signature<'db> {
+    fn has_potential_receiver(&self) -> bool {
+        self.parameters().is_top()
+            || self.parameters().is_gradual()
+            || self
+                .parameters()
+                .get(0)
+                .is_some_and(Parameter::is_positional)
+    }
+
     pub(crate) fn new(parameters: Parameters<'db>, return_ty: Type<'db>) -> Self {
         Self {
             generic_context: None,


### PR DESCRIPTION
## Summary

We previously modeled every `Callable`-typed dunder class member as a function-like descriptor. This supported implicit special-method calls, but it also changed ordinary attribute access: we bound away the first parameter and exposed function-only members such as `__get__`, even though a `Callable` annotation does not promise that the value is a function descriptor.

This change restricts the receiver heuristic to implicit dunder operations. Before descriptor resolution, we bind a concrete first positional parameter only when it can accept the receiver. Incompatible receivers, parameterless callables, and callables declared with a bare `ParamSpec` remain unbound, and a callable returned by a custom descriptor is not bound a second time.

```python
class Tensor:
    __pow__: Callable[[Tensor, int], Tensor]

Tensor() ** 2
reveal_type(Tensor().__pow__)  # (Tensor, int, /) -> Tensor
```

All implicit-call paths use the same lookup policy, including constructors, augmented and subscript assignment, and structural checks for dunder protocols. The semantic and IDE test suites pass, with focused coverage for ordinary attribute access, descriptor resolution, constructors, operators, assignments, and protocol conformance.

Follow-up to #26696.
