### PR TITLE
[ty] Treat transparent callable decorators consistently in class assignments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -174,27 +174,16 @@ class C3:
 reveal_type(C3().method_decorated(1))  # revealed: int | str
 ```
 
-Note that we currently only apply this heuristic when calling a function such as `memoize` via the
-decorator syntax. This is inconsistent, because the above *should* be equivalent to the following,
-but here we emit errors:
+Transparent decorators are also treated consistently when spelled as an equivalent assignment:
 
 ```py
-def memoize3(f: Callable[[C4, int], str]) -> Callable[[C4, int], str]:
-    raise NotImplementedError
-
 class C4:
     def method(self, x: int) -> str:
         return str(x)
-    method_decorated = memoize3(method)
+    method_decorated = memoize(method)
 
-# error: [missing-argument]
-# error: [invalid-argument-type]
 C4().method_decorated(1)
 ```
-
-The reason for this is that the heuristic is problematic. We don't *know* that the `Callable` in the
-return type of `memoize` is actually related to the method that we pass in. But when `memoize` is
-applied as a decorator, it is reasonable to assume so.
 
 In general, a function call might however return a `Callable` that is unrelated to the argument
 passed in. And here, it seems more reasonable and safe to treat the `Callable` as a non-descriptor.

--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -185,6 +185,24 @@ class C4:
 C4().method_decorated(1)
 ```
 
+For non-transparent decorators, avoid resolving the decorated function's signature before the
+decorator itself has been rejected. Doing so can introduce a cycle when the signature refers back to
+the decorated name:
+
+```py
+decorated = lambda: decorated
+try:
+    pass
+except* Exception:
+    pass
+
+unknown_decorator: Any
+
+@unknown_decorator  # error: [unresolved-reference]
+def decorated(argument: lambda: decorated, /):  # error: [invalid-type-form]
+    pass
+```
+
 In general, a function call might however return a `Callable` that is unrelated to the argument
 passed in. And here, it seems more reasonable and safe to treat the `Callable` as a non-descriptor.
 This allows correct programs like the following to pass type checking (that are currently rejected

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -376,55 +376,43 @@ fn callable_paramspec_and_return_typevar<'db>(
     Some((paramspec, signature.return_ty.as_typevar()?))
 }
 
-fn is_transparent_callable_decorator<'db>(
-    db: &'db dyn Db,
-    decorator_ty: Type<'db>,
-    decorated_ty: Type<'db>,
-) -> bool {
-    if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
-        return false;
-    }
-    let Some(decorator_callable) = decorator_ty
-        .try_upcast_to_callable(db)
-        .and_then(CallableTypes::exactly_one)
-    else {
-        return false;
-    };
-    let decorator_signatures = decorator_callable.signatures(db);
-    let [decorator_signature] = decorator_signatures.overloads.as_slice() else {
-        return false;
-    };
-    let [parameter] = decorator_signature.parameters().as_slice() else {
-        return false;
-    };
-
-    let Some((parameter_callable_paramspec, parameter_callable_return_typevar)) =
-        callable_paramspec_and_return_typevar(db, parameter.annotated_type())
-    else {
-        return false;
-    };
-    let Some((return_callable_paramspec, return_callable_typevar)) =
-        callable_paramspec_and_return_typevar(db, decorator_signature.return_ty)
-    else {
-        return false;
-    };
-    parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
-        && parameter_callable_return_typevar.is_same_typevar_as(db, return_callable_typevar)
-}
-
 fn transparent_callable_decorator_result<'db>(
     db: &'db dyn Db,
     decorator_ty: Type<'db>,
     decorated_ty: Type<'db>,
 ) -> Option<Type<'db>> {
