### PR TITLE
[ty] Prevent type that is written with a code span from being incorrectly re-wrapped during docstring Markdown rendering

### DIFF
--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -50,6 +50,14 @@ pub(in crate::docstring) fn starts_with_markdown_list_item(line: &str) -> bool {
         && matches!(bytes.get(digits + 1), Some(b' ' | b'\t'))
 }
 
+/// Returns whether `text` consists of a complete Markdown code span.
+///
+/// For example, this returns `true` for ``"`value`"`` and `false` for
+/// ``"`value` trailing"``.
+pub(in crate::docstring) fn is_markdown_code_span(text: &str) -> bool {
+    markdown_code_span_len(text) == Some(TextSize::of(text))
+}
+
 /// Returns the length of a complete Markdown code span at the start of `text`.
 ///
 /// For example, given `text` equal to ``"`value` trailing"``, the returned length covers only

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -50,6 +50,47 @@ pub(in crate::docstring) fn starts_with_markdown_list_item(line: &str) -> bool {
         && matches!(bytes.get(digits + 1), Some(b' ' | b'\t'))
 }
 
+/// Returns the length of a complete Markdown code span at the start of `text`.
+///
+/// For example, given `text` equal to ``"`value` trailing"``, the returned length covers only
+/// ``"`value`"``.
+///
+/// Lengths are measured in UTF-8 bytes. A closing backtick run must be the same length as the
+/// opening run.
+pub(in crate::docstring) fn markdown_code_span_len(text: &str) -> Option<TextSize> {
+    let opening = find_backtick_run(text, TextSize::ZERO)?;
+    if opening.start() != TextSize::ZERO {
+        return None;
+    }
+
+    let mut search_from = opening.end();
+    while let Some(closing) = find_backtick_run(text, search_from) {
+        if closing.len() == opening.len() {
+            return Some(closing.end());
+        }
+        search_from = closing.end();
+    }
+
+    None
+}
+
+/// Returns the byte range of the first consecutive backtick run at or after `from`.
+///
+/// For example, searching ``"value `code`"`` from the start returns the range covering the
+/// opening ``"`"``.
+pub(in crate::docstring) fn find_backtick_run(text: &str, from: TextSize) -> Option<TextRange> {
+    let from = from.to_usize();
+    let start = from + text.get(from..)?.find('`')?;
+    let len = text[start..]
+        .bytes()
+        .take_while(|byte| *byte == b'`')
+        .count();
+    Some(TextRange::new(
+        TextSize::of(&text[..start]),
+        TextSize::of(&text[..start + len]),
+    ))
+}
+
 /// Returns the end of an indented Markdown or reStructuredText container block.
 pub(super) fn container_block_end(lines: &[ParsedLine<'_>], index: usize) -> Option<usize> {
     let marker = lines.get(index)?;
@@ -187,4 +228,30 @@ pub(super) fn indentation(line: &str) -> TextSize {
                 _ => column + 1,
             }),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_text_size::TextSize;
+
+    use super::markdown_code_span_len;
+
+    #[test]
+    fn finds_markdown_code_span_len() {
+        assert_eq!(
+            markdown_code_span_len("`value` trailing"),
+            Some(TextSize::of("`value`"))
+        );
+        assert_eq!(
+            markdown_code_span_len("``value`with:ticks``"),
+            Some(TextSize::of("``value`with:ticks``"))
+        );
+        assert_eq!(
+            markdown_code_span_len("`first` second`"),
+            Some(TextSize::of("`first`"))
+        );
+        assert_eq!(markdown_code_span_len("``value```"), None);
+        assert_eq!(markdown_code_span_len("``"), None);
+        assert_eq!(markdown_code_span_len("value"), None);
+    }
 }

--- a/crates/ty_ide/src/docstring/markdown/general/inline.rs
+++ b/crates/ty_ide/src/docstring/markdown/general/inline.rs
@@ -49,6 +49,10 @@
 
 use std::borrow::Cow;
 
