### PR TITLE
[ty] Render the `math` reStructuredText directive as a literal block

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -1036,6 +1036,45 @@ Summary.
         "#);
     }
 
+    #[test]
+    fn math_blocks() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = r#"
+        Compute the value.
+
+        .. math:: x^2 + y^2 = z^2
+
+        A multiline formula follows.
+
+        .. math::
+            x_1 + x_2
+            = y
+
+        More prose after the formulas.
+        "#;
+
+        let docstring = Docstring::new(docstring.to_owned());
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Compute the value.<HB>
+        <HB>
+
+        ```````````text
+        x^2 + y^2 = z^2
+
+        ```````````
+        A multiline formula follows.<HB>
+        <HB>
+        <HB>
+        ```````````text
+            x_1 + x_2
+            = y
+
+        ```````````
+        More prose after the formulas.
+        ");
+    }
+
     // I don't know if this is valid syntax but we preserve stuff before `..code ::`
     #[test]
     fn code_block_prefix_gunk() {

--- a/crates/ty_ide/src/docstring/document/preformatted.rs
+++ b/crates/ty_ide/src/docstring/document/preformatted.rs
@@ -1,7 +1,7 @@
 use ruff_python_trivia::leading_indentation;
 use ruff_text_size::TextSize;
 
-use super::syntax::indentation as visual_indentation;
+use super::syntax::{indentation as visual_indentation, parse_rest_directive};
 
 /// Represents a fenced Markdown code block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -204,59 +204,30 @@ impl RestLiteralBlockScanner {
 
     /// Whether or not the given line marks the start of a reST literal block.
     fn line_starts_literal_block(line: &str) -> bool {
-        let Some(marker) = Self::literal_block_marker(line) else {
-            return false;
-        };
+        if let Some(directive) = parse_rest_directive(line) {
+            // The renderer does not recognize `seealso` as prose yet, but the document scanner
+            // has historically excluded its body from preformatted content.
+            return !directive.is_named("seealso") && directive.kind().is_preformatted();
+        }
 
-        !matches!(
-            marker,
-            RestLiteralBlockMarker::Directive(
-                "attention"
-                    | "caution"
-                    | "danger"
-                    | "error"
-                    | "hint"
-                    | "important"
-                    | "note"
-                    | "tip"
-                    | "warning"
-                    | "admonition"
-                    | "seealso"
-                    | "versionadded"
-                    | "version-added"
-                    | "versionchanged"
-                    | "version-changed"
-                    | "version-deprecated"
-                    | "deprecated"
-                    | "version-removed"
-                    | "versionremoved",
-            )
-        )
+        Self::line_starts_paragraph_literal_block(line)
     }
 
-    /// Tries to identify a marker that introduces a reST literal block.
-    fn literal_block_marker(line: &str) -> Option<RestLiteralBlockMarker<'_>> {
-        let marker = if let Some(marker) = line.strip_suffix("::") {
-            marker
+    /// Returns whether a paragraph ends with a reST literal block marker.
+    fn line_starts_paragraph_literal_block(line: &str) -> bool {
+        if line.ends_with("::") {
+            true
         } else {
-            let (before_language, _language) = line.rsplit_once(' ')?;
-            before_language.trim_end().strip_suffix("::")?
-        };
-
-        if let Some(directive) = marker.strip_prefix(".. ") {
-            Some(RestLiteralBlockMarker::Directive(directive))
-        } else {
-            Some(RestLiteralBlockMarker::Paragraph)
+            line.rsplit_once(' ')
+                .is_some_and(|(before_language, _)| before_language.trim_end().ends_with("::"))
         }
     }
 
     /// Whether or not a particular literal block can contain an unindented quoted literal block.
     fn allows_quoted_literal_block(line: &str) -> bool {
         line.ends_with("::")
-            && matches!(
-                Self::literal_block_marker(line),
-                Some(RestLiteralBlockMarker::Paragraph)
-            )
+            && parse_rest_directive(line).is_none()
+            && Self::line_starts_paragraph_literal_block(line)
     }
 
     /// Returns the quote character for a quoted literal block line.
@@ -270,13 +241,6 @@ impl RestLiteralBlockScanner {
             .contains(quote)
             .then_some(quote)
     }
-}
-
-/// Identifies the syntax that introduced a potential reST literal block.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RestLiteralBlockMarker<'a> {
-    Paragraph,
-    Directive(&'a str),
 }
 
 /// Tracks the state of a literal block introduced by reST syntax.

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -30,6 +30,93 @@ pub(super) struct ParsedLine<'a> {
     pub(super) indent: TextSize,
 }
 
