### PR TITLE
[ty] Avoid broad invalidation from file check eligibility

### DIFF
--- a/crates/ty_ide/src/hints.rs
+++ b/crates/ty_ide/src/hints.rs
@@ -41,7 +41,7 @@ impl HintKind {
 }
 
 pub fn hints(db: &dyn Db, file: File) -> Vec<Hint> {
-    if !db.project().should_check_file(db, file) {
+    if !db.should_check_file(file) {
         return Vec::new();
     }
 

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -175,7 +175,7 @@ impl ProjectDatabase {
 
     #[tracing::instrument(level = "debug", skip(self))]
     pub fn check_file(&self, file: File) -> Vec<Diagnostic> {
-        self.project().check_file(self, file)
+        crate::check_file(self, file)
     }
 
     /// Set the check mode for the project.
@@ -560,8 +560,14 @@ impl SemanticDb for ProjectDatabase {
 #[salsa::db]
 impl ty_python_core::Db for ProjectDatabase {
     fn should_check_file(&self, file: File) -> bool {
-        self.project
-            .is_some_and(|project| project.should_check_file(self, file))
+        let path = file.path(self);
+        if path.is_vendored_path() {
+            tracing::trace!("Not checking {path} because it is a vendored path");
+            false
+        } else {
+            self.project
+                .is_some_and(|_| crate::should_check_file(self, file))
+        }
     }
 }
 
@@ -754,7 +760,13 @@ pub(crate) mod testing {
     #[salsa::db]
     impl ty_python_core::Db for TestDb {
         fn should_check_file(&self, file: ruff_db::files::File) -> bool {
-            !file.path(self).is_vendored_path()
+            let path = file.path(self);
+            if path.is_vendored_path() {
+                tracing::trace!("Not checking {path} because it is a vendored path");
+                false
+            } else {
+                crate::should_check_file(self, file)
+            }
         }
     }
 
@@ -762,7 +774,7 @@ pub(crate) mod testing {
     impl ty_python_semantic::Db for TestDb {
         #[inline]
         fn check_file(&self, file: File) -> Vec<Diagnostic> {
-            self.project().check_file(self, file)
+            crate::check_file(self, file)
         }
 
         fn rule_selection(&self, _file: ruff_db::files::File) -> &RuleSelection {

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -560,14 +560,13 @@ impl SemanticDb for ProjectDatabase {
 #[salsa::db]
 impl ty_python_core::Db for ProjectDatabase {
     fn should_check_file(&self, file: File) -> bool {
-        let path = file.path(self);
-        if path.is_vendored_path() {
-            tracing::trace!("Not checking {path} because it is a vendored path");
-            false
-        } else {
-            self.project
-                .is_some_and(|_| crate::should_check_file(self, file))
+        // Avoid creating a dependency on the `should_check_file` query for vendored files.
+        if file.path(self).is_vendored_path() {
+            return false;
         }
+
+        self.project
+            .is_some_and(|_| crate::should_check_file(self, file))
     }
 }
 
@@ -760,13 +759,7 @@ pub(crate) mod testing {
     #[salsa::db]
     impl ty_python_core::Db for TestDb {
         fn should_check_file(&self, file: ruff_db::files::File) -> bool {
-            let path = file.path(self);
-            if path.is_vendored_path() {
-                tracing::trace!("Not checking {path} because it is a vendored path");
-                false
-            } else {
-                crate::should_check_file(self, file)
-            }
+            crate::should_check_file(self, file)
         }
     }
 

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -423,16 +423,6 @@ impl Project {
         );
     }
 
-    pub(crate) fn check_file(self, db: &dyn Db, file: File) -> Vec<Diagnostic> {
-        if !self.should_check_file(db, file) {
-            return Vec::new();
-        }
-
-        check_file_impl(db, file)
-            .map(<[Diagnostic]>::to_vec)
-            .unwrap_or_else(|diagnostic| vec![diagnostic.clone()])
-    }
-
     /// Opens a file in the project.
     pub fn open_file(self, db: &mut dyn Db, file: File) {
         tracing::debug!("Opening file `{}`", file.path(db));
@@ -517,78 +507,6 @@ impl Project {
         // Salsa will cancel any pending queries and remove its own reference to `open_files`
         // so that the reference counter to `open_files` now drops to 1.
         self.set_open_fileset(db).to(FxHashSet::default())
-    }
-
-    /// Returns `true` if the file should be checked.
-    ///
-    /// This depends on the project's check mode:
-    /// * For [`OpenFiles`], it checks if the file is either explicitly set as an open file using
-    ///   [`open_file`] or a system virtual path
-    /// * For [`AllFiles`], it checks if the file is either a system virtual path or a part of the
-    ///   indexed files in the project
-    ///
-    /// [`open_file`]: Self::open_file
-    /// [`OpenFiles`]: CheckMode::OpenFiles
-    /// [`AllFiles`]: CheckMode::AllFiles
-    pub fn should_check_file(self, db: &dyn Db, file: File) -> bool {
-        let path = file.path(db);
-
-        // NOTE: The tracing messages below were added because
-        // whether a file should be checked or not can sometimes
-        // be at the root of confusing UX like "diagnostics all
-        // of a sudden stopped working." Having a trace message
-        // indicating *why* a particular file isn't being checked
-        // can be quite helpful for narrowing down the issue.
-        //
-        // The problem is that it's incredibly noisy. Which is why
-        // we set them to the TRACE level.
-
-        // Try to return early to avoid adding a dependency on `open_files` or `file_set` which
-        // both have a durability of `LOW`.
-        if path.is_vendored_path() {
-            tracing::trace!("Not checking {path} because it is a vendored path");
-            return false;
-        }
-
-        match self.check_mode(db) {
-            CheckMode::OpenFiles => {
-                let should_check = self.open_files(db).contains(&file);
-                if !should_check {
-                    tracing::trace!(
-                        "Not checking {path} because check mode is `OpenFiles` \
-                         and it is not in the open file set"
-                    );
-                }
-                should_check
-            }
-            CheckMode::AllFiles => {
-                // Virtual files are always checked.
-                //
-                // We also check the open file set. In theory, we
-                // shouldn't need to do this since it is accounted for
-                // by the virtual file check (for the case when a file
-                // wants to be checked but isn't saved to disk yet).
-                // However, not all clients follow the LSP convention
-                // that URIs for documents not on disk yet use the
-                // `untitled://...` scheme. That is, we assume that a
-                // `file://...` scheme corresponds to a saved file on
-                // disk, and anything else is "virtual." For example,
-                // neovim uses `file://...` even for an open buffer
-                // that does not correspond to a file saved to disk
-                // yet.
-                let should_check = path.is_system_virtual_path()
-                    || self.files(db).contains(&file)
-                    || self.open_files(db).contains(&file);
-                if !should_check {
-                    tracing::trace!(
-                        "Not checking {path} because check mode is `AllFiles` \
-                         and it is not a virtual path, in the project files \
-                         or in the open file set"
-                    );
-                }
-                should_check
-            }
-        }
     }
 
     #[tracing::instrument(level = "debug", skip(self, db))]
@@ -724,6 +642,94 @@ impl Project {
             .iter()
             .map(OptionDiagnostic::to_diagnostic)
             .collect()
+    }
+}
+
+pub(crate) fn check_file(db: &dyn Db, file: File) -> Vec<Diagnostic> {
+    if !db.should_check_file(file) {
+        return Vec::new();
+    }
+
+    check_file_impl(db, file)
+        .map(<[Diagnostic]>::to_vec)
+        .unwrap_or_else(|diagnostic| vec![diagnostic.clone()])
+}
+
+/// Returns `true` if the file should be checked.
+///
+/// This depends on the project's check mode:
+/// * For [`CheckMode::OpenFiles`], it checks if the file is explicitly in the open file set.
+/// * For [`CheckMode::AllFiles`], it checks if the file is virtual, indexed in the project, or in
+///   the open file set.
+///
+/// This query provides a per-file backdating boundary around the project-wide file sets. Updating
+/// either set still revalidates this query, but unchanged results are backdated before invalidation
+/// reaches semantic-index and type-inference queries.
+#[salsa::tracked]
+pub(crate) fn should_check_file(db: &dyn Db, file: File) -> bool {
+    let project = db.project();
+    let path = file.path(db);
+
+    // NOTE: The tracing messages below were added because whether a file should be checked or not
+    // can sometimes be at the root of confusing UX like "diagnostics all of a sudden stopped
+    // working." Having a trace message indicating why a particular file isn't being checked can
+    // be quite helpful for narrowing down the issue. The messages are at TRACE because they are
+    // extremely noisy.
+
+    // Avoid depending on the indexed and open file sets for files that aren't included in the
+    // project. Both sets change frequently, and a dependency on either invalidates this query when
+    // any file is added or removed. Virtual paths bypass this check because they don't have a
+    // system path.
+    // Descendants of an explicitly included directory need to fall through to the indexed file
+    // set. Explicit CLI paths override exclusions unless `--force-exclude` is set, but the ad-hoc
+    // inclusion check still applies those exclusions.
+    if path.as_system_path().is_some_and(|path| {
+        !project.is_file_included(db, path).is_included()
+            && !project
+                .included_paths_list(db)
+                .iter()
+                .any(|included| path.starts_with(included))
+    }) {
+        tracing::trace!("Not checking {path} because it is not included in the project");
+        return false;
+    }
+
+    match project.check_mode(db) {
+        CheckMode::OpenFiles => {
+            let should_check = project.open_files(db).contains(&file);
+            if !should_check {
+                tracing::trace!(
+                    "Not checking {path} because check mode is `OpenFiles` \
+                     and it is not in the open file set"
+                );
+            }
+            should_check
+        }
+        CheckMode::AllFiles => {
+            // Virtual files are always checked.
+            //
+            // We also check the open file set. In theory, we shouldn't need to do this since it is
+            // accounted for by the virtual file check (for the case when a file wants to be checked
+            // but isn't saved to disk yet). However, not all clients follow the LSP convention that
+            // URIs for documents not on disk yet use the `untitled://...` scheme. That is, we assume
+            // that a `file://...` scheme corresponds to a saved file on disk, and anything else is
+            // "virtual." For example, neovim uses `file://...` even for an open buffer that does not
+            // correspond to a file saved to disk yet.
+            if path.is_system_virtual_path() {
+                return true;
+            }
+
+            let should_check =
+                project.files(db).contains(&file) || project.open_files(db).contains(&file);
+            if !should_check {
+                tracing::trace!(
+                    "Not checking {path} because check mode is `AllFiles` \
+                     and it is not a virtual path, in the project files \
+                     or in the open file set"
+                );
+            }
+            should_check
+        }
     }
 }
 
@@ -885,10 +891,11 @@ mod tests {
     use crate::db::Db as _;
     use crate::db::testing::TestDb;
     use crate::{IncludeResult, ProjectMetadata};
-    use ruff_db::files::system_path_to_file;
+    use ruff_db::Db as _;
+    use ruff_db::files::{FileRootKind, system_path_to_file};
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
-    use ruff_db::testing::assert_function_query_was_not_run;
+    use ruff_db::testing::{assert_function_query_was_not_run, find_will_execute_event_by_name};
     use ty_python_semantic::types::check_types;
 
     #[test]
@@ -952,5 +959,56 @@ mod tests {
                 literal_match: Some(true)
             }
         );
+    }
+
+    #[test]
+    fn third_party_type_inference_with_diagnostic_has_medium_durability()
+    -> ruff_db::system::Result<()> {
+        let project_root = SystemPathBuf::from("/project");
+        let third_party_root = SystemPathBuf::from("/site-packages");
+        let dependency_path = third_party_root.join("dependency.py");
+        let project = ProjectMetadata::new("test", project_root.clone());
+        let mut db = TestDb::new(project);
+        db.memory_file_system()
+            .create_directory_all(&project_root)?;
+        db.init_program().unwrap();
+        db.files()
+            .try_add_root(&db, &third_party_root, FileRootKind::SearchPath);
+
+        db.write_file(&dependency_path, "value: int = \"wrong\"")?;
+        let dependency = system_path_to_file(&db, &dependency_path).unwrap();
+        assert!(check_types(&db, dependency).is_empty());
+        db.take_salsa_events();
+
+        // Opening a project file is a LOW-durability change. It shouldn't require re-executing
+        // type inference for a third-party dependency.
+        let project_file_path = project_root.join("main.py");
+        db.write_file(&project_file_path, "")?;
+        let project_file = system_path_to_file(&db, &project_file_path).unwrap();
+        db.project().open_file(&mut db, project_file);
+        db.take_salsa_events();
+
+        check_types(&db, dependency);
+        let events = db.take_salsa_events();
+        assert!(
+            find_will_execute_event_by_name(&db, "infer_scope_types_impl", None, &events).is_none(),
+            "Third-party type inference unexpectedly ran after a LOW-durability change: \
+             {events:#?}"
+        );
+
+        // Changing the included paths has MEDIUM durability and makes the dependency eligible for
+        // checking, so its type inference must be recomputed to emit the diagnostic.
+        db.project()
+            .set_included_paths(&mut db, vec![dependency_path]);
+        db.take_salsa_events();
+
+        assert_eq!(check_types(&db, dependency).len(), 1);
+        let events = db.take_salsa_events();
+        assert!(
+            find_will_execute_event_by_name(&db, "infer_scope_types_impl", None, &events).is_some(),
+            "Third-party type inference didn't run after a MEDIUM-durability change: {events:#?}"
+        );
+
+        Ok(())
     }
 }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -676,24 +676,6 @@ pub(crate) fn should_check_file(db: &dyn Db, file: File) -> bool {
     // be quite helpful for narrowing down the issue. The messages are at TRACE because they are
     // extremely noisy.
 
-    // Avoid depending on the indexed and open file sets for files that aren't included in the
-    // project. Both sets change frequently, and a dependency on either invalidates this query when
-    // any file is added or removed. Virtual paths bypass this check because they don't have a
-    // system path.
-    // Descendants of an explicitly included directory need to fall through to the indexed file
-    // set. Explicit CLI paths override exclusions unless `--force-exclude` is set, but the ad-hoc
-    // inclusion check still applies those exclusions.
-    if path.as_system_path().is_some_and(|path| {
-        !project.is_file_included(db, path).is_included()
-            && !project
-                .included_paths_list(db)
-                .iter()
-                .any(|included| path.starts_with(included))
-    }) {
-        tracing::trace!("Not checking {path} because it is not included in the project");
-        return false;
-    }
-
     match project.check_mode(db) {
         CheckMode::OpenFiles => {
             let should_check = project.open_files(db).contains(&file);
@@ -891,11 +873,10 @@ mod tests {
     use crate::db::Db as _;
     use crate::db::testing::TestDb;
     use crate::{IncludeResult, ProjectMetadata};
-    use ruff_db::Db as _;
-    use ruff_db::files::{FileRootKind, system_path_to_file};
+    use ruff_db::files::system_path_to_file;
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
-    use ruff_db::testing::{assert_function_query_was_not_run, find_will_execute_event_by_name};
+    use ruff_db::testing::assert_function_query_was_not_run;
     use ty_python_semantic::types::check_types;
 
     #[test]
@@ -959,56 +940,5 @@ mod tests {
                 literal_match: Some(true)
             }
         );
-    }
-
-    #[test]
-    fn third_party_type_inference_with_diagnostic_has_medium_durability()
-    -> ruff_db::system::Result<()> {
-        let project_root = SystemPathBuf::from("/project");
-        let third_party_root = SystemPathBuf::from("/site-packages");
-        let dependency_path = third_party_root.join("dependency.py");
-        let project = ProjectMetadata::new("test", project_root.clone());
-        let mut db = TestDb::new(project);
-        db.memory_file_system()
-            .create_directory_all(&project_root)?;
-        db.init_program().unwrap();
-        db.files()
-            .try_add_root(&db, &third_party_root, FileRootKind::SearchPath);
-
-        db.write_file(&dependency_path, "value: int = \"wrong\"")?;
-        let dependency = system_path_to_file(&db, &dependency_path).unwrap();
-        assert!(check_types(&db, dependency).is_empty());
-        db.take_salsa_events();
-
-        // Opening a project file is a LOW-durability change. It shouldn't require re-executing
-        // type inference for a third-party dependency.
-        let project_file_path = project_root.join("main.py");
-        db.write_file(&project_file_path, "")?;
-        let project_file = system_path_to_file(&db, &project_file_path).unwrap();
-        db.project().open_file(&mut db, project_file);
-        db.take_salsa_events();
-
-        check_types(&db, dependency);
-        let events = db.take_salsa_events();
-        assert!(
-            find_will_execute_event_by_name(&db, "infer_scope_types_impl", None, &events).is_none(),
-            "Third-party type inference unexpectedly ran after a LOW-durability change: \
-             {events:#?}"
-        );
-
-        // Changing the included paths has MEDIUM durability and makes the dependency eligible for
-        // checking, so its type inference must be recomputed to emit the diagnostic.
-        db.project()
-            .set_included_paths(&mut db, vec![dependency_path]);
-        db.take_salsa_events();
-
-        assert_eq!(check_types(&db, dependency).len(), 1);
-        let events = db.take_salsa_events();
-        assert!(
-            find_will_execute_event_by_name(&db, "infer_scope_types_impl", None, &events).is_some(),
-            "Third-party type inference didn't run after a MEDIUM-durability change: {events:#?}"
-        );
-
-        Ok(())
     }
 }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -665,7 +665,7 @@ pub(crate) fn check_file(db: &dyn Db, file: File) -> Vec<Diagnostic> {
 /// This query provides a per-file backdating boundary around the project-wide file sets. Updating
 /// either set still revalidates this query, but unchanged results are backdated before invalidation
 /// reaches semantic-index and type-inference queries.
-#[salsa::tracked]
+#[salsa::tracked(returns(copy))]
 pub(crate) fn should_check_file(db: &dyn Db, file: File) -> bool {
     let project = db.project();
     let path = file.path(db);

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -676,6 +676,11 @@ pub(crate) fn should_check_file(db: &dyn Db, file: File) -> bool {
     // be quite helpful for narrowing down the issue. The messages are at TRACE because they are
     // extremely noisy.
 
+    if path.is_vendored_path() {
+        tracing::trace!("Not checking {path} because it is a vendored path");
+        return false;
+    }
+
     match project.check_mode(db) {
         CheckMode::OpenFiles => {
             let should_check = project.open_files(db).contains(&file);


### PR DESCRIPTION
## Summary

Type inference depends on `should_check_file` to determine whether the current file is a first-party file. Only then does it emit a diagnostic for a typing error (assuming the corresponding rule is enabled). 

`should_check_file` itself depends on the `project.files` set and `project.open_files`. The former is updated whenever a new first-party file is added or a file is removed; the latter is updated whenever the user opens or closes a tab in their editor. Both are frequent operations. 

Furthermore, `should_check_file` isn't a query today. That means, Salsa has to re-run any query that calls `should_check_file` whenever the user opens or closes a tab, or a new file is added, or a file is removed from the project. This includes many of our type-inference queries. This is somewhat expensive. Luckily, Salsa won't rerun all type-inference queries. It only runs queries for type-inference regions with diagnostics, and it short-circuits when it sees that the result for that region remains unchanged. However, this can still be substantial work, especially if it involves a file that is itself slow to type-check (see https://github.com/astral-sh/ty/issues/3969). 

This PR makes `should_check_file` a query. This allows Salsa to rerun only the `should_check_file` queries, avoiding any type inference if the result for the given file remains unchanged. This increases memory usage a bit, but this seems a worthwhile trade-off.


