### PR TITLE
[ty] Cache narrowing projections during inference

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4196,14 +4196,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             // narrowing to be preserved after if-statements where one branch
                             // calls a `NoReturn` function like `sys.exit()`.
                             self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
+                                .gate_existing_narrowing_for_all_places(narrowing_constraint);
                         } else {
                             // In non-function scopes, we only record a narrowing constraint
                             // (not a reachability constraint). Recording reachability for
                             // calls in module scope is simply too expensive, and it's not
                             // too important of a use case.
                             self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
+                                .gate_existing_narrowing_for_all_places(narrowing_constraint);
                         }
                     }
                 }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -2085,12 +2085,12 @@ impl<'db> UseDefMapBuilder<'db> {
         }
     }
 
-    /// Records a narrowing constraint for all places in the current scope.
+    /// Gates existing narrowing for all places in the current scope.
     ///
     /// This is used to gate narrowing by `IsNonTerminalCall` constraints: when a branch contains
     /// a call to a `NoReturn` function, all narrowing in that branch should be conditional
     /// on the call actually returning `Never`.
-    pub(super) fn record_narrowing_constraint_for_all_places(
+    pub(super) fn gate_existing_narrowing_for_all_places(
         &mut self,
         constraint: ScopedNarrowingConstraint,
     ) {
@@ -2105,7 +2105,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 pending,
                 &mut self.reachability_constraints,
             );
-            state.record_narrowing_constraint(&mut self.narrowing_constraints, constraint);
+            state.gate_existing_narrowing(&mut self.narrowing_constraints, constraint);
         }
     }
 

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -397,6 +397,20 @@ impl Bindings {
         }
     }
 
+    /// Gate any existing narrowing on the live bindings by the given constraint.
+    pub(super) fn gate_existing_narrowing(
+        &mut self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        constraint: ScopedNarrowingConstraint,
+    ) {
+        for binding in &mut self.live_bindings {
+            if binding.narrowing_constraint != ScopedNarrowingConstraint::ALWAYS_TRUE {
+                binding.narrowing_constraint = narrowing_constraints
+                    .add_and_constraint(binding.narrowing_constraint, constraint);
+            }
+        }
+    }
+
     /// Add given reachability constraint to all live bindings.
     pub(super) fn record_reachability_constraint(
         &mut self,
@@ -512,6 +526,16 @@ impl PlaceState {
     ) {
         self.bindings
             .record_narrowing_constraint(narrowing_constraints, constraint);
+    }
+
+    /// Gate any existing narrowing on the live bindings by the given constraint.
+    pub(super) fn gate_existing_narrowing(
+        &mut self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        constraint: ScopedNarrowingConstraint,
+    ) {
+        self.bindings
+            .gate_existing_narrowing(narrowing_constraints, constraint);
     }
 
     /// Add the given constraint to live bindings that were also present at an earlier use.

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -8,7 +8,7 @@ use ty_module_resolver::{
 
 use crate::dunder_all::dunder_all_names;
 use crate::reachability::{
-    ReachabilityEvaluationCache, evaluate_reachability, evaluate_reachability_with_cache,
+    InferenceEvaluationCache, evaluate_reachability, evaluate_reachability_with_cache,
 };
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::{
@@ -679,16 +679,16 @@ pub(super) fn place_from_bindings<'db>(
     )
 }
 
-pub(super) fn place_from_bindings_with_reachability_cache<'db>(
+pub(super) fn place_from_bindings_with_inference_cache<'db>(
     db: &'db dyn Db,
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
-    reachability_cache: &ReachabilityEvaluationCache<'db>,
+    inference_cache: &InferenceEvaluationCache<'db>,
 ) -> PlaceWithDefinition<'db> {
     place_from_bindings_impl(
         db,
         bindings_with_constraints,
         RequiresExplicitReExport::No,
-        Some(reachability_cache),
+        Some(inference_cache),
     )
 }
 
@@ -707,16 +707,16 @@ pub(crate) fn place_from_declarations<'db>(
     place_from_declarations_impl(db, declarations, RequiresExplicitReExport::No, None)
 }
 
