### PR TITLE
[ty] Compact retained constraint nodes

### DIFF
--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -90,9 +90,70 @@ pub struct InteriorNode {
     pub if_false: ScopedNarrowingConstraint,
 }
 
+/// A compact retained interior node. Constraint IDs are limited to 19 bits by
+/// [`MAX_INTERIOR_NODES`], leaving room to encode the two terminal values in 20 bits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+struct RetainedInteriorNode {
+    atom: ScopedPredicateId,
+    edges: [u32; 2],
+}
+
+impl RetainedInteriorNode {
+    const EDGE_BITS: u32 = 20;
+    const EDGE_MASK: u64 = (1 << Self::EDGE_BITS) - 1;
+    const PACKED_TRUE: u32 = (1 << Self::EDGE_BITS) - 1;
+    const PACKED_FALSE: u32 = Self::PACKED_TRUE - 1;
+
+    fn new(node: InteriorNode) -> Self {
+        let edges = u64::from(Self::pack_edge(node.if_true))
+            | (u64::from(Self::pack_edge(node.if_uncertain)) << Self::EDGE_BITS)
+            | (u64::from(Self::pack_edge(node.if_false)) << (2 * Self::EDGE_BITS));
+
+        #[expect(clippy::cast_possible_truncation)]
+        Self {
+            atom: node.atom,
+            edges: [edges as u32, (edges >> 32) as u32],
+        }
+    }
+
+    fn unpack(self) -> InteriorNode {
+        let edges = u64::from(self.edges[0]) | (u64::from(self.edges[1]) << 32);
+        InteriorNode {
+            atom: self.atom,
+            if_true: Self::unpack_edge((edges & Self::EDGE_MASK) as u32),
+            if_uncertain: Self::unpack_edge(((edges >> Self::EDGE_BITS) & Self::EDGE_MASK) as u32),
+            if_false: Self::unpack_edge(
+                ((edges >> (2 * Self::EDGE_BITS)) & Self::EDGE_MASK) as u32,
+            ),
+        }
+    }
+
+    fn pack_edge(edge: ScopedNarrowingConstraint) -> u32 {
+        match edge {
+            ALWAYS_TRUE => Self::PACKED_TRUE,
+            ALWAYS_FALSE => Self::PACKED_FALSE,
+            edge => {
+                debug_assert!((edge.0 as usize) < MAX_INTERIOR_NODES);
+                edge.0
+            }
+        }
+    }
+
+    const fn unpack_edge(edge: u32) -> ScopedNarrowingConstraint {
+        match edge {
+            Self::PACKED_TRUE => ALWAYS_TRUE,
+            Self::PACKED_FALSE => ALWAYS_FALSE,
+            edge => ScopedNarrowingConstraint(edge),
+        }
+    }
+}
+
+static_assertions::const_assert_eq!(std::mem::size_of::<RetainedInteriorNode>(), 12);
+static_assertions::const_assert!(MAX_INTERIOR_NODES <= RetainedInteriorNode::PACKED_FALSE as usize);
+
 #[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub struct NarrowingConstraints {
-    used_interiors: Box<[InteriorNode]>,
+    used_interiors: Box<[RetainedInteriorNode]>,
     used_indices: Option<RankBitBox>,
 }
 
@@ -102,8 +163,14 @@ impl NarrowingConstraints {
     /// The nodes must satisfy the same ordering and allocation invariants as graphs produced by
     /// [`NarrowingConstraintsBuilder`].
     pub fn from_test_nodes(nodes: Vec<InteriorNode>) -> Self {
+        assert!(nodes.len() <= MAX_INTERIOR_NODES);
+        assert!(nodes.iter().all(|node| {
+            [node.if_true, node.if_uncertain, node.if_false]
+                .into_iter()
+                .all(|edge| edge.is_terminal() || (edge.0 as usize) < MAX_INTERIOR_NODES)
+        }));
         Self {
-            used_interiors: nodes.into_boxed_slice(),
+            used_interiors: nodes.into_iter().map(RetainedInteriorNode::new).collect(),
             used_indices: None,
         }
     }
@@ -120,9 +187,9 @@ impl NarrowingConstraints {
                 used_indices.get_bit(raw_index).unwrap_or(false),
                 "all used narrowing constraints should have been marked as used",
             );
-            self.used_interiors[used_indices.rank(raw_index) as usize]
+            self.used_interiors[used_indices.rank(raw_index) as usize].unpack()
         } else {
-            self.used_interiors[raw_index]
+            self.used_interiors[raw_index].unpack()
         }
     }
 }
