### PR TITLE
[ty] Quantify shallow generic method targets

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -868,7 +868,7 @@ python-version = "3.12"
 ```
 
 ```pyi
-from typing import Never, Self
+from typing import Never, Self, TypeVar
 
 class A:
     def method[T](self, x: T) -> T: ...
@@ -969,6 +969,18 @@ class B5(A5):
 
 class C5(A5):
     def method[S](self, x: S, y: object) -> S: ...  # fine
+
+LegacyT = TypeVar("LegacyT")
+LegacyS = TypeVar("LegacyS")
+
+class A6:
+    def method(self, x: LegacyT) -> LegacyT: ...
+
+class B6(A6):
+    def method(self, x: int) -> int: ...  # error: [invalid-method-override]
+
+class C6(A6):
+    def method(self, x: LegacyS) -> int: ...  # error: [invalid-method-override]
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -880,10 +880,9 @@ class C(A):
     def method(self, x: object) -> Never: ...  # fine
 
 class D(A):
-    # TODO: we should emit [invalid-method-override] here:
     # `A.method` accepts an argument of any type,
     # but `D.method` only accepts `int`s
-    def method(self, x: int) -> int: ...
+    def method(self, x: int) -> int: ...  # error: [invalid-method-override]
 
 class A2:
     def method(self, x: int) -> int: ...

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1023,6 +1023,15 @@ class B10(A10):
 
 class C10(A10):
     def method(self, x: object) -> int: ...  # fine
+
+class A11:
+    def method[T](self, x: list[T], context: Any) -> list[T]: ...
+
+class B11(A11):
+    def method(self, x: list[int], context: Any) -> list[int]: ...  # error: [invalid-method-override]
+
+class B12[S](A9):
+    def method(self, x: list[int]) -> list[int]: ...  # error: [invalid-method-override]
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -884,6 +884,10 @@ class D(A):
     # but `D.method` only accepts `int`s
     def method(self, x: int) -> int: ...  # error: [invalid-method-override]
 
+class E(A):
+    # `E.method` accepts every argument, but does not preserve its type in the return.
+    def method[S](self, x: S) -> int: ...  # error: [invalid-method-override]
+
 class A2:
     def method(self, x: int) -> int: ...
 

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1067,6 +1067,15 @@ class A2[T]:
 
 class B2[T](A2[T]):
     def method[S](self, x: T, y: S) -> S: ...  # fine
+
+class A3[S]:
+    def method[T](self, x: list[T], context: S) -> list[T]: ...
+
+class B3[S](A3[S]):
+    def method(self, x: list[int], context: S) -> list[int]: ...  # error: [invalid-method-override]
+
+class C3[S](A3[S]):
+    def method(self, x: object, context: S) -> Never: ...  # fine
 ```
 
 ## Fully qualified names are used in diagnostics where appropriate

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -868,7 +868,7 @@ python-version = "3.12"
 ```
 
 ```pyi
-from typing import Never, Self, TypeVar
+from typing import Literal, Never, Self, TypeVar
 
 class A:
     def method[T](self, x: T) -> T: ...
@@ -981,6 +981,15 @@ class B6(A6):
 
 class C6(A6):
     def method(self, x: LegacyS) -> int: ...  # error: [invalid-method-override]
+
+class A7:
+    def method[T](self, x: T, option: int | Literal["strict"]) -> T: ...
+
+class B7(A7):
+    def method(self, x: int, option: int | Literal["strict"]) -> int: ...  # error: [invalid-method-override]
+
+class C7(A7):
+    def method[S](self, x: S, option: int | Literal["strict"]) -> S: ...
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1005,6 +1005,24 @@ class B8(A8):
 
 class C8(A8):
     def method[S](self, x: S, context: Any) -> S: ...
+
+class A9:
+    def method[T](self, x: list[T]) -> list[T]: ...
+
+class B9(A9):
+    def method(self, x: list[int]) -> list[int]: ...  # error: [invalid-method-override]
+
+class C9(A9):
+    def method(self, x: object) -> Never: ...  # fine
+
+class A10:
+    def method[T](self, x: list[T]) -> int: ...
+
+class B10(A10):
+    def method(self, x: list[int]) -> int: ...  # error: [invalid-method-override]
+
+class C10(A10):
+    def method(self, x: object) -> int: ...  # fine
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -960,6 +960,15 @@ class B4(A4):
     # but this is not necessarily true for `B4.method`: if passed a `bool`,
     # it could return a non-`bool` `int`!
     def method(self, x: int) -> int: ...
+
+class A5:
+    def method[T, U](self, x: T, y: U) -> T: ...
+
+class B5(A5):
+    def method[S, R](self, x: S, y: R) -> R: ...  # error: [invalid-method-override]
+
+class C5(A5):
+    def method[S](self, x: S, y: object) -> S: ...  # fine
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -868,7 +868,7 @@ python-version = "3.12"
 ```
 
 ```pyi
-from typing import Literal, Never, Self, TypeVar
+from typing import Any, Literal, Never, Self, TypeVar
 
 class A:
     def method[T](self, x: T) -> T: ...
@@ -887,6 +887,12 @@ class D(A):
 class E(A):
     # `E.method` accepts every argument, but does not preserve its type in the return.
     def method[S](self, x: S) -> int: ...  # error: [invalid-method-override]
+
+class F(A):
+    def method(self, x: Any) -> Any: ...  # fine
+
+class G(A):
+    def method(self, x): ...  # fine
 
 class A2:
     def method(self, x: int) -> int: ...
@@ -990,6 +996,15 @@ class B7(A7):
 
 class C7(A7):
     def method[S](self, x: S, option: int | Literal["strict"]) -> S: ...
+
+class A8:
+    def method[T](self, x: T, context: Any) -> T: ...
+
+class B8(A8):
+    def method(self, x: int, context: Any) -> int: ...  # error: [invalid-method-override]
+
+class C8(A8):
+    def method[S](self, x: S, context: Any) -> S: ...
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3116,6 +3116,10 @@ static_assert(not is_subtype_of(NominalGeneric[int], LegacyClassScoped[str]))
 And they can also have generic contexts scoped to the method:
 
 ```py
+class NominalGenericReturningInt:
+    def f[T](self, input: T) -> int:
+        return 1
+
 class NewStyleFunctionScoped(Protocol):
     def f[T](self, input: T) -> T: ...
 
@@ -3135,6 +3139,18 @@ class ReturnsPep695Receiver(Protocol):
 
 class NominalNewStyle:
     def f[T](self, input: T) -> T:
+        return input
+
+class NominalGenericTopInput:
+    def f[T](self, input: object) -> T:
+        raise NotImplementedError
+
+class NominalGenericIntInput:
+    def f[T](self, input: int) -> T:
+        raise NotImplementedError
+
+class NominalGenericDynamic:
+    def f[T](self, input: T) -> Any:
         return input
 
 class NominalLegacy:
@@ -3222,6 +3238,14 @@ static_assert(is_assignable_to(NominalNewStyle, LegacyFunctionScoped))
 static_assert(is_subtype_of(NominalNewStyle, NewStyleFunctionScoped))
 static_assert(is_subtype_of(NominalNewStyle, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalNewStyle, UsesSelf))
