### PR TITLE
[ty] Avoid repeated TypedDict union key lookups

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1254,6 +1254,43 @@ def get_person_from_employee(emp: Employee) -> Person:
     return Person(**emp)
 ```
 
+Unpacking a heterogeneous `TypedDict` union preserves the requiredness and value types of declared
+keys across arms, including keys supplied by `extra_items`:
+
+```py
+from typing_extensions import NotRequired, ReadOnly, TypedDict
+
+class RequiredA(TypedDict, closed=True):
+    a: int
+    shared: int
+
+class OptionalA(TypedDict, closed=True):
+    a: NotRequired[str]
+    shared: str
+
+class Extras(TypedDict, extra_items=ReadOnly[bytes]):
+    b: float
+    shared: bytes
+
+class EmptyClosed(TypedDict, closed=True): ...
+
+class UnionTarget(TypedDict, closed=True):
+    a: int | str | bytes
+    b: NotRequired[float]
+    shared: int | str | bytes
+
+def unpacked(value: RequiredA | OptionalA | Extras | EmptyClosed) -> UnionTarget:
+    # error: [missing-typed-dict-key] "Missing required key 'a' in TypedDict `UnionTarget` constructor"
+    # error: [missing-typed-dict-key] "Missing required key 'shared' in TypedDict `UnionTarget` constructor"
+    # error: [invalid-key] "Unpacked argument may contain unknown keys for TypedDict `UnionTarget`"
+    return UnionTarget(**value)
+
+def accepts(*, a: int | str | bytes, shared: int | str | bytes, b: float = 1) -> None: ...
+def kwargs(value: RequiredA | OptionalA | Extras | EmptyClosed) -> None:
+    # error: [unknown-argument] "Unpacked argument may contain keyword arguments that do not match any known parameter of function `accepts`"
+    accepts(**value)
+```
+
 However, the positional form allows extra keys, by analogy with the fact that assignment
 `p: Person = emp` is allowed (structural subtyping). It's not consistent that `Person(emp)` is more
 lenient than `Person(**emp)`; ultimately this is because extra keys _should_ be always allowed for a

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -21,12 +21,12 @@ use super::{
     ApplyTypeMappingVisitor, ErrorContext, IntersectionType, Type, TypeMapping, TypeQualifiers,
     UnionBuilder, definition_expression_annotation, definition_expression_type, visitor,
 };
-use crate::Db;
 use crate::types::TypeContext;
 use crate::types::TypeDefinition;
 use crate::types::class::FieldKind;
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
 use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
+use crate::{Db, FxOrderMap};
 use ty_python_core::definition::Definition;
 
 bitflags! {
@@ -1809,21 +1809,29 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 .map(|element| extract_unpacked_typed_dict_from_value_type(db, *element))
                 .collect::<Option<_>>()?;
 
-            let all_keys: OrderSet<Name> = unpacked_elements
-                .iter()
-                .flat_map(|unpacked| unpacked.keys.keys().cloned())
-                .collect();
+            let mut keys_by_arm: FxOrderMap<Name, Vec<(usize, &UnpackedTypedDictKey<'db>)>> =
+                FxOrderMap::default();
+            for (arm_index, unpacked) in unpacked_elements.iter().enumerate() {
+                for (key, unpacked_key) in &unpacked.keys {
+                    keys_by_arm
+                        .entry(key.clone())
+                        .or_default()
+                        .push((arm_index, unpacked_key));
+                }
+            }
+
             let mut result = BTreeMap::new();
 
-            for key in all_keys {
+            for (key, unpacked_keys) in keys_by_arm {
                 let mut value_ty = UnionBuilder::new(db);
                 let mut is_required = true;
                 let mut definition = None;
-                let mut saw_key = false;
+                let mut unpacked_keys = unpacked_keys.into_iter().peekable();
 
-                for unpacked in &unpacked_elements {
-                    if let Some(unpacked_key) = unpacked.keys.get(&key) {
-                        saw_key = true;
+                for (arm_index, unpacked) in unpacked_elements.iter().enumerate() {
+                    if let Some((_, unpacked_key)) = unpacked_keys
+                        .next_if(|(declared_arm_index, _)| *declared_arm_index == arm_index)
+                    {
                         value_ty = value_ty.add(unpacked_key.value_ty);
                         is_required &= unpacked_key.is_required;
                         definition = Some(if let Some(definition) = definition {
@@ -1832,7 +1840,6 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                             unpacked_key.definition
                         });
                     } else if let Some(extra_items) = unpacked.openness.effective_extra_items() {
-                        saw_key = true;
                         value_ty = value_ty.add(extra_items.declared_ty);
                         is_required = false;
                         definition = Some(None);
@@ -1842,16 +1849,14 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                     }
                 }
 
-                if saw_key {
-                    result.insert(
-                        key,
-                        UnpackedTypedDictKey {
-                            value_ty: value_ty.build(),
-                            is_required,
-                            definition: definition.flatten(),
-                        },
-                    );
-                }
+                result.insert(
+                    key,
+                    UnpackedTypedDictKey {
+                        value_ty: value_ty.build(),
+                        is_required,
+                        definition: definition.flatten(),
+                    },
+                );
             }
 
             let openness = union_unpacked_typed_dict_openness(


### PR DESCRIPTION
## Summary

When unpacking a union of `TypedDict`s, we currently collect the distinct declared keys and then perform a B-tree lookup for every key in every union arm. This is particularly costly for heterogeneous unions: the Pydantic benchmark performs 482,664 such probes, 438,256 of which miss.

Group declared keys by union arm during the initial traversal and reuse those entries while merging each key. This preserves first-seen key order, requiredness, definitions, and `extra_items` behavior while replacing repeated B-tree searches with a cheap arm-index walk. It also lets us remove the now-redundant `saw_key` check.

In local CodSpeed simulation, this removes about 1.9M `memcmp` calls and consistently saves roughly 63M modeled operations on the affected Pydantic paths. An uncontended hyperfine run improves Pydantic by about 0.8%, with no measurable change on Tanjun and mixed/noisy results on Altair.

Added focused mdtest coverage for heterogeneous unions with required, optional, disjoint, and `extra_items` keys through both `TypedDict` construction and `**kwargs`; the TypedDict and `functools.partial` mdtests pass.