### PR TITLE
[ty] Add fallible constraint projection

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -635,6 +635,10 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         self.verify_builder(builder);
         assumptions.verify_builder(builder);
 
+        if to_remove == InferableTypeVars::None {
+            return Ok(self.and(db, builder, || assumptions));
+        }
+
         let type_mentions_projected = |ty: Type<'db>| {
             any_over_type(db, ty, false, |nested| {
                 nested
@@ -7950,6 +7954,14 @@ mod tests {
                 target,
                 alias_of_source,
             );
+            let unchanged = ConstraintSet::always(&builder)
+                .try_exists_assuming(&db, &builder, InferableTypeVars::None, alias_relation)
+                .expect("projecting no variables is an identity operation");
+            assert!(
+                unchanged
+                    .iff(&db, &builder, alias_relation)
+                    .is_always_satisfied(&db)
+            );
             assert!(matches!(
                 alias_relation.try_exists_assuming(
                     &db,
@@ -7999,6 +8011,15 @@ mod tests {
         let relation =
             ConstraintSet::constrain_typevar_lower_bound(&db, &builder, target, protocol);
         let source_locals = typevar_set(&db, [source]);
+
+        let unchanged = ConstraintSet::always(&builder)
+            .try_exists_assuming(&db, &builder, InferableTypeVars::None, relation)
+            .expect("projecting no variables is an identity operation");
+        assert!(
+            unchanged
+                .iff(&db, &builder, relation)
+                .is_always_satisfied(&db)
+        );
 
         assert!(matches!(
             relation.try_exists_assuming(

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -324,6 +324,8 @@ pub(crate) enum ConstraintProjectionError {
     NegatedTypeVarRelation,
     /// A type alias might conceal a projected variable.
     OpaqueTypeAlias,
+    /// A class-based protocol interface might conceal a projected variable.
+    OpaqueProtocol,
     /// An assumption mentions a variable that the projection removes.
     ProjectedTypeVarInAssumption,
 }
@@ -334,6 +336,12 @@ fn contains_type_alias(db: &dyn Db, ty: Type<'_>) -> bool {
             nested,
             Type::TypeAlias(_) | Type::KnownInstance(KnownInstanceType::TypeAliasType(_))
         )
+    })
+}
+
+fn contains_protocol(db: &dyn Db, ty: Type<'_>) -> bool {
+    any_over_type(db, ty, false, |nested| {
+        matches!(nested, Type::ProtocolInstance(_))
     })
 }
 
@@ -636,6 +644,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         };
         let mut assumption_mentions_projected = false;
         let mut assumption_contains_alias = false;
+        let mut assumption_contains_protocol = false;
         assumptions
             .node
             .for_each_unique_constraint(builder, &mut |constraint, _| {
@@ -651,9 +660,20 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                         .bounds
                         .upper
                         .is_some_and(|ty| contains_type_alias(db, ty));
+                assumption_contains_protocol |= constraint
+                    .bounds
+                    .lower
+                    .is_some_and(|ty| contains_protocol(db, ty))
+                    || constraint
+                        .bounds
+                        .upper
+                        .is_some_and(|ty| contains_protocol(db, ty));
             });
         if assumption_contains_alias {
             return Err(ConstraintProjectionError::OpaqueTypeAlias);
+        }
+        if assumption_contains_protocol {
+            return Err(ConstraintProjectionError::OpaqueProtocol);
         }
         if assumption_mentions_projected {
             return Err(ConstraintProjectionError::ProjectedTypeVarInAssumption);
@@ -4296,6 +4316,9 @@ impl InteriorNode {
                 {
                     if contains_type_alias(db, bound) {
                         return Err(ConstraintProjectionError::OpaqueTypeAlias);
+                    }
+                    if contains_protocol(db, bound) {
+                        return Err(ConstraintProjectionError::OpaqueProtocol);
                     }
                     if subject_is_removed {
                         if bound.as_typevar().is_none() && contains_any_typevar(bound) {
@@ -7946,6 +7969,55 @@ mod tests {
                 Err(ConstraintProjectionError::OpaqueTypeAlias)
             ));
         }
+    }
+
+    #[test]
+    fn fallible_projection_rejects_opaque_protocols() {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/protocol.py",
+            r#"
+            from typing import Protocol
+
+            class P(Protocol):
+                def f(self) -> None: ...
+            "#,
+        )
+        .unwrap();
+        let module = ruff_db::files::system_path_to_file(&db, "/src/protocol.py").unwrap();
+        let protocol_class = global_symbol(&db, module, "P")
+            .place
+            .expect_type()
+            .to_class_type(&db)
+            .expect("expected `P` to be a class");
+        let protocol = Type::instance(&db, protocol_class);
+        assert!(matches!(protocol, Type::ProtocolInstance(_)));
+
+        let source = create_typevar(&db, "S");
+        let target = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let relation =
+            ConstraintSet::constrain_typevar_lower_bound(&db, &builder, target, protocol);
+        let source_locals = typevar_set(&db, [source]);
+
+        assert!(matches!(
+            relation.try_exists_assuming(
+                &db,
+                &builder,
+                source_locals,
+                ConstraintSet::always(&builder),
+            ),
+            Err(ConstraintProjectionError::OpaqueProtocol)
+        ));
+        assert!(matches!(
+            ConstraintSet::always(&builder).try_exists_assuming(
+                &db,
+                &builder,
+                source_locals,
+                relation,
+            ),
+            Err(ConstraintProjectionError::OpaqueProtocol)
+        ));
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -88,6 +88,7 @@
 
 use std::cell::{Ref, RefCell};
 use std::cmp::Ordering;
+use std::convert::Infallible;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::ops::Range;
@@ -312,6 +313,15 @@ impl OwnedConstraintSetInner<'_> {
         );
         self.constraint_indices.rank(index) as usize
     }
+}
+
+/// Describes why quantified constraint projection could not be represented exactly.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ConstraintProjectionError {
+    /// A projected variable occurs inside a type-level bound that cannot yet be preserved.
+    NestedTypeVarRelation,
+    /// An assumption mentions a variable that the projection removes.
+    ProjectedTypeVarInAssumption,
 }
 
 /// A set of constraints under which a type property holds.
@@ -577,6 +587,54 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     ) -> Self {
         self.verify_builder(builder);
         Self::from_node(builder, self.node.exists(db, builder, to_remove))
+    }
+
+    /// Tries to existentially quantify type variables out of this constraint set.
+    ///
+    /// Unlike [`Self::reduce_inferable`], this operation returns an error rather than discarding a
+    /// type-level relationship that the constraint representation cannot preserve exactly.
+    /// `assumptions` must not mention any variable in `to_remove`; because they are independent of
+    /// those variables, they are conjoined only after projection and remain factored during the
+    /// abstraction traversal.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "used by quantified signature projection in the stacked follow-up"
+        )
+    )]
+    pub(crate) fn try_exists_assuming(
+        self,
+        db: &'db dyn Db,
+        builder: &'c ConstraintSetBuilder<'db>,
+        to_remove: InferableTypeVars<'db>,
+        assumptions: Self,
+    ) -> Result<Self, ConstraintProjectionError> {
+        self.verify_builder(builder);
+        assumptions.verify_builder(builder);
+
+        let type_mentions_projected = |ty: Type<'db>| {
+            any_over_type(db, ty, false, |nested| {
+                nested
+                    .as_typevar()
+                    .is_some_and(|typevar| typevar.is_inferable(db, to_remove))
+            })
+        };
+        let mut assumption_mentions_projected = false;
+        assumptions
+            .node
+            .for_each_unique_constraint(builder, &mut |constraint, _| {
+                let constraint = builder.constraint_data(constraint);
+                assumption_mentions_projected |= constraint.typevar.is_inferable(db, to_remove)
+                    || constraint.bounds.lower.is_some_and(type_mentions_projected)
+                    || constraint.bounds.upper.is_some_and(type_mentions_projected);
+            });
+        if assumption_mentions_projected {
+            return Err(ConstraintProjectionError::ProjectedTypeVarInAssumption);
+        }
+
+        let projected = Self::from_node(builder, self.node.try_exists(db, builder, to_remove)?);
+        Ok(projected.and(db, builder, || assumptions))
     }
 
     /// Universally abstracts constraints involving the given type variables from this TDD.
