### PR TITLE
[ty] Refactor the syntax helpers that are used to parse field headers in docstrings

### DIFF
--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -32,13 +32,14 @@ use std::cmp::Ordering;
 
 use indexmap::IndexMap;
 use ruff_python_stdlib::identifiers::is_identifier;
+use ruff_python_trivia::Cursor;
 use ruff_text_size::{TextRange, TextSize};
 
 use super::SectionKind;
 use super::preformatted::PreformattedBlockScanner;
 use super::syntax::{
-    ParsedLine, container_block_end, parse_parenthesized_type, parsed_lines,
-    split_once_unbracketed_colon,
+    ParsedLine, consume_quoted_string, container_block_end, parsed_lines,
+    split_once_at_top_level_colon, split_trailing_parenthetical,
 };
 
 /// Returns parameter documentation from recognized Google-style parameter sections.
@@ -156,12 +157,129 @@ fn extend_parameter_documentation(parameters: &mut Parameters, lines: &[ParsedLi
 
 /// Parses a parameter item into its display name and description.
 fn parse_parameter(line: &str) -> Option<(&str, &str)> {
-    let (name, description) = split_once_unbracketed_colon(line)?;
-    let (display_name, _) = parse_parenthesized_type(name.trim());
+    let (display_name, description) =
+        if let Some((name, description)) = split_once_at_field_delimiter(line) {
+            let (display_name, _ty) = split_name_and_type(name.trim());
+            (display_name, description)
+        } else {
+            // If malformed type syntax hides the delimiter, recover the conventional field shape
+            // and discard the type.
+            recover_parameter_without_type(line)?
+        };
 
     google_parameter_names(display_name)
         .is_some()
         .then_some((display_name, description.trim()))
+}
+
+/// Splits at the field delimiter, skipping top-level colons in reST roles.
+///
+/// For example, ``:exc:`ValueError`: description`` returns
+/// ``(":exc:`ValueError`", " description")``.
+fn split_once_at_field_delimiter(line: &str) -> Option<(&str, &str)> {
+    let mut cursor = Cursor::new(line);
+    loop {
+        let (before_colon, after_colon) = split_once_at_top_level_colon(cursor.as_str())?;
+        cursor.skip_bytes(before_colon.len());
+
+        if consume_rest_prefix_role(&mut cursor) {
+            continue;
+        }
+
+        return Some((&line[..cursor.offset().to_usize()], after_colon));
+    }
+}
+
+/// Consumes the prefix-role pattern recognized by the field parser, leaving the cursor unchanged
+/// otherwise.
+///
+/// For example, this consumes the entire input:
+///
+/// ```text
+/// :exc:`ValueError`
+/// ```
+fn consume_rest_prefix_role(cursor: &mut Cursor<'_>) -> bool {
+    let mut role = cursor.clone();
+
+    // First, require the candidate delimiter to be the opening colon of a role.
+    if !role.eat_char(':') {
+        return false;
+    }
+
+    // Role names start with a Unicode alphanumeric run. Rejecting punctuation here preserves the
+    // first colon in `value::class:` as the field delimiter.
+    if !role.eat_if(char::is_alphanumeric) {
+        return false;
+    }
+
+    // Next, scan the rest of the role name until its closing colon and the opening content
+    // backtick.
+    loop {
+        role.eat_while(char::is_alphanumeric);
+        if role.eat_char2(':', '`') {
+            break;
+        }
+
+        // `-._+:` separators are allowed, but only internally to alphanumeric characters.
+        if !role.eat_if(|character| matches!(character, '-' | '.' | '_' | '+' | ':'))
+            || !role.eat_if(char::is_alphanumeric)
+        {
+            return false;
+        }
+    }
+
+    // Finally, skip the role content so delimiter scanning resumes after its closing backtick.
+    role.eat_while(|character| character != '`');
+    if !role.eat_char('`') {
+        return false;
+    }
+
+    *cursor = role;
+    true
+}
+
+/// Splits a display name from a trailing parenthesized type.
+///
+/// For example, `"value (str)"` yields `("value", Some("str"))`.
+fn split_name_and_type(value: &str) -> (&str, Option<&str>) {
+    let Some((name, ty)) = split_trailing_parenthetical(value) else {
+        return (value, None);
+    };
+
+    if name.is_empty() || ty.is_empty() {
+        (value, None)
+    } else {
+        (name, Some(ty))
+    }
+}
+
+/// Implements a simple heuristic to recover a parameter name and description
+/// from a line with a malformed type.
+///
+/// This assumes the first `" ("` begins the type and the first unquoted `")"` followed by
+/// optional whitespace and `":"` ends it.
+///
+/// For example, `"value (list[str) : description"` yields the name `"value"` and description
+/// `" description"`.
+fn recover_parameter_without_type(line: &str) -> Option<(&str, &str)> {
+    let (display_name, remainder) = line.split_once(" (")?;
+    let mut cursor = Cursor::new(remainder);
+
+    while let Some(character) = cursor.bump() {
+        match character {
+            '\'' | '"' => consume_quoted_string(&mut cursor, character),
+            ')' => {
+                let mut delimiter = cursor.clone();
+                delimiter.eat_while(char::is_whitespace);
+                if delimiter.eat_char(':') {
+                    return Some((display_name.trim(), delimiter.as_str()));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
 }
 
 /// Returns whether `name` is a valid Python parameter name, including variadic prefixes.
@@ -366,7 +484,7 @@ fn section_item_indent(header: SectionHeader, line: ParsedLine<'_>) -> Option<Te
             SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters,
         ) => parse_parameter(trimmed).is_some(),
         HeaderKind::Structured(SectionKind::Attributes | SectionKind::Raises) => {
-            split_once_unbracketed_colon(trimmed).is_some_and(|(name, _)| !name.trim().is_empty())
+            split_once_at_field_delimiter(trimmed).is_some_and(|(name, _)| !name.trim().is_empty())
         }
         HeaderKind::Structured(SectionKind::Returns | SectionKind::Yields) => !trimmed.is_empty(),
         HeaderKind::Opaque => false,
@@ -382,7 +500,7 @@ fn is_inline_section_header(line: &str) -> bool {
         return false;
     }
 
-    let Some((name, description)) = split_once_unbracketed_colon(line) else {
+    let Some((name, description)) = split_once_at_top_level_colon(line) else {
         return false;
     };
 
@@ -438,7 +556,9 @@ mod tests {
     use itertools::Itertools;
     use ruff_text_size::TextSize;
 
-    use super::{SectionKind, parameter_documentation, parsed_lines, sections};
+    use super::{
+        SectionKind, parameter_documentation, parsed_lines, sections, split_once_at_field_delimiter,
+    };
 
     #[test]
     fn extracts_aligned_parameter_items() {
@@ -502,7 +622,7 @@ Partition into non-overlapping windows with padding if needed.
     }
 
     #[test]
-    fn extracts_parameter_with_unbalanced_type_brackets() {
+    fn extracts_parameter_despite_unbalanced_type_brackets() {
         let raw = "\
 Args:
     query_embeddings (`Union[torch.Tensor, list[torch.Tensor]`): Query embeddings.";
@@ -510,6 +630,30 @@ Args:
         assert_snapshot!(display_parameters(raw), @"
         query_embeddings:
           │ Query embeddings.
+        ");
+    }
+
+    #[test]
+    fn recovers_parameter_after_quoted_delimiter_in_malformed_type() {
+        let raw = "\
+Args:
+    value (Literal['):'], list[str): Actual description.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        value:
+          │ Actual description.
+        ");
+    }
+
+    #[test]
+    fn recovers_parameter_after_spaced_delimiter_in_malformed_type() {
+        let raw = "\
+Args:
+    value (list[str) : Description.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        value:
+          │ Description.
         ");
     }
 
@@ -1088,6 +1232,52 @@ Additional details.";
 Returns:
     bool: Result.",
             )]
+        );
+    }
+
+    #[test]
+    fn skips_rest_roles_before_field_delimiter() {
+        assert_eq!(
+            split_once_at_field_delimiter(":py:class:`ValueError`: Invalid value."),
+            Some((":py:class:`ValueError`", " Invalid value."))
+        );
+        assert_eq!(
+            split_once_at_field_delimiter(":external+python:py:class:`ValueError`: Invalid value."),
+            Some((":external+python:py:class:`ValueError`", " Invalid value."))
+        );
+        assert_eq!(
+            split_once_at_field_delimiter(":étiquette:`valeur`: Description."),
+            Some((":étiquette:`valeur`", " Description."))
+        );
+    }
+
+    #[test]
+    fn does_not_skip_invalid_rest_roles() {
+        for (line, description) in [
+            ("value:foo..bar:`X`", "foo..bar:`X`"),
+            ("value:foo-:`X`", "foo-:`X`"),
+        ] {
+            assert_eq!(
+                split_once_at_field_delimiter(line),
+                Some(("value", description)),
+                "{line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn splits_before_rest_role_adjacent_to_field_delimiter() {
+        assert_eq!(
+            split_once_at_field_delimiter("value::class:`Widget` description."),
+            Some(("value", ":class:`Widget` description."))
+        );
+    }
+
+    #[test]
+    fn does_not_split_at_rest_roles_in_prose() {
+        assert_eq!(
+            split_once_at_field_delimiter("Typically :class:`Intermediate` or a subclass is used."),
+            None
         );
     }
 

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -1,4 +1,4 @@
-use ruff_python_trivia::{leading_indentation, tab_offset_u32};
+use ruff_python_trivia::{Cursor, leading_indentation, tab_offset_u32};
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{TextRange, TextSize};
 
@@ -107,6 +107,9 @@ pub(in crate::docstring) fn is_backtick_run_escaped(text: &str, index: usize) ->
 }
 
 /// Returns the end of an indented Markdown or reStructuredText container block.
+///
+/// For example, in `["- item", "  first", "  second", "next"]`, the block at index 0 ends
+/// at index 3.
 pub(super) fn container_block_end(lines: &[ParsedLine<'_>], index: usize) -> Option<usize> {
     let marker = lines.get(index)?;
     if !is_rest_directive_marker(marker.text)
@@ -137,100 +140,119 @@ fn is_rest_directive_marker(line: &str) -> bool {
     !name.is_empty() && !name.chars().any(char::is_whitespace)
 }
 
-/// Splits the input once at the first colon outside bracket pairs and quoted strings.
-pub(super) fn split_once_unbracketed_colon(line: &str) -> Option<(&str, &str)> {
-    let mut depths = [0usize; 3];
-    let mut quote = None;
-    let mut escaped = false;
-    let mut fallback_colon = None;
+/// Splits at the first top-level colon, ignoring colons inside brackets and quoted strings.
+///
+/// Bracket kinds are tracked independently, so mismatched nesting such as `([a)]` is treated as
+/// balanced. This is sufficient because callers only need to find a delimiter after all bracket
+/// groups close; validating the surrounding syntax is outside this helper's scope.
+///
+/// For example, `"value (Literal['a:b']): description"` splits before `"description"`, not at
+/// the colon inside the quoted string.
+/// Returns `None` if every colon is inside a bracket group, including an unclosed one.
+pub(super) fn split_once_at_top_level_colon(line: &str) -> Option<(&str, &str)> {
+    let mut nesting = BracketNesting::default();
+    let mut cursor = Cursor::new(line);
 
-    for (index, character) in line.char_indices() {
-        if let Some(quote_character) = quote {
-            if escaped {
-                escaped = false;
-            } else if character == '\\' {
-                escaped = true;
-            } else if character == quote_character {
-                quote = None;
-            }
-            continue;
-        }
-
+    while let Some(character) = cursor.bump() {
         match character {
-            '\'' | '"' => quote = Some(character),
-            '(' => depths[0] += 1,
-            ')' => depths[0] = depths[0].saturating_sub(1),
-            '[' => depths[1] += 1,
-            ']' => depths[1] = depths[1].saturating_sub(1),
-            '{' => depths[2] += 1,
-            '}' => depths[2] = depths[2].saturating_sub(1),
-            ':' if depths == [0; 3] => {
-                return Some((&line[..index], &line[index + character.len_utf8()..]));
+            '\'' | '"' => consume_quoted_string(&mut cursor, character),
+            ':' if nesting.is_top_level() => {
+                let index = cursor.offset().to_usize() - character.len_utf8();
+                return Some((&line[..index], cursor.as_str()));
             }
-            // Retain a colon outside parentheses as a fallback. This recovers an item delimiter
-            // after malformed square or curly brackets while preferring a fully balanced split.
-            ':' if depths[0] == 0 && fallback_colon.is_none() => fallback_colon = Some(index),
+            _ => nesting.update(character),
+        }
+    }
+
+    None
+}
+
+#[derive(Default)]
+struct BracketNesting {
+    parentheses: usize,
+    square: usize,
+    curly: usize,
+}
+
+impl BracketNesting {
+    fn is_top_level(&self) -> bool {
+        self.parentheses == 0 && self.square == 0 && self.curly == 0
+    }
+
+    /// Updates the nesting depth while tolerating unmatched closing brackets.
+    ///
+    /// For example, `'('` increments the parenthesis depth and a later `')'` decrements it.
+    fn update(&mut self, character: char) {
+        match character {
+            '(' => self.parentheses += 1,
+            ')' => self.parentheses = self.parentheses.saturating_sub(1),
+            '[' => self.square += 1,
+            ']' => self.square = self.square.saturating_sub(1),
+            '{' => self.curly += 1,
+            '}' => self.curly = self.curly.saturating_sub(1),
             _ => {}
         }
     }
-
-    fallback_colon.map(|index| (&line[..index], &line[index + ':'.len_utf8()..]))
 }
 
-/// Splits a trailing parenthesized type from a parameter display name.
-pub(super) fn parse_parenthesized_type(name: &str) -> (&str, Option<&str>) {
-    if !name.ends_with(')') {
-        return (name, None);
+/// Advances past a quoted string after its opening quote has been consumed.
+///
+/// For example, after the opening quote in `"value" trailing` has been consumed, a cursor over
+/// `value" trailing` with `quote` set to `'"'` advances to ` trailing`.
+pub(super) fn consume_quoted_string(cursor: &mut Cursor<'_>, quote: char) {
+    while let Some(character) = cursor.bump() {
+        if character == '\\' {
+            cursor.bump();
+        } else if character == quote {
+            break;
+        }
+    }
+}
+
+/// Splits and trims the prefix and contents of a trailing parenthetical expression.
+///
+/// Parentheses inside quoted strings and Markdown code spans do not affect nesting.
+///
+/// For example, `"value (Callable[[int], str])"` splits into `"value"` and
+/// `"Callable[[int], str]"`.
+pub(super) fn split_trailing_parenthetical(value: &str) -> Option<(&str, &str)> {
+    if !value.ends_with(')') {
+        return None;
     }
 
     let mut depth = 0usize;
-    let mut opening = None;
-    let mut quote = None;
-    let mut escaped = false;
+    let mut outermost_opening = None;
+    let mut cursor = Cursor::new(value);
 
-    for (index, character) in name.char_indices() {
-        if let Some(quote_character) = quote {
-            if escaped {
-                escaped = false;
-            } else if character == '\\' {
-                escaped = true;
-            } else if character == quote_character {
-                quote = None;
-            }
-            continue;
-        }
-
+    while let Some(character) = cursor.bump() {
+        let index = cursor.offset().to_usize() - character.len_utf8();
         match character {
-            '\'' | '"' => quote = Some(character),
+            '\'' | '"' => consume_quoted_string(&mut cursor, character),
+            '`' if !is_backtick_run_escaped(value, index) => {
+                let opening = find_backtick_run(value, TextSize::of(&value[..index]))?;
+                let span = markdown_code_span(value, opening).unwrap_or(opening);
+                cursor.skip_bytes((span.end() - cursor.offset()).to_usize());
+            }
             '(' => {
                 if depth == 0 {
-                    opening = Some(index);
+                    outermost_opening = Some(index);
                 }
                 depth += 1;
             }
             ')' => {
-                depth = match depth.checked_sub(1) {
-                    Some(depth) => depth,
-                    None => return (name, None),
-                };
-                if depth == 0 && index + character.len_utf8() == name.len() {
-                    let Some(opening) = opening else {
-                        return (name, None);
-                    };
-                    let display_name = name[..opening].trim();
-                    let ty = name[opening + '('.len_utf8()..index].trim();
-
-                    return if display_name.is_empty() || ty.is_empty() {
-                        (name, None)
-                    } else {
-                        (display_name, Some(ty))
-                    };
+                depth = depth.checked_sub(1)?;
+                if depth == 0 && cursor.is_eof() {
+                    let opening = outermost_opening?;
+                    let prefix = value[..opening].trim();
+                    let contents = value[opening + '('.len_utf8()..index].trim();
+                    return Some((prefix, contents));
                 }
             }
             _ => {}
         }
     }
-    (name, None)
+
+    None
 }
 
 /// Calculates indentation width, advancing tabs to the next multiple of eight columns.
@@ -247,7 +269,9 @@ pub(super) fn indentation(line: &str) -> TextSize {
 
 #[cfg(test)]
 mod tests {
-    use super::is_markdown_code_span;
+    use super::{
+        is_markdown_code_span, split_once_at_top_level_colon, split_trailing_parenthetical,
+    };
 
     #[test]
     fn recognizes_complete_markdown_code_spans() {
@@ -263,5 +287,97 @@ mod tests {
         ] {
             assert_eq!(is_markdown_code_span(text), expected, "{text:?}");
         }
+    }
+
+    #[test]
+    fn splits_after_nested_brackets() {
+        assert_eq!(
+            split_once_at_top_level_colon("value (dict[str, list[{key: value}]]): Description"),
+            Some(("value (dict[str, list[{key: value}]])", " Description"))
+        );
+    }
+
+    #[test]
+    fn ignores_colons_inside_quoted_strings() {
+        assert_eq!(
+            split_once_at_top_level_colon(r"value (Literal['a\'b:c']): Description"),
+            Some((r"value (Literal['a\'b:c'])", " Description"))
+        );
+    }
+
+    #[test]
+    fn treats_backticks_as_plain_text() {
+        assert_eq!(
+            split_once_at_top_level_colon("value (`str): Description such as `.py`."),
+            Some(("value (`str)", " Description such as `.py`."))
+        );
+    }
+
+    #[test]
+    fn ignores_colons_inside_balanced_brackets() {
+        for line in ["value [a:b]", "value {a:b}"] {
+            assert_eq!(split_once_at_top_level_colon(line), None, "{line:?}");
+        }
+    }
+
+    #[test]
+    fn does_not_split_inside_unclosed_brackets() {
+        for line in [
+            "value (str: Description",
+            "value [str: Description",
+            "value {str: Description",
+        ] {
+            assert_eq!(split_once_at_top_level_colon(line), None, "{line:?}");
+        }
+    }
+
+    #[test]
+    fn splits_trailing_parenthesized_group() {
+        assert_eq!(
+            split_trailing_parenthetical(" value  (  str  )"),
+            Some(("value", "str"))
+        );
+    }
+
+    #[test]
+    fn splits_nested_parenthesized_group() {
+        assert_eq!(
+            split_trailing_parenthetical("value (Callable[(int), tuple[str]])"),
+            Some(("value", "Callable[(int), tuple[str]]"))
+        );
+    }
+
+    #[test]
+    fn ignores_parentheses_inside_quoted_strings() {
+        assert_eq!(
+            split_trailing_parenthetical("value (Literal[')'])"),
+            Some(("value", "Literal[')']"))
+        );
+    }
+
+    #[test]
+    fn ignores_parentheses_inside_code_spans() {
+        assert_eq!(
+            split_trailing_parenthetical("value (`(`)"),
+            Some(("value", "`(`"))
+        );
+    }
+
+    #[test]
+    fn ignores_parentheses_after_escaped_quotes() {
+        assert_eq!(
+            split_trailing_parenthetical(r#"value (Literal["a\"b)c"])"#),
+            Some(("value", r#"Literal["a\"b)c"]"#))
+        );
+    }
+
+    #[test]
+    fn rejects_unclosed_parenthesized_group() {
+        assert_eq!(split_trailing_parenthetical("value (str"), None);
+    }
+
+    #[test]
+    fn rejects_parenthesized_group_before_trailing_text() {
+        assert_eq!(split_trailing_parenthetical("value (str) or None"), None);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This change refactors some syntax primitives such that they can be more easily shared between the existing Google-style docstring parser and the [upcoming NumPy-style docstring parser](https://github.com/astral-sh/ruff/pull/25924).

The previous helpers combined delimiter scanning with Google-specific semantic interpretation. This change replaces them with two format-agnostic operations:

- `split_once_at_top_level_colon` finds a field separator while ignoring colons inside brackets and quoted strings.
- `split_trailing_parenthetical` returns the prefix and contents of a balanced trailing parenthesized group without assigning meaning to either.

Each docstring parser is then responsible for layering semantics on top of those primitives. Google combines those operations to parse `name (type): description`, while the downstream NumPy parser uses them for both `name : type` fields and call-style return types like `tuple(str, int)`.

## Test Plan

See included tests.

<!-- How was it tested? -->
