### PR TITLE
[ty] Preserve terminal narrowing across branch merges

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4187,24 +4187,20 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             .narrowing_constraints
                             .add_atom(predicate_id);
 
-                        if self.in_function_scope() {
+                        let has_reachability_constraint = self.in_function_scope();
+                        if has_reachability_constraint {
                             self.record_reachability_constraint_id(predicate_id);
-
-                            // Also gate narrowing by this constraint: if the call returns
-                            // `Never`, any narrowing in the current branch should be
-                            // invalidated (since this path is unreachable). This enables
-                            // narrowing to be preserved after if-statements where one branch
-                            // calls a `NoReturn` function like `sys.exit()`.
-                            self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
-                        } else {
-                            // In non-function scopes, we only record a narrowing constraint
-                            // (not a reachability constraint). Recording reachability for
-                            // calls in module scope is simply too expensive, and it's not
-                            // too important of a use case.
-                            self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
                         }
+
+                        // Gate narrowing by this constraint: if the call returns `Never`, any
+                        // narrowing in the current branch should be invalidated. Non-function
+                        // scopes intentionally record only the narrowing gate because tracking
+                        // call reachability there is too expensive.
+                        self.current_use_def_map_mut()
+                            .gate_existing_narrowing_for_all_places(
+                                narrowing_constraint,
+                                has_reachability_constraint,
+                            );
                     }
                 }
             }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1383,9 +1383,10 @@ struct PendingReachabilityId;
 struct PendingReachabilityConstraint {
     parent: PendingReachabilityId,
     constraint: ScopedReachabilityConstraintId,
+    narrowing_gate: ScopedNarrowingConstraint,
 }
 
-/// An append-only tree of scope-wide reachability constraints.
+/// An append-only tree of scope-wide reachability constraints and terminal-call gates.
 ///
 /// Each [`PendingPlaceState`] remembers the last node applied to its place state, so snapshots can
 /// share place states and defer applying subsequent constraints until the place is observed or
@@ -1403,6 +1404,7 @@ impl Default for PendingReachability {
         constraints.push(PendingReachabilityConstraint {
             parent: root,
             constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            narrowing_gate: ScopedNarrowingConstraint::ALWAYS_TRUE,
         });
         Self {
             constraints,
@@ -1416,7 +1418,24 @@ impl PendingReachability {
         self.current = self.constraints.push(PendingReachabilityConstraint {
             parent: self.current,
             constraint,
+            narrowing_gate: ScopedNarrowingConstraint::ALWAYS_TRUE,
         });
+    }
+
+    fn record_narrowing_gate(
+        &mut self,
+        narrowing_gate: ScopedNarrowingConstraint,
+        has_reachability_constraint: bool,
+    ) {
+        if has_reachability_constraint {
+            self.constraints[self.current].narrowing_gate = narrowing_gate;
+        } else {
+            self.current = self.constraints.push(PendingReachabilityConstraint {
+                parent: self.current,
+                constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
+                narrowing_gate,
+            });
+        }
     }
 
     /// Applies the constraints between the place's last materialized node and `target`.
@@ -1491,6 +1510,49 @@ impl PendingReachability {
         }
         constraint
     }
+
+    /// Takes the terminal-call gates introduced by each path after their common ancestor.
+    ///
+    /// Gates are consumed when their paths are merged: reusing a branch-local gate in a later
+    /// `elif` merge would incorrectly apply it to the already-merged paths. The gates are combined
+    /// in source order to keep their decision diagrams compact.
+    fn take_narrowing_gates_between_paths(
+        &mut self,
+        mut current: PendingReachabilityId,
+        mut branch: PendingReachabilityId,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+    ) -> (ScopedNarrowingConstraint, ScopedNarrowingConstraint) {
+        let mut current_gates = SmallVec::<[ScopedNarrowingConstraint; 4]>::new();
+        let mut branch_gates = SmallVec::<[ScopedNarrowingConstraint; 4]>::new();
+
+        while current != branch {
+            if current.index() > branch.index() {
+                let event = &mut self.constraints[current];
+                current_gates.push(std::mem::replace(
+                    &mut event.narrowing_gate,
+                    ScopedNarrowingConstraint::ALWAYS_TRUE,
+                ));
+                current = event.parent;
+            } else {
+                let event = &mut self.constraints[branch];
+                branch_gates.push(std::mem::replace(
+                    &mut event.narrowing_gate,
+                    ScopedNarrowingConstraint::ALWAYS_TRUE,
+                ));
+                branch = event.parent;
+            }
+        }
+
+        let mut current_gate = ScopedNarrowingConstraint::ALWAYS_TRUE;
+        for gate in current_gates.into_iter().rev() {
+            current_gate = narrowing_constraints.add_and_constraint(current_gate, gate);
+        }
+        let mut branch_gate = ScopedNarrowingConstraint::ALWAYS_TRUE;
+        for gate in branch_gates.into_iter().rev() {
+            branch_gate = narrowing_constraints.add_and_constraint(branch_gate, gate);
+        }
+        (current_gate, branch_gate)
+    }
 }
 
 /// A copy-on-write place state and the last reachability node materialized into it.
