### PR TITLE
[ty] Support closed unions in higher-rank signatures

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -868,7 +868,7 @@ python-version = "3.12"
 ```
 
 ```pyi
-from typing import Never, Self, TypeVar
+from typing import Literal, Never, Self, TypeVar
 
 class A:
     def method[T](self, x: T) -> T: ...
@@ -980,6 +980,15 @@ class B6(A6):
 
 class C6(A6):
     def method(self, x: LegacyS) -> int: ...  # error: [invalid-method-override]
+
+class A7:
+    def method[T](self, x: T, option: int | Literal["strict"]) -> T: ...
+
+class B7(A7):
+    def method(self, x: int, option: int | Literal["strict"]) -> int: ...  # error: [invalid-method-override]
+
+class C7(A7):
+    def method[S](self, x: S, option: int | Literal["strict"]) -> S: ...
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3630,7 +3630,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Any, final, overload
+from typing import Any, Literal, final, overload
 from typing_extensions import TypeVar, Self, Protocol
 from ty_extensions import static_assert
 from ty_extensions._internal import is_equivalent_to, is_assignable_to, is_subtype_of
@@ -3718,6 +3718,9 @@ class LegacyFunctionScoped(Protocol):
 class LegacyMultipleFunctionScoped(Protocol):
     def multiple(self, first: LegacyFirst, second: LegacySecond) -> LegacyFirst: ...
 
+class ClosedStaticFunctionScoped(Protocol):
+    def transform[T](self, input: T, option: int | Literal["strict"]) -> T: ...
+
 class UsesSelf(Protocol):
     def g(self: Self) -> Self: ...
 
@@ -3755,6 +3758,14 @@ class NominalSingleGenericForMultiple:
 class NominalMultipleConcrete:
     def multiple(self, first: int, second: str) -> int:
         return first
+
+class NominalClosedStaticGeneric:
+    def transform[S](self, input: S, option: int | Literal["strict"]) -> S:
+        return input
+
+class NominalClosedStaticConcrete:
+    def transform(self, input: int, option: int | Literal["strict"]) -> int:
+        return input
 
 class NominalMultipleDynamic:
     def multiple[S, R](self, first: S, second: R) -> Any:
@@ -3871,6 +3882,10 @@ static_assert(not is_assignable_to(NominalMultipleReturningSecond, MultipleFunct
 static_assert(not is_subtype_of(NominalMultipleReturningSecond, MultipleFunctionScoped))
 static_assert(not is_assignable_to(NominalMultipleConcrete, MultipleFunctionScoped))
 static_assert(not is_subtype_of(NominalMultipleConcrete, MultipleFunctionScoped))
+static_assert(is_assignable_to(NominalClosedStaticGeneric, ClosedStaticFunctionScoped))
+static_assert(is_subtype_of(NominalClosedStaticGeneric, ClosedStaticFunctionScoped))
+static_assert(not is_assignable_to(NominalClosedStaticConcrete, ClosedStaticFunctionScoped))
+static_assert(not is_subtype_of(NominalClosedStaticConcrete, ClosedStaticFunctionScoped))
 static_assert(is_assignable_to(NominalMultipleDynamic, MultipleFunctionScoped))
 static_assert(not is_subtype_of(NominalMultipleDynamic, MultipleFunctionScoped))
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1507,15 +1507,19 @@ impl<'db> Signature<'db> {
         }
     }
 
-    /// Returns whether `ty` belongs to the closed concrete fragment supported alongside a simple
-    /// generic source local.
+    /// Returns whether `ty` belongs to the closed static fragment supported alongside simple
+    /// generic source locals.
     ///
     /// Gradual types, aliases, and other type variables keep the signature on the existing
-    /// existential path. This avoids changing generic callable inference outside the relation
-    /// introduced by this branch.
-    fn is_supported_generic_source_concrete_type(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    /// existential path. Unions are supported when each element belongs to this fragment.
+    fn is_supported_generic_source_closed_type(db: &'db dyn Db, ty: Type<'db>) -> bool {
         match ty {
-            Type::Never => true,
+            Type::Never | Type::LiteralValue(_) => true,
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .copied()
+                .all(|element| Self::is_supported_generic_source_closed_type(db, element)),
             Type::NominalInstance(instance) => {
                 !instance.inherits_from_explicit_any()
                     && !ty.has_dynamic(db)
@@ -1561,7 +1565,7 @@ impl<'db> Signature<'db> {
             .all(|ty| {
                 ty.as_typevar()
                     .is_some_and(|typevar| typevar.is_inferable(db, locals))
-                    || Self::is_supported_generic_source_concrete_type(db, ty)
+                    || Self::is_supported_generic_source_closed_type(db, ty)
             })
             .then_some(locals)
     }


### PR DESCRIPTION
## Summary

This builds on #26735 by widening the closed annotation fragment allowed alongside simple generic source locals.

Before this PR, a source such as `[S](S, int | Literal["strict"]) -> S` stayed on the existing existential path because the unrelated union was outside the source classifier. That prevented its source-local specialization from depending on each universally quantified target specialization.

The source classifier now admits literal types and unions whose elements recursively belong to the existing closed static fragment. Gradual types, aliases, nested occurrences of method locals, and other type variables remain excluded. Non-generic sources and PEP 695 target annotations are unchanged; those already use the normal universal-reduction path from #26695 without this source-side restriction.

The protocol and override cases cover both accepted generic implementations and rejected concrete implementations with an otherwise identical closed union parameter.
