### PR TITLE
Use a chunked lexer for ARM module parsing

### DIFF
--- a/crates/ruff_benchmark/benches/lexer.rs
+++ b/crates/ruff_benchmark/benches/lexer.rs
@@ -6,8 +6,11 @@ use criterion::{
 use ruff_benchmark::{
     LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestCase, UNICODE_PYPINYIN,
 };
+#[cfg(not(target_arch = "aarch64"))]
 use ruff_python_ast::token::TokenKind;
-use ruff_python_parser::{Mode, lexer};
+#[cfg(not(target_arch = "aarch64"))]
+use ruff_python_parser::Mode;
+use ruff_python_parser::lexer;
 
 #[cfg(target_os = "windows")]
 #[global_allocator]
@@ -46,22 +49,29 @@ fn benchmark_lexer(criterion: &mut Criterion<WallTime>) {
             BenchmarkId::from_parameter(case.name()),
             &case,
             |b, case| {
-                b.iter(|| {
-                    let mut lexer = lexer::lex(case.code(), Mode::Module);
-                    loop {
-                        let token = lexer.next_token();
-                        match token {
-                            TokenKind::EndOfFile => break,
-                            TokenKind::Unknown => panic!("Input to be a valid Python source code"),
-                            _ => {}
-                        }
-                    }
-                });
+                b.iter(|| lex_module(case.code()));
             },
         );
     }
 
     group.finish();