@@ -2859,6 +2917,25 @@ impl NodeId {
         result
     }
 
+    /// Fallible existential abstraction for type-level relationships.
+    fn try_exists<'db>(
+        self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        bound_typevars: InferableTypeVars<'db>,
+    ) -> Result<Self, ConstraintProjectionError> {
+        if bound_typevars == InferableTypeVars::None {
+            return Ok(self);
+        }
+
+        let Node::Interior(interior) = self.node() else {
+            return Ok(self);
+        };
+
+        let mut path = interior.path_assignments(builder);
+        interior.try_exists_inner(db, builder, bound_typevars, &mut path)
+    }
+
     fn exists_inner<'db>(
         self,
         db: &'db dyn Db,
@@ -2886,18 +2963,18 @@ impl NodeId {
         }
     }
 
-    fn abstract_one_inner<'db>(
+    fn try_abstract_one_inner<'db, E>(
         self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
-        should_remove: &mut dyn FnMut(ConstraintId) -> bool,
+        should_remove: &mut dyn FnMut(ConstraintId) -> Result<bool, E>,
         path: &mut PathAssignments,
-    ) -> Self {
+    ) -> Result<Self, E> {
         match self.node() {
-            Node::AlwaysTrue => ALWAYS_TRUE,
-            Node::AlwaysFalse => ALWAYS_FALSE,
+            Node::AlwaysTrue => Ok(ALWAYS_TRUE),
+            Node::AlwaysFalse => Ok(ALWAYS_FALSE),
             Node::Interior(interior) => {
-                interior.abstract_one_inner(db, builder, should_remove, path)
+                interior.try_abstract_one_inner(db, builder, should_remove, path)
             }
         }
     }
@@ -4121,6 +4198,54 @@ impl InteriorNode {
         )
     }
 
+    fn try_exists_inner<'db>(
+        self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        bound_typevars: InferableTypeVars<'db>,
+        path: &mut PathAssignments,
+    ) -> Result<NodeId, ConstraintProjectionError> {
+        let is_removed =
+            |typevar: BoundTypeVarInstance<'db>| typevar.is_inferable(db, bound_typevars);
+        let contains_removed = |ty: Type<'db>| {
+            any_over_type(db, ty, false, |nested| {
+                nested.as_typevar().is_some_and(is_removed)
+            })
+        };
+        let contains_any_typevar = |ty: Type<'db>| any_over_type(db, ty, false, Type::is_type_var);
+
+        self.try_abstract_one_inner(
+            db,
+            builder,
+            &mut |constraint| {
+                let constraint = builder.constraint_data(constraint);
+                let subject_is_removed = is_removed(constraint.typevar);
+                let mut remove = subject_is_removed;
+
+                for bound in constraint
+                    .bounds
+                    .lower
+                    .into_iter()
+                    .chain(constraint.bounds.upper)
+                {
+                    if subject_is_removed {
+                        if bound.as_typevar().is_none() && contains_any_typevar(bound) {
+                            return Err(ConstraintProjectionError::NestedTypeVarRelation);
+                        }
+                    } else if contains_removed(bound) {
+                        if !bound.as_typevar().is_some_and(is_removed) {
+                            return Err(ConstraintProjectionError::NestedTypeVarRelation);
+                        }
+                        remove = true;
+                    }
+                }
+
+                Ok(remove)
+            },
+            path,
+        )
+    }
+
     fn remove_noninferable<'db>(
         self,
         db: &'db dyn Db,