@@ -146,7 +213,11 @@ impl NarrowingConstraintsBuilder {
     pub(crate) fn build(self) -> NarrowingConstraints {
         if self.interior_used.first_zero().is_none() {
             NarrowingConstraints {
-                used_interiors: self.interiors.raw.into_boxed_slice(),
+                used_interiors: self
+                    .interiors
+                    .into_iter()
+                    .map(RetainedInteriorNode::new)
+                    .collect(),
                 used_indices: None,
             }
         } else {
@@ -155,6 +226,7 @@ impl NarrowingConstraintsBuilder {
                 .into_iter()
                 .zip(&self.interior_used)
                 .filter_map(|(interior, used)| used.then_some(interior))
+                .map(RetainedInteriorNode::new)
                 .collect();
             let used_indices = RankBitBox::from_bits(self.interior_used);
             NarrowingConstraints {
@@ -225,6 +297,14 @@ impl NarrowingConstraintsBuilder {
                 if_uncertain: when_true,
                 if_false: ALWAYS_TRUE,
             });
+        }
+
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return self
+                .interior_cache
+                .get(&node)
+                .copied()
+                .unwrap_or(ALWAYS_TRUE);
         }
 
         *self.interior_cache.entry(node).or_insert_with(|| {
@@ -424,6 +504,46 @@ mod tests {
 
     fn predicate(index: usize) -> ScopedPredicateId {
         ScopedPredicateId::new(index)
+    }
+
+    #[test]
+    fn retained_interior_round_trip() {
+        let max = ScopedNarrowingConstraint::new(MAX_INTERIOR_NODES - 1);
+        for (if_true, if_uncertain, if_false) in [
+            (ALWAYS_TRUE, ALWAYS_FALSE, max),
+            (max, ALWAYS_TRUE, ALWAYS_FALSE),
+        ] {
+            let node = InteriorNode {
+                atom: predicate(0),
+                if_true,
+                if_uncertain,
+                if_false,
+            };
+            assert_eq!(RetainedInteriorNode::new(node).unpack(), node);
+        }
+    }
+
+    #[test]
+    fn adding_atoms_respects_interior_limit() {
+        let existing = InteriorNode {
+            atom: predicate(0),
+            if_true: ALWAYS_TRUE,
+            if_uncertain: ALWAYS_FALSE,
+            if_false: ALWAYS_FALSE,
+        };
+        let existing_id = ScopedNarrowingConstraint(0);
+        let mut constraints = NarrowingConstraintsBuilder {
+            interiors: IndexVec::from_raw(vec![existing; MAX_INTERIOR_NODES]),
+            interior_used: RankBitBox::bits_with_capacity(MAX_INTERIOR_NODES),
+            interior_cache: FxHashMap::from_iter([(existing, existing_id)]),
+            ..NarrowingConstraintsBuilder::default()
+        };
+
+        assert_eq!(constraints.add_atom(predicate(0)), existing_id);
+        assert_eq!(constraints.add_atom(predicate(1)), ALWAYS_TRUE);
+        assert_eq!(constraints.add_negated_atom(predicate(1)), ALWAYS_TRUE);
+        assert_eq!(constraints.interiors.len(), MAX_INTERIOR_NODES);
+        assert_eq!(constraints.interior_used.len(), MAX_INTERIOR_NODES);
     }
 
     fn evaluate(

--- a/crates/ty_python_core/src/reachability_constraints.rs
+++ b/crates/ty_python_core/src/reachability_constraints.rs
@@ -69,6 +69,70 @@ pub struct InteriorNode {
     if_false: ScopedReachabilityConstraintId,
 }
 
+/// A compact retained interior node. Constraint IDs are limited to 19 bits by
+/// [`MAX_INTERIOR_NODES`], leaving room to encode the three terminal values in 20 bits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+struct RetainedInteriorNode {
+    atom: ScopedPredicateId,
+    edges: [u32; 2],
+}
+
+impl RetainedInteriorNode {
+    const EDGE_BITS: u32 = 20;
+    const EDGE_MASK: u64 = (1 << Self::EDGE_BITS) - 1;
+    const PACKED_TRUE: u32 = (1 << Self::EDGE_BITS) - 1;
+    const PACKED_AMBIGUOUS: u32 = Self::PACKED_TRUE - 1;
+    const PACKED_FALSE: u32 = Self::PACKED_TRUE - 2;
+
+    fn new(node: InteriorNode) -> Self {
+        let edges = u64::from(Self::pack_edge(node.if_true))
+            | (u64::from(Self::pack_edge(node.if_ambiguous)) << Self::EDGE_BITS)
+            | (u64::from(Self::pack_edge(node.if_false)) << (2 * Self::EDGE_BITS));
+
+        #[expect(clippy::cast_possible_truncation)]
+        Self {
+            atom: node.atom,
+            edges: [edges as u32, (edges >> 32) as u32],
+        }
+    }
+
+    fn unpack(self) -> InteriorNode {
+        let edges = u64::from(self.edges[0]) | (u64::from(self.edges[1]) << 32);
+        InteriorNode {
+            atom: self.atom,
+            if_true: Self::unpack_edge((edges & Self::EDGE_MASK) as u32),
+            if_ambiguous: Self::unpack_edge(((edges >> Self::EDGE_BITS) & Self::EDGE_MASK) as u32),
+            if_false: Self::unpack_edge(
+                ((edges >> (2 * Self::EDGE_BITS)) & Self::EDGE_MASK) as u32,
+            ),
+        }
+    }
+
+    fn pack_edge(edge: ScopedReachabilityConstraintId) -> u32 {
+        match edge {
+            ALWAYS_TRUE => Self::PACKED_TRUE,
+            AMBIGUOUS => Self::PACKED_AMBIGUOUS,
+            ALWAYS_FALSE => Self::PACKED_FALSE,
+            edge => {
+                debug_assert!((edge.0 as usize) < MAX_INTERIOR_NODES);
+                edge.0
+            }
+        }
+    }
+
+    const fn unpack_edge(edge: u32) -> ScopedReachabilityConstraintId {
+        match edge {
+            Self::PACKED_TRUE => ALWAYS_TRUE,
+            Self::PACKED_AMBIGUOUS => AMBIGUOUS,
+            Self::PACKED_FALSE => ALWAYS_FALSE,
+            edge => ScopedReachabilityConstraintId(edge),
+        }
+    }
+}
+
+static_assertions::const_assert_eq!(std::mem::size_of::<RetainedInteriorNode>(), 12);
+static_assertions::const_assert!(MAX_INTERIOR_NODES <= RetainedInteriorNode::PACKED_FALSE as usize);
+
 impl InteriorNode {
     pub const fn atom(self) -> ScopedPredicateId {
         self.atom
@@ -140,7 +204,7 @@ const MAX_INTERIOR_NODES: usize = 512 * 1024;
 #[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub struct ReachabilityConstraints {
     /// The interior TDD nodes that were marked as used when being built.
-    used_interiors: Box<[InteriorNode]>,
+    used_interiors: Box<[RetainedInteriorNode]>,
     /// A bit vector indicating which interior TDD nodes were marked as used. This is indexed by
     /// the node's [`ScopedReachabilityConstraintId`]. The rank of the corresponding bit gives the
     /// index of that node in the `used_interiors` vector.
@@ -160,14 +224,18 @@ impl ReachabilityConstraints {
                 "all used reachability constraints should have been marked as used",
             );
             let index = used_indices.rank(raw_index) as usize;
-            self.used_interiors[index]
+            self.used_interiors[index].unpack()
         } else {
-            self.used_interiors[raw_index]
+            self.used_interiors[raw_index].unpack()
         }
     }
 
-    pub fn used_interiors(&self) -> &[InteriorNode] {
-        &self.used_interiors
+    pub fn is_empty(&self) -> bool {
+        self.used_interiors.is_empty()
+    }
+
+    pub fn used_interior_count(&self) -> usize {
+        self.used_interiors.len()
     }
 }
 
@@ -197,13 +265,18 @@ impl ReachabilityConstraintsBuilder {
     pub(crate) fn build(self) -> ReachabilityConstraints {
         if self.interior_used.first_zero().is_none() {
             ReachabilityConstraints {
-                used_interiors: self.interiors.raw.into_boxed_slice(),
+                used_interiors: self
+                    .interiors
+                    .into_iter()
+                    .map(RetainedInteriorNode::new)
+                    .collect(),
                 used_indices: None,
             }
         } else {
             let used_interiors = (self.interiors.into_iter())
                 .zip(&self.interior_used)
                 .filter_map(|(interior, used)| used.then_some(interior))
+                .map(RetainedInteriorNode::new)
                 .collect();
             let used_indices = RankBitBox::from_bits(self.interior_used);
             ReachabilityConstraints {
@@ -274,6 +347,10 @@ impl ReachabilityConstraintsBuilder {
         // branch to go there too. And this node is then redundant and can be reduced.
         if node.if_true == node.if_false {
             return node.if_true;
+        }
+
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return self.interior_cache.get(&node).copied().unwrap_or(AMBIGUOUS);
         }
 
         *self.interior_cache.entry(node).or_insert_with(|| {
@@ -484,5 +561,50 @@ impl ReachabilityConstraintsBuilder {
         });
         self.and_cache.insert((a, b), result);
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ruff_index::Idx;
+
+    #[test]
+    fn retained_interior_round_trip() {
+        let max = ScopedReachabilityConstraintId::new(MAX_INTERIOR_NODES - 1);
+        for (if_true, if_ambiguous, if_false) in [
+            (ALWAYS_TRUE, AMBIGUOUS, max),
+            (max, ALWAYS_FALSE, ALWAYS_TRUE),
+        ] {
+            let node = InteriorNode {
+                atom: ScopedPredicateId::new(0),
+                if_true,
+                if_ambiguous,
+                if_false,
+            };
+            assert_eq!(RetainedInteriorNode::new(node).unpack(), node);
+        }
+    }
+
+    #[test]
+    fn adding_atoms_respects_interior_limit() {
+        let existing = InteriorNode {
+            atom: ScopedPredicateId::new(0),
+            if_true: ALWAYS_TRUE,
+            if_ambiguous: AMBIGUOUS,
+            if_false: ALWAYS_FALSE,
+        };
+        let existing_id = ScopedReachabilityConstraintId(0);
+        let mut constraints = ReachabilityConstraintsBuilder {
+            interiors: IndexVec::from_raw(vec![existing; MAX_INTERIOR_NODES]),
+            interior_used: RankBitBox::bits_with_capacity(MAX_INTERIOR_NODES),
+            interior_cache: FxHashMap::from_iter([(existing, existing_id)]),
+            ..ReachabilityConstraintsBuilder::default()
+        };
+
+        assert_eq!(constraints.add_atom(ScopedPredicateId::new(0)), existing_id);
+        assert_eq!(constraints.add_atom(ScopedPredicateId::new(1)), AMBIGUOUS);
+        assert_eq!(constraints.interiors.len(), MAX_INTERIOR_NODES);
+        assert_eq!(constraints.interior_used.len(), MAX_INTERIOR_NODES);
     }
 }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -2641,7 +2641,7 @@ impl<'db> UseDefMapBuilder<'db> {
         let predicates = self.predicates.build();
         let reachability_constraints = self.reachability_constraints.build();
         let narrowing_constraints = self.narrowing_constraints.build();
-        let constraint_tables = (!reachability_constraints.used_interiors().is_empty()
+        let constraint_tables = (!reachability_constraints.is_empty()
             || !narrowing_constraints.is_empty())
         .then(|| {
             Box::new(ConstraintTables {

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1374,7 +1374,7 @@ fn loop_header_reachability_impl<'db>(
     let mut deleted_reachability = Truthiness::AlwaysFalse;
     let mut reachable_bindings = FxIndexSet::default();
     let live_bindings: Vec<_> = loop_header.bindings_for_place(place).collect();
-    let use_exact_reachability = use_def.reachability_constraints().used_interiors().len()
+    let use_exact_reachability = use_def.reachability_constraints().used_interior_count()
         <= MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES;
 
     for live_binding in live_bindings {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2276,7 +2276,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Loop-header types are an approximation point for loop fixpoint analysis. Inferring the
         // exact union of every visible loop-back binding can recursively force inference of large
         // boolean expressions and explode on real-world loops.
-        if use_def.reachability_constraints().used_interiors().len()
+        if use_def.reachability_constraints().used_interior_count()
             > MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES
         {
             self.bindings.insert(definition, Type::unknown());
@@ -2368,8 +2368,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .index
                 .use_def_map(scope_id)
                 .reachability_constraints()
-                .used_interiors()
-                .len()
+                .used_interior_count()
                 > MAX_EXACT_NESTED_BINDING_REACHABILITY_NODES
         {
             // As with loop header definitions above, use a reachability cutoff to avoid excessive


### PR DESCRIPTION
## Summary

Pack the three child edges of finalized narrowing and reachability TDD nodes into two `u32` words, reducing each retained interior node from 16 bytes to 12 bytes. Builder-time nodes remain unchanged; only the Salsa-retained representation is compacted.

The encoding reserves terminal values, enforces the existing interior-node limit for atom insertion, and exposes count/emptiness APIs so callers do not depend on the retained-node layout. Add layout, boundary, and round-trip coverage for both constraint tables.

In the standalone ty retained-memory report at `c360a05e9a`, this accounts for:

- flake8: 48.0 KiB (0.13%)
- Trio: 254.5 KiB (0.28%)
- Sphinx: 608.4 KiB (0.29%)