+use ruff_text_size::TextSize;
+
+use crate::docstring::document::syntax::{find_backtick_run, markdown_code_span_len};
+
 /// Exposes an interface for rendering a line of prose that may contain a hyperlink.
 #[derive(Default)]
 pub(super) struct Renderer {
@@ -272,21 +276,20 @@ enum Candidate<'a> {
 
 /// Finds the first complete hyperlink or plausible wrapped candidate in `input`.
 fn find_link(input: &str) -> Option<(usize, Candidate<'_>)> {
-    let mut offset = 0;
+    let mut offset = TextSize::ZERO;
 
     // Visit each backtick run that could delimit inline markup.
-    while let Some(relative_index) = input[offset..].find('`') {
-        let index = offset + relative_index;
-        let tick_count = leading_backtick_count(&input[index..]);
+    while let Some(run) = find_backtick_run(input, offset) {
+        let index = run.start().to_usize();
 
         // An escaped run is literal text, so continue immediately after it.
         if is_escaped(input, index) {
-            offset = index + tick_count;
+            offset = run.end();
             continue;
         }
 
         // Try parsing a link only when a single backtick has valid surrounding characters.
-        if tick_count == 1
+        if run.len() == TextSize::new(1)
             && is_link_start(input, index)
             && let Some(candidate) = parse_candidate(&input[index..])
         {
@@ -294,9 +297,8 @@ fn find_link(input: &str) -> Option<(usize, Candidate<'_>)> {
         }
 
         // Skip other backtick-delimited spans rather than searching inside them.
-        let after_opening = index + tick_count;
-        let closing_end = find_closing_backtick_run(&input[after_opening..], tick_count)?;
-        offset = after_opening + closing_end;
+        let span_len = markdown_code_span_len(&input[index..])?;
+        offset = run.start() + span_len;
     }
 
     None
@@ -316,7 +318,7 @@ fn parse_candidate(input: &str) -> Option<Candidate<'_>> {
         return None;
     }
 
-    let Some(relative_closing) = after_opening.find('`') else {
+    let Some(closing) = find_backtick_run(input, TextSize::new(1)) else {
         // Eliminate candidates whose content already contains a disallowed
         // backslash or closing `>`, or whose target cannot become HTTP(S). A
         // partial URI scheme remains valid so it can wrap immediately after
@@ -330,22 +332,21 @@ fn parse_candidate(input: &str) -> Option<Candidate<'_>> {
         }
         return Some(Candidate::Pending);
     };
-    let closing_index = relative_closing + 1;
-    if leading_backtick_count(&input[closing_index..]) != 1 {
+    if closing.len() != TextSize::new(1) {
         return None;
     }
 
-    let content = &input[1..closing_index];
+    let content = &input[1..closing.start().to_usize()];
     if content.contains('\\') {
         return None;
     }
 
-    let after_closing = &input[closing_index + 1..];
+    let after_closing = &input[closing.end().to_usize()..];
     let underscore_count = after_closing
         .bytes()
         .take_while(|byte| *byte == b'_')
         .count();
-    let len = closing_index + 1 + underscore_count;
+    let len = closing.end().to_usize() + underscore_count;
     if !(1..=2).contains(&underscore_count) || !is_link_suffix(&after_closing[underscore_count..]) {
         return None;
     }
@@ -464,25 +465,6 @@ fn is_rst_section_adornment(line: &str) -> bool {
         return false;
     };
     marker.is_ascii_punctuation() && characters.all(|character| character == marker)
-}
-
-fn leading_backtick_count(input: &str) -> usize {
-    input.bytes().take_while(|byte| *byte == b'`').count()
-}
-
-fn find_closing_backtick_run(input: &str, opening_tick_count: usize) -> Option<usize> {
-    let mut offset = 0;
-
-    while let Some(relative_index) = input[offset..].find('`') {
-        let index = offset + relative_index;
-        let tick_count = leading_backtick_count(&input[index..]);
-        if tick_count == opening_tick_count {
-            return Some(index + tick_count);
-        }
-        offset = index + tick_count;
-    }
-
-    None
 }
 
 /// Returns whether the backtick at `index` may begin inline markup.

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -6,7 +6,7 @@ use strum::IntoEnumIterator;
 use super::general;
 use crate::docstring::document::SectionKind;
 use crate::docstring::document::preformatted::MarkdownFence;
-use crate::docstring::document::syntax::starts_with_markdown_list_item;
+use crate::docstring::document::syntax::{is_markdown_code_span, starts_with_markdown_list_item};
 
 mod rst;
 
@@ -320,6 +320,12 @@ fn description_block_start(description: &str) -> Option<usize> {
 
 fn render_type_code_span_into(output: &mut String, ty: &str) {
     let normalized = normalize_type_for_code_span(ty);
+
+    if is_markdown_code_span(&normalized) {
+        output.push_str(&normalized);
+        return;
+    }
+
     render_code_span_into(output, normalized.as_ref());
 }
 

--- a/crates/ty_ide/src/docstring/markdown/structured/rst.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/rst.rs
@@ -262,6 +262,21 @@ Summary.
     }
 
     #[test]
+    fn preserve_code_span_wrapped_type() {
+        let docstring = "\
+:param value: The value.
+:type value: `str`
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        ## Parameters
+        **value**: `str`  
+        The value.
+        ");
+    }
+
+    #[test]
     fn render_returns_with_supplemental_type() {
         let docstring = "\
 Summary.


### PR DESCRIPTION

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This does two things:

1. (abe15fe4) It refactors and consolidates the helpers that we use for parsing runs of backticks (which denote the opening and closing of Markdown fences). This lays a foundation for [rendering Google- and NumPy- style docstrings](https://github.com/astral-sh/ty/issues/1667)[^1].

2. (3acd8a4d) It fixes a bug in Markdown rendering for reStructuredText docstrings. Previously the parameter type in the following docstring would incorrectly be rendered as a code span containing literal backticks (i.e., `` `str` ``), because we would re-wrap the type in another set of backticks:

    ```text
    :param value: The value.
    :type value: `str`
    ```

    With this change, we now output a type that is already wrapped verbatim (so that the above example renders as `str`).

[^1]: Google- and NumPy- style docstrings may contain types that are already wrapped in code spans:

    ```text
    Args:
        value (`str`): The value.
    ```
    
    ```text
    Parameters
    ----------
    value : `str`
        The value.
    ```

## Test Plan

See included tests.
<!-- How was it tested? -->
