### PR TITLE
[ty] Move incremental ignore-file checking down into `System`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4772,7 +4772,6 @@ dependencies = [
  "crossbeam",
  "get-size2",
  "globset",
- "ignore",
  "insta",
  "notify",
  "ordermap",

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -4,7 +4,7 @@ pub use memory_fs::MemoryFileSystem;
 pub use os::testing::UserConfigDirectoryOverrideGuard;
 
 #[cfg(feature = "os")]
-pub use os::OsSystem;
+pub use os::{IgnoreFiles, Ignored, OsSystem};
 
 use filetime::FileTime;
 use ruff_notebook::{Notebook, NotebookError};

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -4,7 +4,7 @@ pub use memory_fs::MemoryFileSystem;
 pub use os::testing::UserConfigDirectoryOverrideGuard;
 
 #[cfg(feature = "os")]
-pub use os::{IgnoreFiles, Ignored, OsSystem};
+pub use os::OsSystem;
 
 use filetime::FileTime;
 use ruff_notebook::{Notebook, NotebookError};

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -13,8 +13,8 @@ use crate::system::{
 };
 
 use super::walk_directory::{
-    DirectoryWalker, WalkDirectoryBuilder, WalkDirectoryConfiguration, WalkDirectoryVisitor,
-    WalkDirectoryVisitorBuilder, WalkState,
+    DirectoryWalker, IgnoreIncremental, Ignored, WalkDirectoryBuilder, WalkDirectoryConfiguration,
+    WalkDirectoryVisitor, WalkDirectoryVisitorBuilder, WalkState,
 };
 
 /// File system that stores all content in memory.
@@ -564,6 +564,24 @@ impl Iterator for ReadDirectory {
 
 impl FusedIterator for ReadDirectory {}
 
+struct MemoryIgnoreIncremental {
+    ignore_hidden: bool,
+}
+
+impl IgnoreIncremental for MemoryIgnoreIncremental {
+    fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored {
+        // This matches the semantics of the in-memory recursive
+        // directory traversal. That is, the only thing we care
+        // about filtering is hidden files. We let everything else
+        // through.
+        if self.ignore_hidden && !is_directory && is_hidden(path) {
+            Ignored::Yes
+        } else {
+            Ignored::Uncertain
+        }
+    }
+}
+
 /// Recursively walks a directory in the memory file system.
 #[derive(Debug)]
 struct MemoryWalker {
@@ -592,12 +610,7 @@ impl MemoryWalker {
             }
 
             state
-        } else if ignore_hidden
-            && entry
-                .path
-                .file_name()
-                .is_some_and(|name| name.starts_with('.'))
-        {
+        } else if ignore_hidden && is_hidden(&entry.path) {
             WalkState::Skip
         } else {
             visitor.visit(Ok(entry))
@@ -702,6 +715,14 @@ impl DirectoryWalker for MemoryWalker {
             }
         }
     }
+
+    fn incremental_matcher(
+        &self,
+        configuration: WalkDirectoryConfiguration,
+    ) -> Box<dyn IgnoreIncremental> {
+        let WalkDirectoryConfiguration { ignore_hidden, .. } = configuration;
+        Box::new(MemoryIgnoreIncremental { ignore_hidden })
+    }
 }
 
 #[derive(Debug)]
@@ -711,6 +732,10 @@ enum WalkerState {
 
     /// Traverse into the directory with the given path at the given depth.
     Nested { path: SystemPathBuf, depth: usize },
+}
+
+fn is_hidden(path: &SystemPath) -> bool {
+    path.file_name().is_some_and(|name| name.starts_with('.'))
 }
 
 #[cfg(test)]

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -2,10 +2,9 @@
 
 mod ignore;
 
-pub use ignore::{IgnoreFiles, Ignored};
-
+use self::ignore::IgnoreFiles;
 use super::walk_directory::{
-    self, DirectoryWalker, WalkDirectoryBuilder, WalkDirectoryConfiguration,
+    self, DirectoryWalker, IgnoreIncremental, WalkDirectoryBuilder, WalkDirectoryConfiguration,
     WalkDirectoryVisitorBuilder, WalkState,
 };
 use crate::max_parallelism;
