### PR TITLE
[ty] Cache generic context

### DIFF
--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -267,6 +267,11 @@ impl<'db> StaticClassLiteral<'db> {
         None
     }
 
+    #[salsa::tracked(
+        returns(copy),
+        cycle_initial=|_, _, _| None,
+        heap_size=ruff_memory_usage::heap_size,
+    )]
     pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
         // Several typeshed definitions examine `sys.version_info`. To break cycles, we hard-code
         // the knowledge that this class is not generic.


### PR DESCRIPTION
## Summary

Cache `StaticClassLiteral::generic_context` so callers record one dependency instead of repeatedly recording its downstream queries. Local traces reduced recorded dependencies by 2.37–3.89% and memo metadata by 1.20–2.58% across benchmark projects.

## Test Plan
Testing: Passed semantic Markdown tests, formatting, and repository hooks on Salsa 0.28.
