### PR TITLE
docs: remove redundant HTML anchor tags from README headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For more, see the [documentation](https://docs.astral.sh/ruff/).
 1. [Who's Using Ruff?](#whos-using-ruff)
 1. [License](#license)
 
-## Getting Started<a id="getting-started"></a>
+## Getting Started
 
 For more, see the [documentation](https://docs.astral.sh/ruff/).
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Summary

Remove redundant HTML anchor tags (`<a id="..."></a>`) from README section headings.

GitHub automatically generates heading anchors, so these explicit IDs are unnecessary. Removing them simplifies the Markdown while preserving all existing links and navigation.

No functional changes.
