### PR TITLE
[ty] Expand transparent callable workaround with overloads and `Awaitable[T]`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1088,6 +1088,19 @@ reveal_type(
 async def check_awaitable() -> None:
     reveal_type(await awaitable(1))  # revealed: int
     reveal_type(await awaitable("one"))  # revealed: str
+
+def unwrap_awaitable(function: Callable[P, Awaitable[R]], /) -> Callable[P, R]:
+    raise NotImplementedError
+
+@overload
+async def unwrapped(value: int) -> int: ...
+@overload
+async def unwrapped(value: str) -> str: ...
+@unwrap_awaitable
+async def unwrapped(value: int | str) -> int | str:
+    raise NotImplementedError
+
+reveal_type(unwrapped(1))  # revealed: int | str
 ```
 
 The selected decorator overload can use an `Awaitable` return type.

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1038,6 +1038,94 @@ reveal_type(lazy_frame.collect(background=False))  # revealed: DataFrame
 reveal_type(lazy_frame.collect(background=True))  # revealed: InProcessQuery
 ```
 
+The transparent decorator can be one overload among several. The workaround only inspects the
+overload selected by the decorator call.
+
+```py
+from typing import Any, Callable, overload, reveal_type
+
+@overload
+def select_transparent(function: Callable[P, R], /) -> Callable[P, R]: ...
+@overload
+def select_transparent(*, value: int | None = None) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
+def select_transparent(function: Callable[P, R] | None = None, *, value: int | None = None) -> Any:
+    raise NotImplementedError
+
+@overload
+def selected(value: int) -> int: ...
+@overload
+def selected(value: str) -> str: ...
+@select_transparent
+def selected(value: int | str) -> int | str:
+    raise NotImplementedError
+
+reveal_type(selected)  # revealed: Overload[(value: int) -> int, (value: str) -> str]
+reveal_type(selected(1))  # revealed: int
+reveal_type(selected("one"))  # revealed: str
+```
+
+A transparent decorator can preserve a return type variable wrapped in `Awaitable`.
+
+```py
+from collections.abc import Awaitable, Callable
+from typing import overload
+
+def awaitable_transparent(function: Callable[P, Awaitable[R]], /) -> Callable[P, Awaitable[R]]:
+    raise NotImplementedError
+
+@overload
+async def awaitable(value: int) -> int: ...
+@overload
+async def awaitable(value: str) -> str: ...
+@awaitable_transparent
+async def awaitable(value: int | str) -> int | str:
+    raise NotImplementedError
+
+reveal_type(
+    awaitable  # revealed: Overload[(value: int) -> CoroutineType[Any, Any, int], (value: str) -> CoroutineType[Any, Any, str]]
+)
+
+async def check_awaitable() -> None:
+    reveal_type(await awaitable(1))  # revealed: int
+    reveal_type(await awaitable("one"))  # revealed: str
+```
+
+The selected decorator overload can use an `Awaitable` return type.
+
+```py
+from collections.abc import Awaitable, Callable
+from typing import overload
+
+@overload
+def select_awaitable_transparent(function: Callable[P, Awaitable[R]], /) -> Callable[P, Awaitable[R]]: ...
+@overload
+def select_awaitable_transparent(
+    *, value: int | None = None
+) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]: ...
+def select_awaitable_transparent(
+    function: Callable[P, Awaitable[R]] | None = None,
+    *,
+    value: int | None = None,
+) -> Any:
+    raise NotImplementedError
+
+@overload
+async def selected_awaitable(value: int) -> int: ...
+@overload
+async def selected_awaitable(value: str) -> str: ...
+@select_awaitable_transparent
+async def selected_awaitable(value: int | str) -> int | str:
+    raise NotImplementedError
+
+reveal_type(
+    selected_awaitable  # revealed: Overload[(value: int) -> CoroutineType[Any, Any, int], (value: str) -> CoroutineType[Any, Any, str]]
+)
+
+async def check_selected_awaitable() -> None:
+    reveal_type(await selected_awaitable(1))  # revealed: int
+    reveal_type(await selected_awaitable("one"))  # revealed: str
+```
+
 ### Overloads
 
 #### Return type filtering

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -362,35 +362,54 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
 /// An expression cache shared across builders during multi-inference.
 type ExpressionCache<'db> = FxHashMap<(ExpressionNodeKey, TypeContext<'db>), Type<'db>>;
 