+}
+
+#[cfg(target_arch = "aarch64")]
+fn lex_module(source: &str) -> usize {
+    lexer::lex_chunked(source).expect("benchmark input should be supported by the chunked lexer")
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn lex_module(source: &str) {
+    let mut lexer = lexer::lex(source, Mode::Module);
+    loop {
+        match lexer.next_token() {
+            TokenKind::EndOfFile => return,
+            TokenKind::Unknown => panic!("benchmark input should be valid Python source code"),
+            _ => {}
+        }
+    }
 }
 
 criterion_group!(lexer, benchmark_lexer);

--- a/crates/ruff_python_ast/src/token.rs
+++ b/crates/ruff_python_ast/src/token.rs
@@ -44,6 +44,12 @@ impl Token {
         self.kind
     }
 
+    /// Returns the flags associated with this token.
+    #[inline]
+    pub const fn flags(&self) -> TokenFlags {
+        self.flags
+    }
+
     /// Returns the token as a tuple of (kind, range).
     #[inline]
     pub const fn as_tuple(&self) -> (TokenKind, TextRange) {

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -25,7 +25,13 @@ use crate::lexer::interpolated_string::{
 };
 use crate::string::InterpolatedStringKind;
 
+#[cfg(target_arch = "aarch64")]
+pub(crate) mod chunked;
+#[cfg(target_arch = "aarch64")]
+mod classify;
 mod cursor;
+#[cfg(target_arch = "aarch64")]
+mod fast_token;
 mod indentation;
 mod interpolated_string;
 
@@ -1622,6 +1628,13 @@ fn is_identifier_continuation(c: char, identifier_is_ascii_only: &mut bool) -> b
 /// Create a new [`Lexer`] for the given source code and [`Mode`].
 pub fn lex(source: &str, mode: Mode) -> Lexer<'_> {
     Lexer::new(source, mode, TextSize::default())
+}
+
+/// Lex a Python module with the experimental ARM chunked lexer, returning the number of tokens
+/// (including EOF) on success. `None` indicates that the source requires the streaming lexer.
+#[cfg(target_arch = "aarch64")]
+pub fn lex_chunked(source: &str) -> Option<usize> {
+    chunked::lex(source).map(|tokens| tokens.tokens.len())
 }
 
 #[cfg(test)]

--- a/crates/ruff_python_parser/src/lexer/chunked.rs
+++ b/crates/ruff_python_parser/src/lexer/chunked.rs
@@ -1,0 +1,619 @@
+use std::cmp::Ordering;
+
+use ruff_python_ast::token::{Token, TokenFlags, TokenKind};
+use ruff_text_size::{TextRange, TextSize};
+use unicode_ident::{is_xid_continue, is_xid_start};
+
+use crate::Mode;
+use crate::lexer::Lexer;
+use crate::lexer::classify::{Classified, classify_into};
+use crate::lexer::fast_token::{keyword, number, operator};
+use crate::lexer::indentation::{Indentation, Indentations};
+
+/// Tokens produced by the chunked lexer. Parser results store tokens as a `Vec<Token>`, so the
+/// lexer builds that representation directly and the parser consumes it by index.
+#[derive(Debug)]
+pub(crate) struct ChunkedTokens {
+    pub(crate) tokens: Vec<Token>,
+    pub(crate) rewrites: Vec<(usize, Token)>,
+}
+
+impl ChunkedTokens {
+    #[inline]
+    fn push(&mut self, kind: TokenKind, start: usize, end: usize, flags: TokenFlags) {
+        self.tokens.push(Token::new(
+            kind,
+            TextRange::new(text_size(start), text_size(end)),
+            flags,
+        ));
+    }
+
+    #[inline]
+    fn push_range(&mut self, kind: TokenKind, range: TextRange, flags: TokenFlags) {
+        self.tokens.push(Token::new(kind, range, flags));
+    }
+}
+
+const CHUNK_SIZE: usize = 32 * 1024;
+
+/// An on-demand lexer that classifies fixed-size source batches with SIMD and buffers complete
+/// tokens for the parser. Unsupported or malformed input returns `None` so parsing can restart
+/// with the streaming lexer.
+#[derive(Debug)]
+pub(crate) struct ChunkedLexer<'src> {
+    pub(crate) tokens: ChunkedTokens,
+    source: &'src str,
+    offset: usize,
+    classified: Classified,
+    indentations: Indentations,
+    indentation: Indentation,
+    line_start: usize,
+    at_logical_line_start: bool,
+    logical_line_has_token: bool,
+    nesting: u32,
+    finished: bool,
+}
+
+impl<'src> ChunkedLexer<'src> {
+    /// Creates a chunked lexer for a source whose byte offsets fit in [`TextSize`].
+    pub(crate) fn new(source: &'src str) -> Option<Self> {
+        u32::try_from(source.len()).ok()?;
+        Some(Self {
+            tokens: ChunkedTokens {
+                tokens: Vec::with_capacity(source.len() / 8),
+                rewrites: Vec::new(),
+            },
+            source,
+            offset: 0,
+            classified: Classified::default(),
+            indentations: Indentations::default(),
+            indentation: Indentation::root(),
+            line_start: 0,
+            at_logical_line_start: true,
+            logical_line_has_token: false,
+            nesting: 0,
+            finished: false,
+        })
+    }
+
+    pub(crate) const fn is_finished(&self) -> bool {
+        self.finished
+    }
+
+    /// Classify a batch with NEON, then carve and coalesce it into complete tokens. A final word
+    /// or whitespace run is extended so that the next batch always starts at a token boundary.
+    pub(crate) fn fill(&mut self) -> Option<()> {
+        if self.finished {
+            return Some(());
+        }
+
+        let source = self.source;
+        let bytes = source.as_bytes();
+        let tokens = &mut self.tokens;
+        let chunk_start = self.offset;
+        let mut chunk_end = (chunk_start + CHUNK_SIZE).min(bytes.len());
+        if chunk_end < bytes.len() {
+            if is_word(bytes[chunk_end - 1]) {
+                while chunk_end < bytes.len() && is_word(bytes[chunk_end]) {
+                    chunk_end += 1;
+                }
+            } else if is_whitespace(bytes[chunk_end - 1]) {
+                while chunk_end < bytes.len() && is_whitespace(bytes[chunk_end]) {
+                    chunk_end += 1;
+                }
+            }
+        }
+
+        classify_into(&bytes[chunk_start..chunk_end], &mut self.classified);
+        let mut structural = Starts::new(&self.classified.starts, chunk_start);
+        let mut next_offset = chunk_end;
+        let mut indentation = self.indentation;
+        let mut line_start = self.line_start;
+        let mut at_logical_line_start = self.at_logical_line_start;
+        let mut logical_line_has_token = self.logical_line_has_token;
+        let mut nesting = self.nesting;
+
+        while let Some(start) = structural.next() {
+            let byte = bytes[start];
+
+            if matches!(byte, b' ' | b'\t' | b'\x0c') {
+                let end = structural.peek().unwrap_or(chunk_end);
+                if at_logical_line_start && nesting == 0 {
+                    for byte in &bytes[start..end] {
+                        indentation = match byte {
+                            b' ' => indentation.add_space(),
+                            b'\t' => indentation.add_tab(),
+                            b'\x0c' => Indentation::root(),
+                            _ => return None,
+                        };
+                    }
+                }
+                continue;
+            }
+
+            match byte {
+                b'\n' | b'\r' => {
+                    let end = start
+                        + usize::from(byte == b'\r' && bytes.get(start + 1) == Some(&b'\n'))
+                        + 1;
+                    let kind = if nesting == 0 && logical_line_has_token {
+                        at_logical_line_start = true;
+                        logical_line_has_token = false;
+                        indentation = Indentation::root();
+                        line_start = end;
+                        TokenKind::Newline
+                    } else {
+                        if nesting == 0 {
+                            at_logical_line_start = true;
+                            indentation = Indentation::root();
+                            line_start = end;
+                        }
+                        TokenKind::NonLogicalNewline
+                    };
+                    tokens.push(kind, start, end, TokenFlags::empty());
+                    if end > start + 1 {
+                        structural.seek(end);
+                        next_offset = next_offset.max(end);
+                    }
+                    continue;
+                }
+                b'#' => {
+                    let end = memchr::memchr2(b'\n', b'\r', &bytes[start..])
+                        .map_or(bytes.len(), |index| start + index);
+                    tokens.push(TokenKind::Comment, start, end, TokenFlags::empty());
+                    structural.seek(end);
+                    next_offset = next_offset.max(end);
+                    continue;
+                }
+                b'\\' => {
+                    // Explicit continuations in indentation have slightly different semantics; leave
+                    // those rare cases, and a continuation at EOF, to the existing lexer.
+                    if at_logical_line_start {
+                        return None;
+                    }
+                    let end = match bytes.get(start + 1..) {
+                        Some([b'\n', ..]) => start + 2,
+                        Some([b'\r', b'\n', ..]) => start + 3,
+                        Some([b'\r', ..]) => start + 2,
+                        _ => return None,
+                    };
+                    if end == bytes.len() {
+                        return None;
+                    }
+                    structural.seek(end);
+                    next_offset = next_offset.max(end);
+                    continue;
+                }
+                _ => {}
+            }
+
+            if at_logical_line_start && nesting == 0 {
+                match self.indentations.current().try_compare(indentation).ok()? {
+                    Ordering::Less => {
+                        self.indentations.indent(indentation);
+                        tokens.push(TokenKind::Indent, line_start, start, TokenFlags::empty());
+                    }
+                    Ordering::Greater => {
+                        while self.indentations.current().try_compare(indentation).ok()?
+                            == Ordering::Greater
+                        {
+                            self.indentations.dedent_one(indentation).ok()?;
+                            tokens.push(TokenKind::Dedent, start, start, TokenFlags::empty());
+                        }
+                    }
+                    Ordering::Equal => {}
+                }
+                at_logical_line_start = false;
+            }
+
+            if byte.is_ascii_alphanumeric() || byte == b'_' || !byte.is_ascii() {
+                let end = structural.peek().unwrap_or(chunk_end);
+
+                if matches!(bytes.get(end), Some(b'\'' | b'"'))
+                    && let Some(flags) = string_prefix(&bytes[start..end])
+                {
+                    let end = if flags.intersects(TokenFlags::F_STRING | TokenFlags::T_STRING) {
+                        append_interpolated_string(source, start, tokens)?
+                    } else {
+                        let (end, flags) = string(bytes, end, flags)?;
+                        tokens.push(TokenKind::String, start, end, flags);
+                        end
+                    };
+                    structural.seek(end);
+                    next_offset = next_offset.max(end);
+                    logical_line_has_token = true;
+                    continue;
+                }
+
+                if byte.is_ascii_digit() {
+                    let (kind, end) = number(bytes, start)?;
+                    tokens.push(kind, start, end, TokenFlags::empty());
+                    structural.seek(end);
+                    next_offset = next_offset.max(end);
+                    logical_line_has_token = true;
+                    continue;
+                }
+
+                let (kind, flags) = if self.classified.ascii_source {
+                    (keyword(&bytes[start..end]), TokenFlags::empty())
+                } else {
+                    let text = &source[start..end];
+                    if text.is_ascii() {
+                        (keyword(text.as_bytes()), TokenFlags::empty())
+                    } else if valid_identifier(text) {
+                        (TokenKind::Name, TokenFlags::NON_ASCII_NAME)
+                    } else {
+                        return None;
+                    }
+                };
+                tokens.push(kind, start, end, flags);
+                logical_line_has_token = true;
+                continue;
+            }
+
+            if matches!(byte, b'\'' | b'"') {
+                let (end, flags) = string(bytes, start, TokenFlags::empty())?;
+                tokens.push(TokenKind::String, start, end, flags);
+                structural.seek(end);
+                next_offset = next_offset.max(end);
+                logical_line_has_token = true;
+                continue;
+            }
+
+            if byte == b'.' && bytes.get(start + 1).is_some_and(u8::is_ascii_digit) {
+                let (kind, end) = number(bytes, start)?;
+                tokens.push(kind, start, end, TokenFlags::empty());
+                structural.seek(end);
+                next_offset = next_offset.max(end);
+                logical_line_has_token = true;
+                continue;
+            }
+
+            // `?` is only a token in IPython mode.
+            if byte == b'?' {
+                return None;
+            }
+            let (kind, end) = operator(bytes, start)?;
+            match kind {
+                TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace => nesting += 1,
+                TokenKind::Rpar | TokenKind::Rsqb | TokenKind::Rbrace => {
+                    nesting = nesting.saturating_sub(1);
+                }
+                _ => {}
+            }
+            tokens.push(kind, start, end, TokenFlags::empty());
+            if end > start + 1 {
+                structural.seek(end);
+                next_offset = next_offset.max(end);
+            }
+            logical_line_has_token = true;
+        }
+
+        self.offset = next_offset;
+        self.indentation = indentation;
+        self.line_start = line_start;
+        self.at_logical_line_start = at_logical_line_start;
+        self.logical_line_has_token = logical_line_has_token;
+        self.nesting = nesting;
+
+        if next_offset == bytes.len() {
+            if nesting != 0 {
+                return None;
+            }
+            if logical_line_has_token {
+                tokens.push(
+                    TokenKind::Newline,
+                    bytes.len(),
+                    bytes.len(),
+                    TokenFlags::empty(),
+                );
+            }
+            while self.indentations.dedent().is_some() {
+                tokens.push(
+                    TokenKind::Dedent,
+                    bytes.len(),
+                    bytes.len(),
+                    TokenFlags::empty(),
+                );
+            }
+            tokens.push(
+                TokenKind::EndOfFile,
+                bytes.len(),
+                bytes.len(),
+                TokenFlags::empty(),
+            );
+            self.finished = true;
+        }
+
+        Some(())
+    }
+}
+
+/// Drain the chunked lexer for standalone lexer benchmarks and differential tests.
+pub(crate) fn lex(source: &str) -> Option<ChunkedTokens> {
+    let mut lexer = ChunkedLexer::new(source)?;
+    while !lexer.is_finished() {
+        lexer.fill()?;
+    }
+    Some(lexer.tokens)
+}
+
+const fn is_word(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || !byte.is_ascii()
+}
+
+const fn is_whitespace(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\t' | b'\x0c')
+}
+
+/// Appends one complete f-string or t-string, including nested interpolation tokens, using the
+/// streaming lexer to preserve its context-sensitive tokenization.
+///
+/// ```python
+/// value = f"{item!r:{width}}"
+/// ```
+fn append_interpolated_string(
+    source: &str,
+    start: usize,
+    tokens: &mut ChunkedTokens,
+) -> Option<usize> {
+    let mut lexer = Lexer::new(source, Mode::ParenthesizedExpression, text_size(start));
+    let mut depth = 0_u32;
+
+    loop {
+        let kind = lexer.next_token();
+        match kind {
+            TokenKind::FStringStart | TokenKind::TStringStart => depth += 1,
+            TokenKind::FStringEnd | TokenKind::TStringEnd => {
+                depth = depth.checked_sub(1)?;
+                tokens.push_range(kind, lexer.current_range(), lexer.current_flags());
+                if depth == 0 {
+                    let end = lexer.current_range().end().to_usize();
+                    return lexer.finish().is_empty().then_some(end);
+                }
+                continue;
+            }
+            TokenKind::Unknown | TokenKind::EndOfFile => return None,
+            _ => {}
+        }
+        tokens.push_range(kind, lexer.current_range(), lexer.current_flags());
+    }
+}
+
+/// Converts a valid Python string prefix into token flags, preserving raw-prefix casing.
+fn string_prefix(text: &[u8]) -> Option<TokenFlags> {
+    let flags = match text {
+        b"f" | b"F" => TokenFlags::F_STRING,
+        b"t" | b"T" => TokenFlags::T_STRING,
+        b"u" | b"U" => TokenFlags::UNICODE_STRING,
+        b"b" | b"B" => TokenFlags::BYTE_STRING,
+        b"r" => TokenFlags::RAW_STRING_LOWERCASE,
+        b"R" => TokenFlags::RAW_STRING_UPPERCASE,
+        [b'r', b'f' | b'F'] | [b'f' | b'F', b'r'] => {
+            TokenFlags::F_STRING | TokenFlags::RAW_STRING_LOWERCASE
+        }
+        [b'R', b'f' | b'F'] | [b'f' | b'F', b'R'] => {
+            TokenFlags::F_STRING | TokenFlags::RAW_STRING_UPPERCASE
+        }
+        [b'r', b't' | b'T'] | [b't' | b'T', b'r'] => {
+            TokenFlags::T_STRING | TokenFlags::RAW_STRING_LOWERCASE
+        }
+        [b'R', b't' | b'T'] | [b't' | b'T', b'R'] => {
+            TokenFlags::T_STRING | TokenFlags::RAW_STRING_UPPERCASE
+        }
+        [b'r', b'b' | b'B'] | [b'b' | b'B', b'r'] => {
+            TokenFlags::BYTE_STRING | TokenFlags::RAW_STRING_LOWERCASE
+        }
+        [b'R', b'b' | b'B'] | [b'b' | b'B', b'R'] => {
+            TokenFlags::BYTE_STRING | TokenFlags::RAW_STRING_UPPERCASE
+        }
+        _ => return None,
+    };
+    Some(flags)
+}
+
+/// Scans a non-interpolated string from its opening quote and returns its end and quote flags.
+/// Unterminated strings and single-quoted strings containing a newline fall back to the streaming
+/// lexer for diagnostics.
+fn string(source: &[u8], quote: usize, mut flags: TokenFlags) -> Option<(usize, TokenFlags)> {
+    let quote_byte = *source.get(quote)?;
+    if quote_byte == b'"' {
+        flags |= TokenFlags::DOUBLE_QUOTES;
+    }
+    let triple = source.get(quote + 1..quote + 3) == Some(&[quote_byte, quote_byte]);
+    if triple {
+        flags |= TokenFlags::TRIPLE_QUOTED_STRING;
+    }
+    let mut offset = quote + if triple { 3 } else { 1 };
+
+    loop {
+        let relative = if triple {
+            memchr::memchr(quote_byte, source.get(offset..)?)?
+        } else {
+            memchr::memchr3(quote_byte, b'\n', b'\r', source.get(offset..)?)?
+        };
+        let found = offset + relative;
+        let escaped = source[..found]
+            .iter()
+            .rev()
+            .take_while(|&&byte| byte == b'\\')
+            .count()
+            % 2
+            == 1;
+        if escaped {
+            offset = found + 1 + usize::from(source.get(found..found + 2) == Some(b"\r\n"));
+            continue;
+        }
+        if !triple && matches!(source[found], b'\n' | b'\r') {
+            return None;
+        }
+        if !triple {
+            return Some((found + 1, flags));
+        }
+        if source.get(found + 1..found + 3) == Some(&[quote_byte, quote_byte]) {
+            return Some((found + 3, flags));
+        }
+        offset = found + 1;
+    }
+}
+
+fn valid_identifier(text: &str) -> bool {
+    let mut chars = text.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || is_xid_start(first)) && chars.all(is_xid_continue)
+}
+
+/// Iterates structural-token starts from the classifier bitmap and can skip the interior of a
+/// token that was coalesced by the scalar pass.
+struct Starts<'a> {
+    bitmap: &'a [u64],
+    block: usize,
+    pending: u64,
+    base: usize,
+}
+
+impl<'a> Starts<'a> {
+    fn new(bitmap: &'a [u64], base: usize) -> Self {
+        Self {
+            bitmap,
+            block: 0,
+            pending: bitmap.first().copied().unwrap_or(0),
+            base,
+        }
+    }
+
+    #[inline]
+    fn next(&mut self) -> Option<usize> {
+        while self.pending == 0 {
+            self.block += 1;
+            self.pending = *self.bitmap.get(self.block)?;
+        }
+        let bit = self.pending.trailing_zeros() as usize;
+        self.pending &= self.pending - 1;
+        Some(self.base + self.block * 64 + bit)
+    }
+
+    #[inline]
+    fn peek(&self) -> Option<usize> {
+        if self.pending != 0 {
+            return Some(self.base + self.block * 64 + self.pending.trailing_zeros() as usize);
+        }
+        self.bitmap[self.block + 1..]
+            .iter()
+            .position(|&word| word != 0)
+            .map(|index| {
+                let block = self.block + index + 1;
+                self.base + block * 64 + self.bitmap[block].trailing_zeros() as usize
+            })
+    }
+
+    /// Discards every pending structural start before `offset`.
+    #[inline]
+    fn seek(&mut self, offset: usize) {
+        let offset = offset - self.base;
+        self.block = offset / 64;
+        self.pending =
+            self.bitmap.get(self.block).copied().unwrap_or(0) & (u64::MAX << (offset % 64));
+    }
+}
+
+// The public lexer rejects sources larger than `u32::MAX`, so every byte offset above is
+// representable as a `TextSize`.
+#[expect(clippy::cast_possible_truncation)]
+fn text_size(offset: usize) -> TextSize {
+    TextSize::new(offset as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_python_ast::token::{Token, TokenKind};
+
+    use crate::Mode;
+    use crate::lexer::Lexer;
+    use crate::lexer::chunked::{CHUNK_SIZE, lex};
+
+    fn legacy(source: &str) -> Vec<Token> {
+        let mut lexer = Lexer::new(source, Mode::Module, 0.into());
+        let mut tokens = Vec::new();
+        loop {
+            let kind = lexer.next_token();
+            tokens.push(Token::new(
+                kind,
+                lexer.current_range(),
+                lexer.current_flags(),
+            ));
+            if kind == TokenKind::EndOfFile {
+                break;
+            }
+        }
+        assert!(lexer.finish().is_empty());
+        tokens
+    }
+
+    fn assert_matches(source: &str) {
+        let actual = lex(source).expect("chunked lexer to accept the source");
+        assert_eq!(actual.tokens, legacy(source));
+    }
+
+    #[test]
+    fn common_python() {
+        assert_matches(
+            "def calculate(first, second=0x_f):\n    values = [first, second, .5, 1_000e-2j]\n    return values[0] ** 2 // 3  # result\n",
+        );
+    }
+
+    #[test]
+    fn indentation_comments_and_eols() {
+        assert_matches("# leading\r\nif True:\r\n\tif False:\r\n\t\tpass\r\n\r\npass\r\n");
+        assert_matches("if True:\n    value = (\n        1,\n        2,\n    )\n    # trailing\n");
+    }
+
+    #[test]
+    fn strings_and_interpolated_strings() {
+        assert_matches("a = 'one'\nb = rb\"two\\\"three\"\nc = '''three\nlines'''\n");
+        assert_matches("value = f\"{name!r}: {items[0]:04d}\"\nother = rf'{path}\\suffix'\n");
+    }
+
+    #[test]
+    fn unicode_identifiers_and_strings() {
+        assert_matches("变量 = 'λ'\nprint(变量)\n");
+    }
+
+    #[test]
+    fn chunk_boundaries() {
+        let prefix = "x=0;".repeat(CHUNK_SIZE / 4 - 1);
+        for suffix in [
+            "long_identifier_crossing_the_boundary = 1\n",
+            "    spaced = 1\n",
+            "# comment crossing the boundary\nvalue = 1\n",
+            "value = 'a string crossing the boundary'\n",
+            "value = f'{name}: interpolation crossing the boundary'\n",
+            "变量跨越边界 = 1\n",
+            "x=0\r\nvalue = 1\r\n",
+        ] {
+            assert_matches(&format!("{prefix}{suffix}"));
+        }
+
+        let prefix = "x=0\n".repeat(CHUNK_SIZE / 4 - 2);
+        assert_matches(&format!(
+            "{prefix}if True:\n    values = (\n        1,\n        2,\n    )\n"
+        ));
+    }
+
+    #[test]
+    fn invalid_or_contextual_input_falls_back() {
+        for source in [
+            "value = 01\n",
+            "value = 'unterminated\n",
+            "(value\n",
+            "?value\n",
+            "value = 1\\\n",
+            "value = 1\\\r",
+            "value = 1\\\r\n",
+        ] {
+            assert!(lex(source).is_none(), "{source:?}");
+        }
+    }
+}

--- a/crates/ruff_python_parser/src/lexer/classify.rs
+++ b/crates/ruff_python_parser/src/lexer/classify.rs
@@ -1,0 +1,273 @@
+#![expect(unsafe_code, reason = "the SIMD classifier uses bounded vector loads")]
+
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::{
+    uint8x16_t, vandq_u8, vdupq_n_u8, vgetq_lane_u64, vld1q_u8, vmaxvq_u8, vorrq_u8, vpaddq_u8,
+    vqtbl1q_u8, vreinterpretq_u64_u8, vshrq_n_u8, vtstq_u8,
+};
+
+/// Structural starts for one source batch. Each set bit begins a word run, whitespace run, or
+/// single structural byte; `ascii_source` lets the carver avoid per-identifier Unicode checks.
+#[derive(Debug, Default)]
+pub(super) struct Classified {
+    pub(super) starts: Vec<u64>,
+    pub(super) ascii_source: bool,
+}
+
+/// Intersecting the low- and high-nibble entries classifies a byte. Bits 0..=4 are ASCII word
+/// ranges, bits 5..=6 are horizontal whitespace, and bit 7 marks non-ASCII word bytes.
+#[cfg(target_arch = "aarch64")]
+const LOW_NIBBLE_CLASSES: [u8; 16] = [
+    213, 159, 159, 159, 159, 159, 159, 159, 159, 191, 158, 138, 170, 138, 138, 142,
+];
+#[cfg(target_arch = "aarch64")]
+const HIGH_NIBBLE_CLASSES: [u8; 16] = [
+    32, 0, 64, 1, 2, 4, 8, 16, 128, 128, 128, 128, 128, 128, 128, 128,
+];
+
+#[cfg(test)]
+pub(super) fn classify(source: &[u8]) -> Classified {
+    let mut classified = Classified::default();
+    classify_into(source, &mut classified);
+    classified
+}
+
+/// Reuses `classified` to identify token boundaries across the complete source batch.
+pub(super) fn classify_into(source: &[u8], classified: &mut Classified) {
+    let blocks = source.len().div_ceil(64);
+    classified.starts.clear();
+    classified.starts.reserve(blocks);
+    classified.ascii_source = true;
+    let mut previous_word = 0;
+    let mut previous_whitespace = 0;
+
+    let mut chunks = source.chunks_exact(64);
+    let mut source_or = unsafe { vdupq_n_u8(0) };
+
+    for chunk in &mut chunks {
+        // SAFETY: `chunks_exact(64)` guarantees that all four 16-byte loads are in bounds.
+        let (word, whitespace, chunk_or) = unsafe { classify_chunk(chunk.as_ptr()) };
+        // SAFETY: All NEON operations are valid for arbitrary byte vectors.
+        source_or = unsafe { vorrq_u8(source_or, chunk_or) };
+        push_block(
+            classified,
+            word,
+            whitespace,
+            &mut previous_word,
+            &mut previous_whitespace,
+            u64::MAX,
+        );
+    }
+
+    // SAFETY: All NEON operations are valid for arbitrary byte vectors.
+    classified.ascii_source = unsafe { vmaxvq_u8(source_or) < 0x80 };
+
+    let tail = chunks.remainder();
+    if !tail.is_empty() {
+        let mut word = 0;
+        let mut whitespace = 0;
+        for (bit, byte) in tail.iter().copied().enumerate() {
+            let is_non_ascii = !byte.is_ascii();
+            classified.ascii_source &= !is_non_ascii;
+            if byte.is_ascii_alphanumeric() || byte == b'_' || is_non_ascii {
+                word |= 1 << bit;
+            } else if matches!(byte, b' ' | b'\t' | b'\x0c') {
+                whitespace |= 1 << bit;
+            }
+        }
+        let valid = (1 << tail.len()) - 1;
+        push_block(
+            classified,
+            word,
+            whitespace,
+            &mut previous_word,
+            &mut previous_whitespace,
+            valid,
+        );
+    }
+}
+
+/// Converts word and whitespace masks into structural starts while carrying runs across blocks.
+fn push_block(
+    classified: &mut Classified,
+    word: u64,
+    whitespace: u64,
+    previous_word: &mut u64,
+    previous_whitespace: &mut u64,
+    valid: u64,
+) {
+    let word_starts = word & !((word << 1) | *previous_word);
+    let whitespace_starts = whitespace & !((whitespace << 1) | *previous_whitespace);
+    let other = !(word | whitespace) & valid;
+
+    classified
+        .starts
+        .push(word_starts | whitespace_starts | other);
+
+    *previous_word = word >> 63;
+    *previous_whitespace = whitespace >> 63;
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+unsafe fn classify_chunk(source: *const u8) -> (u64, u64, uint8x16_t) {
+    // SAFETY: The caller guarantees that `source..source + 64` is valid.
+    unsafe {
+        let first = vld1q_u8(source);
+        let second = vld1q_u8(source.add(16));
+        let third = vld1q_u8(source.add(32));
+        let fourth = vld1q_u8(source.add(48));
+        let bits = vld1q_u8([1_u8, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128].as_ptr());
+
+        let low = vld1q_u8(LOW_NIBBLE_CLASSES.as_ptr());
+        let high = vld1q_u8(HIGH_NIBBLE_CLASSES.as_ptr());
+        let (word_first, whitespace_first) = classify_bytes(first, low, high);
+        let (word_second, whitespace_second) = classify_bytes(second, low, high);
+        let (word_third, whitespace_third) = classify_bytes(third, low, high);
+        let (word_fourth, whitespace_fourth) = classify_bytes(fourth, low, high);
+
+        let word = mask64(bits, word_first, word_second, word_third, word_fourth);
+        let whitespace = mask64(
+            bits,
+            whitespace_first,
+            whitespace_second,
+            whitespace_third,
+            whitespace_fourth,
+        );
+        let source_or = vorrq_u8(vorrq_u8(first, second), vorrq_u8(third, fourth));
+        (word, whitespace, source_or)
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+unsafe fn classify_bytes(
+    bytes: uint8x16_t,
+    low: uint8x16_t,
+    high: uint8x16_t,
+) -> (uint8x16_t, uint8x16_t) {
+    // SAFETY: All NEON operations are valid for arbitrary byte vectors.
+    unsafe {
+        let low = vqtbl1q_u8(low, vandq_u8(bytes, vdupq_n_u8(0x0f)));
+        let high = vqtbl1q_u8(high, vshrq_n_u8::<4>(bytes));
+        let classes = vandq_u8(low, high);
+        let word = vtstq_u8(classes, vdupq_n_u8(0x9f));
+        let whitespace = vtstq_u8(classes, vdupq_n_u8(0x60));
+        (word, whitespace)
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+unsafe fn mask64(
+    bits: uint8x16_t,
+    first: uint8x16_t,
+    second: uint8x16_t,
+    third: uint8x16_t,
+    fourth: uint8x16_t,
+) -> u64 {
+    // SAFETY: All NEON operations are valid for arbitrary predicate vectors.
+    unsafe {
+        let first = vandq_u8(first, bits);
+        let second = vandq_u8(second, bits);
+        let third = vandq_u8(third, bits);
+        let fourth = vandq_u8(fourth, bits);
+        let first = vpaddq_u8(first, second);
+        let second = vpaddq_u8(third, fourth);
+        let result = vpaddq_u8(first, second);
+        vgetq_lane_u64::<0>(vreinterpretq_u64_u8(vpaddq_u8(result, result)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify;
+
+    fn assert_matches_scalar(source: &[u8]) {
+        let classified = classify(source);
+        let mut expected_starts = vec![0; source.len().div_ceil(64)];
+        let mut previous_word = false;
+        let mut previous_whitespace = false;
+
+        for (offset, byte) in source.iter().copied().enumerate() {
+            let word = byte.is_ascii_alphanumeric() || byte == b'_' || !byte.is_ascii();
+            let whitespace = matches!(byte, b' ' | b'\t' | b'\x0c');
+            let block = offset / 64;
+            let bit = 1 << (offset % 64);
+
+            if (!word && !whitespace)
+                || (word && !previous_word)
+                || (whitespace && !previous_whitespace)
+            {
+                expected_starts[block] |= bit;
+            }
+
+            previous_word = word;
+            previous_whitespace = whitespace;
+        }
+
+        assert_eq!(classified.starts, expected_starts);
+        assert_eq!(classified.ascii_source, source.is_ascii());
+    }
+
+    #[test]
+    fn every_boundary_bit() {
+        for bit in 0..64 {
+            let mut source = [b' '; 64];
+            source[bit] = b'a';
+            assert_matches_scalar(&source);
+
+            let mut source = [b'a'; 64];
+            source[bit] = b'+';
+            assert_matches_scalar(&source);
+        }
+    }
+
+    #[test]
+    fn runs_cross_chunk_boundary() {
+        for offset in [63, 64, 65] {
+            for byte in *b"a \t\x0c" {
+                let mut source = vec![b'+'; offset];
+                source.extend(std::iter::repeat_n(byte, 65));
+                source.push(b'+');
+                assert_matches_scalar(&source);
+            }
+        }
+
+        for length in [63, 64, 65] {
+            assert_matches_scalar(&vec![b'a'; length]);
+            assert_matches_scalar(&vec![b' '; length]);
+        }
+    }
+
+    #[test]
+    fn punctuation_and_newlines_start_tokens() {
+        assert_matches_scalar(b"a+-*/=()[]{},.:;@!<>\r\nb");
+    }
+
+    #[test]
+    fn non_ascii_is_part_of_a_word_run() {
+        let source = "before \u{03bb}\u{53d8}\u{91cf}_2 + after".as_bytes();
+        assert_matches_scalar(source);
+    }
+
+    #[test]
+    fn non_ascii_is_detected_at_chunk_boundaries() {
+        for offset in [0, 15, 16, 31, 32, 47, 48, 63, 64, 65, 127, 128, 129] {
+            let mut source = vec![b'a'; offset];
+            source.push(0x80);
+            source.extend(std::iter::repeat_n(b'a', 65));
+            assert_matches_scalar(&source);
+        }
+    }
+
+    #[test]
+    fn all_byte_values_match_scalar() {
+        let bytes: Vec<_> = (0..=u8::MAX).collect();
+        for offset in 0..64 {
+            let mut source = vec![b'+'; offset];
+            source.extend(&bytes);
+            assert_matches_scalar(&source);
+        }
+    }
+}

--- a/crates/ruff_python_parser/src/lexer/fast_token.rs
+++ b/crates/ruff_python_parser/src/lexer/fast_token.rs
@@ -1,0 +1,411 @@
+use ruff_python_ast::token::TokenKind;
+
+/// Classifies an already-delimited identifier as a keyword or name.
+#[inline]
+pub(super) fn keyword(text: &[u8]) -> TokenKind {
+    match text {
+        b"False" => TokenKind::False,
+        b"None" => TokenKind::None,
+        b"True" => TokenKind::True,
+        b"and" => TokenKind::And,
+        b"as" => TokenKind::As,
+        b"assert" => TokenKind::Assert,
+        b"async" => TokenKind::Async,
+        b"await" => TokenKind::Await,
+        b"break" => TokenKind::Break,
+        b"case" => TokenKind::Case,
+        b"class" => TokenKind::Class,
+        b"continue" => TokenKind::Continue,
+        b"def" => TokenKind::Def,
+        b"del" => TokenKind::Del,
+        b"elif" => TokenKind::Elif,
+        b"else" => TokenKind::Else,
+        b"except" => TokenKind::Except,
+        b"finally" => TokenKind::Finally,
+        b"for" => TokenKind::For,
+        b"from" => TokenKind::From,
+        b"global" => TokenKind::Global,
+        b"if" => TokenKind::If,
+        b"import" => TokenKind::Import,
+        b"in" => TokenKind::In,
+        b"is" => TokenKind::Is,
+        b"lambda" => TokenKind::Lambda,
+        b"lazy" => TokenKind::Lazy,
+        b"match" => TokenKind::Match,
+        b"nonlocal" => TokenKind::Nonlocal,
+        b"not" => TokenKind::Not,
+        b"or" => TokenKind::Or,
+        b"pass" => TokenKind::Pass,
+        b"raise" => TokenKind::Raise,
+        b"return" => TokenKind::Return,
+        b"try" => TokenKind::Try,
+        b"type" => TokenKind::Type,
+        b"while" => TokenKind::While,
+        b"with" => TokenKind::With,
+        b"yield" => TokenKind::Yield,
+        _ => TokenKind::Name,
+    }
+}
+
+/// Matches the longest Python operator or delimiter beginning at `start`.
+#[inline]
+pub(super) fn operator(source: &[u8], start: usize) -> Option<(TokenKind, usize)> {
+    let source = source.get(start..)?;
+    let (kind, len) = match source {
+        [b'.', b'.', b'.', ..] => (TokenKind::Ellipsis, 3),
+        [b'*', b'*', b'=', ..] => (TokenKind::DoubleStarEqual, 3),
+        [b'/', b'/', b'=', ..] => (TokenKind::DoubleSlashEqual, 3),
+        [b'<', b'<', b'=', ..] => (TokenKind::LeftShiftEqual, 3),
+        [b'>', b'>', b'=', ..] => (TokenKind::RightShiftEqual, 3),
+        [b'=', b'=', ..] => (TokenKind::EqEqual, 2),
+        [b'!', b'=', ..] => (TokenKind::NotEqual, 2),
+        [b'<', b'=', ..] => (TokenKind::LessEqual, 2),
+        [b'>', b'=', ..] => (TokenKind::GreaterEqual, 2),
+        [b'<', b'<', ..] => (TokenKind::LeftShift, 2),
+        [b'>', b'>', ..] => (TokenKind::RightShift, 2),
+        [b'*', b'*', ..] => (TokenKind::DoubleStar, 2),
+        [b'/', b'/', ..] => (TokenKind::DoubleSlash, 2),
+        [b'+', b'=', ..] => (TokenKind::PlusEqual, 2),
+        [b'-', b'=', ..] => (TokenKind::MinusEqual, 2),
+        [b'*', b'=', ..] => (TokenKind::StarEqual, 2),
+        [b'/', b'=', ..] => (TokenKind::SlashEqual, 2),
+        [b'%', b'=', ..] => (TokenKind::PercentEqual, 2),
+        [b'&', b'=', ..] => (TokenKind::AmperEqual, 2),
+        [b'|', b'=', ..] => (TokenKind::VbarEqual, 2),
+        [b'^', b'=', ..] => (TokenKind::CircumflexEqual, 2),
+        [b'@', b'=', ..] => (TokenKind::AtEqual, 2),
+        [b':', b'=', ..] => (TokenKind::ColonEqual, 2),
+        [b'-', b'>', ..] => (TokenKind::Rarrow, 2),
+        [b'?', ..] => (TokenKind::Question, 1),
+        [b'!', ..] => (TokenKind::Exclamation, 1),
+        [b'(', ..] => (TokenKind::Lpar, 1),
+        [b')', ..] => (TokenKind::Rpar, 1),
+        [b'[', ..] => (TokenKind::Lsqb, 1),
+        [b']', ..] => (TokenKind::Rsqb, 1),
+        [b'{', ..] => (TokenKind::Lbrace, 1),
+        [b'}', ..] => (TokenKind::Rbrace, 1),
+        [b':', ..] => (TokenKind::Colon, 1),
+        [b',', ..] => (TokenKind::Comma, 1),
+        [b';', ..] => (TokenKind::Semi, 1),
+        [b'+', ..] => (TokenKind::Plus, 1),
+        [b'-', ..] => (TokenKind::Minus, 1),
+        [b'*', ..] => (TokenKind::Star, 1),
+        [b'/', ..] => (TokenKind::Slash, 1),
+        [b'|', ..] => (TokenKind::Vbar, 1),
+        [b'&', ..] => (TokenKind::Amper, 1),
+        [b'<', ..] => (TokenKind::Less, 1),
+        [b'>', ..] => (TokenKind::Greater, 1),
+        [b'=', ..] => (TokenKind::Equal, 1),
+        [b'.', ..] => (TokenKind::Dot, 1),
+        [b'%', ..] => (TokenKind::Percent, 1),
+        [b'~', ..] => (TokenKind::Tilde, 1),
+        [b'^', ..] => (TokenKind::CircumFlex, 1),
+        [b'@', ..] => (TokenKind::At, 1),
+        _ => return None,
+    };
+
+    Some((kind, start + len))
+}
+
+/// Scans a Python numeric literal and returns its kind and end. Malformed or ambiguous literals
+/// return `None` so the streaming lexer can produce the canonical diagnostic.
+///
+/// ```python
+/// value = 0x_f + 1_000e-2j + .5
+/// ```
+#[inline]
+pub(super) fn number(source: &[u8], start: usize) -> Option<(TokenKind, usize)> {
+    let first = *source.get(start)?;
+    if first == b'.' && !source.get(start + 1).is_some_and(u8::is_ascii_digit) {
+        return None;
+    }
+    if first != b'.' && !first.is_ascii_digit() {
+        return None;
+    }
+
+    if first == b'0'
+        && let Some(&prefix) = source.get(start + 1)
+        && matches!(prefix, b'x' | b'X' | b'o' | b'O' | b'b' | b'B')
+    {
+        let radix = match prefix {
+            b'x' | b'X' => 16,
+            b'o' | b'O' => 8,
+            b'b' | b'B' => 2,
+            _ => return None,
+        };
+        let mut end = start + 2;
+        if source.get(end) == Some(&b'_') {
+            end += 1;
+            if !source.get(end).is_some_and(|&byte| is_digit(byte, radix)) {
+                return None;
+            }
+        }
+        let (end, has_digit, _) = digit_run(source, end, radix);
+        if !has_digit || is_number_continuation(source.get(end).copied()) {
+            return None;
+        }
+        return Some((TokenKind::Int, end));
+    }
+
+    let (mut end, _, has_nonzero_digit) = if first == b'.' {
+        (start, false, false)
+    } else {
+        digit_run(source, start, 10)
+    };
+    let mut is_float = first == b'.';
+
+    if source.get(end) == Some(&b'.') {
+        is_float = true;
+        end += 1;
+        if source.get(end) == Some(&b'_') {
+            return None;
+        }
+        (end, _, _) = digit_run(source, end, 10);
+    }
+
+    if matches!(source.get(end), Some(b'e' | b'E')) {
+        is_float = true;
+        end += 1;
+        if matches!(source.get(end), Some(b'+' | b'-')) {
+            end += 1;
+        }
+        if !source.get(end).is_some_and(u8::is_ascii_digit) {
+            return None;
+        }
+        let (exponent_end, has_digit, _) = digit_run(source, end, 10);
+        if !has_digit {
+            return None;
+        }
+        end = exponent_end;
+    }
+
+    let is_complex = matches!(source.get(end), Some(b'j' | b'J'));
+    if is_complex {
+        end += 1;
+    }
+    if is_number_continuation(source.get(end).copied()) {
+        return None;
+    }
+    if !is_float && !is_complex && first == b'0' && has_nonzero_digit {
+        return None;
+    }
+
+    let kind = if is_complex {
+        TokenKind::Complex
+    } else if is_float {
+        TokenKind::Float
+    } else {
+        TokenKind::Int
+    };
+    Some((kind, end))
+}
+
+#[inline]
+fn digit_run(source: &[u8], mut position: usize, radix: u8) -> (usize, bool, bool) {
+    let mut has_digit = false;
+    let mut has_nonzero_digit = false;
+    while let Some(&byte) = source.get(position) {
+        if is_digit(byte, radix) {
+            has_digit = true;
+            has_nonzero_digit |= byte != b'0';
+            position += 1;
+        } else if byte == b'_'
+            && source
+                .get(position + 1)
+                .is_some_and(|&next| is_digit(next, radix))
+        {
+            position += 1;
+        } else {
+            break;
+        }
+    }
+    (position, has_digit, has_nonzero_digit)
+}
+
+#[inline]
+const fn is_digit(byte: u8, radix: u8) -> bool {
+    match radix {
+        2 => matches!(byte, b'0'..=b'1'),
+        8 => matches!(byte, b'0'..=b'7'),
+        10 => byte.is_ascii_digit(),
+        16 => byte.is_ascii_hexdigit(),
+        _ => false,
+    }
+}
+
+#[inline]
+const fn is_number_continuation(byte: Option<u8>) -> bool {
+    matches!(
+        byte,
+        Some(b'_' | b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | 0x80..=0xff)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_python_ast::token::TokenKind;
+
+    use super::{keyword, number, operator};
+
+    #[test]
+    fn keywords() {
+        for (text, kind) in [
+            (b"False".as_slice(), TokenKind::False),
+            (b"None", TokenKind::None),
+            (b"True", TokenKind::True),
+            (b"and", TokenKind::And),
+            (b"as", TokenKind::As),
+            (b"assert", TokenKind::Assert),
+            (b"async", TokenKind::Async),
+            (b"await", TokenKind::Await),
+            (b"break", TokenKind::Break),
+            (b"case", TokenKind::Case),
+            (b"class", TokenKind::Class),
+            (b"continue", TokenKind::Continue),
+            (b"def", TokenKind::Def),
+            (b"del", TokenKind::Del),
+            (b"elif", TokenKind::Elif),
+            (b"else", TokenKind::Else),
+            (b"except", TokenKind::Except),
+            (b"finally", TokenKind::Finally),
+            (b"for", TokenKind::For),
+            (b"from", TokenKind::From),
+            (b"global", TokenKind::Global),
+            (b"if", TokenKind::If),
+            (b"import", TokenKind::Import),
+            (b"in", TokenKind::In),
+            (b"is", TokenKind::Is),
+            (b"lambda", TokenKind::Lambda),
+            (b"lazy", TokenKind::Lazy),
+            (b"match", TokenKind::Match),
+            (b"nonlocal", TokenKind::Nonlocal),
+            (b"not", TokenKind::Not),
+            (b"or", TokenKind::Or),
+            (b"pass", TokenKind::Pass),
+            (b"raise", TokenKind::Raise),
+            (b"return", TokenKind::Return),
+            (b"try", TokenKind::Try),
+            (b"type", TokenKind::Type),
+            (b"while", TokenKind::While),
+            (b"with", TokenKind::With),
+            (b"yield", TokenKind::Yield),
+        ] {
+            assert_eq!(keyword(text), kind, "keyword {text:?}");
+        }
+        for text in [b"false".as_slice(), b"TRUE", b"match_", b"identifier", b""] {
+            assert_eq!(keyword(text), TokenKind::Name, "name {text:?}");
+        }
+    }
+
+    #[test]
+    fn operators() {
+        for (text, kind) in [
+            ("...", TokenKind::Ellipsis),
+            ("**=", TokenKind::DoubleStarEqual),
+            ("//=", TokenKind::DoubleSlashEqual),
+            ("<<=", TokenKind::LeftShiftEqual),
+            (">>=", TokenKind::RightShiftEqual),
+            ("==", TokenKind::EqEqual),
+            ("!=", TokenKind::NotEqual),
+            ("<=", TokenKind::LessEqual),
+            (">=", TokenKind::GreaterEqual),
+            ("<<", TokenKind::LeftShift),
+            (">>", TokenKind::RightShift),
+            ("**", TokenKind::DoubleStar),
+            ("//", TokenKind::DoubleSlash),
+            ("+=", TokenKind::PlusEqual),
+            ("-=", TokenKind::MinusEqual),
+            ("*=", TokenKind::StarEqual),
+            ("/=", TokenKind::SlashEqual),
+            ("%=", TokenKind::PercentEqual),
+            ("&=", TokenKind::AmperEqual),
+            ("|=", TokenKind::VbarEqual),
+            ("^=", TokenKind::CircumflexEqual),
+            ("@=", TokenKind::AtEqual),
+            (":=", TokenKind::ColonEqual),
+            ("->", TokenKind::Rarrow),
+            ("?", TokenKind::Question),
+            ("!", TokenKind::Exclamation),
+            ("(", TokenKind::Lpar),
+            (")", TokenKind::Rpar),
+            ("[", TokenKind::Lsqb),
+            ("]", TokenKind::Rsqb),
+            ("{", TokenKind::Lbrace),
+            ("}", TokenKind::Rbrace),
+            (":", TokenKind::Colon),
+            (",", TokenKind::Comma),
+            (";", TokenKind::Semi),
+            ("+", TokenKind::Plus),
+            ("-", TokenKind::Minus),
+            ("*", TokenKind::Star),
+            ("/", TokenKind::Slash),
+            ("|", TokenKind::Vbar),
+            ("&", TokenKind::Amper),
+            ("<", TokenKind::Less),
+            (">", TokenKind::Greater),
+            ("=", TokenKind::Equal),
+            (".", TokenKind::Dot),
+            ("%", TokenKind::Percent),
+            ("~", TokenKind::Tilde),
+            ("^", TokenKind::CircumFlex),
+            ("@", TokenKind::At),
+        ] {
+            let source = format!("x{text}y");
+            assert_eq!(
+                operator(source.as_bytes(), 1),
+                Some((kind, 1 + text.len())),
+                "operator {text:?}"
+            );
+        }
+        assert_eq!(operator(b"..", 0), Some((TokenKind::Dot, 1)));
+        assert_eq!(operator(b"***", 0), Some((TokenKind::DoubleStar, 2)));
+        assert_eq!(operator(b"///", 0), Some((TokenKind::DoubleSlash, 2)));
+        assert_eq!(operator(b"x", 0), None);
+        assert_eq!(operator(b"", 0), None);
+    }
+
+    #[test]
+    fn valid_numbers() {
+        for (text, kind) in [
+            ("0", TokenKind::Int),
+            ("00_0", TokenKind::Int),
+            ("1_234", TokenKind::Int),
+            ("0b1_0", TokenKind::Int),
+            ("0B_1", TokenKind::Int),
+            ("0o7_0", TokenKind::Int),
+            ("0O_7", TokenKind::Int),
+            ("0xF_f", TokenKind::Int),
+            ("0X_a", TokenKind::Int),
+            ("1.", TokenKind::Float),
+            (".1", TokenKind::Float),
+            ("1_2.3_4", TokenKind::Float),
+            ("00_1.0", TokenKind::Float),
+            ("1e2", TokenKind::Float),
+            ("1E+2", TokenKind::Float),
+            ("1_2e-3_4", TokenKind::Float),
+            ("1j", TokenKind::Complex),
+            ("01J", TokenKind::Complex),
+            (".1j", TokenKind::Complex),
+            ("1.e2J", TokenKind::Complex),
+        ] {
+            let source = format!("x{text}+");
+            assert_eq!(
+                number(source.as_bytes(), 1),
+                Some((kind, 1 + text.len())),
+                "number {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_or_ambiguous_numbers_fall_back() {
+        for text in [
+            "", ".", ".x", "0x", "0x_", "0x__1", "0b2", "0o8", "1__2", "1_", "1._2", "1e", "1e+",
+            "1e_2", "01", "00_1", "123abc", "1π", "0x1g", "1j2", "1j_",
+        ] {
+            assert_eq!(number(text.as_bytes(), 0), None, "number {text:?}");
+        }
+        assert_eq!(number(b"x1", 0), None);
+        assert_eq!(number(b"x1", 2), None);
+    }
+}

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -133,6 +133,27 @@ impl<'src> Parser<'src> {
         options: ParseOptions,
     ) -> Self {
         let tokens = TokenSource::from_source(source, options.mode, start_offset);
+        Self::new_with_token_source(source, start_offset, options, tokens)
+    }
+
+    /// Creates a parser that bypasses chunked lexing, for a single fallback reparse.
+    #[cfg(target_arch = "aarch64")]
+    fn new_starts_at_with_legacy_lexer(
+        source: &'src str,
+        start_offset: TextSize,
+        options: ParseOptions,
+    ) -> Self {
+        let tokens = TokenSource::from_streaming_source(source, options.mode, start_offset);
+        Self::new_with_token_source(source, start_offset, options, tokens)
+    }
+
+    /// Initializes parser state around an already-selected token source.
+    fn new_with_token_source(
+        source: &'src str,
+        start_offset: TextSize,
+        options: ParseOptions,
+        tokens: TokenSource<'src>,
+    ) -> Self {
         let depth_remaining = options.max_recursion_depth;
         let max_nesting_depth = u32::from(options.max_recursion_depth.saturating_sub(2));
 
@@ -197,6 +218,16 @@ impl<'src> Parser<'src> {
             }
             Mode::Module | Mode::Ipython => Mod::Module(self.parse_module()),
         };
+
+        #[cfg(target_arch = "aarch64")]
+        if self.tokens.should_reparse_with_legacy_lexer() {
+            return Parser::new_starts_at_with_legacy_lexer(
+                self.source,
+                self.start_offset,
+                self.options,
+            )
+            .parse();
+        }
 
         self.finish(syntax)
     }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -2,12 +2,36 @@ use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, St
 
 use crate::{Mode, ParseErrorType, ParseOptions, parse, parse_expression, parse_module};
 
+#[cfg(target_arch = "aarch64")]
+use super::Parser;
+
 #[test]
 fn test_modes() {
     let source = "a[0][1][2][3][4]";
 
     assert!(parse(source, ParseOptions::from(Mode::Expression)).is_ok());
     assert!(parse(source, ParseOptions::from(Mode::Module)).is_ok());
+}
+
+#[cfg(target_arch = "aarch64")]
+#[test]
+fn chunked_lexer_reparses_after_late_error() {
+    let prefix = "value = 1\n".repeat(2_000);
+    let options = ParseOptions::from(Mode::Module);
+
+    for suffix in [
+        "value = 01\n",
+        "value = 'unterminated\n",
+        "(value\n",
+        "value = 1\\\n",
+        "values = [\n    first,\n    second\nif condition:\n    pass\n",
+    ] {
+        let source = format!("{prefix}{suffix}");
+        let streaming =
+            Parser::new_starts_at_with_legacy_lexer(&source, 0.into(), options.clone()).parse();
+        let chunked = crate::parse_unchecked(&source, options.clone());
+        assert_eq!(streaming, chunked, "{suffix:?}");
+    }
 }
 
 #[test]

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -3,6 +3,8 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::Mode;
 use crate::error::LexicalError;
+#[cfg(target_arch = "aarch64")]
+use crate::lexer::chunked::ChunkedLexer;
 use crate::lexer::{Lexer, LexerCheckpoint};
 use crate::string::InterpolatedStringKind;
 
@@ -10,7 +12,16 @@ use crate::string::InterpolatedStringKind;
 #[derive(Debug)]
 pub(crate) struct TokenSource<'src> {
     /// The underlying source for the tokens.
-    lexer: Lexer<'src>,
+    lexer: LexerSource<'src>,
+
+    /// The current non-trivia token. Keeping this separate from the buffered stream avoids an
+    /// enum match and an indexed load for every parser predicate.
+    #[cfg(target_arch = "aarch64")]
+    current: Token,
+
+    /// Whether error recovery requested a logical-token re-lex that requires the streaming lexer.
+    #[cfg(target_arch = "aarch64")]
+    needs_legacy_reparse: bool,
 
     /// A vector containing all the tokens emitted by the lexer. This is returned when the parser
     /// is finished consuming all the tokens. Note that unlike the emitted tokens, this vector
@@ -18,19 +29,67 @@ pub(crate) struct TokenSource<'src> {
     tokens: Vec<Token>,
 }
 
+#[derive(Debug)]
+enum LexerSource<'src> {
+    Streaming(Lexer<'src>),
+    #[cfg(target_arch = "aarch64")]
+    Chunked {
+        lexer: ChunkedLexer<'src>,
+        position: usize,
+        nesting: u32,
+    },
+}
+
 impl<'src> TokenSource<'src> {
-    /// Create a new token source for the given lexer.
-    pub(crate) fn new(lexer: Lexer<'src>, source: &str, start_offset: TextSize) -> Self {
-        TokenSource {
-            lexer,
-            tokens: allocate_tokens_vec(&source[start_offset.to_usize()..]),
+    /// Creates a token source, using chunked lexing for complete modules when the first batch is
+    /// supported and the streaming lexer otherwise.
+    pub(crate) fn from_source(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
+        #[cfg(target_arch = "aarch64")]
+        if mode == Mode::Module
+            && start_offset == TextSize::new(0)
+            && let Some(mut lexer) = ChunkedLexer::new(source)
+            && lexer.fill().is_some()
+        {
+            let mut source = TokenSource {
+                lexer: LexerSource::Chunked {
+                    lexer,
+                    position: usize::MAX,
+                    nesting: 0,
+                },
+                current: Token::new(
+                    TokenKind::EndOfFile,
+                    TextRange::empty(start_offset),
+                    TokenFlags::empty(),
+                ),
+                needs_legacy_reparse: false,
+                tokens: Vec::new(),
+            };
+            source.do_bump();
+            return source;
         }
+
+        Self::from_streaming_source(source, mode, start_offset)
     }
 
-    /// Create a new token source from the given source code which starts at the given offset.
-    pub(crate) fn from_source(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
-        let lexer = Lexer::new(source, mode, start_offset);
-        let mut source = TokenSource::new(lexer, source, start_offset);
+    /// Creates a token source that always uses the streaming lexer, including when reparsing a
+    /// module after a late chunked-lexer failure.
+    pub(crate) fn from_streaming_source(
+        source: &'src str,
+        mode: Mode,
+        start_offset: TextSize,
+    ) -> Self {
+        let mut source = TokenSource {
+            lexer: LexerSource::Streaming(Lexer::new(source, mode, start_offset)),
+            #[cfg(target_arch = "aarch64")]
+            current: Token::new(
+                TokenKind::EndOfFile,
+                TextRange::empty(start_offset),
+                TokenFlags::empty(),
+            ),
+            #[cfg(target_arch = "aarch64")]
+            needs_legacy_reparse: false,
+            tokens: allocate_tokens_vec(&source[start_offset.to_usize()..]),
+        };
 
         // Initialize the token source so that the current token is set correctly.
         source.do_bump();
@@ -38,31 +97,66 @@ impl<'src> TokenSource<'src> {
     }
 
     /// Returns the kind of the current token.
-    pub(crate) const fn current_kind(&self) -> TokenKind {
-        self.lexer.current_kind()
+    #[inline]
+    pub(crate) fn current_kind(&self) -> TokenKind {
+        #[cfg(target_arch = "aarch64")]
+        return self.current.kind();
+
+        #[cfg(not(target_arch = "aarch64"))]
+        match &self.lexer {
+            LexerSource::Streaming(lexer) => lexer.current_kind(),
+        }
     }
 
     /// Returns the range of the current token.
-    pub(crate) const fn current_range(&self) -> TextRange {
-        self.lexer.current_range()
+    #[inline]
+    pub(crate) fn current_range(&self) -> TextRange {
+        #[cfg(target_arch = "aarch64")]
+        return self.current.range();
+
+        #[cfg(not(target_arch = "aarch64"))]
+        match &self.lexer {
+            LexerSource::Streaming(lexer) => lexer.current_range(),
+        }
     }
 
     /// Returns the current parenthesis, bracket, and brace nesting level.
     #[inline]
-    pub(crate) const fn nesting(&self) -> u32 {
-        self.lexer.nesting()
+    pub(crate) fn nesting(&self) -> u32 {
+        match &self.lexer {
+            LexerSource::Streaming(lexer) => lexer.nesting(),
+            #[cfg(target_arch = "aarch64")]
+            LexerSource::Chunked { nesting, .. } => *nesting,
+        }
     }
 
     /// Returns the flags for the current token.
-    pub(crate) const fn current_flags(&self) -> TokenFlags {
-        self.lexer.current_flags()
+    #[inline]
+    pub(crate) fn current_flags(&self) -> TokenFlags {
+        #[cfg(target_arch = "aarch64")]
+        return self.current.flags();
+
+        #[cfg(not(target_arch = "aarch64"))]
+        match &self.lexer {
+            LexerSource::Streaming(lexer) => lexer.current_flags(),
+        }
     }
 
     /// Calls the underlying [`re_lex_logical_token`] method on the lexer with the new lexer
     /// position and updates the token vector accordingly.
     ///
     /// [`re_lex_logical_token`]: Lexer::re_lex_logical_token
+    #[cfg_attr(
+        not(target_arch = "aarch64"),
+        expect(irrefutable_let_patterns, reason = "the chunked variant is SIMD-only")
+    )]
     pub(crate) fn re_lex_logical_token(&mut self) {
+        #[cfg(target_arch = "aarch64")]
+        if matches!(self.lexer, LexerSource::Chunked { .. }) {
+            self.needs_legacy_reparse = true;
+            return;
+        }
+
         let mut non_logical_newline = None;
 
         #[cfg(debug_assertions)]
@@ -84,10 +178,10 @@ impl<'src> TokenSource<'src> {
             }
         }
 
-        if !self
-            .lexer
-            .re_lex_logical_token(non_logical_newline.map(|(_, start)| start))
-        {
+        let LexerSource::Streaming(lexer) = &mut self.lexer else {
+            return;
+        };
+        if !lexer.re_lex_logical_token(non_logical_newline.map(|(_, start)| start)) {
             return;
         }
 
@@ -99,6 +193,9 @@ impl<'src> TokenSource<'src> {
 
         // Trim the already bumped logical line token (and comments coming after it) as it might now have become a logical line token
         self.tokens.truncate(non_logical_line_index);
+
+        #[cfg(target_arch = "aarch64")]
+        self.refresh_current();
 
         #[cfg(debug_assertions)]
         {
@@ -119,16 +216,35 @@ impl<'src> TokenSource<'src> {
         }
     }
 
+    /// Re-lexes a string token in an interpolation element for the streaming lexer. Chunked
+    /// f/t-strings are emitted as complete token sequences and need no adjustment.
     pub(crate) fn re_lex_string_token_in_interpolation_element(
         &mut self,
         kind: InterpolatedStringKind,
     ) {
-        self.lexer
-            .re_lex_string_token_in_interpolation_element(kind);
+        match &mut self.lexer {
+            LexerSource::Streaming(lexer) => {
+                lexer.re_lex_string_token_in_interpolation_element(kind);
+            }
+            #[cfg(target_arch = "aarch64")]
+            LexerSource::Chunked { .. } => return,
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        self.refresh_current();
     }
 
+    /// Re-lexes a raw string in a format spec for the streaming lexer; this is already resolved
+    /// when the chunked lexer appends an interpolated string.
     pub(crate) fn re_lex_raw_string_in_format_spec(&mut self) {
-        self.lexer.re_lex_raw_string_in_format_spec();
+        match &mut self.lexer {
+            LexerSource::Streaming(lexer) => lexer.re_lex_raw_string_in_format_spec(),
+            #[cfg(target_arch = "aarch64")]
+            LexerSource::Chunked { .. } => return,
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        self.refresh_current();
     }
 
     /// Returns the next non-trivia token without consuming it.
@@ -136,11 +252,20 @@ impl<'src> TokenSource<'src> {
     /// Use [`peek2`] to get the next two tokens.
     ///
     /// [`peek2`]: TokenSource::peek2
+    #[inline]
     pub(crate) fn peek(&mut self) -> TokenKind {
-        let checkpoint = self.lexer.checkpoint();
-        let next = self.next_non_trivia_token();
-        self.lexer.rewind(checkpoint);
-        next
+        match &mut self.lexer {
+            LexerSource::Streaming(lexer) => {
+                let checkpoint = lexer.checkpoint();
+                let next = next_non_trivia_token(lexer);
+                lexer.rewind(checkpoint);
+                next
+            }
+            #[cfg(target_arch = "aarch64")]
+            LexerSource::Chunked {
+                lexer, position, ..
+            } => next_buffered_token(lexer, *position + 1, &mut self.needs_legacy_reparse).0,
+        }
     }
 
     /// Returns the next two non-trivia tokens without consuming it.
@@ -148,86 +273,189 @@ impl<'src> TokenSource<'src> {
     /// Use [`peek`] to only get the next token.
     ///
     /// [`peek`]: TokenSource::peek
+    #[inline]
     pub(crate) fn peek2(&mut self) -> (TokenKind, TokenKind) {
-        let checkpoint = self.lexer.checkpoint();
-        let first = self.next_non_trivia_token();
-        let second = self.next_non_trivia_token();
-        self.lexer.rewind(checkpoint);
-        (first, second)
+        match &mut self.lexer {
+            LexerSource::Streaming(lexer) => {
+                let checkpoint = lexer.checkpoint();
+                let first = next_non_trivia_token(lexer);
+                let second = next_non_trivia_token(lexer);
+                lexer.rewind(checkpoint);
+                (first, second)
+            }
+            #[cfg(target_arch = "aarch64")]
+            LexerSource::Chunked {
+                lexer, position, ..
+            } => {
+                let (first, position) =
+                    next_buffered_token(lexer, *position + 1, &mut self.needs_legacy_reparse);
+                let (second, _) =
+                    next_buffered_token(lexer, position + 1, &mut self.needs_legacy_reparse);
+                (first, second)
+            }
+        }
     }
 
     /// Bumps the token source to the next non-trivia token.
     ///
     /// It pushes the given kind to the token vector with the current token range.
+    #[inline]
     pub(crate) fn bump(&mut self, kind: TokenKind) {
-        self.tokens
-            .push(Token::new(kind, self.current_range(), self.current_flags()));
+        match &mut self.lexer {
+            LexerSource::Streaming(lexer) => {
+                self.tokens.push(Token::new(
+                    kind,
+                    lexer.current_range(),
+                    lexer.current_flags(),
+                ));
+            }
+            #[cfg(target_arch = "aarch64")]
+            LexerSource::Chunked {
+                lexer,
+                position,
+                nesting,
+            } => {
+                let current_position = *position;
+                let token = self.current;
+                if token.kind() != kind {
+                    lexer.tokens.rewrites.push((current_position, token));
+                    lexer.tokens.tokens[current_position] =
+                        Token::new(kind, token.range(), token.flags());
+                }
+                self.current =
+                    bump_buffered_token(lexer, position, nesting, &mut self.needs_legacy_reparse);
+                return;
+            }
+        }
         self.do_bump();
     }
 
     /// Bumps the token source to the next non-trivia token without adding the current token to the
     /// token vector. It does add the trivia tokens to the token vector.
+    #[inline]
     fn do_bump(&mut self) {
-        loop {
-            let kind = self.lexer.next_token();
-            if kind.is_trivia() {
-                self.tokens
-                    .push(Token::new(kind, self.current_range(), self.current_flags()));
-                continue;
-            }
-            break;
-        }
-    }
+        match &mut self.lexer {
+            LexerSource::Streaming(lexer) => {
+                loop {
+                    let kind = lexer.next_token();
+                    if kind.is_trivia() {
+                        self.tokens.push(Token::new(
+                            kind,
+                            lexer.current_range(),
+                            lexer.current_flags(),
+                        ));
+                        continue;
+                    }
+                    break;
+                }
 
-    /// Returns the next non-trivia token without adding it to the token vector.
-    fn next_non_trivia_token(&mut self) -> TokenKind {
-        loop {
-            let kind = self.lexer.next_token();
-            if kind.is_trivia() {
-                continue;
+                #[cfg(target_arch = "aarch64")]
+                {
+                    self.current = Token::new(
+                        lexer.current_kind(),
+                        lexer.current_range(),
+                        lexer.current_flags(),
+                    );
+                }
             }
-            break kind;
+            #[cfg(target_arch = "aarch64")]
+            LexerSource::Chunked {
+                lexer,
+                position,
+                nesting,
+            } => {
+                self.current =
+                    bump_buffered_token(lexer, position, nesting, &mut self.needs_legacy_reparse);
+            }
         }
     }
 
     /// Creates a checkpoint to which the token source can later return to using [`Self::rewind`].
     pub(crate) fn checkpoint(&self) -> TokenSourceCheckpoint {
         TokenSourceCheckpoint {
-            lexer_checkpoint: self.lexer.checkpoint(),
+            lexer_checkpoint: match &self.lexer {
+                LexerSource::Streaming(lexer) => {
+                    LexerSourceCheckpoint::Streaming(lexer.checkpoint())
+                }
+                #[cfg(target_arch = "aarch64")]
+                LexerSource::Chunked {
+                    lexer,
+                    position,
+                    nesting,
+                    ..
+                } => LexerSourceCheckpoint::Chunked {
+                    position: *position,
+                    nesting: *nesting,
+                    rewrites_position: lexer.tokens.rewrites.len(),
+                },
+            },
             tokens_position: self.tokens.len(),
         }
     }
 
     /// Restore the token source to the given checkpoint.
+    #[cfg_attr(
+        not(target_arch = "aarch64"),
+        expect(irrefutable_let_patterns, reason = "the chunked variant is SIMD-only")
+    )]
     pub(crate) fn rewind(&mut self, checkpoint: TokenSourceCheckpoint) {
         let TokenSourceCheckpoint {
             lexer_checkpoint,
             tokens_position,
         } = checkpoint;
 
-        self.lexer.rewind(lexer_checkpoint);
+        match lexer_checkpoint {
+            LexerSourceCheckpoint::Streaming(checkpoint) => {
+                if let LexerSource::Streaming(lexer) = &mut self.lexer {
+                    lexer.rewind(checkpoint);
+                }
+            }
+            #[cfg(target_arch = "aarch64")]
+            LexerSourceCheckpoint::Chunked {
+                position,
+                nesting,
+                rewrites_position,
+            } => {
+                if let LexerSource::Chunked {
+                    lexer,
+                    position: current_position,
+                    nesting: current_nesting,
+                    ..
+                } = &mut self.lexer
+                {
+                    rewind_rewrites(lexer, rewrites_position);
+                    *current_position = position;
+                    *current_nesting = nesting;
+                }
+            }
+        }
         self.tokens.truncate(tokens_position);
+
+        #[cfg(target_arch = "aarch64")]
+        self.refresh_current();
     }
 
     /// Returns a slice of [`Token`] that are within the given `range`.
     pub(crate) fn in_range(&self, range: TextRange) -> &[Token] {
-        let start = self
-            .tokens
-            .iter()
-            .rposition(|tok| tok.start() == range.start());
-        let end = self.tokens.iter().rposition(|tok| tok.end() == range.end());
+        let tokens = match &self.lexer {
+            LexerSource::Streaming(_) => &self.tokens,
+            #[cfg(target_arch = "aarch64")]
+            LexerSource::Chunked {
+                lexer, position, ..
+            } => &lexer.tokens.tokens[..=*position],
+        };
+        let start = tokens.iter().rposition(|tok| tok.start() == range.start());
+        let end = tokens.iter().rposition(|tok| tok.end() == range.end());
 
         let (Some(start), Some(end)) = (start, end) else {
-            return &self.tokens;
+            return tokens;
         };
 
-        &self.tokens[start..=end]
+        &tokens[start..=end]
     }
 
-    /// Consumes the token source, returning the collected tokens, comment ranges, and any errors
-    /// encountered during lexing. The token collection includes both the trivia and non-trivia
-    /// tokens.
-    pub(crate) fn finish(mut self) -> (Vec<Token>, Vec<LexicalError>) {
+    /// Consumes the token source, returning all trivia and non-trivia tokens plus lexical errors.
+    pub(crate) fn finish(self) -> (Vec<Token>, Vec<LexicalError>) {
         assert_eq!(
             self.current_kind(),
             TokenKind::EndOfFile,
@@ -236,19 +464,166 @@ impl<'src> TokenSource<'src> {
 
         // The `EndOfFile` token shouldn't be included in the token stream, it's mainly to signal
         // the parser to stop. This isn't in `do_bump` because it only needs to be done once.
-        if let Some(last) = self.tokens.pop() {
+        let (mut tokens, errors) = match self.lexer {
+            LexerSource::Streaming(lexer) => (self.tokens, lexer.finish()),
+            #[cfg(target_arch = "aarch64")]
+            LexerSource::Chunked { lexer, .. } => (lexer.tokens.tokens, Vec::new()),
+        };
+
+        if let Some(last) = tokens.pop() {
             assert_eq!(last.kind(), TokenKind::EndOfFile);
         }
+        tokens.shrink_to_fit();
 
-        self.tokens.shrink_to_fit();
+        (tokens, errors)
+    }
 
-        (self.tokens, self.lexer.finish())
+    /// Returns whether chunked lexing or parser-directed re-lexing requires a streaming reparse.
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn should_reparse_with_legacy_lexer(&self) -> bool {
+        self.needs_legacy_reparse
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[inline]
+    fn refresh_current(&mut self) {
+        self.current = match &self.lexer {
+            LexerSource::Streaming(lexer) => Token::new(
+                lexer.current_kind(),
+                lexer.current_range(),
+                lexer.current_flags(),
+            ),
+            LexerSource::Chunked {
+                lexer, position, ..
+            } => lexer.tokens.tokens[*position],
+        };
     }
 }
 
 pub(crate) struct TokenSourceCheckpoint {
-    lexer_checkpoint: LexerCheckpoint,
+    lexer_checkpoint: LexerSourceCheckpoint,
     tokens_position: usize,
+}
+
+enum LexerSourceCheckpoint {
+    Streaming(LexerCheckpoint),
+    #[cfg(target_arch = "aarch64")]
+    Chunked {
+        position: usize,
+        nesting: u32,
+        rewrites_position: usize,
+    },
+}
+
+fn next_non_trivia_token(lexer: &mut Lexer) -> TokenKind {
+    loop {
+        let kind = lexer.next_token();
+        if !kind.is_trivia() {
+            break kind;
+        }
+    }
+}
+
+/// Finds the next non-trivia buffered token, refilling on demand without advancing the parser.
+#[cfg(target_arch = "aarch64")]
+fn next_buffered_token(
+    lexer: &mut ChunkedLexer,
+    mut position: usize,
+    needs_legacy_reparse: &mut bool,
+) -> (TokenKind, usize) {
+    loop {
+        position = ensure_buffered_token(lexer, position, needs_legacy_reparse);
+        let token = lexer.tokens.tokens[position];
+        if !token.kind().is_trivia() {
+            return (token.kind(), position);
+        }
+        position += 1;
+    }
+}
+
+/// Advances to the next non-trivia buffered token and maintains delimiter nesting for the parser.
+#[cfg(target_arch = "aarch64")]
+#[inline]
+fn bump_buffered_token(
+    lexer: &mut ChunkedLexer,
+    position: &mut usize,
+    nesting: &mut u32,
+    needs_legacy_reparse: &mut bool,
+) -> Token {
+    let mut next = position.wrapping_add(1);
+    loop {
+        next = ensure_buffered_token(lexer, next, needs_legacy_reparse);
+        let token = lexer.tokens.tokens[next];
+        match token.kind() {
+            TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace => *nesting += 1,
+            TokenKind::Rpar | TokenKind::Rsqb | TokenKind::Rbrace => {
+                *nesting = nesting.saturating_sub(1);
+            }
+            _ => {}
+        }
+        if !token.kind().is_trivia() {
+            *position = next;
+            return token;
+        }
+        next += 1;
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+fn ensure_buffered_token(
+    lexer: &mut ChunkedLexer,
+    position: usize,
+    needs_legacy_reparse: &mut bool,
+) -> usize {
+    if position < lexer.tokens.tokens.len() {
+        return position;
+    }
+
+    refill_buffered_tokens(lexer, position, needs_legacy_reparse);
+    position.min(lexer.tokens.tokens.len() - 1)
+}
+
+/// Refills through `position`. A failed batch appends a synthetic EOF and requests one streaming
+/// reparse, preventing repeated failed refills during error recovery.
+#[cfg(target_arch = "aarch64")]
+#[cold]
+fn refill_buffered_tokens(
+    lexer: &mut ChunkedLexer,
+    position: usize,
+    needs_legacy_reparse: &mut bool,
+) {
+    while position >= lexer.tokens.tokens.len()
+        && !lexer.is_finished()
+        && lexer
+            .tokens
+            .tokens
+            .last()
+            .is_none_or(|token| token.kind() != TokenKind::EndOfFile)
+    {
+        if lexer.fill().is_none() {
+            *needs_legacy_reparse = true;
+            let end = lexer
+                .tokens
+                .tokens
+                .last()
+                .map_or(TextSize::default(), Token::end);
+            lexer.tokens.tokens.push(Token::new(
+                TokenKind::EndOfFile,
+                TextRange::empty(end),
+                TokenFlags::empty(),
+            ));
+            break;
+        }
+    }
+}
+
+/// Restores contextual token-kind rewrites made after a parser checkpoint.
+#[cfg(target_arch = "aarch64")]
+fn rewind_rewrites(lexer: &mut ChunkedLexer, position: usize) {
+    for (index, token) in lexer.tokens.rewrites.drain(position..).rev() {
+        lexer.tokens.tokens[index] = token;
+    }
 }
 
 /// Allocates a token buffer with a capacity intended to skip early grows.
@@ -267,4 +642,18 @@ fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
     // Stay on a power-of-two bucket so that later geometric growth does not preserve an
     // arbitrary capacity offset.
     Vec::with_capacity(1 << capacity_hint.ilog2())
+}
+
+#[cfg(all(test, target_arch = "aarch64"))]
+mod tests {
+    use ruff_text_size::TextSize;
+
+    use crate::Mode;
+    use crate::token_source::{LexerSource, TokenSource};
+
+    #[test]
+    fn module_uses_chunked_lexer() {
+        let source = TokenSource::from_source("value = 1\n", Mode::Module, TextSize::new(0));
+        assert!(matches!(source.lexer, LexerSource::Chunked { .. }));
+    }
 }


### PR DESCRIPTION
## Summary

Add a chunked lexer for ARM module parsing. The lexer uses NEON to classify fixed-size source batches, carves those structural starts into complete Python tokens, and lets the parser consume the resulting buffered stream on demand.

The chunked lexer is enabled by default for module parsing on ARM. Unsupported or malformed input falls back to the existing streaming lexer, including a single full reparse when parser-directed re-lexing is required. Differential tests compare the resulting tokens and parser output with the streaming implementation, and the existing lexer benchmarks now exercise the chunked path.
