### PR TITLE
[ty] Skip `open_files` and `files` check in `should_check_file` for files that are known to be not included

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -2003,7 +2003,7 @@ impl<'a> ProjectBenchmark<'a> {
             self.project
                 .check_paths()
                 .iter()
-                .map(|path| SystemPathBuf::from(*path))
+                .map(|path| SystemPath::absolute(path, src_root))
                 .collect(),
         );
 
@@ -2030,15 +2030,15 @@ fn bench_project_named(
         let result = db.check();
         let diagnostics = result.len();
 
-        if diagnostics > max_diagnostics {
+        if diagnostics <= 1 || diagnostics > max_diagnostics {
             let details = result
                 .into_iter()
                 .map(|diagnostic| diagnostic.concise_message().to_string())
                 .collect::<Vec<_>>()
                 .join("\n  ");
             assert!(
-                diagnostics <= max_diagnostics,
-                "{project_name}: Expected <={max_diagnostics} diagnostics but got {diagnostics}:\n  {details}",
+                diagnostics > 1 && diagnostics <= max_diagnostics,
+                "{project_name}: Expected between 2 and {max_diagnostics} diagnostics but got {diagnostics}:\n  {details}",
             );
         }
     }

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1386,7 +1386,7 @@ impl<'a> ProjectBenchmark<'a> {
             self.project
                 .check_paths()
                 .iter()
-                .map(|path| SystemPathBuf::from(*path))
+                .map(|path| SystemPath::absolute(path, src_root))
                 .collect(),
         );
 
@@ -1413,15 +1413,15 @@ fn bench_project_named(
         let result = db.check();
         let diagnostics = result.len();
 
-        if diagnostics > max_diagnostics {
+        if diagnostics <= 1 || diagnostics > max_diagnostics {
             let details = result
                 .into_iter()
                 .map(|diagnostic| diagnostic.concise_message().to_string())
                 .collect::<Vec<_>>()
                 .join("\n  ");
             assert!(
-                diagnostics <= max_diagnostics,
-                "{project_name}: Expected <={max_diagnostics} diagnostics but got {diagnostics}:\n  {details}",
+                diagnostics > 1 && diagnostics <= max_diagnostics,
+                "{project_name}: Expected between 2 and {max_diagnostics} diagnostics but got {diagnostics}:\n  {details}",
             );
         }
     }

--- a/crates/ty/tests/cli/file_selection.rs
+++ b/crates/ty/tests/cli/file_selection.rs
@@ -634,11 +634,18 @@ fn explicit_path_overrides_exclude() -> anyhow::Result<()> {
             print(other_undefined_var)  # error: unresolved-reference
             "#,
         ),
+        ("dist/generated/direct.py", "print(direct_undefined_var)"),
+        (
+            "dist/generated/nested/module.py",
+            "print(nested_undefined_var)",
+        ),
+        ("dist/not-included.py", "print(not_included_undefined_var)"),
         (
             "ty.toml",
             r#"
             [src]
-            exclude = ["tests/generated.py"]
+            include = ["src/main.py", "dist/other.py", "dist/generated/**"]
+            exclude = ["tests/generated.py", "dist/generated/direct.py", "dist/generated/nested"]
             "#,
         ),
     ])?;
