### PR TITLE
[ty] Quantify unbounded legacy method locals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -868,7 +868,7 @@ python-version = "3.12"
 ```
 
 ```pyi
-from typing import Never, Self
+from typing import Never, Self, TypeVar
 
 class A:
     def method[T](self, x: T) -> T: ...
@@ -968,6 +968,18 @@ class B5(A5):
 
 class C5(A5):
     def method[S](self, x: S, y: object) -> S: ...  # fine
+
+LegacyT = TypeVar("LegacyT")
+LegacyS = TypeVar("LegacyS")
+
+class A6:
+    def method(self, x: LegacyT) -> LegacyT: ...
+
+class B6(A6):
+    def method(self, x: int) -> int: ...  # error: [invalid-method-override]
+
+class C6(A6):
+    def method(self, x: LegacyS) -> int: ...  # error: [invalid-method-override]
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3706,12 +3706,23 @@ class MultipleFunctionScoped(Protocol):
     def multiple[T, U](self, first: T, second: U) -> T: ...
 
 FunctionT = TypeVar("FunctionT")
+LegacyFirst = TypeVar("LegacyFirst")
+LegacySecond = TypeVar("LegacySecond")
+LegacyReturningIntT = TypeVar("LegacyReturningIntT")
+LegacyDynamicT = TypeVar("LegacyDynamicT")
+LegacyReceiverT = TypeVar("LegacyReceiverT")
 
 class LegacyFunctionScoped(Protocol):
     def f(self, input: FunctionT) -> FunctionT: ...
 
+class LegacyMultipleFunctionScoped(Protocol):
+    def multiple(self, first: LegacyFirst, second: LegacySecond) -> LegacyFirst: ...
+
 class UsesSelf(Protocol):
     def g(self: Self) -> Self: ...
+
+class UsesLegacyReceiver(Protocol):
+    def compare(self: LegacyReceiverT, other: LegacyReceiverT) -> bool: ...
 
 class NominalNewStyle:
     def f[T](self, input: T) -> T:
@@ -3752,6 +3763,22 @@ class NominalMultipleDynamic:
 class NominalLegacy:
     def f(self, input: FunctionT) -> FunctionT:
         return input
+
+class NominalLegacyReturningInt:
+    def f(self, input: LegacyReturningIntT) -> int:
+        return 1
+
+class NominalLegacyDynamic:
+    def f(self, input: LegacyDynamicT) -> Any:
+        return input
+
+class NominalLegacyMultiple:
+    def multiple(self, first: LegacyFirst, second: LegacySecond) -> LegacyFirst:
+        return first
+
+class NominalLegacyReceiver:
+    def compare(self, other: "NominalLegacyReceiver") -> bool:
+        return True
 
 class NominalWithSelf:
     def g(self: Self) -> Self:
@@ -3852,18 +3879,32 @@ static_assert(is_assignable_to(NominalLegacy, LegacyFunctionScoped))
 static_assert(is_subtype_of(NominalLegacy, NewStyleFunctionScoped))
 static_assert(is_subtype_of(NominalLegacy, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalLegacy, UsesSelf))
+static_assert(not is_assignable_to(NominalLegacyReturningInt, NewStyleFunctionScoped))
+static_assert(not is_assignable_to(NominalLegacyReturningInt, LegacyFunctionScoped))
+static_assert(not is_subtype_of(NominalLegacyReturningInt, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalLegacyReturningInt, LegacyFunctionScoped))
+static_assert(is_assignable_to(NominalLegacyDynamic, LegacyFunctionScoped))
+static_assert(not is_subtype_of(NominalLegacyDynamic, LegacyFunctionScoped))
+static_assert(is_assignable_to(NominalLegacyMultiple, LegacyMultipleFunctionScoped))
+static_assert(is_subtype_of(NominalLegacyMultiple, LegacyMultipleFunctionScoped))
+static_assert(not is_assignable_to(NominalMultipleReturningSecond, LegacyMultipleFunctionScoped))
+static_assert(not is_subtype_of(NominalMultipleReturningSecond, LegacyMultipleFunctionScoped))
+static_assert(not is_assignable_to(NominalMultipleConcrete, LegacyMultipleFunctionScoped))
+static_assert(not is_subtype_of(NominalMultipleConcrete, LegacyMultipleFunctionScoped))
 
 static_assert(not is_assignable_to(NominalWithSelf, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalWithSelf, LegacyFunctionScoped))
 static_assert(is_assignable_to(NominalWithSelf, UsesSelf))
 static_assert(is_subtype_of(NominalWithSelf, UsesSelf))
