### PR TITLE
[ty] Compact retained statement AST nodes

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -56,7 +56,6 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 returns,
                 parameters,
                 body,
-                type_params: _,
                 range: _,
                 node_index: _,
             },
@@ -718,7 +717,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             },
         ) => {
             let level = *level;
-            let module = module.as_deref();
+            let module = module.as_deref().map(ast::Identifier::as_str);
             if checker.is_rule_enabled(Rule::ModuleImportNotAtTopOfFile) {
                 pycodestyle::rules::module_import_not_at_top_of_file(checker, stmt);
             }
@@ -1128,7 +1127,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
 
                 bad_version_info_comparison(checker, test.as_ref(), has_else_clause);
                 for clause in elif_else_clauses {
-                    if let Some(test) = clause.test.as_ref() {
+                    if let Some(test) = clause.test.as_deref() {
                         bad_version_info_comparison(checker, test, has_else_clause);
                     }
                 }
@@ -1331,16 +1330,14 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 ruff::rules::needless_else(checker, for_stmt.into());
             }
         }
-        Stmt::Try(
-            try_stmt @ ast::StmtTry {
+        Stmt::Try(try_stmt) => {
+            let ast::StmtTryInner {
                 body,
                 handlers,
                 orelse,
                 finalbody,
                 is_star,
-                ..
-            },
-        ) => {
+            } = try_stmt.inner.as_ref();
             if checker.is_rule_enabled(Rule::TooManyNestedBlocks) {
                 pylint::rules::too_many_nested_blocks(checker, stmt);
             }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1007,7 +1007,12 @@ impl<'a> Visitor<'a> for Checker<'a> {
 
                 // Allow eager `__future__` imports until we see any other import. Lazy imports,
                 // including `lazy from __future__ import ...`, don't enable future annotations.
-                if !*is_lazy && matches!(module.as_deref(), Some("__future__")) {
+                if !*is_lazy
+                    && matches!(
+                        module.as_deref().map(ast::Identifier::as_str),
+                        Some("__future__")
+                    )
+                {
                     if names
                         .iter()
                         .any(|alias| alias.name.as_str() == "annotations")
@@ -1127,7 +1132,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     self.importer.visit_import(stmt);
                 }
 
-                let module = module.as_deref();
+                let module = module.as_deref().map(ast::Identifier::as_str);
                 let level = *level;
                 let is_lazy = *is_lazy;
 
@@ -1253,7 +1258,6 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     parameters,
                     decorator_list,
                     returns,
-                    type_params,
                     ..
                 },
             ) => {
@@ -1315,7 +1319,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
 
                 self.semantic.push_scope(ScopeKind::Type);
 
-                if let Some(type_params) = type_params {
+                if let Some(type_params) = &name.type_params {
                     self.visit_type_params(type_params);
                 }
 
@@ -1457,15 +1461,14 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 self.semantic.pop_scope();
                 self.visit_expr(name);
             }
-            Stmt::Try(
-                try_node @ ast::StmtTry {
+            Stmt::Try(try_node) => {
+                let ast::StmtTryInner {
                     body,
                     handlers,
                     orelse,
                     finalbody,
-                    ..
-                },
-            ) => {
+                    is_star: _,
+                } = try_node.inner.as_ref();
                 // Iterate over the `body`, then the `handlers`, then the `orelse`, then the
                 // `finalbody`, but treat the body and the `orelse` as a single branch for
                 // flow analysis purposes.

--- a/crates/ruff_linter/src/fix/edits.rs
+++ b/crates/ruff_linter/src/fix/edits.rs
@@ -507,20 +507,15 @@ fn is_lone_child(child: &Stmt, parent: &Stmt) -> bool {
         {
             return true;
         }
-        Stmt::Try(ast::StmtTry {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-            ..
-        }) if (is_only(body, child)
-            || is_only(orelse, child)
-            || is_only(finalbody, child)
-            || handlers.iter().any(|handler| match handler {
-                ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler { body, .. }) => {
-                    is_only(body, child)
-                }
-            })) =>
+        Stmt::Try(try_stmt)
+            if (is_only(&try_stmt.body, child)
+                || is_only(&try_stmt.orelse, child)
+                || is_only(&try_stmt.finalbody, child)
+                || try_stmt.handlers.iter().any(|handler| match handler {
+                    ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler {
+                        body, ..
+                    }) => is_only(body, child),
+                })) =>
         {
             return true;
         }

--- a/crates/ruff_linter/src/importer/mod.rs
+++ b/crates/ruff_linter/src/importer/mod.rs
@@ -463,7 +463,7 @@ impl<'a> Importer<'a> {
             }) = stmt
             {
                 if *level == 0
-                    && name.as_ref().is_some_and(|name| name == module)
+                    && name.as_deref().is_some_and(|name| name == module)
                     && names.iter().all(|alias| alias.name.as_str() != "*")
                 {
                     import_from = Some(*stmt);
@@ -541,7 +541,9 @@ impl<'a> Importer<'a> {
 
         body.take_while(|stmt| {
             stmt.as_import_from_stmt().is_some_and(|import_from| {
-                !import_from.is_lazy && import_from.module.as_deref() == Some("__future__")
+                !import_from.is_lazy
+                    && import_from.module.as_deref().map(ast::Identifier::as_str)
+                        == Some("__future__")
             })
         })
         .last()

--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -644,7 +644,6 @@ pub(crate) fn definition(
         is_async: _,
         decorator_list,
         name,
-        type_params: _,
         parameters,
         returns,
         body,

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -204,7 +204,7 @@ pub(crate) fn abstract_base_class(
         {
             checker.report_diagnostic(
                 EmptyMethodWithoutAbstractDecorator {
-                    name: format!("{name}.{method_name}"),
+                    name: format!("{name}.{}", method_name.as_str()),
                 },
                 stmt.range(),
             );

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/jump_statement_in_finally.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/jump_statement_in_finally.rs
@@ -74,11 +74,10 @@ fn walk_stmt(checker: &Checker, body: &[Stmt], f: fn(&Stmt) -> bool) {
             Stmt::While(ast::StmtWhile { body, .. }) | Stmt::For(ast::StmtFor { body, .. }) => {
                 walk_stmt(checker, body, Stmt::is_return_stmt);
             }
-            Stmt::If(ast::StmtIf { body, .. })
-            | Stmt::Try(ast::StmtTry { body, .. })
-            | Stmt::With(ast::StmtWith { body, .. }) => {
+            Stmt::If(ast::StmtIf { body, .. }) | Stmt::With(ast::StmtWith { body, .. }) => {
                 walk_stmt(checker, body, f);
             }
+            Stmt::Try(try_stmt) => walk_stmt(checker, &try_stmt.body, f),
             Stmt::Match(ast::StmtMatch { cases, .. }) => {
                 for case in cases {
                     walk_stmt(checker, &case.body, f);

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
@@ -7,7 +7,8 @@ use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::statement_visitor::{self, StatementVisitor};
 use ruff_python_ast::{
     ExceptHandler, ExceptHandlerExceptHandler, Expr, ExprAttribute, ExprCall, ExprSubscript,
-    ExprTuple, Stmt, StmtAssign, StmtAugAssign, StmtDelete, StmtFor, StmtIf, StmtTry, StmtWhile,
+    ExprTuple, Stmt, StmtAssign, StmtAugAssign, StmtDelete, StmtFor, StmtIf, StmtTryInner,
+    StmtWhile,
     visitor::{self, Visitor},
 };
 use ruff_text_size::TextRange;
@@ -445,13 +446,14 @@ impl<'a> Visitor<'a> for LoopMutationsVisitor<'a> {
             }
 
             // Ex) `try: ... except: ... else: ... finally: ...`
-            Stmt::Try(StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                ..
-            }) => {
+            Stmt::Try(try_stmt) => {
+                let StmtTryInner {
+                    body,
+                    handlers,
+                    orelse,
+                    finalbody,
+                    is_star: _,
+                } = try_stmt.inner.as_ref();
                 let saved_branch = self.branch;
 
                 self.enter_new_branch();

--- a/crates/ruff_linter/src/rules/flake8_django/rules/all_with_model_form.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/all_with_model_form.rs
@@ -62,7 +62,7 @@ pub(crate) fn all_with_model_form(checker: &Checker, class_def: &ast::StmtClassD
         let Stmt::ClassDef(ast::StmtClassDef { name, body, .. }) = element else {
             continue;
         };
-        if name != "Meta" {
+        if name.as_str() != "Meta" {
             continue;
         }
         for element in body {

--- a/crates/ruff_linter/src/rules/flake8_django/rules/exclude_with_model_form.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/exclude_with_model_form.rs
@@ -60,7 +60,7 @@ pub(crate) fn exclude_with_model_form(checker: &Checker, class_def: &ast::StmtCl
         let Stmt::ClassDef(ast::StmtClassDef { name, body, .. }) = element else {
             continue;
         };
-        if name != "Meta" {
+        if name.as_str() != "Meta" {
             continue;
         }
         for element in body {

--- a/crates/ruff_linter/src/rules/flake8_django/rules/model_without_dunder_str.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/model_without_dunder_str.rs
@@ -72,7 +72,7 @@ pub(crate) fn model_without_dunder_str(checker: &Checker, class_def: &ast::StmtC
 fn has_dunder_method(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> bool {
     analyze::class::any_super_class(class_def, semantic, |class_def| {
         class_def.body.iter().any(|val| match val {
-            Stmt::FunctionDef(ast::StmtFunctionDef { name, .. }) => name == "__str__",
+            Stmt::FunctionDef(ast::StmtFunctionDef { name, .. }) => name.as_str() == "__str__",
             _ => false,
         })
     })
@@ -93,7 +93,7 @@ fn is_model_abstract(class_def: &ast::StmtClassDef) -> bool {
         let Stmt::ClassDef(ast::StmtClassDef { name, body, .. }) = element else {
             continue;
         };
-        if name != "Meta" {
+        if name.as_str() != "Meta" {
             continue;
         }
         for element in body {

--- a/crates/ruff_linter/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
+++ b/crates/ruff_linter/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
@@ -170,7 +170,7 @@ fn get_element_type(element: &Stmt, semantic: &SemanticModel) -> Option<ContentT
             }
         }
         Stmt::ClassDef(ast::StmtClassDef { name, .. }) => {
-            if name == "Meta" {
+            if name.as_str() == "Meta" {
                 Some(ContentType::MetaClass)
             } else {
                 None

--- a/crates/ruff_linter/src/rules/flake8_logging/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging/helpers.rs
@@ -1,14 +1,15 @@
-use ruff_python_ast::{Stmt, StmtTry};
+use ruff_python_ast::Stmt;
 use ruff_python_semantic::SemanticModel;
 use ruff_text_size::{Ranged, TextSize};
 
 pub(super) fn outside_handlers(offset: TextSize, semantic: &SemanticModel) -> bool {
     for stmt in semantic.current_statements() {
-        let Stmt::Try(StmtTry { handlers, .. }) = stmt else {
+        let Stmt::Try(try_stmt) = stmt else {
             continue;
         };
 
-        if handlers
+        if try_stmt
+            .handlers
             .iter()
             .any(|handler| handler.range().contains(offset))
         {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
@@ -132,11 +132,10 @@ pub(crate) fn custom_type_var_instead_of_self(checker: &Checker, binding: &Bindi
         parameters,
         returns,
         decorator_list,
-        type_params,
         ..
     } = function_def;
 
-    let type_params = type_params.as_deref();
+    let type_params = function_name.type_params.as_deref();
 
     // Given, e.g., `def foo(self: _S, arg: bytes)`, extract `_S`.
     let Some(self_or_cls_parameter) = parameters.posonlyargs.iter().chain(&parameters.args).next()
@@ -357,7 +356,7 @@ fn replace_custom_typevar_with_self(
 
     // (3) If it was a PEP-695 type variable, remove that `TypeVar` from the PEP-695 type-parameter list
     if custom_typevar.is_pep695_typevar() {
-        let type_params = function_def.type_params.as_deref().context(
+        let type_params = function_def.name.type_params.as_deref().context(
             "Should not be possible to have a type parameter without a type parameter list",
         )?;
         let deletion_edit = remove_pep695_typevar_declaration(type_params, custom_typevar)

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -320,7 +320,9 @@ fn check_positional_args_for_overloaded_method(
         .iter()
         .filter_map(|stmt| {
             let func_def = stmt.as_function_def_stmt()?;
-            if &func_def.name == kind.as_str() && is_overload(&func_def.decorator_list, semantic) {
+            if func_def.name.as_str() == kind.as_str()
+                && is_overload(&func_def.decorator_list, semantic)
+            {
                 Some(func_def)
             } else {
                 None

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/future_annotations_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/future_annotations_in_stub.rs
@@ -46,7 +46,7 @@ pub(crate) fn from_future_import(checker: &Checker, target: &StmtImportFrom) {
         return;
     };
 
-    if module_name != "__future__" {
+    if module_name.as_str() != "__future__" {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
@@ -214,7 +214,7 @@ fn nested_if_body(stmt_if: &ast::StmtIf) -> Option<NestedIf<'_>> {
     // It must be the last condition, otherwise there could be another `elif` or `else` that only
     // depends on the outer of the two conditions
     let (test, nested_if) = if let Some(clause) = elif_else_clauses.last() {
-        if let Some(test) = &clause.test {
+        if let Some(test) = clause.test.as_deref() {
             (test, NestedIf::Elif(clause))
         } else {
             // The last condition is an `else` (different rule)

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
@@ -124,7 +124,7 @@ pub(crate) fn if_else_block_instead_of_dict_lookup(checker: &Checker, stmt_if: &
             return;
         };
 
-        match test.as_ref() {
+        match test.as_deref() {
             // `else`
             None => {
                 // The else must also be a single effect-free return statement

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -142,7 +142,7 @@ pub(crate) fn needless_bool(checker: &Checker, stmt: &Stmt) {
                 node_index: _,
             },
         ] => (
-            elif_test,
+            elif_test.as_ref(),
             elif_body,
             else_body.as_slice(),
             TextRange::new(elif_range.start(), else_range.end()),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -266,7 +266,7 @@ pub(crate) fn open_file_with_context_handler(checker: &Checker, call: &ast::Expr
     if let ScopeKind::Function(ast::StmtFunctionDef { name, .. }) =
         &checker.semantic().current_scope().kind
     {
-        if name == "__enter__" {
+        if name.as_str() == "__enter__" {
             return;
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_module_level_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/banned_module_level_imports.rs
@@ -95,7 +95,7 @@ impl<'a> BannedModuleImportPolicies<'a> {
             Stmt::ImportFrom(import @ StmtImportFrom { module, level, .. }) => {
                 let module = resolve_imported_module_path(
                     *level,
-                    module.as_deref(),
+                    module.as_deref().map(ruff_python_ast::Identifier::as_str),
                     checker.module.qualified_name(),
                 );
 

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/lazy_import_mismatch.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/lazy_import_mismatch.rs
@@ -117,8 +117,10 @@ fn lazy_import_policy(checker: &Checker, stmt: &Stmt) -> Option<LazyImportPolicy
             is_lazy,
             ..
         }) => {
-            if matches!(module.as_deref(), Some("__future__"))
-                || names.iter().any(|alias| alias.name.as_str() == "*")
+            if matches!(
+                module.as_deref().map(ruff_python_ast::Identifier::as_str),
+                Some("__future__")
+            ) || names.iter().any(|alias| alias.name.as_str() == "*")
             {
                 None
             } else {

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/relative_imports.rs
@@ -103,10 +103,10 @@ fn fix_banned_relative_import(
         panic!("Expected Stmt::ImportFrom");
     };
     let node = ast::StmtImportFrom {
-        module: Some(Identifier::new(
+        module: Some(Box::new(Identifier::new(
             module_path.to_string(),
             TextRange::default(),
-        )),
+        ))),
         names: names.clone(),
         level: 0,
         is_lazy: *is_lazy,

--- a/crates/ruff_linter/src/rules/isort/annotate.rs
+++ b/crates/ruff_linter/src/rules/isort/annotate.rs
@@ -156,7 +156,7 @@ pub(crate) fn annotate_imports<'a>(
                     }
 
                     AnnotatedImport::ImportFrom {
-                        module: module.as_ref().map(|module| locator.slice(module)),
+                        module: module.as_deref().map(|module| locator.slice(module)),
                         names: aliases,
                         level: *level,
                         is_lazy: *is_lazy,

--- a/crates/ruff_linter/src/rules/isort/block.rs
+++ b/crates/ruff_linter/src/rules/isort/block.rs
@@ -242,13 +242,14 @@ impl<'a> StatementVisitor<'a> for BlockBuilder<'a> {
                     self.visit_match_case(match_case);
                 }
             }
-            Stmt::Try(ast::StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                ..
-            }) => {
+            Stmt::Try(try_stmt) => {
+                let ast::StmtTryInner {
+                    body,
+                    handlers,
+                    orelse,
+                    finalbody,
+                    is_star: _,
+                } = try_stmt.inner.as_ref();
                 for except_handler in handlers {
                     self.visit_except_handler(except_handler);
                 }

--- a/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff_linter/src/rules/isort/rules/add_required_imports.rs
@@ -86,7 +86,7 @@ fn includes_import(stmt: &Stmt, target: &NameImport) -> bool {
             else {
                 return false;
             };
-            module.as_deref() == target.module.as_deref()
+            module.as_deref().map(ast::Identifier::as_str) == target.module.as_deref()
                 && *level == target.level
                 && names.iter().any(|alias| {
                     alias.name == target.name.name

--- a/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
+++ b/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
@@ -129,13 +129,14 @@ fn get_complexity_number(stmts: &[Stmt]) -> usize {
                     }
                 }
             }
-            Stmt::Try(ast::StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                ..
-            }) => {
+            Stmt::Try(try_stmt) => {
+                let ast::StmtTryInner {
+                    body,
+                    handlers,
+                    orelse,
+                    finalbody,
+                    is_star: _,
+                } = try_stmt.inner.as_ref();
                 complexity += get_complexity_number(body);
                 if !orelse.is_empty() {
                     complexity += 1;

--- a/crates/ruff_linter/src/rules/numpy/helpers.rs
+++ b/crates/ruff_linter/src/rules/numpy/helpers.rs
@@ -29,7 +29,9 @@ impl StatementVisitor<'_> for ImportSearcher<'_> {
             return;
         }
         if let Stmt::ImportFrom(StmtImportFrom { module, names, .. }) = stmt {
-            if module.as_ref().is_some_and(|module| module == self.module)
+            if module
+                .as_deref()
+                .is_some_and(|module| module == self.module)
                 && names.iter().any(|Alias { name, .. }| name == self.name)
             {
                 self.found_import = true;

--- a/crates/ruff_linter/src/rules/perflint/rules/try_except_in_loop.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/try_except_in_loop.rs
@@ -1,6 +1,6 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
-use ruff_python_ast::{self as ast, PythonVersion, Stmt};
+use ruff_python_ast::{PythonVersion, Stmt};
 use ruff_text_size::Ranged;
 
 use crate::Violation;
@@ -93,17 +93,17 @@ pub(crate) fn try_except_in_loop(checker: &Checker, body: &[Stmt]) {
         return;
     }
 
-    let [Stmt::Try(ast::StmtTry { handlers, body, .. })] = body else {
+    let [Stmt::Try(try_stmt)] = body else {
         return;
     };
 
-    let Some(handler) = handlers.first() else {
+    let Some(handler) = try_stmt.handlers.first() else {
         return;
     };
 
     // Avoid flagging `try`-`except` blocks that contain `break` or `continue`,
     // which rely on the exception handling mechanism.
-    if has_break_or_continue(body) {
+    if has_break_or_continue(&try_stmt.body) {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -225,7 +225,10 @@ fn function(
                 .collect::<ast::ParameterWithDefaults>();
             let func = Stmt::FunctionDef(ast::StmtFunctionDef {
                 is_async: false,
-                name: Identifier::new(name.to_string(), TextRange::default()),
+                name: Box::new(ast::FunctionDefName {
+                    name: Identifier::new(name.to_string(), TextRange::default()),
+                    type_params: None,
+                }),
                 parameters: Box::new(Parameters {
                     posonlyargs: new_posonlyargs,
                     args: new_args,
@@ -234,7 +237,6 @@ fn function(
                 body: ast::Suite::from([body]),
                 decorator_list: ast::DecoratorList::new(),
                 returns: Some(Box::new(return_type)),
-                type_params: None,
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             });
@@ -245,12 +247,14 @@ fn function(
     }
     let function = Stmt::FunctionDef(ast::StmtFunctionDef {
         is_async: false,
-        name: Identifier::new(name.to_string(), TextRange::default()),
+        name: Box::new(ast::FunctionDefName {
+            name: Identifier::new(name.to_string(), TextRange::default()),
+            type_params: None,
+        }),
         parameters: Box::new(parameters),
         body: ast::Suite::from([body]),
         decorator_list: DecoratorList::new(),
         returns: None,
-        type_params: None,
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     });

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -33,7 +33,7 @@ pub(super) fn in_dunder_method(
     else {
         return false;
     };
-    if name != dunder_name {
+    if name.as_str() != dunder_name {
         return false;
     }
     let Some(parent) = semantic.first_non_type_parent_scope(scope) else {
@@ -349,13 +349,14 @@ pub(super) fn num_statements(stmts: &[Stmt]) -> usize {
                     count += num_statements(&case.body);
                 }
             }
-            Stmt::Try(ast::StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                ..
-            }) => {
+            Stmt::Try(try_stmt) => {
+                let ast::StmtTryInner {
+                    body,
+                    handlers,
+                    orelse,
+                    finalbody,
+                    is_star: _,
+                } = try_stmt.inner.as_ref();
                 count += 1;
                 count += num_statements(body);
                 if !orelse.is_empty() {

--- a/crates/ruff_linter/src/rules/pylint/rules/continue_in_finally.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/continue_in_finally.rs
@@ -64,9 +64,9 @@ fn traverse_body(checker: &Checker, body: &[Stmt]) {
                     traverse_body(checker, &clause.body);
                 }
             }
-            Stmt::Try(ast::StmtTry { body, orelse, .. }) => {
-                traverse_body(checker, body);
-                traverse_body(checker, orelse);
+            Stmt::Try(try_stmt) => {
+                traverse_body(checker, &try_stmt.body);
+                traverse_body(checker, &try_stmt.orelse);
             }
             Stmt::For(ast::StmtFor { orelse, .. }) | Stmt::While(ast::StmtWhile { orelse, .. }) => {
                 traverse_body(checker, orelse);

--- a/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
@@ -1,7 +1,5 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{
-    Expr, ExprName, Identifier, StmtAnnAssign, StmtAssign, StmtClassDef, StmtFunctionDef,
-};
+use ruff_python_ast::{Expr, ExprName, StmtAnnAssign, StmtAssign, StmtClassDef, StmtFunctionDef};
 use ruff_python_semantic::analyze::class::{
     ClassMemberBoundness, ClassMemberKind, any_member_declaration,
 };
@@ -117,10 +115,7 @@ impl EqHash {
 
                     id
                 }
-                ClassMemberKind::FunctionDef(StmtFunctionDef {
-                    name: Identifier { id, .. },
-                    ..
-                }) => id.as_str(),
+                ClassMemberKind::FunctionDef(StmtFunctionDef { name, .. }) => name.as_str(),
             };
 
             match id {

--- a/crates/ruff_linter/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/manual_import_from.rs
@@ -87,7 +87,10 @@ pub(crate) fn manual_from_import(checker: &Checker, stmt: &Stmt, alias: &Alias, 
             .as_import_stmt()
             .is_some_and(|import_stmt| import_stmt.is_lazy);
         let node = ast::StmtImportFrom {
-            module: Some(Identifier::new(module.to_string(), TextRange::default())),
+            module: Some(Box::new(Identifier::new(
+                module.to_string(),
+                TextRange::default(),
+            ))),
             names: vec![Alias {
                 name: asname.clone(),
                 asname: None,

--- a/crates/ruff_linter/src/rules/pylint/rules/non_ascii_module_import.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_ascii_module_import.rs
@@ -65,7 +65,7 @@ enum Kind {
 
 /// PLC2403
 pub(crate) fn non_ascii_module_import(checker: &Checker, alias: &Alias) {
-    if let Some(asname) = &alias.asname {
+    if let Some(asname) = alias.asname.as_deref() {
         if asname.as_str().is_ascii() {
             return;
         }

--- a/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_slot_assignment.rs
@@ -197,7 +197,7 @@ fn is_attributes_not_in_slots(body: &[Stmt]) -> Vec<AttributeAssignment<'_>> {
             continue;
         };
 
-        if name == "__init__" {
+        if name.as_str() == "__init__" {
             for statement in body {
                 match statement {
                     // Ex) `self.name = name`

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_boolean_expressions.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_boolean_expressions.rs
@@ -59,7 +59,7 @@ pub(crate) fn too_many_boolean_expressions(checker: &Checker, stmt: &StmtIf) {
     }
 
     for elif in &stmt.elif_else_clauses {
-        if let Some(bool_op) = elif.test.as_ref().and_then(Expr::as_bool_op_expr) {
+        if let Some(bool_op) = elif.test.as_deref().and_then(Expr::as_bool_op_expr) {
             let expressions = count_bools(bool_op);
             if expressions > checker.settings().pylint.max_bool_expr {
                 checker.report_diagnostic(

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_branches.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_branches.rs
@@ -196,13 +196,14 @@ fn num_branches(stmts: &[Stmt]) -> usize {
                         1 + num_branches(orelse)
                     })
             }
-            Stmt::Try(ast::StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                ..
-            }) => {
+            Stmt::Try(try_stmt) => {
+                let ast::StmtTryInner {
+                    body,
+                    handlers,
+                    orelse,
+                    finalbody,
+                    is_star: _,
+                } = try_stmt.inner.as_ref();
                 // Count each `except` clause as a branch; the `else` and `finally` clauses also
                 // count, but the `try` clause itself does not.
                 num_branches(body)

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_nested_blocks.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_nested_blocks.rs
@@ -111,13 +111,14 @@ fn has_nested_block(stmt: &Stmt) -> bool {
         Stmt::For(ast::StmtFor { body, orelse, .. }) => {
             body.iter().any(is_nested_block) || orelse.iter().any(is_nested_block)
         }
-        Stmt::Try(ast::StmtTry {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-            ..
-        }) => {
+        Stmt::Try(try_stmt) => {
+            let ast::StmtTryInner {
+                body,
+                handlers,
+                orelse,
+                finalbody,
+                is_star: _,
+            } = try_stmt.inner.as_ref();
             body.iter().any(is_nested_block)
                 || handlers.iter().any(|handler| match handler {
                     ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler {

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_else_on_loop.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_else_on_loop.rs
@@ -101,13 +101,14 @@ fn loop_exits_early(body: &[Stmt]) -> bool {
         Stmt::Match(ast::StmtMatch { cases, .. }) => cases
             .iter()
             .any(|MatchCase { body, .. }| loop_exits_early(body)),
-        Stmt::Try(ast::StmtTry {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-            ..
-        }) => {
+        Stmt::Try(try_stmt) => {
+            let ast::StmtTryInner {
+                body,
+                handlers,
+                orelse,
+                finalbody,
+                is_star: _,
+            } = try_stmt.inner.as_ref();
             loop_exits_early(body)
                 || loop_exits_early(orelse)
                 || loop_exits_early(finalbody)

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_import_alias.rs
@@ -69,7 +69,7 @@ impl Violation for UselessImportAlias {
 
 /// PLC0414
 pub(crate) fn useless_import_alias(checker: &Checker, alias: &Alias) {
-    let Some(asname) = &alias.asname else {
+    let Some(asname) = alias.asname.as_deref() else {
         return;
     };
     if alias.name.as_str() != asname.as_str() {
@@ -108,7 +108,7 @@ pub(crate) fn useless_import_from_alias(
     module: Option<&str>,
     level: u32,
 ) {
-    let Some(asname) = &alias.asname else {
+    let Some(asname) = alias.asname.as_deref() else {
         return;
     };
     if alias.name.as_str() != asname.as_str() {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -234,7 +234,7 @@ fn create_fields_from_keywords(keywords: &[Keyword]) -> Option<Suite> {
 /// keywords.
 fn create_class_def_stmt(typename: &str, body: Suite, base_class: &Expr) -> Stmt {
     ast::StmtClassDef {
-        name: Identifier::new(typename.to_string(), TextRange::default()),
+        name: Box::new(Identifier::new(typename.to_string(), TextRange::default())),
         arguments: Some(Box::new(Arguments {
             args: Box::from([base_class.clone()]),
             keywords: std::iter::empty().collect(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -174,7 +174,10 @@ fn create_class_def_stmt(
     base_class: &Expr,
 ) -> Stmt {
     ast::StmtClassDef {
-        name: Identifier::new(class_name.to_string(), TextRange::default()),
+        name: Box::new(Identifier::new(
+            class_name.to_string(),
+            TextRange::default(),
+        )),
         arguments: Some(Box::new(Arguments {
             args: Box::from([base_class.clone()]),
             keywords: match total_keyword {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -79,10 +79,10 @@ pub(crate) fn deprecated_c_element_tree(checker: &Checker, stmt: &Stmt) {
             if *level > 0 {
                 // Ex) `import .xml.etree.cElementTree as ET`
             } else if let Some(module) = module {
-                if module == "xml.etree.cElementTree" {
+                if module.as_str() == "xml.etree.cElementTree" {
                     // Ex) `from xml.etree.cElementTree import XML`
                     add_check_for_node(checker, stmt);
-                } else if module == "xml.etree" {
+                } else if module.as_str() == "xml.etree" {
                     // Ex) `from xml.etree import cElementTree as ET`
                     for name in names {
                         if &name.name == "cElementTree" && name.asname.is_some() {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -729,7 +729,7 @@ impl<'a> ImportReplacer<'a> {
         // Generate the formatted names.
         let qualified_names: String = names
             .iter()
-            .map(|name| match &name.asname {
+            .map(|name| match name.asname.as_deref() {
                 Some(asname) => format!("{} as {}", name.name, asname),
                 None => format!("{}", name.name),
             })

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -342,7 +342,7 @@ pub(crate) fn deprecated_mock_import(checker: &Checker, stmt: &Stmt) {
                 return;
             }
 
-            if module == "mock" {
+            if module.as_str() == "mock" {
                 if names.iter().any(|alias| {
                     alias.name.as_str() == "mock"
                         && is_import_required_by_isort(

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
@@ -116,10 +116,7 @@ pub(crate) fn non_pep695_generic_function(checker: &Checker, function_def: &Stmt
     }
 
     let StmtFunctionDef {
-        name,
-        type_params,
-        parameters,
-        ..
+        name, parameters, ..
     } = function_def;
 
     // TODO(brent) handle methods, for now return early in a class body. For example, an additional
@@ -141,7 +138,7 @@ pub(crate) fn non_pep695_generic_function(checker: &Checker, function_def: &Stmt
     }
 
     // invalid to mix old-style and new-style generics
-    if type_params.is_some() {
+    if name.type_params.is_some() {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/fallible_context_manager.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/fallible_context_manager.rs
@@ -124,13 +124,14 @@ impl Visitor<'_> for YieldFinallyVisitor<'_, '_> {
         match stmt {
             Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {}
 
-            Stmt::Try(ast::StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                ..
-            }) => {
+            Stmt::Try(try_stmt) => {
+                let ast::StmtTryInner {
+                    body,
+                    handlers,
+                    orelse,
+                    finalbody,
+                    is_star: _,
+                } = try_stmt.inner.as_ref();
                 // Only the `try` body itself catches exceptions. Yields in
                 // `except` / `else` / `finally` are unprotected, but they
                 // inherit the surrounding terminal position because the

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
@@ -143,20 +143,21 @@ impl<'src, 'loc> UselessSuppressionComments<'src, 'loc> {
         }
 
         if comment.kind == SuppressionKind::Off || comment.kind == SuppressionKind::On {
-            if let Some(
-                AnyNodeRef::StmtClassDef(StmtClassDef {
+            let enclosing = match comment.enclosing {
+                Some(AnyNodeRef::StmtClassDef(StmtClassDef {
                     name,
                     decorator_list,
                     ..
-                })
-                | AnyNodeRef::StmtFunctionDef(StmtFunctionDef {
+                })) => Some((name.start(), decorator_list)),
+                Some(AnyNodeRef::StmtFunctionDef(StmtFunctionDef {
                     name,
                     decorator_list,
                     ..
-                }),
-            ) = comment.enclosing
-            {
-                if comment.line_position.is_own_line() && comment.range.start() < name.start() {
+                })) => Some((name.start(), decorator_list)),
+                _ => None,
+            };
+            if let Some((name_start, decorator_list)) = enclosing {
+                if comment.line_position.is_own_line() && comment.range.start() < name_start {
                     if let Some(decorator) = decorator_list.first() {
                         if decorator.end() < comment.range.start() {
                             return Err(IgnoredReason::AfterDecorator);

--- a/crates/ruff_linter/src/rules/ruff/rules/needless_else.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/needless_else.rs
@@ -240,11 +240,12 @@ impl<'a> AnyNodeWithOrElse<'a> {
     /// Returns the suite before the else block.
     fn body_before_else(self) -> &'a [Stmt] {
         match self {
-            Self::Try(StmtTry { body, handlers, .. }) => handlers
+            Self::Try(try_stmt) => try_stmt
+                .handlers
                 .last()
                 .and_then(|handler| handler.as_except_handler())
                 .map(|handler| &handler.body)
-                .unwrap_or(body),
+                .unwrap_or(&try_stmt.body),
 
             Self::While(StmtWhile { body, .. }) | Self::For(StmtFor { body, .. }) => body,
 
@@ -265,9 +266,8 @@ impl<'a> AnyNodeWithOrElse<'a> {
     /// Defaults to an empty suite if the statement has no `else` block.
     fn else_body(self) -> &'a [Stmt] {
         match self {
-            Self::While(StmtWhile { orelse, .. })
-            | Self::For(StmtFor { orelse, .. })
-            | Self::Try(StmtTry { orelse, .. }) => orelse,
+            Self::While(StmtWhile { orelse, .. }) | Self::For(StmtFor { orelse, .. }) => orelse,
+            Self::Try(try_stmt) => &try_stmt.orelse,
 
             Self::If(StmtIf {
                 elif_else_clauses, ..

--- a/crates/ruff_linter/src/rules/ruff/rules/non_empty_init_module.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/non_empty_init_module.rs
@@ -121,7 +121,9 @@ pub(crate) fn non_empty_init_module(checker: &Checker, stmt: &Stmt) {
             Stmt::Import(_) | Stmt::ImportFrom(_) => return,
 
             // Allow PEP-562 module `__getattr__` and `__dir__`
-            Stmt::FunctionDef(func) if matches!(&*func.name, "__getattr__" | "__dir__") => return,
+            Stmt::FunctionDef(func) if matches!(func.name.as_str(), "__getattr__" | "__dir__") => {
+                return;
+            }
 
             // Allow `TYPE_CHECKING` blocks
             Stmt::If(stmt_if) if is_type_checking_block(stmt_if, semantic) => return,

--- a/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/post_init_default.rs
@@ -93,7 +93,7 @@ impl Violation for PostInitDefault {
 
 /// RUF033
 pub(crate) fn post_init_default(checker: &Checker, function_def: &ast::StmtFunctionDef) {
-    if &function_def.name != "__post_init__" {
+    if function_def.name.as_str() != "__post_init__" {
         return;
     }
 
@@ -150,7 +150,7 @@ fn use_initvar(
     // If the annotation references a type variable scoped to `__post_init__`
     // (PEP 695), moving it to the class body would produce a `NameError`.
     if let Some(annotation) = parameter.annotation() {
-        if let Some(type_params) = &post_init_def.type_params {
+        if let Some(type_params) = &post_init_def.name.type_params {
             if any_over_expr(annotation, |expr| {
                 expr.as_name_expr()
                     .is_some_and(|name| type_params.iter().any(|tp| tp.name().id == name.id))

--- a/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
@@ -114,7 +114,6 @@ fn function_def_visit_preorder_except_body<'a, V>(
         parameters,
         decorator_list,
         returns,
-        type_params,
         ..
     } = function_def;
 
@@ -122,7 +121,7 @@ fn function_def_visit_preorder_except_body<'a, V>(
         visitor.visit_decorator(decorator);
     }
 
-    if let Some(type_params) = type_params {
+    if let Some(type_params) = &function_def.name.type_params {
         visitor.visit_type_params(type_params);
     }
 

--- a/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/verbose_raise.rs
@@ -98,10 +98,8 @@ impl<'a> StatementVisitor<'a> for RaiseStatementVisitor<'a> {
             Stmt::Raise(raise @ ast::StmtRaise { .. }) => {
                 self.raises.push(raise);
             }
-            Stmt::Try(ast::StmtTry {
-                body, finalbody, ..
-            }) => {
-                for stmt in body.iter().chain(finalbody) {
+            Stmt::Try(try_stmt) => {
+                for stmt in try_stmt.body.iter().chain(&try_stmt.finalbody) {
                     walk_stmt(self, stmt);
                 }
             }

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -93,11 +93,11 @@ doc = """See also [FunctionDef](https://docs.python.org/3/library/ast.html#ast.F
 and [AsyncFunctionDef](https://docs.python.org/3/library/ast.html#ast.AsyncFunctionDef).
 
 This type differs from the original Python AST, as it collapses the synchronous and asynchronous variants into a single type."""
+custom_source_order = true
 fields = [
   { name = "is_async", type = "bool" },
   { name = "decorator_list", type = "ThinVec<Decorator>" },
-  { name = "name", type = "Identifier" },
-  { name = "type_params", type = "Box<crate::TypeParams>?" },
+  { name = "name", type = "Box<crate::FunctionDefName>", skip_visit = true },
   { name = "parameters", type = "Box<crate::Parameters>" },
   { name = "returns", type = "Expr?", is_annotation = true },
   { name = "body", type = "ThinVec<Stmt>" },
@@ -107,7 +107,7 @@ fields = [
 doc = "See also [ClassDef](https://docs.python.org/3/library/ast.html#ast.ClassDef)"
 fields = [
   { name = "decorator_list", type = "ThinVec<Decorator>" },
-  { name = "name", type = "Identifier" },
+  { name = "name", type = "Box<crate::Identifier>" },
   { name = "type_params", type = "Box<crate::TypeParams>?" },
   { name = "arguments", type = "Box<crate::Arguments>?" },
   { name = "body", type = "ThinVec<Stmt>" },
@@ -209,13 +209,8 @@ fields = [{ name = "exc", type = "Expr?" }, { name = "cause", type = "Expr?" }]
 [Stmt.nodes.StmtTry]
 doc = """See also [Try](https://docs.python.org/3/library/ast.html#ast.Try)
 and [TryStar](https://docs.python.org/3/library/ast.html#ast.TryStar)"""
-fields = [
-  { name = "body", type = "ThinVec<Stmt>" },
-  { name = "handlers", type = "ExceptHandler*" },
-  { name = "orelse", type = "ThinVec<Stmt>" },
-  { name = "finalbody", type = "ThinVec<Stmt>" },
-  { name = "is_star", type = "bool" },
-]
+custom_source_order = true
+fields = [{ name = "inner", type = "Box<crate::StmtTryInner>", skip_visit = true }]
 
 [Stmt.nodes.StmtAssert]
 doc = "See also [Assert](https://docs.python.org/3/library/ast.html#ast.Assert)"
@@ -231,7 +226,7 @@ fields = [
 [Stmt.nodes.StmtImportFrom]
 doc = "See also [ImportFrom](https://docs.python.org/3/library/ast.html#ast.ImportFrom)"
 fields = [
-  { name = "module", type = "Identifier?" },
+  { name = "module", type = "Box<crate::Identifier>?" },
   { name = "names", type = "Alias*" },
   { name = "level", type = "u32" },
   { name = "is_lazy", type = "bool" },

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -611,7 +611,7 @@ impl<'a> From<&'a ast::ElifElseClause> for ComparableElifElseClause<'a> {
             body,
         } = elif_else_clause;
         Self {
-            test: test.as_ref().map(Into::into),
+            test: test.as_deref().map(Into::into),
             body: body.iter().map(Into::into).collect(),
         }
     }
@@ -1632,7 +1632,6 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 body,
                 decorator_list,
                 returns,
-                type_params,
                 range: _,
                 node_index: _,
             }) => Self::FunctionDef(StmtFunctionDef {
@@ -1642,7 +1641,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 body: body.iter().map(Into::into).collect(),
                 decorator_list: decorator_list.iter().map(Into::into).collect(),
                 returns: returns.as_ref().map(Into::into),
-                type_params: type_params.as_ref().map(Into::into),
+                type_params: name.type_params.as_ref().map(Into::into),
             }),
             ast::Stmt::ClassDef(ast::StmtClassDef {
                 name,
@@ -1783,20 +1782,12 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 exc: exc.as_ref().map(Into::into),
                 cause: cause.as_ref().map(Into::into),
             }),
-            ast::Stmt::Try(ast::StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                is_star,
-                range: _,
-                node_index: _,
-            }) => Self::Try(StmtTry {
-                body: body.iter().map(Into::into).collect(),
-                handlers: handlers.iter().map(Into::into).collect(),
-                orelse: orelse.iter().map(Into::into).collect(),
-                finalbody: finalbody.iter().map(Into::into).collect(),
-                is_star: *is_star,
+            ast::Stmt::Try(stmt) => Self::Try(StmtTry {
+                body: stmt.body.iter().map(Into::into).collect(),
+                handlers: stmt.handlers.iter().map(Into::into).collect(),
+                orelse: stmt.orelse.iter().map(Into::into).collect(),
+                finalbody: stmt.finalbody.iter().map(Into::into).collect(),
+                is_star: stmt.is_star,
             }),
             ast::Stmt::Assert(ast::StmtAssert {
                 test,
@@ -1824,7 +1815,7 @@ impl<'a> From<&'a ast::Stmt> for ComparableStmt<'a> {
                 range: _,
                 node_index: _,
             }) => Self::ImportFrom(StmtImportFrom {
-                module: module.as_deref(),
+                module: module.as_deref().map(ast::Identifier::as_str),
                 names: names.iter().map(Into::into).collect(),
                 level: *level,
                 is_lazy: *is_lazy,

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -9291,8 +9291,7 @@ pub struct StmtFunctionDef {
     pub range: ruff_text_size::TextRange,
     pub is_async: bool,
     pub decorator_list: thin_vec::ThinVec<crate::Decorator>,
-    pub name: crate::Identifier,
-    pub type_params: Option<Box<crate::TypeParams>>,
+    pub name: Box<crate::FunctionDefName>,
     pub parameters: Box<crate::Parameters>,
     pub returns: Option<Box<Expr>>,
     pub body: thin_vec::ThinVec<Stmt>,
@@ -9305,7 +9304,7 @@ pub struct StmtClassDef {
     pub node_index: crate::AtomicNodeIndex,
     pub range: ruff_text_size::TextRange,
     pub decorator_list: thin_vec::ThinVec<crate::Decorator>,
-    pub name: crate::Identifier,
+    pub name: Box<crate::Identifier>,
     pub type_params: Option<Box<crate::TypeParams>>,
     pub arguments: Option<Box<crate::Arguments>>,
     pub body: thin_vec::ThinVec<Stmt>,
@@ -9453,11 +9452,7 @@ pub struct StmtRaise {
 pub struct StmtTry {
     pub node_index: crate::AtomicNodeIndex,
     pub range: ruff_text_size::TextRange,
-    pub body: thin_vec::ThinVec<Stmt>,
-    pub handlers: Vec<ExceptHandler>,
-    pub orelse: thin_vec::ThinVec<Stmt>,
-    pub finalbody: thin_vec::ThinVec<Stmt>,
-    pub is_star: bool,
+    pub inner: Box<crate::StmtTryInner>,
 }
 
 /// See also [Assert](https://docs.python.org/3/library/ast.html#ast.Assert)
@@ -9486,7 +9481,7 @@ pub struct StmtImport {
 pub struct StmtImportFrom {
     pub node_index: crate::AtomicNodeIndex,
     pub range: ruff_text_size::TextRange,
-    pub module: Option<crate::Identifier>,
+    pub module: Option<Box<crate::Identifier>>,
     pub names: Vec<crate::Alias>,
     pub level: u32,
     pub is_lazy: bool,
@@ -10087,42 +10082,6 @@ impl ModExpression {
     }
 }
 
-impl StmtFunctionDef {
-    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
-    where
-        V: SourceOrderVisitor<'a> + ?Sized,
-    {
-        let StmtFunctionDef {
-            is_async: _,
-            decorator_list,
-            name,
-            type_params,
-            parameters,
-            returns,
-            body,
-            range: _,
-            node_index: _,
-        } = self;
-
-        for elm in decorator_list {
-            visitor.visit_decorator(elm);
-        }
-        visitor.visit_identifier(name);
-
-        if let Some(type_params) = type_params {
-            visitor.visit_type_params(type_params);
-        }
-
-        visitor.visit_parameters(parameters);
-
-        if let Some(returns) = returns {
-            visitor.visit_annotation(returns);
-        }
-
-        visitor.visit_body(body);
-    }
-}
-
 impl StmtClassDef {
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
@@ -10388,30 +10347,6 @@ impl StmtRaise {
         if let Some(cause) = cause {
             visitor.visit_expr(cause);
         }
-    }
-}
-
-impl StmtTry {
-    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
-    where
-        V: SourceOrderVisitor<'a> + ?Sized,
-    {
-        let StmtTry {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-            is_star: _,
-            range: _,
-            node_index: _,
-        } = self;
-        visitor.visit_body(body);
-
-        for elm in handlers {
-            visitor.visit_except_handler(elm);
-        }
-        visitor.visit_body(orelse);
-        visitor.visit_body(finalbody);
     }
 }
 

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -549,7 +549,7 @@ where
         match stmt {
             Stmt::FunctionDef(ast::StmtFunctionDef {
                 parameters,
-                type_params,
+                name,
                 body,
                 decorator_list,
                 returns,
@@ -562,7 +562,7 @@ where
                         || param
                             .annotation()
                             .is_some_and(|annotation| any_over_expr(annotation, &mut *func))
-                }) || type_params.as_ref().is_some_and(|type_params| {
+                }) || name.type_params.as_ref().is_some_and(|type_params| {
                     type_params
                         .iter()
                         .any(|type_param| any_over_type_param(type_param, &mut *func))
@@ -681,7 +681,7 @@ where
                     || elif_else_clauses.iter().any(|clause| {
                         clause
                             .test
-                            .as_ref()
+                            .as_deref()
                             .is_some_and(|test| any_over_expr(test, &mut *func))
                             || any_over_body(&clause.body, &mut *func)
                     })
@@ -707,17 +707,9 @@ where
                         .as_ref()
                         .is_some_and(|value| any_over_expr(value, &mut *func))
             }
-            Stmt::Try(ast::StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                is_star: _,
-                range: _,
-                node_index: _,
-            }) => {
-                any_over_body(body, &mut *func)
-                    || handlers.iter().any(|handler| {
+            Stmt::Try(stmt) => {
+                any_over_body(&stmt.body, &mut *func)
+                    || stmt.handlers.iter().any(|handler| {
                         let ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler {
                             type_,
                             body,
@@ -728,8 +720,8 @@ where
                             .is_some_and(|expr| any_over_expr(expr, &mut *func))
                             || any_over_body(body, &mut *func)
                     })
-                    || any_over_body(orelse, &mut *func)
-                    || any_over_body(finalbody, &mut *func)
+                    || any_over_body(&stmt.orelse, &mut *func)
+                    || any_over_body(&stmt.finalbody, &mut *func)
             }
             Stmt::Assert(ast::StmtAssert {
                 test,

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -623,25 +623,19 @@ impl<'a> AnyNodeRef<'a> {
                     return cases.last().map(AnyNodeRef::from);
                 }
 
-                AnyNodeRef::StmtTry(ast::StmtTry {
-                    body,
-                    handlers,
-                    orelse,
-                    finalbody,
-                    ..
-                }) => {
-                    if finalbody.is_empty() {
-                        if orelse.is_empty() {
-                            if handlers.is_empty() {
-                                body
+                AnyNodeRef::StmtTry(stmt) => {
+                    if stmt.finalbody.is_empty() {
+                        if stmt.orelse.is_empty() {
+                            if stmt.handlers.is_empty() {
+                                &stmt.body
                             } else {
-                                return handlers.last().map(AnyNodeRef::from);
+                                return stmt.handlers.last().map(AnyNodeRef::from);
                             }
                         } else {
-                            orelse
+                            &stmt.orelse
                         }
                     } else {
-                        finalbody
+                        &stmt.finalbody
                     }
                 }
 
@@ -700,15 +694,10 @@ impl<'a> AnyNodeRef<'a> {
                 are_same_optional(*self, body.first()) || are_same_optional(*self, orelse.first())
             }
 
-            AnyNodeRef::StmtTry(ast::StmtTry {
-                body,
-                orelse,
-                finalbody,
-                ..
-            }) => {
-                are_same_optional(*self, body.first())
-                    || are_same_optional(*self, orelse.first())
-                    || are_same_optional(*self, finalbody.first())
+            AnyNodeRef::StmtTry(stmt) => {
+                are_same_optional(*self, stmt.body.first())
+                    || are_same_optional(*self, stmt.orelse.first())
+                    || are_same_optional(*self, stmt.finalbody.first())
             }
 
             AnyNodeRef::StmtIf(ast::StmtIf { body, .. })
@@ -740,15 +729,10 @@ impl<'a> AnyNodeRef<'a> {
                 are_same_optional(*self, orelse.first())
             }
 
-            AnyNodeRef::StmtTry(ast::StmtTry {
-                handlers,
-                orelse,
-                finalbody,
-                ..
-            }) => {
-                are_same_optional(*self, handlers.first())
-                    || are_same_optional(*self, orelse.first())
-                    || are_same_optional(*self, finalbody.first())
+            AnyNodeRef::StmtTry(stmt) => {
+                are_same_optional(*self, stmt.handlers.first())
+                    || are_same_optional(*self, stmt.orelse.first())
+                    || are_same_optional(*self, stmt.finalbody.first())
             }
 
             AnyNodeRef::StmtIf(ast::StmtIf {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3,7 +3,7 @@
 use crate::AtomicNodeIndex;
 use crate::generated::{
     ExprBytesLiteral, ExprDict, ExprFString, ExprList, ExprName, ExprSet, ExprStringLiteral,
-    ExprTString, ExprTuple, PatternMatchAs, PatternMatchOr, StmtClassDef,
+    ExprTString, ExprTuple, PatternMatchAs, PatternMatchOr, StmtClassDef, StmtFunctionDef, StmtTry,
 };
 use std::borrow::Cow;
 use std::fmt;
@@ -22,11 +22,92 @@ use crate::str_prefix::{
     AnyStringPrefix, ByteStringPrefix, FStringPrefix, StringLiteralPrefix, TStringPrefix,
 };
 use crate::{
-    Expr, ExprRef, InterpolatedStringElement, LiteralExpressionRef, OperatorPrecedence, Pattern,
-    Stmt, TypeParam, int,
+    ExceptHandler, Expr, ExprRef, InterpolatedStringElement, LiteralExpressionRef,
+    OperatorPrecedence, Pattern, Stmt, TypeParam, int,
     name::Name,
     str::{Quote, TripleQuotes},
 };
+
+/// A function name and its optional type parameters, co-located in the name allocation.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+pub struct FunctionDefName {
+    pub name: Identifier,
+    pub type_params: Option<Box<TypeParams>>,
+}
+
+impl Deref for FunctionDefName {
+    type Target = Identifier;
+
+    fn deref(&self) -> &Self::Target {
+        &self.name
+    }
+}
+
+impl DerefMut for FunctionDefName {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.name
+    }
+}
+
+impl StmtFunctionDef {
+    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
+    where
+        V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
+    {
+        for decorator in &self.decorator_list {
+            visitor.visit_decorator(decorator);
+        }
+        visitor.visit_identifier(&self.name.name);
+        if let Some(type_params) = &self.name.type_params {
+            visitor.visit_type_params(type_params);
+        }
+        visitor.visit_parameters(&self.parameters);
+        if let Some(returns) = &self.returns {
+            visitor.visit_annotation(returns);
+        }
+        visitor.visit_body(&self.body);
+    }
+}
+
+/// The payload for a `try` statement, stored out of line because `try` statements are rare.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+pub struct StmtTryInner {
+    pub body: Suite,
+    pub handlers: Vec<ExceptHandler>,
+    pub orelse: Suite,
+    pub finalbody: Suite,
+    pub is_star: bool,
+}
+
+impl Deref for StmtTry {
+    type Target = StmtTryInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for StmtTry {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl StmtTry {
+    pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
+    where
+        V: crate::visitor::source_order::SourceOrderVisitor<'a> + ?Sized,
+    {
+        visitor.visit_body(&self.body);
+        for handler in &self.handlers {
+            visitor.visit_except_handler(handler);
+        }
+        visitor.visit_body(&self.orelse);
+        visitor.visit_body(&self.finalbody);
+    }
+}
 
 impl StmtClassDef {
     /// Return an iterator over the bases of the class.
@@ -51,7 +132,7 @@ impl StmtClassDef {
 pub struct ElifElseClause {
     pub range: TextRange,
     pub node_index: AtomicNodeIndex,
-    pub test: Option<Expr>,
+    pub test: Option<Box<Expr>>,
     pub body: Suite,
 }
 
@@ -3943,10 +4024,11 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn size() {
-        assert_eq!(std::mem::size_of::<Stmt>(), 96);
-        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 96);
-        assert_eq!(std::mem::size_of::<StmtClassDef>(), 88);
-        assert_eq!(std::mem::size_of::<StmtTry>(), 64);
+        assert_eq!(std::mem::size_of::<Stmt>(), 64);
+        assert_eq!(std::mem::size_of::<StmtFunctionDef>(), 56);
+        assert_eq!(std::mem::size_of::<StmtClassDef>(), 56);
+        assert_eq!(std::mem::size_of::<StmtTry>(), 24);
+        assert_eq!(std::mem::size_of::<crate::ElifElseClause>(), 32);
         assert_eq!(std::mem::size_of::<crate::Alias>(), 56);
         assert_eq!(std::mem::size_of::<Mod>(), 32);
         assert_eq!(std::mem::size_of::<Pattern>(), 80);

--- a/crates/ruff_python_ast/src/statement_visitor.rs
+++ b/crates/ruff_python_ast/src/statement_visitor.rs
@@ -61,19 +61,13 @@ pub fn walk_stmt<'a, V: StatementVisitor<'a> + ?Sized>(visitor: &mut V, stmt: &'
                 visitor.visit_match_case(match_case);
             }
         }
-        Stmt::Try(ast::StmtTry {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-            ..
-        }) => {
-            visitor.visit_body(body);
-            for except_handler in handlers {
+        Stmt::Try(stmt) => {
+            visitor.visit_body(&stmt.body);
+            for except_handler in &stmt.handlers {
                 visitor.visit_except_handler(except_handler);
             }
-            visitor.visit_body(orelse);
-            visitor.visit_body(finalbody);
+            visitor.visit_body(&stmt.orelse);
+            visitor.visit_body(&stmt.finalbody);
         }
         _ => {}
     }

--- a/crates/ruff_python_ast/src/stmt_if.rs
+++ b/crates/ruff_python_ast/src/stmt_if.rs
@@ -43,7 +43,7 @@ pub fn if_elif_branches(stmt_if: &StmtIf) -> impl Iterator<Item = IfElifBranch<'
     .chain(stmt_if.elif_else_clauses.iter().filter_map(|clause| {
         Some(IfElifBranch {
             kind: BranchKind::Elif,
-            test: clause.test.as_ref()?,
+            test: clause.test.as_deref()?,
             body: clause.body.as_slice(),
             range: clause.range,
         })

--- a/crates/ruff_python_ast/src/traversal.rs
+++ b/crates/ruff_python_ast/src/traversal.rs
@@ -33,16 +33,11 @@ pub fn suite<'a>(
             .iter()
             .map(|case| &case.body)
             .find_map(|body| EnclosingSuite::new(body, stmt)),
-        AnyNodeRef::StmtTry(ast::StmtTry {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-            ..
-        }) => [body, orelse, finalbody]
+        AnyNodeRef::StmtTry(try_stmt) => [&try_stmt.body, &try_stmt.orelse, &try_stmt.finalbody]
             .into_iter()
             .chain(
-                handlers
+                try_stmt
+                    .handlers
                     .iter()
                     .filter_map(ExceptHandler::as_except_handler)
                     .map(|handler| &handler.body),

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -134,25 +134,18 @@ pub fn walk_elif_else_clause<'a, V: Visitor<'a> + ?Sized>(
 
 pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
     match stmt {
-        Stmt::FunctionDef(ast::StmtFunctionDef {
-            parameters,
-            body,
-            decorator_list,
-            returns,
-            type_params,
-            ..
-        }) => {
-            for decorator in decorator_list {
+        Stmt::FunctionDef(stmt) => {
+            for decorator in &stmt.decorator_list {
                 visitor.visit_decorator(decorator);
             }
-            if let Some(type_params) = type_params {
+            if let Some(type_params) = &stmt.name.type_params {
                 visitor.visit_type_params(type_params);
             }
-            visitor.visit_parameters(parameters);
-            if let Some(expr) = returns {
+            visitor.visit_parameters(&stmt.parameters);
+            if let Some(expr) = &stmt.returns {
                 visitor.visit_annotation(expr);
             }
-            visitor.visit_body(body);
+            visitor.visit_body(&stmt.body);
         }
         Stmt::ClassDef(ast::StmtClassDef {
             arguments,
@@ -301,21 +294,13 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
                 visitor.visit_expr(expr);
             }
         }
-        Stmt::Try(ast::StmtTry {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-            is_star: _,
-            range: _,
-            node_index: _,
-        }) => {
-            visitor.visit_body(body);
-            for except_handler in handlers {
+        Stmt::Try(stmt) => {
+            visitor.visit_body(&stmt.body);
+            for except_handler in &stmt.handlers {
                 visitor.visit_except_handler(except_handler);
             }
-            visitor.visit_body(orelse);
-            visitor.visit_body(finalbody);
+            visitor.visit_body(&stmt.orelse);
+            visitor.visit_body(&stmt.finalbody);
         }
         Stmt::Assert(ast::StmtAssert {
             test,

--- a/crates/ruff_python_ast/src/visitor/transformer.rs
+++ b/crates/ruff_python_ast/src/visitor/transformer.rs
@@ -121,25 +121,18 @@ pub fn walk_elif_else_clause<V: Transformer + ?Sized>(
 
 pub fn walk_stmt<V: Transformer + ?Sized>(visitor: &V, stmt: &mut Stmt) {
     match stmt {
-        Stmt::FunctionDef(ast::StmtFunctionDef {
-            parameters,
-            body,
-            decorator_list,
-            returns,
-            type_params,
-            ..
-        }) => {
-            for decorator in decorator_list {
+        Stmt::FunctionDef(stmt) => {
+            for decorator in &mut stmt.decorator_list {
                 visitor.visit_decorator(decorator);
             }
-            if let Some(type_params) = type_params {
+            if let Some(type_params) = &mut stmt.name.type_params {
                 visitor.visit_type_params(type_params);
             }
-            visitor.visit_parameters(parameters);
-            if let Some(expr) = returns {
+            visitor.visit_parameters(&mut stmt.parameters);
+            if let Some(expr) = &mut stmt.returns {
                 visitor.visit_annotation(expr);
             }
-            visitor.visit_body(body);
+            visitor.visit_body(&mut stmt.body);
         }
         Stmt::ClassDef(ast::StmtClassDef {
             arguments,
@@ -285,21 +278,13 @@ pub fn walk_stmt<V: Transformer + ?Sized>(visitor: &V, stmt: &mut Stmt) {
                 visitor.visit_expr(expr);
             }
         }
-        Stmt::Try(ast::StmtTry {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-            is_star: _,
-            range: _,
-            node_index: _,
-        }) => {
-            visitor.visit_body(body);
-            for except_handler in handlers {
+        Stmt::Try(stmt) => {
+            visitor.visit_body(&mut stmt.body);
+            for except_handler in &mut stmt.handlers {
                 visitor.visit_except_handler(except_handler);
             }
-            visitor.visit_body(orelse);
-            visitor.visit_body(finalbody);
+            visitor.visit_body(&mut stmt.orelse);
+            visitor.visit_body(&mut stmt.finalbody);
         }
         Stmt::Assert(ast::StmtAssert {
             test,

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -263,7 +263,6 @@ impl<'a> Generator<'a> {
                 body,
                 returns,
                 decorator_list,
-                type_params,
                 ..
             }) => {
                 self.newlines(if self.indent_depth == 0 { 2 } else { 1 });
@@ -278,8 +277,8 @@ impl<'a> Generator<'a> {
                         self.p("async ");
                     }
                     self.p("def ");
-                    self.p_id(name);
-                    if let Some(type_params) = type_params {
+                    self.p_id(&name.name);
+                    if let Some(type_params) = &name.type_params {
                         self.unparse_type_params(type_params);
                     }
                     self.p("(");
@@ -584,15 +583,14 @@ impl<'a> Generator<'a> {
                     }
                 });
             }
-            Stmt::Try(ast::StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                is_star,
-                range: _,
-                node_index: _,
-            }) => {
+            Stmt::Try(try_stmt) => {
+                let ast::StmtTryInner {
+                    body,
+                    handlers,
+                    orelse,
+                    finalbody,
+                    is_star,
+                } = try_stmt.inner.as_ref();
                 statement!({
                     self.p("try:");
                 });

--- a/crates/ruff_python_formatter/src/range.rs
+++ b/crates/ruff_python_formatter/src/range.rs
@@ -5,7 +5,7 @@ use ruff_formatter::{
     FormatContext, FormatError, FormatOptions, IndentStyle, PrintedRange, SourceCode, format,
 };
 use ruff_python_ast::visitor::source_order::{SourceOrderVisitor, TraversalSignal, walk_body};
-use ruff_python_ast::{AnyNodeRef, Stmt, StmtMatch, StmtTry};
+use ruff_python_ast::{AnyNodeRef, Stmt, StmtMatch};
 use ruff_python_parser::{ParseOptions, parse};
 use ruff_python_trivia::{
     BackwardsTokenizer, SimpleToken, SimpleTokenKind, TriviaRanges, indentation_at_offset,
@@ -410,15 +410,14 @@ impl SourceOrderVisitor<'_> for NarrowRange<'_> {
                 // Already traversed as part of `enter_node`.
                 TraversalSignal::Skip
             }
-            AnyNodeRef::StmtTry(StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                is_star: _,
-                range: _,
-                node_index: _,
-            }) => {
+            AnyNodeRef::StmtTry(try_stmt) => {
+                let ruff_python_ast::StmtTryInner {
+                    body,
+                    handlers,
+                    orelse,
+                    finalbody,
+                    is_star: _,
+                } = try_stmt.inner.as_ref();
                 self.visit_body(body);
                 if let Some(except_handler_saved) =
                     self.enter_level(handlers.first().map(AnyNodeRef::from))

--- a/crates/ruff_python_formatter/src/statement/clause.rs
+++ b/crates/ruff_python_formatter/src/statement/clause.rs
@@ -52,20 +52,20 @@ impl<'a> ClauseHeader<'a> {
             | ClauseHeader::Function(StmtFunctionDef { body, .. })
             | ClauseHeader::If(StmtIf { body, .. })
             | ClauseHeader::ElifElse(ElifElseClause { body, .. })
-            | ClauseHeader::Try(StmtTry { body, .. })
             | ClauseHeader::MatchCase(MatchCase { body, .. })
             | ClauseHeader::For(StmtFor { body, .. })
             | ClauseHeader::While(StmtWhile { body, .. })
             | ClauseHeader::With(StmtWith { body, .. })
             | ClauseHeader::ExceptHandler(ExceptHandlerExceptHandler { body, .. })
             | ClauseHeader::OrElse(
-                ElseClause::Try(StmtTry { orelse: body, .. })
-                | ElseClause::For(StmtFor { orelse: body, .. })
+                ElseClause::For(StmtFor { orelse: body, .. })
                 | ElseClause::While(StmtWhile { orelse: body, .. }),
-            )
-            | ClauseHeader::TryFinally(StmtTry {
-                finalbody: body, ..
-            }) => body.last().map(AnyNodeRef::from),
+            ) => body.last().map(AnyNodeRef::from),
+            ClauseHeader::Try(try_stmt) => try_stmt.body.last().map(AnyNodeRef::from),
+            ClauseHeader::OrElse(ElseClause::Try(try_stmt)) => {
+                try_stmt.orelse.last().map(AnyNodeRef::from)
+            }
+            ClauseHeader::TryFinally(try_stmt) => try_stmt.finalbody.last().map(AnyNodeRef::from),
             ClauseHeader::Match(StmtMatch { cases, .. }) => cases
                 .last()
                 .and_then(|case| case.body.last().map(AnyNodeRef::from)),
@@ -136,17 +136,16 @@ impl<'a> ClauseHeader<'a> {
                 }
             }
             ClauseHeader::Function(StmtFunctionDef {
-                type_params,
                 parameters,
                 range: _,
                 node_index: _,
                 is_async: _,
                 decorator_list: _,
-                name: _,
+                name,
                 returns,
                 body: _,
             }) => {
-                if let Some(type_params) = type_params.as_deref() {
+                if let Some(type_params) = name.type_params.as_deref() {
                     visit(type_params, visitor);
                 }
                 visit(parameters.as_ref(), visitor);
@@ -170,7 +169,7 @@ impl<'a> ClauseHeader<'a> {
                 node_index: _,
                 body: _,
             }) => {
-                if let Some(test) = test.as_ref() {
+                if let Some(test) = test.as_deref() {
                     visit(test, visitor);
                 }
             }

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -98,7 +98,6 @@ fn format_function_header(f: &mut PyFormatter, item: &StmtFunctionDef) -> Format
         is_async,
         decorator_list: _,
         name,
-        type_params,
         parameters,
         returns,
         body: _,
@@ -110,9 +109,9 @@ fn format_function_header(f: &mut PyFormatter, item: &StmtFunctionDef) -> Format
         write!(f, [token("async"), space()])?;
     }
 
-    write!(f, [token("def"), space(), name.format()])?;
+    write!(f, [token("def"), space(), name.name.format()])?;
 
-    if let Some(type_params) = type_params.as_ref() {
+    if let Some(type_params) = name.type_params.as_ref() {
         type_params.format().fmt(f)?;
     }
 

--- a/crates/ruff_python_formatter/src/statement/stmt_import_from.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_import_from.rs
@@ -36,7 +36,7 @@ impl FormatNodeRule<StmtImportFrom> for FormatStmtImportFrom {
                     }
                     Ok(())
                 }),
-                module.as_ref().map(DotDelimitedIdentifier::new),
+                module.as_deref().map(DotDelimitedIdentifier::new),
                 space(),
                 token("import"),
                 space(),

--- a/crates/ruff_python_formatter/src/statement/stmt_try.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_try.rs
@@ -59,15 +59,13 @@ impl<'ast> AsFormat<PyFormatContext<'ast>> for ExceptHandler {
 
 impl FormatNodeRule<StmtTry> for FormatStmtTry {
     fn fmt_fields(&self, item: &StmtTry, f: &mut PyFormatter) -> FormatResult<()> {
-        let StmtTry {
+        let ruff_python_ast::StmtTryInner {
             body,
             handlers,
             orelse,
             finalbody,
             is_star,
-            range: _,
-            node_index: _,
-        } = item;
+        } = item.inner.as_ref();
 
         let comments_info = f.context().comments().clone();
         let mut dangling_comments = comments_info.dangling(item);

--- a/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__ipython_escape_commands.snap
+++ b/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__ipython_escape_commands.snap
@@ -146,13 +146,15 @@ Module(
                     range: 566..626,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 570..573,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 570..573,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 573..575,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -761,7 +761,7 @@ impl<'src> Parser<'src> {
         names.shrink_to_fit();
 
         ast::StmtImportFrom {
-            module,
+            module: module.map(Box::new),
             names,
             level: leading_dots,
             is_lazy,
@@ -1493,10 +1493,10 @@ impl<'src> Parser<'src> {
             //     pass
             // elif yield x:
             //     pass
-            Some(
+            Some(Box::new(
                 self.parse_named_expression_or_higher(ExpressionContext::default())
                     .expr,
-            )
+            ))
         } else {
             None
         };
@@ -1662,11 +1662,13 @@ impl<'src> Parser<'src> {
         // except    *     Error: ...
 
         ast::StmtTry {
-            body: try_body,
-            handlers,
-            orelse,
-            finalbody,
-            is_star,
+            inner: Box::new(ast::StmtTryInner {
+                body: try_body,
+                handlers,
+                orelse,
+                finalbody,
+                is_star,
+            }),
             range: self.node_range(try_start),
             node_index: AtomicNodeIndex::NONE,
         }
@@ -2100,8 +2102,10 @@ impl<'src> Parser<'src> {
         let body = self.parse_body(Clause::FunctionDef);
 
         ast::StmtFunctionDef {
-            name,
-            type_params: type_params.map(Box::new),
+            name: Box::new(ast::FunctionDefName {
+                name,
+                type_params: type_params.map(Box::new),
+            }),
             parameters: Box::new(parameters),
             body,
             decorator_list,
@@ -2179,7 +2183,7 @@ impl<'src> Parser<'src> {
         ast::StmtClassDef {
             range: self.node_range(start),
             decorator_list,
-            name,
+            name: Box::new(name),
             type_params: type_params.map(Box::new),
             arguments,
             body,
@@ -3055,13 +3059,15 @@ impl<'src> Parser<'src> {
                     range,
                     is_async: false,
                     decorator_list: decorators,
-                    name: ast::Identifier {
-                        id: Name::empty(),
-                        range: self.missing_node_range(),
-                        node_index: AtomicNodeIndex::NONE,
-                        parameter_node_index: AtomicNodeIndex::NONE,
-                    },
-                    type_params: None,
+                    name: Box::new(ast::FunctionDefName {
+                        name: ast::Identifier {
+                            id: Name::empty(),
+                            range: self.missing_node_range(),
+                            node_index: AtomicNodeIndex::NONE,
+                            parameter_node_index: AtomicNodeIndex::NONE,
+                        },
+                        type_params: None,
+                    }),
                     parameters: Box::new(ast::Parameters {
                         range: self.missing_node_range(),
                         ..ast::Parameters::default()

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -130,7 +130,10 @@ impl SemanticSyntaxChecker {
                         //     lazy from sys import *
                         Self::add_error(ctx, SemanticSyntaxErrorKind::LazyImportStar, *range);
                         handled_lazy_error = true;
-                    } else if matches!(module.as_deref(), Some("__future__")) {
+                    } else if matches!(
+                        module.as_deref().map(ast::Identifier::as_str),
+                        Some("__future__")
+                    ) {
                         Self::add_error(ctx, SemanticSyntaxErrorKind::LazyFutureImport, *range);
                         handled_lazy_error = true;
                     }
@@ -139,7 +142,10 @@ impl SemanticSyntaxChecker {
                 if handled_lazy_error {
                     // Skip the regular `from`-import validations after reporting the lazy-specific
                     // syntax error with the highest precedence.
-                } else if matches!(module.as_deref(), Some("__future__")) {
+                } else if matches!(
+                    module.as_deref().map(ast::Identifier::as_str),
+                    Some("__future__")
+                ) {
                     for name in names {
                         if !is_known_future_feature(&name.name) {
                             // test_ok valid_future_feature
@@ -179,7 +185,11 @@ impl SemanticSyntaxChecker {
                         Self::add_error(
                             ctx,
                             SemanticSyntaxErrorKind::NonModuleImportStar(
-                                helpers::format_import_from(*level, module.as_deref()).to_string(),
+                                helpers::format_import_from(
+                                    *level,
+                                    module.as_deref().map(ast::Identifier::as_str),
+                                )
+                                .to_string(),
                             ),
                             *range,
                         );
@@ -205,11 +215,9 @@ impl SemanticSyntaxChecker {
                 }
             }
             Stmt::FunctionDef(ast::StmtFunctionDef {
-                type_params,
-                parameters,
-                ..
+                name, parameters, ..
             }) => {
-                if let Some(type_params) = type_params {
+                if let Some(type_params) = &name.type_params {
                     Self::duplicate_type_parameter_name(type_params, ctx);
                     Self::type_parameter_default_order(type_params, ctx);
                 }
@@ -390,7 +398,7 @@ impl SemanticSyntaxChecker {
                 }
             }
             Stmt::FunctionDef(ast::StmtFunctionDef {
-                type_params,
+                name,
                 parameters,
                 returns,
                 ..
@@ -446,13 +454,13 @@ impl SemanticSyntaxChecker {
                     position: InvalidExpressionPosition::TypeAnnotation,
                     ctx,
                 };
-                if let Some(type_params) = type_params {
+                if let Some(type_params) = &name.type_params {
                     visitor.visit_type_params(type_params);
                 }
                 // the __future__ annotation error takes precedence over the generic error
                 if ctx.future_annotations_or_stub() || ctx.python_version() > PythonVersion::PY313 {
                     visitor.position = InvalidExpressionPosition::TypeAnnotation;
-                } else if type_params.is_some() {
+                } else if name.type_params.is_some() {
                     visitor.position = InvalidExpressionPosition::GenericDefinition;
                 } else {
                     return;
@@ -577,10 +585,7 @@ impl SemanticSyntaxChecker {
     fn debug_shadowing<Ctx: SemanticSyntaxContext>(stmt: &ast::Stmt, ctx: &Ctx) {
         match stmt {
             Stmt::FunctionDef(ast::StmtFunctionDef {
-                name,
-                type_params,
-                parameters,
-                ..
+                name, parameters, ..
             }) => {
                 // test_err debug_shadow_function
                 // def __debug__(): ...  # function name
@@ -588,7 +593,7 @@ impl SemanticSyntaxChecker {
                 // def f(__debug__): ...  # parameter name
                 // lambda __debug__: 0  # lambda parameter name
                 Self::check_identifier(name, ctx);
-                if let Some(type_params) = type_params {
+                if let Some(type_params) = &name.type_params {
                     for type_param in type_params.iter() {
                         Self::check_identifier(type_param.name(), ctx);
                     }
@@ -640,11 +645,12 @@ impl SemanticSyntaxChecker {
                     }
                 }
             }
-            Stmt::Try(ast::StmtTry { handlers, .. }) => {
+            Stmt::Try(stmt) => {
                 // test_err debug_shadow_try
                 // try: ...
                 // except Exception as __debug__: ...
-                for handler in handlers
+                for handler in stmt
+                    .handlers
                     .iter()
                     .filter_map(ast::ExceptHandler::as_except_handler)
                 {
@@ -832,7 +838,12 @@ impl SemanticSyntaxChecker {
             }) => {
                 // Allow eager `__future__` imports until we see any other import. Lazy imports,
                 // including `lazy from __future__ import ...`, always close the boundary.
-                if *is_lazy || !matches!(module.as_deref(), Some("__future__")) {
+                if *is_lazy
+                    || !matches!(
+                        module.as_deref().map(ast::Identifier::as_str),
+                        Some("__future__")
+                    )
+                {
                     self.seen_futures_boundary = true;
                 }
             }

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@async_unexpected_token.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@async_unexpected_token.py.snap
@@ -99,13 +99,15 @@ Module(
                     range: 61..81,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 71..74,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 71..74,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 74..76,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_function.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_function.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..20,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("__debug__"),
-                        range: 4..13,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("__debug__"),
+                            range: 4..13,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 13..15,
                         node_index: NodeIndex(None),
@@ -55,34 +57,36 @@ Module(
                     range: 38..61,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 42..43,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 43..54,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 42..43,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 44..53,
-                                        name: Identifier {
-                                            id: Name("__debug__"),
-                                            range: 44..53,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 43..54,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 44..53,
+                                            name: Identifier {
+                                                id: Name("__debug__"),
+                                                range: 44..53,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 54..56,
                         node_index: NodeIndex(None),
@@ -115,13 +119,15 @@ Module(
                     range: 85..106,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 89..90,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 89..90,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 90..101,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_try.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_try.py.snap
@@ -14,63 +14,65 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..43,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 5..8,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 5..8,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 9..43,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 5..8,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 16..25,
-                                            id: Name("Exception"),
-                                            ctx: Load,
+                                            range: 5..8,
                                         },
                                     ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("__debug__"),
-                                        range: 29..38,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 9..43,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 16..25,
+                                                id: Name("Exception"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("__debug__"),
+                                            range: 29..38,
                                             node_index: NodeIndex(None),
-                                            range: 40..43,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 40..43,
-                                                },
-                                            ),
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 40..43,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 40..43,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_await_expression_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_await_expression_py38.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 45..95,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 55..58,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 55..58,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 58..60,
                         node_index: NodeIndex(None),
@@ -59,13 +61,15 @@ Module(
                                         ),
                                     },
                                 ],
-                                name: Identifier {
-                                    id: Name("baz"),
-                                    range: 85..88,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("baz"),
+                                        range: 85..88,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 88..90,
                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_dict_literal_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_dict_literal_py38.py.snap
@@ -51,13 +51,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("bar"),
-                        range: 57..60,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("bar"),
+                            range: 57..60,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 60..62,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_expression_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_expression_py38.py.snap
@@ -71,13 +71,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("spam"),
-                        range: 77..81,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("spam"),
+                            range: 77..81,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 81..83,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_float_literal_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_float_literal_py38.py.snap
@@ -30,13 +30,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("bar"),
-                        range: 55..58,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("bar"),
+                            range: 55..58,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 58..60,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_invalid_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_invalid_expression.py.snap
@@ -112,13 +112,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 45..48,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 45..48,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 48..50,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_missing_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_missing_expression.py.snap
@@ -29,13 +29,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 5..8,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 5..8,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 8..10,
                         node_index: NodeIndex(None),
@@ -81,13 +83,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 22..25,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 22..25,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 25..27,
                         node_index: NodeIndex(None),
@@ -148,13 +152,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 40..43,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 40..43,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 43..45,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_missing_newline.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_missing_newline.py.snap
@@ -29,13 +29,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 7..10,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 7..10,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 10..12,
                         node_index: NodeIndex(None),
@@ -81,13 +83,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 31..34,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 31..34,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 34..36,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_named_expression_py37.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_named_expression_py37.py.snap
@@ -97,13 +97,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("bar"),
-                        range: 74..77,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("bar"),
+                            range: 74..77,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 77..79,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_non_toplevel_call_expression_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_non_toplevel_call_expression_py38.py.snap
@@ -66,13 +66,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("baz"),
-                        range: 62..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("baz"),
+                            range: 62..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..67,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_unexpected_token.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@decorator_unexpected_token.py.snap
@@ -29,13 +29,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name(""),
-                        range: 4..4,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name(""),
+                            range: 4..4,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 4..4,
                         node_index: NodeIndex(None),
@@ -104,13 +106,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name(""),
-                        range: 27..27,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name(""),
+                            range: 27..27,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 27..27,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@duplicate_type_parameter_names.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@duplicate_type_parameter_names.py.snap
@@ -72,48 +72,50 @@ Module(
                     range: 23..45,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 27..28,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 28..34,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 27..28,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 29..30,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 29..30,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 32..33,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 32..33,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 28..34,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 29..30,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 29..30,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 32..33,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 32..33,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 34..40,
                         node_index: NodeIndex(None),
@@ -390,62 +392,64 @@ Module(
                     range: 133..154,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 137..138,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 138..147,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 137..138,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 139..140,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 139..140,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 142..143,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 142..143,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 145..146,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 145..146,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 138..147,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 139..140,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 139..140,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 142..143,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 142..143,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 145..146,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 145..146,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 147..149,
                         node_index: NodeIndex(None),
@@ -478,47 +482,49 @@ Module(
                     range: 169..188,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 173..174,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 174..181,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 173..174,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 175..176,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 175..176,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                                TypeVarTuple(
-                                    TypeParamTypeVarTuple {
-                                        node_index: NodeIndex(None),
-                                        range: 178..180,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 179..180,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 174..181,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 175..176,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 175..176,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                    TypeVarTuple(
+                                        TypeParamTypeVarTuple {
+                                            node_index: NodeIndex(None),
+                                            range: 178..180,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 179..180,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 181..183,
                         node_index: NodeIndex(None),
@@ -551,47 +557,49 @@ Module(
                     range: 218..238,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 222..223,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 223..231,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 222..223,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 224..225,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 224..225,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                                ParamSpec(
-                                    TypeParamParamSpec {
-                                        node_index: NodeIndex(None),
-                                        range: 227..230,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 229..230,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 223..231,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 224..225,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 224..225,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                    ParamSpec(
+                                        TypeParamParamSpec {
+                                            node_index: NodeIndex(None),
+                                            range: 227..230,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 229..230,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 231..233,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_star_py310.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_star_py310.py.snap
@@ -14,118 +14,120 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 44..125,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 49..52,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 49..52,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 53..76,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 49..52,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 61..71,
-                                            id: Name("ValueError"),
-                                            ctx: Load,
+                                            range: 49..52,
                                         },
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 73..76,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 73..76,
-                                                },
-                                            ),
-                                        },
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 53..76,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 61..71,
+                                                id: Name("ValueError"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 77..98,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 85..93,
-                                            id: Name("KeyError"),
-                                            ctx: Load,
-                                        },
+                                    name: None,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 73..76,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 73..76,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 77..98,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 85..93,
+                                                id: Name("KeyError"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 95..98,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 95..98,
-                                                },
-                                            ),
-                                        },
+                                    name: None,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 95..98,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 95..98,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 99..125,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 115..120,
+                                                id: Name("Error"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 99..125,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 115..120,
-                                            id: Name("Error"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 122..125,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 122..125,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                    name: None,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 122..125,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 122..125,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_invalid_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_invalid_expression.py.snap
@@ -14,103 +14,107 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..38,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 9..13,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 14..38,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Yield(
-                                        ExprYield {
-                                            node_index: NodeIndex(None),
-                                            range: 21..28,
-                                            value: Some(
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 27..28,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 9..13,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 14..38,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Yield(
+                                            ExprYield {
+                                                node_index: NodeIndex(None),
+                                                range: 21..28,
+                                                value: Some(
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 27..28,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                 ),
-                                            ),
-                                        },
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 34..38,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 34..38,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 39..73,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 48..52,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 53..73,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Starred(
-                                        ExprStarred {
-                                            node_index: NodeIndex(None),
-                                            range: 61..63,
-                                            value: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 62..63,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            ctx: Load,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 48..52,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 53..73,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Starred(
+                                            ExprStarred {
+                                                node_index: NodeIndex(None),
+                                                range: 61..63,
+                                                value: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 62..63,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 69..73,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 69..73,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_missing_as_name.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_missing_as_name.py.snap
@@ -14,69 +14,71 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..72,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 9..13,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 14..43,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 21..30,
-                                            id: Name("Exception"),
-                                            ctx: Load,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 9..13,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 14..43,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 21..30,
+                                                id: Name("Exception"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 39..43,
-                                        },
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 39..43,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 44..72,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 51..60,
+                                                id: Name("Exception"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 44..72,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 51..60,
-                                            id: Name("Exception"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 68..72,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 68..72,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_missing_exception.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_missing_exception.py.snap
@@ -14,116 +14,120 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..37,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 9..13,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 14..37,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: Some(
-                                    Identifier {
-                                        id: Name("exc"),
-                                        range: 24..27,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Pass(
-                                        StmtPass {
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 9..13,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 14..37,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("exc"),
+                                            range: 24..27,
                                             node_index: NodeIndex(None),
-                                            range: 33..37,
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 33..37,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 92..165,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 101..105,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 106..123,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 101..105,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 106..123,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 119..123,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 124..140,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 136..140,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 141..165,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("exc"),
+                                            range: 152..155,
                                             node_index: NodeIndex(None),
-                                            range: 119..123,
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 124..140,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 136..140,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 141..165,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: Some(
-                                    Identifier {
-                                        id: Name("exc"),
-                                        range: 152..155,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 161..165,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 161..165,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_missing_exception_and_as_name.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_missing_exception_and_as_name.py.snap
@@ -14,35 +14,37 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..33,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 9..13,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 14..33,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 29..33,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 9..13,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 14..33,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 29..33,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_unparenthesized_tuple_as.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_unparenthesized_tuple_as.py.snap
@@ -14,138 +14,142 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..42,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 9..13,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 14..42,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Tuple(
-                                        ExprTuple {
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 9..13,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 14..42,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Tuple(
+                                            ExprTuple {
+                                                node_index: NodeIndex(None),
+                                                range: 21..25,
+                                                elts: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 21..22,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 24..25,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                                ctx: Load,
+                                                parenthesized: false,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("exc"),
+                                            range: 29..32,
                                             node_index: NodeIndex(None),
-                                            range: 21..25,
-                                            elts: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 21..22,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 24..25,
-                                                        id: Name("y"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                            ],
-                                            ctx: Load,
-                                            parenthesized: false,
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("exc"),
-                                        range: 29..32,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 38..42,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 38..42,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 43..85,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 52..56,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 57..85,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Tuple(
-                                        ExprTuple {
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 52..56,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 57..85,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Tuple(
+                                            ExprTuple {
+                                                node_index: NodeIndex(None),
+                                                range: 65..69,
+                                                elts: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 65..66,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 68..69,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                                ctx: Load,
+                                                parenthesized: false,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("eg"),
+                                            range: 73..75,
                                             node_index: NodeIndex(None),
-                                            range: 65..69,
-                                            elts: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 65..66,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 68..69,
-                                                        id: Name("y"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                            ],
-                                            ctx: Load,
-                                            parenthesized: false,
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("eg"),
-                                        range: 73..75,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 81..85,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 81..85,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_unparenthesized_tuple_no_as_py313.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@except_stmt_unparenthesized_tuple_no_as_py313.py.snap
@@ -14,124 +14,128 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 44..79,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 53..57,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 58..79,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Tuple(
-                                        ExprTuple {
-                                            node_index: NodeIndex(None),
-                                            range: 65..69,
-                                            elts: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 65..66,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 68..69,
-                                                        id: Name("y"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                            ],
-                                            ctx: Load,
-                                            parenthesized: false,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 53..57,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 58..79,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Tuple(
+                                            ExprTuple {
+                                                node_index: NodeIndex(None),
+                                                range: 65..69,
+                                                elts: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 65..66,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 68..69,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                                ctx: Load,
+                                                parenthesized: false,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 75..79,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 75..79,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 80..116,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 89..93,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 94..116,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Tuple(
-                                        ExprTuple {
-                                            node_index: NodeIndex(None),
-                                            range: 102..106,
-                                            elts: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 102..103,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 105..106,
-                                                        id: Name("y"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                            ],
-                                            ctx: Load,
-                                            parenthesized: false,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 89..93,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 94..116,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Tuple(
+                                            ExprTuple {
+                                                node_index: NodeIndex(None),
+                                                range: 102..106,
+                                                elts: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 102..103,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 105..106,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                                ctx: Load,
+                                                parenthesized: false,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 112..116,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 112..116,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_0.py.snap
@@ -42,13 +42,15 @@ Module(
                     range: 7..26,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 11..14,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 11..14,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 14..16,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_1.py.snap
@@ -51,13 +51,15 @@ Module(
                     range: 8..27,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 12..15,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 12..15,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 15..17,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__arguments__unclosed_2.py.snap
@@ -51,13 +51,15 @@ Module(
                     range: 9..28,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 13..16,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 13..16,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 16..18,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__await__no_expression_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__await__no_expression_1.py.snap
@@ -36,13 +36,15 @@ Module(
                     range: 66..85,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 70..73,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 70..73,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 73..75,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__missing_closing_brace_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__missing_closing_brace_2.py.snap
@@ -51,13 +51,15 @@ Module(
                     range: 8..27,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 12..15,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 12..15,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 15..17,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__if__missing_orelse_expr_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__if__missing_orelse_expr_0.py.snap
@@ -52,13 +52,15 @@ Module(
                     range: 69..88,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 73..76,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 73..76,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 76..78,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__if__missing_test_expr_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__if__missing_test_expr_0.py.snap
@@ -52,13 +52,15 @@ Module(
                     range: 57..76,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 61..64,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 61..64,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 64..66,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__missing_closing_bracket_3.py.snap
@@ -49,13 +49,15 @@ Module(
                     range: 121..140,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 125..128,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 125..128,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 128..130,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__missing_closing_paren_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__missing_closing_paren_3.py.snap
@@ -50,13 +50,15 @@ Module(
                     range: 125..144,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 129..132,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 129..132,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 132..134,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__missing_closing_curly_brace_3.py.snap
@@ -48,13 +48,15 @@ Module(
                     range: 125..144,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 129..132,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 129..132,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 132..134,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_empty_body.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_empty_body.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..10,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..9,
                         node_index: NodeIndex(None),
@@ -42,13 +44,15 @@ Module(
                     range: 11..28,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 15..18,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 15..18,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 18..20,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_invalid_return_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_invalid_return_expr.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..22,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..9,
                         node_index: NodeIndex(None),
@@ -71,13 +73,15 @@ Module(
                     range: 23..47,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 27..30,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 27..30,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 30..32,
                         node_index: NodeIndex(None),
@@ -126,13 +130,15 @@ Module(
                     range: 48..73,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 52..55,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 52..55,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 55..57,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_missing_identifier.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_missing_identifier.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..11,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name(""),
-                        range: 3..3,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name(""),
+                            range: 3..3,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 4..6,
                         node_index: NodeIndex(None),
@@ -55,13 +57,15 @@ Module(
                     range: 12..30,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name(""),
-                        range: 15..15,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name(""),
+                            range: 15..15,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 16..18,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_missing_return_type.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_missing_return_type.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..18,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..9,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unclosed_parameter_list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unclosed_parameter_list.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..18,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..18,
                         node_index: NodeIndex(None),
@@ -82,13 +84,15 @@ Module(
                     range: 19..43,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 23..26,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 23..26,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 26..28,
                         node_index: NodeIndex(None),
@@ -126,13 +130,15 @@ Module(
                     range: 44..74,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 48..51,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 48..51,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 51..74,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unclosed_type_param_list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unclosed_type_param_list.py.snap
@@ -16,47 +16,49 @@ Module(
                     range: 0..39,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 7..15,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 8..10,
-                                        name: Identifier {
-                                            id: Name("T1"),
-                                            range: 8..10,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                                TypeVarTuple(
-                                    TypeParamTypeVarTuple {
-                                        node_index: NodeIndex(None),
-                                        range: 12..15,
-                                        name: Identifier {
-                                            id: Name("T2"),
-                                            range: 13..15,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 7..15,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 8..10,
+                                            name: Identifier {
+                                                id: Name("T1"),
+                                                range: 8..10,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                    TypeVarTuple(
+                                        TypeParamTypeVarTuple {
+                                            node_index: NodeIndex(None),
+                                            range: 12..15,
+                                            name: Identifier {
+                                                id: Name("T2"),
+                                                range: 13..15,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 15..21,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unparenthesized_return_types.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_def_unparenthesized_return_types.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..22,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..9,
                         node_index: NodeIndex(None),
@@ -74,13 +76,15 @@ Module(
                     range: 23..49,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 27..30,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 27..30,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 30..32,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_type_params_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@function_type_params_py311.py.snap
@@ -16,34 +16,36 @@ Module(
                     range: 44..61,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 48..51,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 51..54,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 48..51,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 52..53,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 52..53,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 51..54,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 52..53,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 52..53,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 54..56,
                         node_index: NodeIndex(None),
@@ -76,19 +78,21 @@ Module(
                     range: 62..78,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 66..69,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 69..71,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 66..69,
                             node_index: NodeIndex(None),
-                            type_params: [],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 69..71,
+                                node_index: NodeIndex(None),
+                                type_params: [],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 71..73,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_from_star.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@import_from_star.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..34,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f1"),
-                        range: 4..6,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f1"),
+                            range: 4..6,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 6..8,
                         node_index: NodeIndex(None),
@@ -118,13 +120,15 @@ Module(
                     range: 69..105,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f2"),
-                        range: 73..75,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f2"),
+                            range: 73..75,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 75..77,
                         node_index: NodeIndex(None),
@@ -174,13 +178,15 @@ Module(
                     range: 106..143,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f3"),
-                        range: 110..112,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f3"),
+                            range: 110..112,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 112..114,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_function.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_function.py.snap
@@ -16,34 +16,36 @@ Module(
                     range: 0..28,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("d"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 5..8,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("d"),
+                            range: 4..5,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 6..7,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 6..7,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 5..8,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 6..7,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 6..7,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 8..10,
                         node_index: NodeIndex(None),
@@ -92,34 +94,36 @@ Module(
                     range: 29..58,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("e"),
-                        range: 33..34,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 34..37,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("e"),
+                            range: 33..34,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 35..36,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 35..36,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 34..37,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 35..36,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 35..36,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 37..53,
                         node_index: NodeIndex(None),
@@ -184,34 +188,36 @@ Module(
                     range: 59..86,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 63..64,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 64..67,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 63..64,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 65..66,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 65..66,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 64..67,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 65..66,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 65..66,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 67..69,
                         node_index: NodeIndex(None),
@@ -268,34 +274,36 @@ Module(
                     range: 87..115,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("g"),
-                        range: 91..92,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 92..95,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("g"),
+                            range: 91..92,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 93..94,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 93..94,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 92..95,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 93..94,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 93..94,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 95..110,
                         node_index: NodeIndex(None),
@@ -368,34 +376,36 @@ Module(
                     range: 116..143,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("h"),
-                        range: 120..121,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 121..124,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("h"),
+                            range: 120..121,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 122..123,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 122..123,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 121..124,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 122..123,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 122..123,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 124..138,
                         node_index: NodeIndex(None),
@@ -462,34 +472,36 @@ Module(
                     range: 144..172,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("j"),
-                        range: 148..149,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 149..152,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("j"),
+                            range: 148..149,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 150..151,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 150..151,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 149..152,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 150..151,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 150..151,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 152..154,
                         node_index: NodeIndex(None),
@@ -540,34 +552,36 @@ Module(
                     range: 173..205,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("l"),
-                        range: 177..178,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 178..181,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("l"),
+                            range: 177..178,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 179..180,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 179..180,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 178..181,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 179..180,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 179..180,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 181..200,
                         node_index: NodeIndex(None),
@@ -632,34 +646,36 @@ Module(
                     range: 206..239,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("n"),
-                        range: 210..211,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 211..214,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("n"),
+                            range: 210..211,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 212..213,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 212..213,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 211..214,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 212..213,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 212..213,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 214..216,
                         node_index: NodeIndex(None),
@@ -708,52 +724,54 @@ Module(
                     range: 240..266,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("p"),
-                        range: 244..245,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 245..259,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("p"),
+                            range: 244..245,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 246..258,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 246..247,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: Some(
-                                            Yield(
-                                                ExprYield {
-                                                    node_index: NodeIndex(None),
-                                                    range: 250..257,
-                                                    value: Some(
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 256..257,
-                                                                value: Int(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 245..259,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 246..258,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 246..247,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: Some(
+                                                Yield(
+                                                    ExprYield {
+                                                        node_index: NodeIndex(None),
+                                                        range: 250..257,
+                                                        value: Some(
+                                                            NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 256..257,
+                                                                    value: Int(
+                                                                        1,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 259..261,
                         node_index: NodeIndex(None),
@@ -786,52 +804,54 @@ Module(
                     range: 297..324,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("q"),
-                        range: 301..302,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 302..317,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("q"),
+                            range: 301..302,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 303..316,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 303..304,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: Some(
-                                            Yield(
-                                                ExprYield {
-                                                    node_index: NodeIndex(None),
-                                                    range: 308..315,
-                                                    value: Some(
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 314..315,
-                                                                value: Int(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 302..317,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 303..316,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 303..304,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: Some(
+                                                Yield(
+                                                    ExprYield {
+                                                        node_index: NodeIndex(None),
+                                                        range: 308..315,
+                                                        value: Some(
+                                                            NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 314..315,
+                                                                    value: Int(
+                                                                        1,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 317..319,
                         node_index: NodeIndex(None),
@@ -864,51 +884,53 @@ Module(
                     range: 356..385,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("r"),
-                        range: 360..361,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 361..378,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("r"),
+                            range: 360..361,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVarTuple(
-                                    TypeParamTypeVarTuple {
-                                        node_index: NodeIndex(None),
-                                        range: 362..377,
-                                        name: Identifier {
-                                            id: Name("Ts"),
-                                            range: 363..365,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: Some(
-                                            Yield(
-                                                ExprYield {
-                                                    node_index: NodeIndex(None),
-                                                    range: 369..376,
-                                                    value: Some(
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 375..376,
-                                                                value: Int(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 361..378,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVarTuple(
+                                        TypeParamTypeVarTuple {
+                                            node_index: NodeIndex(None),
+                                            range: 362..377,
+                                            name: Identifier {
+                                                id: Name("Ts"),
+                                                range: 363..365,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: Some(
+                                                Yield(
+                                                    ExprYield {
+                                                        node_index: NodeIndex(None),
+                                                        range: 369..376,
+                                                        value: Some(
+                                                            NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 375..376,
+                                                                    value: Int(
+                                                                        1,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 378..380,
                         node_index: NodeIndex(None),
@@ -941,51 +963,53 @@ Module(
                     range: 420..450,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("s"),
-                        range: 424..425,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 425..443,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("s"),
+                            range: 424..425,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                ParamSpec(
-                                    TypeParamParamSpec {
-                                        node_index: NodeIndex(None),
-                                        range: 426..442,
-                                        name: Identifier {
-                                            id: Name("Ts"),
-                                            range: 428..430,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: Some(
-                                            Yield(
-                                                ExprYield {
-                                                    node_index: NodeIndex(None),
-                                                    range: 434..441,
-                                                    value: Some(
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 440..441,
-                                                                value: Int(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 425..443,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    ParamSpec(
+                                        TypeParamParamSpec {
+                                            node_index: NodeIndex(None),
+                                            range: 426..442,
+                                            name: Identifier {
+                                                id: Name("Ts"),
+                                                range: 428..430,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: Some(
+                                                Yield(
+                                                    ExprYield {
+                                                        node_index: NodeIndex(None),
+                                                        range: 434..441,
+                                                        value: Some(
+                                                            NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 440..441,
+                                                                    value: Int(
+                                                                        1,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 443..445,
                         node_index: NodeIndex(None),
@@ -1018,58 +1042,60 @@ Module(
                     range: 481..506,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("t"),
-                        range: 485..486,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 486..499,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("t"),
+                            range: 485..486,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 487..498,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 487..488,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: Some(
-                                            Named(
-                                                ExprNamed {
-                                                    node_index: NodeIndex(None),
-                                                    range: 491..497,
-                                                    target: Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 491..492,
-                                                            id: Name("x"),
-                                                            ctx: Store,
-                                                        },
-                                                    ),
-                                                    value: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 496..497,
-                                                            value: Int(
-                                                                1,
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 486..499,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 487..498,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 487..488,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: Some(
+                                                Named(
+                                                    ExprNamed {
+                                                        node_index: NodeIndex(None),
+                                                        range: 491..497,
+                                                        target: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 491..492,
+                                                                id: Name("x"),
+                                                                ctx: Store,
+                                                            },
+                                                        ),
+                                                        value: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 496..497,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 499..501,
                         node_index: NodeIndex(None),
@@ -1102,58 +1128,60 @@ Module(
                     range: 543..569,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("u"),
-                        range: 547..548,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 548..562,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("u"),
+                            range: 547..548,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 549..561,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 549..550,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: Some(
-                                            Named(
-                                                ExprNamed {
-                                                    node_index: NodeIndex(None),
-                                                    range: 554..560,
-                                                    target: Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 554..555,
-                                                            id: Name("x"),
-                                                            ctx: Store,
-                                                        },
-                                                    ),
-                                                    value: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 559..560,
-                                                            value: Int(
-                                                                1,
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 548..562,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 549..561,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 549..550,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: Some(
+                                                Named(
+                                                    ExprNamed {
+                                                        node_index: NodeIndex(None),
+                                                        range: 554..560,
+                                                        target: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 554..555,
+                                                                id: Name("x"),
+                                                                ctx: Store,
+                                                            },
+                                                        ),
+                                                        value: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 559..560,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 562..564,
                         node_index: NodeIndex(None),
@@ -1186,57 +1214,59 @@ Module(
                     range: 607..635,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("v"),
-                        range: 611..612,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 612..628,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("v"),
+                            range: 611..612,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVarTuple(
-                                    TypeParamTypeVarTuple {
-                                        node_index: NodeIndex(None),
-                                        range: 613..627,
-                                        name: Identifier {
-                                            id: Name("Ts"),
-                                            range: 614..616,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: Some(
-                                            Named(
-                                                ExprNamed {
-                                                    node_index: NodeIndex(None),
-                                                    range: 620..626,
-                                                    target: Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 620..621,
-                                                            id: Name("x"),
-                                                            ctx: Store,
-                                                        },
-                                                    ),
-                                                    value: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 625..626,
-                                                            value: Int(
-                                                                1,
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 612..628,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVarTuple(
+                                        TypeParamTypeVarTuple {
+                                            node_index: NodeIndex(None),
+                                            range: 613..627,
+                                            name: Identifier {
+                                                id: Name("Ts"),
+                                                range: 614..616,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: Some(
+                                                Named(
+                                                    ExprNamed {
+                                                        node_index: NodeIndex(None),
+                                                        range: 620..626,
+                                                        target: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 620..621,
+                                                                id: Name("x"),
+                                                                ctx: Store,
+                                                            },
+                                                        ),
+                                                        value: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 625..626,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 628..630,
                         node_index: NodeIndex(None),
@@ -1269,57 +1299,59 @@ Module(
                     range: 676..705,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("w"),
-                        range: 680..681,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 681..698,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("w"),
+                            range: 680..681,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                ParamSpec(
-                                    TypeParamParamSpec {
-                                        node_index: NodeIndex(None),
-                                        range: 682..697,
-                                        name: Identifier {
-                                            id: Name("Ts"),
-                                            range: 684..686,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: Some(
-                                            Named(
-                                                ExprNamed {
-                                                    node_index: NodeIndex(None),
-                                                    range: 690..696,
-                                                    target: Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 690..691,
-                                                            id: Name("x"),
-                                                            ctx: Store,
-                                                        },
-                                                    ),
-                                                    value: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 695..696,
-                                                            value: Int(
-                                                                1,
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 681..698,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    ParamSpec(
+                                        TypeParamParamSpec {
+                                            node_index: NodeIndex(None),
+                                            range: 682..697,
+                                            name: Identifier {
+                                                id: Name("Ts"),
+                                                range: 684..686,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: Some(
+                                                Named(
+                                                    ExprNamed {
+                                                        node_index: NodeIndex(None),
+                                                        range: 690..696,
+                                                        target: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 690..691,
+                                                                id: Name("x"),
+                                                                ctx: Store,
+                                                            },
+                                                        ),
+                                                        value: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 695..696,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 698..700,
                         node_index: NodeIndex(None),
@@ -1352,50 +1384,52 @@ Module(
                     range: 742..768,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("t"),
-                        range: 746..747,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 747..761,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("t"),
+                            range: 746..747,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 748..760,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 748..749,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: Some(
-                                            Await(
-                                                ExprAwait {
-                                                    node_index: NodeIndex(None),
-                                                    range: 752..759,
-                                                    value: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 758..759,
-                                                            value: Int(
-                                                                1,
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 747..761,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 748..760,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 748..749,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: Some(
+                                                Await(
+                                                    ExprAwait {
+                                                        node_index: NodeIndex(None),
+                                                        range: 752..759,
+                                                        value: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 758..759,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 761..763,
                         node_index: NodeIndex(None),
@@ -1428,50 +1462,52 @@ Module(
                     range: 800..827,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("u"),
-                        range: 804..805,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 805..820,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("u"),
+                            range: 804..805,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 806..819,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 806..807,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: Some(
-                                            Await(
-                                                ExprAwait {
-                                                    node_index: NodeIndex(None),
-                                                    range: 811..818,
-                                                    value: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 817..818,
-                                                            value: Int(
-                                                                1,
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 805..820,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 806..819,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 806..807,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: Some(
+                                                Await(
+                                                    ExprAwait {
+                                                        node_index: NodeIndex(None),
+                                                        range: 811..818,
+                                                        value: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 817..818,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 820..822,
                         node_index: NodeIndex(None),
@@ -1504,49 +1540,51 @@ Module(
                     range: 860..889,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("v"),
-                        range: 864..865,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 865..882,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("v"),
+                            range: 864..865,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVarTuple(
-                                    TypeParamTypeVarTuple {
-                                        node_index: NodeIndex(None),
-                                        range: 866..881,
-                                        name: Identifier {
-                                            id: Name("Ts"),
-                                            range: 867..869,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: Some(
-                                            Await(
-                                                ExprAwait {
-                                                    node_index: NodeIndex(None),
-                                                    range: 873..880,
-                                                    value: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 879..880,
-                                                            value: Int(
-                                                                1,
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 865..882,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVarTuple(
+                                        TypeParamTypeVarTuple {
+                                            node_index: NodeIndex(None),
+                                            range: 866..881,
+                                            name: Identifier {
+                                                id: Name("Ts"),
+                                                range: 867..869,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: Some(
+                                                Await(
+                                                    ExprAwait {
+                                                        node_index: NodeIndex(None),
+                                                        range: 873..880,
+                                                        value: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 879..880,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 882..884,
                         node_index: NodeIndex(None),
@@ -1579,49 +1617,51 @@ Module(
                     range: 925..955,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("w"),
-                        range: 929..930,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 930..948,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("w"),
+                            range: 929..930,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                ParamSpec(
-                                    TypeParamParamSpec {
-                                        node_index: NodeIndex(None),
-                                        range: 931..947,
-                                        name: Identifier {
-                                            id: Name("Ts"),
-                                            range: 933..935,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: Some(
-                                            Await(
-                                                ExprAwait {
-                                                    node_index: NodeIndex(None),
-                                                    range: 939..946,
-                                                    value: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 945..946,
-                                                            value: Int(
-                                                                1,
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 930..948,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    ParamSpec(
+                                        TypeParamParamSpec {
+                                            node_index: NodeIndex(None),
+                                            range: 931..947,
+                                            name: Identifier {
+                                                id: Name("Ts"),
+                                                range: 933..935,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: Some(
+                                                Await(
+                                                    ExprAwait {
+                                                        node_index: NodeIndex(None),
+                                                        range: 939..946,
+                                                        value: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 945..946,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 948..950,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_function_py314.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_function_py314.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 44..68,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 48..49,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 48..49,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 49..51,
                         node_index: NodeIndex(None),
@@ -79,13 +81,15 @@ Module(
                     range: 69..94,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("g"),
-                        range: 73..74,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("g"),
+                            range: 73..74,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 74..89,
                         node_index: NodeIndex(None),
@@ -158,13 +162,15 @@ Module(
                     range: 95..235,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("outer"),
-                        range: 99..104,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("outer"),
+                            range: 99..104,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 104..106,
                         node_index: NodeIndex(None),
@@ -182,13 +188,15 @@ Module(
                                 range: 112..136,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("i"),
-                                    range: 116..117,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("i"),
+                                        range: 116..117,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 117..131,
                                     node_index: NodeIndex(None),
@@ -255,13 +263,15 @@ Module(
                                 range: 141..166,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("k"),
-                                    range: 145..146,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("k"),
+                                        range: 145..146,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 146..148,
                                     node_index: NodeIndex(None),
@@ -312,13 +322,15 @@ Module(
                                 range: 171..200,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("m"),
-                                    range: 175..176,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("m"),
+                                        range: 175..176,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 176..195,
                                     node_index: NodeIndex(None),
@@ -383,13 +395,15 @@ Module(
                                 range: 205..235,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("o"),
-                                    range: 209..210,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("o"),
+                                        range: 209..210,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 210..212,
                                     node_index: NodeIndex(None),
@@ -441,13 +455,15 @@ Module(
                     range: 236..315,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("outer"),
-                        range: 246..251,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("outer"),
+                            range: 246..251,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 251..253,
                         node_index: NodeIndex(None),
@@ -465,13 +481,15 @@ Module(
                                 range: 259..284,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("f"),
-                                    range: 263..264,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("f"),
+                                        range: 263..264,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 264..266,
                                     node_index: NodeIndex(None),
@@ -520,13 +538,15 @@ Module(
                                 range: 289..315,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("g"),
-                                    range: 293..294,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("g"),
+                                        range: 293..294,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 294..310,
                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_py314.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_annotation_py314.py.snap
@@ -55,13 +55,15 @@ Module(
                     range: 56..107,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("outer"),
-                        range: 60..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("outer"),
+                            range: 60..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..67,
                         node_index: NodeIndex(None),
@@ -146,13 +148,15 @@ Module(
                     range: 108..143,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("outer"),
-                        range: 118..123,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("outer"),
+                            range: 118..123,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 123..125,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@iter_unpack_return_py37.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@iter_unpack_return_py37.py.snap
@@ -69,13 +69,15 @@ Module(
                     range: 60..90,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 64..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 64..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..67,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@iter_unpack_yield_py37.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@iter_unpack_yield_py37.py.snap
@@ -69,13 +69,15 @@ Module(
                     range: 60..89,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("g"),
-                        range: 64..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("g"),
+                            range: 64..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..67,
                         node_index: NodeIndex(None),
@@ -162,13 +164,15 @@ Module(
                     range: 90..127,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("h"),
-                        range: 94..95,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("h"),
+                            range: 94..95,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 95..97,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@lazy_import_invalid_context_py315.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@lazy_import_invalid_context_py315.py.snap
@@ -14,115 +14,119 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 44..84,
-                    body: [
-                        Import(
-                            StmtImport {
-                                node_index: NodeIndex(None),
-                                range: 53..67,
-                                names: [
-                                    Alias {
-                                        end: 67,
-                                        node_index: NodeIndex(None),
-                                        name: Identifier {
-                                            id: Name("os"),
-                                            range: 65..67,
+                    inner: StmtTryInner {
+                        body: [
+                            Import(
+                                StmtImport {
+                                    node_index: NodeIndex(None),
+                                    range: 53..67,
+                                    names: [
+                                        Alias {
+                                            end: 67,
                                             node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
+                                            name: Identifier {
+                                                id: Name("os"),
+                                                range: 65..67,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            asname: None,
                                         },
-                                        asname: None,
-                                    },
-                                ],
-                                is_lazy: true,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 68..84,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 80..84,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    ],
+                                    is_lazy: true,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 68..84,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 80..84,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 86..135,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 95..96,
-                                value: Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 95..96,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 97..135,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 95..96,
+                                    value: Name(
                                         ExprName {
                                             node_index: NodeIndex(None),
-                                            range: 105..114,
-                                            id: Name("Exception"),
+                                            range: 95..96,
+                                            id: Name("x"),
                                             ctx: Load,
                                         },
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Import(
-                                        StmtImport {
-                                            node_index: NodeIndex(None),
-                                            range: 120..135,
-                                            names: [
-                                                Alias {
-                                                    end: 135,
-                                                    node_index: NodeIndex(None),
-                                                    name: Identifier {
-                                                        id: Name("sys"),
-                                                        range: 132..135,
-                                                        node_index: NodeIndex(None),
-                                                        parameter_node_index: NodeIndex(None),
-                                                    },
-                                                    asname: None,
-                                                },
-                                            ],
-                                            is_lazy: true,
-                                        },
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 97..135,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 105..114,
+                                                id: Name("Exception"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                    name: None,
+                                    body: [
+                                        Import(
+                                            StmtImport {
+                                                node_index: NodeIndex(None),
+                                                range: 120..135,
+                                                names: [
+                                                    Alias {
+                                                        end: 135,
+                                                        node_index: NodeIndex(None),
+                                                        name: Identifier {
+                                                            id: Name("sys"),
+                                                            range: 132..135,
+                                                            node_index: NodeIndex(None),
+                                                            parameter_node_index: NodeIndex(None),
+                                                        },
+                                                        asname: None,
+                                                    },
+                                                ],
+                                                is_lazy: true,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
             FunctionDef(
@@ -131,13 +135,15 @@ Module(
                     range: 137..169,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("func"),
-                        range: 141..145,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("func"),
+                            range: 141..145,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 145..147,
                         node_index: NodeIndex(None),
@@ -178,13 +184,15 @@ Module(
                     range: 171..226,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("async_func"),
-                        range: 181..191,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("async_func"),
+                            range: 181..191,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 191..193,
                         node_index: NodeIndex(None),
@@ -271,13 +279,15 @@ Module(
                     range: 267..321,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("outer"),
-                        range: 271..276,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("outer"),
+                            range: 271..276,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 276..278,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@lazy_import_invalid_from_py315.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@lazy_import_invalid_from_py315.py.snap
@@ -74,13 +74,15 @@ Module(
                     range: 107..145,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("func"),
-                        range: 111..115,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("func"),
+                            range: 111..115,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 115..117,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@multiple_clauses_on_same_line.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@multiple_clauses_on_same_line.py.snap
@@ -206,116 +206,120 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 151..202,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 156..160,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 161..177,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 168..171,
-                                            id: Name("exc"),
-                                            ctx: Load,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 156..160,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 161..177,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 168..171,
+                                                id: Name("exc"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 173..177,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 184..188,
-                            },
-                        ),
-                    ],
-                    finalbody: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 198..202,
-                            },
-                        ),
-                    ],
-                    is_star: false,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 173..177,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 184..188,
+                                },
+                            ),
+                        ],
+                        finalbody: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 198..202,
+                                },
+                            ),
+                        ],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 203..257,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 208..212,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 214..230,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 221..224,
-                                            id: Name("exc"),
-                                            ctx: Load,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 208..212,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 214..230,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 221..224,
+                                                id: Name("exc"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 226..230,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 238..242,
-                            },
-                        ),
-                    ],
-                    finalbody: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 253..257,
-                            },
-                        ),
-                    ],
-                    is_star: false,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 226..230,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 238..242,
+                                },
+                            ),
+                        ],
+                        finalbody: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 253..257,
+                                },
+                            ),
+                        ],
+                        is_star: false,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@nested_async_comprehension_py310.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@nested_async_comprehension_py310.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 44..111,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 54..55,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 54..55,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 55..57,
                         node_index: NodeIndex(None),
@@ -162,13 +164,15 @@ Module(
                     range: 122..192,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("g"),
-                        range: 132..133,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("g"),
+                            range: 132..133,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 133..135,
                         node_index: NodeIndex(None),
@@ -319,13 +323,15 @@ Module(
                     range: 200..267,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("h"),
-                        range: 210..211,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("h"),
+                            range: 210..211,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 211..213,
                         node_index: NodeIndex(None),
@@ -465,13 +471,15 @@ Module(
                     range: 277..371,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("i"),
-                        range: 287..288,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("i"),
+                            range: 287..288,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 288..290,
                         node_index: NodeIndex(None),
@@ -682,13 +690,15 @@ Module(
                     range: 372..466,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("j"),
-                        range: 382..383,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("j"),
+                            range: 382..383,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 383..385,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@node_range_with_gaps.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@node_range_with_gaps.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..7,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..7,
                         node_index: NodeIndex(None),
@@ -42,13 +44,15 @@ Module(
                     range: 18..32,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("bar"),
-                        range: 22..25,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("bar"),
+                            range: 22..25,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 25..27,
                         node_index: NodeIndex(None),
@@ -81,13 +85,15 @@ Module(
                     range: 33..40,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("baz"),
-                        range: 37..40,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("baz"),
+                            range: 37..40,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 40..40,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@nonlocal_stmt_empty.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@nonlocal_stmt_empty.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..21,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("_"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("_"),
+                            range: 4..5,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 5..7,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@nonlocal_stmt_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@nonlocal_stmt_expression.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..27,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("_"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("_"),
+                            range: 4..5,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 5..7,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@nonlocal_stmt_trailing_comma.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@nonlocal_stmt_trailing_comma.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..58,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("_"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("_"),
+                            range: 4..5,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 5..7,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_missing_annotation.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_missing_annotation.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..16,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..11,
                         node_index: NodeIndex(None),
@@ -71,13 +73,15 @@ Module(
                     range: 17..34,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 21..24,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 21..24,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 24..29,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_missing_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_missing_default.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..16,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..11,
                         node_index: NodeIndex(None),
@@ -71,13 +73,15 @@ Module(
                     range: 17..40,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 21..24,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 21..24,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 24..35,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_with_invalid_annotation.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_with_invalid_annotation.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..23,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..18,
                         node_index: NodeIndex(None),
@@ -87,13 +89,15 @@ Module(
                     range: 24..52,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 28..31,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 28..31,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 31..47,
                         node_index: NodeIndex(None),
@@ -159,13 +163,15 @@ Module(
                     range: 53..80,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 57..60,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 57..60,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 60..75,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_with_invalid_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_with_invalid_default.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..20,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..15,
                         node_index: NodeIndex(None),
@@ -87,13 +89,15 @@ Module(
                     range: 21..43,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 25..28,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 25..28,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 28..38,
                         node_index: NodeIndex(None),
@@ -158,13 +162,15 @@ Module(
                     range: 44..67,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 48..51,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 48..51,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 51..62,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_with_invalid_star_annotation.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_with_invalid_star_annotation.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..22,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..17,
                         node_index: NodeIndex(None),
@@ -82,13 +84,15 @@ Module(
                     range: 23..57,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 27..30,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 27..30,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 30..52,
                         node_index: NodeIndex(None),
@@ -163,13 +167,15 @@ Module(
                     range: 58..90,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 62..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 62..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..85,
                         node_index: NodeIndex(None),
@@ -246,13 +252,15 @@ Module(
                     range: 91..120,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 95..98,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 95..98,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 98..115,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_with_star_annotation_py310.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@param_with_star_annotation_py310.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 44..68,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 48..51,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 48..51,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 51..63,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_duplicate_names.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_duplicate_names.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..41,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..36,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_expected_after_star_separator.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_expected_after_star_separator.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..15,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..10,
                         node_index: NodeIndex(None),
@@ -55,13 +57,15 @@ Module(
                     range: 16..32,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 20..23,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 20..23,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 23..27,
                         node_index: NodeIndex(None),
@@ -94,13 +98,15 @@ Module(
                     range: 33..51,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 37..40,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 37..40,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 40..46,
                         node_index: NodeIndex(None),
@@ -149,13 +155,15 @@ Module(
                     range: 52..71,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 56..59,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 56..59,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 59..66,
                         node_index: NodeIndex(None),
@@ -204,13 +212,15 @@ Module(
                     range: 72..97,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 76..79,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 76..79,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 79..92,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_follows_var_keyword_param.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_follows_var_keyword_param.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..44,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..39,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_kwarg_after_star_separator.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_kwarg_after_star_separator.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..25,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..20,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_multiple_kwargs.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_multiple_kwargs.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..37,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..32,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_multiple_slash_separator.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_multiple_slash_separator.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..24,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..19,
                         node_index: NodeIndex(None),
@@ -87,13 +89,15 @@ Module(
                     range: 25..52,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 29..32,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 29..32,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 32..47,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_multiple_star_separator.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_multiple_star_separator.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..24,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..19,
                         node_index: NodeIndex(None),
@@ -87,13 +89,15 @@ Module(
                     range: 25..52,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 29..32,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 29..32,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 32..47,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_multiple_varargs.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_multiple_varargs.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..28,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..23,
                         node_index: NodeIndex(None),
@@ -98,13 +100,15 @@ Module(
                     range: 63..97,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 67..70,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 67..70,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 70..92,
                         node_index: NodeIndex(None),
@@ -180,13 +184,15 @@ Module(
                     range: 98..135,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 102..105,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 102..105,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 105..130,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_no_arg_before_slash.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_no_arg_before_slash.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..15,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..10,
                         node_index: NodeIndex(None),
@@ -55,13 +57,15 @@ Module(
                     range: 16..34,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 20..23,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 20..23,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 23..29,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_non_default_after_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_non_default_after_default.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..29,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..24,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_star_after_slash.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_star_after_slash.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..19,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..14,
                         node_index: NodeIndex(None),
@@ -66,13 +68,15 @@ Module(
                     range: 20..48,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 24..27,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 24..27,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 27..43,
                         node_index: NodeIndex(None),
@@ -148,13 +152,15 @@ Module(
                     range: 49..73,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 53..56,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 53..56,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 56..68,
                         node_index: NodeIndex(None),
@@ -219,13 +225,15 @@ Module(
                     range: 74..104,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 78..81,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 78..81,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 81..99,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_star_separator_after_star_param.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_star_separator_after_star_param.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..28,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..23,
                         node_index: NodeIndex(None),
@@ -98,13 +100,15 @@ Module(
                     range: 29..60,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 33..36,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 33..36,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 36..55,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_var_keyword_with_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_var_keyword_with_default.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..36,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..20,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_var_positional_with_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@params_var_positional_with_default.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..23,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..17,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@pos_only_py37.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@pos_only_py37.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 43..61,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 47..50,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 47..50,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 50..56,
                         node_index: NodeIndex(None),
@@ -71,13 +73,15 @@ Module(
                     range: 62..86,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 66..69,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 66..69,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 69..81,
                         node_index: NodeIndex(None),
@@ -142,13 +146,15 @@ Module(
                     range: 87..115,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 91..94,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 91..94,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 94..110,
                         node_index: NodeIndex(None),
@@ -224,13 +230,15 @@ Module(
                     range: 116..135,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 120..123,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 120..123,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 123..130,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token.py.snap
@@ -53,13 +53,15 @@ Module(
                     range: 60..79,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("bar"),
-                        range: 64..67,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("bar"),
+                            range: 64..67,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 67..69,
                         node_index: NodeIndex(None),
@@ -120,13 +122,15 @@ Module(
                                 range: 129..152,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("bar"),
-                                    range: 133..136,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("bar"),
+                                        range: 133..136,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 136..138,
                                     node_index: NodeIndex(None),
@@ -191,13 +195,15 @@ Module(
                                 range: 246..269,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("bar"),
-                                    range: 250..253,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("bar"),
+                                        range: 250..253,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 253..255,
                                     node_index: NodeIndex(None),
@@ -262,13 +268,15 @@ Module(
                                 range: 369..392,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("bar"),
-                                    range: 373..376,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("bar"),
+                                        range: 373..376,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 376..378,
                                     node_index: NodeIndex(None),
@@ -358,13 +366,15 @@ Module(
                                 range: 476..499,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("bar"),
-                                    range: 480..483,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("bar"),
+                                        range: 480..483,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 483..485,
                                     node_index: NodeIndex(None),
@@ -454,13 +464,15 @@ Module(
                                 range: 588..611,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("bar"),
-                                    range: 592..595,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("bar"),
+                                        range: 592..595,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 595..597,
                                     node_index: NodeIndex(None),
@@ -550,13 +562,15 @@ Module(
                                 range: 801..824,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("bar"),
-                                    range: 805..808,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("bar"),
+                                        range: 805..808,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 808..810,
                                     node_index: NodeIndex(None),
@@ -661,13 +675,15 @@ Module(
                                 range: 910..933,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("bar"),
-                                    range: 914..917,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("bar"),
+                                        range: 914..917,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 917..919,
                                     node_index: NodeIndex(None),
@@ -758,13 +774,15 @@ Module(
                     range: 956..979,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("bar"),
-                        range: 960..963,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("bar"),
+                            range: 960..963,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 963..965,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token_mac_eol.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token_mac_eol.py.snap
@@ -75,13 +75,15 @@ Module(
                                 range: 23..46,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("bar"),
-                                    range: 27..30,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("bar"),
+                                        range: 27..30,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 30..32,
                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token_windows_eol.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token_windows_eol.py.snap
@@ -75,13 +75,15 @@ Module(
                                 range: 24..48,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("bar"),
-                                    range: 28..31,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("bar"),
+                                        range: 28..31,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 31..33,
                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_1.py.snap
@@ -59,13 +59,15 @@ Module(
                     range: 16..35,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("bar"),
-                        range: 20..23,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("bar"),
+                            range: 20..23,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 23..25,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_windows_eol.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__line_continuation_windows_eol.py.snap
@@ -59,13 +59,15 @@ Module(
                     range: 26..46,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("bar"),
-                        range: 30..33,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("bar"),
+                            range: 30..33,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 33..35,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@single_star_return.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@single_star_return.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..18,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 4..5,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 5..7,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@single_star_yield.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@single_star_yield.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..17,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 4..5,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 5..7,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__function_type_parameters.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__function_type_parameters.py.snap
@@ -16,48 +16,50 @@ Module(
                     range: 796..824,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("keyword"),
-                        range: 800..807,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 807..817,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("keyword"),
+                            range: 800..807,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 808..809,
-                                        name: Identifier {
-                                            id: Name("A"),
-                                            range: 808..809,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 811..816,
-                                        name: Identifier {
-                                            id: Name("await"),
-                                            range: 811..816,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 807..817,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 808..809,
+                                            name: Identifier {
+                                                id: Name("A"),
+                                                range: 808..809,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 811..816,
+                                            name: Identifier {
+                                                id: Name("await"),
+                                                range: 811..816,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 817..819,
                         node_index: NodeIndex(None),
@@ -90,48 +92,50 @@ Module(
                     range: 826..862,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("not_a_type_param"),
-                        range: 830..846,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 846..855,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("not_a_type_param"),
+                            range: 830..846,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 847..848,
-                                        name: Identifier {
-                                            id: Name("A"),
-                                            range: 847..848,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 853..854,
-                                        name: Identifier {
-                                            id: Name("B"),
-                                            range: 853..854,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 846..855,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 847..848,
+                                            name: Identifier {
+                                                id: Name("A"),
+                                                range: 847..848,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 853..854,
+                                            name: Identifier {
+                                                id: Name("B"),
+                                                range: 853..854,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 855..857,
                         node_index: NodeIndex(None),
@@ -164,48 +168,50 @@ Module(
                     range: 864..896,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("multiple_commas"),
-                        range: 868..883,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 883..889,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("multiple_commas"),
+                            range: 868..883,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 884..885,
-                                        name: Identifier {
-                                            id: Name("A"),
-                                            range: 884..885,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 887..888,
-                                        name: Identifier {
-                                            id: Name("B"),
-                                            range: 887..888,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 883..889,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 884..885,
+                                            name: Identifier {
+                                                id: Name("A"),
+                                                range: 884..885,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 887..888,
+                                            name: Identifier {
+                                                id: Name("B"),
+                                                range: 887..888,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 889..891,
                         node_index: NodeIndex(None),
@@ -238,34 +244,36 @@ Module(
                     range: 898..938,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("multiple_trailing_commas"),
-                        range: 902..926,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 926..931,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("multiple_trailing_commas"),
+                            range: 902..926,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 927..928,
-                                        name: Identifier {
-                                            id: Name("A"),
-                                            range: 927..928,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 926..931,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 927..928,
+                                            name: Identifier {
+                                                id: Name("A"),
+                                                range: 927..928,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 931..933,
                         node_index: NodeIndex(None),
@@ -298,34 +306,36 @@ Module(
                     range: 940..979,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("multiple_commas_and_recovery"),
-                        range: 944..972,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 972..976,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("multiple_commas_and_recovery"),
+                            range: 944..972,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 973..974,
-                                        name: Identifier {
-                                            id: Name("A"),
-                                            range: 973..974,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 972..976,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 973..974,
+                                            name: Identifier {
+                                                id: Name("A"),
+                                                range: 973..974,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 976..976,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@try_stmt_invalid_order.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@try_stmt_invalid_order.py.snap
@@ -14,25 +14,27 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..31,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 9..13,
-                            },
-                        ),
-                    ],
-                    handlers: [],
-                    orelse: [],
-                    finalbody: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 27..31,
-                            },
-                        ),
-                    ],
-                    is_star: false,
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 9..13,
+                                },
+                            ),
+                        ],
+                        handlers: [],
+                        orelse: [],
+                        finalbody: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 27..31,
+                                },
+                            ),
+                        ],
+                        is_star: false,
+                    },
                 },
             ),
             Pass(

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@try_stmt_missing_except_finally.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@try_stmt_missing_except_finally.py.snap
@@ -14,43 +14,47 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..13,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 9..13,
-                            },
-                        ),
-                    ],
-                    handlers: [],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 9..13,
+                                },
+                            ),
+                        ],
+                        handlers: [],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 14..42,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 23..27,
-                            },
-                        ),
-                    ],
-                    handlers: [],
-                    orelse: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 38..42,
-                            },
-                        ),
-                    ],
-                    finalbody: [],
-                    is_star: false,
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 23..27,
+                                },
+                            ),
+                        ],
+                        handlers: [],
+                        orelse: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 38..42,
+                                },
+                            ),
+                        ],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@try_stmt_misspelled_except.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@try_stmt_misspelled_except.py.snap
@@ -14,18 +14,20 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..13,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 9..13,
-                            },
-                        ),
-                    ],
-                    handlers: [],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 9..13,
+                                },
+                            ),
+                        ],
+                        handlers: [],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             AnnAssign(
@@ -93,35 +95,37 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 83..113,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 92..96,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 97..113,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 109..113,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 92..96,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 97..113,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 109..113,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             AnnAssign(

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@try_stmt_mixed_except_kind.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@try_stmt_mixed_except_kind.py.snap
@@ -14,221 +14,227 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..63,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 9..13,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 14..30,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 26..30,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 9..13,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 14..30,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 26..30,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 31..63,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 39..53,
+                                                id: Name("ExceptionGroup"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 31..63,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 39..53,
-                                            id: Name("ExceptionGroup"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 59..63,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 59..63,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 64..127,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 73..77,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 78..110,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 86..100,
-                                            id: Name("ExceptionGroup"),
-                                            ctx: Load,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 73..77,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 78..110,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 86..100,
+                                                id: Name("ExceptionGroup"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 106..110,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 111..127,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 123..127,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 106..110,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 111..127,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 123..127,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 128..241,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 137..141,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 142..158,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 154..158,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 137..141,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 142..158,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 154..158,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 159..175,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 171..175,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 176..208,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 184..198,
+                                                id: Name("ExceptionGroup"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 159..175,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 171..175,
-                                        },
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 204..208,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 209..241,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 217..231,
+                                                id: Name("ExceptionGroup"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 176..208,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 184..198,
-                                            id: Name("ExceptionGroup"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 204..208,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 209..241,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 217..231,
-                                            id: Name("ExceptionGroup"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 237..241,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 237..241,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_default_py312.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_param_default_py312.py.snap
@@ -69,43 +69,45 @@ Module(
                     range: 66..87,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 70..71,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 71..80,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 70..71,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 72..79,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 72..73,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: Some(
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 76..79,
-                                                    id: Name("int"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 71..80,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 72..79,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 72..73,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: Some(
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 76..79,
+                                                        id: Name("int"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 80..82,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_parameter_default_order.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_parameter_default_order.py.snap
@@ -190,57 +190,59 @@ Module(
                     range: 60..84,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 64..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 65..77,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 64..65,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 66..73,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 66..67,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: Some(
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 70..73,
-                                                    id: Name("int"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 75..76,
-                                        name: Identifier {
-                                            id: Name("U"),
-                                            range: 75..76,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 65..77,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 66..73,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 66..67,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: Some(
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 70..73,
+                                                        id: Name("int"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 75..76,
+                                            name: Identifier {
+                                                id: Name("U"),
+                                                range: 75..76,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 77..79,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_params_empty.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@type_params_empty.py.snap
@@ -16,19 +16,21 @@ Module(
                     range: 0..21,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 7..9,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
                             node_index: NodeIndex(None),
-                            type_params: [],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 7..9,
+                                node_index: NodeIndex(None),
+                                type_params: [],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 9..11,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@yield_after_comma.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@yield_after_comma.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..19,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 4..5,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 5..7,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@yield_from_in_async_function.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@yield_from_in_async_function.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..27,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 10..11,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 10..11,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 11..13,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@all_async_comprehension_py310.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@all_async_comprehension_py310.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 44..125,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("test"),
-                        range: 54..58,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("test"),
+                            range: 54..58,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 58..60,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@async_function_definition.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@async_function_definition.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..20,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 10..13,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 10..13,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 13..15,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_async_function.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_async_function.py.snap
@@ -29,13 +29,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 21..24,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 21..24,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 24..26,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_await_expression_py39.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_await_expression_py39.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 45..95,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 55..58,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 55..58,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 58..60,
                         node_index: NodeIndex(None),
@@ -59,13 +61,15 @@ Module(
                                         ),
                                     },
                                 ],
-                                name: Identifier {
-                                    id: Name("baz"),
-                                    range: 85..88,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("baz"),
+                                        range: 85..88,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 88..90,
                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_expression_dotted_ident_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_expression_dotted_ident_py38.py.snap
@@ -55,13 +55,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("spam"),
-                        range: 74..78,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("spam"),
+                            range: 74..78,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 78..80,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_expression_eval_hack_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_expression_eval_hack_py38.py.snap
@@ -63,13 +63,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("spam"),
-                        range: 85..89,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("spam"),
+                            range: 85..89,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 89..91,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_expression_identity_hack_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_expression_identity_hack_py38.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 45..63,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("_"),
-                        range: 49..50,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("_"),
+                            range: 49..50,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 50..53,
                         node_index: NodeIndex(None),
@@ -151,13 +153,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("spam"),
-                        range: 99..103,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("spam"),
+                            range: 99..103,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 103..105,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_expression_py39.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@decorator_expression_py39.py.snap
@@ -71,13 +71,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("spam"),
-                        range: 77..81,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("spam"),
+                            range: 77..81,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 81..83,
                         node_index: NodeIndex(None),
@@ -191,13 +193,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("bar"),
-                        range: 118..121,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("bar"),
+                            range: 118..121,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 121..123,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@except_star_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@except_star_py311.py.snap
@@ -14,56 +14,58 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 44..76,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 49..52,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 49..52,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 53..76,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 49..52,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 61..71,
-                                            id: Name("ValueError"),
-                                            ctx: Load,
+                                            range: 49..52,
                                         },
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 73..76,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 73..76,
-                                                },
-                                            ),
-                                        },
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 53..76,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 61..71,
+                                                id: Name("ValueError"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                    name: None,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 73..76,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 73..76,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@except_stmt_as_name_soft_keyword.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@except_stmt_as_name_soft_keyword.py.snap
@@ -14,139 +14,141 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..99,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 5..8,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 5..8,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 9..39,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 5..8,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 16..25,
-                                            id: Name("Exception"),
-                                            ctx: Load,
+                                            range: 5..8,
                                         },
                                     ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("match"),
-                                        range: 29..34,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 9..39,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 16..25,
+                                                id: Name("Exception"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("match"),
+                                            range: 29..34,
                                             node_index: NodeIndex(None),
-                                            range: 36..39,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 36..39,
-                                                },
-                                            ),
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 40..69,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 36..39,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 36..39,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 40..69,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 47..56,
+                                                id: Name("Exception"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("case"),
+                                            range: 60..64,
                                             node_index: NodeIndex(None),
-                                            range: 47..56,
-                                            id: Name("Exception"),
-                                            ctx: Load,
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("case"),
-                                        range: 60..64,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 66..69,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 66..69,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 70..99,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 77..86,
+                                                id: Name("Exception"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("type"),
+                                            range: 90..94,
                                             node_index: NodeIndex(None),
-                                            range: 66..69,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 66..69,
-                                                },
-                                            ),
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 70..99,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 77..86,
-                                            id: Name("Exception"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("type"),
-                                        range: 90..94,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 96..99,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 96..99,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 96..99,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 96..99,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@except_stmt_unparenthesized_tuple_no_as_py314.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@except_stmt_unparenthesized_tuple_no_as_py314.py.snap
@@ -14,124 +14,128 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 44..79,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 53..57,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 58..79,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Tuple(
-                                        ExprTuple {
-                                            node_index: NodeIndex(None),
-                                            range: 65..69,
-                                            elts: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 65..66,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 68..69,
-                                                        id: Name("y"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                            ],
-                                            ctx: Load,
-                                            parenthesized: false,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 53..57,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 58..79,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Tuple(
+                                            ExprTuple {
+                                                node_index: NodeIndex(None),
+                                                range: 65..69,
+                                                elts: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 65..66,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 68..69,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                                ctx: Load,
+                                                parenthesized: false,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 75..79,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 75..79,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 80..116,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 89..93,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 94..116,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Tuple(
-                                        ExprTuple {
-                                            node_index: NodeIndex(None),
-                                            range: 102..106,
-                                            elts: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 102..103,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 105..106,
-                                                        id: Name("y"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                            ],
-                                            ctx: Load,
-                                            parenthesized: false,
-                                        },
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 89..93,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 94..116,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Tuple(
+                                            ExprTuple {
+                                                node_index: NodeIndex(None),
+                                                range: 102..106,
+                                                elts: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 102..103,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 105..106,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                                ctx: Load,
+                                                parenthesized: false,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 112..116,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 112..116,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
         ],

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@function_def_parameter_range.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@function_def_parameter_range.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..55,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..43,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@function_def_parenthesized_return_types.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@function_def_parenthesized_return_types.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..24,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..9,
                         node_index: NodeIndex(None),
@@ -74,13 +76,15 @@ Module(
                     range: 25..53,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 29..32,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 29..32,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 32..34,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@function_def_valid_return_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@function_def_valid_return_expr.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..27,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..9,
                         node_index: NodeIndex(None),
@@ -79,13 +81,15 @@ Module(
                     range: 28..57,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 32..35,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 32..35,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 35..37,
                         node_index: NodeIndex(None),
@@ -160,13 +164,15 @@ Module(
                     range: 58..96,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 62..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 62..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..67,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@function_type_params_py312.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@function_type_params_py312.py.snap
@@ -16,34 +16,36 @@ Module(
                     range: 44..61,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 48..51,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 51..54,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 48..51,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 52..53,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 52..53,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 51..54,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 52..53,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 52..53,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 54..56,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@iter_unpack_return_py37.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@iter_unpack_return_py37.py.snap
@@ -69,13 +69,15 @@ Module(
                     range: 60..92,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 64..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 64..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..67,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@iter_unpack_return_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@iter_unpack_return_py38.py.snap
@@ -69,13 +69,15 @@ Module(
                     range: 60..90,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 64..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 64..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..67,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@iter_unpack_yield_py37.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@iter_unpack_yield_py37.py.snap
@@ -69,13 +69,15 @@ Module(
                     range: 60..91,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("g"),
-                        range: 64..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("g"),
+                            range: 64..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..67,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@iter_unpack_yield_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@iter_unpack_yield_py38.py.snap
@@ -69,13 +69,15 @@ Module(
                     range: 60..89,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("g"),
-                        range: 64..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("g"),
+                            range: 64..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..67,
                         node_index: NodeIndex(None),
@@ -162,13 +164,15 @@ Module(
                     range: 90..127,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("h"),
-                        range: 94..95,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("h"),
+                            range: 94..95,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 95..97,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@nested_async_comprehension_py310.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@nested_async_comprehension_py310.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 44..116,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 54..55,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 54..55,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 55..57,
                         node_index: NodeIndex(None),
@@ -175,13 +177,15 @@ Module(
                     range: 117..180,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 127..128,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 127..128,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 128..130,
                         node_index: NodeIndex(None),
@@ -199,13 +203,15 @@ Module(
                                 range: 136..148,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("g"),
-                                    range: 140..141,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("g"),
+                                        range: 140..141,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 141..143,
                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@nested_async_comprehension_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@nested_async_comprehension_py311.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 44..111,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 54..55,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 54..55,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 55..57,
                         node_index: NodeIndex(None),
@@ -162,13 +164,15 @@ Module(
                     range: 122..192,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("g"),
-                        range: 132..133,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("g"),
+                            range: 132..133,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 133..135,
                         node_index: NodeIndex(None),
@@ -319,13 +323,15 @@ Module(
                     range: 200..267,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("h"),
-                        range: 210..211,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("h"),
+                            range: 210..211,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 211..213,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@non_duplicate_type_parameter_names.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@non_duplicate_type_parameter_names.py.snap
@@ -75,34 +75,36 @@ Module(
                     range: 24..43,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 28..29,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 29..32,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 28..29,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 30..31,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 30..31,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 29..32,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 30..31,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 30..31,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 32..38,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@nonlocal_declaration_at_module_level.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@nonlocal_declaration_at_module_level.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..23,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("_"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("_"),
+                            range: 4..5,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 5..7,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@nonlocal_stmt.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@nonlocal_stmt.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..44,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("_"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("_"),
+                            range: 4..5,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 5..7,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@other__decorator.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@other__decorator.py.snap
@@ -29,13 +29,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("test"),
-                        range: 24..28,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("test"),
+                            range: 24..28,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 28..30,
                         node_index: NodeIndex(None),
@@ -111,13 +113,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 98..99,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 98..99,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 99..101,
                         node_index: NodeIndex(None),
@@ -189,13 +193,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 120..121,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 120..121,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 121..123,
                         node_index: NodeIndex(None),
@@ -279,13 +285,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 145..146,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 145..146,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 146..148,
                         node_index: NodeIndex(None),
@@ -626,13 +634,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 261..262,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 261..262,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 262..264,
                         node_index: NodeIndex(None),
@@ -693,13 +703,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 370..373,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 370..373,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 373..375,
                         node_index: NodeIndex(None),
@@ -757,13 +769,15 @@ Module(
                             ),
                         },
                     ],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 397..400,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 397..400,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 400..402,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@param_with_annotation.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@param_with_annotation.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..22,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..17,
                         node_index: NodeIndex(None),
@@ -80,13 +82,15 @@ Module(
                     range: 23..53,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 27..30,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 27..30,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 30..48,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@param_with_default.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@param_with_default.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..27,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..22,
                         node_index: NodeIndex(None),
@@ -113,13 +115,15 @@ Module(
                     range: 28..60,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 32..35,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 32..35,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 35..55,
                         node_index: NodeIndex(None),
@@ -200,13 +204,15 @@ Module(
                     range: 61..84,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 65..68,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 65..68,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 68..79,
                         node_index: NodeIndex(None),
@@ -270,13 +276,15 @@ Module(
                     range: 85..110,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 89..92,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 89..92,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 92..105,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@param_with_star_annotation.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@param_with_star_annotation.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..31,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..26,
                         node_index: NodeIndex(None),
@@ -97,13 +99,15 @@ Module(
                     range: 32..66,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 36..39,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 36..39,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 39..61,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@param_with_star_annotation_py310.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@param_with_star_annotation_py310.py.snap
@@ -56,13 +56,15 @@ Module(
                     range: 207..230,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 211..214,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 211..214,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 214..225,
                         node_index: NodeIndex(None),
@@ -115,13 +117,15 @@ Module(
                     range: 231..295,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 235..238,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 235..238,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 238..290,
                         node_index: NodeIndex(None),
@@ -202,13 +206,15 @@ Module(
                     range: 296..367,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 300..303,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 300..303,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 303..362,
                         node_index: NodeIndex(None),
@@ -307,13 +313,15 @@ Module(
                     range: 368..405,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 372..375,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 372..375,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 375..400,
                         node_index: NodeIndex(None),
@@ -386,13 +394,15 @@ Module(
                     range: 406..431,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("union"),
-                        range: 410..415,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("union"),
+                            range: 410..415,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 415..426,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@param_with_star_annotation_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@param_with_star_annotation_py311.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 44..68,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 48..51,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 48..51,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 51..63,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@params_non_default_after_star.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@params_non_default_after_star.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..33,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..28,
                         node_index: NodeIndex(None),
@@ -137,13 +139,15 @@ Module(
                     range: 34..71,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 38..41,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 38..41,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 41..66,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@params_seen_keyword_only_param_after_star.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@params_seen_keyword_only_param_after_star.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..28,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 4..7,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 4..7,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 7..23,
                         node_index: NodeIndex(None),
@@ -82,13 +84,15 @@ Module(
                     range: 29..60,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 33..36,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 33..36,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 36..55,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@pos_only_py38.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@pos_only_py38.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 43..61,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 47..50,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 47..50,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 50..56,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@single_star_in_tuple.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@single_star_in_tuple.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..20,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 4..5,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 5..7,
                         node_index: NodeIndex(None),
@@ -82,13 +84,15 @@ Module(
                     range: 21..42,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 25..26,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 25..26,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 26..28,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__class.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__class.py.snap
@@ -66,13 +66,15 @@ Module(
                                 range: 44..80,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("__init__"),
-                                    range: 48..56,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("__init__"),
+                                        range: 48..56,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 56..62,
                                     node_index: NodeIndex(None),
@@ -219,13 +221,15 @@ Module(
                                 range: 135..168,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("method"),
-                                    range: 139..145,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("method"),
+                                        range: 139..145,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 145..147,
                                     node_index: NodeIndex(None),
@@ -329,13 +333,15 @@ Module(
                                 range: 193..225,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("__init__"),
-                                    range: 197..205,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("__init__"),
+                                        range: 197..205,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 205..211,
                                     node_index: NodeIndex(None),
@@ -378,13 +384,15 @@ Module(
                                 range: 231..289,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("method_with_default"),
-                                    range: 235..254,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("method_with_default"),
+                                        range: 235..254,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 254..275,
                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__function.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__function.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..29,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("no_parameters"),
-                        range: 4..17,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("no_parameters"),
+                            range: 4..17,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 17..19,
                         node_index: NodeIndex(None),
@@ -49,13 +51,15 @@ Module(
                     range: 32..76,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("positional_parameters"),
-                        range: 36..57,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("positional_parameters"),
+                            range: 36..57,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 57..66,
                         node_index: NodeIndex(None),
@@ -128,13 +132,15 @@ Module(
                     range: 79..149,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("positional_parameters_with_default_values"),
-                        range: 83..124,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("positional_parameters_with_default_values"),
+                            range: 83..124,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 124..139,
                         node_index: NodeIndex(None),
@@ -227,13 +233,15 @@ Module(
                     range: 152..226,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("positional_parameters_with_default_values2"),
-                        range: 156..198,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("positional_parameters_with_default_values2"),
+                            range: 156..198,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 198..216,
                         node_index: NodeIndex(None),
@@ -327,13 +335,15 @@ Module(
                     range: 229..296,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("positional_only_and_positional_parameters"),
-                        range: 233..274,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("positional_only_and_positional_parameters"),
+                            range: 233..274,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 274..286,
                         node_index: NodeIndex(None),
@@ -407,13 +417,15 @@ Module(
                     range: 299..393,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("pos_args_with_defaults_and_varargs_and_kwargs"),
-                        range: 303..348,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("pos_args_with_defaults_and_varargs_and_kwargs"),
+                            range: 303..348,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 348..383,
                         node_index: NodeIndex(None),
@@ -529,13 +541,15 @@ Module(
                     range: 396..445,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("keyword_only_parameters"),
-                        range: 400..423,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("keyword_only_parameters"),
+                            range: 400..423,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 423..435,
                         node_index: NodeIndex(None),
@@ -608,13 +622,15 @@ Module(
                     range: 448..517,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("keyword_only_parameters_with_defaults"),
-                        range: 452..489,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("keyword_only_parameters_with_defaults"),
+                            range: 452..489,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 489..507,
                         node_index: NodeIndex(None),
@@ -707,13 +723,15 @@ Module(
                     range: 520..594,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("kw_only_args_with_defaults_and_varargs"),
-                        range: 524..562,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("kw_only_args_with_defaults_and_varargs"),
+                            range: 524..562,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 562..584,
                         node_index: NodeIndex(None),
@@ -817,13 +835,15 @@ Module(
                     range: 597..676,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("kw_only_args_with_defaults_and_kwargs"),
-                        range: 601..638,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("kw_only_args_with_defaults_and_kwargs"),
+                            range: 601..638,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 638..666,
                         node_index: NodeIndex(None),
@@ -927,13 +947,15 @@ Module(
                     range: 679..774,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("kw_only_args_with_defaults_and_varargs_and_kwargs"),
-                        range: 683..732,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("kw_only_args_with_defaults_and_varargs_and_kwargs"),
+                            range: 683..732,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 732..764,
                         node_index: NodeIndex(None),
@@ -1048,13 +1070,15 @@ Module(
                     range: 777..835,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("pos_and_kw_only_args"),
-                        range: 781..801,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("pos_and_kw_only_args"),
+                            range: 781..801,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 801..825,
                         node_index: NodeIndex(None),
@@ -1174,13 +1198,15 @@ Module(
                     range: 838..916,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("pos_and_kw_only_args_with_defaults"),
-                        range: 842..876,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("pos_and_kw_only_args_with_defaults"),
+                            range: 842..876,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 876..906,
                         node_index: NodeIndex(None),
@@ -1320,13 +1346,15 @@ Module(
                     range: 919..1013,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("pos_and_kw_only_args_with_defaults_and_varargs"),
-                        range: 923..969,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("pos_and_kw_only_args_with_defaults_and_varargs"),
+                            range: 923..969,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 969..1003,
                         node_index: NodeIndex(None),
@@ -1477,13 +1505,15 @@ Module(
                     range: 1016..1121,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("pos_and_kw_only_args_with_defaults_and_kwargs"),
-                        range: 1020..1065,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("pos_and_kw_only_args_with_defaults_and_kwargs"),
+                            range: 1020..1065,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 1065..1111,
                         node_index: NodeIndex(None),
@@ -1634,13 +1664,15 @@ Module(
                     range: 1124..1245,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("pos_and_kw_only_args_with_defaults_and_varargs_and_kwargs"),
-                        range: 1128..1185,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("pos_and_kw_only_args_with_defaults_and_varargs_and_kwargs"),
+                            range: 1128..1185,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 1185..1235,
                         node_index: NodeIndex(None),
@@ -1802,13 +1834,15 @@ Module(
                     range: 1248..1316,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("positional_and_keyword_parameters"),
-                        range: 1252..1285,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("positional_and_keyword_parameters"),
+                            range: 1252..1285,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 1285..1306,
                         node_index: NodeIndex(None),
@@ -1927,13 +1961,15 @@ Module(
                     range: 1319..1407,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("positional_and_keyword_parameters_with_defaults"),
-                        range: 1323..1370,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("positional_and_keyword_parameters_with_defaults"),
+                            range: 1323..1370,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 1370..1397,
                         node_index: NodeIndex(None),
@@ -2072,13 +2108,15 @@ Module(
                     range: 1410..1520,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("positional_and_keyword_parameters_with_defaults_and_varargs"),
-                        range: 1414..1473,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("positional_and_keyword_parameters_with_defaults_and_varargs"),
+                            range: 1414..1473,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 1473..1510,
                         node_index: NodeIndex(None),
@@ -2228,13 +2266,15 @@ Module(
                     range: 1523..1654,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("positional_and_keyword_parameters_with_defaults_and_varargs_and_kwargs"),
-                        range: 1527..1597,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("positional_and_keyword_parameters_with_defaults_and_varargs_and_kwargs"),
+                            range: 1527..1597,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 1597..1644,
                         node_index: NodeIndex(None),
@@ -2395,34 +2435,36 @@ Module(
                     range: 1703..1735,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("func"),
-                        range: 1707..1711,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 1711..1714,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("func"),
+                            range: 1707..1711,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 1712..1713,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 1712..1713,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 1711..1714,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 1712..1713,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 1712..1713,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 1714..1720,
                         node_index: NodeIndex(None),
@@ -2483,43 +2525,45 @@ Module(
                     range: 1738..1775,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("func"),
-                        range: 1742..1746,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 1746..1754,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("func"),
+                            range: 1742..1746,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 1747..1753,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 1747..1748,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: Some(
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 1750..1753,
-                                                    id: Name("str"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ),
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 1746..1754,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 1747..1753,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 1747..1748,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: Some(
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 1750..1753,
+                                                        id: Name("str"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ),
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 1754..1760,
                         node_index: NodeIndex(None),
@@ -2580,61 +2624,63 @@ Module(
                     range: 1778..1824,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("func"),
-                        range: 1782..1786,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 1786..1803,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("func"),
+                            range: 1782..1786,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 1787..1802,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 1787..1788,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: Some(
-                                            Tuple(
-                                                ExprTuple {
-                                                    node_index: NodeIndex(None),
-                                                    range: 1790..1802,
-                                                    elts: [
-                                                        Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 1791..1794,
-                                                                id: Name("str"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 1796..1801,
-                                                                id: Name("bytes"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                    ],
-                                                    ctx: Load,
-                                                    parenthesized: true,
-                                                },
-                                            ),
-                                        ),
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 1786..1803,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 1787..1802,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 1787..1788,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: Some(
+                                                Tuple(
+                                                    ExprTuple {
+                                                        node_index: NodeIndex(None),
+                                                        range: 1790..1802,
+                                                        elts: [
+                                                            Name(
+                                                                ExprName {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 1791..1794,
+                                                                    id: Name("str"),
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                            Name(
+                                                                ExprName {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 1796..1801,
+                                                                    id: Name("bytes"),
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        ctx: Load,
+                                                        parenthesized: true,
+                                                    },
+                                                ),
+                                            ),
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 1803..1809,
                         node_index: NodeIndex(None),
@@ -2695,33 +2741,35 @@ Module(
                     range: 1827..1873,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("func"),
-                        range: 1831..1835,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 1835..1840,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("func"),
+                            range: 1831..1835,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVarTuple(
-                                    TypeParamTypeVarTuple {
-                                        node_index: NodeIndex(None),
-                                        range: 1836..1839,
-                                        name: Identifier {
-                                            id: Name("Ts"),
-                                            range: 1837..1839,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 1835..1840,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVarTuple(
+                                        TypeParamTypeVarTuple {
+                                            node_index: NodeIndex(None),
+                                            range: 1836..1839,
+                                            name: Identifier {
+                                                id: Name("Ts"),
+                                                range: 1837..1839,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 1840..1849,
                         node_index: NodeIndex(None),
@@ -2816,33 +2864,35 @@ Module(
                     range: 1876..1934,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("func"),
-                        range: 1880..1884,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 1884..1889,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("func"),
+                            range: 1880..1884,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                ParamSpec(
-                                    TypeParamParamSpec {
-                                        node_index: NodeIndex(None),
-                                        range: 1885..1888,
-                                        name: Identifier {
-                                            id: Name("P"),
-                                            range: 1887..1888,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 1884..1889,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    ParamSpec(
+                                        TypeParamParamSpec {
+                                            node_index: NodeIndex(None),
+                                            range: 1885..1888,
+                                            name: Identifier {
+                                                id: Name("P"),
+                                                range: 1887..1888,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 1889..1924,
                         node_index: NodeIndex(None),
@@ -2935,83 +2985,85 @@ Module(
                     range: 1937..1978,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("func"),
-                        range: 1941..1945,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 1945..1966,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("func"),
+                            range: 1941..1945,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 1946..1947,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 1946..1947,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: None,
-                                    },
-                                ),
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 1949..1955,
-                                        name: Identifier {
-                                            id: Name("U"),
-                                            range: 1949..1950,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: Some(
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 1952..1955,
-                                                    id: Name("str"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ),
-                                        default: None,
-                                    },
-                                ),
-                                TypeVarTuple(
-                                    TypeParamTypeVarTuple {
-                                        node_index: NodeIndex(None),
-                                        range: 1957..1960,
-                                        name: Identifier {
-                                            id: Name("Ts"),
-                                            range: 1958..1960,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: None,
-                                    },
-                                ),
-                                ParamSpec(
-                                    TypeParamParamSpec {
-                                        node_index: NodeIndex(None),
-                                        range: 1962..1965,
-                                        name: Identifier {
-                                            id: Name("P"),
-                                            range: 1964..1965,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        default: None,
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 1945..1966,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 1946..1947,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 1946..1947,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: None,
+                                        },
+                                    ),
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 1949..1955,
+                                            name: Identifier {
+                                                id: Name("U"),
+                                                range: 1949..1950,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: Some(
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 1952..1955,
+                                                        id: Name("str"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ),
+                                            default: None,
+                                        },
+                                    ),
+                                    TypeVarTuple(
+                                        TypeParamTypeVarTuple {
+                                            node_index: NodeIndex(None),
+                                            range: 1957..1960,
+                                            name: Identifier {
+                                                id: Name("Ts"),
+                                                range: 1958..1960,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: None,
+                                        },
+                                    ),
+                                    ParamSpec(
+                                        TypeParamParamSpec {
+                                            node_index: NodeIndex(None),
+                                            range: 1962..1965,
+                                            name: Identifier {
+                                                id: Name("P"),
+                                                range: 1964..1965,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            default: None,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 1966..1968,
                         node_index: NodeIndex(None),
@@ -3038,13 +3090,15 @@ Module(
                     range: 1981..2000,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("ellipsis"),
-                        range: 1985..1993,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("ellipsis"),
+                            range: 1985..1993,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 1993..1995,
                         node_index: NodeIndex(None),
@@ -3077,13 +3131,15 @@ Module(
                     range: 2003..2064,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("multiple_statements"),
-                        range: 2007..2026,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("multiple_statements"),
+                            range: 2007..2026,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2026..2028,
                         node_index: NodeIndex(None),
@@ -3157,13 +3213,15 @@ Module(
                     range: 2067..2091,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 2071..2074,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 2071..2074,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2074..2081,
                         node_index: NodeIndex(None),
@@ -3201,13 +3259,15 @@ Module(
                     range: 2094..2121,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 2098..2101,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 2098..2101,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2101..2111,
                         node_index: NodeIndex(None),
@@ -3245,13 +3305,15 @@ Module(
                     range: 2124..2158,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 2128..2131,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 2128..2131,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2131..2148,
                         node_index: NodeIndex(None),
@@ -3300,13 +3362,15 @@ Module(
                     range: 2161..2184,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 2165..2168,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 2165..2168,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2168..2174,
                         node_index: NodeIndex(None),
@@ -3349,13 +3413,15 @@ Module(
                     range: 2187..2213,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 2191..2194,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 2191..2194,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2194..2203,
                         node_index: NodeIndex(None),
@@ -3414,13 +3480,15 @@ Module(
                     range: 2216..2242,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 2220..2223,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 2220..2223,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2223..2232,
                         node_index: NodeIndex(None),
@@ -3473,13 +3541,15 @@ Module(
                     range: 2245..2277,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 2249..2252,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 2249..2252,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2252..2267,
                         node_index: NodeIndex(None),
@@ -3553,13 +3623,15 @@ Module(
                     range: 2280..2309,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 2284..2287,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 2284..2287,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2287..2299,
                         node_index: NodeIndex(None),
@@ -3628,13 +3700,15 @@ Module(
                     range: 2312..2357,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 2316..2319,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 2316..2319,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2319..2347,
                         node_index: NodeIndex(None),
@@ -3764,13 +3838,15 @@ Module(
                     range: 2360..2398,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("foo"),
-                        range: 2364..2367,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("foo"),
+                            range: 2364..2367,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 2367..2388,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__try.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__try.py.snap
@@ -14,1733 +14,1755 @@ Module(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 0..28,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 9..12,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 9..12,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 13..28,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Expr(
-                                        StmtExpr {
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 9..12,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 25..28,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 25..28,
-                                                },
-                                            ),
+                                            range: 9..12,
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 13..28,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 25..28,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 25..28,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 30..106,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 39..42,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 39..42,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 43..74,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 39..42,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 50..60,
-                                            id: Name("Exception1"),
-                                            ctx: Load,
+                                            range: 39..42,
                                         },
                                     ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("e"),
-                                        range: 64..65,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 43..74,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 50..60,
+                                                id: Name("Exception1"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("e"),
+                                            range: 64..65,
                                             node_index: NodeIndex(None),
-                                            range: 71..74,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 71..74,
-                                                },
-                                            ),
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 75..106,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 71..74,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 71..74,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 75..106,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 82..92,
+                                                id: Name("Exception2"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("e"),
+                                            range: 96..97,
                                             node_index: NodeIndex(None),
-                                            range: 82..92,
-                                            id: Name("Exception2"),
-                                            ctx: Load,
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("e"),
-                                        range: 96..97,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 103..106,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 103..106,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 103..106,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 103..106,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 108..184,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 117..120,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 117..120,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 121..151,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 117..120,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 128..137,
-                                            id: Name("Exception"),
-                                            ctx: Load,
+                                            range: 117..120,
                                         },
                                     ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("e"),
-                                        range: 141..142,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 121..151,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 128..137,
+                                                id: Name("Exception"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("e"),
+                                            range: 141..142,
                                             node_index: NodeIndex(None),
-                                            range: 148..151,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 148..151,
-                                                },
-                                            ),
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 152..167,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Expr(
-                                        StmtExpr {
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 148..151,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 148..151,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 152..167,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 164..167,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 164..167,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 181..184,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 164..167,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 164..167,
-                                                },
-                                            ),
+                                            range: 181..184,
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 181..184,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 181..184,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    is_star: false,
+                                },
+                            ),
+                        ],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 186..228,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 195..198,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 195..198,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 199..214,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Expr(
-                                        StmtExpr {
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 195..198,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 211..214,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 211..214,
-                                                },
-                                            ),
+                                            range: 195..198,
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 225..228,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 225..228,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    finalbody: [],
-                    is_star: false,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 199..214,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 211..214,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 211..214,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 225..228,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 225..228,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 230..289,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 239..242,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 239..242,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 243..258,
-                                node_index: NodeIndex(None),
-                                type_: None,
-                                name: None,
-                                body: [
-                                    Expr(
-                                        StmtExpr {
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 239..242,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 255..258,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 255..258,
-                                                },
-                                            ),
+                                            range: 239..242,
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 269..272,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 269..272,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    finalbody: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 286..289,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 286..289,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    is_star: false,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 243..258,
+                                    node_index: NodeIndex(None),
+                                    type_: None,
+                                    name: None,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 255..258,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 255..258,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 269..272,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 269..272,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                        finalbody: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 286..289,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 286..289,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 291..320,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 300..303,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 300..303,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [],
-                    orelse: [],
-                    finalbody: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 317..320,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 317..320,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    is_star: false,
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 300..303,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 300..303,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                        handlers: [],
+                        orelse: [],
+                        finalbody: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 317..320,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 317..320,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 322..365,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 331..334,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 331..334,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [],
-                    orelse: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 345..348,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 345..348,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    finalbody: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 362..365,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 362..365,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    is_star: false,
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 331..334,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 331..334,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                        handlers: [],
+                        orelse: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 345..348,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 345..348,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                        finalbody: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 362..365,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 362..365,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 367..441,
-                    body: [
-                        Expr(
-                            StmtExpr {
-                                node_index: NodeIndex(None),
-                                range: 376..379,
-                                value: EllipsisLiteral(
-                                    ExprEllipsisLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 376..379,
-                                    },
-                                ),
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 380..409,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
+                    inner: StmtTryInner {
+                        body: [
+                            Expr(
+                                StmtExpr {
+                                    node_index: NodeIndex(None),
+                                    range: 376..379,
+                                    value: EllipsisLiteral(
+                                        ExprEllipsisLiteral {
                                             node_index: NodeIndex(None),
-                                            range: 388..394,
-                                            id: Name("GroupA"),
-                                            ctx: Load,
+                                            range: 376..379,
                                         },
                                     ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("eg"),
-                                        range: 398..400,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 380..409,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 388..394,
+                                                id: Name("GroupA"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("eg"),
+                                            range: 398..400,
                                             node_index: NodeIndex(None),
-                                            range: 406..409,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 406..409,
-                                                },
-                                            ),
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 410..441,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 418..432,
-                                            id: Name("ExceptionGroup"),
-                                            ctx: Load,
-                                        },
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 406..409,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 406..409,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 410..441,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 418..432,
+                                                id: Name("ExceptionGroup"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 438..441,
-                                            value: EllipsisLiteral(
-                                                ExprEllipsisLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 438..441,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                    name: None,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 438..441,
+                                                value: EllipsisLiteral(
+                                                    ExprEllipsisLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 438..441,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 443..577,
-                    body: [
-                        Raise(
-                            StmtRaise {
-                                node_index: NodeIndex(None),
-                                range: 452..471,
-                                exc: Some(
-                                    Call(
-                                        ExprCall {
-                                            node_index: NodeIndex(None),
-                                            range: 458..471,
-                                            func: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 458..468,
-                                                    id: Name("ValueError"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            arguments: Arguments {
-                                                range: 468..471,
+                    inner: StmtTryInner {
+                        body: [
+                            Raise(
+                                StmtRaise {
+                                    node_index: NodeIndex(None),
+                                    range: 452..471,
+                                    exc: Some(
+                                        Call(
+                                            ExprCall {
                                                 node_index: NodeIndex(None),
-                                                args: [
-                                                    NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 469..470,
-                                                            value: Int(
-                                                                1,
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                                keywords: [],
+                                                range: 458..471,
+                                                func: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 458..468,
+                                                        id: Name("ValueError"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                arguments: Arguments {
+                                                    range: 468..471,
+                                                    node_index: NodeIndex(None),
+                                                    args: [
+                                                        NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 469..470,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ],
+                                                    keywords: [],
+                                                },
                                             },
+                                        ),
+                                    ),
+                                    cause: None,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 472..525,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 479..488,
+                                                id: Name("TypeError"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("e"),
+                                            range: 492..493,
+                                            node_index: NodeIndex(None),
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ),
-                                cause: None,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 472..525,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 479..488,
-                                            id: Name("TypeError"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("e"),
-                                        range: 492..493,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 499..525,
-                                            value: Call(
-                                                ExprCall {
-                                                    node_index: NodeIndex(None),
-                                                    range: 499..525,
-                                                    func: Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 499..504,
-                                                            id: Name("print"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    arguments: Arguments {
-                                                        range: 504..525,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 499..525,
+                                                value: Call(
+                                                    ExprCall {
                                                         node_index: NodeIndex(None),
-                                                        args: [
-                                                            FString(
-                                                                ExprFString {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 505..524,
-                                                                    value: FStringValue {
-                                                                        inner: Single(
-                                                                            FString(
-                                                                                FString {
-                                                                                    range: 505..524,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    elements: [
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 507..514,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "caught ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 514..523,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Call(
-                                                                                                    ExprCall {
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        range: 515..522,
-                                                                                                        func: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 515..519,
-                                                                                                                id: Name("type"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        arguments: Arguments {
-                                                                                                            range: 519..522,
-                                                                                                            node_index: NodeIndex(None),
-                                                                                                            args: [
-                                                                                                                Name(
-                                                                                                                    ExprName {
-                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                        range: 520..521,
-                                                                                                                        id: Name("e"),
-                                                                                                                        ctx: Load,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                            keywords: [],
-                                                                                                        },
-                                                                                                    },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                    flags: FStringFlags {
-                                                                                        quote_style: Double,
-                                                                                        prefix: Regular,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
-                                                                                    },
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                    },
-                                                                },
-                                                            ),
-                                                        ],
-                                                        keywords: [],
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 526..577,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 533..540,
-                                            id: Name("OSError"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("e"),
-                                        range: 544..545,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 551..577,
-                                            value: Call(
-                                                ExprCall {
-                                                    node_index: NodeIndex(None),
-                                                    range: 551..577,
-                                                    func: Name(
-                                                        ExprName {
+                                                        range: 499..525,
+                                                        func: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 499..504,
+                                                                id: Name("print"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        arguments: Arguments {
+                                                            range: 504..525,
                                                             node_index: NodeIndex(None),
-                                                            range: 551..556,
-                                                            id: Name("print"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    arguments: Arguments {
-                                                        range: 556..577,
-                                                        node_index: NodeIndex(None),
-                                                        args: [
-                                                            FString(
-                                                                ExprFString {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 557..576,
-                                                                    value: FStringValue {
-                                                                        inner: Single(
-                                                                            FString(
-                                                                                FString {
-                                                                                    range: 557..576,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    elements: [
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 559..566,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "caught ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 566..575,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Call(
-                                                                                                    ExprCall {
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        range: 567..574,
-                                                                                                        func: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 567..571,
-                                                                                                                id: Name("type"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        arguments: Arguments {
-                                                                                                            range: 571..574,
+                                                            args: [
+                                                                FString(
+                                                                    ExprFString {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 505..524,
+                                                                        value: FStringValue {
+                                                                            inner: Single(
+                                                                                FString(
+                                                                                    FString {
+                                                                                        range: 505..524,
+                                                                                        node_index: NodeIndex(None),
+                                                                                        elements: [
+                                                                                            Literal(
+                                                                                                InterpolatedStringLiteralElement {
+                                                                                                    range: 507..514,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    value: "caught ",
+                                                                                                },
+                                                                                            ),
+                                                                                            Interpolation(
+                                                                                                InterpolatedElement {
+                                                                                                    range: 514..523,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    expression: Call(
+                                                                                                        ExprCall {
                                                                                                             node_index: NodeIndex(None),
-                                                                                                            args: [
-                                                                                                                Name(
-                                                                                                                    ExprName {
-                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                        range: 572..573,
-                                                                                                                        id: Name("e"),
-                                                                                                                        ctx: Load,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                            keywords: [],
+                                                                                                            range: 515..522,
+                                                                                                            func: Name(
+                                                                                                                ExprName {
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    range: 515..519,
+                                                                                                                    id: Name("type"),
+                                                                                                                    ctx: Load,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            arguments: Arguments {
+                                                                                                                range: 519..522,
+                                                                                                                node_index: NodeIndex(None),
+                                                                                                                args: [
+                                                                                                                    Name(
+                                                                                                                        ExprName {
+                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                            range: 520..521,
+                                                                                                                            id: Name("e"),
+                                                                                                                            ctx: Load,
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                ],
+                                                                                                                keywords: [],
+                                                                                                            },
                                                                                                         },
-                                                                                                    },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                    flags: FStringFlags {
-                                                                                        quote_style: Double,
-                                                                                        prefix: Regular,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
+                                                                                                    ),
+                                                                                                    debug_text: None,
+                                                                                                    conversion: None,
+                                                                                                    format_spec: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ],
+                                                                                        flags: FStringFlags {
+                                                                                            quote_style: Double,
+                                                                                            prefix: Regular,
+                                                                                            triple_quoted: false,
+                                                                                            unclosed: false,
+                                                                                        },
                                                                                     },
-                                                                                },
+                                                                                ),
                                                                             ),
-                                                                        ),
+                                                                        },
                                                                     },
-                                                                },
-                                                            ),
-                                                        ],
-                                                        keywords: [],
+                                                                ),
+                                                            ],
+                                                            keywords: [],
+                                                        },
                                                     },
-                                                },
-                                            ),
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 526..577,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 533..540,
+                                                id: Name("OSError"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("e"),
+                                            range: 544..545,
+                                            node_index: NodeIndex(None),
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 551..577,
+                                                value: Call(
+                                                    ExprCall {
+                                                        node_index: NodeIndex(None),
+                                                        range: 551..577,
+                                                        func: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 551..556,
+                                                                id: Name("print"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        arguments: Arguments {
+                                                            range: 556..577,
+                                                            node_index: NodeIndex(None),
+                                                            args: [
+                                                                FString(
+                                                                    ExprFString {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 557..576,
+                                                                        value: FStringValue {
+                                                                            inner: Single(
+                                                                                FString(
+                                                                                    FString {
+                                                                                        range: 557..576,
+                                                                                        node_index: NodeIndex(None),
+                                                                                        elements: [
+                                                                                            Literal(
+                                                                                                InterpolatedStringLiteralElement {
+                                                                                                    range: 559..566,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    value: "caught ",
+                                                                                                },
+                                                                                            ),
+                                                                                            Interpolation(
+                                                                                                InterpolatedElement {
+                                                                                                    range: 566..575,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    expression: Call(
+                                                                                                        ExprCall {
+                                                                                                            node_index: NodeIndex(None),
+                                                                                                            range: 567..574,
+                                                                                                            func: Name(
+                                                                                                                ExprName {
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    range: 567..571,
+                                                                                                                    id: Name("type"),
+                                                                                                                    ctx: Load,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            arguments: Arguments {
+                                                                                                                range: 571..574,
+                                                                                                                node_index: NodeIndex(None),
+                                                                                                                args: [
+                                                                                                                    Name(
+                                                                                                                        ExprName {
+                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                            range: 572..573,
+                                                                                                                            id: Name("e"),
+                                                                                                                            ctx: Load,
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                ],
+                                                                                                                keywords: [],
+                                                                                                            },
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    debug_text: None,
+                                                                                                    conversion: None,
+                                                                                                    format_spec: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ],
+                                                                                        flags: FStringFlags {
+                                                                                            quote_style: Double,
+                                                                                            prefix: Regular,
+                                                                                            triple_quoted: false,
+                                                                                            unclosed: false,
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            keywords: [],
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 579..831,
-                    body: [
-                        Raise(
-                            StmtRaise {
-                                node_index: NodeIndex(None),
-                                range: 588..669,
-                                exc: Some(
-                                    Call(
-                                        ExprCall {
-                                            node_index: NodeIndex(None),
-                                            range: 594..669,
-                                            func: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 594..608,
-                                                    id: Name("ExceptionGroup"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            arguments: Arguments {
-                                                range: 608..669,
+                    inner: StmtTryInner {
+                        body: [
+                            Raise(
+                                StmtRaise {
+                                    node_index: NodeIndex(None),
+                                    range: 588..669,
+                                    exc: Some(
+                                        Call(
+                                            ExprCall {
                                                 node_index: NodeIndex(None),
-                                                args: [
-                                                    StringLiteral(
-                                                        ExprStringLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 609..613,
-                                                            value: StringLiteralValue {
-                                                                inner: Single(
-                                                                    StringLiteral {
-                                                                        range: 609..613,
-                                                                        node_index: NodeIndex(None),
-                                                                        value: "eg",
-                                                                        flags: StringLiteralFlags {
-                                                                            quote_style: Double,
-                                                                            prefix: Empty,
-                                                                            triple_quoted: false,
-                                                                            unclosed: false,
+                                                range: 594..669,
+                                                func: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 594..608,
+                                                        id: Name("ExceptionGroup"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                arguments: Arguments {
+                                                    range: 608..669,
+                                                    node_index: NodeIndex(None),
+                                                    args: [
+                                                        StringLiteral(
+                                                            ExprStringLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 609..613,
+                                                                value: StringLiteralValue {
+                                                                    inner: Single(
+                                                                        StringLiteral {
+                                                                            range: 609..613,
+                                                                            node_index: NodeIndex(None),
+                                                                            value: "eg",
+                                                                            flags: StringLiteralFlags {
+                                                                                quote_style: Double,
+                                                                                prefix: Empty,
+                                                                                triple_quoted: false,
+                                                                                unclosed: false,
+                                                                            },
                                                                         },
-                                                                    },
-                                                                ),
+                                                                    ),
+                                                                },
                                                             },
-                                                        },
-                                                    ),
-                                                    List(
-                                                        ExprList {
+                                                        ),
+                                                        List(
+                                                            ExprList {
+                                                                node_index: NodeIndex(None),
+                                                                range: 615..668,
+                                                                elts: [
+                                                                    Call(
+                                                                        ExprCall {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 616..629,
+                                                                            func: Name(
+                                                                                ExprName {
+                                                                                    node_index: NodeIndex(None),
+                                                                                    range: 616..626,
+                                                                                    id: Name("ValueError"),
+                                                                                    ctx: Load,
+                                                                                },
+                                                                            ),
+                                                                            arguments: Arguments {
+                                                                                range: 626..629,
+                                                                                node_index: NodeIndex(None),
+                                                                                args: [
+                                                                                    NumberLiteral(
+                                                                                        ExprNumberLiteral {
+                                                                                            node_index: NodeIndex(None),
+                                                                                            range: 627..628,
+                                                                                            value: Int(
+                                                                                                1,
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                keywords: [],
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    Call(
+                                                                        ExprCall {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 631..643,
+                                                                            func: Name(
+                                                                                ExprName {
+                                                                                    node_index: NodeIndex(None),
+                                                                                    range: 631..640,
+                                                                                    id: Name("TypeError"),
+                                                                                    ctx: Load,
+                                                                                },
+                                                                            ),
+                                                                            arguments: Arguments {
+                                                                                range: 640..643,
+                                                                                node_index: NodeIndex(None),
+                                                                                args: [
+                                                                                    NumberLiteral(
+                                                                                        ExprNumberLiteral {
+                                                                                            node_index: NodeIndex(None),
+                                                                                            range: 641..642,
+                                                                                            value: Int(
+                                                                                                2,
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                keywords: [],
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    Call(
+                                                                        ExprCall {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 645..655,
+                                                                            func: Name(
+                                                                                ExprName {
+                                                                                    node_index: NodeIndex(None),
+                                                                                    range: 645..652,
+                                                                                    id: Name("OSError"),
+                                                                                    ctx: Load,
+                                                                                },
+                                                                            ),
+                                                                            arguments: Arguments {
+                                                                                range: 652..655,
+                                                                                node_index: NodeIndex(None),
+                                                                                args: [
+                                                                                    NumberLiteral(
+                                                                                        ExprNumberLiteral {
+                                                                                            node_index: NodeIndex(None),
+                                                                                            range: 653..654,
+                                                                                            value: Int(
+                                                                                                3,
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                keywords: [],
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    Call(
+                                                                        ExprCall {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 657..667,
+                                                                            func: Name(
+                                                                                ExprName {
+                                                                                    node_index: NodeIndex(None),
+                                                                                    range: 657..664,
+                                                                                    id: Name("OSError"),
+                                                                                    ctx: Load,
+                                                                                },
+                                                                            ),
+                                                                            arguments: Arguments {
+                                                                                range: 664..667,
+                                                                                node_index: NodeIndex(None),
+                                                                                args: [
+                                                                                    NumberLiteral(
+                                                                                        ExprNumberLiteral {
+                                                                                            node_index: NodeIndex(None),
+                                                                                            range: 665..666,
+                                                                                            value: Int(
+                                                                                                4,
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                keywords: [],
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                    ],
+                                                    keywords: [],
+                                                },
+                                            },
+                                        ),
+                                    ),
+                                    cause: None,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 670..751,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 678..687,
+                                                id: Name("TypeError"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("e"),
+                                            range: 691..692,
+                                            node_index: NodeIndex(None),
+                                            parameter_node_index: NodeIndex(None),
+                                        },
+                                    ),
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 698..751,
+                                                value: Call(
+                                                    ExprCall {
+                                                        node_index: NodeIndex(None),
+                                                        range: 698..751,
+                                                        func: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 698..703,
+                                                                id: Name("print"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        arguments: Arguments {
+                                                            range: 703..751,
                                                             node_index: NodeIndex(None),
-                                                            range: 615..668,
-                                                            elts: [
-                                                                Call(
-                                                                    ExprCall {
+                                                            args: [
+                                                                FString(
+                                                                    ExprFString {
                                                                         node_index: NodeIndex(None),
-                                                                        range: 616..629,
-                                                                        func: Name(
-                                                                            ExprName {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 616..626,
-                                                                                id: Name("ValueError"),
-                                                                                ctx: Load,
-                                                                            },
-                                                                        ),
-                                                                        arguments: Arguments {
-                                                                            range: 626..629,
-                                                                            node_index: NodeIndex(None),
-                                                                            args: [
-                                                                                NumberLiteral(
-                                                                                    ExprNumberLiteral {
+                                                                        range: 704..750,
+                                                                        value: FStringValue {
+                                                                            inner: Single(
+                                                                                FString(
+                                                                                    FString {
+                                                                                        range: 704..750,
                                                                                         node_index: NodeIndex(None),
-                                                                                        range: 627..628,
-                                                                                        value: Int(
-                                                                                            1,
-                                                                                        ),
+                                                                                        elements: [
+                                                                                            Literal(
+                                                                                                InterpolatedStringLiteralElement {
+                                                                                                    range: 706..713,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    value: "caught ",
+                                                                                                },
+                                                                                            ),
+                                                                                            Interpolation(
+                                                                                                InterpolatedElement {
+                                                                                                    range: 713..722,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    expression: Call(
+                                                                                                        ExprCall {
+                                                                                                            node_index: NodeIndex(None),
+                                                                                                            range: 714..721,
+                                                                                                            func: Name(
+                                                                                                                ExprName {
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    range: 714..718,
+                                                                                                                    id: Name("type"),
+                                                                                                                    ctx: Load,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            arguments: Arguments {
+                                                                                                                range: 718..721,
+                                                                                                                node_index: NodeIndex(None),
+                                                                                                                args: [
+                                                                                                                    Name(
+                                                                                                                        ExprName {
+                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                            range: 719..720,
+                                                                                                                            id: Name("e"),
+                                                                                                                            ctx: Load,
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                ],
+                                                                                                                keywords: [],
+                                                                                                            },
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    debug_text: None,
+                                                                                                    conversion: None,
+                                                                                                    format_spec: None,
+                                                                                                },
+                                                                                            ),
+                                                                                            Literal(
+                                                                                                InterpolatedStringLiteralElement {
+                                                                                                    range: 722..735,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    value: " with nested ",
+                                                                                                },
+                                                                                            ),
+                                                                                            Interpolation(
+                                                                                                InterpolatedElement {
+                                                                                                    range: 735..749,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    expression: Attribute(
+                                                                                                        ExprAttribute {
+                                                                                                            node_index: NodeIndex(None),
+                                                                                                            range: 736..748,
+                                                                                                            value: Name(
+                                                                                                                ExprName {
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    range: 736..737,
+                                                                                                                    id: Name("e"),
+                                                                                                                    ctx: Load,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            attr: Identifier {
+                                                                                                                id: Name("exceptions"),
+                                                                                                                range: 738..748,
+                                                                                                                node_index: NodeIndex(None),
+                                                                                                                parameter_node_index: NodeIndex(None),
+                                                                                                            },
+                                                                                                            ctx: Load,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    debug_text: None,
+                                                                                                    conversion: None,
+                                                                                                    format_spec: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ],
+                                                                                        flags: FStringFlags {
+                                                                                            quote_style: Double,
+                                                                                            prefix: Regular,
+                                                                                            triple_quoted: false,
+                                                                                            unclosed: false,
+                                                                                        },
                                                                                     },
                                                                                 ),
-                                                                            ],
-                                                                            keywords: [],
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                Call(
-                                                                    ExprCall {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 631..643,
-                                                                        func: Name(
-                                                                            ExprName {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 631..640,
-                                                                                id: Name("TypeError"),
-                                                                                ctx: Load,
-                                                                            },
-                                                                        ),
-                                                                        arguments: Arguments {
-                                                                            range: 640..643,
-                                                                            node_index: NodeIndex(None),
-                                                                            args: [
-                                                                                NumberLiteral(
-                                                                                    ExprNumberLiteral {
-                                                                                        node_index: NodeIndex(None),
-                                                                                        range: 641..642,
-                                                                                        value: Int(
-                                                                                            2,
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                            keywords: [],
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                Call(
-                                                                    ExprCall {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 645..655,
-                                                                        func: Name(
-                                                                            ExprName {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 645..652,
-                                                                                id: Name("OSError"),
-                                                                                ctx: Load,
-                                                                            },
-                                                                        ),
-                                                                        arguments: Arguments {
-                                                                            range: 652..655,
-                                                                            node_index: NodeIndex(None),
-                                                                            args: [
-                                                                                NumberLiteral(
-                                                                                    ExprNumberLiteral {
-                                                                                        node_index: NodeIndex(None),
-                                                                                        range: 653..654,
-                                                                                        value: Int(
-                                                                                            3,
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                            keywords: [],
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                Call(
-                                                                    ExprCall {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 657..667,
-                                                                        func: Name(
-                                                                            ExprName {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 657..664,
-                                                                                id: Name("OSError"),
-                                                                                ctx: Load,
-                                                                            },
-                                                                        ),
-                                                                        arguments: Arguments {
-                                                                            range: 664..667,
-                                                                            node_index: NodeIndex(None),
-                                                                            args: [
-                                                                                NumberLiteral(
-                                                                                    ExprNumberLiteral {
-                                                                                        node_index: NodeIndex(None),
-                                                                                        range: 665..666,
-                                                                                        value: Int(
-                                                                                            4,
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                            keywords: [],
+                                                                            ),
                                                                         },
                                                                     },
                                                                 ),
                                                             ],
-                                                            ctx: Load,
+                                                            keywords: [],
                                                         },
-                                                    ),
-                                                ],
-                                                keywords: [],
+                                                    },
+                                                ),
                                             },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 752..831,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 760..767,
+                                                id: Name("OSError"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    ),
+                                    name: Some(
+                                        Identifier {
+                                            id: Name("e"),
+                                            range: 771..772,
+                                            node_index: NodeIndex(None),
+                                            parameter_node_index: NodeIndex(None),
                                         },
                                     ),
-                                ),
-                                cause: None,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 670..751,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 678..687,
-                                            id: Name("TypeError"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("e"),
-                                        range: 691..692,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 698..751,
-                                            value: Call(
-                                                ExprCall {
-                                                    node_index: NodeIndex(None),
-                                                    range: 698..751,
-                                                    func: Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 698..703,
-                                                            id: Name("print"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    arguments: Arguments {
-                                                        range: 703..751,
+                                    body: [
+                                        Expr(
+                                            StmtExpr {
+                                                node_index: NodeIndex(None),
+                                                range: 778..831,
+                                                value: Call(
+                                                    ExprCall {
                                                         node_index: NodeIndex(None),
-                                                        args: [
-                                                            FString(
-                                                                ExprFString {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 704..750,
-                                                                    value: FStringValue {
-                                                                        inner: Single(
-                                                                            FString(
-                                                                                FString {
-                                                                                    range: 704..750,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    elements: [
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 706..713,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "caught ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 713..722,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Call(
-                                                                                                    ExprCall {
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        range: 714..721,
-                                                                                                        func: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 714..718,
-                                                                                                                id: Name("type"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        arguments: Arguments {
-                                                                                                            range: 718..721,
-                                                                                                            node_index: NodeIndex(None),
-                                                                                                            args: [
-                                                                                                                Name(
-                                                                                                                    ExprName {
-                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                        range: 719..720,
-                                                                                                                        id: Name("e"),
-                                                                                                                        ctx: Load,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                            keywords: [],
-                                                                                                        },
-                                                                                                    },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 722..735,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: " with nested ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 735..749,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Attribute(
-                                                                                                    ExprAttribute {
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        range: 736..748,
-                                                                                                        value: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 736..737,
-                                                                                                                id: Name("e"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        attr: Identifier {
-                                                                                                            id: Name("exceptions"),
-                                                                                                            range: 738..748,
-                                                                                                            node_index: NodeIndex(None),
-                                                                                                            parameter_node_index: NodeIndex(None),
-                                                                                                        },
-                                                                                                        ctx: Load,
-                                                                                                    },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                    flags: FStringFlags {
-                                                                                        quote_style: Double,
-                                                                                        prefix: Regular,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
-                                                                                    },
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                    },
-                                                                },
-                                                            ),
-                                                        ],
-                                                        keywords: [],
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 752..831,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 760..767,
-                                            id: Name("OSError"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                ),
-                                name: Some(
-                                    Identifier {
-                                        id: Name("e"),
-                                        range: 771..772,
-                                        node_index: NodeIndex(None),
-                                        parameter_node_index: NodeIndex(None),
-                                    },
-                                ),
-                                body: [
-                                    Expr(
-                                        StmtExpr {
-                                            node_index: NodeIndex(None),
-                                            range: 778..831,
-                                            value: Call(
-                                                ExprCall {
-                                                    node_index: NodeIndex(None),
-                                                    range: 778..831,
-                                                    func: Name(
-                                                        ExprName {
+                                                        range: 778..831,
+                                                        func: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 778..783,
+                                                                id: Name("print"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        arguments: Arguments {
+                                                            range: 783..831,
                                                             node_index: NodeIndex(None),
-                                                            range: 778..783,
-                                                            id: Name("print"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    arguments: Arguments {
-                                                        range: 783..831,
-                                                        node_index: NodeIndex(None),
-                                                        args: [
-                                                            FString(
-                                                                ExprFString {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 784..830,
-                                                                    value: FStringValue {
-                                                                        inner: Single(
-                                                                            FString(
-                                                                                FString {
-                                                                                    range: 784..830,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    elements: [
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 786..793,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "caught ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 793..802,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Call(
-                                                                                                    ExprCall {
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        range: 794..801,
-                                                                                                        func: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 794..798,
-                                                                                                                id: Name("type"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        arguments: Arguments {
-                                                                                                            range: 798..801,
+                                                            args: [
+                                                                FString(
+                                                                    ExprFString {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 784..830,
+                                                                        value: FStringValue {
+                                                                            inner: Single(
+                                                                                FString(
+                                                                                    FString {
+                                                                                        range: 784..830,
+                                                                                        node_index: NodeIndex(None),
+                                                                                        elements: [
+                                                                                            Literal(
+                                                                                                InterpolatedStringLiteralElement {
+                                                                                                    range: 786..793,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    value: "caught ",
+                                                                                                },
+                                                                                            ),
+                                                                                            Interpolation(
+                                                                                                InterpolatedElement {
+                                                                                                    range: 793..802,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    expression: Call(
+                                                                                                        ExprCall {
                                                                                                             node_index: NodeIndex(None),
-                                                                                                            args: [
-                                                                                                                Name(
-                                                                                                                    ExprName {
-                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                        range: 799..800,
-                                                                                                                        id: Name("e"),
-                                                                                                                        ctx: Load,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                            keywords: [],
-                                                                                                        },
-                                                                                                    },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 802..815,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: " with nested ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 815..829,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Attribute(
-                                                                                                    ExprAttribute {
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        range: 816..828,
-                                                                                                        value: Name(
-                                                                                                            ExprName {
+                                                                                                            range: 794..801,
+                                                                                                            func: Name(
+                                                                                                                ExprName {
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    range: 794..798,
+                                                                                                                    id: Name("type"),
+                                                                                                                    ctx: Load,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            arguments: Arguments {
+                                                                                                                range: 798..801,
                                                                                                                 node_index: NodeIndex(None),
-                                                                                                                range: 816..817,
-                                                                                                                id: Name("e"),
-                                                                                                                ctx: Load,
+                                                                                                                args: [
+                                                                                                                    Name(
+                                                                                                                        ExprName {
+                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                            range: 799..800,
+                                                                                                                            id: Name("e"),
+                                                                                                                            ctx: Load,
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                ],
+                                                                                                                keywords: [],
                                                                                                             },
-                                                                                                        ),
-                                                                                                        attr: Identifier {
-                                                                                                            id: Name("exceptions"),
-                                                                                                            range: 818..828,
-                                                                                                            node_index: NodeIndex(None),
-                                                                                                            parameter_node_index: NodeIndex(None),
                                                                                                         },
-                                                                                                        ctx: Load,
-                                                                                                    },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                    flags: FStringFlags {
-                                                                                        quote_style: Double,
-                                                                                        prefix: Regular,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
+                                                                                                    ),
+                                                                                                    debug_text: None,
+                                                                                                    conversion: None,
+                                                                                                    format_spec: None,
+                                                                                                },
+                                                                                            ),
+                                                                                            Literal(
+                                                                                                InterpolatedStringLiteralElement {
+                                                                                                    range: 802..815,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    value: " with nested ",
+                                                                                                },
+                                                                                            ),
+                                                                                            Interpolation(
+                                                                                                InterpolatedElement {
+                                                                                                    range: 815..829,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    expression: Attribute(
+                                                                                                        ExprAttribute {
+                                                                                                            node_index: NodeIndex(None),
+                                                                                                            range: 816..828,
+                                                                                                            value: Name(
+                                                                                                                ExprName {
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    range: 816..817,
+                                                                                                                    id: Name("e"),
+                                                                                                                    ctx: Load,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            attr: Identifier {
+                                                                                                                id: Name("exceptions"),
+                                                                                                                range: 818..828,
+                                                                                                                node_index: NodeIndex(None),
+                                                                                                                parameter_node_index: NodeIndex(None),
+                                                                                                            },
+                                                                                                            ctx: Load,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    debug_text: None,
+                                                                                                    conversion: None,
+                                                                                                    format_spec: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ],
+                                                                                        flags: FStringFlags {
+                                                                                            quote_style: Double,
+                                                                                            prefix: Regular,
+                                                                                            triple_quoted: false,
+                                                                                            unclosed: false,
+                                                                                        },
                                                                                     },
-                                                                                },
+                                                                                ),
                                                                             ),
-                                                                        ),
+                                                                        },
                                                                     },
-                                                                },
-                                                            ),
-                                                        ],
-                                                        keywords: [],
+                                                                ),
+                                                            ],
+                                                            keywords: [],
+                                                        },
                                                     },
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: true,
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: true,
+                    },
                 },
             ),
             Try(
                 StmtTry {
                     node_index: NodeIndex(None),
                     range: 833..1075,
-                    body: [
-                        Pass(
-                            StmtPass {
-                                node_index: NodeIndex(None),
-                                range: 842..846,
-                            },
-                        ),
-                    ],
-                    handlers: [
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 847..875,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    StringLiteral(
-                                        ExprStringLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 854..865,
-                                            value: StringLiteralValue {
-                                                inner: Single(
-                                                    StringLiteral {
-                                                        range: 854..865,
-                                                        node_index: NodeIndex(None),
-                                                        value: "exception",
-                                                        flags: StringLiteralFlags {
-                                                            quote_style: Double,
-                                                            prefix: Empty,
-                                                            triple_quoted: false,
-                                                            unclosed: false,
+                    inner: StmtTryInner {
+                        body: [
+                            Pass(
+                                StmtPass {
+                                    node_index: NodeIndex(None),
+                                    range: 842..846,
+                                },
+                            ),
+                        ],
+                        handlers: [
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 847..875,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        StringLiteral(
+                                            ExprStringLiteral {
+                                                node_index: NodeIndex(None),
+                                                range: 854..865,
+                                                value: StringLiteralValue {
+                                                    inner: Single(
+                                                        StringLiteral {
+                                                            range: 854..865,
+                                                            node_index: NodeIndex(None),
+                                                            value: "exception",
+                                                            flags: StringLiteralFlags {
+                                                                quote_style: Double,
+                                                                prefix: Empty,
+                                                                triple_quoted: false,
+                                                                unclosed: false,
+                                                            },
                                                         },
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                    ),
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 871..875,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 876..894,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        NumberLiteral(
+                                            ExprNumberLiteral {
+                                                node_index: NodeIndex(None),
+                                                range: 883..884,
+                                                value: Int(
+                                                    1,
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 890..894,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 895..916,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        BooleanLiteral(
+                                            ExprBooleanLiteral {
+                                                node_index: NodeIndex(None),
+                                                range: 902..906,
+                                                value: true,
+                                            },
+                                        ),
+                                    ),
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 912..916,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 917..939,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        BinOp(
+                                            ExprBinOp {
+                                                node_index: NodeIndex(None),
+                                                range: 924..929,
+                                                left: NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 924..925,
+                                                        value: Int(
+                                                            1,
+                                                        ),
+                                                    },
+                                                ),
+                                                op: Add,
+                                                right: NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 928..929,
+                                                        value: Int(
+                                                            1,
+                                                        ),
                                                     },
                                                 ),
                                             },
-                                        },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 871..875,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 876..894,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    NumberLiteral(
-                                        ExprNumberLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 883..884,
-                                            value: Int(
-                                                1,
-                                            ),
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 890..894,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 895..916,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    BooleanLiteral(
-                                        ExprBooleanLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 902..906,
-                                            value: true,
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 912..916,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 917..939,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    BinOp(
-                                        ExprBinOp {
-                                            node_index: NodeIndex(None),
-                                            range: 924..929,
-                                            left: NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 924..925,
-                                                    value: Int(
-                                                        1,
-                                                    ),
-                                                },
-                                            ),
-                                            op: Add,
-                                            right: NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 928..929,
-                                                    value: Int(
-                                                        1,
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 935..939,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 940..962,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    BinOp(
-                                        ExprBinOp {
-                                            node_index: NodeIndex(None),
-                                            range: 947..952,
-                                            left: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 947..948,
-                                                    id: Name("a"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            op: BitOr,
-                                            right: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 951..952,
-                                                    id: Name("b"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 958..962,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 963..987,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    BoolOp(
-                                        ExprBoolOp {
-                                            node_index: NodeIndex(None),
-                                            range: 970..977,
-                                            op: And,
-                                            values: [
-                                                Name(
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 935..939,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 940..962,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        BinOp(
+                                            ExprBinOp {
+                                                node_index: NodeIndex(None),
+                                                range: 947..952,
+                                                left: Name(
                                                     ExprName {
                                                         node_index: NodeIndex(None),
-                                                        range: 970..971,
+                                                        range: 947..948,
+                                                        id: Name("a"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                op: BitOr,
+                                                right: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 951..952,
+                                                        id: Name("b"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 958..962,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 963..987,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        BoolOp(
+                                            ExprBoolOp {
+                                                node_index: NodeIndex(None),
+                                                range: 970..977,
+                                                op: And,
+                                                values: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 970..971,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 976..977,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    ),
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 983..987,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 988..1012,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Await(
+                                            ExprAwait {
+                                                node_index: NodeIndex(None),
+                                                range: 995..1002,
+                                                value: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 1001..1002,
                                                         id: Name("x"),
                                                         ctx: Load,
                                                     },
                                                 ),
-                                                Name(
+                                            },
+                                        ),
+                                    ),
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 1008..1012,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 1013..1041,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        Lambda(
+                                            ExprLambda {
+                                                node_index: NodeIndex(None),
+                                                range: 1020..1031,
+                                                parameters: Some(
+                                                    Parameters {
+                                                        range: 1027..1028,
+                                                        node_index: NodeIndex(None),
+                                                        posonlyargs: [],
+                                                        args: [
+                                                            ParameterWithDefault {
+                                                                end: 1028,
+                                                                node_index: NodeIndex(None),
+                                                                parameter: Parameter {
+                                                                    range: 1027..1028,
+                                                                    name: Identifier {
+                                                                        id: Name("x"),
+                                                                        range: 1027..1028,
+                                                                        node_index: NodeIndex(None),
+                                                                        parameter_node_index: NodeIndex(None),
+                                                                    },
+                                                                    annotation: None,
+                                                                },
+                                                                default: None,
+                                                            },
+                                                        ],
+                                                        vararg: None,
+                                                        kwonlyargs: [],
+                                                        kwarg: None,
+                                                    },
+                                                ),
+                                                body: Name(
                                                     ExprName {
                                                         node_index: NodeIndex(None),
-                                                        range: 976..977,
+                                                        range: 1030..1031,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 1037..1041,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            ExceptHandler(
+                                ExceptHandlerExceptHandler {
+                                    range: 1042..1075,
+                                    node_index: NodeIndex(None),
+                                    type_: Some(
+                                        If(
+                                            ExprIf {
+                                                node_index: NodeIndex(None),
+                                                range: 1049..1065,
+                                                test: BooleanLiteral(
+                                                    ExprBooleanLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 1054..1058,
+                                                        value: true,
+                                                    },
+                                                ),
+                                                body: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 1049..1050,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                orelse: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 1064..1065,
                                                         id: Name("y"),
                                                         ctx: Load,
                                                     },
                                                 ),
-                                            ],
-                                        },
+                                            },
+                                        ),
                                     ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 983..987,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 988..1012,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Await(
-                                        ExprAwait {
-                                            node_index: NodeIndex(None),
-                                            range: 995..1002,
-                                            value: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 1001..1002,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 1008..1012,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 1013..1041,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    Lambda(
-                                        ExprLambda {
-                                            node_index: NodeIndex(None),
-                                            range: 1020..1031,
-                                            parameters: Some(
-                                                Parameters {
-                                                    range: 1027..1028,
-                                                    node_index: NodeIndex(None),
-                                                    posonlyargs: [],
-                                                    args: [
-                                                        ParameterWithDefault {
-                                                            end: 1028,
-                                                            node_index: NodeIndex(None),
-                                                            parameter: Parameter {
-                                                                range: 1027..1028,
-                                                                name: Identifier {
-                                                                    id: Name("x"),
-                                                                    range: 1027..1028,
-                                                                    node_index: NodeIndex(None),
-                                                                    parameter_node_index: NodeIndex(None),
-                                                                },
-                                                                annotation: None,
-                                                            },
-                                                            default: None,
-                                                        },
-                                                    ],
-                                                    vararg: None,
-                                                    kwonlyargs: [],
-                                                    kwarg: None,
-                                                },
-                                            ),
-                                            body: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 1030..1031,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 1037..1041,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                        ExceptHandler(
-                            ExceptHandlerExceptHandler {
-                                range: 1042..1075,
-                                node_index: NodeIndex(None),
-                                type_: Some(
-                                    If(
-                                        ExprIf {
-                                            node_index: NodeIndex(None),
-                                            range: 1049..1065,
-                                            test: BooleanLiteral(
-                                                ExprBooleanLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 1054..1058,
-                                                    value: true,
-                                                },
-                                            ),
-                                            body: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 1049..1050,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            orelse: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 1064..1065,
-                                                    id: Name("y"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ),
-                                name: None,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 1071..1075,
-                                        },
-                                    ),
-                                ],
-                            },
-                        ),
-                    ],
-                    orelse: [],
-                    finalbody: [],
-                    is_star: false,
+                                    name: None,
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 1071..1075,
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                        orelse: [],
+                        finalbody: [],
+                        is_star: false,
+                    },
                 },
             ),
             If(
@@ -1759,25 +1781,27 @@ Module(
                             StmtTry {
                                 node_index: NodeIndex(None),
                                 range: 1090..1133,
-                                body: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 1103..1107,
-                                        },
-                                    ),
-                                ],
-                                handlers: [],
-                                orelse: [],
-                                finalbody: [
-                                    Pass(
-                                        StmtPass {
-                                            node_index: NodeIndex(None),
-                                            range: 1129..1133,
-                                        },
-                                    ),
-                                ],
-                                is_star: false,
+                                inner: StmtTryInner {
+                                    body: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 1103..1107,
+                                            },
+                                        ),
+                                    ],
+                                    handlers: [],
+                                    orelse: [],
+                                    finalbody: [
+                                        Pass(
+                                            StmtPass {
+                                                node_index: NodeIndex(None),
+                                                range: 1129..1133,
+                                            },
+                                        ),
+                                    ],
+                                    is_star: false,
+                                },
                             },
                         ),
                     ],

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_param_default_py313.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@type_param_default_py313.py.snap
@@ -69,43 +69,45 @@ Module(
                     range: 66..87,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 70..71,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
-                    },
-                    type_params: Some(
-                        TypeParams {
-                            range: 71..80,
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 70..71,
                             node_index: NodeIndex(None),
-                            type_params: [
-                                TypeVar(
-                                    TypeParamTypeVar {
-                                        node_index: NodeIndex(None),
-                                        range: 72..79,
-                                        name: Identifier {
-                                            id: Name("T"),
-                                            range: 72..73,
-                                            node_index: NodeIndex(None),
-                                            parameter_node_index: NodeIndex(None),
-                                        },
-                                        bound: None,
-                                        default: Some(
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 76..79,
-                                                    id: Name("int"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ],
+                            parameter_node_index: NodeIndex(None),
                         },
-                    ),
+                        type_params: Some(
+                            TypeParams {
+                                range: 71..80,
+                                node_index: NodeIndex(None),
+                                type_params: [
+                                    TypeVar(
+                                        TypeParamTypeVar {
+                                            node_index: NodeIndex(None),
+                                            range: 72..79,
+                                            name: Identifier {
+                                                id: Name("T"),
+                                                range: 72..73,
+                                                node_index: NodeIndex(None),
+                                                parameter_node_index: NodeIndex(None),
+                                            },
+                                            bound: None,
+                                            default: Some(
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 76..79,
+                                                        id: Name("int"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                     parameters: Parameters {
                         range: 80..82,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@valid_annotation_class.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@valid_annotation_class.py.snap
@@ -75,13 +75,15 @@ Module(
                     range: 24..93,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 28..29,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 28..29,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 29..31,
                         node_index: NodeIndex(None),
@@ -208,13 +210,15 @@ Module(
                     range: 94..136,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 104..105,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 104..105,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 105..107,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@valid_annotation_function_py313.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@valid_annotation_function_py313.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 44..68,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 48..49,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 48..49,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 49..51,
                         node_index: NodeIndex(None),
@@ -79,13 +81,15 @@ Module(
                     range: 69..94,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("g"),
-                        range: 73..74,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("g"),
+                            range: 73..74,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 74..89,
                         node_index: NodeIndex(None),
@@ -158,13 +162,15 @@ Module(
                     range: 95..235,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("outer"),
-                        range: 99..104,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("outer"),
+                            range: 99..104,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 104..106,
                         node_index: NodeIndex(None),
@@ -182,13 +188,15 @@ Module(
                                 range: 112..136,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("i"),
-                                    range: 116..117,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("i"),
+                                        range: 116..117,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 117..131,
                                     node_index: NodeIndex(None),
@@ -255,13 +263,15 @@ Module(
                                 range: 141..166,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("k"),
-                                    range: 145..146,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("k"),
+                                        range: 145..146,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 146..148,
                                     node_index: NodeIndex(None),
@@ -312,13 +322,15 @@ Module(
                                 range: 171..200,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("m"),
-                                    range: 175..176,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("m"),
+                                        range: 175..176,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 176..195,
                                     node_index: NodeIndex(None),
@@ -383,13 +395,15 @@ Module(
                                 range: 205..235,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("o"),
-                                    range: 209..210,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("o"),
+                                        range: 209..210,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 210..212,
                                     node_index: NodeIndex(None),
@@ -441,13 +455,15 @@ Module(
                     range: 236..315,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("outer"),
-                        range: 246..251,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("outer"),
+                            range: 246..251,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 251..253,
                         node_index: NodeIndex(None),
@@ -465,13 +481,15 @@ Module(
                                 range: 259..284,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("f"),
-                                    range: 263..264,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("f"),
+                                        range: 263..264,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 264..266,
                                     node_index: NodeIndex(None),
@@ -520,13 +538,15 @@ Module(
                                 range: 289..315,
                                 is_async: false,
                                 decorator_list: [],
-                                name: Identifier {
-                                    id: Name("g"),
-                                    range: 293..294,
-                                    node_index: NodeIndex(None),
-                                    parameter_node_index: NodeIndex(None),
+                                name: FunctionDefName {
+                                    name: Identifier {
+                                        id: Name("g"),
+                                        range: 293..294,
+                                        node_index: NodeIndex(None),
+                                        parameter_node_index: NodeIndex(None),
+                                    },
+                                    type_params: None,
                                 },
-                                type_params: None,
                                 parameters: Parameters {
                                     range: 294..310,
                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@valid_annotation_py313.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@valid_annotation_py313.py.snap
@@ -55,13 +55,15 @@ Module(
                     range: 56..107,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("outer"),
-                        range: 60..65,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("outer"),
+                            range: 60..65,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 65..67,
                         node_index: NodeIndex(None),
@@ -146,13 +148,15 @@ Module(
                     range: 108..143,
                     is_async: true,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("outer"),
-                        range: 118..123,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("outer"),
+                            range: 118..123,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 123..125,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@yield_after_comma_parenthesized.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@yield_after_comma_parenthesized.py.snap
@@ -16,13 +16,15 @@ Module(
                     range: 0..21,
                     is_async: false,
                     decorator_list: [],
-                    name: Identifier {
-                        id: Name("f"),
-                        range: 4..5,
-                        node_index: NodeIndex(None),
-                        parameter_node_index: NodeIndex(None),
+                    name: FunctionDefName {
+                        name: Identifier {
+                            id: Name("f"),
+                            range: 4..5,
+                            node_index: NodeIndex(None),
+                            parameter_node_index: NodeIndex(None),
+                        },
+                        type_params: None,
                     },
-                    type_params: None,
                     parameters: Parameters {
                         range: 5..7,
                         node_index: NodeIndex(None),

--- a/crates/ruff_python_semantic/src/analyze/class.rs
+++ b/crates/ruff_python_semantic/src/analyze/class.rs
@@ -9,7 +9,7 @@ use ruff_python_ast::helpers::map_subscript;
 use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::{
     ExceptHandler, Expr, ExprName, ExprStarred, ExprSubscript, ExprTuple, Stmt, StmtFor, StmtIf,
-    StmtMatch, StmtTry, StmtWhile, StmtWith,
+    StmtMatch, StmtWhile, StmtWith,
 };
 
 /// Return `true` if any base class matches a [`QualifiedName`] predicate.
@@ -232,13 +232,14 @@ where
                     None
                 }
 
-                Stmt::Try(StmtTry {
-                    body,
-                    handlers,
-                    orelse,
-                    finalbody,
-                    ..
-                }) => {
+                Stmt::Try(try_stmt) => {
+                    let ast::StmtTryInner {
+                        body,
+                        handlers,
+                        orelse,
+                        finalbody,
+                        is_star: _,
+                    } = try_stmt.inner.as_ref();
                     if any_stmt_in_body(body, func, ClassMemberBoundness::PossiblyUnbound)
                         || any_stmt_in_body(orelse, func, ClassMemberBoundness::PossiblyUnbound)
                         || any_stmt_in_body(finalbody, func, ClassMemberBoundness::PossiblyUnbound)
@@ -348,7 +349,7 @@ fn has_metaclass_new_signature(class_def: &ast::StmtClassDef, semantic: &Semanti
             continue;
         };
 
-        if name != "__new__" {
+        if name.as_str() != "__new__" {
             continue;
         }
 

--- a/crates/ruff_python_semantic/src/analyze/terminal.rs
+++ b/crates/ruff_python_semantic/src/analyze/terminal.rs
@@ -107,13 +107,14 @@ impl Terminal {
                         }
                     }
                 }
-                Stmt::Try(ast::StmtTry {
-                    body,
-                    handlers,
-                    orelse,
-                    finalbody,
-                    ..
-                }) => {
+                Stmt::Try(try_stmt) => {
+                    let ast::StmtTryInner {
+                        body,
+                        handlers,
+                        orelse,
+                        finalbody,
+                        is_star: _,
+                    } = try_stmt.inner.as_ref();
                     // If the body returns, then this can't be a non-returning function. We assume
                     // that _any_ statement in the body could raise an exception, so we don't
                     // consider the body to be exhaustive. In other words, we assume the exception
@@ -323,21 +324,17 @@ fn sometimes_breaks(stmts: &[Stmt], semantic: &SemanticModel) -> bool {
             {
                 return true;
             }
-            Stmt::Try(ast::StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                ..
-            }) if (sometimes_breaks(body, semantic)
-                || handlers.iter().any(|handler| {
-                    let ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler {
-                        body, ..
-                    }) = handler;
-                    sometimes_breaks(body, semantic)
-                })
-                || sometimes_breaks(orelse, semantic)
-                || sometimes_breaks(finalbody, semantic)) =>
+            Stmt::Try(try_stmt)
+                if (sometimes_breaks(&try_stmt.body, semantic)
+                    || try_stmt.handlers.iter().any(|handler| {
+                        let ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler {
+                            body,
+                            ..
+                        }) = handler;
+                        sometimes_breaks(body, semantic)
+                    })
+                    || sometimes_breaks(&try_stmt.orelse, semantic)
+                    || sometimes_breaks(&try_stmt.finalbody, semantic)) =>
             {
                 return true;
             }

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -700,12 +700,9 @@ bitflags! {
 }
 
 impl Exceptions {
-    pub fn from_try_stmt(
-        ast::StmtTry { handlers, .. }: &ast::StmtTry,
-        semantic: &SemanticModel,
-    ) -> Self {
+    pub fn from_try_stmt(try_stmt: &ast::StmtTry, semantic: &SemanticModel) -> Self {
         let mut handled_exceptions = Self::empty();
-        for type_ in extract_handled_exceptions(handlers) {
+        for type_ in extract_handled_exceptions(&try_stmt.handlers) {
             handled_exceptions |= match semantic.resolve_builtin_symbol(type_) {
                 Some("NameError") => Self::NAME_ERROR,
                 Some("ModuleNotFoundError") => Self::MODULE_NOT_FOUND_ERROR,

--- a/crates/ty_ide/src/call_hierarchy/outgoing_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/outgoing_calls.rs
@@ -71,7 +71,7 @@ pub fn outgoing_calls(db: &dyn Db, file: File, offset: TextSize) -> Vec<Outgoing
                 let func = fn_ref.node(&parsed);
                 finder.walk_callable_signature(
                     &func.decorator_list,
-                    func.type_params.as_deref(),
+                    func.name.type_params.as_deref(),
                     Some(&func.parameters),
                     func.returns.as_deref(),
                 );
@@ -246,7 +246,7 @@ impl<'a> SourceOrderVisitor<'a> for OutgoingCallsFinder<'a, '_> {
             AnyNodeRef::StmtFunctionDef(func) => {
                 self.walk_callable_signature(
                     &func.decorator_list,
-                    func.type_params.as_deref(),
+                    func.name.type_params.as_deref(),
                     Some(&func.parameters),
                     func.returns.as_deref(),
                 );

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1380,7 +1380,7 @@ impl<'m> ContextCursor<'m> {
                     || stmt
                         .elif_else_clauses
                         .iter()
-                        .any(|clause| clause.test.as_ref().is_some_and(contains))
+                        .any(|clause| clause.test.as_deref().is_some_and(contains))
             }
             // while_stmt := 'while' named_expression ':' block [else_block]
             ast::AnyNodeRef::StmtWhile(stmt) => contains(&stmt.test),
@@ -2924,7 +2924,10 @@ impl<'a> ImportStatement<'a> {
                 }
                 FromImportKind::Attribute => {
                     let module_dependency_kind = model
-                        .resolve_module(ast.module.as_ref().map(ast::Identifier::as_str), ast.level)
+                        .resolve_module(
+                            ast.module.as_deref().map(ast::Identifier::as_str),
+                            ast.level,
+                        )
                         .map(|module| ModuleDependencyKind::from_module(db, module));
                     add_import_completions_with_module_dependency_kind(
                         db,

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -1003,7 +1003,7 @@ impl GotoTarget<'_> {
                             // Regular import statement like "import x.y as z"
 
                             // Is the offset within the alias name (asname) part?
-                            if let Some(asname) = &alias.asname {
+                            if let Some(asname) = alias.asname.as_deref() {
                                 if asname.range.contains_inclusive(offset) {
                                     return Some(GotoTarget::ImportModuleAlias { alias, asname });
                                 }
@@ -1035,7 +1035,7 @@ impl GotoTarget<'_> {
                             // From import statement like "from x import y as z"
 
                             // Is the offset within the alias name (asname) part?
-                            if let Some(asname) = &alias.asname {
+                            if let Some(asname) = alias.asname.as_deref() {
                                 if asname.range.contains_inclusive(offset) {
                                     return Some(GotoTarget::ImportSymbolAlias { alias, asname });
                                 }

--- a/crates/ty_ide/src/importer.rs
+++ b/crates/ty_ide/src/importer.rs
@@ -302,7 +302,11 @@ impl<'a> Importer<'a> {
                     .stmt
                     .as_import_from_stmt()
                     .is_some_and(|import_from| {
-                        !import_from.is_lazy && import_from.module.as_deref() == Some("__future__")
+                        !import_from.is_lazy
+                            && import_from
+                                .module
+                                .as_ref()
+                                .is_some_and(|module| module.id == "__future__")
                     })
             })
             .last()

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -493,7 +493,7 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
             }
             AnyNodeRef::Alias(alias) => {
                 // Handle import alias declarations
-                if let Some(asname) = &alias.asname {
+                if let Some(asname) = alias.asname.as_deref() {
                     self.check_declaration_identifier(asname);
                 }
                 // Only check the original name if it matches our target text

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -738,7 +738,7 @@ impl SourceOrderVisitor<'_> for SemanticTokenVisitor<'_> {
                 );
 
                 // Type parameters (Python 3.12+ syntax)
-                if let Some(type_params) = &func.type_params {
+                if let Some(type_params) = &func.name.type_params {
                     for type_param in &type_params.type_params {
                         self.visit_type_param(type_param);
                     }

--- a/crates/ty_module_resolver/src/module_name.rs
+++ b/crates/ty_module_resolver/src/module_name.rs
@@ -322,7 +322,12 @@ impl ModuleName {
             range: _,
             node_index: _,
         } = node;
-        Self::from_identifier_parts(db, importing_file, module.as_deref(), *level)
+        Self::from_identifier_parts(
+            db,
+            importing_file,
+            module.as_ref().map(|module| module.id.as_str()),
+            *level,
+        )
     }
 
     /// Computes the absolute module name from the LHS components of `from LHS import RHS`

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2712,7 +2712,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let ast::StmtFunctionDef {
                     decorator_list,
                     parameters,
-                    type_params,
                     name,
                     returns,
                     body,
@@ -2743,7 +2742,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 let nested_bindings = self.with_type_params(
                     NodeWithScopeRef::FunctionTypeParameters(function_def),
-                    type_params.as_deref(),
+                    name.type_params.as_deref(),
                     |builder| {
                         builder.visit_parameters(parameters);
                         if let Some(returns) = returns {
@@ -2817,7 +2816,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // used to collect all the overloaded definitions of a function. This needs to be
                 // done on the `Identifier` node as opposed to `ExprName` because that's what the
                 // AST uses.
-                let use_id = self.current_ast_ids_mut().record_use(name);
+                let use_id = self.current_ast_ids_mut().record_use(&name.name);
                 self.current_use_def_map_mut()
                     .record_use(symbol.into(), use_id);
 
@@ -2926,7 +2925,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     && let Ok(module_name) = ModuleName::from_identifier_parts(
                         self.db,
                         self.file,
-                        node.module.as_deref(),
+                        node.module.as_ref().map(|module| module.id.as_str()),
                         node.level,
                     )
                     && let Ok(thispackage) = ModuleName::package_for_file(self.db, self.file)
@@ -3101,7 +3100,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     // miss-placed `__future__` import.)
                     self.has_future_annotations |= !node.is_lazy
                         && alias.name.id == "annotations"
-                        && node.module.as_deref() == Some("__future__");
+                        && node
+                            .module
+                            .as_ref()
+                            .is_some_and(|module| module.id == "__future__");
 
                     let symbol = self.add_symbol(symbol_name.clone());
 
@@ -3316,7 +3318,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let elif_else_clauses = node
                     .elif_else_clauses
                     .iter()
-                    .map(|clause| (clause.test.as_ref(), clause.body.as_slice()));
+                    .map(|clause| (clause.test.as_deref(), clause.body.as_slice()));
                 let has_else = node
                     .elif_else_clauses
                     .last()
@@ -3798,15 +3800,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.flow_merge(post_clause_state);
                 }
             }
-            ast::Stmt::Try(ast::StmtTry {
-                body,
-                handlers,
-                orelse,
-                finalbody,
-                is_star,
-                range: _,
-                node_index: _,
-            }) => {
+            ast::Stmt::Try(try_stmt) => {
+                let ast::StmtTryInner {
+                    body,
+                    handlers,
+                    orelse,
+                    finalbody,
+                    is_star,
+                } = try_stmt.inner.as_ref();
                 let was_in_try = std::mem::replace(&mut self.in_try, true);
                 self.record_ambiguous_reachability();
 

--- a/crates/ty_python_core/src/re_exports.rs
+++ b/crates/ty_python_core/src/re_exports.rs
@@ -197,8 +197,7 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
                 decorator_list,
                 parameters,
                 returns,
-                type_params: _, // We don't want to visit the type params of the function
-                body: _,        // We don't want to visit the body of the function
+                body: _, // We don't want to visit the body of the function
                 range: _,
                 node_index: _,
                 is_async: _,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -574,9 +574,13 @@ impl<'db> OverloadLiteral<'db> {
         let function_stmt_node = scope.node(db).expect_function().node(&module);
         let definition = self.definition(db);
         let index = semantic_index(db, scope.file(db));
-        let pep695_ctx = function_stmt_node.type_params.as_ref().map(|type_params| {
-            GenericContext::from_type_params(db, index, definition, type_params)
-        });
+        let pep695_ctx = function_stmt_node
+            .name
+            .type_params
+            .as_ref()
+            .map(|type_params| {
+                GenericContext::from_type_params(db, index, definition, type_params)
+            });
         let file_scope_id = scope.file_scope_id(db);
 
         let has_implicitly_positional_first_parameter = has_implicitly_positional_only_first_param(

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1545,7 +1545,7 @@ mod resolve_definition {
     ) -> Vec<ResolvedDefinition<'db>> {
         if alias_resolution == ImportAliasResolution::PreserveAliases {
             for alias in &import_node.names {
-                if let Some(asname) = &alias.asname {
+                if let Some(asname) = alias.asname.as_deref() {
                     if asname.as_str() == symbol_name {
                         return vec![ResolvedDefinition::FileWithRange(FileRange::new(
                             file,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1946,7 +1946,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 body,
             } = clause;
 
-            if let Some(test) = &test {
+            if let Some(test) = test.as_deref() {
                 let test_ty = self.infer_standalone_expression(test, TypeContext::default());
 
                 if let Err(err) = test_ty.try_bool(self.db()) {
@@ -1959,15 +1959,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn infer_try_statement(&mut self, try_statement: &ast::StmtTry) {
-        let ast::StmtTry {
-            range: _,
-            node_index: _,
+        let ast::StmtTryInner {
             body,
             handlers,
             orelse,
             finalbody,
             is_star: _,
-        } = try_statement;
+        } = try_statement.inner.as_ref();
 
         self.infer_body(body);
 

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -84,7 +84,7 @@ impl<'db> ExpectedReturnType<'db> {
             same_module_uncached_raw_signature(db, function, ReturnCallableTypeVarScope::Public)
                 .return_ty,
         );
-        let lexical = function_node.type_params.is_some().then(|| {
+        let lexical = function_node.name.type_params.is_some().then(|| {
             normalize(
                 db,
                 same_module_uncached_raw_signature(
@@ -301,12 +301,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             node_index: _,
             is_async: _,
             name,
-            type_params,
             parameters,
             returns: _,
             body: _,
             decorator_list,
         } = function;
+        let type_params = &name.type_params;
+        let name = &name.name;
 
         let db = self.db();
 
@@ -428,7 +429,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Check that the function's own type parameters don't shadow
         // type variables from enclosing scopes (by name).
-        if let Some(type_params) = &function.type_params {
+        if let Some(type_params) = &function.name.type_params {
             let current_scope = self.scope().file_scope_id(db);
             for type_param in type_params.iter() {
                 let param_name = type_param.name();
@@ -490,7 +491,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 };
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Useless body for `@overload`-decorated function `{}`",
-                    &function.name
+                    function.name.as_str()
                 ));
                 diagnostic.set_primary_message("This statement will never be executed");
                 diagnostic.info(
@@ -528,7 +529,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .inference_flags
             .set(InferenceFlags::IN_NO_TYPE_CHECK, prev_in_no_type_check);
 
-        let has_type_params = function.type_params.is_some();
+        let has_type_params = function.name.type_params.is_some();
         let has_defaults = function
             .parameters
             .iter_non_variadic_params()
@@ -609,6 +610,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     pub(super) fn infer_function_type_params(&mut self, function: &ast::StmtFunctionDef) {
         let type_params = function
+            .name
             .type_params
             .as_deref()
             .expect("function type params scope without type params");
@@ -985,7 +987,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let function_node = function_definition.node(self.module());
-        let function_name = &function_node.name;
+        let function_name = &function_node.name.name;
 
         let mut is_classmethod = is_implicit_classmethod(function_name);
         let inference = infer_definition_types(db, method_definition);

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -258,10 +258,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // For diagnostics, we want to highlight the unresolvable
         // module and not the entire `from ... import ...` statement.
         let module_ref = module
-            .as_ref()
+            .as_deref()
             .map(ast::AnyNodeRef::from)
             .unwrap_or_else(|| ast::AnyNodeRef::from(import_from));
-        let module = module.as_deref();
+        let module = module.as_ref().map(|module| module.id.as_str());
 
         tracing::trace!(
             "Resolving import statement from module `{}` into file `{}`",
@@ -554,7 +554,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let Some(final_part) = ModuleName::from_identifier_parts(
             db,
             self.file(),
-            import_from.module.as_deref(),
+            import_from.module.as_ref().map(|module| module.id.as_str()),
             import_from.level,
         )
         .ok()

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -56,7 +56,7 @@ fn check_pep695_function_legacy_typevars<'db>(
 ) {
     let db = context.db();
     let node = last_definition.node(db, context.file(), context.module());
-    let Some(type_params) = node.type_params.as_deref() else {
+    let Some(type_params) = node.name.type_params.as_deref() else {
         return;
     };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -108,10 +108,10 @@ pub(crate) fn check_overloaded_function<'db>(
     // Check that the overloaded function has at least two overloads
     if let [single_overload] = overloads {
         let function_node = single_overload.node(db, context.file(), context.module());
-        if let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name) {
+        if let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name.name) {
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Overloaded function `{}` requires at least two overloads",
-                &function_node.name
+                function_node.name.as_str()
             ));
             diagnostic.set_primary_message("Only one overload defined here");
             if let Some(decorator) =
@@ -154,15 +154,16 @@ pub(crate) fn check_overloaded_function<'db>(
 
         if implementation_required {
             let function_node = overloads[0].node(db, context.file(), context.module());
-            if let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name) {
+            if let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name.name)
+            {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Overloads for function `{}` must be followed by a \
                     non-`@overload`-decorated implementation function",
-                    &function_node.name
+                    function_node.name.as_str()
                 ));
                 diagnostic.info(format_args!(
                     "Attempting to call `{}` will raise `TypeError` at runtime",
-                    &function_node.name
+                    function_node.name.as_str()
                 ));
                 diagnostic.info("Overloaded functions without implementations are only permitted:");
                 diagnostic.info(" - in stub files");
@@ -179,11 +180,12 @@ pub(crate) fn check_overloaded_function<'db>(
 
     for inconsistency in binding_decorator_inconsistencies {
         let function_node = function.node(db, context.file(), context.module());
-        if let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name) {
+        if let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name.name) {
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Overloaded function `{}` does not use the `@{}` decorator \
                     consistently",
-                &function_node.name, inconsistency.decorator_name
+                function_node.name.as_str(),
+                inconsistency.decorator_name
             ));
             for function in inconsistency.missing {
                 diagnostic.annotate(
@@ -210,7 +212,8 @@ pub(crate) fn check_overloaded_function<'db>(
                     continue;
                 }
                 let function_node = overload.node(db, context.file(), context.module());
-                let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name)
+                let Some(builder) =
+                    context.report_lint(&INVALID_OVERLOAD, &function_node.name.name)
                 else {
                     continue;
                 };
@@ -241,7 +244,8 @@ pub(crate) fn check_overloaded_function<'db>(
                     continue;
                 }
                 let function_node = overload.node(db, context.file(), context.module());
-                let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name)
+                let Some(builder) =
+                    context.report_lint(&INVALID_OVERLOAD, &function_node.name.name)
                 else {
                     continue;
                 };
@@ -340,7 +344,7 @@ fn check_non_generic_overload_implementation_consistency<'db>(
                 ),
             };
 
-        let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name) else {
+        let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name.name) else {
             continue;
         };
         let mut diagnostic = builder.into_diagnostic(format_args!("{message}"));

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -933,7 +933,8 @@ pub(crate) fn check_static_class_definitions<'db>(
 
         if kw_only_sentinel_fields.len() > 1 {
             // TODO: The fields should be displayed in a subdiagnostic.
-            if let Some(builder) = context.report_lint(&DUPLICATE_KW_ONLY, &class_node.name) {
+            if let Some(builder) = context.report_lint(&DUPLICATE_KW_ONLY, class_node.name.as_ref())
+            {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Dataclass has more than one field annotated with `KW_ONLY`"
                 ));
@@ -1215,7 +1216,8 @@ fn check_final_class_abstract_methods<'db>(
         return;
     };
 
-    let Some(builder) = context.report_lint(&ABSTRACT_METHOD_IN_FINAL_CLASS, &class_node.name)
+    let Some(builder) =
+        context.report_lint(&ABSTRACT_METHOD_IN_FINAL_CLASS, class_node.name.as_ref())
     else {
         return;
     };


### PR DESCRIPTION
## Summary

Compact the large statement variants retained in parsed modules. Co-locate function names and optional type parameters in one boxed allocation, box class and `from`-import module identifiers, move the uncommon `try` payload out of line, and box `elif` tests so ordinary `else` clauses do not retain an inline expression. Source-order traversal and all Ruff/ty consumers are updated for the new representation.

The coordinated layout lowers the `Stmt` stride from 96 to 64 bytes (`StmtFunctionDef` 96 to 56, `StmtClassDef` 88 to 56, and `StmtTry` 64 to 24), accounting for approximately 410 kB (1.11%) of the Flake8 total-memory reduction. AST and parser tests, all parser fixtures, the focused manual-from-import lint fixture, and a workspace/all-targets compilation pass; snapshots are regenerated for this layout.

Atop #26727.