@@ -675,7 +682,7 @@ fn explicit_path_overrides_exclude() -> anyhow::Result<()> {
     ----- stderr -----
     ");
 
-    // Explicitly checking the entire excluded directory should check all files in it
+    // Explicitly checking an excluded directory still applies its include and descendant exclude filters.
     assert_cmd_snapshot!(case.command().arg("dist/"), @"
     success: false
     exit_code: 1

--- a/crates/ty_project/src/glob.rs
+++ b/crates/ty_project/src/glob.rs
@@ -38,7 +38,7 @@ impl IncludeExcludeFilter {
     pub(crate) fn is_directory_maybe_included(
         &self,
         path: &SystemPath,
-        mode: GlobFilterCheckMode,
+        mode: GlobFilterCheckMode<'_>,
     ) -> IncludeResult {
         if self.exclude.match_directory(path, mode) {
             IncludeResult::Excluded
@@ -54,7 +54,7 @@ impl IncludeExcludeFilter {
     pub(crate) fn is_file_included(
         &self,
         path: &SystemPath,
-        mode: GlobFilterCheckMode,
+        mode: GlobFilterCheckMode<'_>,
     ) -> IncludeResult {
         if self.exclude.match_file(path, mode) {
             IncludeResult::Excluded
@@ -113,7 +113,7 @@ impl std::fmt::Display for IncludeExcludeFilter {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub(crate) enum GlobFilterCheckMode {
+pub(crate) enum GlobFilterCheckMode<'a> {
     /// The paths are checked top-to-bottom and inclusion is determined
     /// for each path during the traversal.
     TopDown,
@@ -122,8 +122,8 @@ pub(crate) enum GlobFilterCheckMode {
     ///
     /// This is more expensive than a [`Self::TopDown`] check
     /// because it may require testing every ancestor path in addition to the
-    /// path itself to ensure no ancestor path matches an exclude rule.
-    Adhoc,
+    /// path itself to ensure no ancestor path below `stop_at` matches an exclude rule.
+    Adhoc { stop_at: Option<&'a SystemPath> },
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/ty_project/src/glob/exclude.rs
+++ b/crates/ty_project/src/glob/exclude.rs
@@ -30,16 +30,16 @@ pub(crate) struct ExcludeFilter {
 
 impl ExcludeFilter {
     /// Returns `true` if the path to a directory is definitely excluded and `false` otherwise.
-    pub(crate) fn match_directory(&self, path: &SystemPath, mode: GlobFilterCheckMode) -> bool {
+    pub(crate) fn match_directory(&self, path: &SystemPath, mode: GlobFilterCheckMode<'_>) -> bool {
         self.matches(path, mode, true)
     }
 
     /// Returns `true` if the path to a file is definitely excluded and `false` otherwise.
-    pub(crate) fn match_file(&self, path: &SystemPath, mode: GlobFilterCheckMode) -> bool {
+    pub(crate) fn match_file(&self, path: &SystemPath, mode: GlobFilterCheckMode<'_>) -> bool {
         self.matches(path, mode, false)
     }
 
-    fn matches(&self, path: &SystemPath, mode: GlobFilterCheckMode, directory: bool) -> bool {
+    fn matches(&self, path: &SystemPath, mode: GlobFilterCheckMode<'_>, directory: bool) -> bool {
         // If the path is excluded, return `ignore`
         if self.ignore.matched(path, directory).is_ignore() {
             return true;
@@ -50,11 +50,12 @@ impl ExcludeFilter {
                 // No hit or an allow hit means the file or directory is not excluded.
                 false
             }
-            GlobFilterCheckMode::Adhoc => {
+            GlobFilterCheckMode::Adhoc { stop_at } => {
                 // If the path is allowlisted or there's no hit, try the parent to ensure we don't return false
                 // for a folder where there's an exclude for a parent.
                 path.ancestors()
                     .skip(1)
+                    .take_while(|ancestor| Some(*ancestor) != stop_at)
                     .any(|ancestor| self.ignore.matched(ancestor, true).is_ignore())
             }
         }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -277,13 +277,13 @@ impl Project {
     /// that won't be included when checking the project because they're ignored in a `.gitignore` file.
     pub fn is_file_included(self, db: &dyn Db, path: &SystemPath) -> IncludeResult {
         ProjectFilesFilter::from_project(db, self)
-            .is_file_included(path, GlobFilterCheckMode::Adhoc)
+            .is_file_included(path, GlobFilterCheckMode::Adhoc { stop_at: None })
     }
 
     fn is_directory_included(self, db: &dyn Db, path: &SystemPath) -> bool {
         matches!(
             ProjectFilesFilter::from_project(db, self)
-                .is_directory_included(path, GlobFilterCheckMode::Adhoc),
+                .is_directory_included(path, GlobFilterCheckMode::Adhoc { stop_at: None }),
             IncludeResult::Included { .. }
         )
     }
@@ -681,6 +681,18 @@ pub(crate) fn should_check_file(db: &dyn Db, file: File) -> bool {
         return false;
     }
 
+    // Avoid depending on the indexed and open file sets for files that aren't included in the
+    // project. Both sets change frequently, and a dependency on either invalidates this query when
+    // any file is added or removed. Virtual paths bypass this check because they don't have a
+    // system path.
+    if path
+        .as_system_path()
+        .is_some_and(|path| !project.is_file_included(db, path).is_included())
+    {
+        tracing::trace!("Not checking {path} because it is not included in the project");
+        return false;
+    }
+
     match project.check_mode(db) {
         CheckMode::OpenFiles => {
             let should_check = project.open_files(db).contains(&file);
@@ -884,10 +896,11 @@ mod tests {
     use crate::db::Db as _;
     use crate::db::testing::TestDb;
     use crate::{IncludeResult, ProjectMetadata};
-    use ruff_db::files::system_path_to_file;
+    use ruff_db::Db as _;
+    use ruff_db::files::{FileRootKind, system_path_to_file};
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
-    use ruff_db::testing::assert_function_query_was_not_run;
+    use ruff_db::testing::{assert_function_query_was_not_run, find_will_execute_event_by_name};
     use ty_python_semantic::Db as _;
     use ty_python_semantic::types::check_types;
 
@@ -951,5 +964,76 @@ mod tests {
                 literal_match: Some(true)
             }
         );
+    }
+
+    #[test]
+    fn explicit_included_directory_applies_descendant_excludes() {
+        let root = SystemPathBuf::from("/project");
+        let dist = root.join("dist");
+        let mut db = TestDb::new(ProjectMetadata::new("test", root));
+        let project = db.project();
+
+        project.set_included_paths(&mut db, vec![dist.clone()]);
+
+        assert!(
+            project
+                .is_file_included(&db, &dist.join("main.py"))
+                .is_included()
+        );
+        assert_eq!(
+            project.is_file_included(&db, &dist.join(".venv/main.py")),
+            IncludeResult::Excluded
+        );
+        assert!(!project.is_directory_included(&db, &dist.join(".venv/src")));
+    }
+
+    #[test]
+    fn third_party_type_inference_with_diagnostic_has_medium_durability()
+    -> ruff_db::system::Result<()> {
+        let project_root = SystemPathBuf::from("/project");
+        let third_party_root = SystemPathBuf::from("/site-packages");
+        let dependency_path = third_party_root.join("dependency.py");
+        let project = ProjectMetadata::new("test", project_root.clone());
+        let mut db = TestDb::new(project);
+        db.memory_file_system()
+            .create_directory_all(&project_root)?;
+        db.files()
+            .try_add_root(&db, &third_party_root, FileRootKind::SearchPath);
+
+        db.write_file(&dependency_path, "value: int = \"wrong\"")?;
+        let dependency = system_path_to_file(&db, &dependency_path).unwrap();
+        assert!(check_types(&db, db.program_file(dependency)).is_empty());
+        db.take_salsa_events();
+
+        // Opening a project file is a LOW-durability change. It shouldn't require re-executing
+        // type inference for a third-party dependency.
+        let project_file_path = project_root.join("main.py");
+        db.write_file(&project_file_path, "")?;
+        let project_file = system_path_to_file(&db, &project_file_path).unwrap();
+        db.project().open_file(&mut db, project_file);
+        db.take_salsa_events();
+
+        check_types(&db, db.program_file(dependency));
+        let events = db.take_salsa_events();
+        assert!(
+            find_will_execute_event_by_name(&db, "infer_scope_types_impl", None, &events).is_none(),
+            "Third-party type inference unexpectedly ran after a LOW-durability change: \
+             {events:#?}"
+        );
+
+        // Changing the included paths has MEDIUM durability and makes the dependency eligible for
+        // checking, so its type inference must be recomputed to emit the diagnostic.
+        db.project()
+            .set_included_paths(&mut db, vec![dependency_path]);
+        db.take_salsa_events();
+
+        assert_eq!(check_types(&db, db.program_file(dependency)).len(), 1);
+        let events = db.take_salsa_events();
+        assert!(
+            find_will_execute_event_by_name(&db, "infer_scope_types_impl", None, &events).is_some(),
+            "Third-party type inference didn't run after a MEDIUM-durability change: {events:#?}"
+        );
+
+        Ok(())
     }
 }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -256,13 +256,13 @@ impl Project {
     /// that won't be included when checking the project because they're ignored in a `.gitignore` file.
     pub fn is_file_included(self, db: &dyn Db, path: &SystemPath) -> IncludeResult {
         ProjectFilesFilter::from_project(db, self)
-            .is_file_included(path, GlobFilterCheckMode::Adhoc)
+            .is_file_included(path, GlobFilterCheckMode::Adhoc { stop_at: None })
     }
 
     fn is_directory_included(self, db: &dyn Db, path: &SystemPath) -> bool {
         matches!(
             ProjectFilesFilter::from_project(db, self)
-                .is_directory_included(path, GlobFilterCheckMode::Adhoc),
+                .is_directory_included(path, GlobFilterCheckMode::Adhoc { stop_at: None }),
             IncludeResult::Included { .. }
         )
     }
@@ -688,6 +688,18 @@ pub(crate) fn should_check_file(db: &dyn Db, file: File) -> bool {
         return false;
     }
 
+    // Avoid depending on the indexed and open file sets for files that aren't included in the
+    // project. Both sets change frequently, and a dependency on either invalidates this query when
+    // any file is added or removed. Virtual paths bypass this check because they don't have a
+    // system path.
+    if path
+        .as_system_path()
+        .is_some_and(|path| !project.is_file_included(db, path).is_included())
+    {
+        tracing::trace!("Not checking {path} because it is not included in the project");
+        return false;
+    }
+
     match project.check_mode(db) {
         CheckMode::OpenFiles => {
             let should_check = project.open_files(db).contains(&file);
@@ -885,10 +897,11 @@ mod tests {
     use crate::db::Db as _;
     use crate::db::testing::TestDb;
     use crate::{IncludeResult, ProjectMetadata};
-    use ruff_db::files::system_path_to_file;
+    use ruff_db::Db as _;
+    use ruff_db::files::{FileRootKind, system_path_to_file};
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
-    use ruff_db::testing::assert_function_query_was_not_run;
+    use ruff_db::testing::{assert_function_query_was_not_run, find_will_execute_event_by_name};
     use ty_python_semantic::types::check_types;
 
     #[test]
@@ -952,5 +965,77 @@ mod tests {
                 literal_match: Some(true)
             }
         );
+    }
+
+    #[test]
+    fn explicit_included_directory_applies_descendant_excludes() {
+        let root = SystemPathBuf::from("/project");
+        let dist = root.join("dist");
+        let mut db = TestDb::new(ProjectMetadata::new("test", root));
+        let project = db.project();
+
+        project.set_included_paths(&mut db, vec![dist.clone()]);
+
+        assert!(
+            project
+                .is_file_included(&db, &dist.join("main.py"))
+                .is_included()
+        );
+        assert_eq!(
+            project.is_file_included(&db, &dist.join(".venv/main.py")),
+            IncludeResult::Excluded
+        );
+        assert!(!project.is_directory_included(&db, &dist.join(".venv/src")));
+    }
+
+    #[test]
+    fn third_party_type_inference_with_diagnostic_has_medium_durability()
+    -> ruff_db::system::Result<()> {
+        let project_root = SystemPathBuf::from("/project");
+        let third_party_root = SystemPathBuf::from("/site-packages");
+        let dependency_path = third_party_root.join("dependency.py");
+        let project = ProjectMetadata::new("test", project_root.clone());
+        let mut db = TestDb::new(project);
+        db.memory_file_system()
+            .create_directory_all(&project_root)?;
+        db.init_program().unwrap();
+        db.files()
+            .try_add_root(&db, &third_party_root, FileRootKind::SearchPath);
+
+        db.write_file(&dependency_path, "value: int = \"wrong\"")?;
+        let dependency = system_path_to_file(&db, &dependency_path).unwrap();
+        assert!(check_types(&db, dependency).is_empty());
+        db.take_salsa_events();
+
+        // Opening a project file is a LOW-durability change. It shouldn't require re-executing
+        // type inference for a third-party dependency.
+        let project_file_path = project_root.join("main.py");
+        db.write_file(&project_file_path, "")?;
+        let project_file = system_path_to_file(&db, &project_file_path).unwrap();
+        db.project().open_file(&mut db, project_file);
+        db.take_salsa_events();
+
+        check_types(&db, dependency);
+        let events = db.take_salsa_events();
+        assert!(
+            find_will_execute_event_by_name(&db, "infer_scope_types_impl", None, &events).is_none(),
+            "Third-party type inference unexpectedly ran after a LOW-durability change: \
+             {events:#?}"
+        );
+
+        // Changing the included paths has MEDIUM durability and makes the dependency eligible for
+        // checking, so its type inference must be recomputed to emit the diagnostic.
+        db.project()
+            .set_included_paths(&mut db, vec![dependency_path]);
+        db.take_salsa_events();
+
+        assert_eq!(check_types(&db, dependency).len(), 1);
+        let events = db.take_salsa_events();
+        assert!(
+            find_will_execute_event_by_name(&db, "infer_scope_types_impl", None, &events).is_some(),
+            "Third-party type inference didn't run after a MEDIUM-durability change: {events:#?}"
+        );
+
+        Ok(())
     }
 }

--- a/crates/ty_project/src/metadata/settings.rs
+++ b/crates/ty_project/src/metadata/settings.rs
@@ -116,7 +116,7 @@ impl Override {
 
         matches!(
             self.files
-                .is_file_included(path, GlobFilterCheckMode::Adhoc),
+                .is_file_included(path, GlobFilterCheckMode::Adhoc { stop_at: None }),
             IncludeResult::Included { .. }
         )
     }

--- a/crates/ty_project/src/walk.rs
+++ b/crates/ty_project/src/walk.rs
@@ -21,6 +21,9 @@ pub(crate) struct ProjectFilesFilter<'a> {
     /// The same as [`Project::included_paths_or_root`].
     included_paths: &'a [SystemPathBuf],
 
+    /// Whether any paths were explicitly included on the CLI.
+    has_explicit_paths: bool,
+
     /// The resolved `src.include` and `src.exclude` filter.
     src_filter: &'a IncludeExcludeFilter,
 
@@ -31,6 +34,7 @@ impl<'a> ProjectFilesFilter<'a> {
     pub(crate) fn from_project(db: &'a dyn Db, project: Project) -> Self {
         Self {
             included_paths: project.included_paths_or_root(db),
+            has_explicit_paths: !project.included_paths_list(db).is_empty(),
             src_filter: &project.settings(db).src().files,
             force_exclude: project.force_exclude(db),
         }
@@ -43,26 +47,31 @@ impl<'a> ProjectFilesFilter<'a> {
     fn match_included_paths(
         &self,
         path: &SystemPath,
-        mode: GlobFilterCheckMode,
-    ) -> Option<CheckPathMatch> {
+        mode: GlobFilterCheckMode<'_>,
+    ) -> Option<CheckPathMatch<'_>> {
         match mode {
-            GlobFilterCheckMode::TopDown => Some(CheckPathMatch::Partial),
-            GlobFilterCheckMode::Adhoc => {
-                self.included_paths
+            GlobFilterCheckMode::TopDown => {
+                Some(CheckPathMatch::Partial(GlobFilterCheckMode::TopDown))
+            }
+            GlobFilterCheckMode::Adhoc { .. } => {
+                let included_path = self
+                    .included_paths
                     .iter()
-                    .filter_map(|included_path| {
-                        if let Ok(relative_path) = path.strip_prefix(included_path) {
-                            // Exact matches are always included, unless forced to exclude
-                            if relative_path.as_str().is_empty() && !self.force_exclude {
-                                Some(CheckPathMatch::Full)
-                            } else {
-                                Some(CheckPathMatch::Partial)
-                            }
-                        } else {
-                            None
-                        }
-                    })
-                    .max()
+                    .filter(|included_path| path.starts_with(included_path))
+                    .max_by_key(|included_path| included_path.as_str().len())?;
+                let included_path = included_path.as_path();
+
+                if self.force_exclude || !self.has_explicit_paths {
+                    Some(CheckPathMatch::Partial(GlobFilterCheckMode::Adhoc {
+                        stop_at: None,
+                    }))
+                } else if path == included_path {
+                    Some(CheckPathMatch::Full)
+                } else {
+                    Some(CheckPathMatch::Partial(GlobFilterCheckMode::Adhoc {
+                        stop_at: Some(included_path),
+                    }))
+                }
             }
         }
     }
@@ -83,11 +92,11 @@ impl<'a> ProjectFilesFilter<'a> {
     pub(crate) fn is_file_included(
         &self,
         path: &SystemPath,
-        mode: GlobFilterCheckMode,
+        mode: GlobFilterCheckMode<'_>,
     ) -> IncludeResult {
         match self.match_included_paths(path, mode) {
             None => IncludeResult::NotIncluded,
-            Some(CheckPathMatch::Partial) => self.src_filter.is_file_included(path, mode),
+            Some(CheckPathMatch::Partial(mode)) => self.src_filter.is_file_included(path, mode),
             Some(CheckPathMatch::Full) => IncludeResult::Included {
                 literal_match: Some(true),
             },
@@ -97,11 +106,11 @@ impl<'a> ProjectFilesFilter<'a> {
     pub(crate) fn is_directory_included(
         &self,
         path: &SystemPath,
-        mode: GlobFilterCheckMode,
+        mode: GlobFilterCheckMode<'_>,
     ) -> IncludeResult {
         match self.match_included_paths(path, mode) {
             None => IncludeResult::NotIncluded,
-            Some(CheckPathMatch::Partial) => {
+            Some(CheckPathMatch::Partial(mode)) => {
                 self.src_filter.is_directory_maybe_included(path, mode)
             }
             Some(CheckPathMatch::Full) => IncludeResult::Included {
@@ -111,10 +120,10 @@ impl<'a> ProjectFilesFilter<'a> {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-enum CheckPathMatch {
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum CheckPathMatch<'a> {
     /// The path is a partial match of the checked path (it's a sub path)
-    Partial,
+    Partial(GlobFilterCheckMode<'a>),
 
     /// The path matches a check path exactly.
     Full,
@@ -224,7 +233,7 @@ impl ProjectFilesWalker {
                             // check if they're included in the project.
                             if entry.depth() > 0 || force_exclude {
                                 let match_mode = if entry.depth() == 0 && force_exclude {
-                                    GlobFilterCheckMode::Adhoc
+                                    GlobFilterCheckMode::Adhoc { stop_at: None }
                                 } else {
                                     GlobFilterCheckMode::TopDown
                                 };


### PR DESCRIPTION
## Summary

Early return from `should_check_file` for files that are clearly not included in the project. This improves incrementally because both `open_files` and `files` have low-durability, but the project's settings have a medium durability. The path-based pre-filtering allows us to skip some of those low-durability reads, which in turn helps to make the `should_check_file` query medium durability, and this increases the durability from low to medium for third-party code that has diagnostics (that calls `should_check_file`). 

This does come at a small memory usage cost, because `should_check_file` now depends on the project's settings. The cost is proportional to the files that have diagnostics. The other risk is if `is_file_included` returns false for a file that in fact should be included in the project. In fact, this PR revealed that this is already the case today. I argue that this is actually good. We use `is_file_included` in other places where we assume that it is an over-approximation of `files`. Using this method in more places will make it easier to discover differences between file-walking and ad-hoc checking, which benefits ty overall.

Closes https://github.com/astral-sh/ty/issues/114


## Performance

Codspeed reports a 1-2% perf improvement for most project benchmarks.