### PR TITLE
[ty] Remove inferable typevar artifacts recursively

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -936,6 +936,22 @@ reveal_type(x20)  # revealed: dict[Hashable, list[(...) -> Any]]
 
 x21: Mapping[Hashable, list[Callable[..., Any]]] = dict(x=[variadic])
 reveal_type(x21)  # revealed: dict[Hashable, list[(...) -> Any]]
+
+x22: Mapping[str, Literal["+", "-"]] = {
+    "plus": "+",
+    "minus": "-",
+}
+reveal_type(x22)  # revealed: dict[str, Literal["+", "-"]]
+
+class DataFrame: ...
+
+type Aggregate = Callable[[DataFrame], object] | str
+type AggregateSpec = Aggregate | list[Aggregate]
+
+def mean(data: DataFrame) -> float:
+    return 0.0
+
+x23: Mapping[Hashable, AggregateSpec] = {"col1": ["sum", mean], "col2": mean}
 ```
 
 ## Implicit generic class specialization

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2280,35 +2280,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         target: BoundTypeVarInstance<'db>,
         ty: Type<'db>,
     ) -> Type<'db> {
-        let ty = self.remove_inferable_typevar_artifacts_from_lower_bound(target, ty);
-        self.remove_inferable_typevar_artifacts_from_upper_bound(target, ty)
-    }
-
-    fn remove_inferable_typevar_artifacts_from_lower_bound(
-        &self,
-        target: BoundTypeVarInstance<'db>,
-        ty: Type<'db>,
-    ) -> Type<'db> {
-        match ty {
-            Type::Union(union)
-                if union
-                    .elements(self.db)
-                    .iter()
-                    .any(|element| !self.is_inferable_typevar_artifact(target, *element)) =>
-            {
-                union.filter(self.db, |element| {
-                    !self.is_inferable_typevar_artifact(target, *element)
-                })
-            }
-            _ => ty,
-        }
-    }
-
-    fn remove_inferable_typevar_artifacts_from_upper_bound(
-        &self,
-        target: BoundTypeVarInstance<'db>,
-        ty: Type<'db>,
-    ) -> Type<'db> {
         match ty {
             Type::Intersection(intersection)
                 if intersection
@@ -2320,6 +2291,20 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         Type::object()
                     } else {
                         *element
+                    }
+                })
+            }
+            Type::Union(union)
+                if union
+                    .elements(self.db)
+                    .iter()
+                    .any(|element| !self.is_inferable_typevar_artifact(target, *element)) =>
+            {
+                union.map(self.db, |element| {
+                    if self.is_inferable_typevar_artifact(target, *element) {
+                        Type::Never
+                    } else {
+                        self.remove_inferable_typevar_artifacts_from_solution(target, *element)
                     }
                 })
             }


### PR DESCRIPTION
Fixes the issues identified in https://github.com/astral-sh/ruff/pull/26782#issuecomment-4963166161 by improving our inferable typevar artifact detection, e.g.,
```py
from typing import Literal, Mapping

# error[invalid-assignment] Object of type `dict[str, str]` is not assignable to `Mapping[str, Literal["+", "-"]]`
operators: Mapping[str, Literal["+", "-"]] = {
    "plus": "+",
    "minus": "-",
}
```

Note that these were fixed indirectly by https://github.com/astral-sh/ruff/pull/26782, but that PR did not solve the underlying a problem, instead avoiding the solver path entirely.