### PR TITLE
Avoid panics for invalid LSP ranges

### DIFF
--- a/crates/ruff_server/src/edit/notebook.rs
+++ b/crates/ruff_server/src/edit/notebook.rs
@@ -183,7 +183,7 @@ impl NotebookDocument {
                         self.cell_by_uri_mut(&content_change.document.text_document_identifier.uri)
                     {
                         cell.document
-                            .apply_changes(content_change.changes, version, encoding);
+                            .apply_changes(content_change.changes, version, encoding)?;
                     }
                 }
             }

--- a/crates/ruff_server/src/edit/range.rs
+++ b/crates/ruff_server/src/edit/range.rs
@@ -4,7 +4,7 @@ use lsp_types as types;
 use ruff_notebook::NotebookIndex;
 use ruff_source_file::LineIndex;
 use ruff_source_file::{OneIndexed, SourceLocation};
-use ruff_text_size::TextRange;
+use ruff_text_size::{TextRange, TextSize};
 
 pub(crate) struct NotebookRange {
     pub(crate) cell: notebook::CellId,
@@ -12,8 +12,12 @@ pub(crate) struct NotebookRange {
 }
 
 pub(crate) trait RangeExt {
-    fn to_text_range(&self, text: &str, index: &LineIndex, encoding: PositionEncoding)
-    -> TextRange;
+    fn to_text_range(
+        &self,
+        text: &str,
+        index: &LineIndex,
+        encoding: PositionEncoding,
+    ) -> Result<TextRange, PositionError>;
 }
 
 pub(crate) trait ToRangeExt {
@@ -31,35 +35,107 @@ fn u32_index_to_usize(index: u32) -> usize {
     usize::try_from(index).expect("u32 fits in usize")
 }
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PositionError {
+    #[error("line {line} is out of bounds")]
+    LineOutOfBounds { line: u32 },
+    #[error("character {character} is not a valid {encoding:?} position on line {line}")]
+    InvalidCharacter {
+        line: u32,
+        character: u32,
+        encoding: PositionEncoding,
+    },
+    #[error("range start must not be after its end")]
+    ReversedRange,
+}
+
 impl RangeExt for lsp_types::Range {
     fn to_text_range(
         &self,
         text: &str,
         index: &LineIndex,
         encoding: PositionEncoding,
-    ) -> TextRange {
-        let start = index.offset(
-            SourceLocation {
-                line: OneIndexed::from_zero_indexed(u32_index_to_usize(self.start.line)),
-                character_offset: OneIndexed::from_zero_indexed(u32_index_to_usize(
-                    self.start.character,
-                )),
-            },
-            text,
-            encoding.into(),
-        );
-        let end = index.offset(
-            SourceLocation {
-                line: OneIndexed::from_zero_indexed(u32_index_to_usize(self.end.line)),
-                character_offset: OneIndexed::from_zero_indexed(u32_index_to_usize(
-                    self.end.character,
-                )),
-            },
-            text,
-            encoding.into(),
-        );
+    ) -> Result<TextRange, PositionError> {
+        let start = position_to_offset(self.start, text, index, encoding)?;
+        let end = position_to_offset(self.end, text, index, encoding)?;
 
-        TextRange::new(start, end)
+        if start > end {
+            return Err(PositionError::ReversedRange);
+        }
+
+        Ok(TextRange::new(start, end))
+    }
+}
+
+fn position_to_offset(
+    position: types::Position,
+    text: &str,
+    index: &LineIndex,
+    encoding: PositionEncoding,
+) -> Result<TextSize, PositionError> {
+    let line_index = u32_index_to_usize(position.line);
+    if line_index >= index.line_count() {
+        return Err(PositionError::LineOutOfBounds {
+            line: position.line,
+        });
+    }
+
+    let line = OneIndexed::from_zero_indexed(line_index);
+    let line_start = index.line_start(line, text);
+    let line_end = index.line_end_exclusive(line, text);
+    let text_on_line = &text[usize::from(line_start)..usize::from(line_end)];
+    let character = u32_index_to_usize(position.character);
+
+    let byte_offset = match encoding {
+        PositionEncoding::UTF8 => {
+            if character > text_on_line.len() || !text_on_line.is_char_boundary(character) {
+                return Err(PositionError::InvalidCharacter {
+                    line: position.line,
+                    character: position.character,
+                    encoding,
+                });
+            }
+            character
+        }
+        PositionEncoding::UTF16 => offset_for_encoded_character(
+            text_on_line,
+            character,
+            char::len_utf16,
+            position,
+            encoding,
+        )?,
+        PositionEncoding::UTF32 => {
+            offset_for_encoded_character(text_on_line, character, |_| 1, position, encoding)?
+        }
+    };
+
+    Ok(line_start + TextSize::try_from(byte_offset).expect("line offset fits in TextSize"))
+}
+
+fn offset_for_encoded_character(
+    text: &str,
+    character: usize,
+    encoded_len: impl Fn(char) -> usize,
+    position: types::Position,
+    encoding: PositionEncoding,
+) -> Result<usize, PositionError> {
+    let mut encoded_offset = 0;
+
+    for (byte_offset, current) in text.char_indices() {
+        if encoded_offset == character {
+            return Ok(byte_offset);
+        }
+        encoded_offset += encoded_len(current);
+    }
+
+    if encoded_offset == character {
+        Ok(text.len())
+    } else {
+        Err(PositionError::InvalidCharacter {
+            line: position.line,
+            character: position.character,
+            encoding,
+        })
     }
 }
 

--- a/crates/ruff_server/src/edit/text_document.rs
+++ b/crates/ruff_server/src/edit/text_document.rs
@@ -86,7 +86,7 @@ impl TextDocument {
         changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
         new_version: DocumentVersion,
         encoding: PositionEncoding,
-    ) {
+    ) -> crate::Result<()> {
         if let [
             TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
                 TextDocumentContentChangeWholeDocument { text },
@@ -98,7 +98,7 @@ impl TextDocument {
                 contents.clone_from(text);
                 *version = new_version;
             });
-            return;
+            return Ok(());
         }
 
         let mut new_contents = self.contents().to_string();
@@ -109,7 +109,7 @@ impl TextDocument {
                 TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
                     TextDocumentContentChangePartial { range, text, .. },
                 ) => {
-                    let range = range.to_text_range(&new_contents, &active_index, encoding);
+                    let range = range.to_text_range(&new_contents, &active_index, encoding)?;
 
                     new_contents
                         .replace_range(usize::from(range.start())..usize::from(range.end()), &text);
@@ -129,6 +129,8 @@ impl TextDocument {
             *contents = new_contents;
             *version = new_version;
         });
+
+        Ok(())
     }
 
     pub fn update_version(&mut self, new_version: DocumentVersion) {
@@ -180,33 +182,35 @@ def interface():
         );
 
         // Add an `s`, remove it again (back to the original code), and then re-add the `s`
-        document.apply_changes(
-            vec![
-                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
-                    TextDocumentContentChangePartial {
-                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
-                        text: "s".to_string(),
-                        ..Default::default()
-                    },
-                ),
-                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
-                    TextDocumentContentChangePartial {
-                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 8)),
-                        text: String::new(),
-                        ..Default::default()
-                    },
-                ),
-                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
-                    TextDocumentContentChangePartial {
-                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
-                        text: "s".to_string(),
-                        ..Default::default()
-                    },
-                ),
-            ],
-            1,
-            PositionEncoding::UTF16,
-        );
+        document
+            .apply_changes(
+                vec![
+                    TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                        TextDocumentContentChangePartial {
+                            range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
+                            text: "s".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                        TextDocumentContentChangePartial {
+                            range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 8)),
+                            text: String::new(),
+                            ..Default::default()
+                        },
+                    ),
+                    TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                        TextDocumentContentChangePartial {
+                            range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
+                            text: "s".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                ],
+                1,
+                PositionEncoding::UTF16,
+            )
+            .unwrap();
 
         assert_eq!(
             &document.contents,

--- a/crates/ruff_server/src/server/api/requests/format_range.rs
+++ b/crates/ruff_server/src/server/api/requests/format_range.rs
@@ -78,7 +78,9 @@ fn format_text_document_range(
 
     let text = text_document.contents();
     let index = text_document.index();
-    let range = range.to_text_range(text, index, encoding);
+    let range = range
+        .to_text_range(text, index, encoding)
+        .with_failure_code(lsp_server::ErrorCode::InvalidParams)?;
     let formatted_range = crate::format::format_range(
         text_document,
         source_type,

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -62,6 +62,9 @@ pub(crate) fn hover(
         .line
         .try_into()
         .expect("line number should fit within a usize");
+    if line_number >= document.index().line_count() {
+        return None;
+    }
     let line_range = document.index().line_range(
         OneIndexed::from_zero_indexed(line_number),
         document.contents(),
@@ -74,6 +77,7 @@ pub(crate) fn hover(
 
     let cursor = types::Range::new(position.position, position.position)
         .to_text_range(document.contents(), document.index(), snapshot.encoding())
+        .ok()?
         .start();
     let parsed = parse_unchecked_source(document.contents(), source_type);
     let comment = parsed

--- a/crates/ruff_server/src/session/index.rs
+++ b/crates/ruff_server/src/session/index.rs
@@ -119,7 +119,7 @@ impl Index {
             return Ok(());
         }
 
-        document.apply_changes(content_changes, new_version, encoding);
+        document.apply_changes(content_changes, new_version, encoding)?;
 
         Ok(())
     }

--- a/crates/ruff_server/tests/document.rs
+++ b/crates/ruff_server/tests/document.rs
@@ -93,8 +93,86 @@ fn delete_lines_pandas_html() {
     ];
 
     for (version, change) in (2..).zip(changes) {
-        document.apply_changes(vec![change], version, PositionEncoding::UTF16);
+        document
+            .apply_changes(vec![change], version, PositionEncoding::UTF16)
+            .unwrap();
     }
 
     insta::assert_snapshot!(document.contents());
+}
+
+#[test]
+fn rejects_reversed_changes() {
+    let mut document = TextDocument::new("abc".to_string(), 1);
+
+    let result = document.apply_changes(
+        vec![
+            TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                TextDocumentContentChangePartial {
+                    range: Range::new(Position::new(0, 2), Position::new(0, 1)),
+                    text: String::new(),
+                    ..Default::default()
+                },
+            ),
+        ],
+        2,
+        PositionEncoding::UTF16,
+    );
+
+    assert!(result.is_err());
+    assert_eq!(document.contents(), "abc");
+    assert_eq!(document.version(), 1);
+}
+
+#[test]
+fn rejects_utf8_changes_inside_characters() {
+    let mut document = TextDocument::new("é".to_string(), 1);
+
+    let result = document.apply_changes(
+        vec![
+            TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                TextDocumentContentChangePartial {
+                    range: Range::new(Position::new(0, 1), Position::new(0, 1)),
+                    text: "x".to_string(),
+                    ..Default::default()
+                },
+            ),
+        ],
+        2,
+        PositionEncoding::UTF8,
+    );
+
+    assert!(result.is_err());
+    assert_eq!(document.contents(), "é");
+    assert_eq!(document.version(), 1);
+}
+
+#[test]
+fn rejects_invalid_changes_without_committing_preceding_changes() {
+    let mut document = TextDocument::new("é".to_string(), 1);
+
+    let result = document.apply_changes(
+        vec![
+            TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                TextDocumentContentChangePartial {
+                    range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+                    text: "x".to_string(),
+                    ..Default::default()
+                },
+            ),
+            TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                TextDocumentContentChangePartial {
+                    range: Range::new(Position::new(0, 2), Position::new(0, 2)),
+                    text: "y".to_string(),
+                    ..Default::default()
+                },
+            ),
+        ],
+        2,
+        PositionEncoding::UTF8,
+    );
+
+    assert!(result.is_err());
+    assert_eq!(document.contents(), "é");
+    assert_eq!(document.version(), 1);
 }


### PR DESCRIPTION
## Summary
- validate LSP positions before converting them to text ranges
- reject reversed and non-character-boundary ranges instead of panicking
- keep document updates unchanged when a batch contains an invalid edit

## Related
- #26768

## Testing
- CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_DEV_OPT_LEVEL=1 cargo test -p ruff_server
- CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_DEV_OPT_LEVEL=1 cargo clippy -p ruff_server --lib -- -D warnings
- uv run --only-group dev --locked prek run --files crates/ruff_server/src/edit/notebook.rs crates/ruff_server/src/edit/range.rs crates/ruff_server/src/edit/text_document.rs crates/ruff_server/src/server/api/requests/format_range.rs crates/ruff_server/src/server/api/requests/hover.rs crates/ruff_server/src/session/index.rs crates/ruff_server/tests/document.rs