### PR TITLE
[ty] Cache non-terminal call reachability prefixes

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -258,7 +258,9 @@ use crate::narrowing_constraints::{
     ConstraintKey, NarrowingConstraints, NarrowingConstraintsBuilder, ScopedNarrowingConstraint,
 };
 use crate::place::{PlaceExprRef, ScopedPlaceId};
-use crate::predicate::{PredicateOrLiteral, Predicates, PredicatesBuilder, ScopedPredicateId};
+use crate::predicate::{
+    PredicateNode, PredicateOrLiteral, Predicates, PredicatesBuilder, ScopedPredicateId,
+};
 use crate::reachability_constraints::{
     ReachabilityConstraints, ReachabilityConstraintsBuilder, ScopedReachabilityConstraintId,
 };
@@ -589,6 +591,7 @@ enum InternedEnclosingSnapshotId {
 #[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 struct ConstraintTables<'db> {
     predicates: Predicates<'db>,
+    non_terminal_call_predicate_ids: Box<[ScopedPredicateId]>,
     reachability_constraints: ReachabilityConstraints,
     narrowing_constraints: NarrowingConstraints,
 }
@@ -621,6 +624,7 @@ struct UseDefMapExtra {
 static EMPTY_CONSTRAINT_TABLES: LazyLock<ConstraintTables<'static>> =
     LazyLock::new(|| ConstraintTables {
         predicates: IndexVec::new().into(),
+        non_terminal_call_predicate_ids: Box::default(),
         reachability_constraints: ReachabilityConstraintsBuilder::default().build(),
         narrowing_constraints: NarrowingConstraintsBuilder::default().build(),
     });
@@ -864,6 +868,11 @@ impl<'db> UseDefMap<'db> {
 
     pub fn predicates(&self) -> &Predicates<'db> {
         &self.constraint_tables().predicates
+    }
+
+    /// Returns the IDs of all statement-level call predicates in source order.
+    pub fn non_terminal_call_predicate_ids(&self) -> &[ScopedPredicateId] {
+        &self.constraint_tables().non_terminal_call_predicate_ids
     }
 
     pub fn range_reachability(
@@ -2639,6 +2648,12 @@ impl<'db> UseDefMapBuilder<'db> {
             })
         });
         let predicates = self.predicates.build();