-fn callable_paramspec_and_return_typevar<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-) -> Option<(BoundTypeVarInstance<'db>, BoundTypeVarInstance<'db>)> {
-    let callable = ty.resolve_type_alias(db).as_callable()?;
-    if callable.kind(db) != CallableTypeKind::Regular {
-        return None;
-    }
-    let [signature] = callable.signatures(db).overloads.as_slice() else {
-        return None;
-    };
-    let paramspec = signature.parameters().as_paramspec()?;
-    let return_typevar = signature.return_ty.as_typevar().or_else(|| {
-        let specialization = signature
-            .return_ty
-            .known_specialization(db, KnownClass::Awaitable)?;
-        let [inner] = specialization.types(db) else {
-            return None;
-        };
-        inner.as_typevar()
-    })?;
-    Some((paramspec, return_typevar))
-}
-
 fn transparent_callable_decorator_result<'db>(
     db: &'db dyn Db,
     bindings: &Bindings<'db>,
     decorated_ty: Type<'db>,
 ) -> Option<Type<'db>> {
+    enum TransparentCallableReturn<'db> {
+        TypeVar(BoundTypeVarInstance<'db>),
+        Awaitable(BoundTypeVarInstance<'db>),
+    }
+
+    impl<'db> TransparentCallableReturn<'db> {
+        fn matches(self, db: &'db dyn Db, other: Self) -> bool {
+            match (self, other) {
+                (Self::TypeVar(left), Self::TypeVar(right))
+                | (Self::Awaitable(left), Self::Awaitable(right)) => {
+                    left.is_same_typevar_as(db, right)
+                }
+                _ => false,
+            }
+        }
+    }
+
+    fn callable_paramspec_and_return<'db>(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+    ) -> Option<(BoundTypeVarInstance<'db>, TransparentCallableReturn<'db>)> {
+        let callable = ty.resolve_type_alias(db).as_callable()?;
+        if callable.kind(db) != CallableTypeKind::Regular {
+            return None;
+        }
+        let [signature] = callable.signatures(db).overloads.as_slice() else {
+            return None;
+        };
+        let paramspec = signature.parameters().as_paramspec()?;
+        let return_typevar = if let Some(typevar) = signature.return_ty.as_typevar() {
+            TransparentCallableReturn::TypeVar(typevar)
+        } else {
+            let specialization = signature
+                .return_ty
+                .known_specialization(db, KnownClass::Awaitable)?;
+            let [inner] = specialization.types(db) else {
+                return None;
+            };
+            TransparentCallableReturn::Awaitable(inner.as_typevar()?)
+        };
+        Some((paramspec, return_typevar))
+    }
+
     if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
         return None;
     }
@@ -405,12 +424,12 @@ fn transparent_callable_decorator_result<'db>(
         return None;
     };
 
-    let (parameter_callable_paramspec, parameter_callable_return_typevar) =
-        callable_paramspec_and_return_typevar(db, parameter.annotated_type())?;
-    let (return_callable_paramspec, return_callable_typevar) =
-        callable_paramspec_and_return_typevar(db, decorator_signature.return_ty)?;
+    let (parameter_callable_paramspec, parameter_callable_return) =
+        callable_paramspec_and_return(db, parameter.annotated_type())?;
+    let (return_callable_paramspec, return_callable_return) =
+        callable_paramspec_and_return(db, decorator_signature.return_ty)?;
     if !parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
-        || !parameter_callable_return_typevar.is_same_typevar_as(db, return_callable_typevar)
+        || !parameter_callable_return.matches(db, return_callable_return)
     {
         return None;
     }
@@ -4881,11 +4900,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // TODO: Remove this special case once the new constraint solver can preserve
         // per-overload ParamSpec/return correlations for transparent callable decorators.
         if let Some(decorator_bindings) = decorator_bindings.as_ref()
-            && let Some(result) = transparent_callable_decorator_result(
-                self.db(),
-                decorator_bindings,
-                decorated_ty,
-            )
+            && let Some(result) =
+                transparent_callable_decorator_result(self.db(), decorator_bindings, decorated_ty)
         {
             return result;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -374,24 +374,33 @@ fn callable_paramspec_and_return_typevar<'db>(
         return None;
     };
     let paramspec = signature.parameters().as_paramspec()?;
