### PR TITLE
[ty] Compact retained range metadata

### DIFF
--- a/crates/ty_python_core/src/reachability_constraints.rs
+++ b/crates/ty_python_core/src/reachability_constraints.rs
@@ -107,6 +107,27 @@ impl ScopedReachabilityConstraintId {
     pub fn as_u32(self) -> u32 {
         self.0
     }
+
+    pub(crate) fn compact(self) -> u32 {
+        match self {
+            ALWAYS_TRUE => COMPACT_ALWAYS_TRUE,
+            AMBIGUOUS => COMPACT_AMBIGUOUS,
+            ALWAYS_FALSE => COMPACT_ALWAYS_FALSE,
+            constraint => {
+                debug_assert!((constraint.0 as usize) < MAX_INTERIOR_NODES);
+                constraint.0
+            }
+        }
+    }
+
+    pub(crate) const fn from_compact(value: u32) -> Self {
+        match value {
+            COMPACT_ALWAYS_TRUE => ALWAYS_TRUE,
+            COMPACT_AMBIGUOUS => AMBIGUOUS,
+            COMPACT_ALWAYS_FALSE => ALWAYS_FALSE,
+            constraint => Self(constraint),
+        }
+    }
 }
 
 impl Idx for ScopedReachabilityConstraintId {
@@ -135,6 +156,11 @@ const SMALLEST_TERMINAL: ScopedReachabilityConstraintId = ALWAYS_FALSE;
 /// (e.g., a 5000-line while loop with hundreds of if-branches). This can lead to less precise
 /// reachability analysis and type narrowing.
 const MAX_INTERIOR_NODES: usize = 512 * 1024;
+const COMPACT_ALWAYS_TRUE: u32 = (1 << 20) - 1;
+const COMPACT_AMBIGUOUS: u32 = COMPACT_ALWAYS_TRUE - 1;
+const COMPACT_ALWAYS_FALSE: u32 = COMPACT_ALWAYS_TRUE - 2;
+
+static_assertions::const_assert!(MAX_INTERIOR_NODES <= COMPACT_ALWAYS_FALSE as usize);
 
 /// A collection of reachability constraints for a given scope.
 #[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
@@ -274,6 +300,10 @@ impl ReachabilityConstraintsBuilder {
         // branch to go there too. And this node is then redundant and can be reduced.
         if node.if_true == node.if_false {
             return node.if_true;
+        }
+
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return self.interior_cache.get(&node).copied().unwrap_or(AMBIGUOUS);
         }
 
         *self.interior_cache.entry(node).or_insert_with(|| {
@@ -484,5 +514,34 @@ impl ReachabilityConstraintsBuilder {
         });
         self.and_cache.insert((a, b), result);
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_index::Idx;
+
+    use super::*;
+
+    #[test]
+    fn adding_atoms_respects_interior_limit() {
+        let existing = InteriorNode {
+            atom: ScopedPredicateId::new(0),
+            if_true: ALWAYS_TRUE,
+            if_ambiguous: AMBIGUOUS,
+            if_false: ALWAYS_FALSE,
+        };
+        let existing_id = ScopedReachabilityConstraintId(0);
+        let mut constraints = ReachabilityConstraintsBuilder {
+            interiors: IndexVec::from_raw(vec![existing; MAX_INTERIOR_NODES]),
+            interior_used: RankBitBox::bits_with_capacity(MAX_INTERIOR_NODES),
+            interior_cache: FxHashMap::from_iter([(existing, existing_id)]),
+            ..ReachabilityConstraintsBuilder::default()
+        };
+
+        assert_eq!(constraints.add_atom(ScopedPredicateId::new(0)), existing_id);
+        assert_eq!(constraints.add_atom(ScopedPredicateId::new(1)), AMBIGUOUS);
+        assert_eq!(constraints.interiors.len(), MAX_INTERIOR_NODES);
+        assert_eq!(constraints.interior_used.len(), MAX_INTERIOR_NODES);
     }
 }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -797,16 +797,60 @@ pub struct UseDefMap<'db> {
 
 /// Information about a given range of source code.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
-struct RangeInfo {
-    reachability: ScopedReachabilityConstraintId,
-    in_type_checking_block: bool,
-}
+struct RangeInfo(u32);
+
+static_assertions::assert_eq_size!(RangeInfo, u32);
+static_assertions::assert_eq_size!((TextRange, RangeInfo), [u32; 3]);
 
 impl Default for RangeInfo {
     fn default() -> Self {
-        Self {
-            reachability: ScopedReachabilityConstraintId::ALWAYS_TRUE,
-            in_type_checking_block: false,
+        Self::new(ScopedReachabilityConstraintId::ALWAYS_TRUE, false)
+    }
+}
+
+impl RangeInfo {
+    const IN_TYPE_CHECKING_BLOCK: u32 = 1 << 31;
+
+    fn new(reachability: ScopedReachabilityConstraintId, in_type_checking_block: bool) -> Self {
+        let flag = u32::from(in_type_checking_block) << 31;
+        Self(reachability.compact() | flag)
+    }
+
+    fn reachability(self) -> ScopedReachabilityConstraintId {
+        ScopedReachabilityConstraintId::from_compact(self.0 & !Self::IN_TYPE_CHECKING_BLOCK)
+    }
+
+    fn in_type_checking_block(self) -> bool {
+        self.0 & Self::IN_TYPE_CHECKING_BLOCK != 0
+    }
+}
+
+#[cfg(test)]
+mod range_info_tests {
+    use ruff_index::Idx;
+
+    use super::*;
+
+    #[test]
+    fn compact_reachability_and_type_checking_round_trip() {
+        let default = RangeInfo::default();
+        assert_eq!(
+            default.reachability(),
+            ScopedReachabilityConstraintId::ALWAYS_TRUE
+        );
+        assert!(!default.in_type_checking_block());
+
+        for reachability in [
+            ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            ScopedReachabilityConstraintId::AMBIGUOUS,
+            ScopedReachabilityConstraintId::ALWAYS_FALSE,
+            ScopedReachabilityConstraintId::new(512 * 1024 - 1),
+        ] {
+            for in_type_checking_block in [false, true] {
+                let info = RangeInfo::new(reachability, in_type_checking_block);
+                assert_eq!(info.reachability(), reachability);
+                assert_eq!(info.in_type_checking_block(), in_type_checking_block);
+            }
         }
     }
 }
@@ -871,7 +915,7 @@ impl<'db> UseDefMap<'db> {
     ) -> impl Iterator<Item = (TextRange, ScopedReachabilityConstraintId)> + '_ {
         self.range_reachability
             .iter()
-            .map(|&(range, RangeInfo { reachability, .. })| (range, reachability))
+            .map(|&(range, info)| (range, info.reachability()))
     }
 
     pub fn end_of_scope_reachability(&self) -> ScopedReachabilityConstraintId {
@@ -962,7 +1006,7 @@ impl<'db> UseDefMap<'db> {
             .iter()
             .take_while(|(entry_range, _)| entry_range.start() <= range.start())
             .any(|&(entry_range, block)| {
-                block.in_type_checking_block && entry_range.contains_range(range)
+                block.in_type_checking_block() && entry_range.contains_range(range)
             })
     }
     pub fn end_of_scope_bindings(
@@ -2296,10 +2340,7 @@ impl<'db> UseDefMapBuilder<'db> {
         range: TextRange,
         is_type_checking_block: bool,
     ) {
-        let this_range_info = RangeInfo {
-            reachability: self.reachability,
-            in_type_checking_block: is_type_checking_block,
-        };
+        let this_range_info = RangeInfo::new(self.reachability, is_type_checking_block);
 
         // If the last entry has the same reachability constraint and the same
         // "in-TYPE_CHECKING" status, extend it to cover this range too, collapsing
@@ -2609,8 +2650,8 @@ impl<'db> UseDefMapBuilder<'db> {
         // default of reachable code outside a `TYPE_CHECKING` block.
         self.range_reachability
             .retain(|(_, info)| *info != RangeInfo::default());
-        for &(_, RangeInfo { reachability, .. }) in &self.range_reachability {
-            self.reachability_constraints.mark_used(reachability);
+        for &(_, info) in &self.range_reachability {
+            self.reachability_constraints.mark_used(info.reachability());
         }
         for enclosing_snapshot in &enclosing_snapshots {
             // Bindings are already marked above.


### PR DESCRIPTION
## Summary

Pack a range's reachability constraint and `TYPE_CHECKING` flag into one `u32`, reducing each retained `(TextRange, RangeInfo)` entry from 16 bytes to 12 bytes. Terminal reachability IDs receive compact encodings, while interior IDs remain bounded by the existing constraint limit.

Preserve main's default-range elision and add layout, terminal/boundary round-trip, and interior-limit coverage.

In the standalone ty retained-memory report at `c360a05e9a` (before default-range elision landed on main), this accounts for:

- flake8: 42.6 KiB (0.12%)
- Trio: 107.4 KiB (0.12%)
- Sphinx: 235.4 KiB (0.11%)