@@ -4167,8 +4292,62 @@ impl InteriorNode {
         should_remove: &mut dyn FnMut(ConstraintId) -> bool,
         path: &mut PathAssignments,
     ) -> NodeId {
+        let mut fallible = |constraint| Ok::<_, Infallible>(should_remove(constraint));
+        match self.try_abstract_one_inner(db, builder, &mut fallible, path) {
+            Ok(result) => result,
+            Err(unreachable) => match unreachable {},
+        }
+    }
+
+    fn try_abstract_edge<'db, E>(
+        child: NodeId,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        edge: (ConstraintAssignment, usize),
+        should_remove: &mut dyn FnMut(ConstraintId) -> Result<bool, E>,
+        path: &mut PathAssignments,
+        retain_derived: bool,
+    ) -> Result<NodeId, E> {
+        let (assignment, source_order) = edge;
+        let result = path.walk_edge(db, builder, assignment, source_order, |path, new_range| {
+            let branch = child.try_abstract_one_inner(db, builder, should_remove, path)?;
+            if !retain_derived {
+                return Ok(branch);
+            }
+
+            path.assignments[new_range].iter().try_fold(
+                branch,
+                |branch, (assignment, (derived_source_order, _))| {
+                    if should_remove(assignment.constraint())? {
+                        Ok(branch)
+                    } else {
+                        Ok(branch.and(
+                            builder,
+                            Node::new_satisfied_constraint(
+                                builder,
+                                *assignment,
+                                *derived_source_order,
+                            ),
+                        ))
+                    }
+                },
+            )
+        });
+        match result {
+            Some(result) => result,
+            None => Ok(ALWAYS_FALSE),
+        }
+    }
+
+    fn try_abstract_one_inner<'db, E>(
+        self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        should_remove: &mut dyn FnMut(ConstraintId) -> Result<bool, E>,
+        path: &mut PathAssignments,
+    ) -> Result<NodeId, E> {
         let self_interior = builder.interior_node_data(self.node());
-        if should_remove(self_interior.constraint) {
+        if should_remove(self_interior.constraint)? {
             // If we should remove constraints involving this typevar, then we replace this node
             // with the OR of all of its outgoing edges. That is, the result is true if there's
             // any assignment of this node's constraint that is true.
@@ -4181,146 +4360,81 @@ impl InteriorNode {
             // TODO: This might not be stable enough, if we add more than one derived fact for this
             // constraint. If we still see inconsistent test output, we might need a more complex
             // way of tracking source order for derived facts.
-            let if_true = path
-                .walk_edge(
-                    db,
-                    builder,
+            let if_true = Self::try_abstract_edge(
+                self_interior.if_true,
+                db,
+                builder,
+                (
                     self_interior.constraint.when_true(),
                     self_interior.source_order,
-                    |path, new_range| {
-                        let branch = self_interior.if_true.abstract_one_inner(
-                            db,
-                            builder,
-                            should_remove,
-                            path,
-                        );
-                        path.assignments[new_range]
-                            .iter()
-                            .filter(|(assignment, _)| {
-                                // Don't add back any derived facts if they are ones that we would have
-                                // removed!
-                                !should_remove(assignment.constraint())
-                            })
-                            .fold(branch, |branch, (assignment, (source_order, _))| {
-                                branch.and(
-                                    builder,
-                                    Node::new_satisfied_constraint(
-                                        builder,
-                                        *assignment,
-                                        *source_order,
-                                    ),
-                                )
-                            })
-                    },
-                )
-                .unwrap_or(ALWAYS_FALSE);
-            let if_false = path
-                .walk_edge(
-                    db,
-                    builder,
+                ),
+                should_remove,
+                path,
+                true,
+            )?;
+            let if_false = Self::try_abstract_edge(
+                self_interior.if_false,
+                db,
+                builder,
+                (
                     self_interior.constraint.when_false(),
                     self_interior.source_order,
-                    |path, new_range| {
-                        let branch = self_interior.if_false.abstract_one_inner(
-                            db,
-                            builder,
-                            should_remove,
-                            path,
-                        );
-                        path.assignments[new_range]
-                            .iter()
-                            .filter(|(assignment, _)| {
-                                // Don't add back any derived facts if they are ones that we would have
-                                // removed!
-                                !should_remove(assignment.constraint())
-                            })
-                            .fold(branch, |branch, (assignment, (source_order, _))| {
-                                branch.and(
-                                    builder,
-                                    Node::new_satisfied_constraint(
-                                        builder,
-                                        *assignment,
-                                        *source_order,
-                                    ),
-                                )
-                            })
-                    },
-                )
-                .unwrap_or(ALWAYS_FALSE);
-            let if_uncertain = path
-                .walk_edge(
-                    db,
-                    builder,
+                ),
+                should_remove,
+                path,
+                true,
+            )?;
+            let if_uncertain = Self::try_abstract_edge(
+                self_interior.if_uncertain,
+                db,
+                builder,
+                (
                     self_interior.constraint.when_unconstrained(),
                     self_interior.source_order,
-                    |path, new_range| {
-                        let branch = self_interior.if_uncertain.abstract_one_inner(
-                            db,
-                            builder,
-                            should_remove,
-                            path,
-                        );
-                        path.assignments[new_range]
-                            .iter()
-                            .filter(|(assignment, _)| !should_remove(assignment.constraint()))
-                            .fold(branch, |branch, (assignment, (source_order, _))| {
-                                branch.and(
-                                    builder,
-                                    Node::new_satisfied_constraint(
-                                        builder,
-                                        *assignment,
-                                        *source_order,
-                                    ),
-                                )
-                            })
-                    },
-                )
-                .unwrap_or(ALWAYS_FALSE);
-            if_true.or(builder, if_uncertain).or(builder, if_false)
+                ),
+                should_remove,
+                path,
+                true,
+            )?;
+            Ok(if_true.or(builder, if_uncertain).or(builder, if_false))
         } else {
             // Otherwise, we abstract the if_false/if_true edges recursively.
-            let if_true = path
-                .walk_edge(
-                    db,
-                    builder,
+            let if_true = Self::try_abstract_edge(
+                self_interior.if_true,
+                db,
+                builder,
+                (
                     self_interior.constraint.when_true(),
                     self_interior.source_order,
-                    |path, _| {
-                        self_interior
-                            .if_true
-                            .abstract_one_inner(db, builder, should_remove, path)
-                    },
-                )
-                .unwrap_or(ALWAYS_FALSE);
-            let if_uncertain = path
-                .walk_edge(
-                    db,
-                    builder,
+                ),
+                should_remove,
+                path,
+                false,
+            )?;
+            let if_uncertain = Self::try_abstract_edge(
+                self_interior.if_uncertain,
+                db,
+                builder,
+                (
                     self_interior.constraint.when_unconstrained(),
                     self_interior.source_order,
-                    |path, _| {
-                        self_interior.if_uncertain.abstract_one_inner(
-                            db,
-                            builder,
-                            should_remove,
-                            path,
-                        )
-                    },
-                )
-                .unwrap_or(ALWAYS_FALSE);
-            let if_false = path
-                .walk_edge(
-                    db,
-                    builder,
+                ),
+                should_remove,
+                path,
+                false,
+            )?;
+            let if_false = Self::try_abstract_edge(
+                self_interior.if_false,
+                db,
+                builder,
+                (
                     self_interior.constraint.when_false(),
                     self_interior.source_order,
-                    |path, _| {
-                        self_interior
-                            .if_false
-                            .abstract_one_inner(db, builder, should_remove, path)
-                    },
-                )
-                .unwrap_or(ALWAYS_FALSE);
+                ),
+                should_remove,
+                path,
+                false,
+            )?;
             // Absorb the uncertain branch into both the true and false branches before
             // constructing the ITE, matching TDD semantics: when the constraint holds the result
             // is C ∨ U, and when it doesn't the result is D ∨ U.
@@ -4328,7 +4442,7 @@ impl InteriorNode {
             // NB: We cannot use `Node::new` here, because the recursive calls might introduce new
             // derived constraints into the result, and those constraints might appear before this
             // one in the BDD ordering.
-            Node::new_constraint(
+            Ok(Node::new_constraint(
                 builder,
                 self_interior.constraint,
                 self_interior.source_order,
@@ -4337,7 +4451,7 @@ impl InteriorNode {
                 builder,
                 if_true.or(builder, if_uncertain),
                 if_false.or(builder, if_uncertain),
-            )
+            ))
         }
     }
 
@@ -7541,6 +7655,154 @@ mod tests {
             .for_all(&db, &builder, typevar_set(&db, [target]))
             .reduce_inferable(&db, &builder, typevar_set(&db, [source]));
         assert!(exists_source_forall_target.is_never_satisfied(&db));
+    }
+
+    #[test]
+    fn fallible_projection_preserves_bare_relations() {
+        let db = setup_db();
+        let source = create_typevar(&db, "S");
+        let target = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let int = known_instance(&db, KnownClass::Int);
+
+        let relation = ConstraintSet::constrain_typevar_lower_bound(&db, &builder, source, int)
+            .and(&db, &builder, || {
+                ConstraintSet::constrain_typevar_upper_bound(
+                    &db,
+                    &builder,
+                    source,
+                    Type::TypeVar(target),
+                )
+            });
+        let projected = relation
+            .try_exists_assuming(
+                &db,
+                &builder,
+                typevar_set(&db, [source]),
+                ConstraintSet::always(&builder),
+            )
+            .expect("bare type-variable relations are exactly projectable");
+        let expected = ConstraintSet::constrain_typevar_lower_bound(&db, &builder, target, int);
+
+        assert!(
+            projected
+                .iff(&db, &builder, expected)
+                .is_always_satisfied(&db)
+        );
+    }
+
+    #[test]
+    fn fallible_projection_rejects_nested_relations() {
+        let db = setup_db();
+        let source = create_typevar(&db, "S");
+        let target = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let list_of_target =
+            KnownClass::List.to_specialized_instance(&db, &[Type::TypeVar(target)]);
+        let source_below_list =
+            ConstraintSet::constrain_typevar_upper_bound(&db, &builder, source, list_of_target);
+
+        assert!(matches!(
+            source_below_list.try_exists_assuming(
+                &db,
+                &builder,
+                typevar_set(&db, [source]),
+                ConstraintSet::always(&builder),
+            ),
+            Err(ConstraintProjectionError::NestedTypeVarRelation)
+        ));
+
+        let list_of_source =
+            KnownClass::List.to_specialized_instance(&db, &[Type::TypeVar(source)]);
+        let target_above_list =
+            ConstraintSet::constrain_typevar_lower_bound(&db, &builder, target, list_of_source);
+        assert!(matches!(
+            target_above_list.try_exists_assuming(
+                &db,
+                &builder,
+                typevar_set(&db, [source]),
+                ConstraintSet::always(&builder),
+            ),
+            Err(ConstraintProjectionError::NestedTypeVarRelation)
+        ));
+    }
+
+    #[test]
+    fn fallible_projection_preserves_independent_assumptions() {
+        let db = setup_db();
+        let source = create_typevar(&db, "S");
+        let target = create_typevar(&db, "T");
+        let outer = create_typevar(&db, "U");
+        let builder = ConstraintSetBuilder::new();
+        let int = known_instance(&db, KnownClass::Int);
+        let str = known_instance(&db, KnownClass::Str);
+
+        let relation = ConstraintSet::constrain_typevar_lower_bound(&db, &builder, source, int)
+            .and(&db, &builder, || {
+                ConstraintSet::constrain_typevar_upper_bound(
+                    &db,
+                    &builder,
+                    source,
+                    Type::TypeVar(target),
+                )
+            });
+        let assumptions = ConstraintSet::constrain_typevar(&db, &builder, outer, str, str);
+        let projected = relation
+            .try_exists_assuming(&db, &builder, typevar_set(&db, [source]), assumptions)
+            .expect("independent assumptions do not affect projection");
+        let expected = ConstraintSet::constrain_typevar_lower_bound(&db, &builder, target, int)
+            .and(&db, &builder, || assumptions);
+
+        assert!(
+            projected
+                .iff(&db, &builder, expected)
+                .is_always_satisfied(&db)
+        );
+        assert!(matches!(
+            relation.try_exists_assuming(
+                &db,
+                &builder,
+                typevar_set(&db, [source]),
+                ConstraintSet::constrain_typevar(&db, &builder, source, int, int),
+            ),
+            Err(ConstraintProjectionError::ProjectedTypeVarInAssumption)
+        ));
+    }
+
+    #[test]
+    fn fallible_projection_is_independent_of_variable_order() {
+        let db = setup_db();
+        let first = create_typevar(&db, "S");
+        let second = create_typevar(&db, "R");
+        let target = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let int = known_instance(&db, KnownClass::Int);
+        let str = known_instance(&db, KnownClass::Str);
+
+        let bounded_by_target = |typevar| {
+            ConstraintSet::constrain_typevar_upper_bound(
+                &db,
+                &builder,
+                typevar,
+                Type::TypeVar(target),
+            )
+        };
+        let relation = ConstraintSet::constrain_typevar_lower_bound(&db, &builder, first, int)
+            .and(&db, &builder, || bounded_by_target(first))
+            .and(&db, &builder, || {
+                ConstraintSet::constrain_typevar_lower_bound(&db, &builder, second, str)
+            })
+            .and(&db, &builder, || bounded_by_target(second));
+
+        let project = |typevars| {
+            relation
+                .try_exists_assuming(&db, &builder, typevars, ConstraintSet::always(&builder))
+                .expect("bare relations are exactly projectable")
+        };
+        let forward = project(typevar_set(&db, [first, second]));
+        let reverse = project(typevar_set(&db, [second, first]));
+
+        assert!(forward.iff(&db, &builder, reverse).is_always_satisfied(&db));
     }
 
     /// Double negation of a TDD with uncertain branches is semantically equivalent to the

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -343,6 +343,16 @@ fn contains_protocol(db: &dyn Db, ty: Type<'_>) -> bool {
     any_over_type(db, ty, false, |nested| {
         matches!(nested, Type::ProtocolInstance(_))
             || matches!(nested, Type::NominalInstance(instance) if instance.class(db).is_protocol(db))
+            || matches!(nested, Type::ClassLiteral(class) if class.is_protocol(db))
+            || matches!(nested, Type::GenericAlias(alias) if alias.origin(db).is_protocol(db))
+            || matches!(
+                nested,
+                Type::SubclassOf(subclass)
+                    if subclass
+                        .subclass_of()
+                        .into_class(db)
+                        .is_some_and(|class| class.is_protocol(db))
+            )
     })
 }
 
@@ -8065,6 +8075,33 @@ mod tests {
                 &builder,
                 source_locals,
                 nominal_relation,
+            ),
+            Err(ConstraintProjectionError::OpaqueProtocol)
+        ));
+
+        let protocol_class_object = protocol_instance.to_meta_type(&db);
+        assert!(matches!(protocol_class_object, Type::SubclassOf(_)));
+        let class_object_relation = ConstraintSet::constrain_typevar_lower_bound(
+            &db,
+            &builder,
+            target,
+            protocol_class_object,
+        );
+        assert!(matches!(
+            class_object_relation.try_exists_assuming(
+                &db,
+                &builder,
+                source_locals,
+                ConstraintSet::always(&builder),
+            ),
+            Err(ConstraintProjectionError::OpaqueProtocol)
+        ));
+        assert!(matches!(
+            ConstraintSet::always(&builder).try_exists_assuming(
+                &db,
+                &builder,
+                source_locals,
+                class_object_relation,
             ),
             Err(ConstraintProjectionError::OpaqueProtocol)
         ));

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -320,8 +320,14 @@ impl OwnedConstraintSetInner<'_> {
 pub(crate) enum ConstraintProjectionError {
     /// A projected variable occurs inside a type-level bound that cannot yet be preserved.
     NestedTypeVarRelation,
+    /// A type alias might conceal a projected variable.
+    OpaqueTypeAlias,
     /// An assumption mentions a variable that the projection removes.
     ProjectedTypeVarInAssumption,
+}
+
+fn contains_type_alias(db: &dyn Db, ty: Type<'_>) -> bool {
+    any_over_type(db, ty, false, |nested| matches!(nested, Type::TypeAlias(_)))
 }
 
 /// A set of constraints under which a type property holds.
@@ -595,7 +601,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// type-level relationship that the constraint representation cannot preserve exactly.
     /// `assumptions` must not mention any variable in `to_remove`; because they are independent of
     /// those variables, they are conjoined only after projection and remain factored during the
-    /// abstraction traversal.
+    /// abstraction traversal. Type aliases are rejected conservatively because their opaque values
+    /// might contain a projected variable.
     #[cfg_attr(
         not(test),
         expect(
@@ -621,6 +628,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
             })
         };
         let mut assumption_mentions_projected = false;
