### PR TITLE
[ty] Pydantic: Support `populate_by_name` and custom initializers

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -690,6 +690,20 @@ AliasAndName(name=1)
 AliasAndName(name=None)  # error: [invalid-argument-type]
 ```
 
+The older `populate_by_name=True` setting has the same behavior:
+
+```py
+class PopulatedByName(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: int = Field(alias="alias")
+
+PopulatedByName(alias=1)
+PopulatedByName(name=1)
+PopulatedByName(alias=None)  # error: [invalid-argument-type]
+PopulatedByName(name=None)  # error: [invalid-argument-type]
+```
+
 Passing none of these should be an error:
 
 ```py
@@ -804,6 +818,9 @@ A fixed custom initializer continues to control the accepted arguments:
 class RestrictiveBase(BaseModel):
     def __init__(self, name: str) -> None:
         super().__init__(name=name)
+
+RestrictiveBase(name="Alice")
+RestrictiveBase(name="Alice", city="Berlin")  # error: [unknown-argument]
 
 class RestrictiveUser(RestrictiveBase):
     name: str

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -46,25 +46,17 @@ impl<'db> ModelMetadata<'db> {
     }
 
     pub(in crate::types) fn validates_by_alias(self, db: &'db dyn Db) -> bool {
-        self.config(db).validate_by_alias.enabled_or(true)
+        let (validate_by_alias, _) = self.config(db).validation_config();
+        validate_by_alias.enabled_or(true)
     }
 
     pub(in crate::types) fn validates_by_name(self, db: &'db dyn Db) -> bool {
-        let config = self.config(db);
-        let validate_by_name = config.validate_by_name;
-        // If `validate_by_alias=False` is set without specifying `validate_by_name`, Pydantic
-        // implicitly enables validation by name.
-        if matches!(validate_by_name, ConfigBoolean::Unspecified)
-            && matches!(config.validate_by_alias, ConfigBoolean::Disabled)
-        {
-            true
-        } else {
-            validate_by_name.enabled_or(false)
-        }
+        let (_, validate_by_name) = self.config(db).validation_config();
+        validate_by_name.enabled_or(false)
     }
 
     pub(in crate::types) fn is_frozen(self, db: &'db dyn Db) -> bool {
-        matches!(self.config(db).frozen, ConfigBoolean::Enabled)
+        self.config(db).frozen.is_enabled()
     }
 }
 
@@ -255,7 +247,7 @@ impl<'db> FieldMetadata<'db> {
         if let Some(alias) = field.alias(db) {
             self.alias = Some(alias.clone());
         }
-        if !matches!(field.strict(db), ConfigBoolean::Unspecified) {
+        if !field.strict(db).is_unspecified() {
             self.strict = field.strict(db);
         }
     }
@@ -331,6 +323,8 @@ pub(crate) struct ModelConfig {
     validate_by_alias: ConfigBoolean,
     /// Whether fields with aliases can be initialized by their field name.
     validate_by_name: ConfigBoolean,
+    /// The deprecated setting that enables validation by both alias and field name.
+    populate_by_name: ConfigBoolean,
 }
 
 impl ModelConfig {
@@ -341,6 +335,7 @@ impl ModelConfig {
             frozen: ConfigBoolean::Unknown,
             validate_by_alias: ConfigBoolean::Unknown,
             validate_by_name: ConfigBoolean::Unknown,
+            populate_by_name: ConfigBoolean::Unknown,
         }
     }
 
@@ -351,6 +346,28 @@ impl ModelConfig {
         self.frozen = other.frozen.or(self.frozen);
         self.validate_by_alias = other.validate_by_alias.or(self.validate_by_alias);
         self.validate_by_name = other.validate_by_name.or(self.validate_by_name);
+        self.populate_by_name = other.populate_by_name.or(self.populate_by_name);
+    }
+
+    /// Resolve compatibility behavior after inherited and local configuration has been merged.
+    fn validation_config(self) -> (ConfigBoolean, ConfigBoolean) {
+        let mut validate_by_alias = self.validate_by_alias;
+        let mut validate_by_name = self.validate_by_name;
+
+        // `populate_by_name` enables validation by both alias and field name. The newer
+        // `validate_by_name` setting takes precedence when both are specified.
+        if validate_by_name.is_unspecified() && self.populate_by_name.is_specified() {
+            validate_by_alias = ConfigBoolean::Enabled;
+            validate_by_name = self.populate_by_name;
+        }
+
+        // If `validate_by_alias=False` is set without specifying `validate_by_name`, Pydantic
+        // implicitly enables validation by name.
+        if validate_by_alias.is_disabled() && validate_by_name.is_unspecified() {
+            validate_by_name = ConfigBoolean::Enabled;
+        }
+
+        (validate_by_alias, validate_by_name)
     }
 }
 