-    Some((paramspec, signature.return_ty.as_typevar()?))
+    let return_typevar = signature.return_ty.as_typevar().or_else(|| {
+        let specialization = signature
+            .return_ty
+            .known_specialization(db, KnownClass::Awaitable)?;
+        let [inner] = specialization.types(db) else {
+            return None;
+        };
+        inner.as_typevar()
+    })?;
+    Some((paramspec, return_typevar))
 }
 
 fn transparent_callable_decorator_result<'db>(
     db: &'db dyn Db,
-    decorator_ty: Type<'db>,
+    bindings: &Bindings<'db>,
     decorated_ty: Type<'db>,
 ) -> Option<Type<'db>> {
     if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
         return None;
     }
-    let decorator_callable = decorator_ty
-        .try_upcast_to_callable(db)
-        .and_then(CallableTypes::exactly_one)?;
-    let decorator_signatures = decorator_callable.signatures(db);
-    let [decorator_signature] = decorator_signatures.overloads.as_slice() else {
-        return None;
-    };
+    let binding = bindings.single_element()?;
+    let (_, overload) = binding.matching_overloads().exactly_one().ok()?;
+    let decorator_signature = &overload.signature;
+    let bound_signature = binding
+        .bound_type
+        .map(|bound_type| decorator_signature.bind_self(db, Some(bound_type)));
+    let decorator_signature = bound_signature.as_ref().unwrap_or(decorator_signature);
     let [parameter] = decorator_signature.parameters().as_slice() else {
         return None;
     };
@@ -4763,11 +4772,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let decorated_ty =
             self.get_or_infer_expression(decorated_expression, TypeContext::default());
         let call_arguments = CallArguments::positional([decorated_ty]);
-        if decorator_ty.try_call(self.db(), &call_arguments).is_err() {
+        let Ok(bindings) = decorator_ty.try_call(self.db(), &call_arguments) else {
             return return_ty;
-        }
+        };
 
-        transparent_callable_decorator_result(self.db(), decorator_ty, decorated_ty)
+        transparent_callable_decorator_result(self.db(), &bindings, decorated_ty)
             .unwrap_or(return_ty)
     }
 
@@ -4860,21 +4869,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let call_arguments = CallArguments::positional([decorated_ty]);
-        let mut decorator_call_succeeded = true;
-        let return_ty = decorator_ty
-            .try_call(self.db(), &call_arguments)
-            .map(|bindings| bindings.return_type(self.db()))
-            .unwrap_or_else(|CallError(_, bindings)| {
-                decorator_call_succeeded = false;
-                bindings.report_diagnostics(&self.context, decorator_node.into());
-                bindings.return_type(self.db())
-            });
+        let (return_ty, decorator_bindings) =
+            match decorator_ty.try_call(self.db(), &call_arguments) {
+                Ok(bindings) => (bindings.return_type(self.db()), Some(bindings)),
+                Err(CallError(_, bindings)) => {
+                    bindings.report_diagnostics(&self.context, decorator_node.into());
+                    (bindings.return_type(self.db()), None)
+                }
+            };
 
         // TODO: Remove this special case once the new constraint solver can preserve
-        // per-overload ParamSpec/return correlations for `Callable[P, R] -> Callable[P, R]`.
-        if decorator_call_succeeded
-            && let Some(result) =
-                transparent_callable_decorator_result(self.db(), decorator_ty, decorated_ty)
+        // per-overload ParamSpec/return correlations for transparent callable decorators.
+        if let Some(decorator_bindings) = decorator_bindings.as_ref()
+            && let Some(result) = transparent_callable_decorator_result(
+                self.db(),
+                decorator_bindings,
+                decorated_ty,
+            )
         {
             return result;
         }


### PR DESCRIPTION
## Summary

Extend the transparent callable decorator workaround to inspect the uniquely selected overload and recognize matching return type variables wrapped in `Awaitable` without treating `Awaitable[R]` and `R` as equivalent. This is part of the work tracked in [astral-sh/ty#2278](https://github.com/astral-sh/ty/issues/2278) and builds on [astral-sh/ruff#25030](https://github.com/astral-sh/ruff/pull/25030) and [astral-sh/ruff#25806](https://github.com/astral-sh/ruff/pull/25806).

## Test plan

Added mdtests covering selection of a transparent overload, matching `Awaitable[T]` return types including rejection of an `Awaitable[T]`-to-`T` mismatch, and the combination of overload selection with `Awaitable[T]`.
