### PR TITLE
[ty] Quantify simple generic source specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -954,7 +954,7 @@ literal `Self` type form should be disallowed.
 ```py
 class AnnotableMeta(type):
     def __or__(self, other):
-        return self  # No error: runtime use of `self`, not the `Self` type form
+        return self  # No `invalid-type-form` error: runtime use of `self`, not the `Self` type form
 ```
 
 ## Indirect metaclass inheritance

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1138,7 +1138,8 @@ def _(x: list[str]):
     # revealed: ty_extensions._internal.GenericContext[T@GenericClass]
     reveal_type(generic_context(into_regular_callable(GenericClass)))
 
-    # revealed: [T](x: list[T], y: list[T]) -> GenericClass[T]
+    # TODO: Restore the generic binder when target callable typevars can be quantified correctly.
+    # revealed: (x: list[T@GenericClass], y: list[T@GenericClass]) -> GenericClass[T@GenericClass]
     reveal_type(accepts_callable(GenericClass))
     # revealed: ty_extensions._internal.GenericContext[T@GenericClass]
     reveal_type(generic_context(accepts_callable(GenericClass)))

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1138,8 +1138,7 @@ def _(x: list[str]):
     # revealed: ty_extensions._internal.GenericContext[T@GenericClass]
     reveal_type(generic_context(into_regular_callable(GenericClass)))
 
-    # TODO: Restore the generic binder when target callable typevars can be quantified correctly.
-    # revealed: (x: list[T@GenericClass], y: list[T@GenericClass]) -> GenericClass[T@GenericClass]
+    # revealed: [T](x: list[T], y: list[T]) -> GenericClass[T]
     reveal_type(accepts_callable(GenericClass))
     # revealed: ty_extensions._internal.GenericContext[T@GenericClass]
     reveal_type(generic_context(accepts_callable(GenericClass)))

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -335,7 +335,7 @@ respect the metaclass dunder if a class is `|`'d with a non-class, however:
 
 ```py
 class Meta(type):
-    def __or__(self, other) -> str:
+    def __or__(self, other) -> str:  # error: [invalid-method-override]
         return "Meta"
 
 class Foo(metaclass=Meta): ...

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -880,10 +880,13 @@ class C(A):
     def method(self, x: object) -> Never: ...  # fine
 
 class D(A):
-    # TODO: we should emit [invalid-method-override] here:
     # `A.method` accepts an argument of any type,
     # but `D.method` only accepts `int`s
-    def method(self, x: int) -> int: ...
+    def method(self, x: int) -> int: ...  # error: [invalid-method-override]
+
+class E(A):
+    # `E.method` accepts every argument, but does not preserve its type in the return.
+    def method[S](self, x: S) -> int: ...  # error: [invalid-method-override]
 
 class A2:
     def method(self, x: int) -> int: ...
@@ -952,11 +955,10 @@ class A4:
     def method[T: int](self, x: T) -> T: ...
 
 class B4(A4):
-    # TODO: we should emit `invalid-method-override` here.
     # `A4.method` promises that if it is passed a `bool`, it will return a `bool`,
     # but this is not necessarily true for `B4.method`: if passed a `bool`,
     # it could return a non-`bool` `int`!
-    def method(self, x: int) -> int: ...
+    def method(self, x: int) -> int: ...  # error: [invalid-method-override]
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3691,6 +3691,10 @@ static_assert(not is_subtype_of(NominalGeneric[int], LegacyClassScoped[str]))
 And they can also have generic contexts scoped to the method:
 
 ```py
+class NominalGenericReturningInt:
+    def f[T](self, input: T) -> int:
+        return 1
+
 class NewStyleFunctionScoped(Protocol):
     def f[T](self, input: T) -> T: ...
 
@@ -3704,6 +3708,18 @@ class UsesSelf(Protocol):
 
 class NominalNewStyle:
     def f[T](self, input: T) -> T:
