### PR TITLE
[ty] Avoid duplicate diagnostics for overloaded TypeIs

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -108,6 +108,30 @@ def _(a: int) -> TypeIs[str]: ...
 def _(a: bool | str) -> TypeIs[int]: ...
 ```
 
+## Overloaded definitions
+
+Each overload is checked exactly once, and distinct invalid overloads each report their own
+diagnostic.
+
+```pyi
+from typing import overload
+from typing_extensions import Never, TypeIs
+
+@overload
+# error: [invalid-type-guard-definition] "Narrowed type `bool` is not assignable to the declared parameter type `Never`"
+def one_invalid(value: Never) -> TypeIs[bool]: ...
+@overload
+def one_invalid(value: object) -> TypeIs[str]: ...
+
+# Two distinct invalid overloads should each report their own diagnostic.
+@overload
+# error: [invalid-type-guard-definition] "Narrowed type `bool` is not assignable to the declared parameter type `Never`"
+def two_invalid(value: Never) -> TypeIs[bool]: ...
+@overload
+# error: [invalid-type-guard-definition] "Narrowed type `str` is not assignable to the declared parameter type `int`"
+def two_invalid(value: int) -> TypeIs[str]: ...
+```
+
 ## Methods
 
 Methods narrow the first positional argument after `self` or `cls`

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/typeguard.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/typeguard.rs
@@ -16,54 +16,51 @@ pub(crate) fn check_type_guard_definition<'db>(
 
     let db = context.db();
 
-    for overload in function.iter_overloads_and_implementation(db) {
-        let signature = overload.signature(db);
-        let return_ty = signature.return_ty;
+    let overload = function.literal(db).last_definition;
+    let signature = overload.signature(db);
+    let return_ty = signature.return_ty;
 
-        // Check if this is a `TypeIs` or `TypeGuard` return type.
-        let (type_guard_form_name, narrowed_type) = match return_ty {
-            Type::TypeIs(type_is) => ("TypeIs", Some(type_is.return_type(db))),
-            Type::TypeGuard(_) => ("TypeGuard", None),
-            _ => continue,
-        };
+    // Check if this is a `TypeIs` or `TypeGuard` return type.
+    let (type_guard_form_name, narrowed_type) = match return_ty {
+        Type::TypeIs(type_is) => ("TypeIs", Some(type_is.return_type(db))),
+        Type::TypeGuard(_) => ("TypeGuard", None),
+        _ => return,
+    };
 
-        // The return type annotation must exist since we matched `TypeIs`/`TypeGuard`.
-        let Some(returns_expr) = node.returns.as_deref() else {
-            continue;
-        };
+    // The return type annotation must exist since we matched `TypeIs`/`TypeGuard`.
+    let Some(returns_expr) = node.returns.as_deref() else {
+        return;
+    };
 
-        // Check if this is a non-static method (first parameter is implicit `self`/`cls`).
-        let has_implicit_receiver = overload.has_implicit_receiver(db);
+    // Check if this is a non-static method (first parameter is implicit `self`/`cls`).
+    let has_implicit_receiver = overload.has_implicit_receiver(db);
 
-        // Find the first positional parameter to narrow (skip implicit `self`/`cls`).
-        let positional_params: Vec<_> = signature.parameters().positional().collect();
-        let first_narrowed_param_index = usize::from(has_implicit_receiver);
-        let first_narrowed_param = positional_params.get(first_narrowed_param_index);
+    // Find the first positional parameter to narrow (skip implicit `self`/`cls`).
+    let positional_params: Vec<_> = signature.parameters().positional().collect();
+    let first_narrowed_param_index = usize::from(has_implicit_receiver);
+    let first_narrowed_param = positional_params.get(first_narrowed_param_index);
 
-        let Some(first_narrowed_param) = first_narrowed_param else {
-            if let Some(builder) = context.report_lint(&INVALID_TYPE_GUARD_DEFINITION, returns_expr)
-            {
-                builder.into_diagnostic(format_args!(
-                    "`{type_guard_form_name}` function must have a parameter to narrow"
-                ));
-            }
-            continue;
-        };
+    let Some(first_narrowed_param) = first_narrowed_param else {
+        if let Some(builder) = context.report_lint(&INVALID_TYPE_GUARD_DEFINITION, returns_expr) {
+            builder.into_diagnostic(format_args!(
+                "`{type_guard_form_name}` function must have a parameter to narrow"
+            ));
+        }
+        return;
+    };
 
-        // For `TypeIs`, check that the narrowed type is assignable to the parameter type.
-        if let Some(narrowed_ty) = narrowed_type {
-            let param_ty = first_narrowed_param.annotated_type();
-            if !narrowed_ty.is_assignable_to(db, param_ty)
-                && let Some(builder) =
-                    context.report_lint(&INVALID_TYPE_GUARD_DEFINITION, returns_expr)
-            {
-                builder.into_diagnostic(format_args!(
-                    "Narrowed type `{narrowed}` is not assignable \
-                        to the declared parameter type `{param}`",
-                    narrowed = narrowed_ty.display(db),
-                    param = param_ty.display(db)
-                ));
-            }
+    // For `TypeIs`, check that the narrowed type is assignable to the parameter type.
+    if let Some(narrowed_ty) = narrowed_type {
+        let param_ty = first_narrowed_param.annotated_type();
+        if !narrowed_ty.is_assignable_to(db, param_ty)
+            && let Some(builder) = context.report_lint(&INVALID_TYPE_GUARD_DEFINITION, returns_expr)
+        {
+            builder.into_diagnostic(format_args!(
+                "Narrowed type `{narrowed}` is not assignable \
+                    to the declared parameter type `{param}`",
+                narrowed = narrowed_ty.display(db),
+                param = param_ty.display(db)
+            ));
         }
     }
 }


### PR DESCRIPTION
## Summary

Check only the current function definition when validating `TypeIs` and `TypeGuard` definitions. `check_type_guard_definition` runs for every `FunctionDef`, which includes each individual overload, so it shouldn't iterate previous overloads each time also.

Fixes astral-sh/ty#3968

## Validation

Added mdtests.

