### PR TITLE
[ty] Avoid exponential inference for bare generic constructors

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -1318,6 +1318,22 @@ reveal_type(Class7(0, ""))  # revealed: Class7[str, int]
 reveal_type(Class7[str, int](0, ""))  # revealed: Class7[str, int]
 ```
 
+An explicit receiver specialization still determines the inferred constructor return type when it
+conflicts with the surrounding type context.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class ExplicitSelf(Generic[T]):
+    def __init__(self: "ExplicitSelf[int]") -> None: ...
+
+def incompatible_context() -> ExplicitSelf[str]:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `ExplicitSelf[str]`, found `ExplicitSelf[int]`"
+    return ExplicitSelf()
+```
+
 ## Constructor calls through `type[T]` with a bound TypeVar
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -498,6 +498,33 @@ class A6(Any): ...
 reveal_type(W(C[A1, A2, A3, A4, A5, A6]()))  # revealed: W[A1, A2, A3, A4, A5, A6]
 ```
 
+### Many invariant parameters with an unparameterized constructor context
+
+Applying an unparameterized return context to the bound `self` argument caused constructor inference
+time to grow exponentially in [ty#3972](https://github.com/astral-sh/ty/issues/3972).
+
+```py
+from typing import Generic, TypeVar
+
+T0 = TypeVar("T0")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+T6 = TypeVar("T6")
+T7 = TypeVar("T7")
+T8 = TypeVar("T8")
+T9 = TypeVar("T9")
+T10 = TypeVar("T10")
+
+class C(Generic[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]):
+    def __init__(self) -> None: ...
+
+def f() -> C:  # error: [missing-type-argument]
+    return C()
+```
+
 ### Identical `__new__` and `__init__` signatures
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1216,6 +1216,41 @@ reveal_type(LegacyProperty[str].value.fget)  # revealed: (self, /) -> str
 reveal_type(LegacyProperty("height", 3.4).value)  # revealed: int | float
 ```
 
+### Many optional generic fields with an unparameterized constructor context
+
+Generic named tuple constructors use a synthetic `type[Self]` receiver. Applying an unparameterized
+return context must not derive every combination of its type variables.
+
+```py
+from typing import Generic, NamedTuple, TypeVar
+
+T0 = TypeVar("T0")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+T6 = TypeVar("T6")
+T7 = TypeVar("T7")
+T8 = TypeVar("T8")
+T9 = TypeVar("T9")
+
+class C(NamedTuple, Generic[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]):
+    x0: T0 | None = None
+    x1: T1 | None = None
+    x2: T2 | None = None
+    x3: T3 | None = None
+    x4: T4 | None = None
+    x5: T5 | None = None
+    x6: T6 | None = None
+    x7: T7 | None = None
+    x8: T8 | None = None
+    x9: T9 | None = None
+
+def f() -> C:  # error: [missing-type-argument]
+    return C()
+```
+
 ### Functional syntax with generics
 
 Generic namedtuples can also be defined using the functional syntax with type variables in the field

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5137,7 +5137,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         specialization_errors: &mut Vec<BindingError<'db>>,
     ) -> bool {
         let parameters = self.signature.parameters();
-        for (argument_index, adjusted_argument_index, _, argument_types) in
+        let mut preferred_specialization = None;
+
+        for (argument_index, adjusted_argument_index, argument, argument_types) in
             self.enumerate_argument_types()
         {
             for matched_parameter in self.argument_matches[argument_index].iter() {
@@ -5148,10 +5150,38 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
                 let declared_type = parameters[parameter_index].annotated_type();
                 let argument_type = argument_types.get_for_declared_type(declared_type);
-                let specialization_result = builder.infer(
-                    declared_type,
-                    matched_parameter.argument_type.unwrap_or(argument_type),
-                );
+                let argument_type = matched_parameter.argument_type.unwrap_or(argument_type);
+
+                // Applying the contextual specialization before inferring an implicit `Self`
+                // receiver avoids deriving every combination of the class type variables.
+                let argument_type = if matches!(argument, Argument::Synthetic)
+                    && !preferred_type_mappings.is_empty()
+                    && let Some(generic_context) = self.signature.generic_context
+                    && match declared_type {
+                        Type::TypeVar(typevar) => typevar.typevar(self.db).is_self(self.db),
+                        Type::SubclassOf(subclass_of) => subclass_of
+                            .into_type_var()
+                            .is_some_and(|typevar| typevar.typevar(self.db).is_self(self.db)),
+                        _ => false,
+                    } {
+                    let specialization = *preferred_specialization.get_or_insert_with(|| {
+                        generic_context.specialize_recursive(
+                            self.db,
+                            generic_context.variables(self.db).map(|typevar| {
+                                Some(
+                                    preferred_type_mappings
+                                        .get(&typevar.identity(self.db))
+                                        .copied()
+                                        .unwrap_or(Type::TypeVar(typevar)),
+                                )
+                            }),
+                        )
+                    });
+                    argument_type.apply_specialization(self.db, specialization)
+                } else {
+                    argument_type
+                };
+                let specialization_result = builder.infer(declared_type, argument_type);
 
                 if let Err(error) = specialization_result {
                     specialization_errors.push(BindingError::SpecializationError {


### PR DESCRIPTION
## Summary

Applying an unparameterized return context to a legacy generic constructor could make inference grow exponentially with the number of invariant type variables:

```python
from typing import Generic, TypeVar

T0 = TypeVar("T0")
T1 = TypeVar("T1")
T2 = TypeVar("T2")
T3 = TypeVar("T3")

class C(Generic[T0, T1, T2, T3]):
    def __init__(self) -> None: ...

def f() -> C:
    return C()
```

The return context produces `Ti = Unknown` constraints, while the synthetic receiver adds a `C[T0, T1, ...] <= Self` constraint. Path-assignment saturation then derives a receiver for every combination of substituted type variables.

We now apply the contextual specialization to implicit `Self` and `type[Self]` receivers before argument inference, eliminating those redundant intermediate constraints for regular and generic `NamedTuple` constructors. Explicitly specialized receivers remain on the normal argument-inference path, so a constructor declared with `self: C[int]` still infers `C[int]` and reports only the incompatible return type when the surrounding context expects `C[str]`.

This is intentionally a narrow fix for unparameterized contexts with an implicit receiver... It doesn't eliminate _every_ exponential constructor-inference path: fully or partially parameterized contexts, compatible constructor arguments, and explicitly specialized, remapped, or inherited receivers can still be slow (including explicit receivers in a bare context).

Closes https://github.com/astral-sh/ty/issues/3972.