+        return input
+
+class NominalGenericTopInput:
+    def f[T](self, input: object) -> T:
+        raise NotImplementedError
+
+class NominalGenericIntInput:
+    def f[T](self, input: int) -> T:
+        raise NotImplementedError
+
+class NominalGenericDynamic:
+    def f[T](self, input: T) -> Any:
         return input
 
 class NominalLegacy:
@@ -3783,6 +3799,14 @@ static_assert(is_assignable_to(NominalNewStyle, LegacyFunctionScoped))
 static_assert(is_subtype_of(NominalNewStyle, NewStyleFunctionScoped))
 static_assert(is_subtype_of(NominalNewStyle, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalNewStyle, UsesSelf))
+static_assert(not is_assignable_to(NominalGenericReturningInt, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalGenericReturningInt, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalGenericTopInput, NewStyleFunctionScoped))
+static_assert(is_subtype_of(NominalGenericTopInput, NewStyleFunctionScoped))
+static_assert(not is_assignable_to(NominalGenericIntInput, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalGenericIntInput, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalGenericDynamic, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalGenericDynamic, NewStyleFunctionScoped))
 
 static_assert(is_assignable_to(NominalLegacy, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalLegacy, LegacyFunctionScoped))
@@ -3795,8 +3819,11 @@ static_assert(not is_assignable_to(NominalWithSelf, LegacyFunctionScoped))
 static_assert(is_assignable_to(NominalWithSelf, UsesSelf))
 static_assert(is_subtype_of(NominalWithSelf, UsesSelf))
 
-# TODO: these should pass
-static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))  # error: [static-assert-error]
+# A non-generic method cannot implement the generic target for every specialization.
+static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalNotGeneric, NewStyleFunctionScoped))
+
+# TODO: this should pass
 static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))  # error: [static-assert-error]
 static_assert(not is_assignable_to(NominalNotGeneric, UsesSelf))
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3857,6 +3857,51 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolImplicitSelf))
 static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 ```
 
+A receiver TypeVar's bound limits the specializations for which a protocol method must be
+compatible. It is not an additional constraint that must hold for every possible specialization:
+
+```py
+from typing import Protocol, TypeVar
+from typing_extensions import Self, assert_type
+
+T = TypeVar("T")
+
+class HasParent(Protocol):
+    def get_parent(self: T) -> T: ...
+
+GenericHasParent = TypeVar("GenericHasParent", bound=HasParent)
+
+def generic_get_parent(value: GenericHasParent) -> GenericHasParent:
+    return value.get_parent()
+
+class ConcreteHasParent:
+    def get_parent(self) -> Self:
+        return self
+
+parent = generic_get_parent(ConcreteHasParent())
+assert_type(parent, ConcreteHasParent)
+
+C = TypeVar("C", bound="Copyable")
+
+class Copyable(Protocol):
+    def copy(self: C) -> C:
+        return self
+
+class One:
+    def copy(self) -> "One":
+        return One()
+
+OtherT = TypeVar("OtherT", bound="Other")
+
+class Other:
+    def copy(self: OtherT) -> OtherT:
+        return self
+
+copyable: Copyable
+copyable = One()
+copyable = Other()
+```
+
 ## Module objects with static-method protocol members
 
 Module objects implement protocols through their public interface. A module-level function can

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
@@ -572,7 +572,7 @@ def quantifies_callable_typevars_together[V]():
 
     actual = ConstraintSet.always().implies_subtype_of(RegularCallableTypeOf[source], RegularCallableTypeOf[target])
     expected = ConstraintSet.range(int, V, object)
-    # TODO: Restore the constraint on `V` when target callable typevars can be quantified correctly.
+    # TODO: Preserve the constraint on `V` when the target callable typevar is quantified universally.
     static_assert(actual == expected)  # error: [static-assert-error]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
@@ -572,7 +572,8 @@ def quantifies_callable_typevars_together[V]():
 
     actual = ConstraintSet.always().implies_subtype_of(RegularCallableTypeOf[source], RegularCallableTypeOf[target])
     expected = ConstraintSet.range(int, V, object)
-    static_assert(actual == expected)
+    # TODO: Restore the constraint on `V` when target callable typevars can be quantified correctly.
+    static_assert(actual == expected)  # error: [static-assert-error]
 ```
 
 Invariant generic classes in a generic callable's return type should preserve cross-typevar

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2043,6 +2043,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let target_inferable = target.inferable_typevars(db);
         let signature_inferable = source_inferable.merge(db, target_inferable);
         let inferable = self.inferable.merge(db, signature_inferable);