-    if !is_transparent_callable_decorator(db, decorator_ty, decorated_ty) {
-        return None;
-    }
-
-    decorated_ty
+    let decorated_ty = match decorated_ty {
+        Type::FunctionLiteral(function) => Type::Callable(function.into_callable_type(db)),
+        Type::Callable(_) => decorated_ty,
+        _ => return None,
+    };
+    let Some(decorator_callable) = decorator_ty
         .try_upcast_to_callable(db)
         .and_then(CallableTypes::exactly_one)
-        .map(Type::Callable)
+    else {
+        return None;
+    };
+    let decorator_signatures = decorator_callable.signatures(db);
+    let [decorator_signature] = decorator_signatures.overloads.as_slice() else {
+        return None;
+    };
+    let [parameter] = decorator_signature.parameters().as_slice() else {
+        return None;
+    };
+
+    let Some((parameter_callable_paramspec, parameter_callable_return_typevar)) =
+        callable_paramspec_and_return_typevar(db, parameter.annotated_type())
+    else {
+        return None;
+    };
+    let Some((return_callable_paramspec, return_callable_typevar)) =
+        callable_paramspec_and_return_typevar(db, decorator_signature.return_ty)
+    else {
+        return None;
+    };
+    (parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
+        && parameter_callable_return_typevar.is_same_typevar_as(db, return_callable_typevar))
+    .then_some(decorated_ty)
 }
 
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -381,11 +381,9 @@ fn transparent_callable_decorator_result<'db>(
     decorator_ty: Type<'db>,
     decorated_ty: Type<'db>,
 ) -> Option<Type<'db>> {
-    let decorated_ty = match decorated_ty {
-        Type::FunctionLiteral(function) => Type::Callable(function.into_callable_type(db)),
-        Type::Callable(_) => decorated_ty,
-        _ => return None,
-    };
+    if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
+        return None;
+    }
     let decorator_callable = decorator_ty
         .try_upcast_to_callable(db)
         .and_then(CallableTypes::exactly_one)?;
@@ -401,9 +399,17 @@ fn transparent_callable_decorator_result<'db>(
         callable_paramspec_and_return_typevar(db, parameter.annotated_type())?;
     let (return_callable_paramspec, return_callable_typevar) =
         callable_paramspec_and_return_typevar(db, decorator_signature.return_ty)?;
-    (parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
-        && parameter_callable_return_typevar.is_same_typevar_as(db, return_callable_typevar))
-    .then_some(decorated_ty)
+    if !parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
+        || !parameter_callable_return_typevar.is_same_typevar_as(db, return_callable_typevar)
+    {
+        return None;
+    }
+
+    match decorated_ty {
+        Type::FunctionLiteral(function) => Some(Type::Callable(function.into_callable_type(db))),
+        Type::Callable(_) => Some(decorated_ty),
+        _ => None,
+    }
 }
 
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -386,12 +386,9 @@ fn transparent_callable_decorator_result<'db>(
         Type::Callable(_) => decorated_ty,
         _ => return None,
     };
-    let Some(decorator_callable) = decorator_ty
+    let decorator_callable = decorator_ty
         .try_upcast_to_callable(db)
-        .and_then(CallableTypes::exactly_one)
-    else {
-        return None;
-    };
+        .and_then(CallableTypes::exactly_one)?;
     let decorator_signatures = decorator_callable.signatures(db);
     let [decorator_signature] = decorator_signatures.overloads.as_slice() else {
         return None;
@@ -400,16 +397,10 @@ fn transparent_callable_decorator_result<'db>(
         return None;
     };
 