+        let mut assumption_contains_alias = false;
         assumptions
             .node
             .for_each_unique_constraint(builder, &mut |constraint, _| {
@@ -628,7 +636,18 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                 assumption_mentions_projected |= constraint.typevar.is_inferable(db, to_remove)
                     || constraint.bounds.lower.is_some_and(type_mentions_projected)
                     || constraint.bounds.upper.is_some_and(type_mentions_projected);
+                assumption_contains_alias |= constraint
+                    .bounds
+                    .lower
+                    .is_some_and(|ty| contains_type_alias(db, ty))
+                    || constraint
+                        .bounds
+                        .upper
+                        .is_some_and(|ty| contains_type_alias(db, ty));
             });
+        if assumption_contains_alias {
+            return Err(ConstraintProjectionError::OpaqueTypeAlias);
+        }
         if assumption_mentions_projected {
             return Err(ConstraintProjectionError::ProjectedTypeVarInAssumption);
         }
@@ -4214,6 +4233,9 @@ impl InteriorNode {
                     .into_iter()
                     .chain(constraint.bounds.upper)
                 {
+                    if contains_type_alias(db, bound) {
+                        return Err(ConstraintProjectionError::OpaqueTypeAlias);
+                    }
                     if subject_is_removed {
                         if bound.as_typevar().is_none() && contains_any_typevar(bound) {
                             return Err(ConstraintProjectionError::NestedTypeVarRelation);
@@ -7153,9 +7175,13 @@ mod tests {
 
     use indoc::indoc;
     use pretty_assertions::assert_eq;
+    use ruff_db::system::DbWithWritableSystem;
 
-    use crate::db::tests::setup_db;
-    use crate::types::{BoundTypeVarInstance, KnownClass, TypeVarVariance};
+    use crate::db::tests::{TestDb, setup_db};
+    use crate::place::global_symbol;
+    use crate::types::{
+        BoundTypeVarInstance, KnownClass, KnownInstanceType, TypeAliasType, TypeVarVariance,
+    };
     use ruff_python_ast::name::Name;
 
     fn create_typevar<'db>(db: &'db dyn Db, name: &'static str) -> BoundTypeVarInstance<'db> {
@@ -7187,6 +7213,19 @@ mod tests {
 
     fn known_instance(db: &dyn Db, class: KnownClass) -> Type<'_> {
         class.to_instance(db)
+    }
+
+    fn identity_alias<'db>(db: &'db TestDb, argument: Type<'db>) -> Type<'db> {
+        let module = ruff_db::files::system_path_to_file(db, "/src/alias.py").unwrap();
+        let alias = global_symbol(db, module, "Identity").place.expect_type();
+        let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias))) =
+            alias
+        else {
+            panic!("expected `Identity` to be a PEP 695 type alias");
+        };
+        Type::TypeAlias(TypeAliasType::PEP695(
+            alias.apply_specialization(db, |context| context.specialize(db, &[argument])),
+        ))
     }
 
     #[test]
@@ -7767,6 +7806,44 @@ mod tests {
                 ConstraintSet::always(&builder),
             ),
             Err(ConstraintProjectionError::NestedTypeVarRelation)
+        ));
+    }
+
+    #[test]
+    fn fallible_projection_rejects_opaque_aliases() {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/alias.py",
+            r#"
+            type Identity[T] = T
+            "#,
+        )
+        .unwrap();
+        let source = create_typevar(&db, "S");
+        let target = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let alias_of_source = identity_alias(&db, Type::TypeVar(source));
+        let alias_relation =
+            ConstraintSet::constrain_typevar_lower_bound(&db, &builder, target, alias_of_source);
+        let source_locals = typevar_set(&db, [source]);
+
+        assert!(matches!(
+            alias_relation.try_exists_assuming(
+                &db,
+                &builder,
+                source_locals,
+                ConstraintSet::always(&builder),
+            ),
+            Err(ConstraintProjectionError::OpaqueTypeAlias)
+        ));
+        assert!(matches!(
+            ConstraintSet::always(&builder).try_exists_assuming(
+                &db,
+                &builder,
+                source_locals,
+                alias_relation,
+            ),
+            Err(ConstraintProjectionError::OpaqueTypeAlias)
         ));
     }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -109,8 +109,8 @@ use crate::types::visitor::{
     TypeCollector, TypeVisitor, any_over_type, walk_type_with_recursion_guard,
 };
 use crate::types::{
-    BoundTypeVarInstance, IntersectionType, Type, TypeVarBoundOrConstraints, TypeVarVariance,
-    UnionType,
+    BoundTypeVarInstance, IntersectionType, KnownInstanceType, Type, TypeVarBoundOrConstraints,
+    TypeVarVariance, UnionType,
 };
 use crate::{Db, FxIndexMap, FxIndexSet, FxOrderSet};
 
