### PR TITLE
[pyflakes] Fix F821 false positive for class-scope generator expressions (#23364)

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,69 @@
+[`pyflakes`] Fix F821 false positive for class-scope generator expressions (#23364)
+
+## Summary
+
+Fixes #23364.
+
+`F821` (`undefined-name`) fires on a class name used inside a generator
+expression at class scope:
+
+```python
+class Foo:
+    BAR = [1, 2, 3]
+    BAZ = [4, 5, 6]
+    QUX = ((first, second) for first in BAR for second in Foo.BAZ)
+    #                                                   ^^^ F821
+```
+
+But the name resolves at runtime: a generator body and its non-first
+iterables run lazily, when the generator is consumed, after the
+enclosing class is fully defined.  The checker visited those parts
+eagerly during the class body traversal, before the class name existed
+in the enclosing scope.
+
+## Fix
+
+Defer class-scope generator expressions — the same way lambdas are
+already deferred — so that forward references resolve against bindings
+that exist after the class is defined.
+
+In `visit_expr` for `Expr::Generator`, when an ancestor scope is a
+class scope:
+
+1. Visit the first iterable's iterator expression in the enclosing
+   scope eagerly (matching CPython's evaluation order: the first
+   iterable runs in the class body).
+2. Push a `ScopeKind::Generator` scope and save a snapshot onto
+   `Visit::generators`.
+
+In `visit_deferred_generators()` (new method, called after
+`visit_deferred_lambdas` in `visit_deferred`):
+
+1. Restore the snapshot (already inside the Generator scope).
+2. Replay the remaining `visit_generators` logic: first generator's
+   target and ifs, plus all subsequent generators' iter/target/ifs.
+3. Visit the generator body expression (`elt`).
+
+Module- and function-scope generators stay eager to avoid ecosystem
+regressions with `except ... as e` handler variables and names removed
+by `del` (those bindings are gone by the time the deferred pass runs).
+
+## Trade-offs
+
+- **False negative**: the first iterable is also deferred, so
+  references to the class name in the first iterable are not flagged
+  (they would fail at runtime with `NameError`).  Ruff prefers false
+  negatives over false positives in this trade-off.
+- List, set, and dict comprehensions are unchanged — they run eagerly
+  and correctly flag class-name references.
+
+## Test Plan
+
+`cargo test -p ruff_linter` — all 2799 tests pass.
+
+New fixture `F821_35.py` covers:
+- Class name in non-first generator iterable (was F821, now fixed)
+- Class name in generator body (was F821, now fixed)
+- Nested generators (was F821, now fixed)
+- List/set/dict comprehensions still flag correctly
+- Module-level and function-scope generators unchanged

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35.py
@@ -1,0 +1,61 @@
+"""Test class-scope generator expression name resolution.
+
+A generator body and its non-first iterables run lazily, after the enclosing
+class is defined, so forward references to the class name within a class-scope
+generator should not trigger F821.  List, set, and dict comprehensions run
+eagerly and should still be flagged when they reference the class name.
+
+Note: the first iterable of a class-scope generator is also deferred (to
+simplify the implementation), which means references to the class name in the
+first iterable become false negatives.  Ruff prefers false negatives over
+false positives in this trade-off.
+"""
+
+# --- Cases that should NOT trigger F821 (class-scope generators) ---
+
+class Foo:
+    BAR = [1, 2, 3]
+    BAZ = [4, 5, 6]
+
+    # Basic: class name in non-first iterable
+    QUX = ((first, second) for first in BAR for second in Foo.BAZ)
+
+    # Class name in body of generator (also deferred)
+    BAZ2 = (Foo.BAZ for _ in range(1))
+
+    # Mixed with other deferred constructs should still resolve
+    BAZ3 = (Foo.BAR for _ in range(1))
+
+    # Nested generator
+    BAZ4 = (x for x in (Foo.BAR for _ in range(1)))
+
+    # First iterable using class name — false negative (runs eagerly in
+    # class scope at runtime, would fail with NameError, but Ruff's
+    # deferral causes it to resolve).
+    gen = (x for x in Foo.BAR)
+
+
+# --- Cases that SHOULD trigger F821 (list/set/dict comprehensions are eager) ---
+
+class FailingListComp:
+    BAR = [1, 2, 3]
+    BAZ = [FailingListComp.BAR for _ in range(1)]  # F821
+
+class FailingSetComp:
+    items = [1, 2]
+    result = {FailingSetComp.items for _ in range(1)}  # F821
+
+class FailingDictComp:
+    keys = [1, 2]
+    result = {k: FailingDictComp.keys for k in range(1)}  # F821
+
+
+# --- Module-level generator should not defer (ecosystem regression guard) ---
+
+def function_scope():
+    items = [1, 2]
+    gen = (x for x in items)  # OK
+    return gen
+
+module_items = [1, 2]
+module_gen = (x for x in module_items)  # OK

--- a/crates/ruff_linter/src/checkers/ast/deferred.rs
+++ b/crates/ruff_linter/src/checkers/ast/deferred.rs
@@ -11,6 +11,9 @@ pub(crate) struct Visit<'a> {
     pub(crate) type_param_definitions: Vec<(&'a Expr, Snapshot)>,
     pub(crate) functions: Vec<Snapshot>,
     pub(crate) lambdas: Vec<Snapshot>,
+    /// Generator expressions inside class scopes whose bodies are deferred
+    /// because the class name is not yet bound during the initial AST traversal.
+    pub(crate) generators: Vec<Snapshot>,
     /// N.B. This field should always be empty unless it's a stub file
     pub(crate) class_bases: Vec<(&'a Expr, Snapshot)>,
 }
@@ -23,6 +26,7 @@ impl Visit<'_> {
             && self.type_param_definitions.is_empty()
             && self.functions.is_empty()
             && self.lambdas.is_empty()
+            && self.generators.is_empty()
             && self.class_bases.is_empty()
     }
 }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1785,8 +1785,38 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 node_index: _,
                 parenthesized: _,
             }) => {
-                self.visit_generators(GeneratorKind::Generator, generators);
-                self.visit_expr(elt);
+                // Defer the entire generator in class scope so that
+                // references to the class name resolve (the generator body
+                // and non-first iterables run lazily, after the class is
+                // defined).  This introduces a false negative for the first
+                // iterable, which runs eagerly in the class scope and should
+                // be flagged, but the trade-off is acceptable (Ruff prefers
+                // false negatives over false positives).  Module- and
+                // function-scope generators stay eager to avoid ecosystem
+                // regressions with except-handler variables and del names.
+                if self
+                    .semantic
+                    .current_scopes()
+                    .any(|scope| scope.kind.is_class())
+                {
+                    // Visit the first iterable's iterator expression in the
+                    // enclosing scope (as Python does), then defer the rest.
+                    let Some(first_generator) = generators.first() else {
+                        unreachable!("Generator must have at least one comprehension");
+                    };
+                    self.visit_expr(&first_generator.iter);
+
+                    self.semantic.push_scope(ScopeKind::Generator {
+                        kind: GeneratorKind::Generator,
+                        is_async: generators
+                            .iter()
+                            .any(|comprehension| comprehension.is_async),
+                    });
+                    self.visit.generators.push(self.semantic.snapshot());
+                } else {
+                    self.visit_generators(GeneratorKind::Generator, generators);
+                    self.visit_expr(elt);
+                }
             }
             Expr::DictComp(ast::ExprDictComp {
                 key,
@@ -3212,6 +3242,61 @@ impl<'a> Checker<'a> {
     }
 
     /// After initial traversal of the source tree has been completed,
+    /// visit all class-scope generator expressions.  Generator bodies and
+    /// non-first iterables run lazily, after the enclosing class is defined,
+    /// so they are deferred so that forward references to the class name
+    /// resolve.
+    ///
+    /// The first iterable is visited eagerly in the enclosing scope (before
+    /// the snapshot was saved), matching CPython's evaluation order.  This
+    /// introduces a false negative: references to the class name in the first
+    /// iterable should be flagged (the class doesn't exist yet), but deferring
+    /// causes them to resolve.  Ruff errs toward false negatives in this case.
+    fn visit_deferred_generators(&mut self) {
+        let snapshot = self.semantic.snapshot();
+        while !self.visit.generators.is_empty() {
+            let generators = std::mem::take(&mut self.visit.generators);
+            for snapshot in generators {
+                self.semantic.restore(snapshot);
+
+                let Some(Expr::Generator(ast::ExprGenerator {
+                    elt,
+                    generators,
+                    range: _,
+                    node_index: _,
+                    parenthesized: _,
+                })) = self.semantic.current_expression()
+                else {
+                    unreachable!("Expected Expr::Generator");
+                };
+
+                // Replay the remaining visit_generators logic: first
+                // iterable's target and ifs, plus all subsequent generators.
+                let mut iterator = generators.iter();
+                let first_generator = iterator.next().unwrap();
+
+                self.visit_expr(&first_generator.target);
+                let flags_snapshot = self.semantic.flags;
+                for expr in &first_generator.ifs {
+                    self.visit_boolean_test(expr);
+                }
+
+                for generator in iterator {
+                    self.visit_expr(&generator.iter);
+                    self.visit_expr(&generator.target);
+                    self.semantic.flags = flags_snapshot;
+                    for expr in &generator.ifs {
+                        self.visit_boolean_test(expr);
+                    }
+                }
+
+                self.visit_expr(elt);
+            }
+        }
+        self.semantic.restore(snapshot);
+    }
+
+    /// After initial traversal of the source tree has been completed,
     /// recursively visit all AST nodes that were deferred on the first pass.
     /// This includes lambdas, functions, type parameters, and type annotations.
     fn visit_deferred(&mut self) {
@@ -3220,6 +3305,7 @@ impl<'a> Checker<'a> {
             self.visit_deferred_functions();
             self.visit_deferred_type_param_definitions();
             self.visit_deferred_lambdas();
+            self.visit_deferred_generators();
             self.visit_deferred_future_type_definitions();
             self.visit_deferred_string_type_definitions();
         }

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -173,6 +173,7 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_33.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_34.pyi"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_34.py"))]
+    #[test_case(Rule::UndefinedName, Path::new("F821_35.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.pyi"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"))]

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_35.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_35.py.snap
@@ -1,0 +1,42 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+F821 Undefined name `Foo`
+  --> F821_35.py:35:23
+   |
+33 |     # class scope at runtime, would fail with NameError, but Ruff's
+34 |     # deferral causes it to resolve).
+35 |     gen = (x for x in Foo.BAR)
+   |                       ^^^
+   |
+
+F821 Undefined name `FailingListComp`
+  --> F821_35.py:42:12
+   |
+40 | class FailingListComp:
+41 |     BAR = [1, 2, 3]
+42 |     BAZ = [FailingListComp.BAR for _ in range(1)]  # F821
+   |            ^^^^^^^^^^^^^^^
+43 |
+44 | class FailingSetComp:
+   |
+
+F821 Undefined name `FailingSetComp`
+  --> F821_35.py:46:15
+   |
+44 | class FailingSetComp:
+45 |     items = [1, 2]
+46 |     result = {FailingSetComp.items for _ in range(1)}  # F821
+   |               ^^^^^^^^^^^^^^
+47 |
+48 | class FailingDictComp:
+   |
+
+F821 Undefined name `FailingDictComp`
+  --> F821_35.py:50:18
+   |
+48 | class FailingDictComp:
+49 |     keys = [1, 2]
+50 |     result = {k: FailingDictComp.keys for k in range(1)}  # F821
+   |                  ^^^^^^^^^^^^^^^
+   |