-    let Some((parameter_callable_paramspec, parameter_callable_return_typevar)) =
-        callable_paramspec_and_return_typevar(db, parameter.annotated_type())
-    else {
-        return None;
-    };
-    let Some((return_callable_paramspec, return_callable_typevar)) =
-        callable_paramspec_and_return_typevar(db, decorator_signature.return_ty)
-    else {
-        return None;
-    };
+    let (parameter_callable_paramspec, parameter_callable_return_typevar) =
+        callable_paramspec_and_return_typevar(db, parameter.annotated_type())?;
+    let (return_callable_paramspec, return_callable_typevar) =
+        callable_paramspec_and_return_typevar(db, decorator_signature.return_ty)?;
     (parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
         && parameter_callable_return_typevar.is_same_typevar_as(db, return_callable_typevar))
     .then_some(decorated_ty)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -361,6 +361,72 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
 /// An expression cache shared across builders during multi-inference.
 type ExpressionCache<'db> = FxHashMap<(ExpressionNodeKey, TypeContext<'db>), Type<'db>>;
 
+fn callable_paramspec_and_return_typevar<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<(BoundTypeVarInstance<'db>, BoundTypeVarInstance<'db>)> {
+    let callable = ty.resolve_type_alias(db).as_callable()?;
+    if callable.kind(db) != CallableTypeKind::Regular {
+        return None;
+    }
+    let [signature] = callable.signatures(db).overloads.as_slice() else {
+        return None;
+    };
+    let paramspec = signature.parameters().as_paramspec()?;
+    Some((paramspec, signature.return_ty.as_typevar()?))
+}
+
+fn is_transparent_callable_decorator<'db>(
+    db: &'db dyn Db,
+    decorator_ty: Type<'db>,
+    decorated_ty: Type<'db>,
+) -> bool {
+    if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
+        return false;
+    }
+    let Some(decorator_callable) = decorator_ty
+        .try_upcast_to_callable(db)
+        .and_then(CallableTypes::exactly_one)
+    else {
+        return false;
+    };
+    let decorator_signatures = decorator_callable.signatures(db);
+    let [decorator_signature] = decorator_signatures.overloads.as_slice() else {
+        return false;
+    };
+    let [parameter] = decorator_signature.parameters().as_slice() else {
+        return false;
+    };
+
+    let Some((parameter_callable_paramspec, parameter_callable_return_typevar)) =
+        callable_paramspec_and_return_typevar(db, parameter.annotated_type())
+    else {
+        return false;
+    };
+    let Some((return_callable_paramspec, return_callable_typevar)) =
+        callable_paramspec_and_return_typevar(db, decorator_signature.return_ty)
+    else {
+        return false;
+    };
+    parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
+        && parameter_callable_return_typevar.is_same_typevar_as(db, return_callable_typevar)
+}
+
+fn transparent_callable_decorator_result<'db>(
+    db: &'db dyn Db,
+    decorator_ty: Type<'db>,
+    decorated_ty: Type<'db>,
+) -> Option<Type<'db>> {
+    if !is_transparent_callable_decorator(db, decorator_ty, decorated_ty) {
+        return None;
+    }
+
+    decorated_ty
+        .try_upcast_to_callable(db)
+        .and_then(CallableTypes::exactly_one)
+        .map(Type::Callable)
+}
+
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// How big a string do we build before bailing?
     ///
@@ -3132,6 +3198,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
                     };
 
+                    let ty = if target.as_name_expr().is_some()
+                        && self
+                            .index
+                            .scope(self.scope().file_scope_id(self.db()))
+                            .kind()
+                            == ScopeKind::Class
+                    {
+                        self.apply_desugared_decorator(callable_type, call_expr, ty)
+                    } else {
+                        ty
+                    };
+
                     self.store_expression_type(value, ty);
                     ty
                 } else {
@@ -4680,6 +4758,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_expression(expression, TypeContext::default())
     }
 
