### PR TITLE
[ty] Cache known class instances

### DIFF
--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1020,10 +1020,21 @@ impl KnownClass {
             KnownClass::Tuple,
             "Use `Type::heterogeneous_tuple` or `Type::homogeneous_tuple` to create `tuple` instances"
         );
-        self.to_class_literal(db)
-            .to_class_type(db)
-            .map(|class| Type::instance(db, class))
-            .unwrap_or_else(Type::unknown)
+
+        #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+        fn known_class_to_instance<'db>(
+            db: &'db dyn Db,
+            class: KnownClassArgument<'db>,
+        ) -> Type<'db> {
+            class
+                .class(db)
+                .to_class_literal(db)
+                .to_class_type(db)
+                .map(|class| Type::instance(db, class))
+                .unwrap_or_else(Type::unknown)
+        }
+
+        known_class_to_instance(db, KnownClassArgument::new(db, self))
     }
 
     /// Similar to [`KnownClass::to_instance`], but returns the Unknown-specialization where each type
@@ -1125,12 +1136,6 @@ impl KnownClass {
         self,
         db: &dyn Db,
     ) -> Result<Option<StaticClassLiteral<'_>>, KnownClassLookupError<'_>> {
-        #[salsa::interned(heap_size=ruff_memory_usage::heap_size)]
-        struct KnownClassArgument {
-            #[returns(copy)]
-            class: KnownClass,
-        }
-
         #[salsa::tracked(returns(copy), cycle_initial=|_, _, _| Ok(None), heap_size=ruff_memory_usage::heap_size)]
         fn known_class_to_class_literal<'db>(
             db: &'db dyn Db,
@@ -1972,6 +1977,12 @@ impl KnownClass {
             _ => {}
         }
     }
+}
+
+#[salsa::interned(heap_size=ruff_memory_usage::heap_size)]
+struct KnownClassArgument {
+    #[returns(copy)]
+    class: KnownClass,
 }
 
 /// Enumeration of ways in which looking up a [`KnownClass`] in its canonical module could fail.


### PR DESCRIPTION
## Summary

Cache `KnownClass::to_instance` using the existing interned known-class key, avoiding repeated lookup and specialization dependencies in callers. Local traces reduced recorded dependencies by 0.38–1.26% and memo metadata by 30–547 KB, with a 1.16% Pandas walltime improvement.

Codspeed benchmarks show a 1-3% performance improvement

## Test Plan
Testing: Passed semantic Markdown tests, formatting, and repository hooks on Salsa 0.28.