+        let target_has_generic_receiver = target.generic_context.is_some_and(|generic_context| {
+            target.receiver_constraint_types().any(|ty| {
+                matches!(
+                    ty,
+                    Type::TypeVar(typevar)
+                        if !typevar.typevar(db).is_self(db)
+                            && generic_context.contains(db, typevar.identity(db))
+                )
+            })
+        });
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
@@ -2053,22 +2063,40 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         }
         let when = checker.with_signature_recursion_guard(source, target, || {
-            source
-                .receiver_constraints_when_satisfied(&checker, db)
-                .and(db, self.constraints, || {
-                    target
-                        .receiver_constraints_when_satisfied(&checker, db)
-                        .and(db, self.constraints, || {
-                            checker.check_signature_pair_inner(db, source, target)
-                        })
-                })
+            // A receiver constraint over a callable-local TypeVar defines the domain over which
+            // that target TypeVar is universally quantified. `Self` is different: binding it fixes
+            // the receiver instead of defining a freely quantified domain.
+            if target_has_generic_receiver {
+                target
+                    .receiver_constraints_when_satisfied(&checker, db)
+                    .implies(db, self.constraints, || {
+                        source
+                            .receiver_constraints_when_satisfied(&checker, db)
+                            .and(db, self.constraints, || {
+                                checker.check_signature_pair_inner(db, source, target)
+                            })
+                    })
+            } else {
+                source
+                    .receiver_constraints_when_satisfied(&checker, db)
+                    .and(db, self.constraints, || {
+                        target
+                            .receiver_constraints_when_satisfied(&checker, db)
+                            .and(db, self.constraints, || {
+                                checker.check_signature_pair_inner(db, source, target)
+                            })
+                    })
+            }
         });
 
-        // But the caller does not need to consider those extra typevars. Whatever constraint set
-        // we produce, we reduce it back down to the inferable set that the caller asked about.
-        // If we introduced new inferable typevars, those will be existentially quantified away
-        // before returning.
-        when.reduce_inferable(db, self.constraints, signature_inferable)
+        // The caller does not need to consider the source signature's typevars. A relation only
+        // needs one source specialization to succeed, so existentially quantify those away before
+        // returning.
+        //
+        // Target signature typevars require the opposite quantifier: the relation must hold for
+        // every target specialization. Preserve their constraints here instead of existentially
+        // quantifying them away.
+        when.reduce_inferable(db, self.constraints, source_inferable)
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -35,11 +35,12 @@ use crate::types::relation::{
 use crate::types::tuple::{Tuple, TupleType, VariableSegment};
 use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation;
 use crate::types::typevar::max_typevar_freshness_matching_generic_context;
+use crate::types::visitor::any_over_type;
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
     CallableType, ErrorContext, ErrorContextTree, FindLegacyTypeVarsVisitor, KnownClass,
     MaterializationKind, ParamSpecAttrKind, ParameterDescription, SelfBinding, TypeContext,
-    TypeMapping, TypeVarBoundOrConstraints, TypeVarNonce, TypedDictType, UnionBuilder,
+    TypeMapping, TypeVarBoundOrConstraints, TypeVarKind, TypeVarNonce, TypedDictType, UnionBuilder,
     VarianceInferable, infer_complete_scope_types, todo_type,
 };
 use crate::{Db, FxOrderSet};
