### PR TITLE
[ty] Compact retained decorator inference

### DIFF
--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -209,10 +209,15 @@ pub(crate) fn function_known_decorator_flags<'db>(
 #[derive(Debug, Eq, PartialEq, Default, salsa::Update, get_size2::GetSize)]
 pub(crate) struct FunctionDecoratorInference<'db> {
     expression_types: FrozenMap<ExpressionNodeKey, Type<'db>>,
-    bindings: Box<[(Definition<'db>, Type<'db>)]>,
-    called_functions: Box<[FunctionType<'db>]>,
     known_decorators: FunctionDecorators,
     diagnostics: TypeCheckDiagnostics,
+    extra: Option<Box<FunctionDecoratorInferenceExtra<'db>>>,
+}
+
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+struct FunctionDecoratorInferenceExtra<'db> {
+    bindings: Box<[(Definition<'db>, Type<'db>)]>,
+    called_functions: Box<[FunctionType<'db>]>,
 }
 
 impl<'db> FunctionDecoratorInference<'db> {
@@ -232,11 +237,17 @@ impl<'db> FunctionDecoratorInference<'db> {
     pub(crate) fn bindings(
         &self,
     ) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> + '_ {
-        self.bindings.iter().copied()
+        self.extra
+            .as_deref()
+            .map_or(&[][..], |extra| extra.bindings.as_ref())
+            .iter()
+            .copied()
     }
 
     pub(crate) fn called_functions(&self) -> &[FunctionType<'db>] {
-        &self.called_functions
+        self.extra
+            .as_deref()
+            .map_or(&[], |extra| extra.called_functions.as_ref())
     }
 
     pub(crate) fn known_decorators(&self) -> FunctionDecorators {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -25,9 +25,10 @@ use ty_python_core::statement::StatementInner;
 use super::{
     DeferredAndUndecorated, DefinitionInference, DefinitionInferenceExtra, DefinitionTypes,
     ExpressionInference, ExpressionInferenceExtra, FrozenMap, FrozenSet, FrozenValueMap,
-    FunctionDecoratorInference, InferenceRegion, OtherDefinitionInferenceExtra, ScopeInference,
-    ScopeInferenceExtra, infer_deferred_types, infer_definition_types, infer_expression_types,
-    infer_same_file_expression_type, infer_unpack_types,
+    FunctionDecoratorInference, FunctionDecoratorInferenceExtra, InferenceRegion,
+    OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra, infer_deferred_types,
+    infer_definition_types, infer_expression_types, infer_same_file_expression_type,
+    infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -10352,15 +10353,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = self;
         let diagnostics = context.finish();
 
+        let extra = (!bindings.is_empty() || !called_functions.is_empty()).then(|| {
+            Box::new(FunctionDecoratorInferenceExtra {
+                bindings: bindings.into_boxed_slice(),
+                called_functions: called_functions
+                    .into_iter()
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
+            })
+        });
+
         FunctionDecoratorInference {
             expression_types: FrozenMap::from(expressions),
-            bindings: bindings.into_boxed_slice(),
-            called_functions: called_functions
-                .into_iter()
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
             known_decorators,
             diagnostics,
+            extra,
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -116,6 +116,45 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg(target_pointer_width = "64")]
+fn empty_function_decorator_inference_is_compact() {
+    assert_eq!(std::mem::size_of::<FunctionDecoratorInference>(), 88);
+
+    let inference = FunctionDecoratorInference::default();
+    assert_eq!(inference.expression_types().len(), 0);
+    assert_eq!(inference.bindings().len(), 0);
+    assert!(inference.called_functions().is_empty());
+    assert!(inference.known_decorators().is_empty());
+    assert!(inference.diagnostics().is_empty());
+}
+
+#[test]
+fn function_decorator_inference_retains_non_empty_extra() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_file("/src/decorators.py", "def decorator(): ...")?;
+
+    let file = system_path_to_file(&db, "/src/decorators.py").unwrap();
+    let definition = first_public_binding(&db, file, "decorator");
+    let function = global_symbol(&db, file, "decorator")
+        .place
+        .expect_type()
+        .expect_function_literal();
+    let ty = Type::unknown();
+    let inference = FunctionDecoratorInference {
+        extra: Some(Box::new(FunctionDecoratorInferenceExtra {
+            bindings: vec![(definition, ty)].into_boxed_slice(),
+            called_functions: vec![function].into_boxed_slice(),
+        })),
+        ..FunctionDecoratorInference::default()
+    };
+
+    assert_eq!(inference.bindings().collect::<Vec<_>>(), [(definition, ty)]);
+    assert_eq!(inference.called_functions(), [function]);
+
+    Ok(())
+}
+
+#[test]
 fn not_literal_string() -> anyhow::Result<()> {
     let mut db = setup_db();
     let content = format!(


### PR DESCRIPTION
## Summary

Avoid retaining two empty boxed-slice headers in the common decorator-inference result. Move `bindings` and `called_functions` into one optional `FunctionDecoratorInferenceExtra` allocation that is created only when either collection is populated; accessors continue to expose empty slices/iterators when no extra state exists.

This saves 24 bytes per cached result: the Flake8 memory report measured 8,904 bytes (about 0.02% of total memory, 6.65% of the decorator query). Focused tests cover both the compact empty representation and preservation of populated bindings/called functions and pass.