### PR TITLE
[flake8-bugbear] Fix panic in reuse-of-groupby-generator (B031) on match subject

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B031.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B031.py
@@ -225,6 +225,22 @@ def foo():
             collect_shop_items(shopper, section_items)
         collect_shop_items(shopper, section_items)  # B031
 
+# Regression test for https://github.com/astral-sh/ruff/issues/26624
+# Using the group in a `match` subject must not panic. Here it is consumed
+# exactly once, so it should not be flagged.
+for _section, section_items in groupby(items, key=lambda p: p[1]):
+    match list(section_items):
+        case _:
+            pass
+
+# The group is consumed by the `match` subject and then reused afterwards,
+# which should be flagged.
+for _section, section_items in groupby(items, key=lambda p: p[1]):
+    match list(section_items):
+        case _:
+            pass
+    collect_shop_items(shopper, section_items)  # B031
+
 # Let's redefine the `groupby` function to make sure we pick up the correct one.
 # NOTE: This should always be at the end of the file.
 def groupby(data, key=None):

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -183,8 +183,13 @@ impl<'a> Visitor<'a> for GroupNameFinder<'a> {
                 range: _,
                 node_index: _,
             }) => {
-                self.counter_stack.push(Vec::with_capacity(cases.len()));
+                // The subject is evaluated once, unconditionally, before any
+                // case is tried, so its usage is counted in the enclosing
+                // context rather than in a per-case branch counter. Visiting it
+                // before pushing the branch stack also avoids incrementing into
+                // an empty counter (which previously panicked, see #26624).
                 self.visit_expr(subject);
+                self.counter_stack.push(Vec::with_capacity(cases.len()));
                 for match_case in cases {
                     self.counter_stack.last_mut().unwrap().push(0);
                     self.visit_match_case(match_case);

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B031_B031.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B031_B031.py.snap
@@ -244,5 +244,16 @@ B031 Using the generator returned from `itertools.groupby()` more than once will
 226 |         collect_shop_items(shopper, section_items)  # B031
     |                                     ^^^^^^^^^^^^^
 227 |
-228 | # Let's redefine the `groupby` function to make sure we pick up the correct one.
+228 | # Regression test for https://github.com/astral-sh/ruff/issues/26624
+    |
+
+B031 Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage
+   --> B031.py:242:33
+    |
+240 |         case _:
+241 |             pass
+242 |     collect_shop_items(shopper, section_items)  # B031
+    |                                 ^^^^^^^^^^^^^
+243 |
+244 | # Let's redefine the `groupby` function to make sure we pick up the correct one.
     |


### PR DESCRIPTION
## Summary

`B031` (`reuse-of-groupby-generator`) panics on a `match` statement whose subject references the group:

```python
from itertools import groupby


for key, group in groupby([]):
    match list(group):
        case _:
            pass
```

```
ruff check --isolated --select B031
panic: called `Option::unwrap()` on a `None` value
  at crates/ruff_linter/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs:99
```

Root cause: the `Stmt::Match` arm pushed an empty per-branch counter frame onto `counter_stack` and then visited the subject. Because the subject uses the group, `increment_usage_count` tried to increment the last element of that still-empty inner `Vec`, unwrapping `None`.

The subject is evaluated once, unconditionally, before any case is tried, so this visits it before pushing the branch stack, mirroring the existing `Stmt::If` handler (which seeds a branch slot before visiting the test). This removes the panic and counts the subject's usage in the enclosing context, so genuine reuse across a `match` subject is still reported.

Fixes #26624.

## Test Plan

Added two cases to `B031.py`:

- the minimal repro from the issue (group consumed once in the `match` subject): must not panic and is not flagged;
- the group consumed in the subject and then reused afterwards: still flagged as `B031`.

Regenerated the `B031` snapshot; the only change is the single new expected diagnostic. `cargo clippy --workspace --all-targets --all-features -- -D warnings` and the full `ruff_linter` test suite pass.
