### PR TITLE
Upgrade compact_str to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ clap_complete_command = { version = "0.6.0" }
 clearscreen = { version = "4.0.0" }
 codspeed-criterion-compat = { version = "5.0.0", default-features = false }
 colored = { version = "3.0.0" }
-compact_str = "0.9.0"
+compact_str = "0.9.1"
 console_error_panic_hook = { version = "0.1.7" }
 console_log = { version = "1.0.0" }
 countme = { version = "3.0.1" }


### PR DESCRIPTION
## Summary

Upgrade the workspace `compact_str` requirement from 0.9.0 to the newly released 0.9.1. The lockfile already resolves to 0.9.1, so this updates the declared minimum version to match.