@@ -329,7 +329,12 @@ pub(crate) enum ConstraintProjectionError {
 }
 
 fn contains_type_alias(db: &dyn Db, ty: Type<'_>) -> bool {
-    any_over_type(db, ty, false, |nested| matches!(nested, Type::TypeAlias(_)))
+    any_over_type(db, ty, false, |nested| {
+        matches!(
+            nested,
+            Type::TypeAlias(_) | Type::KnownInstance(KnownInstanceType::TypeAliasType(_))
+        )
+    })
 }
 
 /// A set of constraints under which a type property holds.
@@ -7271,7 +7276,7 @@ mod tests {
         class.to_instance(db)
     }
 
-    fn identity_alias<'db>(db: &'db TestDb, argument: Type<'db>) -> Type<'db> {
+    fn specialized_identity_alias<'db>(db: &'db TestDb, argument: Type<'db>) -> TypeAliasType<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/alias.py").unwrap();
         let alias = global_symbol(db, module, "Identity").place.expect_type();
         let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias))) =
@@ -7279,9 +7284,9 @@ mod tests {
         else {
             panic!("expected `Identity` to be a PEP 695 type alias");
         };
-        Type::TypeAlias(TypeAliasType::PEP695(
+        TypeAliasType::PEP695(
             alias.apply_specialization(db, |context| context.specialize(db, &[argument])),
-        ))
+        )
     }
 
     #[test]