+/// Parses a reStructuredText directive marker and its complete argument.
+pub(in crate::docstring) fn parse_rest_directive(line: &str) -> Option<RestDirective<'_>> {
+    let directive = line.trim_start().strip_prefix(".. ")?;
+    let (name, argument) = directive.split_once("::")?;
+    if name.is_empty() || name.chars().any(char::is_whitespace) {
+        return None;
+    }
+
+    Some(RestDirective {
+        name,
+        argument: argument.trim(),
+    })
+}
+
+/// A parsed reStructuredText directive marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::docstring) struct RestDirective<'a> {
+    name: &'a str,
+    argument: &'a str,
+}
+
+impl<'a> RestDirective<'a> {
+    /// Returns the directive name without the leading `..` or trailing `::`.
+    pub(in crate::docstring) const fn name(self) -> &'a str {
+        self.name
+    }
+
+    /// Returns all text following the directive marker on the same line.
+    pub(in crate::docstring) const fn argument(self) -> &'a str {
+        self.argument
+    }
+
+    /// Returns whether this directive has the given name.
+    pub(in crate::docstring) fn is_named(self, name: &str) -> bool {
+        self.name == name
+    }
+
+    /// Returns how the directive's content should be rendered.
+    pub(in crate::docstring) fn kind(self) -> RestDirectiveKind {
+        if self.is_named("math") {
+            RestDirectiveKind::Preformatted
+        } else if matches!(
+            self.name,
+            "attention"
+                | "caution"
+                | "danger"
+                | "error"
+                | "hint"
+                | "important"
+                | "note"
+                | "tip"
+                | "warning"
+                | "admonition"
+                | "versionadded"
+                | "version-added"
+                | "versionchanged"
+                | "version-changed"
+                | "version-deprecated"
+                | "deprecated"
+                | "version-removed"
+                | "versionremoved"
+        ) {
+            RestDirectiveKind::Prose
+        } else {
+            RestDirectiveKind::Code
+        }
+    }
+}
+
+/// Describes how a reStructuredText directive's content should be rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::docstring) enum RestDirectiveKind {
+    /// Source code or interactive examples.
+    Code,
+    /// Whitespace-sensitive content that is not source code.
+    Preformatted,
+    /// Content parsed as ordinary reStructuredText body elements.
+    Prose,
+}
+
+impl RestDirectiveKind {
+    /// Returns whether the directive introduces content whose whitespace must be preserved.
+    pub(in crate::docstring) const fn is_preformatted(self) -> bool {
+        matches!(self, Self::Code | Self::Preformatted)
+    }
+}
+
 /// Returns whether `line` starts with a `CommonMark` list-item marker.
 ///
 /// `CommonMark` limits ordered-list markers to nine digits to avoid integer
@@ -53,7 +140,7 @@ pub(in crate::docstring) fn starts_with_markdown_list_item(line: &str) -> bool {
 /// Returns the end of an indented Markdown or reStructuredText container block.
 pub(super) fn container_block_end(lines: &[ParsedLine<'_>], index: usize) -> Option<usize> {
     let marker = lines.get(index)?;
-    if !is_rest_directive_marker(marker.text)
+    if parse_rest_directive(marker.text).is_none()
         && !is_field_list_marker(marker.text)
         && !starts_with_markdown_list_item(marker.text.trim_start())
     {
@@ -68,17 +155,6 @@ pub(super) fn container_block_end(lines: &[ParsedLine<'_>], index: usize) -> Opt
             })
             .unwrap_or(lines.len()),
     )
-}
-
-fn is_rest_directive_marker(line: &str) -> bool {
-    let Some(directive) = line.trim_start().strip_prefix(".. ") else {
-        return false;
-    };
-    let Some((name, _)) = directive.split_once("::") else {
-        return false;
-    };
-
-    !name.is_empty() && !name.chars().any(char::is_whitespace)
 }
 
 /// Splits the input once at the first colon outside bracket pairs and quoted strings.
@@ -187,4 +263,37 @@ pub(super) fn indentation(line: &str) -> TextSize {
                 _ => column + 1,
             }),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RestDirectiveKind, parse_rest_directive};