+    /// Preserve the descriptor behavior of a transparent callable decorator when it is written
+    /// as the equivalent assignment form in a class body.
+    fn apply_desugared_decorator(
+        &mut self,
+        decorator_ty: Type<'db>,
+        call_expression: &ast::ExprCall,
+        return_ty: Type<'db>,
+    ) -> Type<'db> {
+        let arguments = &call_expression.arguments;
+        let [decorated_expression] = &arguments.args[..] else {
+            return return_ty;
+        };
+        if !arguments.keywords.is_empty() || decorated_expression.is_starred_expr() {
+            return return_ty;
+        }
+
+        let decorated_ty =
+            self.get_or_infer_expression(decorated_expression, TypeContext::default());
+        let call_arguments = CallArguments::positional([decorated_ty]);
+        if decorator_ty.try_call(self.db(), &call_arguments).is_err() {
+            return return_ty;
+        }
+
+        transparent_callable_decorator_result(self.db(), decorator_ty, decorated_ty)
+            .unwrap_or(return_ty)
+    }
+
     /// Apply a decorator to a function or class type and return the resulting type.
     ///
     /// Constructor semantics for class-like decorators are handled by `Type::bindings`, so we
@@ -4744,57 +4849,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        fn callable_paramspec_and_return_typevar<'db>(
-            db: &'db dyn Db,
-            ty: Type<'db>,
-        ) -> Option<(BoundTypeVarInstance<'db>, BoundTypeVarInstance<'db>)> {
-            let callable = ty.resolve_type_alias(db).as_callable()?;
-            if callable.kind(db) != CallableTypeKind::Regular {
-                return None;
-            }
-            let [signature] = callable.signatures(db).overloads.as_slice() else {
-                return None;
-            };
-            let paramspec = signature.parameters().as_paramspec()?;
-            Some((paramspec, signature.return_ty.as_typevar()?))
-        }
-
-        fn is_transparent_callable_decorator<'d>(
-            db: &'d dyn Db,
-            decorator_ty: Type<'d>,
-            decorated_ty: Type<'d>,
-        ) -> bool {
-            if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
-                return false;
-            }
-            let Some(decorator_callable) = decorator_ty
-                .try_upcast_to_callable(db)
-                .and_then(CallableTypes::exactly_one)
-            else {
-                return false;
-            };
-            let decorator_signatures = decorator_callable.signatures(db);
-            let [decorator_signature] = decorator_signatures.overloads.as_slice() else {
-                return false;
-            };
-            let [parameter] = decorator_signature.parameters().as_slice() else {
-                return false;
-            };
-
-            let Some((parameter_callable_paramspec, parameter_callable_return_typevar)) =
-                callable_paramspec_and_return_typevar(db, parameter.annotated_type())
-            else {
-                return false;
-            };
-            let Some((return_callable_paramspec, return_callable_typevar)) =
-                callable_paramspec_and_return_typevar(db, decorator_signature.return_ty)
-            else {
-                return false;
-            };
-            parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
-                && parameter_callable_return_typevar.is_same_typevar_as(db, return_callable_typevar)
-        }
-
         // For FunctionLiteral, get the kind directly without computing the full signature.
         // This avoids a query cycle when the function has default parameter values, since
         // computing the signature requires evaluating those defaults which may trigger
@@ -4833,12 +4887,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // TODO: Remove this special case once the new constraint solver can preserve
         // per-overload ParamSpec/return correlations for `Callable[P, R] -> Callable[P, R]`.
         if decorator_call_succeeded
-            && is_transparent_callable_decorator(self.db(), decorator_ty, decorated_ty)
-            && let Some(callable) = decorated_ty
-                .try_upcast_to_callable(self.db())
-                .and_then(CallableTypes::exactly_one)
+            && let Some(result) =
+                transparent_callable_decorator_result(self.db(), decorator_ty, decorated_ty)
         {
-            return Type::Callable(callable);
+            return result;
         }
 
         // When a method on a class is decorated with a function that returns a


### PR DESCRIPTION
## Summary

Recognize transparent callable decorators in class-body assignment form, not just decorator syntax. Preserve descriptor behavior when a decorator `Callable[P, R] -> Callable[P, R]` is called in an assignment to a method name inside a class.

Closes https://github.com/astral-sh/ty/issues/3961

## Testing

Update mdtests.