### PR TITLE
Add x86 support for the chunked lexer

### DIFF
--- a/crates/ruff_benchmark/benches/lexer.rs
+++ b/crates/ruff_benchmark/benches/lexer.rs
@@ -6,9 +6,9 @@ use criterion::{
 use ruff_benchmark::{
     LARGE_DATASET, NUMPY_CTYPESLIB, NUMPY_GLOBALS, PYDANTIC_TYPES, TestCase, UNICODE_PYPINYIN,
 };
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
 use ruff_python_ast::token::TokenKind;
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
 use ruff_python_parser::Mode;
 use ruff_python_parser::lexer;
 
@@ -57,12 +57,12 @@ fn benchmark_lexer(criterion: &mut Criterion<WallTime>) {
     group.finish();
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 fn lex_module(source: &str) -> usize {
     lexer::lex_chunked(source).expect("benchmark input should be supported by the chunked lexer")
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
 fn lex_module(source: &str) {
     let mut lexer = lexer::lex(source, Mode::Module);
     loop {

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -25,12 +25,12 @@ use crate::lexer::interpolated_string::{
 };
 use crate::string::InterpolatedStringKind;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) mod chunked;
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 mod classify;
 mod cursor;
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 mod fast_token;
 mod indentation;
 mod interpolated_string;
@@ -1630,9 +1630,9 @@ pub fn lex(source: &str, mode: Mode) -> Lexer<'_> {
     Lexer::new(source, mode, TextSize::default())
 }
 
-/// Lex a Python module with the experimental ARM chunked lexer, returning the number of tokens
+/// Lex a Python module with the experimental SIMD chunked lexer, returning the number of tokens
 /// (including EOF) on success. `None` indicates that the source requires the streaming lexer.
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 pub fn lex_chunked(source: &str) -> Option<usize> {
     chunked::lex(source).map(|tokens| tokens.tokens.len())
 }

--- a/crates/ruff_python_parser/src/lexer/chunked.rs
+++ b/crates/ruff_python_parser/src/lexer/chunked.rs
@@ -80,7 +80,7 @@ impl<'src> ChunkedLexer<'src> {
         self.finished
     }
 
-    /// Classify a batch with NEON, then carve and coalesce it into complete tokens. A final word
+    /// Classify a batch with SIMD, then carve and coalesce it into complete tokens. A final word
     /// or whitespace run is extended so that the next batch always starts at a token boundary.
     pub(crate) fn fill(&mut self) -> Option<()> {
         if self.finished {

--- a/crates/ruff_python_parser/src/lexer/classify.rs
+++ b/crates/ruff_python_parser/src/lexer/classify.rs
@@ -5,6 +5,16 @@ use std::arch::aarch64::{
     uint8x16_t, vandq_u8, vdupq_n_u8, vgetq_lane_u64, vld1q_u8, vmaxvq_u8, vorrq_u8, vpaddq_u8,
     vqtbl1q_u8, vreinterpretq_u64_u8, vshrq_n_u8, vtstq_u8,
 };
+#[cfg(target_arch = "x86")]
+use std::arch::x86::{
+    __m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_min_epu8, _mm_movemask_epi8, _mm_or_si128,
+    _mm_set1_epi8, _mm_setzero_si128, _mm_sub_epi8,
+};
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::{
+    __m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_min_epu8, _mm_movemask_epi8, _mm_or_si128,
+    _mm_set1_epi8, _mm_setzero_si128, _mm_sub_epi8,
+};
 
 /// Structural starts for one source batch. Each set bit begins a word run, whitespace run, or
 /// single structural byte; `ascii_source` lets the carver avoid per-identifier Unicode checks.
@@ -42,13 +52,24 @@ pub(super) fn classify_into(source: &[u8], classified: &mut Classified) {
     let mut previous_whitespace = 0;
 
     let mut chunks = source.chunks_exact(64);
+    #[cfg(target_arch = "aarch64")]
     let mut source_or = unsafe { vdupq_n_u8(0) };
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    let mut source_or = unsafe { _mm_setzero_si128() };
 
     for chunk in &mut chunks {
         // SAFETY: `chunks_exact(64)` guarantees that all four 16-byte loads are in bounds.
         let (word, whitespace, chunk_or) = unsafe { classify_chunk(chunk.as_ptr()) };
-        // SAFETY: All NEON operations are valid for arbitrary byte vectors.
-        source_or = unsafe { vorrq_u8(source_or, chunk_or) };
+        #[cfg(target_arch = "aarch64")]
+        {
+            // SAFETY: All NEON operations are valid for arbitrary byte vectors.
+            source_or = unsafe { vorrq_u8(source_or, chunk_or) };
+        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            // SAFETY: All SSE2 operations are valid for arbitrary byte vectors.
+            source_or = unsafe { _mm_or_si128(source_or, chunk_or) };
+        }
         push_block(
             classified,
             word,
@@ -59,8 +80,16 @@ pub(super) fn classify_into(source: &[u8], classified: &mut Classified) {
         );
     }
 
-    // SAFETY: All NEON operations are valid for arbitrary byte vectors.
-    classified.ascii_source = unsafe { vmaxvq_u8(source_or) < 0x80 };
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: All NEON operations are valid for arbitrary byte vectors.
+        classified.ascii_source = unsafe { vmaxvq_u8(source_or) < 0x80 };
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        // SAFETY: Ruff's supported x86 targets guarantee SSE2 support.
+        classified.ascii_source = unsafe { _mm_movemask_epi8(source_or) == 0 };
+    }
 
     let tail = chunks.remainder();
     if !tail.is_empty() {
@@ -176,6 +205,73 @@ unsafe fn mask64(
         let second = vpaddq_u8(third, fourth);
         let result = vpaddq_u8(first, second);
         vgetq_lane_u64::<0>(vreinterpretq_u64_u8(vpaddq_u8(result, result)))
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[inline]
+unsafe fn classify_chunk(source: *const u8) -> (u64, u64, __m128i) {
+    // SAFETY: The caller guarantees that `source..source + 64` is valid and Ruff's supported x86
+    // targets guarantee SSE2 support.
+    unsafe {
+        let first = _mm_loadu_si128(source.cast());
+        let second = _mm_loadu_si128(source.add(16).cast());
+        let third = _mm_loadu_si128(source.add(32).cast());
+        let fourth = _mm_loadu_si128(source.add(48).cast());
+
+        let word = mask64_x86(
+            word_predicate_x86(first),
+            word_predicate_x86(second),
+            word_predicate_x86(third),
+            word_predicate_x86(fourth),
+        );
+        let whitespace = mask64_x86(
+            whitespace_predicate_x86(first),
+            whitespace_predicate_x86(second),
+            whitespace_predicate_x86(third),
+            whitespace_predicate_x86(fourth),
+        );
+        let source_or = _mm_or_si128(_mm_or_si128(first, second), _mm_or_si128(third, fourth));
+        (word, whitespace, source_or)
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[inline]
+unsafe fn word_predicate_x86(bytes: __m128i) -> __m128i {
+    // SAFETY: All SSE2 operations are valid for arbitrary byte vectors.
+    unsafe {
+        let lower = _mm_or_si128(bytes, _mm_set1_epi8(0x20));
+        let alpha_delta = _mm_sub_epi8(lower, _mm_set1_epi8(b'a'.cast_signed()));
+        let alpha = _mm_cmpeq_epi8(_mm_min_epu8(alpha_delta, _mm_set1_epi8(25)), alpha_delta);
+        let digit_delta = _mm_sub_epi8(bytes, _mm_set1_epi8(b'0'.cast_signed()));
+        let digit = _mm_cmpeq_epi8(_mm_min_epu8(digit_delta, _mm_set1_epi8(9)), digit_delta);
+        let underscore = _mm_cmpeq_epi8(bytes, _mm_set1_epi8(b'_'.cast_signed()));
+        _mm_or_si128(_mm_or_si128(alpha, digit), _mm_or_si128(underscore, bytes))
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[inline]
+unsafe fn whitespace_predicate_x86(bytes: __m128i) -> __m128i {
+    // SAFETY: All SSE2 operations are valid for arbitrary byte vectors.
+    unsafe {
+        let space = _mm_cmpeq_epi8(bytes, _mm_set1_epi8(b' '.cast_signed()));
+        let tab = _mm_cmpeq_epi8(bytes, _mm_set1_epi8(b'\t'.cast_signed()));
+        let form_feed = _mm_cmpeq_epi8(bytes, _mm_set1_epi8(b'\x0c'.cast_signed()));
+        _mm_or_si128(_mm_or_si128(space, tab), form_feed)
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[inline]
+unsafe fn mask64_x86(first: __m128i, second: __m128i, third: __m128i, fourth: __m128i) -> u64 {
+    // SAFETY: Ruff's supported x86 targets guarantee SSE2 support.
+    unsafe {
+        u64::from(_mm_movemask_epi8(first).cast_unsigned())
+            | (u64::from(_mm_movemask_epi8(second).cast_unsigned()) << 16)
+            | (u64::from(_mm_movemask_epi8(third).cast_unsigned()) << 32)
+            | (u64::from(_mm_movemask_epi8(fourth).cast_unsigned()) << 48)
     }
 }
 

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -137,7 +137,7 @@ impl<'src> Parser<'src> {
     }
 
     /// Creates a parser that bypasses chunked lexing, for a single fallback reparse.
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
     fn new_starts_at_with_legacy_lexer(
         source: &'src str,
         start_offset: TextSize,
@@ -219,7 +219,7 @@ impl<'src> Parser<'src> {
             Mode::Module | Mode::Ipython => Mod::Module(self.parse_module()),
         };
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
         if self.tokens.should_reparse_with_legacy_lexer() {
             return Parser::new_starts_at_with_legacy_lexer(
                 self.source,

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -2,7 +2,6 @@ use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, St
 
 use crate::{Mode, ParseErrorType, ParseOptions, parse, parse_expression, parse_module};
 
-#[cfg(target_arch = "aarch64")]
 use super::Parser;
 
 #[test]
@@ -13,7 +12,7 @@ fn test_modes() {
     assert!(parse(source, ParseOptions::from(Mode::Module)).is_ok());
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 #[test]
 fn chunked_lexer_reparses_after_late_error() {
     let prefix = "value = 1\n".repeat(2_000);

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -3,7 +3,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::Mode;
 use crate::error::LexicalError;
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 use crate::lexer::chunked::ChunkedLexer;
 use crate::lexer::{Lexer, LexerCheckpoint};
 use crate::string::InterpolatedStringKind;
@@ -16,11 +16,11 @@ pub(crate) struct TokenSource<'src> {
 
     /// The current non-trivia token. Keeping this separate from the buffered stream avoids an
     /// enum match and an indexed load for every parser predicate.
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
     current: Token,
 
     /// Whether error recovery requested a logical-token re-lex that requires the streaming lexer.
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
     needs_legacy_reparse: bool,
 
     /// A vector containing all the tokens emitted by the lexer. This is returned when the parser
@@ -32,7 +32,7 @@ pub(crate) struct TokenSource<'src> {
 #[derive(Debug)]
 enum LexerSource<'src> {
     Streaming(Lexer<'src>),
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
     Chunked {
         lexer: ChunkedLexer<'src>,
         position: usize,
@@ -44,7 +44,7 @@ impl<'src> TokenSource<'src> {
     /// Creates a token source, using chunked lexing for complete modules when the first batch is
     /// supported and the streaming lexer otherwise.
     pub(crate) fn from_source(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
         if mode == Mode::Module
             && start_offset == TextSize::new(0)
             && let Some(mut lexer) = ChunkedLexer::new(source)
@@ -80,13 +80,13 @@ impl<'src> TokenSource<'src> {
     ) -> Self {
         let mut source = TokenSource {
             lexer: LexerSource::Streaming(Lexer::new(source, mode, start_offset)),
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             current: Token::new(
                 TokenKind::EndOfFile,
                 TextRange::empty(start_offset),
                 TokenFlags::empty(),
             ),
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             needs_legacy_reparse: false,
             tokens: allocate_tokens_vec(&source[start_offset.to_usize()..]),
         };
@@ -99,10 +99,10 @@ impl<'src> TokenSource<'src> {
     /// Returns the kind of the current token.
     #[inline]
     pub(crate) fn current_kind(&self) -> TokenKind {
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
         return self.current.kind();
 
-        #[cfg(not(target_arch = "aarch64"))]
+        #[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
         match &self.lexer {
             LexerSource::Streaming(lexer) => lexer.current_kind(),
         }
@@ -111,10 +111,10 @@ impl<'src> TokenSource<'src> {
     /// Returns the range of the current token.
     #[inline]
     pub(crate) fn current_range(&self) -> TextRange {
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
         return self.current.range();
 
-        #[cfg(not(target_arch = "aarch64"))]
+        #[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
         match &self.lexer {
             LexerSource::Streaming(lexer) => lexer.current_range(),
         }
@@ -125,7 +125,7 @@ impl<'src> TokenSource<'src> {
     pub(crate) fn nesting(&self) -> u32 {
         match &self.lexer {
             LexerSource::Streaming(lexer) => lexer.nesting(),
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             LexerSource::Chunked { nesting, .. } => *nesting,
         }
     }
@@ -133,10 +133,10 @@ impl<'src> TokenSource<'src> {
     /// Returns the flags for the current token.
     #[inline]
     pub(crate) fn current_flags(&self) -> TokenFlags {
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
         return self.current.flags();
 
-        #[cfg(not(target_arch = "aarch64"))]
+        #[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
         match &self.lexer {
             LexerSource::Streaming(lexer) => lexer.current_flags(),
         }
@@ -147,11 +147,11 @@ impl<'src> TokenSource<'src> {
     ///
     /// [`re_lex_logical_token`]: Lexer::re_lex_logical_token
     #[cfg_attr(
-        not(target_arch = "aarch64"),
+        not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")),
         expect(irrefutable_let_patterns, reason = "the chunked variant is SIMD-only")
     )]
     pub(crate) fn re_lex_logical_token(&mut self) {
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
         if matches!(self.lexer, LexerSource::Chunked { .. }) {
             self.needs_legacy_reparse = true;
             return;
@@ -194,7 +194,7 @@ impl<'src> TokenSource<'src> {
         // Trim the already bumped logical line token (and comments coming after it) as it might now have become a logical line token
         self.tokens.truncate(non_logical_line_index);
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
         self.refresh_current();
 
         #[cfg(debug_assertions)]
@@ -226,11 +226,11 @@ impl<'src> TokenSource<'src> {
             LexerSource::Streaming(lexer) => {
                 lexer.re_lex_string_token_in_interpolation_element(kind);
             }
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             LexerSource::Chunked { .. } => return,
         }
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
         self.refresh_current();
     }
 
@@ -239,11 +239,11 @@ impl<'src> TokenSource<'src> {
     pub(crate) fn re_lex_raw_string_in_format_spec(&mut self) {
         match &mut self.lexer {
             LexerSource::Streaming(lexer) => lexer.re_lex_raw_string_in_format_spec(),
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             LexerSource::Chunked { .. } => return,
         }
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
         self.refresh_current();
     }
 
@@ -261,7 +261,7 @@ impl<'src> TokenSource<'src> {
                 lexer.rewind(checkpoint);
                 next
             }
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             LexerSource::Chunked {
                 lexer, position, ..
             } => next_buffered_token(lexer, *position + 1, &mut self.needs_legacy_reparse).0,
@@ -283,7 +283,7 @@ impl<'src> TokenSource<'src> {
                 lexer.rewind(checkpoint);
                 (first, second)
             }
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             LexerSource::Chunked {
                 lexer, position, ..
             } => {
@@ -309,7 +309,7 @@ impl<'src> TokenSource<'src> {
                     lexer.current_flags(),
                 ));
             }
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             LexerSource::Chunked {
                 lexer,
                 position,
@@ -349,7 +349,7 @@ impl<'src> TokenSource<'src> {
                     break;
                 }
 
-                #[cfg(target_arch = "aarch64")]
+                #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
                 {
                     self.current = Token::new(
                         lexer.current_kind(),
@@ -358,7 +358,7 @@ impl<'src> TokenSource<'src> {
                     );
                 }
             }
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             LexerSource::Chunked {
                 lexer,
                 position,
@@ -377,7 +377,7 @@ impl<'src> TokenSource<'src> {
                 LexerSource::Streaming(lexer) => {
                     LexerSourceCheckpoint::Streaming(lexer.checkpoint())
                 }
-                #[cfg(target_arch = "aarch64")]
+                #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
                 LexerSource::Chunked {
                     lexer,
                     position,
@@ -395,7 +395,7 @@ impl<'src> TokenSource<'src> {
 
     /// Restore the token source to the given checkpoint.
     #[cfg_attr(
-        not(target_arch = "aarch64"),
+        not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")),
         expect(irrefutable_let_patterns, reason = "the chunked variant is SIMD-only")
     )]
     pub(crate) fn rewind(&mut self, checkpoint: TokenSourceCheckpoint) {
@@ -410,7 +410,7 @@ impl<'src> TokenSource<'src> {
                     lexer.rewind(checkpoint);
                 }
             }
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             LexerSourceCheckpoint::Chunked {
                 position,
                 nesting,
@@ -431,7 +431,7 @@ impl<'src> TokenSource<'src> {
         }
         self.tokens.truncate(tokens_position);
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
         self.refresh_current();
     }
 
@@ -439,7 +439,7 @@ impl<'src> TokenSource<'src> {
     pub(crate) fn in_range(&self, range: TextRange) -> &[Token] {
         let tokens = match &self.lexer {
             LexerSource::Streaming(_) => &self.tokens,
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             LexerSource::Chunked {
                 lexer, position, ..
             } => &lexer.tokens.tokens[..=*position],
@@ -466,7 +466,7 @@ impl<'src> TokenSource<'src> {
         // the parser to stop. This isn't in `do_bump` because it only needs to be done once.
         let (mut tokens, errors) = match self.lexer {
             LexerSource::Streaming(lexer) => (self.tokens, lexer.finish()),
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
             LexerSource::Chunked { lexer, .. } => (lexer.tokens.tokens, Vec::new()),
         };
 
@@ -479,12 +479,12 @@ impl<'src> TokenSource<'src> {
     }
 
     /// Returns whether chunked lexing or parser-directed re-lexing requires a streaming reparse.
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
     pub(crate) fn should_reparse_with_legacy_lexer(&self) -> bool {
         self.needs_legacy_reparse
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
     #[inline]
     fn refresh_current(&mut self) {
         self.current = match &self.lexer {
@@ -507,7 +507,7 @@ pub(crate) struct TokenSourceCheckpoint {
 
 enum LexerSourceCheckpoint {
     Streaming(LexerCheckpoint),
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
     Chunked {
         position: usize,
         nesting: u32,
@@ -525,7 +525,7 @@ fn next_non_trivia_token(lexer: &mut Lexer) -> TokenKind {
 }
 
 /// Finds the next non-trivia buffered token, refilling on demand without advancing the parser.
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 fn next_buffered_token(
     lexer: &mut ChunkedLexer,
     mut position: usize,
@@ -542,7 +542,7 @@ fn next_buffered_token(
 }
 
 /// Advances to the next non-trivia buffered token and maintains delimiter nesting for the parser.
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 #[inline]
 fn bump_buffered_token(
     lexer: &mut ChunkedLexer,
@@ -569,7 +569,7 @@ fn bump_buffered_token(
     }
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 #[inline]
 fn ensure_buffered_token(
     lexer: &mut ChunkedLexer,
@@ -586,7 +586,7 @@ fn ensure_buffered_token(
 
 /// Refills through `position`. A failed batch appends a synthetic EOF and requests one streaming
 /// reparse, preventing repeated failed refills during error recovery.
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 #[cold]
 fn refill_buffered_tokens(
     lexer: &mut ChunkedLexer,
@@ -619,7 +619,7 @@ fn refill_buffered_tokens(
 }
 
 /// Restores contextual token-kind rewrites made after a parser checkpoint.
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))]
 fn rewind_rewrites(lexer: &mut ChunkedLexer, position: usize) {
     for (index, token) in lexer.tokens.rewrites.drain(position..).rev() {
         lexer.tokens.tokens[index] = token;
@@ -644,7 +644,10 @@ fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
     Vec::with_capacity(1 << capacity_hint.ilog2())
 }
 
-#[cfg(all(test, target_arch = "aarch64"))]
+#[cfg(all(
+    test,
+    any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+))]
 mod tests {
     use ruff_text_size::TextSize;
 


### PR DESCRIPTION
## Summary

Extend the production chunked lexer to x86 and x86-64. The structural classifier uses SSE2 on these targets, while the parser integration, fallback behavior, differential tests, and lexer benchmarks are enabled across both ARM and x86.

This PR is stacked on #26779 so the x86 implementation can be reviewed independently from the ARM lexer and parser contract.