@@ -7909,29 +7914,38 @@ mod tests {
         let source = create_typevar(&db, "S");
         let target = create_typevar(&db, "T");
         let builder = ConstraintSetBuilder::new();
-        let alias_of_source = identity_alias(&db, Type::TypeVar(source));
-        let alias_relation =
-            ConstraintSet::constrain_typevar_lower_bound(&db, &builder, target, alias_of_source);
         let source_locals = typevar_set(&db, [source]);
+        let alias = specialized_identity_alias(&db, Type::TypeVar(source));
 
-        assert!(matches!(
-            alias_relation.try_exists_assuming(
+        for alias_of_source in [
+            Type::TypeAlias(alias),
+            Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)),
+        ] {
+            let alias_relation = ConstraintSet::constrain_typevar_lower_bound(
                 &db,
                 &builder,
-                source_locals,
-                ConstraintSet::always(&builder),
-            ),
-            Err(ConstraintProjectionError::OpaqueTypeAlias)
-        ));
-        assert!(matches!(
-            ConstraintSet::always(&builder).try_exists_assuming(
-                &db,
-                &builder,
-                source_locals,
-                alias_relation,
-            ),
-            Err(ConstraintProjectionError::OpaqueTypeAlias)
-        ));
+                target,
+                alias_of_source,
+            );
+            assert!(matches!(
+                alias_relation.try_exists_assuming(
+                    &db,
+                    &builder,
+                    source_locals,
+                    ConstraintSet::always(&builder),
+                ),
+                Err(ConstraintProjectionError::OpaqueTypeAlias)
+            ));
+            assert!(matches!(
+                ConstraintSet::always(&builder).try_exists_assuming(
+                    &db,
+                    &builder,
+                    source_locals,
+                    alias_relation,
+                ),
+                Err(ConstraintProjectionError::OpaqueTypeAlias)
+            ));
+        }
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -342,6 +342,7 @@ fn contains_type_alias(db: &dyn Db, ty: Type<'_>) -> bool {
 fn contains_protocol(db: &dyn Db, ty: Type<'_>) -> bool {
     any_over_type(db, ty, false, |nested| {
         matches!(nested, Type::ProtocolInstance(_))
+            || matches!(nested, Type::NominalInstance(instance) if instance.class(db).is_protocol(db))
     })
 }
 
@@ -8003,7 +8004,9 @@ mod tests {
             .to_class_type(&db)
             .expect("expected `P` to be a class");
         let protocol = Type::instance(&db, protocol_class);
-        assert!(matches!(protocol, Type::ProtocolInstance(_)));
+        let Type::ProtocolInstance(protocol_instance) = protocol else {
+            panic!("expected `P` to be a protocol instance");
+        };
 
         let source = create_typevar(&db, "S");
         let target = create_typevar(&db, "T");
@@ -8036,6 +8039,32 @@ mod tests {
                 &builder,
                 source_locals,
                 relation,
+            ),
+            Err(ConstraintProjectionError::OpaqueProtocol)
+        ));
+
+        let nominal_protocol = Type::NominalInstance(
+            protocol_instance
+                .to_nominal_instance()
+                .expect("a class-based protocol has a nominal representation"),
+        );
+        let nominal_relation =
+            ConstraintSet::constrain_typevar_lower_bound(&db, &builder, target, nominal_protocol);
+        assert!(matches!(
+            nominal_relation.try_exists_assuming(
+                &db,
+                &builder,
+                source_locals,
+                ConstraintSet::always(&builder),
+            ),
+            Err(ConstraintProjectionError::OpaqueProtocol)
+        ));
+        assert!(matches!(
+            ConstraintSet::always(&builder).try_exists_assuming(
+                &db,
+                &builder,
+                source_locals,
+                nominal_relation,
             ),
             Err(ConstraintProjectionError::OpaqueProtocol)
         ));

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1700,33 +1700,19 @@ impl<'db> Constraint<'db> {
                 )
             }
 
