### PR TITLE
[ty] Preserve shallow dependent source specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1010,6 +1010,12 @@ class B9(A9):
 class C9(A9):
     def method(self, x: object) -> Never: ...  # fine
 
+class D9(A9):
+    def method[S](self, x: S) -> S: ...  # fine
+
+class E9(A9):
+    def method[S](self, x: S) -> int: ...  # error: [invalid-method-override]
+
 class A10:
     def method[T](self, x: list[T]) -> int: ...
 
@@ -1018,6 +1024,9 @@ class B10(A10):
 
 class C10(A10):
     def method(self, x: object) -> int: ...  # fine
+
+class D10(A10):
+    def method[S](self, x: S) -> int: ...  # fine
 
 class A11:
     def method[T](self, x: list[T], context: Any) -> list[T]: ...

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -888,6 +888,9 @@ class E(A):
     # `E.method` accepts every argument, but does not preserve its type in the return.
     def method[S](self, x: S) -> int: ...  # error: [invalid-method-override]
 
+class E2(A):
+    def method[S, R](self, x: S) -> int: ...  # error: [invalid-method-override]
+
 class F(A):
     def method(self, x: Any) -> Any: ...  # fine
 

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1083,6 +1083,21 @@ class B3[S](A3[S]):
 
 class C3[S](A3[S]):
     def method(self, x: object, context: S) -> Never: ...  # fine