+
+    #[test]
+    fn parses_complete_rest_directive_arguments() {
+        let directive = parse_rest_directive("  .. math:: x^2 + y^2 = z^2").unwrap();
+
+        assert_eq!(directive.name(), "math");
+        assert_eq!(directive.argument(), "x^2 + y^2 = z^2");
+        assert_eq!(directive.kind(), RestDirectiveKind::Preformatted);
+    }
+
+    #[test]
+    fn classifies_rest_directives() {
+        for (name, expected) in [
+            ("code", RestDirectiveKind::Code),
+            ("math", RestDirectiveKind::Preformatted),
+            ("warning", RestDirectiveKind::Prose),
+        ] {
+            let marker = format!(".. {name}::");
+            assert_eq!(parse_rest_directive(&marker).unwrap().kind(), expected);
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_rest_directive_markers() {
+        assert_eq!(parse_rest_directive(".. missing-colons"), None);
+        assert_eq!(parse_rest_directive(".. two words::"), None);
+        assert_eq!(parse_rest_directive("prose .. warning::"), None);
+    }
 }

--- a/crates/ty_ide/src/docstring/markdown/general.rs
+++ b/crates/ty_ide/src/docstring/markdown/general.rs
@@ -2,7 +2,10 @@ use std::borrow::Cow;
 
 use ruff_text_size::TextSize;
 
-use super::super::document::preformatted::MarkdownFence;
+use super::super::document::{
+    preformatted::MarkdownFence,
+    syntax::{RestDirectiveKind, parse_rest_directive},
+};
 
 mod inline;
 
@@ -148,6 +151,44 @@ fn render_with_indentation_mode(
             continue;
         }
 
+        // Parse directives before paragraph literal blocks so their complete arguments are
+        // available to directive-specific rendering.
+        let parsed_directive = renderer
+            .block_state
+            .is_prose()
+            .then(|| parse_rest_directive(trimmed_source_line))
+            .flatten();
+        if let Some(directive) = parsed_directive {
+            renderer.flush_pending_link();
+            match directive.kind() {
+                RestDirectiveKind::Code => {
+                    rendered_line = "";
+                    renderer.start_pending_rest_literal(
+                        directive
+                            .argument()
+                            .split_whitespace()
+                            .next()
+                            .unwrap_or("python"),
+                    );
+                }
+                RestDirectiveKind::Preformatted => {
+                    rendered_line = directive.argument();
+                    if rendered_line.is_empty() {
+                        renderer.start_pending_rest_literal("text");
+                    } else {
+                        // Use an indentation deeper than the marker so that following prose closes
+                        // the block while indented continuation lines remain part of the formula.
+                        renderer.start_rest_literal("text", line_indent + TextSize::from(1));
+                    }
+                }
+                RestDirectiveKind::Prose => {
+                    temp_owned_line =
+                        render_prose_directive("", directive.name(), directive.argument());
+                    rendered_line = temp_owned_line.as_str();
+                }
+            }
+        }
+
         // If we're not in a codeblock and we see something that signals a literal block, start one
         let parsed_literal = trimmed_source_line
             // first check for a line ending with `::`
@@ -159,7 +200,8 @@ fn render_with_indentation_mode(
                 let prefix = prefix.trim_end().strip_suffix("::")?;
                 Some((prefix, Some(lang)))
             });
-        if renderer.block_state.is_prose()
+        if parsed_directive.is_none()
+            && renderer.block_state.is_prose()
             && let Some((without_literal, lang)) = parsed_literal
         {
             let mut without_directive = without_literal;
@@ -200,37 +242,13 @@ fn render_with_indentation_mode(
                     // pending hyperlink from the previous line.
                     renderer.flush_pending_link();
 
-                    // Map version directives to human-readable phrases (matching Sphinx output)
-                    let pretty_directive = match directive.unwrap() {
-                        "versionadded" | "version-added" => Cow::Borrowed("Added in version"),
-                        "versionchanged" | "version-changed" => Cow::Borrowed("Changed in version"),
-                        "deprecated" | "version-deprecated" => {
-                            Cow::Borrowed("Deprecated since version")
-                        }
-                        "versionremoved" | "version-removed" => Cow::Borrowed("Removed in version"),
-                        other => Cow::Owned(
-                            other
-                                .char_indices()
-                                .map(|(index, c)| {
-                                    if index == 0 {
-                                        c.to_ascii_uppercase()
-                                    } else {
-                                        c
-                                    }
-                                })
-                                .collect(),
-                        ),
-                    };
-
-                    // Render the argument of things like `.. version-added:: 4.0`
-                    let suffix = if let Some(lang) = lang {
-                        format!(" {lang}")
-                    } else {
-                        String::new()
-                    };
                     // We prepend without_directive here out of caution for preserving input.
                     // This is probably gibberish/invalid syntax? But it's a no-op in normal cases.
-                    temp_owned_line = format!("**{without_directive}{pretty_directive}{suffix}:**");
+                    temp_owned_line = render_prose_directive(
+                        without_directive,
+                        directive.unwrap(),
+                        lang.unwrap_or_default(),
+                    );
 
                     rendered_line = temp_owned_line.as_str();
                 }
@@ -261,6 +279,34 @@ fn render_with_indentation_mode(
         );
     }
     renderer.finish_document();
+}
+
+fn render_prose_directive(prefix: &str, name: &str, argument: &str) -> String {
+    // Map version directives to human-readable phrases (matching Sphinx output).
+    let pretty_name = match name {
+        "versionadded" | "version-added" => Cow::Borrowed("Added in version"),
+        "versionchanged" | "version-changed" => Cow::Borrowed("Changed in version"),
+        "deprecated" | "version-deprecated" => Cow::Borrowed("Deprecated since version"),
+        "versionremoved" | "version-removed" => Cow::Borrowed("Removed in version"),
+        other => Cow::Owned(
+            other
+                .char_indices()
+                .map(|(index, character)| {
+                    if index == 0 {
+                        character.to_ascii_uppercase()
+                    } else {
+                        character
+                    }
+                })
+                .collect(),
+        ),
+    };
+
+    if argument.is_empty() {
+        format!("**{prefix}{pretty_name}:**")
+    } else {
+        format!("**{prefix}{pretty_name} {argument}:**")
+    }
 }
 
 /// How to emit leading indentation outside recognized code blocks.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