-pub(crate) fn place_from_declarations_with_reachability_cache<'db>(
+pub(crate) fn place_from_declarations_with_inference_cache<'db>(
     db: &'db dyn Db,
     declarations: DeclarationsIterator<'_, 'db>,
-    reachability_cache: &ReachabilityEvaluationCache<'db>,
+    inference_cache: &InferenceEvaluationCache<'db>,
 ) -> PlaceFromDeclarationsResult<'db> {
     place_from_declarations_impl(
         db,
         declarations,
         RequiresExplicitReExport::No,
-        Some(reachability_cache),
+        Some(inference_cache),
     )
 }
 
@@ -1210,7 +1210,7 @@ pub(crate) fn place_by_id<'db>(
 enum DeclarationsBoundnessEvaluator<'map, 'db> {
     AssumeBound,
     BasedOnUnboundVisibility {
-        reachability_cache: Option<&'map ReachabilityEvaluationCache<'db>>,
+        inference_cache: Option<&'map InferenceEvaluationCache<'db>>,
         unbound_visibility: Option<DeclarationWithConstraint<'db>>,
         reachability_constraints: &'map ReachabilityConstraints,
         predicates: &'map IndexSlice<ScopedPredicateId, Predicate<'db>>,
@@ -1233,7 +1233,7 @@ impl<'db> DeclarationsBoundnessEvaluator<'_, 'db> {
                 }
             }
             DeclarationsBoundnessEvaluator::BasedOnUnboundVisibility {
-                reachability_cache,
+                inference_cache,
                 reachability_constraints,
                 unbound_visibility,
                 predicates,
@@ -1250,7 +1250,7 @@ impl<'db> DeclarationsBoundnessEvaluator<'_, 'db> {
                     {
                         evaluate_reachability_with_cache(
                             db,
-                            reachability_cache,
+                            inference_cache,
                             reachability_constraints,
                             predicates,
                             reachability_constraint,
@@ -1471,7 +1471,7 @@ fn place_from_bindings_impl<'db>(
     db: &'db dyn Db,
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
     requires_explicit_reexport: RequiresExplicitReExport,
-    reachability_cache: Option<&ReachabilityEvaluationCache<'db>>,
+    inference_cache: Option<&InferenceEvaluationCache<'db>>,
 ) -> PlaceWithDefinition<'db> {
     let predicates = bindings_with_constraints.predicates();
     let reachability_constraints = bindings_with_constraints.reachability_constraints();
@@ -1499,7 +1499,7 @@ fn place_from_bindings_impl<'db>(
         unbound_reachability_constraint.map(|reachability_constraint| {
             evaluate_reachability_with_cache(
                 db,
-                reachability_cache,
+                inference_cache,
                 reachability_constraints,
                 predicates,
                 reachability_constraint,
@@ -1536,7 +1536,7 @@ fn place_from_bindings_impl<'db>(
                     deleted_reachability = deleted_reachability.or_else(|| {
                         evaluate_reachability_with_cache(
                             db,
-                            reachability_cache,
+                            inference_cache,
                             reachability_constraints,
                             predicates,
                             reachability_constraint,
@@ -1552,7 +1552,7 @@ fn place_from_bindings_impl<'db>(
 
             let static_reachability = evaluate_reachability_with_cache(
                 db,
-                reachability_cache,
+                inference_cache,
                 reachability_constraints,
                 predicates,
                 reachability_constraint,
@@ -1636,7 +1636,12 @@ fn place_from_bindings_impl<'db>(
             provenance = provenance.or(Provenance::SingleDefinition(binding));
             let binding_ty = binding_type(db, binding);
             Some((
-                narrowing_constraint.narrow(db, binding_ty, binding.place(db)),
+                narrowing_constraint.narrow_with_cache(
+                    db,
+                    binding_ty,
+                    binding.place(db),
+                    inference_cache,
+                ),
                 static_reachability,
             ))
         },
@@ -1852,7 +1857,7 @@ fn place_from_declarations_impl<'db>(
     db: &'db dyn Db,
     declarations_iterator: DeclarationsIterator<'_, 'db>,
     requires_explicit_reexport: RequiresExplicitReExport,
-    reachability_cache: Option<&ReachabilityEvaluationCache<'db>>,
+    inference_cache: Option<&InferenceEvaluationCache<'db>>,
 ) -> PlaceFromDeclarationsResult<'db> {
     let predicates = declarations_iterator.predicates();
     let reachability_constraints = declarations_iterator.reachability_constraints();
@@ -1870,7 +1875,7 @@ fn place_from_declarations_impl<'db>(
             let unbound_visibility = declarations_iterator.peek().cloned();
             declarations = Either::Right(declarations_iterator);
             DeclarationsBoundnessEvaluator::BasedOnUnboundVisibility {
-                reachability_cache,
+                inference_cache,
                 unbound_visibility,
                 predicates,
                 reachability_constraints,
@@ -1900,7 +1905,7 @@ fn place_from_declarations_impl<'db>(
 
         let static_reachability = evaluate_reachability_with_cache(
             db,
-            reachability_cache,
+            inference_cache,
             reachability_constraints,
             predicates,
             reachability_constraint,

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -660,6 +660,7 @@ pub(crate) fn narrow_type_by_constraint<'db>(
     id: ScopedNarrowingConstraint,
     base_ty: Type<'db>,
     place: ScopedPlaceId,
+    cache: Option<&InferenceEvaluationCache<'db>>,
 ) -> Type<'db> {
     match id {
         ScopedNarrowingConstraint::ALWAYS_TRUE => return base_ty,
@@ -667,16 +668,34 @@ pub(crate) fn narrow_type_by_constraint<'db>(
         _ => {}
     }
 
-    let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
-    let projected_root = projector.project(id);
-    let mut context = ProjectedNarrowingContext {
-        db,
-        base_ty,
-        graph: &projector.graph,
-        joins: projector.graph.joins(projected_root),
-        join_cache: FxHashMap::default(),
+    let mut projector = if let Some(cache) = cache {
+        NarrowingProjector::with_state(
+            db,
+            constraints,
+            predicates,
+            place,
+            cache.take_narrowing_projection_state(constraints, place),
+        )
+    } else {
+        NarrowingProjector::new(db, constraints, predicates, place)
     };
-    context.narrow(projected_root, None)
+    let projected_root = projector.project(id);
+    let result = {
+        let mut context = ProjectedNarrowingContext {
+            db,
+            base_ty,
+            graph: &projector.graph,
+            joins: projector.graph.joins(projected_root),
+            join_cache: FxHashMap::default(),
+        };
+        context.narrow(projected_root, None)
+    };
+
+    if let Some(cache) = cache {
+        cache.store_narrowing_projection_state(constraints, place, projector.into_state());
+    }
+
+    result
 }
 
 fn apply_accumulated_narrowing<'db>(
@@ -896,6 +915,12 @@ struct NarrowingProjector<'a, 'db> {
     graph: ProjectedNarrowingGraph<'db>,
 }
 
+#[derive(Default)]
+struct NarrowingProjectionState<'db> {
+    project_cache: FxHashMap<ScopedNarrowingConstraint, ProjectedNarrowingNodeId>,
+    graph: ProjectedNarrowingGraph<'db>,
+}
+
 impl<'a, 'db> NarrowingProjector<'a, 'db> {
     /// Creates a projector for narrowing `place`.
     fn new(
@@ -904,13 +929,36 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
         place: ScopedPlaceId,
     ) -> Self {
+        Self::with_state(
+            db,
+            constraints,
+            predicates,
+            place,
+            NarrowingProjectionState::default(),
+        )
+    }
+
+    fn with_state(
+        db: &'db dyn Db,
+        constraints: &'a NarrowingConstraints,
+        predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
+        place: ScopedPlaceId,
+        state: NarrowingProjectionState<'db>,
+    ) -> Self {
         Self {
             db,
             constraints,
             predicates,
             place,
-            project_cache: FxHashMap::default(),
-            graph: ProjectedNarrowingGraph::default(),
+            project_cache: state.project_cache,
+            graph: state.graph,
+        }
+    }
+
+    fn into_state(self) -> NarrowingProjectionState<'db> {
+        NarrowingProjectionState {
+            project_cache: self.project_cache,
+            graph: self.graph,
         }
     }
 
@@ -1432,7 +1480,7 @@ pub(crate) fn evaluate_reachability(
         .evaluate(db, use_def.predicates(), reachability)
 }
 
-/// Inference-local cache for static reachability evaluations.
+/// Inference-local cache for static reachability and narrowing-projection evaluations.
 ///
 /// Place lookup may evaluate the same reachability constraint many times while inferring a single
 /// region: once for declarations, again for bindings, and again while recursively looking up
@@ -1444,14 +1492,19 @@ pub(crate) fn evaluate_reachability(
 /// from other use-def maps are less common and are stored separately, keyed by the address of their
 /// [`ReachabilityConstraints`] graph plus the local constraint id. The graph address is part of the
 /// key because scoped constraint ids are only unique within one graph.
-pub(crate) struct ReachabilityEvaluationCache<'db> {
+///
+/// Narrowing-projection state is stored per narrowing graph and place. It is temporarily removed
+/// while projecting because projection can recursively trigger inference and re-enter this cache.
+pub(crate) struct InferenceEvaluationCache<'db> {
     primary_scope: ScopeId<'db>,
     primary_constraints: usize,
     primary_entries: RefCell<Vec<Option<Truthiness>>>,
     other_entries: RefCell<FxHashMap<(usize, ScopedReachabilityConstraintId), Truthiness>>,
+    narrowing_projection_states:
+        RefCell<FxHashMap<(usize, ScopedPlaceId), NarrowingProjectionState<'db>>>,
 }
 
-impl<'db> ReachabilityEvaluationCache<'db> {
+impl<'db> InferenceEvaluationCache<'db> {
     /// Creates a cache optimized for the use-def map of `primary_scope`.
     ///
     /// `primary_constraints` must be the reachability graph for `primary_scope`'s use-def map. The
@@ -1466,6 +1519,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
             primary_constraints: std::ptr::from_ref(primary_constraints).addr(),
             primary_entries: RefCell::new(Vec::new()),
             other_entries: RefCell::new(FxHashMap::default()),
+            narrowing_projection_states: RefCell::new(FxHashMap::default()),
         }
     }
 
@@ -1517,12 +1571,36 @@ impl<'db> ReachabilityEvaluationCache<'db> {
         entries[index] = Some(result);
         result
     }
+
+    fn take_narrowing_projection_state(
+        &self,
+        constraints: &NarrowingConstraints,
+        place: ScopedPlaceId,
+    ) -> NarrowingProjectionState<'db> {
+        let key = (std::ptr::from_ref(constraints).addr(), place);
+        self.narrowing_projection_states
+            .borrow_mut()
+            .remove(&key)
+            .unwrap_or_default()
+    }
+
+    fn store_narrowing_projection_state(
+        &self,
+        constraints: &NarrowingConstraints,
+        place: ScopedPlaceId,
+        state: NarrowingProjectionState<'db>,
+    ) {
+        let key = (std::ptr::from_ref(constraints).addr(), place);
+        self.narrowing_projection_states
+            .borrow_mut()
+            .insert(key, state);
+    }
 }
 
 /// Evaluates a reachability constraint, optionally using an inference-local cache.
 pub(crate) fn evaluate_reachability_with_cache<'db>(
     db: &'db dyn Db,
-    cache: Option<&ReachabilityEvaluationCache<'db>>,
+    cache: Option<&InferenceEvaluationCache<'db>>,
     constraints: &ReachabilityConstraints,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     id: ScopedReachabilityConstraintId,
@@ -1605,6 +1683,74 @@ mod tests {
     use ty_python_core::narrowing_constraints::InteriorNode;
     use ty_python_core::predicate::Predicates;
     use ty_python_core::semantic_index;
+
+    #[test]
+    fn narrowing_projection_cache_reuses_prefixes() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/test.py",
+            r#"
+            def f(x: int, flag: bool) -> None:
+                if flag:
+                    y = x
+            "#,
+        )?;
+
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        let index = semantic_index(&db, file);
+        let function_scope = index.child_scopes(FileScopeId::global()).next().unwrap().0;
+        let use_def = index.use_def_map(function_scope);
+        let predicate = use_def
+            .predicates()
+            .iter()
+            .find(|predicate| matches!(predicate.node, PredicateNode::Expression(_)))
+            .unwrap();
+        let predicates: Predicates = std::iter::repeat_n(*predicate, 2).collect();
+        let constraints = NarrowingConstraints::from_test_nodes(
+            (0..2)
+                .map(|index| InteriorNode {
+                    atom: ScopedPredicateId::new(index),
+                    if_true: ScopedNarrowingConstraint::ALWAYS_TRUE,
+                    if_uncertain: if index == 0 {
+                        ScopedNarrowingConstraint::ALWAYS_FALSE
+                    } else {
+                        ScopedNarrowingConstraint::new(index - 1)
+                    },
+                    if_false: ScopedNarrowingConstraint::ALWAYS_FALSE,
+                })
+                .collect(),
+        );
+        let x = index.place_table(function_scope).symbol_id("x").unwrap();
+        let place = ScopedPlaceId::Symbol(x);
+        let cache = InferenceEvaluationCache::new(
+            function_scope.to_scope_id(&db, file),
+            use_def.reachability_constraints(),
+        );
+        let key = (std::ptr::from_ref(&constraints).addr(), place);
+
+        for index in 0..2 {
+            assert_eq!(
+                narrow_type_by_constraint(
+                    &db,
+                    &constraints,
+                    &predicates,
+                    ScopedNarrowingConstraint::new(index),
+                    Type::int_literal(1),
+                    place,
+                    Some(&cache),
+                ),
+                Type::int_literal(1)
+            );
+            assert_eq!(
+                cache.narrowing_projection_states.borrow()[&key]
+                    .project_cache
+                    .len(),
+                index + 1
+            );
+        }
+
+        Ok(())
+    }
 
     #[test]
     fn deep_constraint_projection_does_not_overflow() -> anyhow::Result<()> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -35,10 +35,10 @@ use crate::place::{
     RequiresExplicitReExport, TypeOrigin, builtins_module_scope, builtins_symbol,
     class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
     module_type_implicit_global_declaration, module_type_implicit_global_symbol, place_by_id,
-    place_from_bindings_with_reachability_cache, place_from_declarations_with_reachability_cache,
+    place_from_bindings_with_inference_cache, place_from_declarations_with_inference_cache,
     typing_extensions_symbol,
 };
-use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
+use crate::reachability::{InferenceEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::attribute_write::{AssignmentAttributeMembers, assignment_attribute_members};
 use crate::types::call::bind::MatchingOverloadIndex;
@@ -250,12 +250,12 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// An expression cache shared across builders during multi-inference.
     expression_cache: Option<Rc<RefCell<ExpressionCache<'db>>>>,
 
-    /// Reachability evaluations reused while inferring this region.
+    /// Reachability and narrowing-projection evaluations reused while inferring this region.
     ///
-    /// Most inference regions never evaluate reachability, so allocate the cache lazily. Speculative
-    /// builders share an initialized cache with their parent so repeated place lookups performed
-    /// during multi-inference can reuse predicate truthiness computed by the parent builder.
-    reachability_cache: OnceCell<Rc<ReachabilityEvaluationCache<'db>>>,
+    /// Allocate the cache lazily. Speculative builders share an initialized cache with their
+    /// parent so repeated place lookups during multi-inference can reuse predicate truthiness
+    /// computed by the parent builder.
+    inference_cache: OnceCell<Rc<InferenceEvaluationCache<'db>>>,
 
     /// Type qualifiers (`Required`, `NotRequired`, etc.) for annotation expressions.
     /// Only populated for expressions that have non-empty qualifiers.
@@ -386,7 +386,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred_state: DeferredExpressionState::None,
             expressions: FxHashMap::default(),
             expression_cache: None,
-            reachability_cache: OnceCell::new(),
+            inference_cache: OnceCell::new(),
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
             collection_use_constraints: FxHashMap::default(),
@@ -403,15 +403,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
-    fn reachability_cache(&self) -> &ReachabilityEvaluationCache<'db> {
-        self.reachability_cache
+    fn inference_cache(&self) -> &InferenceEvaluationCache<'db> {
+        self.inference_cache
             .get_or_init(|| {
                 let scope = self.scope();
                 let reachability_constraints = self
                     .index
                     .use_def_map(scope.file_scope_id(self.db()))
                     .reachability_constraints();
-                Rc::new(ReachabilityEvaluationCache::new(
+                Rc::new(InferenceEvaluationCache::new(
                     scope,
                     reachability_constraints,
                 ))
@@ -1270,10 +1270,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (use_def.declarations_at_binding(binding), true)
         };
 
-        let (mut place_and_quals, conflicting) = place_from_declarations_with_reachability_cache(
+        let (mut place_and_quals, conflicting) = place_from_declarations_with_inference_cache(
             self.db(),
             declarations,
-            self.reachability_cache(),
+            self.inference_cache(),
         )
         .into_place_and_conflicting_declarations();
 
@@ -1461,10 +1461,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let use_def = self.index.use_def_map(declaration.file_scope(self.db()));
         let prior_bindings = use_def.bindings_at_definition(declaration);
         // unbound_ty is Never because for this check we don't care about unbound
-        let inferred_ty = place_from_bindings_with_reachability_cache(
+        let inferred_ty = place_from_bindings_with_inference_cache(
             self.db(),
             prior_bindings,
-            self.reachability_cache(),
+            self.inference_cache(),
         )
         .place
         .with_qualifiers(TypeQualifiers::empty())
@@ -2389,10 +2389,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .symbol_id(&nested_bindings_kind.name)
                 .unwrap();
             let use_def = self.index.use_def_map(declaration.file_scope_id);
-            let Some(ty) = place_from_bindings_with_reachability_cache(
+            let Some(ty) = place_from_bindings_with_inference_cache(
                 db,
                 use_def.reachable_bindings(nested_symbol_id.into()),
-                self.reachability_cache(),
+                self.inference_cache(),
             )
             .place
             .raw_type() else {
@@ -7502,10 +7502,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut elements: Vec<(&str, Type<'db>)> = Vec::new();
 
         for bindings in use_def.multi_bindings_at_use(keyword.scoped_use_id(db, self.file())) {
-            let place = place_from_bindings_with_reachability_cache(
+            let place = place_from_bindings_with_inference_cache(
                 db,
                 bindings.clone(),
-                self.reachability_cache(),
+                self.inference_cache(),
             );
             let Some(key) = place.first_definition.and_then(definition_key) else {
                 continue;
@@ -8612,7 +8612,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     for binding in bindings {
                         let static_reachability = evaluate_reachability_with_cache(
                             db,
-                            Some(self.reachability_cache()),
+                            Some(self.inference_cache()),
                             reachability_constraints,
                             predicates,
                             binding.reachability_constraint,
@@ -8781,10 +8781,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // If we're inferring types of deferred expressions, look them up from end-of-scope.
         if self.is_deferred() {
             let place = if let Some(place_id) = place_table.place_id(expr) {
-                place_from_bindings_with_reachability_cache(
+                place_from_bindings_with_inference_cache(
                     db,
                     use_def.reachable_bindings(place_id),
-                    self.reachability_cache(),
+                    self.inference_cache(),
                 )
                 .place
             } else {
@@ -8817,10 +8817,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             let use_id = expr_ref.scoped_use_id(db, self.file());
-            let place = place_from_bindings_with_reachability_cache(
+            let place = place_from_bindings_with_inference_cache(
                 db,
                 use_def.bindings_at_use(use_id),
-                self.reachability_cache(),
+                self.inference_cache(),
             )
             .place;
 
@@ -8871,10 +8871,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return Place::Undefined.into();
                 }
                 EnclosingSnapshotResult::FoundBindings(bindings) => {
-                    let mut place_and_qualifiers = place_from_bindings_with_reachability_cache(
+                    let mut place_and_qualifiers = place_from_bindings_with_inference_cache(
                         db,
                         bindings,
-                        self.reachability_cache(),
+                        self.inference_cache(),
                     );
                     if assume_bound && let Place::Defined(defined) = place_and_qualifiers.place {
                         place_and_qualifiers.place =
@@ -9087,10 +9087,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             }
                         }
                         EnclosingSnapshotResult::FoundBindings(bindings) => {
-                            let place = place_from_bindings_with_reachability_cache(
+                            let place = place_from_bindings_with_inference_cache(
                                 db,
                                 bindings,
-                                self.reachability_cache(),
+                                self.inference_cache(),
                             )
                             .place
                             .map_type(|ty| {
@@ -10154,7 +10154,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
-            reachability_cache: _,
+            inference_cache: _,
             typevar_binding_context: _,
             deferred_state: _,
             called_functions: _,
@@ -10236,7 +10236,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
-            reachability_cache: _,
+            inference_cache: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10331,7 +10331,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             bindings,
             called_functions,
             expression_cache: _,
-            reachability_cache: _,
+            inference_cache: _,
             declarations: _,
             deferred: _,
             scope: _,
@@ -10389,7 +10389,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
-            reachability_cache: _,
+            inference_cache: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10527,7 +10527,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Builder only state
             expression_cache: _,
-            reachability_cache: _,
+            inference_cache: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10583,7 +10583,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred_state,
             typevar_binding_context,
             ref expression_cache,
-            ref reachability_cache,
+            ref inference_cache,
             ref return_types_and_ranges,
             ref dataclass_field_specifiers,
 
@@ -10616,7 +10616,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         builder.typevar_binding_context = typevar_binding_context;
         builder.context.inference_flags = self.inference_flags();
         builder.expression_cache.clone_from(expression_cache);
-        builder.reachability_cache.clone_from(reachability_cache);
+        builder.inference_cache.clone_from(inference_cache);
         builder
             .return_types_and_ranges
             .clone_from(return_types_and_ranges);
@@ -10656,7 +10656,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
-            reachability_cache: _,
+            inference_cache: _,
             typevar_binding_context: _,
             deferred_state: _,
             called_functions,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2,7 +2,9 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, btree_map::Entry as BTreeEntry, hash_map::Entry};
 
 use crate::Db;
-use crate::reachability::{narrow_type_by_constraint, type_narrowed_by_previous_patterns};
+use crate::reachability::{
+    InferenceEvaluationCache, narrow_type_by_constraint, type_narrowed_by_previous_patterns,
+};
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
@@ -4454,10 +4456,27 @@ fn all_matching_tuple_elements_have_literal_types<'db>(
 
 pub(crate) trait NarrowingEvaluatorExtension<'db> {
     fn narrow(&self, db: &'db dyn Db, base_type: Type<'db>, place: ScopedPlaceId) -> Type<'db>;
+    fn narrow_with_cache(
+        &self,
+        db: &'db dyn Db,
+        base_type: Type<'db>,
+        place: ScopedPlaceId,
+        cache: Option<&InferenceEvaluationCache<'db>>,
+    ) -> Type<'db>;
 }
 
 impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
     fn narrow(&self, db: &'db dyn Db, base_type: Type<'db>, place: ScopedPlaceId) -> Type<'db> {
+        self.narrow_with_cache(db, base_type, place, None)
+    }
+
+    fn narrow_with_cache(
+        &self,
+        db: &'db dyn Db,
+        base_type: Type<'db>,
+        place: ScopedPlaceId,
+        cache: Option<&InferenceEvaluationCache<'db>>,
+    ) -> Type<'db> {
         narrow_type_by_constraint(
             db,
             self.narrowing_constraints(),
@@ -4465,6 +4484,7 @@ impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
             self.constraint(),
             base_type,
             place,
+            cache,
         )
     }
 }


### PR DESCRIPTION
Reuse narrowing-projection state across place lookups within an inference region, avoiding repeated traversal of shared call-prefix constraints for narrowed bindings.
Improves the 6,000-call narrowed reproducer from 8.80 s to 6.26 s; stacked on #26759.
Testing: Ran the ty core and semantic test suites, Clippy, and repository hooks.