@@ -336,6 +335,17 @@ impl DirectoryWalker for OsDirectoryWalker {
                 }
             })
         });
+    }
+
+    fn incremental_matcher(
+        &self,
+        configuration: WalkDirectoryConfiguration,
+    ) -> Box<dyn IgnoreIncremental> {
+        // N.B. The current work-around `IgnoreFiles` implementation doesn't
+        // support any configuration right now. This will be fixed once we
+        // switch to the `ignore` crate's implementation. --AG
+        let WalkDirectoryConfiguration { paths, .. } = configuration;
+        Box::new(IgnoreFiles::new(paths))
     }
 }
 

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -1,5 +1,9 @@
 #![allow(clippy::disallowed_methods)]
 
+mod ignore;
+
+pub use ignore::{IgnoreFiles, Ignored};
+
 use super::walk_directory::{
     self, DirectoryWalker, WalkDirectoryBuilder, WalkDirectoryConfiguration,
     WalkDirectoryVisitorBuilder, WalkState,
@@ -173,7 +177,7 @@ impl System for OsSystem {
 
     /// Creates a builder to recursively walk `path`.
     ///
-    /// The walker ignores files according to [`ignore::WalkBuilder::standard_filters`]
+    /// The walker ignores files according to [`::ignore::WalkBuilder::standard_filters`]
     /// when setting [`WalkDirectoryBuilder::standard_filters`] to true.
     fn walk_directory(&self, path: &SystemPath) -> WalkDirectoryBuilder {
         WalkDirectoryBuilder::new(
@@ -268,7 +272,7 @@ impl DirectoryWalker for OsDirectoryWalker {
             return;
         };
 
-        let mut builder = ignore::WalkBuilder::new(first.as_std_path());
+        let mut builder = ::ignore::WalkBuilder::new(first.as_std_path());
         builder.current_dir(self.cwd.as_std_path());
 
         builder.standard_filters(standard_filters);
@@ -315,7 +319,7 @@ impl DirectoryWalker for OsDirectoryWalker {
                                 }));
 
                                 // Skip the entire directory because all the paths won't be UTF-8 paths.
-                                ignore::WalkState::Skip
+                                ::ignore::WalkState::Skip
                             }
                         }
                     }
@@ -326,7 +330,7 @@ impl DirectoryWalker for OsDirectoryWalker {
                             // (which, should not be reported here but the `ignore` crate doesn't distinguish between ignore and IO errors).
                             // Let's log the error to at least make it visible.
                             tracing::warn!("Failed to traverse directory: {error}.");
-                            ignore::WalkState::Continue
+                            ::ignore::WalkState::Continue
                         }
                     },
                 }