-            // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
-            (Type::TypeVar(lower), Type::TypeVar(upper))
-                if typevar.can_be_bound_for(db, builder, lower)
-                    && typevar.can_be_bound_for(db, builder, upper) =>
-            {
-                let lower = Node::new_constraint(
-                    builder,
-                    ConstraintId::new_with_bounds(
-                        db,
-                        builder,
-                        lower,
-                        None,
-                        Some(Type::TypeVar(typevar)),
-                    ),
-                    1,
-                );
-                let upper = Node::new_constraint(
-                    builder,
-                    ConstraintId::new_with_bounds(
-                        db,
-                        builder,
-                        upper,
-                        Some(Type::TypeVar(typevar)),
-                        None,
-                    ),
-                    1,
-                );
+            // Keep a type-variable relationship separate from the opposite bound. Projection can
+            // then remove the relationship without also discarding the independent bound. The
+            // recursive calls orient each relationship according to the type-variable ordering.
+            //
+            // L ≤ T ≤ U == (L ≤ T) && (T ≤ U)
+            (Type::TypeVar(_), _) if upper.is_some() => {
+                let lower = Constraint::new_node_with_bounds(db, builder, typevar, lower, None);
+                let upper = Constraint::new_node_with_bounds(db, builder, typevar, None, upper);
+                lower.and(builder, upper)
+            }
+            (_, Type::TypeVar(_)) if lower.is_some() => {
+                let lower = Constraint::new_node_with_bounds(db, builder, typevar, lower, None);
+                let upper = Constraint::new_node_with_bounds(db, builder, typevar, None, upper);
                 lower.and(builder, upper)
             }
 
@@ -7689,6 +7675,63 @@ mod tests {
                 .iff(&db, &builder, expected)
                 .is_always_satisfied(&db)
         );
+    }
+
+    #[test]
+    fn fallible_projection_preserves_surviving_mixed_range_bounds() {
+        let db = setup_db();
+        let source = create_typevar(&db, "S");
+        let target = create_typevar(&db, "T");
+        let int = known_instance(&db, KnownClass::Int);
+
+        for source_first in [true, false] {
+            let builder = ConstraintSetBuilder::new();
+            if source_first {
+                builder.intern_typevar(&db, source);
+                builder.intern_typevar(&db, target);
+            } else {
+                builder.intern_typevar(&db, target);
+                builder.intern_typevar(&db, source);
+            }
+
+            let lower_relation =
+                ConstraintSet::constrain_typevar(&db, &builder, target, Type::TypeVar(source), int);
+            let projected_lower = lower_relation
+                .try_exists_assuming(
+                    &db,
+                    &builder,
+                    typevar_set(&db, [source]),
+                    ConstraintSet::always(&builder),
+                )
+                .expect("the bare lower bound can be projected exactly");
+            let expected_upper =
+                ConstraintSet::constrain_typevar_upper_bound(&db, &builder, target, int);
+
+            assert!(
+                projected_lower
+                    .iff(&db, &builder, expected_upper)
+                    .is_always_satisfied(&db)
+            );
+
+            let upper_relation =
+                ConstraintSet::constrain_typevar(&db, &builder, target, int, Type::TypeVar(source));
+            let projected_upper = upper_relation
+                .try_exists_assuming(
+                    &db,
+                    &builder,
+                    typevar_set(&db, [source]),
+                    ConstraintSet::always(&builder),
+                )
+                .expect("the bare upper bound can be projected exactly");
+            let expected_lower =
+                ConstraintSet::constrain_typevar_lower_bound(&db, &builder, target, int);
+
+            assert!(
+                projected_upper
+                    .iff(&db, &builder, expected_lower)
+                    .is_always_satisfied(&db)
+            );
+        }
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -320,6 +320,8 @@ impl OwnedConstraintSetInner<'_> {
 pub(crate) enum ConstraintProjectionError {
     /// A projected variable occurs inside a type-level bound that cannot yet be preserved.
     NestedTypeVarRelation,
+    /// A negated projected bound depends on a type variable that remains after projection.
+    NegatedTypeVarRelation,
     /// A type alias might conceal a projected variable.
     OpaqueTypeAlias,
     /// An assumption mentions a variable that the projection removes.
@@ -3172,6 +3174,33 @@ impl NodeId {
         walk(self, builder, &mut FxHashSet::default(), f);
     }
 
+    /// Returns `true` if any matching constraint has a reachable negative branch.
+    fn has_negative_branch(
+        self,
+        builder: &ConstraintSetBuilder<'_>,
+        predicate: &mut dyn FnMut(ConstraintId) -> bool,
+    ) -> bool {
+        fn walk(
+            node: NodeId,
+            builder: &ConstraintSetBuilder<'_>,
+            seen: &mut FxHashSet<NodeId>,
+            predicate: &mut dyn FnMut(ConstraintId) -> bool,
+        ) -> bool {
+            if node.is_terminal() || !seen.insert(node) {
+                return false;
+            }
+            let interior = builder.interior_node_data(node);
+            if predicate(interior.constraint) && interior.if_false != ALWAYS_FALSE {
+                return true;
+            }
+            walk(interior.if_true, builder, seen, predicate)
+                || walk(interior.if_uncertain, builder, seen, predicate)
+                || walk(interior.if_false, builder, seen, predicate)
+        }
+
+        walk(self, builder, &mut FxHashSet::default(), predicate)
+    }
+
     /// Simplifies a BDD, replacing constraints with simpler or smaller constraints where possible.
     ///
     /// TODO: [Historical note] This is now used only for display purposes, but previously was also
@@ -4218,6 +4247,33 @@ impl InteriorNode {
             })
         };
         let contains_any_typevar = |ty: Type<'db>| any_over_type(db, ty, false, Type::is_type_var);
