### PR TITLE
Avoid redundant pending-indentation writes

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -170,8 +170,8 @@ impl<'src> Lexer<'src> {
         // Avoid `Option::take` here: this check runs for every token, and `take` writes `None`
         // even when there is no pending indentation.
         else if let Some(indentation) = self.pending_indentation {
-            self.cursor.start_token();
             self.pending_indentation = None;
+            self.cursor.start_token();
             match self.indentations.current().try_compare(indentation) {
                 Ok(Ordering::Greater) => {
                     self.pending_indentation = Some(indentation);

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -167,8 +167,11 @@ impl<'src> Lexer<'src> {
             }
         }
         // Return dedent tokens until the current indentation level matches the indentation of the next token.
-        else if let Some(indentation) = self.pending_indentation.take() {
+        // Avoid `Option::take` here: this check runs for every token, and `take` writes `None`
+        // even when there is no pending indentation.
+        else if let Some(indentation) = self.pending_indentation {
             self.cursor.start_token();
+            self.pending_indentation = None;
             match self.indentations.current().try_compare(indentation) {
                 Ok(Ordering::Greater) => {
                     self.pending_indentation = Some(indentation);


### PR DESCRIPTION
## Summary

The lexer checks `pending_indentation` for every token. `Option::take` writes `None` even on the common path where no indentation is pending, so we now read the field first and clear it only when a value is present. This avoids a redundant write in the hot lexer loop while preserving the existing indentation behavior.

This PR is stacked on #26765 so that CodSpeed can measure the pending-indentation optimization independently.