### PR TITLE
[ty] Freeze retained parser errors

### DIFF
--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -415,8 +415,8 @@ impl<T> Parsed<T> {
     }
 
     /// Consumes the [`Parsed`] output and returns a list of syntax errors found during parsing.
-    pub fn into_errors(self) -> Vec<ParseError> {
-        self.errors.into_vec()
+    pub fn into_errors(self) -> Box<[ParseError]> {
+        self.errors
     }
 
     /// Returns `true` if the parsed source code is valid i.e., it has no [`ParseError`]s.

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -367,9 +367,6 @@ pub fn parse_cells_unchecked(
 
     body.shrink_to_fit();
     tokens.shrink_to_fit();
-    errors.shrink_to_fit();
-    unsupported_syntax_errors.shrink_to_fit();
-
     Parsed {
         syntax: ModModule {
             node_index: AtomicNodeIndex::NONE,
@@ -377,8 +374,8 @@ pub fn parse_cells_unchecked(
             body,
         },
         tokens: Tokens::new(tokens),
-        errors,
-        unsupported_syntax_errors,
+        errors: errors.into_boxed_slice(),
+        unsupported_syntax_errors: unsupported_syntax_errors.into_boxed_slice(),
     }
 }
 
@@ -387,8 +384,8 @@ pub fn parse_cells_unchecked(
 pub struct Parsed<T> {
     syntax: T,
     tokens: Tokens,
-    errors: Vec<ParseError>,
-    unsupported_syntax_errors: Vec<UnsupportedSyntaxError>,
+    errors: Box<[ParseError]>,
+    unsupported_syntax_errors: Box<[UnsupportedSyntaxError]>,
 }
 
 impl<T> Parsed<T> {
@@ -419,7 +416,7 @@ impl<T> Parsed<T> {
 
     /// Consumes the [`Parsed`] output and returns a list of syntax errors found during parsing.
     pub fn into_errors(self) -> Vec<ParseError> {
-        self.errors
+        self.errors.into_vec()
     }
 
     /// Returns `true` if the parsed source code is valid i.e., it has no [`ParseError`]s.

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -219,8 +219,8 @@ impl<'src> Parser<'src> {
             return Parsed {
                 syntax,
                 tokens: Tokens::new(tokens),
-                errors: parse_errors,
-                unsupported_syntax_errors: self.unsupported_syntax_errors,
+                errors: parse_errors.into_boxed_slice(),
+                unsupported_syntax_errors: self.unsupported_syntax_errors.into_boxed_slice(),
             };
         }
 
@@ -251,8 +251,8 @@ impl<'src> Parser<'src> {
         Parsed {
             syntax,
             tokens: Tokens::new(tokens),
-            errors: merged,
-            unsupported_syntax_errors: self.unsupported_syntax_errors,
+            errors: merged.into_boxed_slice(),
+            unsupported_syntax_errors: self.unsupported_syntax_errors.into_boxed_slice(),
         }
     }
 


### PR DESCRIPTION
## Summary

Store finalized parser and unsupported-syntax errors as boxed slices instead of `Vec`s. Parsing still accumulates errors normally, then freezes the collections when constructing `Parsed`; the consuming API continues to return a `Vec` where required.

This avoids retaining two vector headers and spare error capacity for every cached parsed module. The Flake8 memory report measured an approximately 22 kB (0.06%) total-memory reduction from this change. Parser unit tests and all parser fixtures pass.