### PR TITLE
[ty] Quantify sets of simple generic method locals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -959,6 +959,15 @@ class B4(A4):
     # but this is not necessarily true for `B4.method`: if passed a `bool`,
     # it could return a non-`bool` `int`!
     def method(self, x: int) -> int: ...  # error: [invalid-method-override]
+
+class A5:
+    def method[T, U](self, x: T, y: U) -> T: ...
+
+class B5(A5):
+    def method[S, R](self, x: S, y: R) -> R: ...  # error: [invalid-method-override]
+
+class C5(A5):
+    def method[S](self, x: S, y: object) -> S: ...  # fine
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3695,8 +3695,15 @@ class NominalGenericReturningInt:
     def f[T](self, input: T) -> int:
         return 1
 
+class NominalMultipleReturningSecond:
+    def multiple[S, R](self, first: S, second: R) -> R:
+        return second
+
 class NewStyleFunctionScoped(Protocol):
     def f[T](self, input: T) -> T: ...
+
+class MultipleFunctionScoped(Protocol):
+    def multiple[T, U](self, first: T, second: U) -> T: ...
 
 FunctionT = TypeVar("FunctionT")
 
@@ -3721,6 +3728,26 @@ class NominalGenericIntInput:
 class NominalGenericDynamic:
     def f[T](self, input: T) -> Any:
         return input
+
+class NominalTwoGenericForSingle:
+    def f[S, R](self, input: S) -> R:
+        raise NotImplementedError
+
+class NominalMultipleGeneric:
+    def multiple[S, R](self, first: S, second: R) -> S:
+        return first
+
+class NominalSingleGenericForMultiple:
+    def multiple[S](self, first: S, second: object) -> S:
+        return first
+
+class NominalMultipleConcrete:
+    def multiple(self, first: int, second: str) -> int:
+        return first
+
+class NominalMultipleDynamic:
+    def multiple[S, R](self, first: S, second: R) -> Any:
+        return first
 
 class NominalLegacy:
     def f(self, input: FunctionT) -> FunctionT:
@@ -3807,6 +3834,18 @@ static_assert(not is_assignable_to(NominalGenericIntInput, NewStyleFunctionScope
 static_assert(not is_subtype_of(NominalGenericIntInput, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalGenericDynamic, NewStyleFunctionScoped))
 static_assert(not is_subtype_of(NominalGenericDynamic, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalTwoGenericForSingle, NewStyleFunctionScoped))
+static_assert(is_subtype_of(NominalTwoGenericForSingle, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalMultipleGeneric, MultipleFunctionScoped))
+static_assert(is_subtype_of(NominalMultipleGeneric, MultipleFunctionScoped))
+static_assert(is_assignable_to(NominalSingleGenericForMultiple, MultipleFunctionScoped))
+static_assert(is_subtype_of(NominalSingleGenericForMultiple, MultipleFunctionScoped))
+static_assert(not is_assignable_to(NominalMultipleReturningSecond, MultipleFunctionScoped))
+static_assert(not is_subtype_of(NominalMultipleReturningSecond, MultipleFunctionScoped))
+static_assert(not is_assignable_to(NominalMultipleConcrete, MultipleFunctionScoped))
+static_assert(not is_subtype_of(NominalMultipleConcrete, MultipleFunctionScoped))
+static_assert(is_assignable_to(NominalMultipleDynamic, MultipleFunctionScoped))
+static_assert(not is_subtype_of(NominalMultipleDynamic, MultipleFunctionScoped))
 
 static_assert(is_assignable_to(NominalLegacy, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalLegacy, LegacyFunctionScoped))

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1528,8 +1528,8 @@ impl<'db> Signature<'db> {
 
     /// Returns the source-local variables supported by the initial generic-source relation.
     ///
-    /// The source must bind exactly one unbounded PEP 695 type variable, used only as a bare
-    /// parameter or return annotation. Its specialization can then be chosen existentially for
+    /// Every source variable must be an unbounded PEP 695 type variable used only as a bare
+    /// parameter or return annotation. Their specializations can then be chosen existentially for
     /// each universally quantified target specialization.
     fn simple_generic_source_typevars(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
         if !self.parameters.is_standard() {
@@ -1537,35 +1537,31 @@ impl<'db> Signature<'db> {
         }
 
         let definition = self.definition?;
-        let mut variables = self.generic_context?.variables(db);
-        let typevar = variables.next()?;
-        if variables.next().is_some()
-            || typevar.kind(db) != TypeVarKind::Pep695TypeVar
-            || typevar.binding_context(db).definition() != Some(definition)
-            || typevar.typevar(db).bound_or_constraints(db).is_some()
-        {
+        let local_identities: FxOrderSet<_> = self
+            .generic_context?
+            .variables(db)
+            .map(|typevar| {
+                (typevar.kind(db) == TypeVarKind::Pep695TypeVar
+                    && typevar.binding_context(db).definition() == Some(definition)
+                    && typevar.typevar(db).bound_or_constraints(db).is_none())
+                .then(|| typevar.identity(db))
+            })
+            .collect::<Option<_>>()?;
+        if local_identities.is_empty() {
             return None;
         }
 
-        let identity = typevar.typevar(db).identity(db);
+        let locals = InferableTypeVars::from_typevars(db, local_identities);
         self.parameters
             .iter()
             .map(Parameter::annotated_type)
             .chain(std::iter::once(self.return_ty))
             .all(|ty| {
-                if ty.references_typevar(db, identity) {
-                    ty.as_typevar()
-                        .is_some_and(|inner| inner.is_same_typevar_as(db, typevar))
-                } else {
-                    Self::is_supported_generic_source_concrete_type(db, ty)
-                }
+                ty.as_typevar()
+                    .is_some_and(|typevar| typevar.is_inferable(db, locals))
+                    || Self::is_supported_generic_source_concrete_type(db, ty)
             })
-            .then(|| {
-                InferableTypeVars::from_typevars(
-                    db,
-                    std::iter::once(typevar.identity(db)).collect(),
-                )
-            })
+            .then_some(locals)
     }
 
     pub(crate) fn is_non_generic(&self) -> bool {


### PR DESCRIPTION
## Summary

#26733 admits one simple generic source local into the universal target relation. Generic methods can bind multiple independent source variables, and the previous cardinality restriction leaves those sources on the existing existential path:

```python
from typing import Protocol

class SelectFirst(Protocol):
    def select[T, U](self, first: T, second: U) -> T: ...

class SelectSecond:
    def select[S, R](self, first: S, second: R) -> R:
        return second

# `SelectSecond.select` cannot preserve the type of `first`.
select_first: SelectFirst = SelectSecond()  # error
```

This PR generalizes the reduction-point source classifier from exactly one variable to a non-empty set of definition-local, unbounded PEP 695 type variables. Every source-local occurrence must still be a bare parameter or return annotation. We existentially eliminate the complete source set before universally eliminating the target set, preserving `forall target, exists source` without enumerating binder combinations or requiring the two sides to bind the same number of variables.

Declared domains, nested occurrences, aliases, gradual annotations, explicit receiver domains, and enclosing inference remain on the existing path. The stacked follow-up in #26735 extends this source fragment to unbounded, definition-local legacy `TypeVar`s.