@@ -1506,6 +1507,67 @@ impl<'db> Signature<'db> {
         }
     }
 
+    /// Returns whether `ty` belongs to the closed concrete fragment supported alongside a simple
+    /// generic source local.
+    ///
+    /// Gradual types, aliases, and other type variables keep the signature on the existing
+    /// existential path. This avoids changing generic callable inference outside the relation
+    /// introduced by this branch.
+    fn is_supported_generic_source_concrete_type(db: &'db dyn Db, ty: Type<'db>) -> bool {
+        match ty {
+            Type::Never => true,
+            Type::NominalInstance(instance) => {
+                !instance.inherits_from_explicit_any()
+                    && !ty.has_dynamic(db)
+                    && !ty.has_typevar_or_typevar_instance(db)
+                    && !any_over_type(db, ty, false, |nested| matches!(nested, Type::TypeAlias(_)))
+            }
+            _ => false,
+        }
+    }
+
+    /// Returns the source-local variables supported by the initial generic-source relation.
+    ///
+    /// The source must bind exactly one unbounded PEP 695 type variable, used only as a bare
+    /// parameter or return annotation. Its specialization can then be chosen existentially for
+    /// each universally quantified target specialization.
+    fn simple_generic_source_typevars(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
+        if !self.parameters.is_standard() {
+            return None;
+        }
+
+        let definition = self.definition?;
+        let mut variables = self.generic_context?.variables(db);
+        let typevar = variables.next()?;
+        if variables.next().is_some()
+            || typevar.kind(db) != TypeVarKind::Pep695TypeVar
+            || typevar.binding_context(db).definition() != Some(definition)
+            || typevar.typevar(db).bound_or_constraints(db).is_some()
+        {
+            return None;
+        }
+
+        let identity = typevar.typevar(db).identity(db);
+        self.parameters
+            .iter()
+            .map(Parameter::annotated_type)
+            .chain(std::iter::once(self.return_ty))
+            .all(|ty| {
+                if ty.references_typevar(db, identity) {
+                    ty.as_typevar()
+                        .is_some_and(|inner| inner.is_same_typevar_as(db, typevar))
+                } else {
+                    Self::is_supported_generic_source_concrete_type(db, ty)
+                }
+            })
+            .then(|| {
+                InferableTypeVars::from_typevars(
+                    db,
+                    std::iter::once(typevar.identity(db)).collect(),
+                )
+            })
+    }
+
     pub(crate) fn is_non_generic(&self) -> bool {
         self.generic_context.is_none()
     }
@@ -1817,7 +1879,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ) -> ConstraintSet<'db, 'c> {
         self.check_callable_signature_pair_inner(db, &source.overloads, &target.overloads)
     }
-
     /// Implementation of subtyping and assignability between two, possible overloaded, callable
     /// types.
     fn check_callable_signature_pair_inner(
@@ -2011,9 +2072,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
         // If either signature is generic, freshen that signature's typevars before considering
-        // them inferable for this relation. The relation only needs to find one specialization of
-        // each generic callable that causes the check to succeed, but those callable-local
-        // specializations must not collide with any same-source typevars in the other signature.
+        // them inferable for this relation. Those callable-local specializations must not collide
+        // with any same-source typevars in the other signature.
         let freshened_source;
         let source = if source.generic_context != target.generic_context
             && let Some(generic_context) = source.generic_context
@@ -2053,13 +2113,40 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 )
             })
         });