+static_assert(not is_assignable_to(NominalGenericReturningInt, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalGenericReturningInt, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalGenericTopInput, NewStyleFunctionScoped))
+static_assert(is_subtype_of(NominalGenericTopInput, NewStyleFunctionScoped))
+static_assert(not is_assignable_to(NominalGenericIntInput, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalGenericIntInput, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalGenericDynamic, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalGenericDynamic, NewStyleFunctionScoped))
 
 static_assert(is_assignable_to(NominalLegacy, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalLegacy, LegacyFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3146,6 +3146,12 @@ class LegacyMultipleFunctionScoped(Protocol):
 class ClosedStaticFunctionScoped(Protocol):
     def transform[T](self, input: T, option: int | Literal["strict"]) -> T: ...
 
+class GradualFunctionScoped(Protocol):
+    def contextual[T](self, input: T, context: Any) -> T: ...
+
+class GradualReturnFunctionScoped(Protocol):
+    def f[T](self, input: T) -> Any: ...
+
 class UsesSelf(Protocol):
     def g(self: Self) -> Self: ...
 
@@ -3198,6 +3204,14 @@ class NominalClosedStaticConcrete:
     def transform(self, input: int, option: int | Literal["strict"]) -> int:
         return input
 
+class NominalGradualGeneric:
+    def contextual[S](self, input: S, context: Any) -> S:
+        return input
+
+class NominalGradualConcrete:
+    def contextual(self, input: int, context: Any) -> int:
+        return input
+
 class NominalMultipleDynamic:
     def multiple[S, R](self, first: S, second: R) -> Any:
         return first
@@ -3231,6 +3245,10 @@ class NominalPep695Receiver:
 
 class NominalDynamic:
     def f(self, input: Any) -> Any:
+        return input
+
+class NominalUnannotated:
+    def f(self, input):
         return input
 
 class NominalTopBottom:
@@ -3321,8 +3339,16 @@ static_assert(is_assignable_to(NominalClosedStaticGeneric, ClosedStaticFunctionS
 static_assert(is_subtype_of(NominalClosedStaticGeneric, ClosedStaticFunctionScoped))
 static_assert(not is_assignable_to(NominalClosedStaticConcrete, ClosedStaticFunctionScoped))
 static_assert(not is_subtype_of(NominalClosedStaticConcrete, ClosedStaticFunctionScoped))
+static_assert(is_assignable_to(NominalGradualGeneric, GradualFunctionScoped))
+static_assert(not is_subtype_of(NominalGradualGeneric, GradualFunctionScoped))
+static_assert(not is_assignable_to(NominalGradualConcrete, GradualFunctionScoped))
+static_assert(not is_subtype_of(NominalGradualConcrete, GradualFunctionScoped))
 static_assert(is_assignable_to(NominalMultipleDynamic, MultipleFunctionScoped))
 static_assert(not is_subtype_of(NominalMultipleDynamic, MultipleFunctionScoped))
+static_assert(is_assignable_to(NominalNewStyle, GradualReturnFunctionScoped))
+static_assert(not is_subtype_of(NominalNewStyle, GradualReturnFunctionScoped))
+static_assert(not is_assignable_to(NominalNotGeneric, GradualReturnFunctionScoped))
+static_assert(not is_subtype_of(NominalNotGeneric, GradualReturnFunctionScoped))
 
 static_assert(is_assignable_to(NominalLegacy, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalLegacy, LegacyFunctionScoped))
@@ -3355,6 +3381,9 @@ static_assert(is_subtype_of(NominalPep695Receiver, ReturnsPep695Receiver))
 static_assert(not is_assignable_to(NominalPep695Receiver, UsesLegacyReceiver))
 static_assert(not is_subtype_of(NominalPep695Receiver, UsesLegacyReceiver))
 static_assert(is_assignable_to(NominalDynamic, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalDynamic, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalUnannotated, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalUnannotated, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalTopBottom, NewStyleFunctionScoped))
 static_assert(is_subtype_of(NominalTopBottom, NewStyleFunctionScoped))
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3264,6 +3264,12 @@ class NominalNestedConcrete:
     def nested(self, input: list[int]) -> list[int]:
         return input
 
+# fmt: off
+class NominalNestedLargeLiteralUnion:
+    def nested_input(self, input: list[Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65]]) -> int:
+        return 0
+# fmt: on
+
 class NominalNestedTopBottom:
     def nested(self, input: object) -> Never:
         raise NotImplementedError
@@ -3422,6 +3428,8 @@ static_assert(is_subtype_of(NominalTopBottom, NewStyleFunctionScoped))
 
 static_assert(not is_assignable_to(NominalNestedConcrete, NestedFunctionScoped))
 static_assert(not is_subtype_of(NominalNestedConcrete, NestedFunctionScoped))
+static_assert(not is_assignable_to(NominalNestedLargeLiteralUnion, NestedInputFunctionScoped))
+static_assert(not is_subtype_of(NominalNestedLargeLiteralUnion, NestedInputFunctionScoped))
 static_assert(is_assignable_to(NominalNestedTopBottom, NestedFunctionScoped))
 static_assert(is_subtype_of(NominalNestedTopBottom, NestedFunctionScoped))
 static_assert(not is_assignable_to(NominalNestedInputConcrete, NestedInputFunctionScoped))
@@ -3435,6 +3443,13 @@ static_assert(not is_subtype_of(NominalNestedConcreteGenericClass[str], NestedFu
 
 # error: [invalid-assignment]
 nested: NestedFunctionScoped = NominalNestedConcreteGenericClass[str]()
+
+def consume_nested[U](value: NestedFunctionScoped, other: U) -> U:
+    return other
+
+# error: [invalid-argument-type]
+consume_nested(NominalNestedConcrete(), 1)
+consume_nested(NominalNestedTopBottom(), 1)
 
 # A concrete implementation cannot satisfy every specialization of a generic method.
 static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3158,6 +3158,9 @@ class NestedFunctionScoped(Protocol):
 class NestedInputFunctionScoped(Protocol):
     def nested_input[T](self, input: list[T]) -> int: ...
 
+class NestedGradualFunctionScoped(Protocol):
+    def nested_gradual[T](self, input: list[T], context: Any) -> list[T]: ...
+
 class UsesSelf(Protocol):
     def g(self: Self) -> Self: ...
 
@@ -3272,6 +3275,14 @@ class NominalNestedInputConcrete:
 class NominalNestedInputTop:
     def nested_input(self, input: object) -> int:
         return 0
+
+class NominalNestedGradualConcrete:
+    def nested_gradual(self, input: list[int], context: Any) -> list[int]:
+        return input
+
+class NominalNestedConcreteGenericClass[S]:
+    def nested(self, input: list[int]) -> list[int]:
+        return input
 
 class NominalTopBottom:
     def f(self, input: object) -> Never:
@@ -3417,6 +3428,13 @@ static_assert(not is_assignable_to(NominalNestedInputConcrete, NestedInputFuncti
 static_assert(not is_subtype_of(NominalNestedInputConcrete, NestedInputFunctionScoped))
 static_assert(is_assignable_to(NominalNestedInputTop, NestedInputFunctionScoped))
 static_assert(is_subtype_of(NominalNestedInputTop, NestedInputFunctionScoped))
+static_assert(not is_assignable_to(NominalNestedGradualConcrete, NestedGradualFunctionScoped))
+static_assert(not is_subtype_of(NominalNestedGradualConcrete, NestedGradualFunctionScoped))
+static_assert(not is_assignable_to(NominalNestedConcreteGenericClass[str], NestedFunctionScoped))
+static_assert(not is_subtype_of(NominalNestedConcreteGenericClass[str], NestedFunctionScoped))
+
+# error: [invalid-assignment]
+nested: NestedFunctionScoped = NominalNestedConcreteGenericClass[str]()
 
 # A concrete implementation cannot satisfy every specialization of a generic method.
 static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3120,8 +3120,15 @@ class NominalGenericReturningInt:
     def f[T](self, input: T) -> int:
         return 1
 
+class NominalMultipleReturningSecond:
+    def multiple[S, R](self, first: S, second: R) -> R:
+        return second
+
 class NewStyleFunctionScoped(Protocol):
     def f[T](self, input: T) -> T: ...
+
+class MultipleFunctionScoped(Protocol):
+    def multiple[T, U](self, first: T, second: U) -> T: ...
 
 FunctionT = TypeVar("FunctionT")
 
@@ -3152,6 +3159,26 @@ class NominalGenericIntInput:
 class NominalGenericDynamic:
     def f[T](self, input: T) -> Any:
         return input
+
+class NominalTwoGenericForSingle:
+    def f[S, R](self, input: S) -> R:
+        raise NotImplementedError
+
+class NominalMultipleGeneric:
+    def multiple[S, R](self, first: S, second: R) -> S:
+        return first
+
+class NominalSingleGenericForMultiple:
+    def multiple[S](self, first: S, second: object) -> S:
+        return first
+
+class NominalMultipleConcrete:
+    def multiple(self, first: int, second: str) -> int:
+        return first
+
+class NominalMultipleDynamic:
+    def multiple[S, R](self, first: S, second: R) -> Any:
+        return first
 
 class NominalLegacy:
     def f(self, input: FunctionT) -> FunctionT:
@@ -3246,6 +3273,18 @@ static_assert(not is_assignable_to(NominalGenericIntInput, NewStyleFunctionScope
 static_assert(not is_subtype_of(NominalGenericIntInput, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalGenericDynamic, NewStyleFunctionScoped))
 static_assert(not is_subtype_of(NominalGenericDynamic, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalTwoGenericForSingle, NewStyleFunctionScoped))
+static_assert(is_subtype_of(NominalTwoGenericForSingle, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalMultipleGeneric, MultipleFunctionScoped))
+static_assert(is_subtype_of(NominalMultipleGeneric, MultipleFunctionScoped))
+static_assert(is_assignable_to(NominalSingleGenericForMultiple, MultipleFunctionScoped))
+static_assert(is_subtype_of(NominalSingleGenericForMultiple, MultipleFunctionScoped))
+static_assert(not is_assignable_to(NominalMultipleReturningSecond, MultipleFunctionScoped))
+static_assert(not is_subtype_of(NominalMultipleReturningSecond, MultipleFunctionScoped))
+static_assert(not is_assignable_to(NominalMultipleConcrete, MultipleFunctionScoped))
+static_assert(not is_subtype_of(NominalMultipleConcrete, MultipleFunctionScoped))
+static_assert(is_assignable_to(NominalMultipleDynamic, MultipleFunctionScoped))
+static_assert(not is_subtype_of(NominalMultipleDynamic, MultipleFunctionScoped))
 
 static_assert(is_assignable_to(NominalLegacy, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalLegacy, LegacyFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3152,6 +3152,12 @@ class GradualFunctionScoped(Protocol):
 class GradualReturnFunctionScoped(Protocol):
     def f[T](self, input: T) -> Any: ...
 
+class NestedFunctionScoped(Protocol):
+    def nested[T](self, input: list[T]) -> list[T]: ...
+
+class NestedInputFunctionScoped(Protocol):
+    def nested_input[T](self, input: list[T]) -> int: ...
+
 class UsesSelf(Protocol):
     def g(self: Self) -> Self: ...
 
@@ -3250,6 +3256,22 @@ class NominalDynamic:
 class NominalUnannotated:
     def f(self, input):
         return input
+
+class NominalNestedConcrete:
+    def nested(self, input: list[int]) -> list[int]:
+        return input
+
+class NominalNestedTopBottom:
+    def nested(self, input: object) -> Never:
+        raise NotImplementedError
+
+class NominalNestedInputConcrete:
+    def nested_input(self, input: list[int]) -> int:
+        return 0
+
+class NominalNestedInputTop:
+    def nested_input(self, input: object) -> int:
+        return 0
 
 class NominalTopBottom:
     def f(self, input: object) -> Never:
@@ -3386,6 +3408,15 @@ static_assert(is_assignable_to(NominalUnannotated, NewStyleFunctionScoped))
 static_assert(not is_subtype_of(NominalUnannotated, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalTopBottom, NewStyleFunctionScoped))
 static_assert(is_subtype_of(NominalTopBottom, NewStyleFunctionScoped))
+
+static_assert(not is_assignable_to(NominalNestedConcrete, NestedFunctionScoped))
+static_assert(not is_subtype_of(NominalNestedConcrete, NestedFunctionScoped))
+static_assert(is_assignable_to(NominalNestedTopBottom, NestedFunctionScoped))
+static_assert(is_subtype_of(NominalNestedTopBottom, NestedFunctionScoped))
+static_assert(not is_assignable_to(NominalNestedInputConcrete, NestedInputFunctionScoped))
+static_assert(not is_subtype_of(NominalNestedInputConcrete, NestedInputFunctionScoped))
+static_assert(is_assignable_to(NominalNestedInputTop, NestedInputFunctionScoped))
+static_assert(is_subtype_of(NominalNestedInputTop, NestedInputFunctionScoped))
 
 # A concrete implementation cannot satisfy every specialization of a generic method.
 static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3158,6 +3158,9 @@ class NestedFunctionScoped(Protocol):
 class NestedInputFunctionScoped(Protocol):
     def nested_input[T](self, input: list[T]) -> int: ...
 
+class RepeatedNestedFunctionScoped(Protocol):
+    def repeated[T](self, first: list[T], second: list[T]) -> list[T]: ...
+
 class NestedGradualFunctionScoped(Protocol):
     def nested_gradual[T](self, input: list[T], context: Any) -> list[T]: ...
 
@@ -3281,6 +3284,10 @@ class NominalNestedInputConcrete:
 class NominalNestedInputTop:
     def nested_input(self, input: object) -> int:
         return 0
+
+class NominalRepeatedNestedConcrete:
+    def repeated(self, first: list[int], second: list[int]) -> list[int]:
+        return first
 
 class NominalNestedGradualConcrete:
     def nested_gradual(self, input: list[int], context: Any) -> list[int]:
@@ -3436,6 +3443,8 @@ static_assert(not is_assignable_to(NominalNestedInputConcrete, NestedInputFuncti
 static_assert(not is_subtype_of(NominalNestedInputConcrete, NestedInputFunctionScoped))
 static_assert(is_assignable_to(NominalNestedInputTop, NestedInputFunctionScoped))
 static_assert(is_subtype_of(NominalNestedInputTop, NestedInputFunctionScoped))
+static_assert(not is_assignable_to(NominalRepeatedNestedConcrete, RepeatedNestedFunctionScoped))
+static_assert(not is_subtype_of(NominalRepeatedNestedConcrete, RepeatedNestedFunctionScoped))
 static_assert(not is_assignable_to(NominalNestedGradualConcrete, NestedGradualFunctionScoped))
 static_assert(not is_subtype_of(NominalNestedGradualConcrete, NestedGradualFunctionScoped))
 static_assert(not is_assignable_to(NominalNestedConcreteGenericClass[str], NestedFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3055,7 +3055,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Any, Never, final, overload
+from typing import Any, Literal, Never, final, overload
 from typing_extensions import TypeVar, Self, Protocol
 from ty_extensions import static_assert
 from ty_extensions._internal import is_equivalent_to, is_assignable_to, is_subtype_of
@@ -3143,6 +3143,9 @@ class LegacyFunctionScoped(Protocol):
 class LegacyMultipleFunctionScoped(Protocol):
     def multiple(self, first: LegacyFirst, second: LegacySecond) -> LegacyFirst: ...
 
+class ClosedStaticFunctionScoped(Protocol):
+    def transform[T](self, input: T, option: int | Literal["strict"]) -> T: ...
+
 class UsesSelf(Protocol):
     def g(self: Self) -> Self: ...
 
@@ -3186,6 +3189,14 @@ class NominalSingleGenericForMultiple:
 class NominalMultipleConcrete:
     def multiple(self, first: int, second: str) -> int:
         return first
+
+class NominalClosedStaticGeneric:
+    def transform[S](self, input: S, option: int | Literal["strict"]) -> S:
+        return input
+
+class NominalClosedStaticConcrete:
+    def transform(self, input: int, option: int | Literal["strict"]) -> int:
+        return input
 
 class NominalMultipleDynamic:
     def multiple[S, R](self, first: S, second: R) -> Any:
@@ -3306,6 +3317,10 @@ static_assert(not is_assignable_to(NominalMultipleReturningSecond, MultipleFunct
 static_assert(not is_subtype_of(NominalMultipleReturningSecond, MultipleFunctionScoped))
 static_assert(not is_assignable_to(NominalMultipleConcrete, MultipleFunctionScoped))
 static_assert(not is_subtype_of(NominalMultipleConcrete, MultipleFunctionScoped))
+static_assert(is_assignable_to(NominalClosedStaticGeneric, ClosedStaticFunctionScoped))
+static_assert(is_subtype_of(NominalClosedStaticGeneric, ClosedStaticFunctionScoped))
+static_assert(not is_assignable_to(NominalClosedStaticConcrete, ClosedStaticFunctionScoped))
+static_assert(not is_subtype_of(NominalClosedStaticConcrete, ClosedStaticFunctionScoped))
 static_assert(is_assignable_to(NominalMultipleDynamic, MultipleFunctionScoped))
 static_assert(not is_subtype_of(NominalMultipleDynamic, MultipleFunctionScoped))
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3131,9 +3131,17 @@ class MultipleFunctionScoped(Protocol):
     def multiple[T, U](self, first: T, second: U) -> T: ...
 
 FunctionT = TypeVar("FunctionT")
+LegacyFirst = TypeVar("LegacyFirst")
+LegacySecond = TypeVar("LegacySecond")
+LegacyReturningIntT = TypeVar("LegacyReturningIntT")
+LegacyDynamicT = TypeVar("LegacyDynamicT")
+LegacyReceiverT = TypeVar("LegacyReceiverT")
 
 class LegacyFunctionScoped(Protocol):
     def f(self, input: FunctionT) -> FunctionT: ...
+
+class LegacyMultipleFunctionScoped(Protocol):
+    def multiple(self, first: LegacyFirst, second: LegacySecond) -> LegacyFirst: ...
 
 class UsesSelf(Protocol):
     def g(self: Self) -> Self: ...
@@ -3143,6 +3151,9 @@ class UsesPep695Receiver(Protocol):
 
 class ReturnsPep695Receiver(Protocol):
     def clone[T](self: T) -> T: ...
+
+class UsesLegacyReceiver(Protocol):
+    def compare(self: LegacyReceiverT, other: LegacyReceiverT) -> bool: ...
 
 class NominalNewStyle:
     def f[T](self, input: T) -> T:
@@ -3183,6 +3194,18 @@ class NominalMultipleDynamic:
 class NominalLegacy:
     def f(self, input: FunctionT) -> FunctionT:
         return input
+
+class NominalLegacyReturningInt:
+    def f(self, input: LegacyReturningIntT) -> int:
+        return 1
+
+class NominalLegacyDynamic:
+    def f(self, input: LegacyDynamicT) -> Any:
+        return input
+
+class NominalLegacyMultiple:
+    def multiple(self, first: LegacyFirst, second: LegacySecond) -> LegacyFirst:
+        return first
 
 class NominalWithSelf:
     def g(self: Self) -> Self:
@@ -3291,6 +3314,18 @@ static_assert(is_assignable_to(NominalLegacy, LegacyFunctionScoped))
 static_assert(is_subtype_of(NominalLegacy, NewStyleFunctionScoped))
 static_assert(is_subtype_of(NominalLegacy, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalLegacy, UsesSelf))
+static_assert(not is_assignable_to(NominalLegacyReturningInt, NewStyleFunctionScoped))
+static_assert(not is_assignable_to(NominalLegacyReturningInt, LegacyFunctionScoped))
+static_assert(not is_subtype_of(NominalLegacyReturningInt, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalLegacyReturningInt, LegacyFunctionScoped))
+static_assert(is_assignable_to(NominalLegacyDynamic, LegacyFunctionScoped))
+static_assert(not is_subtype_of(NominalLegacyDynamic, LegacyFunctionScoped))
+static_assert(is_assignable_to(NominalLegacyMultiple, LegacyMultipleFunctionScoped))
+static_assert(is_subtype_of(NominalLegacyMultiple, LegacyMultipleFunctionScoped))
+static_assert(not is_assignable_to(NominalMultipleReturningSecond, LegacyMultipleFunctionScoped))
+static_assert(not is_subtype_of(NominalMultipleReturningSecond, LegacyMultipleFunctionScoped))
+static_assert(not is_assignable_to(NominalMultipleConcrete, LegacyMultipleFunctionScoped))
+static_assert(not is_subtype_of(NominalMultipleConcrete, LegacyMultipleFunctionScoped))
 
 static_assert(not is_assignable_to(NominalWithSelf, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalWithSelf, LegacyFunctionScoped))
@@ -3302,6 +3337,8 @@ static_assert(not is_assignable_to(NominalPep695Receiver, UsesPep695Receiver))
 static_assert(not is_subtype_of(NominalPep695Receiver, UsesPep695Receiver))
 static_assert(is_assignable_to(NominalPep695Receiver, ReturnsPep695Receiver))
 static_assert(is_subtype_of(NominalPep695Receiver, ReturnsPep695Receiver))
+static_assert(not is_assignable_to(NominalPep695Receiver, UsesLegacyReceiver))
+static_assert(not is_subtype_of(NominalPep695Receiver, UsesLegacyReceiver))
 static_assert(is_assignable_to(NominalDynamic, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalTopBottom, NewStyleFunctionScoped))
 static_assert(is_subtype_of(NominalTopBottom, NewStyleFunctionScoped))
@@ -3310,8 +3347,8 @@ static_assert(is_subtype_of(NominalTopBottom, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))
 static_assert(not is_subtype_of(NominalNotGeneric, NewStyleFunctionScoped))
 
-# TODO: Universally quantify legacy method-local type variables.
-static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))  # error: [static-assert-error]
+static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))
+static_assert(not is_subtype_of(NominalNotGeneric, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalNotGeneric, UsesSelf))
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3055,7 +3055,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Any, final, overload
+from typing import Any, Never, final, overload
 from typing_extensions import TypeVar, Self, Protocol
 from ty_extensions import static_assert
 from ty_extensions._internal import is_equivalent_to, is_assignable_to, is_subtype_of
@@ -3127,6 +3127,12 @@ class LegacyFunctionScoped(Protocol):
 class UsesSelf(Protocol):
     def g(self: Self) -> Self: ...
 
+class UsesPep695Receiver(Protocol):
+    def compare[T](self: T, other: T) -> bool: ...
+
+class ReturnsPep695Receiver(Protocol):
+    def clone[T](self: T) -> T: ...
+
 class NominalNewStyle:
     def f[T](self, input: T) -> T:
         return input
@@ -3138,6 +3144,21 @@ class NominalLegacy:
 class NominalWithSelf:
     def g(self: Self) -> Self:
         return self
+
+class NominalPep695Receiver:
+    def compare(self, other: "NominalPep695Receiver") -> bool:
+        return True
+
+    def clone(self) -> "NominalPep695Receiver":
+        return self
+
+class NominalDynamic:
+    def f(self, input: Any) -> Any:
+        return input
+
+class NominalTopBottom:
+    def f(self, input: object) -> Never:
+        raise NotImplementedError
 
 class NominalNotGeneric:
     def f(self, input: int) -> int:
@@ -3212,9 +3233,21 @@ static_assert(not is_assignable_to(NominalWithSelf, NewStyleFunctionScoped))
 static_assert(not is_assignable_to(NominalWithSelf, LegacyFunctionScoped))
 static_assert(is_assignable_to(NominalWithSelf, UsesSelf))
 static_assert(is_subtype_of(NominalWithSelf, UsesSelf))
+# The receiver restricts `T` to supertypes of `NominalPep695Receiver`. The concrete `compare`
+# method cannot accept every such `T`, while its return type is valid for every such `T`.
+static_assert(not is_assignable_to(NominalPep695Receiver, UsesPep695Receiver))
+static_assert(not is_subtype_of(NominalPep695Receiver, UsesPep695Receiver))
+static_assert(is_assignable_to(NominalPep695Receiver, ReturnsPep695Receiver))
+static_assert(is_subtype_of(NominalPep695Receiver, ReturnsPep695Receiver))
+static_assert(is_assignable_to(NominalDynamic, NewStyleFunctionScoped))
+static_assert(is_assignable_to(NominalTopBottom, NewStyleFunctionScoped))
+static_assert(is_subtype_of(NominalTopBottom, NewStyleFunctionScoped))
 
-# TODO: these should pass
-static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))  # error: [static-assert-error]
+# A concrete implementation cannot satisfy every specialization of a generic method.
+static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalNotGeneric, NewStyleFunctionScoped))
+
+# TODO: Universally quantify legacy method-local type variables.
 static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))  # error: [static-assert-error]
 static_assert(not is_assignable_to(NominalNotGeneric, UsesSelf))
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -593,6 +593,7 @@ impl<'db> OverloadLiteral<'db> {
             file_scope_id,
             index,
         );
+
         let mut raw_signature = Signature::from_function(
             db,
             pep695_ctx,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -593,7 +593,6 @@ impl<'db> OverloadLiteral<'db> {
             file_scope_id,
             index,
         );
-
         let mut raw_signature = Signature::from_function(
             db,
             pep695_ctx,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -344,6 +344,7 @@ impl<'db> Type<'db> {
         let checker = TypeRelationChecker {
             constraints,
             inferable,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::SubtypingAssuming,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: None,
@@ -381,6 +382,7 @@ impl<'db> Type<'db> {
         let checker = TypeRelationChecker {
             constraints: &builder,
             inferable: InferableTypeVars::None,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: Some(ErrorContextTree::new()),
@@ -588,6 +590,7 @@ impl<'db> Type<'db> {
         let checker = TypeRelationChecker {
             constraints,
             inferable,
+            quantified_typevars: InferableTypeVars::None,
             relation,
             typevar_evaluation,
             context_tree: None,
@@ -743,6 +746,7 @@ impl<'db, 'c> IsDisjointVisitor<'db, 'c> {
 pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     pub(super) inferable: InferableTypeVars<'db>,
+    quantified_typevars: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
     pub(super) typevar_evaluation: TypeVarEvaluation,
     context_tree: Option<ErrorContextTree<'db>>,
@@ -772,6 +776,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::Subtyping,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: None,
@@ -793,6 +798,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
             context_tree: None,
@@ -814,6 +820,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
             context_tree: Some(ErrorContextTree::new()),
@@ -835,6 +842,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
+            quantified_typevars: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: Some(ErrorContextTree::new()),
@@ -849,6 +857,22 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     pub(super) fn with_inferable_typevars(&self, inferable: InferableTypeVars<'db>) -> Self {
         Self {
             inferable,
+            ..self.clone()
+        }
+    }
+
+    /// Marks type variables that are locally quantified by this relation.
+    ///
+    /// Direct gradual assignability to these variables must be evaluated before lazy constraint
+    /// capture. A gradual bound is useful evidence for caller-owned inference variables, but does
+    /// not restrict a local variable that is subsequently quantified away.
+    pub(super) fn with_quantified_typevars(
+        &self,
+        db: &'db dyn Db,
+        typevars: InferableTypeVars<'db>,
+    ) -> Self {
+        Self {
+            quantified_typevars: self.quantified_typevars.merge(db, typevars),
             ..self.clone()
         }
     }
@@ -1070,6 +1094,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // only has to hold when the typevar has a valid specialization (i.e., one that
             // satisfies the upper bound/constraints).
             if let Type::TypeVar(bound_typevar) = source {
+                if self.relation.is_assignability()
+                    && matches!(target, Type::Dynamic(_) | Type::Divergent(_))
+                    && bound_typevar.is_inferable(db, self.quantified_typevars)
+                {
+                    return self.always();
+                }
                 let upper = if self.relation.is_subtyping() {
                     target.bottom_materialization(db)
                 } else {
@@ -1082,6 +1112,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     upper,
                 );
             } else if let Type::TypeVar(bound_typevar) = target {
+                if self.relation.is_assignability()
+                    && matches!(source, Type::Dynamic(_) | Type::Divergent(_))
+                    && bound_typevar.is_inferable(db, self.quantified_typevars)
+                {
+                    return self.always();
+                }
                 let lower = if self.relation.is_subtyping() {
                     source.top_materialization(db)
                 } else {
@@ -2377,6 +2413,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             context_tree: None,
             given: self.given,
             inferable: InferableTypeVars::None,
+            quantified_typevars: InferableTypeVars::None,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
@@ -2460,6 +2497,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             typevar_evaluation: TypeVarEvaluation::Eager,
             constraints: self.constraints,
             inferable: self.inferable,
+            quantified_typevars: InferableTypeVars::None,
             context_tree: None,
             given: self.given,
             relation_visitor: self.relation_visitor,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1479,9 +1479,10 @@ impl<'db> Signature<'db> {
 
     /// Returns the callable-local variables supported by the initial higher-rank relation.
     ///
-    /// Every variable must be an unbounded PEP 695 type variable used only as a bare parameter or
-    /// return annotation after binding. In particular, this excludes nested occurrences.
-    fn bare_unbounded_pep695_typevars(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
+    /// Every variable must be an unbounded PEP 695 or legacy type variable bound by this method
+    /// and used only as a bare parameter or return annotation after binding. In particular, this
+    /// excludes class-scoped and nested occurrences.
+    fn bare_unbounded_method_typevars(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
         if !self.parameters.is_standard() {
             return None;
         }
@@ -1491,8 +1492,10 @@ impl<'db> Signature<'db> {
             .generic_context?
             .variables(db)
             .map(|typevar| {
-                (typevar.kind(db) == TypeVarKind::Pep695TypeVar
-                    && typevar.binding_context(db).definition() == Some(definition)
+                (matches!(
+                    typevar.kind(db),
+                    TypeVarKind::Pep695TypeVar | TypeVarKind::LegacyTypeVar
+                ) && typevar.binding_context(db).definition() == Some(definition)
                     && typevar.typevar(db).bound_or_constraints(db).is_none())
                 .then(|| typevar.identity(db))
             })
@@ -1863,7 +1866,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         }
 
         let source_locals = if source.generic_context.is_some() {
-            source.bare_unbounded_pep695_typevars(db)?
+            source.bare_unbounded_method_typevars(db)?
         } else {
             if !source.parameters.is_standard()
                 || !source
@@ -1878,7 +1881,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             InferableTypeVars::None
         };
 
-        let target_locals = target.bare_unbounded_pep695_typevars(db)?;
+        let target_locals = target.bare_unbounded_method_typevars(db)?;
         // The quantifiers must bind distinct occurrences. A signature compared with itself can
         // stay on the existing relation path instead of treating one occurrence as both binders.
         if source_locals

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1824,7 +1824,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ) -> ConstraintSet<'db, 'c> {
         if let ([source], [target]) = (source.overloads.as_slice(), target.overloads.as_slice())
             && let Some(relation) =
-                self.try_check_nongeneric_source_with_universal_target(db, source, target)
+                self.try_check_simple_source_with_universal_target(db, source, target)
         {
             return relation;
         }
@@ -1834,9 +1834,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
     /// Check the initial closed fragment of higher-rank generic callable relations.
     ///
-    /// A non-generic source must satisfy every receiver-compatible specialization of an unbounded
-    /// target-local type variable. Generic sources, overloads, declared domains, nested
-    /// occurrences, and enclosing inference variables remain on the existing relation path.
+    /// The source may have one unbounded local type variable whose specialization can depend on
+    /// each receiver-compatible specialization of the target's one unbounded local type variable.
+    /// Overloads, declared domains, nested occurrences, and enclosing inference variables remain
+    /// on the existing relation path.
     ///
     /// For example, `Concrete.f` does not satisfy `Generic.f`: the former only accepts `int`, while
     /// the latter must work for every `T`.
@@ -1848,31 +1849,50 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     /// class Concrete:
     ///     def f(self, value: int) -> int: ...
     /// ```
-    fn try_check_nongeneric_source_with_universal_target(
+    ///
+    /// A source `[S](S) -> S` does satisfy the target by choosing `S = T` for each target
+    /// specialization, while `[S](S) -> int` does not.
+    fn try_check_simple_source_with_universal_target(
         &self,
         db: &'db dyn Db,
         source: &Signature<'db>,
         target: &Signature<'db>,
     ) -> Option<ConstraintSet<'db, 'c>> {
-        if self.inferable != InferableTypeVars::None
-            || source.generic_context.is_some()
-            || !source.parameters.is_standard()
-            || !source
-                .parameters
-                .iter()
-                .map(Parameter::annotated_type)
-                .chain(std::iter::once(source.return_ty))
-                .all(|ty| Signature::is_supported_higher_rank_concrete_type(db, ty))
-        {
+        if self.inferable != InferableTypeVars::None {
             return None;
         }
 
+        let source_typevar = if source.generic_context.is_some() {
+            Some(source.bare_unbounded_pep695_typevar(db)?)
+        } else {
+            if !source.parameters.is_standard()
+                || !source
+                    .parameters
+                    .iter()
+                    .map(Parameter::annotated_type)
+                    .chain(std::iter::once(source.return_ty))
+                    .all(|ty| Signature::is_supported_higher_rank_concrete_type(db, ty))
+            {
+                return None;
+            }
+            None
+        };
+
         let target_typevar = target.bare_unbounded_pep695_typevar(db)?;
+        // The quantifiers must bind distinct occurrences. A signature compared with itself can
+        // stay on the existing relation path instead of treating one occurrence as both binders.
+        if source_typevar.is_some_and(|source| source.is_same_typevar_as(db, target_typevar)) {
+            return None;
+        }
+
+        let source_local = source_typevar.map_or(InferableTypeVars::None, |source| {
+            InferableTypeVars::from_typevars(db, std::iter::once(source.identity(db)).collect())
+        });
         let target_local = InferableTypeVars::from_typevars(
             db,
             std::iter::once(target_typevar.identity(db)).collect(),
         );
-        let mut checker = self.with_inferable_typevars(target_local);
+        let mut checker = self.with_inferable_typevars(source_local.merge(db, target_local));
         checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         let relation = checker.with_signature_recursion_guard(source, target, || {
             target
@@ -1885,7 +1905,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         })
                 })
         });
-        Some(relation.for_all(db, self.constraints, target_local))
+
+        // The source specialization may depend on the target specialization, so eliminate the
+        // source local existentially before eliminating the target local universally.
+        Some(
+            relation
+                .reduce_inferable(db, self.constraints, source_local)
+                .for_all(db, self.constraints, target_local),
+        )
     }
 
     /// Implementation of subtyping and assignability between two, possible overloaded, callable

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1482,6 +1482,17 @@ impl<'db> Signature<'db> {
         }
     }
 
+    /// Returns whether `ty` is supported as a top-level annotation by the initial higher-rank
+    /// relation.
+    ///
+    /// Direct gradual annotations are supported for assignability, but remain excluded from the
+    /// recursively closed fragment so that gradual unions and invariant containers stay on the
+    /// existing relation path.
+    fn is_supported_higher_rank_annotation(db: &'db dyn Db, ty: Type<'db>) -> bool {
+        matches!(ty, Type::Dynamic(_) | Type::Divergent(_))
+            || Self::is_supported_higher_rank_closed_type(db, ty)
+    }
+
     /// Returns the callable-local variables supported by the initial higher-rank relation.
     ///
     /// Every variable must be an unbounded PEP 695 or legacy type variable bound by this method
@@ -1517,7 +1528,7 @@ impl<'db> Signature<'db> {
             .all(|ty| {
                 ty.as_typevar()
                     .is_some_and(|typevar| typevar.is_inferable(db, locals))
-                    || Self::is_supported_higher_rank_closed_type(db, ty)
+                    || Self::is_supported_higher_rank_annotation(db, ty)
             })
             .then_some(locals)
     }
@@ -1879,7 +1890,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     .iter()
                     .map(Parameter::annotated_type)
                     .chain(std::iter::once(source.return_ty))
-                    .all(|ty| Signature::is_supported_higher_rank_closed_type(db, ty))
+                    .all(|ty| Signature::is_supported_higher_rank_annotation(db, ty))
             {
                 return None;
             }
@@ -1896,7 +1907,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
-        let mut checker = self.with_inferable_typevars(source_locals.merge(db, target_locals));
+        let quantified_typevars = source_locals.merge(db, target_locals);
+        let mut checker = self
+            .with_inferable_typevars(quantified_typevars)
+            .with_quantified_typevars(db, quantified_typevars);
         checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         let relation = checker.with_signature_recursion_guard(source, target, || {
             target

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1536,23 +1536,21 @@ impl<'db> Signature<'db> {
     /// Returns the single target-local variable supported in a shallow nominal annotation.
     ///
     /// This extends the initial higher-rank fragment only for non-generic source signatures.
-    /// Keeping the target to one unbounded PEP 695 variable, at most two occurrences, and one nominal
-    /// layer avoids both dependent source projection and independent-variable TDD expansion. Bare
-    /// class-scoped variables in other annotations remain rigid.
+    /// Keeping the target to one unbounded PEP 695 variable and one nominal layer avoids both
+    /// dependent source projection and independent-variable TDD expansion. Bare class-scoped
+    /// variables in other annotations remain rigid.
     fn single_nested_target_typevar(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
         fn is_supported<'db>(
             db: &'db dyn Db,
             ty: Type<'db>,
             local: BoundTypeVarInstance<'db>,
             allow_nominal: bool,
-            occurrences: &mut u8,
         ) -> bool {
             if ty
                 .as_typevar()
                 .is_some_and(|typevar| typevar.is_same_typevar_as(db, local))
             {
-                *occurrences += 1;
-                return *occurrences <= 2;
+                return true;
             }
 
             if allow_nominal && let Type::NominalInstance(instance) = ty {
@@ -1563,9 +1561,11 @@ impl<'db> Signature<'db> {
                         .class_literal_and_specialization(db)
                         .1
                         .is_none_or(|specialization| {
-                            specialization.types(db).iter().copied().all(|argument| {
-                                is_supported(db, argument, local, false, occurrences)
-                            })
+                            specialization
+                                .types(db)
+                                .iter()
+                                .copied()
+                                .all(|argument| is_supported(db, argument, local, false))
                         });
             }
 
@@ -1593,16 +1593,14 @@ impl<'db> Signature<'db> {
             return None;
         }
 
-        let mut occurrences = 0;
-        let supported = self
-            .parameters
+        self.parameters
             .iter()
             .map(Parameter::annotated_type)
             .chain(std::iter::once(self.return_ty))
-            .all(|ty| is_supported(db, ty, local, true, &mut occurrences));
-        (supported && occurrences > 0).then(|| {
-            InferableTypeVars::from_typevars(db, std::iter::once(local.identity(db)).collect())
-        })
+            .all(|ty| is_supported(db, ty, local, true))
+            .then(|| {
+                InferableTypeVars::from_typevars(db, std::iter::once(local.identity(db)).collect())
+            })
     }
 
     pub(crate) fn is_non_generic(&self) -> bool {
@@ -1971,13 +1969,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
-        let source_has_locals = source.generic_context.is_some_and(|context| {
-            context
-                .variables(db)
-                .any(|typevar| typevar.binding_context(db).definition() == source.definition)
-        });
-        let source_locals = if source_has_locals {
-            source.bare_unbounded_method_typevars(db)?
+        let source_locals = if let Some(source_locals) = source.bare_unbounded_method_typevars(db) {
+            source_locals
         } else {
             if !source.parameters.is_standard()
                 || !source
@@ -1995,6 +1988,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
             InferableTypeVars::None
         };
+        let source_has_locals = source_locals != InferableTypeVars::None;
 
         let bare_target_locals = target.bare_unbounded_method_typevars(db);
         let nested_target_locals = if bare_target_locals.is_none() && !source_has_locals {
@@ -5203,7 +5197,7 @@ mod tests {
             (
                 "/src/repeated.py",
                 "def f[T](first: list[T], second: list[T]) -> list[T]: ...",
-                false,
+                true,
             ),
         ] {
             let mut db = setup_db();

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1533,6 +1533,71 @@ impl<'db> Signature<'db> {
             .then_some(locals)
     }
 
+    /// Returns the single target-local variable supported in a shallow nominal annotation.
+    ///
+    /// This extends the initial higher-rank fragment only for non-generic source signatures.
+    /// Keeping the target to one unbounded PEP 695 variable, at most two occurrences, and one nominal
+    /// layer avoids both dependent source projection and independent-variable TDD expansion.
+    fn single_nested_target_typevar(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
+        fn is_supported<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            local: BoundTypeVarInstance<'db>,
+            allow_nominal: bool,
+            occurrences: &mut u8,
+        ) -> bool {
+            if ty
+                .as_typevar()
+                .is_some_and(|typevar| typevar.is_same_typevar_as(db, local))
+            {
+                *occurrences += 1;
+                return *occurrences <= 2;
+            }
+
+            if allow_nominal && let Type::NominalInstance(instance) = ty {
+                return instance.own_tuple_spec(db).is_none()
+                    && !instance.inherits_from_explicit_any()
+                    && instance
+                        .class(db)
+                        .class_literal_and_specialization(db)
+                        .1
+                        .is_none_or(|specialization| {
+                            specialization.types(db).iter().copied().all(|argument| {
+                                is_supported(db, argument, local, false, occurrences)
+                            })
+                        });
+            }
+
+            Signature::is_supported_higher_rank_closed_type(db, ty)
+        }
+
+        if self.has_explicit_receiver || !self.parameters.is_standard() {
+            return None;
+        }
+
+        let definition = self.definition?;
+        let mut typevars = self.generic_context?.variables(db);
+        let local = typevars.next()?;
+        if typevars.next().is_some()
+            || local.kind(db) != TypeVarKind::Pep695TypeVar
+            || local.binding_context(db).definition() != Some(definition)
+            || local.typevar(db).bound_or_constraints(db).is_some()
+        {
+            return None;
+        }
+
+        let mut occurrences = 0;
+        let supported = self
+            .parameters
+            .iter()
+            .map(Parameter::annotated_type)
+            .chain(std::iter::once(self.return_ty))
+            .all(|ty| is_supported(db, ty, local, true, &mut occurrences));
+        (supported && occurrences > 0).then(|| {
+            InferableTypeVars::from_typevars(db, std::iter::once(local.identity(db)).collect())
+        })
+    }
+
     pub(crate) fn is_non_generic(&self) -> bool {
         self.generic_context.is_none()
     }
@@ -1855,8 +1920,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     /// Check the initial closed fragment of higher-rank generic callable relations.
     ///
     /// The source's unbounded local type variables may depend on each receiver-compatible
-    /// specialization of the target's unbounded local type variables. Overloads, declared domains,
-    /// nested occurrences, and enclosing inference variables remain on the existing relation path.
+    /// specialization of the target's unbounded local type variables. A non-generic source may also
+    /// be checked against a target with one unbounded local occurring in a shallow nominal
+    /// annotation. Overloads, declared domains, other nested occurrences, and enclosing inference
+    /// variables remain on the existing relation path.
     ///
     /// For example, `Concrete.f` does not satisfy `Generic.f`: the former only accepts `int`, while
     /// the latter must work for every `T`.
@@ -1897,7 +1964,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             InferableTypeVars::None
         };
 
-        let target_locals = target.bare_unbounded_method_typevars(db)?;
+        let target_locals = target.bare_unbounded_method_typevars(db).or_else(|| {
+            if source.is_non_generic() {
+                target.single_nested_target_typevar(db)
+            } else {
+                None
+            }
+        })?;
         // The quantifiers must bind distinct occurrences. A signature compared with itself can
         // stay on the existing relation path instead of treating one occurrence as both binders.
         if source_locals
@@ -5032,6 +5105,54 @@ mod tests {
 
         assert!(sig.return_ty.is_unknown());
         assert_params(&sig, &[]);
+    }
+
+    #[test]
+    fn single_nested_target_typevar_is_narrowly_supported() {
+        for (path, source, supported) in [
+            (
+                "/src/supported.py",
+                "def f[T](value: list[T]) -> list[T]: ...",
+                true,
+            ),
+            (
+                "/src/multiple.py",
+                "def f[T, U](value: list[T]) -> list[U]: ...",
+                false,
+            ),
+            (
+                "/src/deep.py",
+                "def f[T](value: list[list[T]]) -> list[list[T]]: ...",
+                false,
+            ),
+            (
+                "/src/tuple.py",
+                "def f[T](value: tuple[list[T], object]) -> None: ...",
+                false,
+            ),
+            (
+                "/src/union.py",
+                "def f[T](value: list[T] | None) -> None: ...",
+                false,
+            ),
+            (
+                "/src/repeated.py",
+                "def f[T](first: list[T], second: list[T]) -> list[T]: ...",
+                false,
+            ),
+        ] {
+            let mut db = setup_db();
+            db.write_dedented(path, source).unwrap();
+            let signature = get_function_f(&db, path)
+                .literal(&db)
+                .last_definition
+                .signature(&db);
+
+            assert_eq!(
+                signature.single_nested_target_typevar(&db).is_some(),
+                supported
+            );
+        }
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1537,7 +1537,8 @@ impl<'db> Signature<'db> {
     ///
     /// This extends the initial higher-rank fragment only for non-generic source signatures.
     /// Keeping the target to one unbounded PEP 695 variable, at most two occurrences, and one nominal
-    /// layer avoids both dependent source projection and independent-variable TDD expansion.
+    /// layer avoids both dependent source projection and independent-variable TDD expansion. Bare
+    /// class-scoped variables in other annotations remain rigid.
     fn single_nested_target_typevar(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
         fn is_supported<'db>(
             db: &'db dyn Db,
@@ -1569,7 +1570,9 @@ impl<'db> Signature<'db> {
             }
 
             if allow_nominal {
-                Signature::is_supported_higher_rank_annotation(db, ty)
+                ty.as_typevar()
+                    .is_some_and(|typevar| typevar.binding_context(db) != local.binding_context(db))
+                    || Signature::is_supported_higher_rank_annotation(db, ty)
             } else {
                 Signature::is_supported_higher_rank_closed_type(db, ty)
             }
@@ -1927,7 +1930,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     /// specialization of the target's unbounded local type variables. A non-generic source may also
     /// be checked against a target with one unbounded local occurring in a shallow nominal
     /// annotation. Overloads, declared domains, other nested occurrences, and enclosing inference
-    /// variables remain on the existing relation path.
+    /// variables that occur in either signature remain on the existing relation path.
     ///
     /// For example, `Concrete.f` does not satisfy `Generic.f`: the former only accepts `int`, while
     /// the latter must work for every `T`.
@@ -1948,13 +1951,31 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
     ) -> Option<ConstraintSet<'db, 'c>> {
-        if self.inferable != InferableTypeVars::None {
+        const MAX_HIGHER_RANK_UNION_ELEMENTS: usize = 64;
+
+        let mentions_caller_inferable = |signature: &Signature<'db>| {
+            signature
+                .parameters
+                .iter()
+                .map(Parameter::annotated_type)
+                .chain(std::iter::once(signature.return_ty))
+                .any(|ty| {
+                    any_over_type(db, ty, false, |nested| {
+                        nested
+                            .as_typevar()
+                            .is_some_and(|typevar| typevar.is_inferable(db, self.inferable))
+                    })
+                })
+        };
+        if mentions_caller_inferable(source) || mentions_caller_inferable(target) {
             return None;
         }
 
-        let source_has_locals = source
-            .generic_context
-            .is_some_and(|context| context.variables(db).next().is_some());
+        let source_has_locals = source.generic_context.is_some_and(|context| {
+            context
+                .variables(db)
+                .any(|typevar| typevar.binding_context(db).definition() == source.definition)
+        });
         let source_locals = if source_has_locals {
             source.bare_unbounded_method_typevars(db)?
         } else {
@@ -1964,20 +1985,52 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     .iter()
                     .map(Parameter::annotated_type)
                     .chain(std::iter::once(source.return_ty))
-                    .all(|ty| Signature::is_supported_higher_rank_annotation(db, ty))
+                    .all(|ty| {
+                        ty.as_typevar().is_some_and(|typevar| {
+                            typevar.binding_context(db).definition() != source.definition
+                        }) || Signature::is_supported_higher_rank_annotation(db, ty)
+                    })
             {
                 return None;
             }
             InferableTypeVars::None
         };
 
-        let target_locals = target.bare_unbounded_method_typevars(db).or_else(|| {
-            if !source_has_locals {
-                target.single_nested_target_typevar(db)
-            } else {
-                None
-            }
-        })?;
+        let bare_target_locals = target.bare_unbounded_method_typevars(db);
+        let nested_target_locals = if bare_target_locals.is_none() && !source_has_locals {
+            target.single_nested_target_typevar(db)
+        } else {
+            None
+        };
+        let target_locals = bare_target_locals.or(nested_target_locals)?;
+
+        // A large closed union cannot cover every specialization of an unbounded target local.
+        // Reject it before invariant comparison distributes the union into a large constraint set.
+        if nested_target_locals.is_some()
+            && source
+                .parameters
+                .iter()
+                .map(Parameter::annotated_type)
+                .chain(std::iter::once(source.return_ty))
+                .zip(
+                    target
+                        .parameters
+                        .iter()
+                        .map(Parameter::annotated_type)
+                        .chain(std::iter::once(target.return_ty)),
+                )
+                .any(|(source_ty, target_ty)| {
+                    any_over_type(db, target_ty, false, |nested| {
+                        nested
+                            .as_typevar()
+                            .is_some_and(|typevar| typevar.is_inferable(db, target_locals))
+                    }) && any_over_type(db, source_ty, false, |nested| {
+                        matches!(nested, Type::Union(union) if union.elements(db).len() > MAX_HIGHER_RANK_UNION_ELEMENTS)
+                    })
+                })
+        {
+            return Some(self.never());
+        }
         // The quantifiers must bind distinct occurrences. A signature compared with itself can
         // stay on the existing relation path instead of treating one occurrence as both binders.
         if source_locals
@@ -1989,7 +2042,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         let quantified_typevars = source_locals.merge(db, target_locals);
         let mut checker = self
-            .with_inferable_typevars(quantified_typevars)
+            .with_inferable_typevars(self.inferable.merge(db, quantified_typevars))
             .with_quantified_typevars(db, quantified_typevars);
         checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         let relation = checker.with_signature_recursion_guard(source, target, || {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -34,11 +34,12 @@ use crate::types::relation::{
 };
 use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation;
 use crate::types::typevar::max_typevar_freshness_matching_generic_context;
+use crate::types::visitor::any_over_type;
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
     CallableType, ErrorContext, ErrorContextTree, FindLegacyTypeVarsVisitor, KnownClass,
     MaterializationKind, ParamSpecAttrKind, ParameterDescription, SelfBinding, TypeContext,
-    TypeMapping, TypeVarNonce, TypedDictType, UnionBuilder, VarianceInferable,
+    TypeMapping, TypeVarKind, TypeVarNonce, TypedDictType, UnionBuilder, VarianceInferable,
     infer_complete_scope_types, todo_type,
 };
 use crate::{Db, FxOrderSet};
@@ -518,7 +519,7 @@ impl<'db> CallableSignature<'db> {
             &signature_relation_visitor,
             &materialization_visitor,
         );
-        checker.check_callable_signature_pair_inner(db, &self.overloads, &other.overloads)
+        checker.check_callable_signature_pair(db, self, other)
     }
 }
 
@@ -749,7 +750,6 @@ impl<'db> Signature<'db> {
             pep695_generic_context,
             legacy_generic_context,
         );
-
         let (generic_context, return_ty) = match return_callable_typevar_scope {
             ReturnCallableTypeVarScope::Lexical => (full_generic_context, return_ty),
             ReturnCallableTypeVarScope::Public => {
@@ -1458,6 +1458,60 @@ impl<'db> Signature<'db> {
         }
     }
 
+    fn is_supported_higher_rank_concrete_type(db: &'db dyn Db, ty: Type<'db>) -> bool {
+        match ty {
+            Type::Never => true,
+            Type::NominalInstance(instance) => {
+                !instance.inherits_from_explicit_any()
+                    && !ty.has_dynamic(db)
+                    && !ty.has_typevar_or_typevar_instance(db)
+                    && !any_over_type(db, ty, false, |nested| matches!(nested, Type::TypeAlias(_)))
+            }
+            _ => false,
+        }
+    }
+
+    fn has_only_supported_higher_rank_concrete_types(&self, db: &'db dyn Db) -> bool {
+        self.parameters
+            .iter()
+            .map(Parameter::annotated_type)
+            .chain(std::iter::once(self.return_ty))
+            .all(|ty| Self::is_supported_higher_rank_concrete_type(db, ty))
+    }
+
+    /// Return the single callable-local variable supported by the initial higher-rank relation.
+    fn bare_unbounded_pep695_typevar(&self, db: &'db dyn Db) -> Option<BoundTypeVarInstance<'db>> {
+        if !self.parameters.is_standard() {
+            return None;
+        }
+
+        let definition = self.definition?;
+        let mut typevars = self.generic_context?.variables(db);
+        let typevar = typevars.next()?;
+        if typevars.next().is_some()
+            || typevar.kind(db) != TypeVarKind::Pep695TypeVar
+            || typevar.binding_context(db).definition() != Some(definition)
+            || typevar.typevar(db).bound_or_constraints(db).is_some()
+        {
+            return None;
+        }
+
+        let identity = typevar.typevar(db).identity(db);
+        self.parameters
+            .iter()
+            .map(Parameter::annotated_type)
+            .chain(std::iter::once(self.return_ty))
+            .all(|ty| {
+                if ty.references_typevar(db, identity) {
+                    ty.as_typevar()
+                        .is_some_and(|inner| inner.is_same_typevar_as(db, typevar))
+                } else {
+                    Self::is_supported_higher_rank_concrete_type(db, ty)
+                }
+            })
+            .then_some(typevar)
+    }
+
     pub(crate) fn is_non_generic(&self) -> bool {
         self.generic_context.is_none()
     }
@@ -1767,7 +1821,54 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &CallableSignature<'db>,
         target: &CallableSignature<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        if let ([source], [target]) = (source.overloads.as_slice(), target.overloads.as_slice())
+            && let Some(relation) =
+                self.try_check_nongeneric_source_with_universal_target(db, source, target)
+        {
+            return relation;
+        }
+
         self.check_callable_signature_pair_inner(db, &source.overloads, &target.overloads)
+    }
+
+    /// Check the initial closed fragment of higher-rank generic callable relations.
+    ///
+    /// A non-generic source must satisfy every receiver-compatible specialization of an unbounded
+    /// target-local type variable. Generic sources, overloads, declared domains, nested
+    /// occurrences, and enclosing inference variables remain on the existing relation path.
+    fn try_check_nongeneric_source_with_universal_target(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+    ) -> Option<ConstraintSet<'db, 'c>> {
+        if self.inferable != InferableTypeVars::None
+            || source.generic_context.is_some()
+            || !source.parameters.is_standard()
+            || !source.has_only_supported_higher_rank_concrete_types(db)
+        {
+            return None;
+        }
+
+        let target_typevar = target.bare_unbounded_pep695_typevar(db)?;
+        let target_local = InferableTypeVars::from_typevars(
+            db,
+            std::iter::once(target_typevar.identity(db)).collect(),
+        );
+        let mut checker = self.with_inferable_typevars(target_local);
+        checker.typevar_evaluation = TypeVarEvaluation::Lazy;
+        let relation = checker.with_signature_recursion_guard(source, target, || {
+            target
+                .receiver_bindings_when_satisfied(&checker, db)
+                .implies(db, self.constraints, || {
+                    source.receiver_bindings_when_satisfied(&checker, db).and(
+                        db,
+                        self.constraints,
+                        || checker.check_signature_pair_inner(db, source, target),
+                    )
+                })
+        });
+        Some(relation.for_all(db, self.constraints, target_local))
     }
 
     /// Implementation of subtyping and assignability between two, possible overloaded, callable

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1568,10 +1568,14 @@ impl<'db> Signature<'db> {
                         });
             }
 
-            Signature::is_supported_higher_rank_closed_type(db, ty)
+            if allow_nominal {
+                Signature::is_supported_higher_rank_annotation(db, ty)
+            } else {
+                Signature::is_supported_higher_rank_closed_type(db, ty)
+            }
         }
 
-        if self.has_explicit_receiver || !self.parameters.is_standard() {
+        if !self.parameters.is_standard() {
             return None;
         }
 
@@ -1948,7 +1952,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
-        let source_locals = if source.generic_context.is_some() {
+        let source_has_locals = source
+            .generic_context
+            .is_some_and(|context| context.variables(db).next().is_some());
+        let source_locals = if source_has_locals {
             source.bare_unbounded_method_typevars(db)?
         } else {
             if !source.parameters.is_standard()
@@ -1965,7 +1972,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         };
 
         let target_locals = target.bare_unbounded_method_typevars(db).or_else(|| {
-            if source.is_non_generic() {
+            if !source_has_locals {
                 target.single_nested_target_typevar(db)
             } else {
                 None
@@ -5119,6 +5126,11 @@ mod tests {
                 "/src/multiple.py",
                 "def f[T, U](value: list[T]) -> list[U]: ...",
                 false,
+            ),
+            (
+                "/src/gradual.py",
+                "from typing import Any\ndef f[T](value: list[T], context: Any) -> list[T]: ...",
+                true,
             ),
             (
                 "/src/deep.py",

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1459,14 +1459,19 @@ impl<'db> Signature<'db> {
         }
     }
 
-    /// Returns whether `ty` belongs to the closed concrete fragment that the initial higher-rank
+    /// Returns whether `ty` belongs to the closed static fragment that the initial higher-rank
     /// relation can quantify without losing type-variable relationships.
     ///
-    /// This deliberately excludes gradual types, type variables, and aliases, even when their
-    /// current expansion is nominal.
-    fn is_supported_higher_rank_concrete_type(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    /// This deliberately excludes gradual types, type variables, and aliases. Unions are supported
+    /// when each of their elements belongs to the fragment.
+    fn is_supported_higher_rank_closed_type(db: &'db dyn Db, ty: Type<'db>) -> bool {
         match ty {
-            Type::Never => true,
+            Type::Never | Type::LiteralValue(_) => true,
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .copied()
+                .all(|element| Self::is_supported_higher_rank_closed_type(db, element)),
             Type::NominalInstance(instance) => {
                 !instance.inherits_from_explicit_any()
                     && !ty.has_dynamic(db)
@@ -1512,7 +1517,7 @@ impl<'db> Signature<'db> {
             .all(|ty| {
                 ty.as_typevar()
                     .is_some_and(|typevar| typevar.is_inferable(db, locals))
-                    || Self::is_supported_higher_rank_concrete_type(db, ty)
+                    || Self::is_supported_higher_rank_closed_type(db, ty)
             })
             .then_some(locals)
     }
@@ -1874,7 +1879,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     .iter()
                     .map(Parameter::annotated_type)
                     .chain(std::iter::once(source.return_ty))
-                    .all(|ty| Signature::is_supported_higher_rank_concrete_type(db, ty))
+                    .all(|ty| Signature::is_supported_higher_rank_closed_type(db, ty))
             {
                 return None;
             }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1477,40 +1477,41 @@ impl<'db> Signature<'db> {
         }
     }
 
-    /// Returns the single callable-local variable supported by the initial higher-rank relation.
+    /// Returns the callable-local variables supported by the initial higher-rank relation.
     ///
-    /// The variable must be an unbounded PEP 695 type variable used only as a bare parameter or
+    /// Every variable must be an unbounded PEP 695 type variable used only as a bare parameter or
     /// return annotation after binding. In particular, this excludes nested occurrences.
-    fn bare_unbounded_pep695_typevar(&self, db: &'db dyn Db) -> Option<BoundTypeVarInstance<'db>> {
+    fn bare_unbounded_pep695_typevars(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
         if !self.parameters.is_standard() {
             return None;
         }
 
         let definition = self.definition?;
-        let mut typevars = self.generic_context?.variables(db);
-        let typevar = typevars.next()?;
-        if typevars.next().is_some()
-            || typevar.kind(db) != TypeVarKind::Pep695TypeVar
-            || typevar.binding_context(db).definition() != Some(definition)
-            || typevar.typevar(db).bound_or_constraints(db).is_some()
-        {
+        let local_identities: FxOrderSet<_> = self
+            .generic_context?
+            .variables(db)
+            .map(|typevar| {
+                (typevar.kind(db) == TypeVarKind::Pep695TypeVar
+                    && typevar.binding_context(db).definition() == Some(definition)
+                    && typevar.typevar(db).bound_or_constraints(db).is_none())
+                .then(|| typevar.identity(db))
+            })
+            .collect::<Option<_>>()?;
+        if local_identities.is_empty() {
             return None;
         }
 
-        let identity = typevar.typevar(db).identity(db);
+        let locals = InferableTypeVars::from_typevars(db, local_identities);
         self.parameters
             .iter()
             .map(Parameter::annotated_type)
             .chain(std::iter::once(self.return_ty))
             .all(|ty| {
-                if ty.references_typevar(db, identity) {
-                    ty.as_typevar()
-                        .is_some_and(|inner| inner.is_same_typevar_as(db, typevar))
-                } else {
-                    Self::is_supported_higher_rank_concrete_type(db, ty)
-                }
+                ty.as_typevar()
+                    .is_some_and(|typevar| typevar.is_inferable(db, locals))
+                    || Self::is_supported_higher_rank_concrete_type(db, ty)
             })
-            .then_some(typevar)
+            .then_some(locals)
     }
 
     pub(crate) fn is_non_generic(&self) -> bool {
@@ -1834,10 +1835,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
     /// Check the initial closed fragment of higher-rank generic callable relations.
     ///
-    /// The source may have one unbounded local type variable whose specialization can depend on
-    /// each receiver-compatible specialization of the target's one unbounded local type variable.
-    /// Overloads, declared domains, nested occurrences, and enclosing inference variables remain
-    /// on the existing relation path.
+    /// The source's unbounded local type variables may depend on each receiver-compatible
+    /// specialization of the target's unbounded local type variables. Overloads, declared domains,
+    /// nested occurrences, and enclosing inference variables remain on the existing relation path.
     ///
     /// For example, `Concrete.f` does not satisfy `Generic.f`: the former only accepts `int`, while
     /// the latter must work for every `T`.
@@ -1862,8 +1862,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
-        let source_typevar = if source.generic_context.is_some() {
-            Some(source.bare_unbounded_pep695_typevar(db)?)
+        let source_locals = if source.generic_context.is_some() {
+            source.bare_unbounded_pep695_typevars(db)?
         } else {
             if !source.parameters.is_standard()
                 || !source
@@ -1875,24 +1875,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             {
                 return None;
             }
-            None
+            InferableTypeVars::None
         };
 
-        let target_typevar = target.bare_unbounded_pep695_typevar(db)?;
+        let target_locals = target.bare_unbounded_pep695_typevars(db)?;
         // The quantifiers must bind distinct occurrences. A signature compared with itself can
         // stay on the existing relation path instead of treating one occurrence as both binders.
-        if source_typevar.is_some_and(|source| source.is_same_typevar_as(db, target_typevar)) {
+        if source_locals
+            .iter(db)
+            .any(|source| source.is_inferable(db, target_locals))
+        {
             return None;
         }
 
-        let source_local = source_typevar.map_or(InferableTypeVars::None, |source| {
-            InferableTypeVars::from_typevars(db, std::iter::once(source.identity(db)).collect())
-        });
-        let target_local = InferableTypeVars::from_typevars(
-            db,
-            std::iter::once(target_typevar.identity(db)).collect(),
-        );
-        let mut checker = self.with_inferable_typevars(source_local.merge(db, target_local));
+        let mut checker = self.with_inferable_typevars(source_locals.merge(db, target_locals));
         checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         let relation = checker.with_signature_recursion_guard(source, target, || {
             target
@@ -1907,11 +1903,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         });
 
         // The source specialization may depend on the target specialization, so eliminate the
-        // source local existentially before eliminating the target local universally.
+        // source locals existentially before eliminating the target locals universally.
         Some(
             relation
-                .reduce_inferable(db, self.constraints, source_local)
-                .for_all(db, self.constraints, target_local),
+                .reduce_inferable(db, self.constraints, source_locals)
+                .for_all(db, self.constraints, target_locals),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1876,13 +1876,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         let relation = checker.with_signature_recursion_guard(source, target, || {
             target
-                .receiver_bindings_when_satisfied(&checker, db)
+                .receiver_constraints_when_satisfied(&checker, db)
                 .implies(db, self.constraints, || {
-                    source.receiver_bindings_when_satisfied(&checker, db).and(
-                        db,
-                        self.constraints,
-                        || checker.check_signature_pair_inner(db, source, target),
-                    )
+                    source
+                        .receiver_constraints_when_satisfied(&checker, db)
+                        .and(db, self.constraints, || {
+                            checker.check_signature_pair_inner(db, source, target)
+                        })
                 })
         });
         Some(relation.for_all(db, self.constraints, target_local))

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -750,6 +750,7 @@ impl<'db> Signature<'db> {
             pep695_generic_context,
             legacy_generic_context,
         );
+
         let (generic_context, return_ty) = match return_callable_typevar_scope {
             ReturnCallableTypeVarScope::Lexical => (full_generic_context, return_ty),
             ReturnCallableTypeVarScope::Public => {
@@ -1458,6 +1459,11 @@ impl<'db> Signature<'db> {
         }
     }
 
+    /// Returns whether `ty` belongs to the closed concrete fragment that the initial higher-rank
+    /// relation can quantify without losing type-variable relationships.
+    ///
+    /// This deliberately excludes gradual types, type variables, and aliases, even when their
+    /// current expansion is nominal.
     fn is_supported_higher_rank_concrete_type(db: &'db dyn Db, ty: Type<'db>) -> bool {
         match ty {
             Type::Never => true,
@@ -1471,15 +1477,10 @@ impl<'db> Signature<'db> {
         }
     }
 
-    fn has_only_supported_higher_rank_concrete_types(&self, db: &'db dyn Db) -> bool {
-        self.parameters
-            .iter()
-            .map(Parameter::annotated_type)
-            .chain(std::iter::once(self.return_ty))
-            .all(|ty| Self::is_supported_higher_rank_concrete_type(db, ty))
-    }
-
-    /// Return the single callable-local variable supported by the initial higher-rank relation.
+    /// Returns the single callable-local variable supported by the initial higher-rank relation.
+    ///
+    /// The variable must be an unbounded PEP 695 type variable used only as a bare parameter or
+    /// return annotation after binding. In particular, this excludes nested occurrences.
     fn bare_unbounded_pep695_typevar(&self, db: &'db dyn Db) -> Option<BoundTypeVarInstance<'db>> {
         if !self.parameters.is_standard() {
             return None;
@@ -1836,6 +1837,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     /// A non-generic source must satisfy every receiver-compatible specialization of an unbounded
     /// target-local type variable. Generic sources, overloads, declared domains, nested
     /// occurrences, and enclosing inference variables remain on the existing relation path.
+    ///
+    /// For example, `Concrete.f` does not satisfy `Generic.f`: the former only accepts `int`, while
+    /// the latter must work for every `T`.
+    ///
+    /// ```python
+    /// class Generic(Protocol):
+    ///     def f[T](self, value: T) -> T: ...
+    ///
+    /// class Concrete:
+    ///     def f(self, value: int) -> int: ...
+    /// ```
     fn try_check_nongeneric_source_with_universal_target(
         &self,
         db: &'db dyn Db,
@@ -1845,7 +1857,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         if self.inferable != InferableTypeVars::None
             || source.generic_context.is_some()
             || !source.parameters.is_standard()
-            || !source.has_only_supported_higher_rank_concrete_types(db)
+            || !source
+                .parameters
+                .iter()
+                .map(Parameter::annotated_type)
+                .chain(std::iter::once(source.return_ty))
+                .all(|ty| Signature::is_supported_higher_rank_concrete_type(db, ty))
         {
             return None;
         }


### PR DESCRIPTION
## Summary

This builds on #26737, extending the higher-rank signature relation to a single unbounded PEP 695 target local that occurs inside a shallow nominal annotation. A concrete implementation cannot satisfy every specialization of that target, including when the implementation belongs to a specialized generic class or the target has an unrelated gradual annotation:

```python
from typing import Any, Protocol

class Identity(Protocol):
    def apply[T](self, value: list[T], context: Any) -> list[T]: ...

class IntIdentity[S]:
    def apply(self, value: list[int], context: Any) -> list[int]:
        return value

identity: Identity = IntIdentity[str]()  # error
```

We now universally check this narrow target shape against concrete bound source methods, fixing both protocol matching and invalid method overrides. An empty generic context left after receiver specialization is treated as non-generic, while methods with actual callable-local variables remain on the existing path. Direct `Any`, `Unknown`, and `Divergent` annotations are supported at the outer signature level without admitting gradual types inside nominal arguments.

The fragment is intentionally limited to one target local, at most two occurrences, one nominal layer, standard parameters, and otherwise closed annotations. Exact tuples, aliases, unions containing the local, deeper nesting, declared domains, and independent locals remain on the existing relation path.

This is the last PR in the current narrow stack. Broader structural targets and source specializations are being rebuilt separately on top of the deferred-quantification work in #25559, so this PR no longer depends on #26738 or #26752.
