### PR TITLE
[ty] Respect `init=False` in dataclass field-order checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -156,6 +156,26 @@ class BadWithInitFalse:
     z: float
 ```
 
+Class-level `init=False` suppresses the ordering check because no constructor is generated:
+
+```py
+@dataclass(init=False)
+class GoodWithClassInitFalse:
+    x: int = 1
+    y: str
+
+    def __init__(self, y: str) -> None:
+        self.y = y
+
+GoodWithClassInitFalse("value")
+
+# Re-enabling `init` makes the inherited default-before-required ordering invalid at runtime.
+# TODO: error: [dataclass-field-order]
+@dataclass
+class BadWithReenabledInit(GoodWithClassInitFalse):
+    pass
+```
+
 Keyword-only fields (using `kw_only=True`) also don't participate in the positional ordering check:
 
 ```toml

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -13,9 +13,9 @@ use crate::{
     diagnostic::format_enumeration,
     place::{DefinedPlace, Place, TypeOrigin, place_from_bindings, place_from_declarations},
     types::{
-        CallArguments, ClassBase, ClassLiteral, ClassType, KnownClass, KnownInstanceType,
-        MemberLookupPolicy, MetaclassCandidate, Parameters, Signature, SpecialFormType,
-        StaticClassLiteral, Type, TypeVarVariance, binding_type,
+        CallArguments, ClassBase, ClassLiteral, ClassType, DataclassFlags, KnownClass,
+        KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, Parameters, Signature,
+        SpecialFormType, StaticClassLiteral, Type, TypeVarVariance, binding_type,
         call::Argument,
         class::{
             AbstractMethod, CodeGeneratorKind, FieldKind, MetaclassErrorKind,
@@ -897,6 +897,7 @@ pub(crate) fn check_static_class_definitions<'db>(
         CodeGeneratorKind::from_class(db, class.into())
     {
         let specialization = None;
+        let class_init = class.has_dataclass_param(db, field_policy, DataclassFlags::INIT);
 
         let mut kw_only_sentinel_fields = vec![];
         let mut required_after_default_field_names = vec![];
@@ -919,8 +920,8 @@ pub(crate) fn check_static_class_definitions<'db>(
                 continue;
             };
 
-            // Fields with init=False or kw_only=true don't participate in ordering check
-            if !init || *kw_only == Some(true) {
+            // Classes or fields with init=False and kw_only fields don't participate in ordering.
+            if !class_init || !init || *kw_only == Some(true) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

Prior to this change, we emitted `dataclass-field-order` for `@dataclass(init=False)` even though no constructor is generated and a custom `__init__` can validly accept the required fields.

We now skip the positional field-order check when the class-level `init` flag is false, while preserving the existing field-level `init=False`, keyword-only, and duplicate-`KW_ONLY` checks. The regression test covers the original custom-constructor case.

This deliberately does not attempt to reconstruct inherited field order when a subclass re-enables `init`; the added TODO test documents that remaining false negative without expanding the field-inheritance model.

Closes https://github.com/astral-sh/ty/issues/3976.