+
+        let constraint_mentions_removed = |constraint: ConstraintId| {
+            let constraint = builder.constraint_data(constraint);
+            is_removed(constraint.typevar)
+                || constraint.bounds.lower.is_some_and(contains_removed)
+                || constraint.bounds.upper.is_some_and(contains_removed)
+        };
+        let mut relates_removed_to_surviving = false;
+        self.0
+            .for_each_unique_constraint(builder, &mut |constraint, _| {
+                let constraint = builder.constraint_data(constraint);
+                let subject_is_removed = is_removed(constraint.typevar);
+                relates_removed_to_surviving |= constraint
+                    .bounds
+                    .lower
+                    .into_iter()
+                    .chain(constraint.bounds.upper)
+                    .filter_map(Type::as_typevar)
+                    .any(|bound| subject_is_removed != is_removed(bound));
+            });
+        if relates_removed_to_surviving
+            && self.0.has_negative_branch(builder, &mut |constraint| {
+                constraint_mentions_removed(constraint)
+            })
+        {
+            return Err(ConstraintProjectionError::NegatedTypeVarRelation);
+        }
 
         self.try_abstract_one_inner(
             db,
@@ -7714,6 +7770,37 @@ mod tests {
                 .iff(&db, &builder, expected)
                 .is_always_satisfied(&db)
         );
+    }
+
+    #[test]
+    fn fallible_projection_rejects_negated_bare_relations() {
+        let db = setup_db();
+        let source = create_typevar(&db, "S");
+        let target = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let int = known_instance(&db, KnownClass::Int);
+
+        let source_is_not_above_int =
+            ConstraintSet::constrain_typevar_lower_bound(&db, &builder, source, int)
+                .negate(&db, &builder);
+        let source_equals_target = ConstraintSet::constrain_typevar(
+            &db,
+            &builder,
+            source,
+            Type::TypeVar(target),
+            Type::TypeVar(target),
+        );
+        let relation = source_is_not_above_int.and(&db, &builder, || source_equals_target);
+
+        assert!(matches!(
+            relation.try_exists_assuming(
+                &db,
+                &builder,
+                typevar_set(&db, [source]),
+                ConstraintSet::always(&builder),
+            ),
+            Err(ConstraintProjectionError::NegatedTypeVarRelation)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This builds on #26751 as the next lower-level piece of higher-rank generic signature support. Existing existential abstraction removes every constraint that mentions a projected variable and relies on the sequent map to retain derived facts. That is exact for bare relationships such as `int ≤ S ≤ T`, but it cannot report when removing `S` would discard a type-level or negated relationship.

This PR adds `ConstraintSet::try_exists_assuming`, which either projects the requested variables exactly or returns a typed `ConstraintProjectionError`. Independent assumptions remain factored until projection is complete. Mixed range constraints are normalized so the non-projected half survives regardless of type-variable ordering, and reachable negated relationships are rejected when they cannot be preserved.

Projection also rejects opaque PEP 695 aliases, runtime alias values, and class-based protocols conservatively. This includes protocol instances, nominal protocol representations, and protocol class objects, all of which can conceal projected variables behind lazy structure.

The existing infallible existential abstraction reuses the same traversal through an infallible callback, avoiding a second BDD algorithm and preserving existing behavior.

This PR is foundational only. The stacked follow-up in #26752 is the first production consumer and permits one narrowly supported shallow dependent-source relation.