+static_assert(not is_assignable_to(NominalLegacyReceiver, UsesLegacyReceiver))
+static_assert(not is_subtype_of(NominalLegacyReceiver, UsesLegacyReceiver))
 
 # A non-generic method cannot implement the generic target for every specialization.
 static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_subtype_of(NominalNotGeneric, NewStyleFunctionScoped))
 
-# TODO: this should pass
-static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))  # error: [static-assert-error]
+static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))
+static_assert(not is_subtype_of(NominalNotGeneric, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalNotGeneric, UsesSelf))
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1526,12 +1526,12 @@ impl<'db> Signature<'db> {
         }
     }
 
-    /// Returns the source-local variables supported by the initial generic-source relation.
+    /// Returns the method-local variables supported by the simple generic-signature relation.
     ///
-    /// Every source variable must be an unbounded PEP 695 type variable used only as a bare
-    /// parameter or return annotation. Their specializations can then be chosen existentially for
-    /// each universally quantified target specialization.
-    fn simple_generic_source_typevars(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
+    /// Every variable must be an unbounded PEP 695 or legacy type variable bound by this method
+    /// and used only as a bare parameter or return annotation. Their specializations can then be
+    /// quantified without capturing class-scoped variables or changing nested inference.
+    fn simple_generic_method_typevars(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
         if !self.parameters.is_standard() {
             return None;
         }
@@ -1541,8 +1541,10 @@ impl<'db> Signature<'db> {
             .generic_context?
             .variables(db)
             .map(|typevar| {
-                (typevar.kind(db) == TypeVarKind::Pep695TypeVar
-                    && typevar.binding_context(db).definition() == Some(definition)
+                (matches!(
+                    typevar.kind(db),
+                    TypeVarKind::Pep695TypeVar | TypeVarKind::LegacyTypeVar
+                ) && typevar.binding_context(db).definition() == Some(definition)
                     && typevar.typevar(db).bound_or_constraints(db).is_none())
                 .then(|| typevar.identity(db))
             })
@@ -2116,19 +2118,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // The inferable set can also include variables referenced by a bound. Do not
                 // universally quantify variables owned by an enclosing context.
                 variables.len() == target_inferable.iter(db).count()
-                    && variables.all(|typevar| {
+                    && (variables.all(|typevar| {
                         matches!(
                             typevar.kind(db),
                             TypeVarKind::Pep695TypeVar
                                 | TypeVarKind::Pep695ParamSpec
                                 | TypeVarKind::Pep695TypeVarTuple
                         )
-                    })
+                    }) || target.simple_generic_method_typevars(db) == Some(target_inferable))
             }) {
             if source.generic_context.is_none() {
                 Some(InferableTypeVars::None)
             } else {
-                source.simple_generic_source_typevars(db)
+                source.simple_generic_method_typevars(db)
             }
         } else {
             None
@@ -2173,9 +2175,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         });
 
         // A non-generic source, or a supported simple generic source, must satisfy every
-        // specialization of a PEP 695 generic target. Eliminate source locals first so their
-        // specialization can depend on the target specialization. Other generic sources, legacy
-        // target typevars, and enclosing inference remain on the existing existential path.
+        // specialization of a supported generic target. Eliminate source locals first so their
+        // specialization can depend on the target specialization. More complex generic sources,
+        // non-local or bounded legacy target typevars, and enclosing inference remain on the
+        // existing existential path.
         if let Some(source_existential) = universal_source_existential {
             when.reduce_inferable(db, self.constraints, source_existential)
                 .for_all(db, self.constraints, target_inferable)


### PR DESCRIPTION
## Summary

This builds on #26734 by extending the supported generic-signature fragment to legacy method-scoped `TypeVar`s.

Legacy variables are admitted only when every variable is unbounded, owned by the method definition, and used as a bare parameter or return annotation. This excludes class-scoped variables, bounds that pull in enclosing inference, and nested occurrences.

The implementation stays on the normal signature-reduction path introduced by #26695. Supported source locals are eliminated existentially before supported target locals are eliminated universally, so a generic source specialization can depend on each target specialization. PEP 695 targets retain the broader support from #26695; the stricter classifier is evaluated lazily only for generic sources or when a target contains legacy variables.

The protocol and override cases cover legacy sources and targets, multiple legacy locals, mixed PEP 695 and legacy signatures, and explicit legacy receiver annotations.