+
+class A4[U: Never]:
+    def method[T](self, x: list[T], context: U) -> list[T]: ...
+
+class B4[U: Never](A4[U]):
+    # The override only needs to hold for valid specializations of `U`. There are none, so it is
+    # vacuously valid.
+    def method[S](self, x: S, context: S) -> S: ...  # fine
+
+class A5[U: object]:
+    def method[T](self, x: list[T], context: U) -> list[T]: ...
+
+class B5[U: object](A5[U]):
+    # The bound on `U` does not make this concrete implementation generic in `T`.
+    def method(self, x: list[int], context: U) -> list[int]: ...  # error: [invalid-method-override]
 ```
 
 ## Fully qualified names are used in diagnostics where appropriate

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3123,6 +3123,10 @@ class NominalTwoGenericForSingle:
     def f[S, R](self, input: S) -> R:
         raise NotImplementedError
 
+class NominalTwoGenericReturningInt:
+    def f[S, R](self, input: S) -> int:
+        return 1
+
 class NominalMultipleGeneric:
     def multiple[S, R](self, first: S, second: R) -> S:
         return first
@@ -3268,6 +3272,8 @@ static_assert(is_assignable_to(NominalGenericDynamic, NewStyleFunctionScoped))
 static_assert(not is_subtype_of(NominalGenericDynamic, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalTwoGenericForSingle, NewStyleFunctionScoped))
 static_assert(is_subtype_of(NominalTwoGenericForSingle, NewStyleFunctionScoped))
+static_assert(not is_assignable_to(NominalTwoGenericReturningInt, NewStyleFunctionScoped))
+static_assert(not is_subtype_of(NominalTwoGenericReturningInt, NewStyleFunctionScoped))
 static_assert(is_assignable_to(NominalMultipleGeneric, MultipleFunctionScoped))
 static_assert(is_subtype_of(NominalMultipleGeneric, MultipleFunctionScoped))
 static_assert(is_assignable_to(NominalSingleGenericForMultiple, MultipleFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3221,6 +3221,18 @@ class NominalNestedConcreteGenericClass[S]:
     def nested(self, input: list[int]) -> list[int]:
         return input
 
+class NominalNestedGenericIdentity:
+    def nested[S](self, input: S) -> S:
+        return input
+
+class NominalNestedGenericReturnsInt:
+    def nested[S](self, input: S) -> int:
+        return 0
+
+class NominalNestedInputGeneric:
+    def nested_input[S](self, input: S) -> int:
+        return 0
+
 class NominalTopBottom:
     def f(self, input: object) -> Never:
         raise NotImplementedError
@@ -3338,6 +3350,13 @@ def consume_nested[U](value: NestedFunctionScoped, other: U) -> U:
 # error: [invalid-argument-type]
 consume_nested(NominalNestedConcrete(), 1)
 consume_nested(NominalNestedTopBottom(), 1)
+
+static_assert(is_assignable_to(NominalNestedGenericIdentity, NestedFunctionScoped))
+static_assert(is_subtype_of(NominalNestedGenericIdentity, NestedFunctionScoped))
+static_assert(not is_assignable_to(NominalNestedGenericReturnsInt, NestedFunctionScoped))
+static_assert(not is_subtype_of(NominalNestedGenericReturnsInt, NestedFunctionScoped))
+static_assert(is_assignable_to(NominalNestedInputGeneric, NestedInputFunctionScoped))
+static_assert(is_subtype_of(NominalNestedInputGeneric, NestedInputFunctionScoped))
 
 # A concrete implementation cannot satisfy every specialization of a generic method.
 static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -692,6 +692,50 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         Ok(projected.and(db, builder, || assumptions))
     }
 
+    /// Returns the valid-specialization constraints for free type variables mentioned by this
+    /// constraint set.
+    pub(crate) fn free_typevar_valid_specializations(
+        self,
+        db: &'db dyn Db,
+        builder: &'c ConstraintSetBuilder<'db>,
+        quantified: InferableTypeVars<'db>,
+    ) -> Self {
+        self.verify_builder(builder);
+        let typevars = RefCell::new(FxOrderSet::default());
+        let collect = |typevar: BoundTypeVarInstance<'db>| {
+            if !typevar.is_inferable(db, quantified) {
+                typevars.borrow_mut().insert(typevar);
+            }
+        };
+        self.node
+            .for_each_unique_constraint(builder, &mut |constraint, _| {
+                let constraint = builder.constraint_data(constraint);
+                collect(constraint.typevar);
+                for bound in constraint
+                    .bounds
+                    .lower
+                    .into_iter()
+                    .chain(constraint.bounds.upper)
+                {
+                    any_over_type(db, bound, false, |nested| {
+                        if let Some(typevar) = nested.as_typevar() {
+                            collect(typevar);
+                        }
+                        false
+                    });
+                }
+            });
+
+        typevars
+            .into_inner()
+            .into_iter()
+            .fold(Self::always(builder), |domain, typevar| {
+                domain.and(db, builder, || {
+                    Self::from_node(builder, typevar.valid_specializations(db, builder))
+                })
+            })
+    }
+
     /// Universally abstracts constraints involving the given type variables from this TDD.
     ///
     /// This is the Boolean dual of [`Self::reduce_inferable`]. Declared type variable bounds and

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -4298,8 +4298,13 @@ impl InteriorNode {
                     .lower
                     .into_iter()
                     .chain(constraint.bounds.upper)
-                    .filter_map(Type::as_typevar)
-                    .any(|bound| subject_is_removed != is_removed(bound));
+                    .any(|bound| {
+                        any_over_type(db, bound, false, |nested| {
+                            nested
+                                .as_typevar()
+                                .is_some_and(|typevar| subject_is_removed != is_removed(typevar))
+                        })
+                    });
             });
         if relates_removed_to_surviving
             && self.0.has_negative_branch(builder, &mut |constraint| {
@@ -7846,6 +7851,36 @@ mod tests {
             Type::TypeVar(target),
         );
         let relation = source_is_not_above_int.and(&db, &builder, || source_equals_target);
+
+        assert!(matches!(
+            relation.try_exists_assuming(
+                &db,
+                &builder,
+                typevar_set(&db, [source]),
+                ConstraintSet::always(&builder),
+            ),
+            Err(ConstraintProjectionError::NegatedTypeVarRelation)
+        ));
+    }
+
+    #[test]
+    fn fallible_projection_rejects_negated_shallow_relations() {
+        let db = setup_db();
+        let source = create_typevar(&db, "S");
+        let target = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let list_of_int =
+            KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+        let list_of_target =
+            KnownClass::List.to_specialized_instance(&db, &[Type::TypeVar(target)]);
+
+        let source_is_not_above_list_int =
+            ConstraintSet::constrain_typevar_lower_bound(&db, &builder, source, list_of_int)
+                .negate(&db, &builder);
+        let source_equals_list_target =
+            ConstraintSet::constrain_typevar(&db, &builder, source, list_of_target, list_of_target);
+        let relation =
+            source_is_not_above_list_int.and(&db, &builder, || source_equals_list_target);
 
         assert!(matches!(
             relation.try_exists_assuming(

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -628,14 +628,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// `assumptions` must not mention any variable in `to_remove`; because they are independent of
     /// those variables, they are conjoined only after projection and remain factored during the
     /// abstraction traversal. Type aliases are rejected conservatively because their opaque values
-    /// might contain a projected variable.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "used by quantified signature projection in the stacked follow-up"
-        )
-    )]
+    /// might contain a projected variable. A projected subject may have shallow nominal bounds
+    /// containing surviving variables; deeper or recursively dependent bounds remain unsupported.
     pub(crate) fn try_exists_assuming(
         self,
         db: &'db dyn Db,
@@ -4337,7 +4331,25 @@ impl InteriorNode {
                     }
                     if subject_is_removed {
                         if bound.as_typevar().is_none() && contains_any_typevar(bound) {
-                            return Err(ConstraintProjectionError::NestedTypeVarRelation);
+                            let Type::NominalInstance(instance) = bound else {
+                                return Err(ConstraintProjectionError::NestedTypeVarRelation);
+                            };
+                            if instance.own_tuple_spec(db).is_some()
+                                || instance.inherits_from_explicit_any()
+                                || contains_removed(bound)
+                                || instance
+                                    .class(db)
+                                    .class_literal_and_specialization(db)
+                                    .1
+                                    .is_some_and(|specialization| {
+                                        specialization.types(db).iter().copied().any(|argument| {
+                                            argument.as_typevar().is_none()
+                                                && contains_any_typevar(argument)
+                                        })
+                                    })
+                            {
+                                return Err(ConstraintProjectionError::NestedTypeVarRelation);
+                            }
                         }
                     } else if contains_removed(bound) {
                         if !bound.as_typevar().is_some_and(is_removed) {
@@ -7904,7 +7916,7 @@ mod tests {
     }
 
     #[test]
-    fn fallible_projection_rejects_nested_relations() {
+    fn fallible_projection_preserves_shallow_subject_bounds() {
         let db = setup_db();
         let source = create_typevar(&db, "S");
         let target = create_typevar(&db, "T");
@@ -7914,8 +7926,65 @@ mod tests {
         let source_below_list =
             ConstraintSet::constrain_typevar_upper_bound(&db, &builder, source, list_of_target);
 
+        let projected = source_below_list
+            .try_exists_assuming(
+                &db,
+                &builder,
+                typevar_set(&db, [source]),
+                ConstraintSet::always(&builder),
+            )
+            .expect("an unbounded source variable can specialize to a shallow nominal type");
+        assert!(projected.is_always_satisfied(&db));
+
+        let source_above_list =
+            ConstraintSet::constrain_typevar_lower_bound(&db, &builder, source, list_of_target);
+        let projected = source_above_list
+            .try_exists_assuming(
+                &db,
+                &builder,
+                typevar_set(&db, [source]),
+                ConstraintSet::always(&builder),
+            )
+            .expect("an unbounded source variable can specialize to a shallow nominal type");
+        assert!(projected.is_always_satisfied(&db));
+
+        let exact_source =
+            ConstraintSet::constrain_typevar(&db, &builder, source, list_of_target, list_of_target);
+        let projected = exact_source
+            .try_exists_assuming(
+                &db,
+                &builder,
+                typevar_set(&db, [source]),
+                ConstraintSet::always(&builder),
+            )
+            .expect("an unbounded source variable can specialize to a shallow nominal type");
+        assert!(projected.is_always_satisfied(&db));
+
+        let list_of_int =
+            KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+        let restricted_source =
+            ConstraintSet::constrain_typevar(&db, &builder, source, list_of_target, list_of_int);
+        let projected = restricted_source
+            .try_exists_assuming(
+                &db,
+                &builder,
+                typevar_set(&db, [source]),
+                ConstraintSet::always(&builder),
+            )
+            .expect("shallow source bounds preserve their relationship during projection")
+            .for_all(&db, &builder, typevar_set(&db, [target]));
+        assert!(projected.is_never_satisfied(&db));
+
+        let nested_list_of_target =
+            KnownClass::List.to_specialized_instance(&db, &[list_of_target]);
+        let source_below_nested_list = ConstraintSet::constrain_typevar_upper_bound(
+            &db,
+            &builder,
+            source,
+            nested_list_of_target,
+        );
         assert!(matches!(
-            source_below_list.try_exists_assuming(
+            source_below_nested_list.try_exists_assuming(
                 &db,
                 &builder,
                 typevar_set(&db, [source]),

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1794,7 +1794,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             None
         };
         let target_locals = bare_target_locals.or(nested_target_local)?;
-
         // A large closed union cannot cover every specialization of an unbounded target local.
         // Reject it before invariant comparison distributes the union into a large constraint set.
         if nested_target_local.is_some()

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1848,7 +1848,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // The source specialization may depend on the target specialization, so eliminate the
         // source locals existentially before eliminating the target locals universally.
         let projected = if source_has_locals && nested_target_local.is_some() {
-            relation
+            let valid_free_specializations = relation.free_typevar_valid_specializations(
+                db,
+                self.constraints,
+                quantified_typevars,
+            );
+            valid_free_specializations
+                .implies(db, self.constraints, || relation)
                 .try_exists_assuming(db, self.constraints, source_locals, self.always())
                 .unwrap_or_else(|_| self.never())
         } else {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1344,10 +1344,9 @@ impl<'db> Signature<'db> {
 
     /// Returns the single target-local variable supported in a shallow nominal annotation.
     ///
-    /// This extends the initial higher-rank fragment only for non-generic source signatures.
-    /// Keeping the target to one unbounded PEP 695 variable and one nominal layer avoids both
-    /// dependent source projection and independent-variable TDD expansion. Bare class-scoped
-    /// variables in other annotations remain rigid.
+    /// Keeping the target to one unbounded PEP 695 variable and one nominal layer avoids
+    /// independent-variable TDD expansion and bounds dependent source projection. Bare
+    /// class-scoped variables in other annotations remain rigid.
     fn single_nested_target_typevar(&self, db: &'db dyn Db) -> Option<InferableTypeVars<'db>> {
         fn is_supported<'db>(
             db: &'db dyn Db,
@@ -1723,10 +1722,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     /// Check the initial closed fragment of higher-rank generic callable relations.
     ///
     /// The source's unbounded local type variables may depend on the target's unbounded local type
-    /// variables. A non-generic source may also be checked against a target with one unbounded local
-    /// occurring in a shallow nominal annotation. Overloads, declared domains, other nested
-    /// occurrences, receiver-bound variables, and enclosing inference variables that occur in
-    /// either signature remain on the existing relation path.
+    /// variables. A target may also contain one unbounded local in a shallow nominal annotation;
+    /// a generic source can specialize its bare local to that annotation. Overloads, declared
+    /// domains, other nested occurrences, receiver-bound variables, and enclosing inference
+    /// variables that occur in either signature remain on the existing relation path.
     ///
     /// For example, `Concrete.f` does not satisfy `Generic.f`: the former only accepts `int`, while
     /// the latter must work for every `T`.
@@ -1789,16 +1788,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let source_has_locals = source_locals != InferableTypeVars::None;
 
         let bare_target_locals = target.bare_unbounded_method_typevars(db);
-        let nested_target_locals = if bare_target_locals.is_none() && !source_has_locals {
+        let nested_target_local = if bare_target_locals.is_none() {
             target.single_nested_target_typevar(db)
         } else {
             None
         };
-        let target_locals = bare_target_locals.or(nested_target_locals)?;
+        let target_locals = bare_target_locals.or(nested_target_local)?;
 
         // A large closed union cannot cover every specialization of an unbounded target local.
         // Reject it before invariant comparison distributes the union into a large constraint set.
-        if nested_target_locals.is_some()
+        if nested_target_local.is_some()
             && source
                 .parameters
                 .iter()
@@ -1823,6 +1822,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         {
             return Some(self.never());
         }
+        if nested_target_local.is_some()
+            && source_has_locals
+            && source_locals.iter(db).nth(1).is_some()
+        {
+            return None;
+        }
         // The quantifiers must bind distinct occurrences. A signature compared with itself can
         // stay on the existing relation path instead of treating one occurrence as both binders.
         if source_locals
@@ -1843,11 +1848,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // The source specialization may depend on the target specialization, so eliminate the
         // source locals existentially before eliminating the target locals universally.
-        Some(
+        let projected = if source_has_locals && nested_target_local.is_some() {
             relation
-                .reduce_inferable(db, self.constraints, source_locals)
-                .for_all(db, self.constraints, target_locals),
-        )
+                .try_exists_assuming(db, self.constraints, source_locals, self.always())
+                .unwrap_or_else(|_| self.never())
+        } else {
+            relation.reduce_inferable(db, self.constraints, source_locals)
+        };
+        Some(projected.for_all(db, self.constraints, target_locals))
     }
 
     /// Implementation of subtyping and assignability between two, possible overloaded, callable


### PR DESCRIPTION
## Summary

This builds on #26738 and uses fallible projection to preserve a source method specialization that depends on the target method's universally quantified variable.

For example, `[S](S) -> S` satisfies `[T](list[T]) -> list[T]`: for each target specialization, the source can choose `S = list[T]`. The ordinary existential abstraction cannot retain that relationship when eliminating `S`; this PR admits the exact shallow nominal case and then universally quantifies `T`.

The projection keeps the lower and upper source bounds correlated, rejects negated shallow relationships that cannot be represented exactly, and guards the relation with the valid domains of surviving class-scoped variables. This preserves vacuous generic-class cases such as an enclosing variable bounded by `Never` without hiding real incompatibilities for inhabited domains.

The supported fragment remains deliberately narrow: one unbounded bare source local, one unbounded PEP 695 target local, standard parameters, and a single shallow nominal layer. Declared method-local domains, deeper nested types, aliases, tuples, local unions, multiple interacting source locals, overloads, and caller inference remain outside this path. Unsupported projection is conservatively incompatible rather than falling back to existential target matching.