@@ -337,11 +341,11 @@ impl DirectoryWalker for OsDirectoryWalker {
 
 #[cold]
 fn ignore_to_walk_directory_error(
-    error: ignore::Error,
+    error: ::ignore::Error,
     path: Option<PathBuf>,
     depth: Option<usize>,
-) -> std::result::Result<walk_directory::Error, ignore::Error> {
-    use ignore::Error;
+) -> std::result::Result<walk_directory::Error, ::ignore::Error> {
+    use ::ignore::Error;
 
     match error {
         Error::WithPath { path, err } => ignore_to_walk_directory_error(*err, Some(path), depth),
@@ -399,12 +403,12 @@ impl From<std::fs::FileType> for FileType {
     }
 }
 
-impl From<WalkState> for ignore::WalkState {
+impl From<WalkState> for ::ignore::WalkState {
     fn from(value: WalkState) -> Self {
         match value {
-            WalkState::Continue => ignore::WalkState::Continue,
-            WalkState::Skip => ignore::WalkState::Skip,
-            WalkState::Quit => ignore::WalkState::Quit,
+            WalkState::Continue => ::ignore::WalkState::Continue,
+            WalkState::Skip => ::ignore::WalkState::Skip,
+            WalkState::Quit => ::ignore::WalkState::Quit,
         }
     }
 }

--- a/crates/ruff_db/src/system/os/ignore.rs
+++ b/crates/ruff_db/src/system/os/ignore.rs
@@ -24,63 +24,26 @@
 use ::ignore::gitignore;
 use rustc_hash::FxHashMap;
 
-use crate::system::{System, SystemPath, SystemPathBuf};
+use crate::system::walk_directory::{IgnoreIncremental, Ignored};
+use crate::system::{SystemPath, SystemPathBuf};
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum Ignored {
-    /// A root ignore file proves that the project walker would skip this path.
-    Yes,
-
-    /// The file might be ignored, but we need to use the ignore walker to know for sure.
-    Uncertain,
-}
-
-impl Ignored {
-    pub const fn is_uncertain(self) -> bool {
-        matches!(self, Self::Uncertain)
-    }
-}
-
-pub struct IgnoreFiles<'a> {
-    walk_roots: &'a [SystemPathBuf],
-    system: Box<dyn System>,
+pub(super) struct IgnoreFiles {
+    walk_roots: Box<[SystemPathBuf]>,
     roots: FxHashMap<SystemPathBuf, RootIgnoreFiles>,
 }
 
-impl<'a> IgnoreFiles<'a> {
-    pub fn new(system: Box<dyn System>, walk_roots: &'a [SystemPathBuf]) -> Self {
+impl IgnoreFiles {
+    pub(super) fn new(walk_roots: Vec<SystemPathBuf>) -> Self {
         Self {
-            walk_roots,
-            system,
+            walk_roots: walk_roots.into_boxed_slice(),
             roots: FxHashMap::default(),
-        }
-    }
-
-    /// Returns `Yes` only when the matching walk root can prune `path`
-    /// from its own ignore files. In all other cases, return uncertain.
-    pub fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored {
-        // A nested explicit walk root gets its own depth-0 walk, so an ancestor
-        // root cannot prove that the nested root's descendants are ignored.
-        let Some(root) = self
-            .walk_roots
-            .iter()
-            .filter(|root| path.starts_with(root))
-            .max_by_key(|root| root.as_str().len())
-        else {
-            return Ignored::Uncertain;
-        };
-
-        if self.root_ignore_prunes_path(root, path, is_directory) {
-            Ignored::Yes
-        } else {
-            Ignored::Uncertain
         }
     }
 
     /// Answers the question whether the ignore file in the `root` directory
     /// ignores `path`.
     fn root_ignore_prunes_path(
-        &mut self,
+        roots: &mut FxHashMap<SystemPathBuf, RootIgnoreFiles>,
         root: &SystemPath,
         path: &SystemPath,
         is_directory: bool,
@@ -98,14 +61,40 @@ impl<'a> IgnoreFiles<'a> {
 
         let first_child_is_directory = !first_child_is_target || is_directory;
 
-        self.root_ignore_files(root)
-            .is_ignored(&first_child, first_child_is_directory)
+        Self::root_ignore_files(roots, root).is_ignored(&first_child, first_child_is_directory)
     }
 
-    fn root_ignore_files(&mut self, root: &SystemPath) -> &RootIgnoreFiles {
-        self.roots
+    fn root_ignore_files<'a>(
+        roots: &'a mut FxHashMap<SystemPathBuf, RootIgnoreFiles>,
+        root: &SystemPath,
+    ) -> &'a RootIgnoreFiles {
+        roots
             .entry(root.to_path_buf())
-            .or_insert_with(|| RootIgnoreFiles::read(self.system.as_ref(), root))
+            .or_insert_with(|| RootIgnoreFiles::read(root))
+    }
+}
+
+impl IgnoreIncremental for IgnoreFiles {
+    /// Returns `Yes` only when the matching walk root can prune `path`
+    /// from its own ignore files. In all other cases, return uncertain.
+    fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored {
+        let Self { walk_roots, roots } = self;
+
+        // A nested explicit walk root gets its own depth-0 walk, so an ancestor
+        // root cannot prove that the nested root's descendants are ignored.
+        let Some(root) = walk_roots
+            .iter()
+            .filter(|root| path.starts_with(root))
+            .max_by_key(|root| root.as_str().len())
+        else {
+            return Ignored::Uncertain;
+        };
+
+        if Self::root_ignore_prunes_path(roots, root, path, is_directory) {
+            Ignored::Yes
+        } else {
+            Ignored::Uncertain
+        }
     }
 }
 
@@ -116,22 +105,26 @@ struct RootIgnoreFiles {
 }
 
 impl RootIgnoreFiles {
-    fn read(system: &dyn System, root: &SystemPath) -> Self {
-        let canonical_root = system.canonicalize_path(root).ok();
+    fn read(root: &SystemPath) -> Self {
+        let canonical_root = root.as_utf8_path().canonicalize_utf8().ok().map(|path| {
+            SystemPathBuf::from_utf8_path_buf(path)
+                .simplified()
+                .to_path_buf()
+        });
 
         let gitignore = if let Some(canonical_root) = canonical_root.as_deref()
-            && in_git_repository(system, canonical_root)
+            && in_git_repository(canonical_root)
             // A parent `.ignore` allowlist takes precedence over a matching
             // `.gitignore` at the walk root. Let the walker resolve that case.
-            && !has_parent_ignore_file(system, canonical_root)
+            && !has_parent_ignore_file(canonical_root)
         {
-            IgnoreFile::read(system, root, ".gitignore")
+            IgnoreFile::read(root, ".gitignore")
         } else {
             None
         };
 
         Self {
-            ignore: IgnoreFile::read(system, root, ".ignore"),
+            ignore: IgnoreFile::read(root, ".ignore"),
             gitignore,
         }
     }
@@ -156,9 +149,9 @@ enum IgnoreFile {
 }
 
 impl IgnoreFile {
-    fn read(system: &dyn System, root: &SystemPath, file_name: &str) -> Option<Self> {
+    fn read(root: &SystemPath, file_name: &str) -> Option<Self> {
         let ignore_path = root.join(file_name);
-        let contents = match system.read_to_string(&ignore_path) {
+        let contents = match std::fs::read_to_string(ignore_path.as_std_path()) {
             Ok(contents) => contents,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
             Err(_) => return Some(Self::Error),
@@ -204,41 +197,51 @@ fn build_matcher(
     builder.build().ok()
 }
 
-fn in_git_repository(system: &dyn System, canonical_root: &SystemPath) -> bool {
+fn in_git_repository(canonical_root: &SystemPath) -> bool {
     canonical_root.ancestors().any(|directory| {
-        system.path_exists(&directory.join(".git")) || system.path_exists(&directory.join(".jj"))
+        directory.join(".git").as_std_path().exists()
+            || directory.join(".jj").as_std_path().exists()
     })
 }
 
-fn has_parent_ignore_file(system: &dyn System, canonical_root: &SystemPath) -> bool {
+fn has_parent_ignore_file(canonical_root: &SystemPath) -> bool {
     canonical_root
         .parent()
         .into_iter()
         .flat_map(SystemPath::ancestors)
-        .any(|directory| system.path_exists(&directory.join(".ignore")))
+        .any(|directory| directory.join(".ignore").as_std_path().exists())
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::system::{InMemorySystem, System, SystemPath, SystemPathBuf};
+    use tempfile::TempDir;
 
-    use super::{IgnoreFiles, Ignored};
+    use crate::system::walk_directory::Ignored;
+    use crate::system::{OsSystem, System, SystemPath, SystemPathBuf};
 
     struct TestProject {
-        system: InMemorySystem,
+        _temp_dir: TempDir,
+        system: OsSystem,
         root: SystemPathBuf,
     }
 
     impl TestProject {
         fn new() -> Self {
-            Self::with_root("/project")
+            Self::with_root("project")
         }
 
         fn with_root(root: &str) -> Self {
-            let system = InMemorySystem::new(root.into());
-            let root = system.current_directory().to_path_buf();
+            let temp_dir = TempDir::new().unwrap();
+            let temp_dir_path = SystemPath::from_std_path(temp_dir.path()).unwrap();
+            let root = temp_dir_path.join(root);
+            std::fs::create_dir_all(root.as_std_path()).unwrap();
+            let system = OsSystem::new(&root);
 
-            Self { system, root }
+            Self {
+                _temp_dir: temp_dir,
+                system,
+                root,
+            }
         }
 
         fn path(&self, relative_path: &str) -> SystemPathBuf {
@@ -246,11 +249,14 @@ mod tests {
         }
 
         fn write_files<'a>(&self, files: impl IntoIterator<Item = (SystemPathBuf, &'a str)>) {
-            self.system.fs().write_files_all(files).unwrap();
+            for (path, contents) in files {
+                std::fs::create_dir_all(path.parent().unwrap().as_std_path()).unwrap();
+                std::fs::write(path.as_std_path(), contents).unwrap();
+            }
         }
 
         fn create_directory(&self, path: impl AsRef<SystemPath>) {
-            self.system.fs().create_directory_all(path).unwrap();
+            std::fs::create_dir_all(path.as_ref().as_std_path()).unwrap();
         }
 
         fn is_ignored(&self, path: &SystemPath) -> Ignored {
@@ -258,7 +264,14 @@ mod tests {
         }
 
         fn is_ignored_from(&self, walk_roots: &[SystemPathBuf], path: &SystemPath) -> Ignored {
-            IgnoreFiles::new(self.system.dyn_clone(), walk_roots).is_ignored(path, false)
+            let (first, additional) = walk_roots.split_first().unwrap();
+            let mut builder = self.system.walk_directory(first);
+
+            for root in additional {
+                builder = builder.add(root);
+            }
+
+            builder.incremental_matcher().is_ignored(path, false)
         }
     }
 
@@ -277,6 +290,7 @@ mod tests {
     #[test]
     fn root_gitignore_file_requires_repository() {
         let project = TestProject::new();
+
         let path = project.path("build/keep.py");
         project.write_files([(project.path(".gitignore"), "build/\n")]);
 
@@ -307,7 +321,7 @@ mod tests {
 
     #[test]
     fn parent_ignore_file_disables_root_gitignore_pruning() {
-        let project = TestProject::with_root("/workspace/project");
+        let project = TestProject::with_root("workspace/project");
         let path = project.path("build/keep.py");
         project.write_files([
             (project.path(".git/HEAD"), "ref: refs/heads/main\n"),

--- a/crates/ruff_db/src/system/os/ignore.rs
+++ b/crates/ruff_db/src/system/os/ignore.rs
@@ -21,12 +21,13 @@
 //! case where a file or directory is already ignored by an ignore file at the
 //! project walk root.
 
-use ignore::gitignore;
-use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use ::ignore::gitignore;
 use rustc_hash::FxHashMap;
 
+use crate::system::{System, SystemPath, SystemPathBuf};
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(super) enum Ignored {
+pub enum Ignored {
     /// A root ignore file proves that the project walker would skip this path.
     Yes,
 
@@ -35,19 +36,19 @@ pub(super) enum Ignored {
 }
 
 impl Ignored {
-    pub(super) const fn is_uncertain(self) -> bool {
+    pub const fn is_uncertain(self) -> bool {
         matches!(self, Self::Uncertain)
     }
 }
 
-pub(super) struct IgnoreFiles<'a> {
+pub struct IgnoreFiles<'a> {
     walk_roots: &'a [SystemPathBuf],
     system: Box<dyn System>,
     roots: FxHashMap<SystemPathBuf, RootIgnoreFiles>,
 }
 
 impl<'a> IgnoreFiles<'a> {
-    pub(super) fn new(system: Box<dyn System>, walk_roots: &'a [SystemPathBuf]) -> Self {
+    pub fn new(system: Box<dyn System>, walk_roots: &'a [SystemPathBuf]) -> Self {
         Self {
             walk_roots,
             system,
@@ -57,7 +58,7 @@ impl<'a> IgnoreFiles<'a> {
 
     /// Returns `Yes` only when the matching walk root can prune `path`
     /// from its own ignore files. In all other cases, return uncertain.
-    pub(super) fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored {
+    pub fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored {
         // A nested explicit walk root gets its own depth-0 walk, so an ancestor
         // root cannot prove that the nested root's descendants are ignored.
         let Some(root) = self
@@ -176,9 +177,9 @@ impl IgnoreFile {
         };
 
         Ok(match matcher.matched(path.as_std_path(), is_directory) {
-            ignore::Match::None => None,
-            ignore::Match::Ignore(_) => Some(true),
-            ignore::Match::Whitelist(_) => Some(false),
+            ::ignore::Match::None => None,
+            ::ignore::Match::Ignore(_) => Some(true),
+            ::ignore::Match::Whitelist(_) => Some(false),
         })
     }
 }
@@ -219,7 +220,7 @@ fn has_parent_ignore_file(system: &dyn System, canonical_root: &SystemPath) -> b
 
 #[cfg(test)]
 mod tests {
-    use ruff_db::system::{InMemorySystem, System, SystemPath, SystemPathBuf};
+    use crate::system::{InMemorySystem, System, SystemPath, SystemPathBuf};
 
     use super::{IgnoreFiles, Ignored};
 

--- a/crates/ruff_db/src/system/walk_directory.rs
+++ b/crates/ruff_db/src/system/walk_directory.rs
@@ -4,6 +4,29 @@ use std::path::PathBuf;
 
 use super::{FileType, SystemPath};
 
+/// Whether a path is known to be ignored by a directory walker.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Ignored {
+    /// An ignore file proves that the directory walker would skip this path.
+    Yes,
+
+    /// The path might be ignored, but a directory walk is required to know for sure.
+    Uncertain,
+}
+
+impl Ignored {
+    /// Returns `true` if a directory walk is required to determine whether the path is ignored.
+    pub const fn is_uncertain(self) -> bool {
+        matches!(self, Self::Uncertain)
+    }
+}
+
+/// A matcher for determining whether paths are ignored during incremental directory walking.
+pub trait IgnoreIncremental {
+    /// Returns whether the directory walker is known to ignore `path`.
+    fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored;
+}
+
 /// A builder for constructing a directory recursive traversal.
 pub struct WalkDirectoryBuilder {
     /// The implementation that does the directory walking.
@@ -65,6 +88,16 @@ impl WalkDirectoryBuilder {
         self
     }
 
+    /// Creates a matcher for determining whether paths are ignored during incremental walking.
+    pub fn incremental_matcher(self) -> Box<dyn IgnoreIncremental> {
+        let configuration = WalkDirectoryConfiguration {
+            paths: self.paths,
+            ignore_hidden: self.ignore_hidden,
+            standard_filters: self.standard_filters,
+        };
+        self.walker.incremental_matcher(configuration)
+    }
+
     /// Runs the directory traversal and calls the passed `builder` to create visitors
     /// that do the visiting. The walker may run multiple threads to visit the directories.
     pub fn run<'s, F>(self, builder: F)
@@ -94,6 +127,12 @@ pub trait DirectoryWalker {
         builder: &mut dyn WalkDirectoryVisitorBuilder,
         configuration: WalkDirectoryConfiguration,
     );
+
+    /// Creates a matcher for determining whether paths are ignored during incremental walking.
+    fn incremental_matcher(
+        &self,
+        configuration: WalkDirectoryConfiguration,
+    ) -> Box<dyn IgnoreIncremental>;
 }
 
 /// Creates a visitor for each thread that does the visiting.

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -40,7 +40,6 @@ compact_str = { workspace = true, features = ["serde"] }
 crossbeam = { workspace = true }
 get-size2 = { workspace = true, features = ["ordermap"] }
 globset = { workspace = true }
-ignore = { workspace = true }
 notify = { workspace = true }
 ordermap = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["version-ranges"] }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -22,7 +22,6 @@ use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 use ty_python_semantic::{AnalysisSettings, Db as SemanticDb};
 
 mod changes;
-mod ignore;
 
 #[salsa::db]
 pub trait Db: SemanticDb {

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -3,10 +3,10 @@ use crate::watch::{ChangeEvent, CreatedKind, DeletedKind};
 use crate::{ProjectMetadata, ProjectReloadResult};
 use std::collections::BTreeSet;
 
-use crate::walk::ProjectFilesWalker;
+use crate::walk::{ProjectFilesWalker, create_walker_builder};
 use ruff_db::Db as _;
 use ruff_db::files::{File, Files, system_path_to_file};
-use ruff_db::system::{IgnoreFiles, SystemPath, SystemPathBuf};
+use ruff_db::system::{SystemPath, SystemPathBuf};
 use rustc_hash::FxHashSet;
 use ty_python_core::program::{FallibleStrategy, Program};
 
@@ -54,12 +54,15 @@ impl ProjectDatabase {
         let mut removed_paths = BTreeSet::default();
         let mut reload_project = false;
         let mut reload_project_files = false;
+        // TODO: This should be removed once the incremental checker is ported
+        // over to the `ignore` crate, since the `ignore` crate will respect
+        // the settings provided in `create_walker`. ---AG
         let respect_ignore_files = project.settings(self).src().respect_ignore_files;
         let ignore_walk_roots =
             respect_ignore_files.then(|| project.included_paths_or_root(self).to_vec());
-        let mut ignore_files = ignore_walk_roots
-            .as_deref()
-            .map(|walk_roots| IgnoreFiles::new(self.system().dyn_clone(), walk_roots));
+        let mut ignore_files = ignore_walk_roots.as_deref().and_then(|walk_roots| {
+            Some(create_walker_builder(self, walk_roots)?.incremental_matcher())
+        });
 
         for change in changes {
             tracing::debug!("Handling file watcher change event: {:?}", change);

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -3,11 +3,10 @@ use crate::watch::{ChangeEvent, CreatedKind, DeletedKind};
 use crate::{ProjectMetadata, ProjectReloadResult};
 use std::collections::BTreeSet;
 
-use super::ignore::IgnoreFiles;
 use crate::walk::ProjectFilesWalker;
 use ruff_db::Db as _;
 use ruff_db::files::{File, Files, system_path_to_file};
-use ruff_db::system::{SystemPath, SystemPathBuf};
+use ruff_db::system::{IgnoreFiles, SystemPath, SystemPathBuf};
 use rustc_hash::FxHashSet;
 use ty_python_core::program::{FallibleStrategy, Program};
 

--- a/crates/ty_project/src/walk.rs
+++ b/crates/ty_project/src/walk.rs
@@ -152,14 +152,14 @@ impl ProjectFilesWalker {
                 return (Vec::new(), Vec::new());
             }
 
-            create_walker(
+            create_walker_builder(
                 db,
                 root_paths.iter().filter(|root| {
                     should_visit_incremental_path(root.as_path(), incremental_paths)
                 }),
             )
         } else {
-            create_walker(db, root_paths)
+            create_walker_builder(db, root_paths)
         };
 
         let Some(walker) = walker else {
@@ -307,24 +307,24 @@ impl ProjectFilesWalker {
     }
 }
 
-fn create_walker<I, T>(db: &dyn Db, paths: I) -> Option<WalkDirectoryBuilder>
+pub(crate) fn create_walker_builder<I, T>(db: &dyn Db, paths: I) -> Option<WalkDirectoryBuilder>
 where
     I: IntoIterator<Item = T>,
     T: AsRef<SystemPath>,
 {
     let mut paths = paths.into_iter();
 
-    let mut walker = db
+    let mut builder = db
         .system()
         .walk_directory(paths.next()?.as_ref())
         .standard_filters(db.project().settings(db).src().respect_ignore_files)
         .ignore_hidden(false);
 
     for path in paths {
-        walker = walker.add(path);
+        builder = builder.add(path);
     }
 
-    Some(walker)
+    Some(builder)
 }
 
 fn should_visit_incremental_path(


### PR DESCRIPTION
Previously, this checking was done on top of our `System` abstraction.
But we want the `ignore` crate to own this, which means it has to
either be within `System` or we need to do some other tomfoolery to
make wasm targets continue to work. The API surface area of incremental
ignore file checking is pretty small, so I chose to push it down into
`System`. It slots in nicely with the existing `WalkDirectoryBuilder`
abstraction. Indeed, this should work with how the `ignore` crate will
build incremental matchers (from a `WalkBuilder`).
