### PR TITLE
[ty] Preserve gradual higher-rank assignability

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -868,7 +868,7 @@ python-version = "3.12"
 ```
 
 ```pyi
-from typing import Literal, Never, Self, TypeVar
+from typing import Any, Literal, Never, Self, TypeVar
 
 class A:
     def method[T](self, x: T) -> T: ...
@@ -887,6 +887,12 @@ class D(A):
 class E(A):
     # `E.method` accepts every argument, but does not preserve its type in the return.
     def method[S](self, x: S) -> int: ...  # error: [invalid-method-override]
+
+class F(A):
+    def method(self, x: Any) -> Any: ...  # fine
+
+class G(A):
+    def method(self, x): ...  # fine
 
 class A2:
     def method(self, x: int) -> int: ...
@@ -989,6 +995,15 @@ class B7(A7):
 
 class C7(A7):
     def method[S](self, x: S, option: int | Literal["strict"]) -> S: ...
+
+class A8:
+    def method[T](self, x: T, context: Any) -> T: ...
+
+class B8(A8):
+    def method(self, x: int, context: Any) -> int: ...  # error: [invalid-method-override]
+
+class C8(A8):
+    def method[S](self, x: S, context: Any) -> S: ...
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3630,7 +3630,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Any, Literal, final, overload
+from typing import Any, Literal, Never, final, overload
 from typing_extensions import TypeVar, Self, Protocol
 from ty_extensions import static_assert
 from ty_extensions._internal import is_equivalent_to, is_assignable_to, is_subtype_of
@@ -3721,6 +3721,12 @@ class LegacyMultipleFunctionScoped(Protocol):
 class ClosedStaticFunctionScoped(Protocol):
     def transform[T](self, input: T, option: int | Literal["strict"]) -> T: ...
 
+class GradualFunctionScoped(Protocol):
+    def contextual[T](self, input: T, context: Any) -> T: ...
+
+class GradualReturnFunctionScoped(Protocol):
+    def f[T](self, input: T) -> Any: ...
+
 class UsesSelf(Protocol):
     def g(self: Self) -> Self: ...
 
@@ -3767,6 +3773,14 @@ class NominalClosedStaticConcrete:
     def transform(self, input: int, option: int | Literal["strict"]) -> int:
         return input
 
+class NominalGradualGeneric:
+    def contextual[S](self, input: S, context: Any) -> S:
+        return input
+
+class NominalGradualConcrete:
+    def contextual(self, input: int, context: Any) -> int:
+        return input
+
 class NominalMultipleDynamic:
     def multiple[S, R](self, first: S, second: R) -> Any:
         return first
@@ -3794,6 +3808,18 @@ class NominalLegacyReceiver:
 class NominalWithSelf:
     def g(self: Self) -> Self:
         return self
+
+class NominalDynamic:
+    def f(self, input: Any) -> Any:
+        return input
+
+class NominalUnannotated:
+    def f(self, input):
+        return input
+
+class NominalTopBottom:
+    def f(self, input: object) -> Never:
+        raise NotImplementedError
 
 class NominalNotGeneric:
     def f(self, input: int) -> int:
