### PR TITLE
[ty] Avoid cross-typevar artifacts in collection context

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -567,6 +567,16 @@ x1: dict[Hashable, Callable[..., object]] = {"x": lambda: 1}
 x2: dict[Hashable, Callable[..., object]] = dict(x=lambda: 1)
 ```
 
+Type context for one dictionary type parameter should not pollute another:
+
+```py
+from collections.abc import Hashable, Mapping
+
+def accepts_mapping(value: Mapping[Hashable, list[object]]) -> None: ...
+
+accepts_mapping({"x": [1]})
+```
+
 ## Generic call argument inference
 
 A function's arguments are also inferred using the type context:

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6321,6 +6321,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let constraints = ConstraintSetBuilder::new();
         let inferable = generic_context.inferable_typevars(self.db());
+        // Reuse the builder to project contextual solutions before using it to infer a precise
+        // type for `T`.
+        let mut builder = SpecializationBuilder::new(self.db(), &constraints, inferable);
         let identity_instance = Type::instance(self.db(), ClassType::Generic(collection_alias));
 
         // Remove any union elements of that are unrelated to the collection type.
@@ -6410,10 +6413,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 // which adds `_KT` to `_VT`'s lower bound. Filter out any
                                 // inferable typevars from the solution, since they represent
                                 // cross-typevar relationships that are resolved independently.
-                                let inferred_ty = binding.solution.filter_union(db, |ty| {
-                                    !ty.as_typevar()
-                                        .is_some_and(|tv| tv.is_inferable(db, inferable))
-                                });
+                                let inferred_ty = builder
+                                    .remove_inferable_typevar_artifacts_from_solution(
+                                        binding.bound_typevar,
+                                        binding.solution,
+                                    );
 
                                 // Avoid inferring a preferred type based on partially specialized
                                 // type context from an outer generic call. If the type context is
@@ -6524,9 +6528,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             pre_inferred_elt_tys = Some(inferred_elts);
         }
-
-        // Create a set of constraints to infer a precise type for `T`.
-        let mut builder = SpecializationBuilder::new(self.db(), &constraints, inferable);
 
         let mut tuple_size_promotion_constraints = TupleSizePromotionConstraints::default();
 


### PR DESCRIPTION
## Summary

Fix bidirectional collection-literal inference for generic supertypes such as `Mapping[Hashable, list[object]]`.

When solving `dict[_KT, _VT]` against a generic supertype, SequentMap transitivity could produce a value context such as `_KT & list[object]`. The previous union-only filter did not remove the inferable `_KT` intersection conjunct. Nested list inference then lost its `list[object]` context, inferred `list[int]`, and reported an invalid-argument-type false positive.

Closes https://github.com/astral-sh/ty/issues/3956

## Validation

Added mdtest.