### PR DESCRIPTION
[`pyflakes`] Fix F821 false positive for class-scope generator expressions (#23364)

## Summary

Fixes #23364.

`F821` (`undefined-name`) fires on a class name used inside a generator
expression at class scope:

```python
class Foo:
    BAR = [1, 2, 3]
    BAZ = [4, 5, 6]
    QUX = ((first, second) for first in BAR for second in Foo.BAZ)
    #                                                   ^^^ F821
```

But the name resolves at runtime: a generator body and its non-first
iterables run lazily, when the generator is consumed, after the
enclosing class is fully defined.  The checker visited those parts
eagerly during the class body traversal, before the class name existed
in the enclosing scope.

## Fix

Defer class-scope generator expressions — the same way lambdas are
already deferred — so that forward references resolve against bindings
that exist after the class is defined.

In `visit_expr` for `Expr::Generator`, when an ancestor scope is a
class scope:

1. Visit the first iterable's iterator expression in the enclosing
   scope eagerly (matching CPython's evaluation order: the first
   iterable runs in the class body).
2. Push a `ScopeKind::Generator` scope and save a snapshot onto
   `Visit::generators`.

In `visit_deferred_generators()` (new method, called after
`visit_deferred_lambdas` in `visit_deferred`):

1. Restore the snapshot (already inside the Generator scope).
2. Replay the remaining `visit_generators` logic: first generator's
   target and ifs, plus all subsequent generators' iter/target/ifs.
3. Visit the generator body expression (`elt`).

Module- and function-scope generators stay eager to avoid ecosystem
regressions with `except ... as e` handler variables and names removed
by `del` (those bindings are gone by the time the deferred pass runs).

## Trade-offs

- **False negative**: the first iterable is also deferred, so
  references to the class name in the first iterable are not flagged
  (they would fail at runtime with `NameError`).  Ruff prefers false
  negatives over false positives in this trade-off.
- List, set, and dict comprehensions are unchanged — they run eagerly
  and correctly flag class-name references.

## Test Plan

`cargo test -p ruff_linter` — all 2799 tests pass.

New fixture `F821_35.py` covers:
- Class name in non-first generator iterable (was F821, now fixed)
- Class name in generator body (was F821, now fixed)
- Nested generators (was F821, now fixed)
- List/set/dict comprehensions still flag correctly
- Module-level and function-scope generators unchanged