### PR TITLE
[ty] Check rule selection before file eligibility

### DIFF
--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -433,12 +433,12 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
         //   returns a rule selector for a given file that respects the package's settings,
         //   any global pragma comments in the file, and any per-file-ignores.
 
-        if !ctx.db.should_check_file(ctx.file) {
-            return None;
-        }
         // Skip over diagnostics if the rule
         // is disabled.
         let (severity, source) = ctx.db.rule_selection(ctx.file).get(lint)?;
+        if !ctx.db.should_check_file(ctx.file) {
+            return None;
+        }
         // If we're not in type checking mode,
         // we can bail now.
         if ctx.is_in_no_type_check() {


### PR DESCRIPTION
## Summary

Move the per-file rule-selection lookup ahead of `should_check_file` when deciding whether to emit a lint diagnostic.

## Motivation

Disabled rules can be rejected directly from the rule selection. Checking the rule first avoids evaluating file-check eligibility for diagnostics that cannot be emitted, reducing unnecessary work without changing diagnostic behavior.

## User impact

This is a performance-only change. Diagnostic output and rule behavior remain unchanged.

## Test plan

- `cargo nextest run -p ty_python_semantic` (722 passed, 35 skipped)
- `uv run --only-group dev --locked prek run --files crates/ty_python_semantic/src/types/context.rs`