@@ -3886,8 +3912,16 @@ static_assert(is_assignable_to(NominalClosedStaticGeneric, ClosedStaticFunctionS
 static_assert(is_subtype_of(NominalClosedStaticGeneric, ClosedStaticFunctionScoped))
 static_assert(not is_assignable_to(NominalClosedStaticConcrete, ClosedStaticFunctionScoped))
 static_assert(not is_subtype_of(NominalClosedStaticConcrete, ClosedStaticFunctionScoped))
+static_assert(is_assignable_to(NominalGradualGeneric, GradualFunctionScoped))
+static_assert(not is_subtype_of(NominalGradualGeneric, GradualFunctionScoped))
+static_assert(not is_assignable_to(NominalGradualConcrete, GradualFunctionScoped))
+static_assert(not is_subtype_of(NominalGradualConcrete, GradualFunctionScoped))
 static_assert(is_assignable_to(NominalMultipleDynamic, MultipleFunctionScoped))
 static_assert(not is_subtype_of(NominalMultipleDynamic, MultipleFunctionScoped))
+static_assert(is_assignable_to(NominalNewStyle, GradualReturnFunctionScoped))
+static_assert(not is_subtype_of(NominalNewStyle, GradualReturnFunctionScoped))
+static_assert(not is_assignable_to(NominalNotGeneric, GradualReturnFunctionScoped))
+static_assert(not is_subtype_of(NominalNotGeneric, GradualReturnFunctionScoped))
 
 static_assert(is_assignable_to(NominalLegacy, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalLegacy, LegacyFunctionScoped))
@@ -3913,6 +3947,12 @@ static_assert(is_assignable_to(NominalWithSelf, UsesSelf))
 static_assert(is_subtype_of(NominalWithSelf, UsesSelf))
 static_assert(not is_assignable_to(NominalLegacyReceiver, UsesLegacyReceiver))
 static_assert(not is_subtype_of(NominalLegacyReceiver, UsesLegacyReceiver))
+static_assert(is_assignable_to(NominalDynamic, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalDynamic, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalUnannotated, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalUnannotated, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalTopBottom, NewStyleFunctionScoped))
+static_assert(is_subtype_of(NominalTopBottom, NewStyleFunctionScoped))
 
 # A non-generic method cannot implement the generic target for every specialization.
 static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -344,6 +344,7 @@ impl<'db> Type<'db> {
         let checker = TypeRelationChecker {
             constraints,
             inferable,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::SubtypingAssuming,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: None,
@@ -381,6 +382,7 @@ impl<'db> Type<'db> {
         let checker = TypeRelationChecker {
             constraints: &builder,
             inferable: InferableTypeVars::None,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: Some(ErrorContextTree::new()),
@@ -588,6 +590,7 @@ impl<'db> Type<'db> {
         let checker = TypeRelationChecker {
             constraints,
             inferable,
+            quantified_typevars: InferableTypeVars::None,
             relation,
             typevar_evaluation,
             context_tree: None,
@@ -743,6 +746,7 @@ impl<'db, 'c> IsDisjointVisitor<'db, 'c> {
 pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     pub(super) inferable: InferableTypeVars<'db>,
+    quantified_typevars: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
     pub(super) typevar_evaluation: TypeVarEvaluation,
     context_tree: Option<ErrorContextTree<'db>>,
@@ -772,6 +776,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::Subtyping,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: None,
@@ -793,6 +798,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
             context_tree: None,
@@ -814,6 +820,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
             context_tree: Some(ErrorContextTree::new()),
@@ -835,6 +842,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: Some(ErrorContextTree::new()),
@@ -849,6 +857,22 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     pub(super) fn with_inferable_typevars(&self, inferable: InferableTypeVars<'db>) -> Self {
         Self {
             inferable,
+            ..self.clone()
+        }
+    }
+
+    /// Marks type variables that are locally quantified by this relation.
+    ///
+    /// Direct gradual assignability to these variables must be evaluated before lazy constraint
+    /// capture. A gradual bound is useful evidence for caller-owned inference variables, but does
+    /// not restrict a local variable that is subsequently quantified away.
+    pub(super) fn with_quantified_typevars(
+        &self,
+        db: &'db dyn Db,
+        typevars: InferableTypeVars<'db>,
+    ) -> Self {
+        Self {
+            quantified_typevars: self.quantified_typevars.merge(db, typevars),
             ..self.clone()
         }
     }
@@ -1059,6 +1083,22 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             return self
                 .given
                 .implies_subtype_of(db, self.constraints, source, target);
+        }
+
+        // A gradual type is assignable to and from every specialization of a locally quantified
+        // type variable. Preserve that behavior before lazy evaluation captures the comparison as
+        // a rigid bound. Caller-owned inference variables remain constrained by gradual evidence.
+        if self.relation.is_assignability()
+            && match (source, target) {
+                (Type::TypeVar(typevar), Type::Dynamic(_))
+                | (Type::Dynamic(_), Type::TypeVar(typevar)) => {
+                    typevar.is_inferable(db, self.quantified_typevars)
+                        || typevar.typevar(db).is_self(db)
+                }
+                _ => false,
+            }
+        {
+            return self.always();
         }
 
         // With lazy evaluation, comparisons with a type variable are translated directly into a
@@ -2403,6 +2443,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             context_tree: None,
             given: self.given,
             inferable: InferableTypeVars::None,
+            quantified_typevars: InferableTypeVars::None,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
@@ -2486,6 +2527,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             typevar_evaluation: TypeVarEvaluation::Eager,
             constraints: self.constraints,
             inferable: self.inferable,
+            quantified_typevars: InferableTypeVars::None,
             context_tree: None,
             given: self.given,
             relation_visitor: self.relation_visitor,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1530,6 +1530,17 @@ impl<'db> Signature<'db> {
         }
     }
 
+    /// Returns whether `ty` is supported as a top-level annotation alongside simple generic
+    /// source locals.
+    ///
+    /// Direct gradual annotations are supported for assignability, but remain excluded from the
+    /// recursively closed fragment so that gradual unions and invariant containers stay on the
+    /// existing relation path.
+    fn is_supported_generic_source_annotation(db: &'db dyn Db, ty: Type<'db>) -> bool {
+        matches!(ty, Type::Dynamic(_) | Type::Divergent(_))
+            || Self::is_supported_generic_source_closed_type(db, ty)
+    }
+
     /// Returns the method-local variables supported by the simple generic-signature relation.
     ///
     /// Every variable must be an unbounded PEP 695 or legacy type variable bound by this method
@@ -1565,7 +1576,7 @@ impl<'db> Signature<'db> {
             .all(|ty| {
                 ty.as_typevar()
                     .is_some_and(|typevar| typevar.is_inferable(db, locals))
-                    || Self::is_supported_generic_source_closed_type(db, ty)
+                    || Self::is_supported_generic_source_annotation(db, ty)
             })
             .then_some(locals)
     }
@@ -2140,9 +2151,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             None
         };
         let universally_quantify_target = universal_source_existential.is_some();
+        let quantified_typevars = universal_source_existential
+            .map_or(InferableTypeVars::None, |source_existential| {
+                source_existential.merge(db, target_inferable)
+            });
 
         // `inner` will create a constraint set that references these newly inferable typevars.
-        let mut checker = self.with_inferable_typevars(inferable);
+        let mut checker = self
+            .with_inferable_typevars(inferable)
+            .with_quantified_typevars(db, quantified_typevars);
         // Receiver constraints and universal target abstraction both require typevar relationships
         // to remain symbolic until quantification.
         if source.receiver_constraints.is_some()


### PR DESCRIPTION
## Summary

This builds on #26736 by admitting direct gradual annotations alongside the simple generic source locals handled by this stack.

Without special handling, lazy comparison captures `Any` or `Unknown` against a locally quantified type variable as a rigid bound. That breaks ordinary gradual assignability after the variable is eliminated, and an unrelated gradual annotation also keeps a generic source on the existential fallback path.

The relation checker now tracks only the source and target variables that this signature relation will actually quantify. Direct gradual assignability involving those variables is resolved before lazy constraint capture; caller-owned inference variables remain unmarked and can still use gradual evidence. Strict subtyping is unchanged.

The source classifier admits direct gradual annotations but continues to reject gradual unions, gradual types nested inside invariant containers, aliases, and nested method-local occurrences. This uses the same `quantified_typevars` mechanism as #26786, so the shared implementation can be deduplicated mechanically whichever PR lands first.

The protocol and override cases cover dynamic and unannotated implementations, gradual return annotations, unrelated gradual parameters, generic implementations, and concrete implementations that must still be rejected.