@@ -387,12 +404,24 @@ pub enum ConfigBoolean {
 }
 
 impl ConfigBoolean {
+    const fn is_unspecified(self) -> bool {
+        matches!(self, Self::Unspecified)
+    }
+
+    const fn is_specified(self) -> bool {
+        matches!(self, Self::Disabled | Self::Enabled | Self::Unknown)
+    }
+
+    const fn is_disabled(self) -> bool {
+        matches!(self, Self::Disabled)
+    }
+
+    const fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled)
+    }
+
     const fn or(self, other: Self) -> Self {
-        if matches!(self, Self::Unspecified) {
-            other
-        } else {
-            self
-        }
+        if self.is_unspecified() { other } else { self }
     }
 
     /// Resolve a boolean configuration value from its inferred type.
@@ -603,6 +632,11 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
         definition,
         call.arguments.find_keyword("validate_by_name"),
     );
+    let populate_by_name = config_boolean(
+        db,
+        definition,
+        call.arguments.find_keyword("populate_by_name"),
+    );
 
     Some(ModelConfig {
         extra,
@@ -610,6 +644,7 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
         frozen,
         validate_by_alias,
         validate_by_name,
+        populate_by_name,
     })
 }
 
@@ -640,6 +675,7 @@ fn model_config_from_dict(db: &dyn Db, definition: Definition<'_>, dict: &ExprDi
             "frozen" => config.frozen = ConfigBoolean::from_type(value),
             "validate_by_alias" => config.validate_by_alias = ConfigBoolean::from_type(value),
             "validate_by_name" => config.validate_by_name = ConfigBoolean::from_type(value),
+            "populate_by_name" => config.populate_by_name = ConfigBoolean::from_type(value),
             _ => {}
         }
     }
@@ -679,6 +715,8 @@ fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelConf
         config_boolean(db, definition, arguments.find_keyword("validate_by_alias"));
     let validate_by_name =
         config_boolean(db, definition, arguments.find_keyword("validate_by_name"));
+    let populate_by_name =
+        config_boolean(db, definition, arguments.find_keyword("populate_by_name"));
 
     ModelConfig {
         extra,
@@ -686,6 +724,7 @@ fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelConf
         frozen,
         validate_by_alias,
         validate_by_name,
+        populate_by_name,
     }
 }
 
@@ -696,7 +735,7 @@ pub(in crate::types) fn constructor_parameter_type<'db>(
     field_strict: ConfigBoolean,
     metadata: ModelMetadata<'db>,
 ) -> Type<'db> {
-    if field_strict.or(metadata.config(db).strict) == ConfigBoolean::Enabled {
+    if field_strict.or(metadata.config(db).strict).is_enabled() {
         return field_type;
     }
 
@@ -904,48 +943,62 @@ fn lax_alias<'db>(db: &'db dyn Db, name: &str) -> Type<'db> {
     }
 }
 
-/// Return `true` if `class` should accept extra keywords in its synthesized constructor.
-pub(in crate::types) fn model_init_accepts_extra(
-    db: &dyn Db,
-    class: StaticClassLiteral<'_>,
-    metadata: ModelMetadata<'_>,
-) -> bool {
-    if !metadata.accepts_extra(db) {
-        return false;
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ModelInitBehavior {
+    BaseModel,
+    CustomVariadic,
+    Other,
+}
 
+fn model_init_behavior(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelInitBehavior {
     for base in class
         .iter_mro(db, None)
-        .skip(1)
         .filter_map(ClassBase::into_class)
         .filter_map(|base| base.static_class_literal(db))
         .map(|(base, _)| base)
     {
         if base.is_known(db, KnownClass::PydanticBaseModel) {
-            return true;
+            return ModelInitBehavior::BaseModel;
         }
 
         // These constructors use variadic keywords for specialized inputs, not arbitrary extras.
         if base.is_known(db, KnownClass::PydanticRootModel)
             || base.is_known(db, KnownClass::PydanticBaseSettings)
         {
-            return false;
+            return ModelInitBehavior::Other;
         }
 
         let init = class_member(db, base.body_scope(db), "__init__");
         if !init.is_undefined() {
-            return init
+            return if init
                 .ignore_possibly_undefined()
                 .and_then(Type::as_function_literal)
                 .is_some_and(|init| {
                     init.signature(db)
                         .iter()
                         .any(|signature| signature.parameters().keyword_variadic().is_some())
-                });
+                }) {
+                ModelInitBehavior::CustomVariadic
+            } else {
+                ModelInitBehavior::Other
+            };
         }
     }
 
-    false
+    ModelInitBehavior::Other
+}
+
+/// Return `true` if `class` should accept extra keywords in its synthesized constructor.
+pub(in crate::types) fn model_init_accepts_extra(
+    db: &dyn Db,
+    class: StaticClassLiteral<'_>,
+    metadata: ModelMetadata<'_>,
+) -> bool {
+    metadata.accepts_extra(db)
+        && matches!(
+            model_init_behavior(db, class),
+            ModelInitBehavior::BaseModel | ModelInitBehavior::CustomVariadic
+        )
 }
 
 /// Create the catch-all keyword parameter for a Pydantic model constructor.


### PR DESCRIPTION
## Summary

This PR contains two loosely related features/fixes around constructor signatures for Pydantic models:

- Recognize Pydantic's legacy `populate_by_name` configuration option as enabling validation by both field name and alias. 
- Inspect the model itself, in addition to its bases, when classifying custom `__init__` behavior

## Test Plan

New Markdown tests