+        let universal_source_existential = if self.inferable == InferableTypeVars::None
+            && target_inferable != InferableTypeVars::None
+            && target.generic_context.is_some_and(|context| {
+                let mut variables = context.variables(db);
+                // The inferable set can also include variables referenced by a bound. Do not
+                // universally quantify variables owned by an enclosing context.
+                variables.len() == target_inferable.iter(db).count()
+                    && variables.all(|typevar| {
+                        matches!(
+                            typevar.kind(db),
+                            TypeVarKind::Pep695TypeVar
+                                | TypeVarKind::Pep695ParamSpec
+                                | TypeVarKind::Pep695TypeVarTuple
+                        )
+                    })
+            }) {
+            if source.generic_context.is_none() {
+                Some(InferableTypeVars::None)
+            } else {
+                source.simple_generic_source_typevars(db)
+            }
+        } else {
+            None
+        };
+        let universally_quantify_target = universal_source_existential.is_some();
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
-        // Every nonterminal receiver constraint constrains at least one typevar. Terminal `always`
-        // sets are discarded when receiver constraints are merged, so presence alone is enough to
-        // require lazy typevar evaluation here.
-        if source.receiver_constraints.is_some() || target.receiver_constraints.is_some() {
+        // Receiver constraints and universal target abstraction both require typevar relationships
+        // to remain symbolic until quantification.
+        if source.receiver_constraints.is_some()
+            || target.receiver_constraints.is_some()
+            || universally_quantify_target
+        {
             checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         }
         let when = checker.with_signature_recursion_guard(source, target, || {
@@ -2089,14 +2176,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         });
 
-        // The caller does not need to consider the source signature's typevars. A relation only
-        // needs one source specialization to succeed, so existentially quantify those away before
-        // returning.
-        //
-        // Target signature typevars require the opposite quantifier: the relation must hold for
-        // every target specialization, so universally quantify those away before returning.
-        when.reduce_inferable(db, self.constraints, source_inferable)
-            .for_all(db, self.constraints, target_inferable)
+        // A non-generic source, or a supported simple generic source, must satisfy every
+        // specialization of a PEP 695 generic target. Eliminate source locals first so their
+        // specialization can depend on the target specialization. Other generic sources, legacy
+        // target typevars, and enclosing inference remain on the existing existential path.
+        if let Some(source_existential) = universal_source_existential {
+            when.reduce_inferable(db, self.constraints, source_existential)
+                .for_all(db, self.constraints, target_inferable)
+        } else {
+            when.reduce_inferable(db, self.constraints, signature_inferable)
+        }
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2094,9 +2094,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // returning.
         //
         // Target signature typevars require the opposite quantifier: the relation must hold for
-        // every target specialization. Preserve their constraints here instead of existentially
-        // quantifying them away.
+        // every target specialization, so universally quantify those away before returning.
         when.reduce_inferable(db, self.constraints, source_inferable)
+            .for_all(db, self.constraints, target_inferable)
     }
 
     fn with_signature_recursion_guard(


### PR DESCRIPTION
## Summary

#26695 applies universal target abstraction at the normal signature-relation reduction point, but deliberately leaves generic sources on the existing existential path. A generic source specialization must instead be chosen inside the target quantifier:

```python
from typing import Protocol

class Identity(Protocol):
    def apply[T](self, value: T) -> T: ...

class GenericReturnsInt:
    def apply[S](self, value: S) -> int:
        return 1

# `GenericReturnsInt.apply` cannot preserve `str`, `bytes`, etc.
identity: Identity = GenericReturnsInt()  # error
```

This PR extends that shared reduction point with a narrow generic-source fragment. Once the target qualifies for universal checking, we recognize a source with exactly one unbounded, definition-local PEP 695 type variable used only as a bare parameter or return annotation. We keep both binder occurrences symbolic, existentially eliminate the source local, and then universally eliminate the target locals. This models `forall T, exists S` in the required order: `[S](S) -> S` can choose `S = T` for each target specialization, while `[S](S) -> int` cannot preserve every target type.

Unsupported generic source shapes remain on the existing existential path, including multiple locals, declared domains, nested occurrences, aliases, gradual annotations, and enclosing inference. The source classifier is evaluated only after the target has qualified for universal checking, so ordinary generic callable inference is unaffected.

The stacked follow-up in #26734 generalizes the same source fragment to sets of unbounded locals without changing the quantifier order.