@@ -1532,6 +1594,7 @@ impl PendingReachability {
         branch_states: IndexVec<I, PendingPlaceState>,
         branch: PendingReachabilityId,
         branch_reachability: ScopedReachabilityConstraintId,
+        narrowing_gates: (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
         narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
@@ -1582,8 +1645,9 @@ impl PendingReachability {
             self.materialize(&mut branch_state, branch, reachability_constraints);
             let branch_state = Rc::unwrap_or_clone(branch_state.state);
             let current = self.materialize(current, self.current, reachability_constraints);
-            current.merge(
+            current.merge_with_narrowing_gates(
                 branch_state,
+                narrowing_gates,
                 narrowing_constraints,
                 reachability_constraints,
             );
@@ -2085,14 +2149,15 @@ impl<'db> UseDefMapBuilder<'db> {
         }
     }
 
-    /// Records a narrowing constraint for all places in the current scope.
+    /// Gates existing narrowing for all places in the current scope.
     ///
     /// This is used to gate narrowing by `IsNonTerminalCall` constraints: when a branch contains
     /// a call to a `NoReturn` function, all narrowing in that branch should be conditional
-    /// on the call actually returning `Never`.
-    pub(super) fn record_narrowing_constraint_for_all_places(
+    /// on the call returning normally.
+    pub(super) fn gate_existing_narrowing_for_all_places(
         &mut self,
         constraint: ScopedNarrowingConstraint,
+        has_reachability_constraint: bool,
     ) {
         let pending = self.pending_reachability.current;
         for state in self
@@ -2105,8 +2170,10 @@ impl<'db> UseDefMapBuilder<'db> {
                 pending,
                 &mut self.reachability_constraints,
             );
-            state.record_narrowing_constraint(&mut self.narrowing_constraints, constraint);
+            state.gate_existing_narrowing(&mut self.narrowing_constraints, constraint);
         }
+        self.pending_reachability
+            .record_narrowing_gate(constraint, has_reachability_constraint);
     }
 
     pub(super) fn record_reachability_constraint(
@@ -2489,12 +2556,17 @@ impl<'db> UseDefMapBuilder<'db> {
         debug_assert!(self.symbol_states.len() >= snapshot.symbol_states.len());
         debug_assert!(self.member_states.len() >= snapshot.member_states.len());
 
+        let current = self.pending_reachability.current;
         let branch = snapshot.pending_reachability;
+        let narrowing_gates = self
+            .pending_reachability
+            .take_narrowing_gates_between_paths(current, branch, &mut self.narrowing_constraints);
         self.pending_reachability.merge_place_states(
             &mut self.symbol_states,
             snapshot.symbol_states,
             branch,
             snapshot.reachability,
+            narrowing_gates,
             &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
@@ -2503,6 +2575,7 @@ impl<'db> UseDefMapBuilder<'db> {
             snapshot.member_states,
             branch,
             snapshot.reachability,
+            narrowing_gates,
             &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -397,6 +397,20 @@ impl Bindings {
         }
     }
 
+    /// Gate any existing narrowing on the live bindings by the given constraint.
+    pub(super) fn gate_existing_narrowing(
+        &mut self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        constraint: ScopedNarrowingConstraint,
+    ) {
+        for binding in &mut self.live_bindings {
+            if binding.narrowing_constraint != ScopedNarrowingConstraint::ALWAYS_TRUE {
+                binding.narrowing_constraint = narrowing_constraints
+                    .add_and_constraint(binding.narrowing_constraint, constraint);
+            }
+        }
+    }
+
     /// Add given reachability constraint to all live bindings.
     pub(super) fn record_reachability_constraint(
         &mut self,
@@ -424,13 +438,36 @@ impl Bindings {
         narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
+        self.merge_with_narrowing_gates(
+            b,
+            (
+                ScopedNarrowingConstraint::ALWAYS_TRUE,
+                ScopedNarrowingConstraint::ALWAYS_TRUE,
+            ),
+            narrowing_constraints,
+            reachability_constraints,
+        );
+    }
+
+    fn merge_with_narrowing_gates(
+        &mut self,
+        b: Self,
+        narrowing_gates: (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+    ) {
         let a = std::mem::take(self);
 
         if let Some((a, b)) = a
             .unbound_narrowing_constraint
             .zip(b.unbound_narrowing_constraint)
         {
-            self.unbound_narrowing_constraint = Some(narrowing_constraints.add_or_constraint(a, b));
+            self.unbound_narrowing_constraint = Some(merge_narrowing_constraints(
+                narrowing_constraints,
+                a,
+                b,
+                narrowing_gates,
+            ));
         }
 
         // Invariant: merge_join_by consumes the two iterators in sorted order, which ensures that
@@ -444,8 +481,12 @@ impl Bindings {
                 EitherOrBoth::Both(a, b) => {
                     // If the same definition is visible through both paths, we OR the narrowing
                     // constraints: the type should be narrowed by whichever path was taken.
-                    let narrowing_constraint = narrowing_constraints
-                        .add_or_constraint(a.narrowing_constraint, b.narrowing_constraint);
+                    let narrowing_constraint = merge_narrowing_constraints(
+                        narrowing_constraints,
+                        a.narrowing_constraint,
+                        b.narrowing_constraint,
+                        narrowing_gates,
+                    );
 
                     // For reachability constraints, we also merge using a ternary OR operation:
                     let reachability_constraint = reachability_constraints
@@ -464,6 +505,24 @@ impl Bindings {
                     self.live_bindings.push(binding);
                 }
             }
+        }
+    }
+}
+
+fn merge_narrowing_constraints(
+    narrowing_constraints: &mut NarrowingConstraintsBuilder,
+    current: ScopedNarrowingConstraint,
+    branch: ScopedNarrowingConstraint,
+    (current_gate, branch_gate): (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
+) -> ScopedNarrowingConstraint {
+    match (current, branch) {
+        (ScopedNarrowingConstraint::ALWAYS_TRUE, ScopedNarrowingConstraint::ALWAYS_TRUE) => {
+            ScopedNarrowingConstraint::ALWAYS_TRUE
+        }
+        (current, branch) => {
+            let current = narrowing_constraints.add_and_constraint(current, current_gate);
+            let branch = narrowing_constraints.add_and_constraint(branch, branch_gate);
+            narrowing_constraints.add_or_constraint(current, branch)
         }
     }
 }
@@ -512,6 +571,16 @@ impl PlaceState {
     ) {
         self.bindings
             .record_narrowing_constraint(narrowing_constraints, constraint);
+    }
+
+    /// Gate any existing narrowing on the live bindings by the given constraint.
+    pub(super) fn gate_existing_narrowing(
+        &mut self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        constraint: ScopedNarrowingConstraint,
+    ) {
+        self.bindings
+            .gate_existing_narrowing(narrowing_constraints, constraint);
     }
 
     /// Add the given constraint to live bindings that were also present at an earlier use.
@@ -579,8 +648,30 @@ impl PlaceState {
         narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
-        self.bindings
-            .merge(b.bindings, narrowing_constraints, reachability_constraints);
+        self.merge_with_narrowing_gates(
+            b,
+            (
+                ScopedNarrowingConstraint::ALWAYS_TRUE,
+                ScopedNarrowingConstraint::ALWAYS_TRUE,
+            ),
+            narrowing_constraints,
+            reachability_constraints,
+        );
+    }
+
+    pub(super) fn merge_with_narrowing_gates(
+        &mut self,
+        b: PlaceState,
+        narrowing_gates: (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+    ) {
+        self.bindings.merge_with_narrowing_gates(
+            b.bindings,
+            narrowing_gates,
+            narrowing_constraints,
+            reachability_constraints,
+        );
         self.declarations
             .merge(b.declarations, reachability_constraints);
     }
@@ -852,6 +943,53 @@ mod tests {
         assert_eq!(bindings[1].1, atom0);
         assert_eq!(bindings[2].0, 3);
         assert_eq!(bindings[2].1, atom3);
+    }
+
+    #[test]
+    fn merge_terminal_narrowing_gate() {
+        let mut narrowing_constraints = NarrowingConstraintsBuilder::default();
+        let mut reachability_constraints = ReachabilityConstraintsBuilder::default();
+        let narrowed = narrowing_constraints.add_atom(ScopedPredicateId::new(0));
+        let terminal_gate = narrowing_constraints.add_atom(ScopedPredicateId::new(1));
+        let other_narrowed = narrowing_constraints.add_atom(ScopedPredicateId::new(2));
+        let other_terminal_gate = narrowing_constraints.add_atom(ScopedPredicateId::new(3));
+        let mut current = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
+        let mut branch = current.clone();
+        current.record_narrowing_constraint(&mut narrowing_constraints, narrowed);
+
+        current.merge_with_narrowing_gates(
+            branch.clone(),
+            (ScopedNarrowingConstraint::ALWAYS_TRUE, terminal_gate),
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+        );
+
+        let expected = narrowing_constraints.add_or_constraint(narrowed, terminal_gate);
+        assert_bindings(&current, &[(0, expected)]);
+
+        let mut narrowed_branch =
+            PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
+        narrowed_branch.record_narrowing_constraint(&mut narrowing_constraints, other_narrowed);
+        current.merge_with_narrowing_gates(
+            narrowed_branch,
+            (terminal_gate, other_terminal_gate),
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+        );
+
+        let expected_current = narrowing_constraints.add_and_constraint(expected, terminal_gate);
+        let expected_branch =
+            narrowing_constraints.add_and_constraint(other_narrowed, other_terminal_gate);
+        let expected = narrowing_constraints.add_or_constraint(expected_current, expected_branch);
+        assert_bindings(&current, &[(0, expected)]);
+
+        branch.merge_with_narrowing_gates(
+            PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE),
+            (terminal_gate, terminal_gate),
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+        );
+        assert_bindings(&branch, &[(0, ScopedNarrowingConstraint::ALWAYS_TRUE)]);
     }
 
     #[test]

--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -728,6 +728,74 @@ def g(x: int | None):
     reveal_type(x)  # revealed: int
 ```
 
+Narrowing in a non-terminal branch must also be preserved when the other branch contains a
+`NoReturn` call, even if the terminal branch did not narrow the binding itself. This includes
+exception handlers and module scope.
+
+```py
+import sys
+from typing import cast
+
+def terminal_except(value: str | int) -> int:
+    try:
+        if not isinstance(value, int):
+            value = 0
+    except Exception:
+        sys.exit()
+    return value
+
+def terminal_sibling(value: str | int, flag: bool) -> int:
+    if flag:
+        sys.exit()
+    elif not isinstance(value, int):
+        value = 0
+    return value
+
+value = cast(str | int, 1)
+flag = cast(bool, True)
+if flag:
+    sys.exit()
+elif not isinstance(value, int):
+    value = 0
+
+reveal_type(value)  # revealed: int
+```
+
+Branch-local terminal-call gates must be consumed when their paths are merged. Reusing one in a
+later `elif` merge would incorrectly gate the already-merged paths, narrowing the discriminator to
+`Never` when the final branch terminates.
+
+```py
+import sys
+
+platform = sys.argv[0]
+version = sys.argv[1]
+
+if platform == "debian" and version == "12":
+    postgres_version = "15"
+elif platform == "debian" and version == "13":
+    postgres_version = "17"
+elif platform == "ubuntu" and version == "22.04":
+    postgres_version = "14"
+elif platform == "ubuntu" and version == "24.04":
+    postgres_version = "16"
+elif platform == "ubuntu" and version == "26.04":
+    postgres_version = "18"
+elif platform == "rhel" and version.startswith("7."):
+    postgres_version = "10"
+elif platform == "centos" and version == "7":
+    postgres_version = "10"
+else:
+    sys.exit(1)
+
+if (platform == "debian" and version == "13") or (platform == "ubuntu" and version == "26.04"):
+    # error: [possibly-unresolved-reference]
+    reveal_type(postgres_version)  # revealed: Literal["15", "17", "14", "16", "18", "10"]
+else:
+    # error: [possibly-unresolved-reference]
+    reveal_type(postgres_version)  # revealed: Literal["15", "17", "14", "16", "18", "10"]
+```
+
 ### Possibly unresolved diagnostics
 
 If the codepath on which a variable is not defined eventually returns `Never`, use of the variable


### PR DESCRIPTION
Keep non-terminal-call narrowing off unnarrowed bindings on straight-line paths while preserving terminal-branch narrowing during merges.
Consume branch-local gates when their paths merge to avoid over-narrowing later branches; fixes the beartype and Zulip ecosystem regressions and retains the many-call performance improvement, related to https://github.com/astral-sh/ty/issues/3986.
Testing: Ran the ty core and semantic suites, repository hooks, and ecosystem correctness and performance checks.