### PR TITLE
[ty] Go to definition on float or complex should go to said class

### DIFF
--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -1561,13 +1561,8 @@ a: float<CURSOR> = 3.14
         LL | a: float = 3.14
            |    ^^^^^ Clicking here
            |
-        info: Found 2 definitions
+        info: Found 1 definition
           --> stdlib/builtins.pyi:LL:7
-           |
-        LL | class int:
-           |       ---
-           |
-          ::: stdlib/builtins.pyi:LL:7
            |
         LL | class float:
            |       -----
@@ -1593,18 +1588,8 @@ a: complex<CURSOR> = 3.14
         LL | a: complex = 3.14
            |    ^^^^^^^ Clicking here
            |
-        info: Found 3 definitions
+        info: Found 1 definition
           --> stdlib/builtins.pyi:LL:7
-           |
-        LL | class int:
-           |       ---
-           |
-          ::: stdlib/builtins.pyi:LL:7
-           |
-        LL | class float:
-           |       -----
-           |
-          ::: stdlib/builtins.pyi:LL:7
            |
         LL | class complex:
            |       -------

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -173,6 +173,7 @@ pub fn definitions_for_name<'db>(
                 // instead of `int` (hover only shows the docstring of the first definition).
                 .rev()
                 .filter_map(|ty| ty.as_nominal_instance())
+                .filter(|instance| instance.class_literal(db).name(db).as_str() == name_str)
                 .filter_map(|instance| {
                     let definition = instance.class_literal(db).definition(db)?;
                     Some(ResolvedDefinition::Definition(definition))


### PR DESCRIPTION
This PR restricts "Go to Definition" and "Go to Declaration" on `float` and `complex` inside type annotations to resolve only to their respective classes, rather than resolving to all members of their numeric promotion unions (`int | float` and `int | float | complex` respectively). This is done by filtering the nominal instances in `definitions_for_name` inside `ide_support.rs` to only keep the class whose name matches the clicked name.

### Checklist
- [x] This pull request references any related issue by including "closes <link to issue>"

  - _Closes [#3975](https://github.com/astral-sh/ty/issues/3975)_ 
  
- [x] If this is a complex change, a maintainer has confirmed the proposed approach on the linked issue.

  - *This is a targeted change to the definition resolution behavior for special-cased float/complex unions.*
  
- [x] If this pull request adds or changes functionality, it includes tests or explains why tests are not needed.

  - *Updated existing snapshot tests `float_annotation` and `complex_annotation` in `goto_definition.rs` to verify that they now resolve to a single definition instead of multiple union members.*
  
- [x] If this pull request changes user-facing behavior, it updates documentation or explains why documentation is not needed.

  - *This modifies internal language server navigation logic to match user expectations; no documentation changes are required.*
  
- [ ] If this pull request removes docs files, it includes redirect settings in mint.json.

  - *No documentation files were deleted.*
  
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

  - *No new functions or classes were added.*