+        let non_terminal_call_predicate_ids = predicates
+            .iter_enumerated()
+            .filter_map(|(id, predicate)| {
+                matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)).then_some(id)
+            })
+            .collect();
         let reachability_constraints = self.reachability_constraints.build();
         let narrowing_constraints = self.narrowing_constraints.build();
         let constraint_tables = (!reachability_constraints.used_interiors().is_empty()
@@ -2646,6 +2661,7 @@ impl<'db> UseDefMapBuilder<'db> {
         .then(|| {
             Box::new(ConstraintTables {
                 predicates,
+                non_terminal_call_predicate_ids,
                 reachability_constraints,
                 narrowing_constraints,
             })

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -258,9 +258,7 @@ use crate::narrowing_constraints::{
     ConstraintKey, NarrowingConstraints, NarrowingConstraintsBuilder, ScopedNarrowingConstraint,
 };
 use crate::place::{PlaceExprRef, ScopedPlaceId};
-use crate::predicate::{
-    PredicateNode, PredicateOrLiteral, Predicates, PredicatesBuilder, ScopedPredicateId,
-};
+use crate::predicate::{PredicateOrLiteral, Predicates, PredicatesBuilder, ScopedPredicateId};
 use crate::reachability_constraints::{
     ReachabilityConstraints, ReachabilityConstraintsBuilder, ScopedReachabilityConstraintId,
 };
@@ -591,7 +589,6 @@ enum InternedEnclosingSnapshotId {
 #[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
 struct ConstraintTables<'db> {
     predicates: Predicates<'db>,
-    non_terminal_call_predicate_ids: Box<[ScopedPredicateId]>,
     reachability_constraints: ReachabilityConstraints,
     narrowing_constraints: NarrowingConstraints,
 }
@@ -624,7 +621,6 @@ struct UseDefMapExtra {
 static EMPTY_CONSTRAINT_TABLES: LazyLock<ConstraintTables<'static>> =
     LazyLock::new(|| ConstraintTables {
         predicates: IndexVec::new().into(),
-        non_terminal_call_predicate_ids: Box::default(),
         reachability_constraints: ReachabilityConstraintsBuilder::default().build(),
         narrowing_constraints: NarrowingConstraintsBuilder::default().build(),
     });
@@ -868,11 +864,6 @@ impl<'db> UseDefMap<'db> {
 
     pub fn predicates(&self) -> &Predicates<'db> {
         &self.constraint_tables().predicates
-    }
-
-    /// Returns the IDs of all statement-level call predicates in source order.
-    pub fn non_terminal_call_predicate_ids(&self) -> &[ScopedPredicateId] {
-        &self.constraint_tables().non_terminal_call_predicate_ids
     }
 
     pub fn range_reachability(
@@ -2648,12 +2639,6 @@ impl<'db> UseDefMapBuilder<'db> {
             })
         });
         let predicates = self.predicates.build();
-        let non_terminal_call_predicate_ids = predicates
-            .iter_enumerated()
-            .filter_map(|(id, predicate)| {
-                matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)).then_some(id)
-            })
-            .collect();
         let reachability_constraints = self.reachability_constraints.build();
         let narrowing_constraints = self.narrowing_constraints.build();
         let constraint_tables = (!reachability_constraints.used_interiors().is_empty()
@@ -2661,7 +2646,6 @@ impl<'db> UseDefMapBuilder<'db> {
         .then(|| {
             Box::new(ConstraintTables {
                 predicates,
-                non_terminal_call_predicate_ids,
                 reachability_constraints,
                 narrowing_constraints,
             })

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -527,8 +527,7 @@ std::thread_local! {
     static ACTIVE_NON_TERMINAL_CALL_PREFIXES: ActiveRecursionDetector<salsa::Id> = ActiveRecursionDetector::default();
 }
 
-const MIN_CACHED_NON_TERMINAL_CALLS: usize = 128;
-const NON_TERMINAL_CALL_RANGE_LEAF_SIZE: usize = 64;
+const NON_TERMINAL_CALL_CHUNK_SIZE: usize = 16;
 
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
@@ -567,27 +566,29 @@ fn analyze_non_terminal_call_prefix<'db>(
     root_predicate: ScopedPredicateId,
 ) {
     let scope = predicate_scope(db, &predicates[root_predicate]);
-    let use_def = use_def_map(db, scope);
-    let call_predicate_ids = use_def.non_terminal_call_predicate_ids();
-    let call_count =
-        call_predicate_ids.partition_point(|predicate| predicate.index() <= root_predicate.index());
-
-    if call_count == 0 {
-        return;
-    }
+    let predicate_count = root_predicate.index() + 1;
 
     ACTIVE_NON_TERMINAL_CALL_PREFIXES.with(|active| {
         active.visit(
             &scope.as_id(),
             || {},
             || {
-                if call_predicate_ids.len() <= MIN_CACHED_NON_TERMINAL_CALLS {
-                    analyze_non_terminal_calls(db, use_def, &call_predicate_ids[..call_count]);
+                // Avoid Salsa ranges for small-call scopes without retaining a separate call-ID
+                // index. Stop at the first call beyond the cutoff so repeated scans stay bounded.
+                if predicates
+                    .iter()
+                    .filter(|predicate| {
+                        matches!(predicate.node, PredicateNode::IsNonTerminalCall(_))
+                    })
+                    .nth(NON_TERMINAL_CALL_CHUNK_SIZE)
+                    .is_none()
+                {
+                    analyze_non_terminal_calls(db, &predicates.raw[..predicate_count]);
                     return;
                 }
 
                 let mut start = 0;
-                let mut remaining = call_count / NON_TERMINAL_CALL_RANGE_LEAF_SIZE;
+                let mut remaining = predicate_count / NON_TERMINAL_CALL_CHUNK_SIZE;
 
                 while remaining > 0 {
                     let level = remaining.ilog2();
@@ -597,34 +598,28 @@ fn analyze_non_terminal_call_prefix<'db>(
                     remaining -= length;
                 }
 
-                let tail_start = call_count / NON_TERMINAL_CALL_RANGE_LEAF_SIZE
-                    * NON_TERMINAL_CALL_RANGE_LEAF_SIZE;
-                analyze_non_terminal_calls(
-                    db,
-                    use_def,
-                    &call_predicate_ids[tail_start..call_count],
-                );
+                let tail_start =
+                    predicate_count / NON_TERMINAL_CALL_CHUNK_SIZE * NON_TERMINAL_CALL_CHUNK_SIZE;
+                analyze_non_terminal_calls(db, &predicates.raw[tail_start..predicate_count]);
             },
         );
     });
 }
 
-fn analyze_non_terminal_calls<'db>(
-    db: &'db dyn Db,
-    use_def: &UseDefMap<'db>,
-    predicate_ids: &[ScopedPredicateId],
-) {
-    for predicate_id in predicate_ids {
-        analyze_single(db, &use_def.predicates()[*predicate_id]);
+fn analyze_non_terminal_calls<'db>(db: &'db dyn Db, predicates: &[Predicate<'db>]) {
+    for predicate in predicates {
+        if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
+            analyze_single(db, predicate);
+        }
     }
 }
 
-/// Analyzes a power-of-two range of statement-level call-predicate blocks in source order.
+/// Analyzes a power-of-two range of predicate blocks in source order.
 ///
 /// Prefixes can be decomposed into these canonical ranges and reused by later expression-inference
 /// queries. Splitting ranges in half keeps the Salsa query stack logarithmic even when the first
-/// requested prefix contains thousands of calls. Each leaf handles multiple calls iteratively to
-/// avoid retaining a Salsa argument and query result for every individual call.
+/// requested prefix contains thousands of calls. Each leaf handles multiple predicates iteratively
+/// to avoid retaining a Salsa argument and query result for every individual predicate.
 #[salsa::tracked(returns(copy), heap_size = get_size2::GetSize::get_heap_size)]
 fn analyze_non_terminal_call_range<'db>(
     db: &'db dyn Db,
@@ -634,13 +629,9 @@ fn analyze_non_terminal_call_range<'db>(
 ) {
     if level == 0 {
         let use_def = use_def_map(db, scope);
-        let start = index * NON_TERMINAL_CALL_RANGE_LEAF_SIZE;
-        let end = start + NON_TERMINAL_CALL_RANGE_LEAF_SIZE;
-        analyze_non_terminal_calls(
-            db,
-            use_def,
-            &use_def.non_terminal_call_predicate_ids()[start..end],
-        );
+        let start = index * NON_TERMINAL_CALL_CHUNK_SIZE;
+        let end = start + NON_TERMINAL_CALL_CHUNK_SIZE;
+        analyze_non_terminal_calls(db, &use_def.predicates().raw[start..end]);
         return;
     }
 
@@ -1669,23 +1660,13 @@ mod tests {
     #[test]
     fn non_terminal_call_prefix_bypasses_ranges_for_small_scope() -> anyhow::Result<()> {
         let mut db = setup_db();
-        db.write_dedented(
-            "/src/test.py",
-            r#"
-            def noop() -> None: ...
-
-            def f(flag: bool) -> None:
-                if flag:
-                    noop()
-                noop()
-                noop()
-                if flag:
-                    noop()
-                noop()
-                noop()
-                noop()
-            "#,
-        )?;
+        let source = format!(
+            "def noop() -> None: ...\n\ndef f(flag: bool) -> None:\n{}{}",
+            "    if flag:\n        value = 1\n    else:\n        value = 2\n"
+                .repeat(NON_TERMINAL_CALL_CHUNK_SIZE * 2),
+            "    noop()\n".repeat(7)
+        );
+        db.write_file("/src/test.py", &source)?;
 
         let file = system_path_to_file(&db, "/src/test.py").unwrap();
         {
@@ -1698,9 +1679,15 @@ mod tests {
                 .to_scope_id(&db, file);
             let use_def = use_def_map(&db, function_scope);
             let predicates = use_def.predicates();
-            let call_predicates = use_def.non_terminal_call_predicate_ids();
+            let call_predicates = predicates
+                .iter_enumerated()
+                .filter_map(|(id, predicate)| {
+                    matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)).then_some(id)
+                })
+                .collect::<Vec<_>>();
 
             assert_eq!(call_predicates.len(), 7);
+            assert!(predicates.len() > NON_TERMINAL_CALL_CHUNK_SIZE);
             assert!(call_predicates.windows(2).all(|ids| ids[0] < ids[1]));
             assert!(
                 call_predicates.iter().all(|id| {
@@ -1742,7 +1729,7 @@ mod tests {
         let mut db = setup_db();
         let source = format!(
             "def noop() -> None: ...\n\ndef f(flag: bool) -> None:\n    if flag:\n        noop()\n{}",
-            "    noop()\n".repeat(MIN_CACHED_NON_TERMINAL_CALLS)
+            "    noop()\n".repeat(NON_TERMINAL_CALL_CHUNK_SIZE * 2)
         );
         db.write_file("/src/test.py", &source)?;
 
@@ -1757,9 +1744,14 @@ mod tests {
                 .to_scope_id(&db, file);
             let use_def = use_def_map(&db, function_scope);
             let predicates = use_def.predicates();
-            let call_predicates = use_def.non_terminal_call_predicate_ids();
+            let call_predicates = predicates
+                .iter_enumerated()
+                .filter_map(|(id, predicate)| {
+                    matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)).then_some(id)
+                })
+                .collect::<Vec<_>>();
 
-            assert_eq!(call_predicates.len(), MIN_CACHED_NON_TERMINAL_CALLS + 1);
+            assert_eq!(call_predicates.len(), NON_TERMINAL_CALL_CHUNK_SIZE * 2 + 1);
             assert!(call_predicates.windows(2).all(|ids| ids[0] < ids[1]));
             assert!(
                 call_predicates.iter().all(|id| {
@@ -1767,8 +1759,16 @@ mod tests {
                 })
             );
 
-            analyze_non_terminal_call_prefix(&db, predicates, call_predicates[95]);
-            analyze_non_terminal_call_prefix(&db, predicates, call_predicates[128]);
+            analyze_non_terminal_call_prefix(
+                &db,
+                predicates,
+                call_predicates[NON_TERMINAL_CALL_CHUNK_SIZE - 1],
+            );
+            analyze_non_terminal_call_prefix(
+                &db,
+                predicates,
+                call_predicates[NON_TERMINAL_CALL_CHUNK_SIZE * 2],
+            );
         }
 
         let events = db.take_salsa_events();
@@ -1786,8 +1786,8 @@ mod tests {
                 .count()
         });
 
-        // The first prefix executes one leaf for calls 0..64. The second prefix reuses that leaf
-        // and executes only the parent range and the leaf for calls 64..128.
+        // The first prefix executes one leaf. The second prefix reuses that leaf and executes
+        // only the parent range and the next leaf.
         assert_eq!(range_executions, 3);
 
         Ok(())
@@ -1798,7 +1798,7 @@ mod tests {
         let mut db = setup_db();
         let source = format!(
             "from dependency import callback\n\ndef f() -> None:\n{}",
-            "    callback()\n".repeat(MIN_CACHED_NON_TERMINAL_CALLS + 1)
+            "    callback()\n".repeat(NON_TERMINAL_CALL_CHUNK_SIZE + 1)
         );
         db.write_files([
             ("/src/dependency.py", "def callback() -> None: ..."),

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -228,6 +228,7 @@ use ty_python_core::{
     },
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
     scope::ScopeId,
+    use_def_map,
 };
 
 /// Narrow `subject_ty` by all preceding unguarded match patterns.
@@ -547,46 +548,73 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
 /// chain. Inferring the expressions in source order turns that chain into cache lookups while
 /// preserving normal reachability and narrowing during every inference.
 ///
-/// Because the prefix is based on predicate indices rather than graph reachability, branch-heavy
+/// Because the prefix is based on source order rather than graph reachability, branch-heavy
 /// code can warm calls from earlier source branches that this evaluation would not otherwise visit.
 /// A demand-driven graph walk could avoid that work, but would require a more complex work list. We
 /// accept the broader eager pass because it keeps the ordering simple, and checking a scope will
 /// typically exercise most of its predicates eventually.
 ///
-/// Reentrant analysis of the same predicate graph skips the prefix pass: because the outer pass is
+/// Reentrant analysis of the same scope skips the prefix pass: because the outer pass is
 /// proceeding in source order, any preceding call needed by the current expression has already
-/// been inferred. A different predicate graph performs its own pass, which is necessary when
+/// been inferred. A different scope performs its own pass, which is necessary when
 /// inferring a call crosses into another large scope.
 fn analyze_non_terminal_call_prefix<'db>(
     db: &'db dyn Db,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     root_predicate: ScopedPredicateId,
 ) {
-    let range = 0..=root_predicate.index();
-    if !range.clone().any(|index| {
-        matches!(
-            predicates[ScopedPredicateId::new(index)].node,
-            PredicateNode::IsNonTerminalCall(_)
-        )
-    }) {
+    let scope = predicate_scope(db, &predicates[root_predicate]);
+    let use_def = use_def_map(db, scope);
+    let call_count = use_def
+        .non_terminal_call_predicate_ids()
+        .partition_point(|predicate| predicate.index() <= root_predicate.index());
+
+    if call_count == 0 {
         return;
     }
 
-    let key = predicate_scope(db, &predicates[root_predicate]).as_id();
     ACTIVE_NON_TERMINAL_CALL_PREFIXES.with(|active| {
         active.visit(
-            &key,
+            &scope.as_id(),
             || {},
             || {
-                for index in range {
-                    let predicate = &predicates[ScopedPredicateId::new(index)];
-                    if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
-                        analyze_single(db, predicate);
-                    }
+                let mut start = 0;
+                let mut remaining = call_count;
+
+                while remaining > 0 {
+                    let level = remaining.ilog2();
+                    let length = 1 << level;
+                    analyze_non_terminal_call_range(db, scope, level, start >> level);
+                    start += length;
+                    remaining -= length;
                 }
             },
         );
     });
+}
+
+/// Analyzes a power-of-two range of statement-level call predicates in source order.
+///
+/// Prefixes can be decomposed into these canonical ranges and reused by later expression-inference
+/// queries. Splitting ranges in half keeps the Salsa query stack logarithmic even when the first
+/// requested prefix contains thousands of calls.
+#[salsa::tracked(returns(copy), heap_size = get_size2::GetSize::get_heap_size)]
+fn analyze_non_terminal_call_range<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    level: u32,
+    index: usize,
+) {
+    if level == 0 {
+        let use_def = use_def_map(db, scope);
+        let predicate_id = use_def.non_terminal_call_predicate_ids()[index];
+        analyze_single(db, &use_def.predicates()[predicate_id]);
+        return;
+    }
+
+    let child_index = index * 2;
+    analyze_non_terminal_call_range(db, scope, level - 1, child_index);
+    analyze_non_terminal_call_range(db, scope, level - 1, child_index + 1);
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
@@ -1605,6 +1633,126 @@ mod tests {
     use ty_python_core::narrowing_constraints::InteriorNode;
     use ty_python_core::predicate::Predicates;
     use ty_python_core::semantic_index;
+
+    #[test]
+    fn non_terminal_call_prefix_reuses_ranges() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/test.py",
+            r#"
+            def noop() -> None: ...
+
+            def f(flag: bool) -> None:
+                if flag:
+                    noop()
+                noop()
+                noop()
+                if flag:
+                    noop()
+                noop()
+                noop()
+                noop()
+            "#,
+        )?;
+
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        {
+            let index = semantic_index(&db, file);
+            let function_scope = index
+                .child_scopes(FileScopeId::global())
+                .nth(1)
+                .unwrap()
+                .0
+                .to_scope_id(&db, file);
+            let use_def = use_def_map(&db, function_scope);
+            let predicates = use_def.predicates();
+            let call_predicates = use_def.non_terminal_call_predicate_ids();
+
+            assert_eq!(call_predicates.len(), 7);
+            assert!(call_predicates.windows(2).all(|ids| ids[0] < ids[1]));
+            assert!(
+                call_predicates.iter().all(|id| {
+                    matches!(predicates[*id].node, PredicateNode::IsNonTerminalCall(_))
+                })
+            );
+            assert!(
+                predicates
+                    .iter()
+                    .any(|predicate| matches!(predicate.node, PredicateNode::Expression(_)))
+            );
+
+            analyze_non_terminal_call_prefix(&db, predicates, call_predicates[3]);
+            analyze_non_terminal_call_prefix(&db, predicates, call_predicates[6]);
+        }
+
+        let events = db.take_salsa_events();
+        let range_executions = salsa::attach(&db, || {
+            events
+                .into_iter()
+                .filter(|event| {
+                    matches!(
+                        &event.kind,
+                        salsa::EventKind::WillExecute { database_key }
+                            if format!("{database_key:?}")
+                                .contains("analyze_non_terminal_call_range")
+                    )
+                })
+                .count()
+        });
+
+        // The first prefix executes the seven nodes for calls 0..4. The second prefix reuses that
+        // range and executes only the three nodes for calls 4..6 plus the final leaf.
+        assert_eq!(range_executions, 11);
+
+        Ok(())
+    }
+
+    #[test]
+    fn non_terminal_call_ranges_invalidate_when_callable_changes() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_files([
+            ("/src/dependency.py", "def callback() -> None: ..."),
+            (
+                "/src/test.py",
+                r#"from dependency import callback
+
+def f() -> None:
+    callback()
+    callback()
+    callback()
+    callback()
+"#,
+            ),
+        ])?;
+
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        {
+            let index = semantic_index(&db, file);
+            let function_scope = index.child_scopes(FileScopeId::global()).next().unwrap().0;
+            let use_def = index.use_def_map(function_scope);
+            assert!(is_reachable(
+                &db,
+                use_def,
+                use_def.end_of_scope_reachability()
+            ));
+        }
+
+        db.write_file(
+            "/src/dependency.py",
+            "from typing import NoReturn\ndef callback() -> NoReturn: ...",
+        )?;
+
+        let index = semantic_index(&db, file);
+        let function_scope = index.child_scopes(FileScopeId::global()).next().unwrap().0;
+        let use_def = index.use_def_map(function_scope);
+        assert!(!is_reachable(
+            &db,
+            use_def,
+            use_def.end_of_scope_reachability()
+        ));
+
+        Ok(())
+    }
 
     #[test]
     fn deep_constraint_projection_does_not_overflow() -> anyhow::Result<()> {

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -527,6 +527,9 @@ std::thread_local! {
     static ACTIVE_NON_TERMINAL_CALL_PREFIXES: ActiveRecursionDetector<salsa::Id> = ActiveRecursionDetector::default();
 }
 
+const MIN_CACHED_NON_TERMINAL_CALLS: usize = 128;
+const NON_TERMINAL_CALL_RANGE_LEAF_SIZE: usize = 64;
+
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression) => expression.scope(db),
@@ -565,9 +568,9 @@ fn analyze_non_terminal_call_prefix<'db>(
 ) {
     let scope = predicate_scope(db, &predicates[root_predicate]);
     let use_def = use_def_map(db, scope);
-    let call_count = use_def
-        .non_terminal_call_predicate_ids()
-        .partition_point(|predicate| predicate.index() <= root_predicate.index());
+    let call_predicate_ids = use_def.non_terminal_call_predicate_ids();
+    let call_count =
+        call_predicate_ids.partition_point(|predicate| predicate.index() <= root_predicate.index());
 
     if call_count == 0 {
         return;
@@ -578,8 +581,13 @@ fn analyze_non_terminal_call_prefix<'db>(
             &scope.as_id(),
             || {},
             || {
+                if call_predicate_ids.len() <= MIN_CACHED_NON_TERMINAL_CALLS {
+                    analyze_non_terminal_calls(db, use_def, &call_predicate_ids[..call_count]);
+                    return;
+                }
+
                 let mut start = 0;
-                let mut remaining = call_count;
+                let mut remaining = call_count / NON_TERMINAL_CALL_RANGE_LEAF_SIZE;
 
                 while remaining > 0 {
                     let level = remaining.ilog2();
@@ -588,16 +596,35 @@ fn analyze_non_terminal_call_prefix<'db>(
                     start += length;
                     remaining -= length;
                 }
+
+                let tail_start = call_count / NON_TERMINAL_CALL_RANGE_LEAF_SIZE
+                    * NON_TERMINAL_CALL_RANGE_LEAF_SIZE;
+                analyze_non_terminal_calls(
+                    db,
+                    use_def,
+                    &call_predicate_ids[tail_start..call_count],
+                );
             },
         );
     });
 }
 
-/// Analyzes a power-of-two range of statement-level call predicates in source order.
+fn analyze_non_terminal_calls<'db>(
+    db: &'db dyn Db,
+    use_def: &UseDefMap<'db>,
+    predicate_ids: &[ScopedPredicateId],
+) {
+    for predicate_id in predicate_ids {
+        analyze_single(db, &use_def.predicates()[*predicate_id]);
+    }
+}
+
+/// Analyzes a power-of-two range of statement-level call-predicate blocks in source order.
 ///
 /// Prefixes can be decomposed into these canonical ranges and reused by later expression-inference
 /// queries. Splitting ranges in half keeps the Salsa query stack logarithmic even when the first
-/// requested prefix contains thousands of calls.
+/// requested prefix contains thousands of calls. Each leaf handles multiple calls iteratively to
+/// avoid retaining a Salsa argument and query result for every individual call.
 #[salsa::tracked(returns(copy), heap_size = get_size2::GetSize::get_heap_size)]
 fn analyze_non_terminal_call_range<'db>(
     db: &'db dyn Db,
@@ -607,8 +634,13 @@ fn analyze_non_terminal_call_range<'db>(
 ) {
     if level == 0 {
         let use_def = use_def_map(db, scope);
-        let predicate_id = use_def.non_terminal_call_predicate_ids()[index];
-        analyze_single(db, &use_def.predicates()[predicate_id]);
+        let start = index * NON_TERMINAL_CALL_RANGE_LEAF_SIZE;
+        let end = start + NON_TERMINAL_CALL_RANGE_LEAF_SIZE;
+        analyze_non_terminal_calls(
+            db,
+            use_def,
+            &use_def.non_terminal_call_predicate_ids()[start..end],
+        );
         return;
     }
 
@@ -1635,7 +1667,7 @@ mod tests {
     use ty_python_core::semantic_index;
 
     #[test]
-    fn non_terminal_call_prefix_reuses_ranges() -> anyhow::Result<()> {
+    fn non_terminal_call_prefix_bypasses_ranges_for_small_scope() -> anyhow::Result<()> {
         let mut db = setup_db();
         db.write_dedented(
             "/src/test.py",
@@ -1700,9 +1732,63 @@ mod tests {
                 .count()
         });
 
-        // The first prefix executes the seven nodes for calls 0..4. The second prefix reuses that
-        // range and executes only the three nodes for calls 4..6 plus the final leaf.
-        assert_eq!(range_executions, 11);
+        assert_eq!(range_executions, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn non_terminal_call_prefix_reuses_ranges() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        let source = format!(
+            "def noop() -> None: ...\n\ndef f(flag: bool) -> None:\n    if flag:\n        noop()\n{}",
+            "    noop()\n".repeat(MIN_CACHED_NON_TERMINAL_CALLS)
+        );
+        db.write_file("/src/test.py", &source)?;
+
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        {
+            let index = semantic_index(&db, file);
+            let function_scope = index
+                .child_scopes(FileScopeId::global())
+                .nth(1)
+                .unwrap()
+                .0
+                .to_scope_id(&db, file);
+            let use_def = use_def_map(&db, function_scope);
+            let predicates = use_def.predicates();
+            let call_predicates = use_def.non_terminal_call_predicate_ids();
+
+            assert_eq!(call_predicates.len(), MIN_CACHED_NON_TERMINAL_CALLS + 1);
+            assert!(call_predicates.windows(2).all(|ids| ids[0] < ids[1]));
+            assert!(
+                call_predicates.iter().all(|id| {
+                    matches!(predicates[*id].node, PredicateNode::IsNonTerminalCall(_))
+                })
+            );
+
+            analyze_non_terminal_call_prefix(&db, predicates, call_predicates[95]);
+            analyze_non_terminal_call_prefix(&db, predicates, call_predicates[128]);
+        }
+
+        let events = db.take_salsa_events();
+        let range_executions = salsa::attach(&db, || {
+            events
+                .into_iter()
+                .filter(|event| {
+                    matches!(
+                        &event.kind,
+                        salsa::EventKind::WillExecute { database_key }
+                            if format!("{database_key:?}")
+                                .contains("analyze_non_terminal_call_range")
+                    )
+                })
+                .count()
+        });
+
+        // The first prefix executes one leaf for calls 0..64. The second prefix reuses that leaf
+        // and executes only the parent range and the leaf for calls 64..128.
+        assert_eq!(range_executions, 3);
 
         Ok(())
     }
@@ -1710,19 +1796,13 @@ mod tests {
     #[test]
     fn non_terminal_call_ranges_invalidate_when_callable_changes() -> anyhow::Result<()> {
         let mut db = setup_db();
+        let source = format!(
+            "from dependency import callback\n\ndef f() -> None:\n{}",
+            "    callback()\n".repeat(MIN_CACHED_NON_TERMINAL_CALLS + 1)
+        );
         db.write_files([
             ("/src/dependency.py", "def callback() -> None: ..."),
-            (
-                "/src/test.py",
-                r#"from dependency import callback
-
-def f() -> None:
-    callback()
-    callback()
-    callback()
-    callback()
-"#,
-            ),
+            ("/src/test.py", source.as_str()),
         ])?;
 
         let file = system_path_to_file(&db, "/src/test.py").unwrap();


### PR DESCRIPTION
Cache source-ordered non-terminal-call prefixes in balanced Salsa-tracked predicate ranges, avoiding repeated prefix scans and deep query stacks during reachability evaluation.
Use a unified 16-predicate chunk and bypass scopes with at most 16 calls without retaining a call-ID index, reducing Salsa memory across representative projects.
This is independent of #26759 and #26760; narrowing optimizations remain separate.
Testing: Ran the ty core and semantic suites, Clippy, repository hooks, profiling and memory repros, and representative project checks.