### PR TITLE
[ty] Represent bound receiver constraints with OwnedConstraintSet

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3055,7 +3055,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import final, overload
+from typing import Any, final, overload
 from typing_extensions import TypeVar, Self, Protocol
 from ty_extensions import static_assert
 from ty_extensions._internal import is_equivalent_to, is_assignable_to, is_subtype_of
@@ -3161,6 +3161,12 @@ class GenericReceiver:
     def f[T](self: T, input: T) -> T:
         return self
 
+class GradualReceiverProtocol(Protocol):
+    def method(self: list[Any]) -> None: ...
+
+class GradualReceiverImplementation(list[int]):
+    def method(self: list[Any]) -> None: ...
+
 class ExplicitReceiverProtocol(Protocol):
     def method(self: "ExplicitReceiverProtocol") -> None: ...
 
@@ -3222,6 +3228,11 @@ static_assert(not is_assignable_to(NominalReturningOtherClass, UsesSelf))
 # `T = int`, so the resulting bound method does not satisfy `ConcreteMethod.f`.
 static_assert(not is_assignable_to(GenericReceiver, ConcreteMethod))
 static_assert(not is_subtype_of(GenericReceiver, ConcreteMethod))
+
+# Specializing the receiver constraint to `GradualReceiverImplementation` must preserve the
+# assignability relation that produced it; `list[int]` is assignable to, but not a subtype of,
+# `list[Any]`.
+static_assert(is_assignable_to(GradualReceiverImplementation, GradualReceiverProtocol))
 
 # Checking the receiver constraint requires the same protocol relation that is already in
 # progress. The recursive check should terminate and establish the structural relation.

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -327,6 +327,8 @@ impl<'db> OwnedConstraintSetTypeMapper<'_, '_, 'db> {
                     .insert(old_interior.constraint, condition);
                 condition
             };
+        let condition = condition
+            .with_adjusted_source_order(self.builder, old_interior.source_order.saturating_sub(1));
         let if_true = self.rebuild_node(old_interior.if_true);
         let if_uncertain = self.rebuild_node(old_interior.if_uncertain);
         let if_false = self.rebuild_node(old_interior.if_false);
@@ -8034,6 +8036,39 @@ mod tests {
                 └─₀ never
             "#},
         );
+    }
+
+    #[test]
+    fn mapped_owned_constraint_set_preserves_source_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let owned = ConstraintSetBuilder::new().into_owned(|builder| {
+            create_constraint(&db, builder, t, KnownClass::Int).and(&db, builder, || {
+                create_constraint(&db, builder, u, KnownClass::Str)
+            })
+        });
+        let generic_context =
+            crate::types::generics::GenericContext::from_typevar_instances(&db, [t, u]);
+        let mapped = owned.apply_type_mapping(
+            &db,
+            &TypeMapping::FreshenBoundTypeVars {
+                generic_context,
+                delta: 1,
+            },
+            TypeContext::default(),
+            &ApplyTypeMappingVisitor::default(),
+        );
+
+        mapped.query(|builder, set| {
+            let mut source_orders = Vec::new();
+            set.node
+                .for_each_unique_constraint(builder, &mut |_, source_order| {
+                    source_orders.push(source_order);
+                });
+            source_orders.sort_unstable();
+            assert_eq!(source_orders, [1, 2]);
+        });
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -256,6 +256,86 @@ struct OwnedConstraintSetInner<'db> {
     node_indices: RankBitBox,
 }
 
+struct OwnedConstraintSetTypeMapper<'a, 'm, 'db> {
+    db: &'db dyn Db,
+    builder: &'a ConstraintSetBuilder<'db>,
+    inner: &'a OwnedConstraintSetInner<'db>,
+    type_mapping: &'a TypeMapping<'m, 'db>,
+    tcx: TypeContext<'db>,
+    visitor: &'a ApplyTypeMappingVisitor<'db>,
+    node_cache: FxHashMap<NodeId, NodeId>,
+    constraint_cache: FxHashMap<ConstraintId, NodeId>,
+}
+
+impl<'db> OwnedConstraintSetTypeMapper<'_, '_, 'db> {
+    fn map_constraint(&self, constraint: Constraint<'db>) -> NodeId {
+        let subject = Type::TypeVar(constraint.typevar).apply_type_mapping_impl(
+            self.db,
+            self.type_mapping,
+            self.tcx,
+            self.visitor,
+        );
+        let lower = constraint.bounds.lower.map(|lower| {
+            lower.apply_type_mapping_impl(self.db, self.type_mapping, self.tcx, self.visitor)
+        });
+        let upper = constraint.bounds.upper.map(|upper| {
+            upper.apply_type_mapping_impl(self.db, self.type_mapping, self.tcx, self.visitor)
+        });
+
+        if let Type::TypeVar(typevar) = subject {
+            return Constraint::new_node_with_bounds(self.db, self.builder, typevar, lower, upper);
+        }
+
+        let lower_holds = lower.map_or(ALWAYS_TRUE, |lower| {
+            self.builder
+                .load(
+                    self.db,
+                    lower.when_constraint_set_subtype_of_owned(self.db, subject),
+                )
+                .node
+        });
+        let upper_holds = upper.map_or(ALWAYS_TRUE, |upper| {
+            self.builder
+                .load(
+                    self.db,
+                    subject.when_constraint_set_subtype_of_owned(self.db, upper),
+                )
+                .node
+        });
+        lower_holds.and_with_offset(self.builder, upper_holds)
+    }
+
+    fn rebuild_node(&mut self, old_node: NodeId) -> NodeId {
+        if old_node.is_terminal() {
+            return old_node;
+        }
+        if let Some(mapped) = self.node_cache.get(&old_node) {
+            return *mapped;
+        }
+
+        let old_interior = self.inner.nodes[self.inner.retained_node_index(old_node)];
+        let condition =
+            if let Some(condition) = self.constraint_cache.get(&old_interior.constraint).copied() {
+                condition
+            } else {
+                let condition = self.map_constraint(
+                    self.inner.constraints[self
+                        .inner
+                        .retained_constraint_index(old_interior.constraint)],
+                );
+                self.constraint_cache
+                    .insert(old_interior.constraint, condition);
+                condition
+            };
+        let if_true = self.rebuild_node(old_interior.if_true);
+        let if_uncertain = self.rebuild_node(old_interior.if_uncertain);
+        let if_false = self.rebuild_node(old_interior.if_false);
+        let mapped = condition.ite_uncertain(self.builder, if_true, if_uncertain, if_false);
+        self.node_cache.insert(old_node, mapped);
+        mapped
+    }
+}
+
 impl Default for OwnedConstraintSet<'_> {
     fn default() -> Self {
         Self {
@@ -291,6 +371,43 @@ impl<'db> OwnedConstraintSet<'db> {
         };
         let set = ConstraintSet::from_node(&builder, self.node);
         f(&builder, set)
+    }
+
+    pub(crate) fn types(&self) -> impl Iterator<Item = Type<'db>> + '_ {
+        self.inner.iter().flat_map(|inner| {
+            inner.constraints.iter().flat_map(|constraint| {
+                std::iter::once(Type::TypeVar(constraint.typevar))
+                    .chain(constraint.bounds.lower)
+                    .chain(constraint.bounds.upper)
+            })
+        })
+    }
+
+    pub(crate) fn apply_type_mapping(
+        &self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'_, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        let Some(inner) = &self.inner else {
+            return self.clone();
+        };
+
+        let builder = ConstraintSetBuilder::new();
+        builder.into_owned(|builder| {
+            let mut mapper = OwnedConstraintSetTypeMapper {
+                db,
+                builder,
+                inner,
+                type_mapping,
+                tcx,
+                visitor,
+                node_cache: FxHashMap::default(),
+                constraint_cache: FxHashMap::default(),
+            };
+            ConstraintSet::from_node(builder, mapper.rebuild_node(self.node))
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -256,88 +256,6 @@ struct OwnedConstraintSetInner<'db> {
     node_indices: RankBitBox,
 }
 
-struct OwnedConstraintSetTypeMapper<'a, 'm, 'db> {
-    db: &'db dyn Db,
-    builder: &'a ConstraintSetBuilder<'db>,
-    inner: &'a OwnedConstraintSetInner<'db>,
-    type_mapping: &'a TypeMapping<'m, 'db>,
-    tcx: TypeContext<'db>,
-    visitor: &'a ApplyTypeMappingVisitor<'db>,
-    node_cache: FxHashMap<NodeId, NodeId>,
-    constraint_cache: FxHashMap<ConstraintId, NodeId>,
-}
-
-impl<'db> OwnedConstraintSetTypeMapper<'_, '_, 'db> {
-    fn map_constraint(&self, constraint: Constraint<'db>) -> NodeId {
-        let subject = Type::TypeVar(constraint.typevar).apply_type_mapping_impl(
-            self.db,
-            self.type_mapping,
-            self.tcx,
-            self.visitor,
-        );
-        let lower = constraint.bounds.lower.map(|lower| {
-            lower.apply_type_mapping_impl(self.db, self.type_mapping, self.tcx, self.visitor)
-        });
-        let upper = constraint.bounds.upper.map(|upper| {
-            upper.apply_type_mapping_impl(self.db, self.type_mapping, self.tcx, self.visitor)
-        });
-
-        if let Type::TypeVar(typevar) = subject {
-            return Constraint::new_node_with_bounds(self.db, self.builder, typevar, lower, upper);
-        }
-
-        let lower_holds = lower.map_or(ALWAYS_TRUE, |lower| {
-            self.builder
-                .load(
-                    self.db,
-                    &lower.when_constraint_set_assignable_to_owned_for_mapping(self.db, subject),
-                )
-                .node
-        });
-        let upper_holds = upper.map_or(ALWAYS_TRUE, |upper| {
-            self.builder
-                .load(
-                    self.db,
-                    &subject.when_constraint_set_assignable_to_owned_for_mapping(self.db, upper),
-                )
-                .node
-        });
-        lower_holds.and_with_offset(self.builder, upper_holds)
-    }
-
-    fn rebuild_node(&mut self, old_node: NodeId) -> NodeId {
-        if old_node.is_terminal() {
-            return old_node;
-        }
-        if let Some(mapped) = self.node_cache.get(&old_node) {
-            return *mapped;
-        }
-
-        let old_interior = self.inner.nodes[self.inner.retained_node_index(old_node)];
-        let condition =
-            if let Some(condition) = self.constraint_cache.get(&old_interior.constraint).copied() {
-                condition
-            } else {
-                let condition = self.map_constraint(
-                    self.inner.constraints[self
-                        .inner
-                        .retained_constraint_index(old_interior.constraint)],
-                );
-                self.constraint_cache
-                    .insert(old_interior.constraint, condition);
-                condition
-            };
-        let condition = condition
-            .with_adjusted_source_order(self.builder, old_interior.source_order.saturating_sub(1));
-        let if_true = self.rebuild_node(old_interior.if_true);
-        let if_uncertain = self.rebuild_node(old_interior.if_uncertain);
-        let if_false = self.rebuild_node(old_interior.if_false);
-        let mapped = condition.ite_uncertain(self.builder, if_true, if_uncertain, if_false);
-        self.node_cache.insert(old_node, mapped);
-        mapped
-    }
-}
-
 impl Default for OwnedConstraintSet<'_> {
     fn default() -> Self {
         Self {
@@ -386,69 +304,6 @@ impl<'db> OwnedConstraintSet<'db> {
                     .chain(constraint.bounds.lower)
                     .chain(constraint.bounds.upper)
             })
-        })
-    }
-
-    pub(crate) fn apply_type_mapping(
-        &self,
-        db: &'db dyn Db,
-        type_mapping: &TypeMapping<'_, 'db>,
-        tcx: TypeContext<'db>,
-        visitor: &ApplyTypeMappingVisitor<'db>,
-    ) -> Self {
-        let Some(inner) = &self.inner else {
-            return self.clone();
-        };
-
-        let changes_constraint = |constraint: &Constraint<'db>| {
-            Type::TypeVar(constraint.typevar).apply_type_mapping_impl(
-                db,
-                type_mapping,
-                tcx,
-                visitor,
-            ) != Type::TypeVar(constraint.typevar)
-                || constraint.bounds.lower.is_some_and(|lower| {
-                    lower.apply_type_mapping_impl(db, type_mapping, tcx, visitor) != lower
-                })
-                || constraint.bounds.upper.is_some_and(|upper| {
-                    upper.apply_type_mapping_impl(db, type_mapping, tcx, visitor) != upper
-                })
-        };
-        if !inner.constraints.iter().any(changes_constraint) {
-            return self.clone();
-        }
-
-        let builder = ConstraintSetBuilder::new();
-        builder.into_owned(|builder| {
-            let mut mapper = OwnedConstraintSetTypeMapper {
-                db,
-                builder,
-                inner,
-                type_mapping,
-                tcx,
-                visitor,
-                node_cache: FxHashMap::default(),
-                constraint_cache: FxHashMap::default(),
-            };
-            if inner.nodes.len() == 1 {
-                let old_interior = inner.nodes[inner.retained_node_index(self.node)];
-                let old_constraint =
-                    inner.constraints[inner.retained_constraint_index(old_interior.constraint)];
-                let condition = mapper
-                    .map_constraint(old_constraint)
-                    .with_adjusted_source_order(
-                        builder,
-                        old_interior.source_order.saturating_sub(1),
-                    );
-                let node = condition.ite_uncertain(
-                    builder,
-                    old_interior.if_true,
-                    old_interior.if_uncertain,
-                    old_interior.if_false,
-                );
-                return ConstraintSet::from_node(builder, node);
-            }
-            ConstraintSet::from_node(builder, mapper.rebuild_node(self.node))
         })
     }
 }
@@ -740,8 +595,54 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         Self::from_node(builder, self.node.exists(db, builder, to_remove))
     }
 
+    /// Copies this constraint set into an owned snapshot.
+    pub(crate) fn into_owned(self, db: &'db dyn Db) -> OwnedConstraintSet<'db> {
+        fn rebuild_node<'db>(
+            db: &'db dyn Db,
+            source: &ConstraintSetBuilder<'db>,
+            target: &ConstraintSetBuilder<'db>,
+            cache: &mut FxHashMap<NodeId, NodeId>,
+            old_node: NodeId,
+        ) -> NodeId {
+            if old_node.is_terminal() {
+                return old_node;
+            }
+            if let Some(remapped) = cache.get(&old_node) {
+                return *remapped;
+            }
+
+            let old_interior = source.interior_node_data(old_node);
+            let old_constraint = source.constraint_data(old_interior.constraint);
+            let condition = Constraint::new_node_with_bounds(
+                db,
+                target,
+                old_constraint.typevar,
+                old_constraint.bounds.lower,
+                old_constraint.bounds.upper,
+            )
+            .with_adjusted_source_order(target, old_interior.source_order.saturating_sub(1));
+            let if_true = rebuild_node(db, source, target, cache, old_interior.if_true);
+            let if_uncertain = rebuild_node(db, source, target, cache, old_interior.if_uncertain);
+            let if_false = rebuild_node(db, source, target, cache, old_interior.if_false);
+            let remapped = condition.ite_uncertain(target, if_true, if_uncertain, if_false);
+            cache.insert(old_node, remapped);
+            remapped
+        }
+
+        let builder = ConstraintSetBuilder::new();
+        builder.into_owned(|builder| {
+            let node = rebuild_node(
+                db,
+                self.builder,
+                builder,
+                &mut FxHashMap::default(),
+                self.node,
+            );
+            ConstraintSet::from_node(builder, node)
+        })
+    }
+
     /// Applies a type mapping to every constraint in this constraint set.
-    #[cfg_attr(not(test), expect(dead_code, reason = "used by a stacked follow-up"))]
     pub(crate) fn apply_type_mapping_impl(
         self,
         db: &'db dyn Db,
@@ -816,13 +717,19 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                     Constraint::new_node_with_bounds(db, builder, typevar, lower, upper)
                 } else {
                     let lower_holds = lower.map_or(ALWAYS_TRUE, |lower| {
-                        lower
-                            .when_constraint_set_assignable_to(db, subject, builder)
+                        builder
+                            .load(
+                                db,
+                                &lower.when_constraint_set_assignable_to_owned(db, subject),
+                            )
                             .node
                     });
                     let upper_holds = upper.map_or(ALWAYS_TRUE, |upper| {
-                        subject
-                            .when_constraint_set_assignable_to(db, upper, builder)
+                        builder
+                            .load(
+                                db,
+                                &subject.when_constraint_set_assignable_to_owned(db, upper),
+                            )
                             .node
                     });
                     lower_holds.and_with_offset(builder, upper_holds)
@@ -8097,67 +8004,6 @@ mod tests {
                 └─₀ never
             "#},
         );
-    }
-
-    #[test]
-    fn mapped_owned_constraint_set_preserves_source_order() {
-        let db = setup_db();
-        let t = create_typevar(&db, "T");
-        let u = create_typevar(&db, "U");
-        let owned = ConstraintSetBuilder::new().into_owned(|builder| {
-            create_constraint(&db, builder, t, KnownClass::Int).and(&db, builder, || {
-                create_constraint(&db, builder, u, KnownClass::Str)
-            })
-        });
-        let generic_context =
-            crate::types::generics::GenericContext::from_typevar_instances(&db, [t, u]);
-        let mapped = owned.apply_type_mapping(
-            &db,
-            &TypeMapping::FreshenBoundTypeVars {
-                generic_context,
-                delta: 1,
-            },
-            TypeContext::default(),
-            &ApplyTypeMappingVisitor::default(),
-        );
-
-        mapped.query(|builder, set| {
-            let mut source_orders = Vec::new();
-            set.node
-                .for_each_unique_constraint(builder, &mut |_, source_order| {
-                    source_orders.push(source_order);
-                });
-            source_orders.sort_unstable();
-            assert_eq!(source_orders, [1, 2]);
-        });
-    }
-
-    #[test]
-    fn no_op_owned_constraint_set_mapping_reuses_storage() {
-        let db = setup_db();
-        let t = create_typevar(&db, "T");
-        let u = create_typevar(&db, "U");
-        let owned = ConstraintSetBuilder::new()
-            .into_owned(|builder| create_constraint(&db, builder, t, KnownClass::Int));
-        let generic_context =
-            crate::types::generics::GenericContext::from_typevar_instances(&db, [u]);
-        let mapped = owned.apply_type_mapping(
-            &db,
-            &TypeMapping::FreshenBoundTypeVars {
-                generic_context,
-                delta: 1,
-            },
-            TypeContext::default(),
-            &ApplyTypeMappingVisitor::default(),
-        );
-
-        assert!(Arc::ptr_eq(
-            owned.inner.as_ref().expect("owned set should have storage"),
-            mapped
-                .inner
-                .as_ref()
-                .expect("mapped set should have storage"),
-        ));
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -290,7 +290,7 @@ impl<'db> OwnedConstraintSetTypeMapper<'_, '_, 'db> {
             self.builder
                 .load(
                     self.db,
-                    lower.when_constraint_set_assignable_to_owned_for_mapping(self.db, subject),
+                    &lower.when_constraint_set_assignable_to_owned_for_mapping(self.db, subject),
                 )
                 .node
         });
@@ -298,7 +298,7 @@ impl<'db> OwnedConstraintSetTypeMapper<'_, '_, 'db> {
             self.builder
                 .load(
                     self.db,
-                    subject.when_constraint_set_assignable_to_owned_for_mapping(self.db, upper),
+                    &subject.when_constraint_set_assignable_to_owned_for_mapping(self.db, upper),
                 )
                 .node
         });
@@ -355,6 +355,10 @@ impl<'db> OwnedConstraintSet<'db> {
         }
     }
 
+    pub(crate) fn is_always(&self) -> bool {
+        self.node == ALWAYS_TRUE
+    }
+
     /// Loads this constraint set into a new builder, invokes a callback with that builder, and
     /// returns the result.
     ///
@@ -396,6 +400,24 @@ impl<'db> OwnedConstraintSet<'db> {
             return self.clone();
         };
 
+        let changes_constraint = |constraint: &Constraint<'db>| {
+            Type::TypeVar(constraint.typevar).apply_type_mapping_impl(
+                db,
+                type_mapping,
+                tcx,
+                visitor,
+            ) != Type::TypeVar(constraint.typevar)
+                || constraint.bounds.lower.is_some_and(|lower| {
+                    lower.apply_type_mapping_impl(db, type_mapping, tcx, visitor) != lower
+                })
+                || constraint.bounds.upper.is_some_and(|upper| {
+                    upper.apply_type_mapping_impl(db, type_mapping, tcx, visitor) != upper
+                })
+        };
+        if !inner.constraints.iter().any(changes_constraint) {
+            return self.clone();
+        }
+
         let builder = ConstraintSetBuilder::new();
         builder.into_owned(|builder| {
             let mut mapper = OwnedConstraintSetTypeMapper {
@@ -408,6 +430,24 @@ impl<'db> OwnedConstraintSet<'db> {
                 node_cache: FxHashMap::default(),
                 constraint_cache: FxHashMap::default(),
             };
+            if inner.nodes.len() == 1 {
+                let old_interior = inner.nodes[inner.retained_node_index(self.node)];
+                let old_constraint =
+                    inner.constraints[inner.retained_constraint_index(old_interior.constraint)];
+                let condition = mapper
+                    .map_constraint(old_constraint)
+                    .with_adjusted_source_order(
+                        builder,
+                        old_interior.source_order.saturating_sub(1),
+                    );
+                let node = condition.ite_uncertain(
+                    builder,
+                    old_interior.if_true,
+                    old_interior.if_uncertain,
+                    old_interior.if_false,
+                );
+                return ConstraintSet::from_node(builder, node);
+            }
             ConstraintSet::from_node(builder, mapper.rebuild_node(self.node))
         })
     }
@@ -1150,6 +1190,27 @@ impl<'db> ConstraintSetBuilder<'db> {
             .inner
             .as_ref()
             .expect("storage-free owned constraint sets must have terminal roots");
+
+        if inner.nodes.len() == 1 {
+            let old_interior = inner.nodes[inner.retained_node_index(other.node)];
+            let old_constraint =
+                inner.constraints[inner.retained_constraint_index(old_interior.constraint)];
+            let condition = Constraint::new_node_with_bounds(
+                db,
+                self,
+                old_constraint.typevar,
+                old_constraint.bounds.lower,
+                old_constraint.bounds.upper,
+            )
+            .with_adjusted_source_order(self, old_interior.source_order.saturating_sub(1));
+            let node = condition.ite_uncertain(
+                self,
+                old_interior.if_true,
+                old_interior.if_uncertain,
+                old_interior.if_false,
+            );
+            return ConstraintSet::from_node(self, node);
+        }
 
         // Load all of the constraints into the this builder first, to maximize the chance that the
         // constraints and typevars will appear in the same order. (This is important because many
@@ -8069,6 +8130,34 @@ mod tests {
             source_orders.sort_unstable();
             assert_eq!(source_orders, [1, 2]);
         });
+    }
+
+    #[test]
+    fn no_op_owned_constraint_set_mapping_reuses_storage() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let owned = ConstraintSetBuilder::new()
+            .into_owned(|builder| create_constraint(&db, builder, t, KnownClass::Int));
+        let generic_context =
+            crate::types::generics::GenericContext::from_typevar_instances(&db, [u]);
+        let mapped = owned.apply_type_mapping(
+            &db,
+            &TypeMapping::FreshenBoundTypeVars {
+                generic_context,
+                delta: 1,
+            },
+            TypeContext::default(),
+            &ApplyTypeMappingVisitor::default(),
+        );
+
+        assert!(Arc::ptr_eq(
+            owned.inner.as_ref().expect("owned set should have storage"),
+            mapped
+                .inner
+                .as_ref()
+                .expect("mapped set should have storage"),
+        ));
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -290,7 +290,7 @@ impl<'db> OwnedConstraintSetTypeMapper<'_, '_, 'db> {
             self.builder
                 .load(
                     self.db,
-                    lower.when_constraint_set_subtype_of_owned(self.db, subject),
+                    lower.when_constraint_set_assignable_to_owned_for_mapping(self.db, subject),
                 )
                 .node
         });
@@ -298,7 +298,7 @@ impl<'db> OwnedConstraintSetTypeMapper<'_, '_, 'db> {
             self.builder
                 .load(
                     self.db,
-                    subject.when_constraint_set_subtype_of_owned(self.db, upper),
+                    subject.when_constraint_set_assignable_to_owned_for_mapping(self.db, upper),
                 )
                 .node
         });

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -237,24 +237,6 @@ impl TypeRelation {
     }
 }
 
-fn constraint_set_assignable_to_owned<'db>(
-    db: &'db dyn Db,
-    source: Type<'db>,
-    target: Type<'db>,
-) -> OwnedConstraintSet<'db> {
-    let constraints = ConstraintSetBuilder::new();
-    constraints.into_owned(|constraints| {
-        source.has_relation_to_with_typevar_evaluation(
-            db,
-            target,
-            constraints,
-            InferableTypeVars::None,
-            TypeRelation::Assignability,
-            TypeVarEvaluation::Lazy,
-        )
-    })
-}
-
 #[salsa::tracked]
 impl<'db> Type<'db> {
     /// Return `true` if subtyping is always reflexive for this type; `T <: T` is always true for
@@ -490,38 +472,17 @@ impl<'db> Type<'db> {
             source: Type<'db>,
             target: Type<'db>,
         ) -> OwnedConstraintSet<'db> {
-            constraint_set_assignable_to_owned(db, source, target)
-        }
-
-        if self.is_trivially_constraint_set_assignable_to(db, target) {
-            return Cow::Owned(OwnedConstraintSet::always());
-        }
-
-        Cow::Borrowed(when_constraint_set_assignable_to_owned_impl(
-            db, self, target,
-        ))
-    }
-
-    /// Computes assignability while remapping an owned constraint set.
-    ///
-    /// Remapping can evaluate recursive protocol relations before the enclosing signature
-    /// comparison establishes its recursion guard, so recursive re-entry is provisionally true.
-    pub(super) fn when_constraint_set_assignable_to_owned_for_mapping(
-        self,
-        db: &'db dyn Db,
-        target: Type<'db>,
-    ) -> Cow<'db, OwnedConstraintSet<'db>> {
-        #[salsa::tracked(
-            returns(ref),
-            cycle_initial=|_, _, _, _| OwnedConstraintSet::always(),
-            heap_size=ruff_memory_usage::heap_size,
-        )]
-        fn when_constraint_set_assignable_to_owned_impl<'db>(
-            db: &'db dyn Db,
-            source: Type<'db>,
-            target: Type<'db>,
-        ) -> OwnedConstraintSet<'db> {
-            constraint_set_assignable_to_owned(db, source, target)
+            let constraints = ConstraintSetBuilder::new();
+            constraints.into_owned(|constraints| {
+                source.has_relation_to_with_typevar_evaluation(
+                    db,
+                    target,
+                    constraints,
+                    InferableTypeVars::None,
+                    TypeRelation::Assignability,
+                    TypeVarEvaluation::Lazy,
+                )
+            })
         }
 
         if self.is_trivially_constraint_set_assignable_to(db, target) {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -237,6 +237,24 @@ impl TypeRelation {
     }
 }
 
+fn constraint_set_assignable_to_owned<'db>(
+    db: &'db dyn Db,
+    source: Type<'db>,
+    target: Type<'db>,
+) -> OwnedConstraintSet<'db> {
+    let constraints = ConstraintSetBuilder::new();
+    constraints.into_owned(|constraints| {
+        source.has_relation_to_with_typevar_evaluation(
+            db,
+            target,
+            constraints,
+            InferableTypeVars::None,
+            TypeRelation::Assignability,
+            TypeVarEvaluation::Lazy,
+        )
+    })
+}
+
 #[salsa::tracked]
 impl<'db> Type<'db> {
     /// Return `true` if subtyping is always reflexive for this type; `T <: T` is always true for
@@ -472,17 +490,7 @@ impl<'db> Type<'db> {
             source: Type<'db>,
             target: Type<'db>,
         ) -> OwnedConstraintSet<'db> {
-            let constraints = ConstraintSetBuilder::new();
-            constraints.into_owned(|constraints| {
-                source.has_relation_to_with_typevar_evaluation(
-                    db,
-                    target,
-                    constraints,
-                    InferableTypeVars::None,
-                    TypeRelation::Assignability,
-                    TypeVarEvaluation::Lazy,
-                )
-            })
+            constraint_set_assignable_to_owned(db, source, target)
         }
 
         if self.is_trivially_constraint_set_assignable_to(db, target) {
@@ -513,17 +521,7 @@ impl<'db> Type<'db> {
             source: Type<'db>,
             target: Type<'db>,
         ) -> OwnedConstraintSet<'db> {
-            let constraints = ConstraintSetBuilder::new();
-            constraints.into_owned(|constraints| {
-                source.has_relation_to_with_typevar_evaluation(
-                    db,
-                    target,
-                    constraints,
-                    InferableTypeVars::None,
-                    TypeRelation::Assignability,
-                    TypeVarEvaluation::Lazy,
-                )
-            })
+            constraint_set_assignable_to_owned(db, source, target)
         }
 
         if self.is_trivially_constraint_set_assignable_to(db, target) {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -494,6 +494,37 @@ impl<'db> Type<'db> {
         ))
     }
 
+    pub(super) fn when_constraint_set_subtype_of_owned(
+        self,
+        db: &'db dyn Db,
+        target: Type<'db>,
+    ) -> &'db OwnedConstraintSet<'db> {
+        #[salsa::tracked(
+            returns(ref),
+            cycle_initial=|_, _, _, _| OwnedConstraintSet::always(),
+            heap_size=ruff_memory_usage::heap_size,
+        )]
+        fn when_constraint_set_subtype_of_owned_impl<'db>(
+            db: &'db dyn Db,
+            source: Type<'db>,
+            target: Type<'db>,
+        ) -> OwnedConstraintSet<'db> {
+            let constraints = ConstraintSetBuilder::new();
+            constraints.into_owned(|constraints| {
+                source.has_relation_to_with_typevar_evaluation(
+                    db,
+                    target,
+                    constraints,
+                    InferableTypeVars::None,
+                    TypeRelation::Subtyping,
+                    TypeVarEvaluation::Lazy,
+                )
+            })
+        }
+
+        when_constraint_set_subtype_of_owned_impl(db, self, target)
+    }
+
     pub(super) fn when_constraint_set_assignable_to<'c>(
         self,
         db: &'db dyn Db,
@@ -851,24 +882,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable,
             ..self.clone()
         }
-    }
-
-    /// Check constraint-set assignability while sharing this checker's recursion state.
-    pub(super) fn check_constraint_set_assignability_pair(
-        &self,
-        db: &'db dyn Db,
-        source: Type<'db>,
-        target: Type<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        let checker = Self {
-            inferable: InferableTypeVars::None,
-            relation: TypeRelation::Assignability,
-            typevar_evaluation: TypeVarEvaluation::Lazy,
-            context_tree: None,
-            given: ConstraintSet::from_bool(self.constraints, false),
-            ..self.clone()
-        };
-        checker.check_type_pair(db, source, target)
     }
 
     pub(super) const fn is_eager_assignability(&self) -> bool {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -494,7 +494,11 @@ impl<'db> Type<'db> {
         ))
     }
 
-    pub(super) fn when_constraint_set_subtype_of_owned(
+    /// Computes assignability while remapping an owned constraint set.
+    ///
+    /// Remapping can evaluate recursive protocol relations before the enclosing signature
+    /// comparison establishes its recursion guard, so recursive re-entry is provisionally true.
+    pub(super) fn when_constraint_set_assignable_to_owned_for_mapping(
         self,
         db: &'db dyn Db,
         target: Type<'db>,
@@ -504,7 +508,7 @@ impl<'db> Type<'db> {
             cycle_initial=|_, _, _, _| OwnedConstraintSet::always(),
             heap_size=ruff_memory_usage::heap_size,
         )]
-        fn when_constraint_set_subtype_of_owned_impl<'db>(
+        fn when_constraint_set_assignable_to_owned_impl<'db>(
             db: &'db dyn Db,
             source: Type<'db>,
             target: Type<'db>,
@@ -516,13 +520,13 @@ impl<'db> Type<'db> {
                     target,
                     constraints,
                     InferableTypeVars::None,
-                    TypeRelation::Subtyping,
+                    TypeRelation::Assignability,
                     TypeVarEvaluation::Lazy,
                 )
             })
         }
 
-        when_constraint_set_subtype_of_owned_impl(db, self, target)
+        when_constraint_set_assignable_to_owned_impl(db, self, target)
     }
 
     pub(super) fn when_constraint_set_assignable_to<'c>(

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -502,7 +502,7 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         target: Type<'db>,
-    ) -> &'db OwnedConstraintSet<'db> {
+    ) -> Cow<'db, OwnedConstraintSet<'db>> {
         #[salsa::tracked(
             returns(ref),
             cycle_initial=|_, _, _, _| OwnedConstraintSet::always(),
@@ -526,7 +526,13 @@ impl<'db> Type<'db> {
             })
         }
 
-        when_constraint_set_assignable_to_owned_impl(db, self, target)
+        if self.is_trivially_constraint_set_assignable_to(db, target) {
+            return Cow::Owned(OwnedConstraintSet::always());
+        }
+
+        Cow::Borrowed(when_constraint_set_assignable_to_owned_impl(
+            db, self, target,
+        ))
     }
 
     pub(super) fn when_constraint_set_assignable_to<'c>(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -10,6 +10,7 @@
 //! argument types and return types. For each callable type in the union, the call expression's
 //! arguments must match _at least one_ overload.
 
+use std::cell::Cell;
 use std::fmt;
 use std::slice::Iter;
 use std::sync::Arc;
@@ -607,6 +608,38 @@ impl<'db> SignatureRelationKey<'db> {
 }
 
 pub(crate) type SignatureRelationVisitor<'db> = ActiveRecursionDetector<SignatureRelationKey<'db>>;
+
+// Receiver constraints can re-enter signature comparison while a signature is being prepared,
+// before the declaration-based recursion guard below is active. Until that recursion can be
+// represented structurally, bound it so an unsupported relation is rejected instead of
+// overflowing the process stack.
+const MAX_RECEIVER_CONSTRAINT_RELATION_DEPTH: u16 = 16;
+
+std::thread_local! {
+    static RECEIVER_CONSTRAINT_RELATION_DEPTH: Cell<u16> = const { Cell::new(0) };
+}
+
+struct ReceiverConstraintRelationDepthGuard;
+
+impl ReceiverConstraintRelationDepthGuard {
+    fn enter() -> Option<Self> {
+        RECEIVER_CONSTRAINT_RELATION_DEPTH.with(|depth| {
+            let current = depth.get();
+            if current >= MAX_RECEIVER_CONSTRAINT_RELATION_DEPTH {
+                None
+            } else {
+                depth.set(current + 1);
+                Some(Self)
+            }
+        })
+    }
+}
+
+impl Drop for ReceiverConstraintRelationDepthGuard {
+    fn drop(&mut self) {
+        RECEIVER_CONSTRAINT_RELATION_DEPTH.with(|depth| depth.set(depth.get() - 1));
+    }
+}
 
 pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
@@ -1953,6 +1986,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let _receiver_constraint_depth_guard =
+            if source.receiver_constraints.is_some() || target.receiver_constraints.is_some() {
+                let Some(guard) = ReceiverConstraintRelationDepthGuard::enter() else {
+                    return self.never();
+                };
+                Some(guard)
+            } else {
+                None
+            };
+
         // If either signature is generic, freshen that signature's typevars before considering
         // them inferable for this relation. The relation only needs to find one specialization of
         // each generic callable that causes the check to succeed, but those callable-local
@@ -4846,6 +4889,21 @@ mod tests {
         assert!(
             merge_receiver_constraints(&db, None, Some(OwnedConstraintSet::always())).is_none()
         );
+    }
+
+    #[test]
+    fn receiver_constraint_relation_depth_is_bounded() {
+        let guards: Vec<_> = (0..MAX_RECEIVER_CONSTRAINT_RELATION_DEPTH)
+            .filter_map(|_| ReceiverConstraintRelationDepthGuard::enter())
+            .collect();
+        assert_eq!(
+            guards.len(),
+            usize::from(MAX_RECEIVER_CONSTRAINT_RELATION_DEPTH)
+        );
+        assert!(ReceiverConstraintRelationDepthGuard::enter().is_none());
+
+        drop(guards);
+        assert!(ReceiverConstraintRelationDepthGuard::enter().is_some());
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -113,7 +113,10 @@ fn merge_receiver_constraints<'db>(
     first: Option<OwnedConstraintSet<'db>>,
     second: Option<OwnedConstraintSet<'db>>,
 ) -> Option<OwnedConstraintSet<'db>> {
-    match (first, second) {
+    match (
+        first.filter(|constraints| !constraints.is_always()),
+        second.filter(|constraints| !constraints.is_always()),
+    ) {
         (None, None) => None,
         (Some(constraints), None) | (None, Some(constraints)) => Some(constraints),
         (Some(first), Some(second)) => {
@@ -316,11 +319,21 @@ impl<'db> CallableSignature<'db> {
                             type_mapping.update_signature_generic_context(db, context)
                         }),
                         definition: self_signature.definition,
-                        receiver_constraints: self_signature.receiver_constraints.as_ref().map(
-                            |constraints| {
-                                constraints.apply_type_mapping(db, type_mapping, tcx, visitor)
-                            },
-                        ),
+                        receiver_constraints: self_signature
+                            .receiver_constraints
+                            .as_ref()
+                            .and_then(|constraints| {
+                                merge_receiver_constraints(
+                                    db,
+                                    None,
+                                    Some(constraints.apply_type_mapping(
+                                        db,
+                                        type_mapping,
+                                        tcx,
+                                        visitor,
+                                    )),
+                                )
+                            }),
                         parameters,
                         return_ty: self_signature.return_ty.apply_type_mapping_impl(
                             db,
@@ -881,10 +894,13 @@ impl<'db> Signature<'db> {
                 .generic_context
                 .map(|context| type_mapping.update_signature_generic_context(db, context)),
             definition: self.definition,
-            receiver_constraints: self
-                .receiver_constraints
-                .as_ref()
-                .map(|constraints| constraints.apply_type_mapping(db, type_mapping, tcx, visitor)),
+            receiver_constraints: self.receiver_constraints.as_ref().and_then(|constraints| {
+                merge_receiver_constraints(
+                    db,
+                    None,
+                    Some(constraints.apply_type_mapping(db, type_mapping, tcx, visitor)),
+                )
+            }),
             parameters: self
                 .parameters
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
@@ -1178,8 +1194,17 @@ impl<'db> Signature<'db> {
         let binding_context = self.definition.map(BindingContext::Definition);
         let self_mapping = TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
         let visitor = ApplyTypeMappingVisitor::default();
-        let receiver_constraints = self.receiver_constraints.as_ref().map(|constraints| {
-            constraints.apply_type_mapping(db, &self_mapping, TypeContext::default(), &visitor)
+        let receiver_constraints = self.receiver_constraints.as_ref().and_then(|constraints| {
+            merge_receiver_constraints(
+                db,
+                None,
+                Some(constraints.apply_type_mapping(
+                    db,
+                    &self_mapping,
+                    TypeContext::default(),
+                    &visitor,
+                )),
+            )
         });
         if !self.needs_self_mapping(db, false) {
             return Self {
@@ -1922,23 +1947,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
-        if source
-            .receiver_constraints
-            .as_ref()
-            .is_some_and(|constraints| {
-                constraints
-                    .types()
-                    .any(|ty| ty.has_typevar_or_typevar_instance(db))
-            })
-            || target
-                .receiver_constraints
-                .as_ref()
-                .is_some_and(|constraints| {
-                    constraints
-                        .types()
-                        .any(|ty| ty.has_typevar_or_typevar_instance(db))
-                })
-        {
+        // Every nonterminal receiver constraint constrains at least one typevar. Terminal `always`
+        // sets are discarded when receiver constraints are merged, so presence alone is enough to
+        // require lazy typevar evaluation here.
+        if source.receiver_constraints.is_some() || target.receiver_constraints.is_some() {
             checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         }
         let when = checker.with_signature_recursion_guard(source, target, || {
@@ -4781,6 +4793,17 @@ mod tests {
                 "source-backed parameter should have a definition"
             );
         }
+    }
+
+    #[test]
+    fn always_satisfied_receiver_constraints_are_discarded() {
+        let db = setup_db();
+        assert!(
+            merge_receiver_constraints(&db, Some(OwnedConstraintSet::always()), None).is_none()
+        );
+        assert!(
+            merge_receiver_constraints(&db, None, Some(OwnedConstraintSet::always())).is_none()
+        );
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -608,14 +608,6 @@ impl<'db> SignatureRelationKey<'db> {
 
 pub(crate) type SignatureRelationVisitor<'db> = ActiveRecursionDetector<SignatureRelationKey<'db>>;
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct ReceiverConstraintRelation;
-
-std::thread_local! {
-    static ACTIVE_RECEIVER_CONSTRAINT_RELATIONS:
-        ActiveRecursionDetector<ReceiverConstraintRelation> = ActiveRecursionDetector::default();
-}
-
 pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     signature: &Signature<'db>,
@@ -1956,45 +1948,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
     /// Implementation of subtyping and assignability for signature.
     fn check_signature_pair(
-        &self,
-        db: &'db dyn Db,
-        source: &Signature<'db>,
-        target: &Signature<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        if source.receiver_constraints.is_none() && target.receiver_constraints.is_none() {
-            return self.check_signature_pair_impl(db, source, target);
-        }
-
-        ACTIVE_RECEIVER_CONSTRAINT_RELATIONS.with(|active| {
-            active.visit(
-                &ReceiverConstraintRelation,
-                // TODO: Support nested relations involving bound receiver constraints. Until
-                // then, fall back to comparing the signatures without those constraints rather
-                // than overflowing the process stack.
-                || self.check_signature_pair_without_receiver_constraints(db, source, target),
-                || self.check_signature_pair_impl(db, source, target),
-            )
-        })
-    }
-
-    fn check_signature_pair_without_receiver_constraints(
-        &self,
-        db: &'db dyn Db,
-        source: &Signature<'db>,
-        target: &Signature<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        let source = Signature {
-            receiver_constraints: None,
-            ..source.clone()
-        };
-        let target = Signature {
-            receiver_constraints: None,
-            ..target.clone()
-        };
-        self.check_signature_pair_impl(db, &source, &target)
-    }
-
-    fn check_signature_pair_impl(
         &self,
         db: &'db dyn Db,
         source: &Signature<'db>,
@@ -4893,40 +4846,6 @@ mod tests {
         assert!(
             merge_receiver_constraints(&db, None, Some(OwnedConstraintSet::always())).is_none()
         );
-    }
-
-    #[test]
-    fn nested_receiver_constraint_relation_uses_unconstrained_fallback() {
-        let mut db = setup_db();
-        db.write_dedented("/src/a.py", "def f(self: int) -> None: ...")
-            .unwrap();
-        let function = get_function_f(&db, "/src/a.py")
-            .literal(&db)
-            .last_definition;
-        let signature = function
-            .signature(&db)
-            .bind_self(&db, Some(KnownClass::Str.to_instance(&db)));
-
-        let constraints = ConstraintSetBuilder::new();
-        assert!(
-            signature
-                .when_constraint_set_assignable_to(&db, &signature, &constraints)
-                .is_never_satisfied(&db)
-        );
-
-        let uses_fallback = ACTIVE_RECEIVER_CONSTRAINT_RELATIONS.with(|active| {
-            active.visit(
-                &ReceiverConstraintRelation,
-                || false,
-                || {
-                    let constraints = ConstraintSetBuilder::new();
-                    signature
-                        .when_constraint_set_assignable_to(&db, &signature, &constraints)
-                        .is_always_satisfied(&db)
-                },
-            )
-        });
-        assert!(uses_fallback);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -10,7 +10,6 @@
 //! argument types and return types. For each callable type in the union, the call expression's
 //! arguments must match _at least one_ overload.
 
-use std::cell::Cell;
 use std::fmt;
 use std::slice::Iter;
 use std::sync::Arc;
@@ -609,36 +608,12 @@ impl<'db> SignatureRelationKey<'db> {
 
 pub(crate) type SignatureRelationVisitor<'db> = ActiveRecursionDetector<SignatureRelationKey<'db>>;
 
-// Receiver constraints can re-enter signature comparison while a signature is being prepared,
-// before the declaration-based recursion guard below is active. Until that recursion can be
-// represented structurally, bound it so an unsupported relation is rejected instead of
-// overflowing the process stack.
-const MAX_RECEIVER_CONSTRAINT_RELATION_DEPTH: u16 = 16;
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct ReceiverConstraintRelation;
 
 std::thread_local! {
-    static RECEIVER_CONSTRAINT_RELATION_DEPTH: Cell<u16> = const { Cell::new(0) };
-}
-
-struct ReceiverConstraintRelationDepthGuard;
-
-impl ReceiverConstraintRelationDepthGuard {
-    fn enter() -> Option<Self> {
-        RECEIVER_CONSTRAINT_RELATION_DEPTH.with(|depth| {
-            let current = depth.get();
-            if current >= MAX_RECEIVER_CONSTRAINT_RELATION_DEPTH {
-                None
-            } else {
-                depth.set(current + 1);
-                Some(Self)
-            }
-        })
-    }
-}
-
-impl Drop for ReceiverConstraintRelationDepthGuard {
-    fn drop(&mut self) {
-        RECEIVER_CONSTRAINT_RELATION_DEPTH.with(|depth| depth.set(depth.get() - 1));
-    }
+    static ACTIVE_RECEIVER_CONSTRAINT_RELATIONS:
+        ActiveRecursionDetector<ReceiverConstraintRelation> = ActiveRecursionDetector::default();
 }
 
 pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
@@ -1986,16 +1961,45 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let _receiver_constraint_depth_guard =
-            if source.receiver_constraints.is_some() || target.receiver_constraints.is_some() {
-                let Some(guard) = ReceiverConstraintRelationDepthGuard::enter() else {
-                    return self.never();
-                };
-                Some(guard)
-            } else {
-                None
-            };
+        if source.receiver_constraints.is_none() && target.receiver_constraints.is_none() {
+            return self.check_signature_pair_impl(db, source, target);
+        }
 
+        ACTIVE_RECEIVER_CONSTRAINT_RELATIONS.with(|active| {
+            active.visit(
+                &ReceiverConstraintRelation,
+                // TODO: Support nested relations involving bound receiver constraints. Until
+                // then, fall back to comparing the signatures without those constraints rather
+                // than overflowing the process stack.
+                || self.check_signature_pair_without_receiver_constraints(db, source, target),
+                || self.check_signature_pair_impl(db, source, target),
+            )
+        })
+    }
+
+    fn check_signature_pair_without_receiver_constraints(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        let source = Signature {
+            receiver_constraints: None,
+            ..source.clone()
+        };
+        let target = Signature {
+            receiver_constraints: None,
+            ..target.clone()
+        };
+        self.check_signature_pair_impl(db, &source, &target)
+    }
+
+    fn check_signature_pair_impl(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+    ) -> ConstraintSet<'db, 'c> {
         // If either signature is generic, freshen that signature's typevars before considering
         // them inferable for this relation. The relation only needs to find one specialization of
         // each generic callable that causes the check to succeed, but those callable-local
@@ -4892,18 +4896,37 @@ mod tests {
     }
 
     #[test]
-    fn receiver_constraint_relation_depth_is_bounded() {
-        let guards: Vec<_> = (0..MAX_RECEIVER_CONSTRAINT_RELATION_DEPTH)
-            .filter_map(|_| ReceiverConstraintRelationDepthGuard::enter())
-            .collect();
-        assert_eq!(
-            guards.len(),
-            usize::from(MAX_RECEIVER_CONSTRAINT_RELATION_DEPTH)
-        );
-        assert!(ReceiverConstraintRelationDepthGuard::enter().is_none());
+    fn nested_receiver_constraint_relation_uses_unconstrained_fallback() {
+        let mut db = setup_db();
+        db.write_dedented("/src/a.py", "def f(self: int) -> None: ...")
+            .unwrap();
+        let function = get_function_f(&db, "/src/a.py")
+            .literal(&db)
+            .last_definition;
+        let signature = function
+            .signature(&db)
+            .bind_self(&db, Some(KnownClass::Str.to_instance(&db)));
 
-        drop(guards);
-        assert!(ReceiverConstraintRelationDepthGuard::enter().is_some());
+        let constraints = ConstraintSetBuilder::new();
+        assert!(
+            signature
+                .when_constraint_set_assignable_to(&db, &signature, &constraints)
+                .is_never_satisfied(&db)
+        );
+
+        let uses_fallback = ACTIVE_RECEIVER_CONSTRAINT_RELATIONS.with(|active| {
+            active.visit(
+                &ReceiverConstraintRelation,
+                || false,
+                || {
+                    let constraints = ConstraintSetBuilder::new();
+                    signature
+                        .when_constraint_set_assignable_to(&db, &signature, &constraints)
+                        .is_always_satisfied(&db)
+                },
+            )
+        });
+        assert!(uses_fallback);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -21,7 +21,7 @@ use smallvec::{SmallVec, smallvec_inline};
 use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{
-    ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
+    ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
 };
 use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::generics::{
@@ -108,233 +108,22 @@ pub struct CallableSignature<'db> {
     pub(crate) overloads: SmallVec<[Signature<'db>; 1]>,
 }
 
-/// One relation introduced when an explicitly annotated method receiver is bound.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-struct ReceiverBinding<'db> {
-    /// The receiver used to bind the method, or `None` if binding is deferred.
-    receiver: Option<Type<'db>>,
-    /// The receiver annotation removed from the public signature.
-    annotation: Type<'db>,
-}
-
-impl<'db> ReceiverBinding<'db> {
-    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
-        Self {
-            receiver: match (self.receiver, previous.receiver) {
-                (Some(receiver), Some(previous)) => {
-                    Some(receiver.cycle_normalized(db, previous, cycle))
-                }
-                (receiver, _) => receiver,
-            },
-            annotation: self
-                .annotation
-                .cycle_normalized(db, previous.annotation, cycle),
+fn merge_receiver_constraints<'db>(
+    db: &'db dyn Db,
+    first: Option<OwnedConstraintSet<'db>>,
+    second: Option<OwnedConstraintSet<'db>>,
+) -> Option<OwnedConstraintSet<'db>> {
+    match (first, second) {
+        (None, None) => None,
+        (Some(constraints), None) | (None, Some(constraints)) => Some(constraints),
+        (Some(first), Some(second)) => {
+            let constraints = ConstraintSetBuilder::new();
+            Some(constraints.into_owned(|builder| {
+                builder
+                    .load(db, &first)
+                    .and(db, builder, || builder.load(db, &second))
+            }))
         }
-    }
-
-    fn recursive_type_normalized_impl(
-        self,
-        db: &'db dyn Db,
-        div: Type<'db>,
-        nested: bool,
-    ) -> Option<Self> {
-        Some(Self {
-            receiver: match self.receiver {
-                Some(receiver) => Some(receiver.recursive_type_normalized_impl(db, div, nested)?),
-                None => None,
-            },
-            annotation: self
-                .annotation
-                .recursive_type_normalized_impl(db, div, nested)?,
-        })
-    }
-
-    fn recursive_type_normalized(self, db: &'db dyn Db, cycle: &salsa::Cycle) -> Self {
-        Self {
-            receiver: self
-                .receiver
-                .map(|receiver| receiver.recursive_type_normalized(db, cycle)),
-            annotation: self.annotation.recursive_type_normalized(db, cycle),
-        }
-    }
-
-    fn apply_type_mapping_impl<'a>(
-        self,
-        db: &'db dyn Db,
-        type_mapping: &TypeMapping<'a, 'db>,
-        tcx: TypeContext<'db>,
-        visitor: &ApplyTypeMappingVisitor<'db>,
-    ) -> Self {
-        Self {
-            receiver: self
-                .receiver
-                .map(|receiver| receiver.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
-            annotation: self
-                .annotation
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-        }
-    }
-
-    fn apply_self_with_receiver(
-        self,
-        db: &'db dyn Db,
-        receiver_type: Type<'db>,
-        self_type: Type<'db>,
-        binding_context: Option<BindingContext<'db>>,
-    ) -> Self {
-        let mapping = TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
-        Self {
-            receiver: self.receiver.or(Some(receiver_type)),
-            annotation: self
-                .annotation
-                .apply_type_mapping(db, &mapping, TypeContext::default()),
-        }
-    }
-
-    fn types(self) -> impl Iterator<Item = Type<'db>> {
-        self.receiver
-            .into_iter()
-            .chain(std::iter::once(self.annotation))
-    }
-
-    fn when_satisfied<'c>(
-        self,
-        checker: &TypeRelationChecker<'_, 'c, 'db>,
-        db: &'db dyn Db,
-    ) -> ConstraintSet<'db, 'c> {
-        let Some(receiver) = self.receiver else {
-            return checker.always();
-        };
-        checker.check_constraint_set_assignability_pair(db, receiver, self.annotation)
-    }
-}
-
-/// Relations retained after binding explicitly annotated method receivers.
-///
-/// Binding removes receiver parameters from a callable's public signature. These relations keep
-/// the removed parameters semantically present while the remaining signature is freshened,
-/// specialized, and compared.
-#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
-struct ReceiverBindings<'db> {
-    #[returns(deref)]
-    bindings: Box<[ReceiverBinding<'db>]>,
-}
-
-// The Salsa heap is tracked separately.
-impl get_size2::GetSize for ReceiverBindings<'_> {}
-
-impl<'db> ReceiverBindings<'db> {
-    fn single(db: &'db dyn Db, receiver: Option<Type<'db>>, annotation: Type<'db>) -> Self {
-        let bindings: Box<[_]> = Box::new([ReceiverBinding {
-            receiver,
-            annotation,
-        }]);
-        Self::new(db, bindings)
-    }
-
-    fn merge_optional(db: &'db dyn Db, first: Option<Self>, second: Option<Self>) -> Option<Self> {
-        match (first, second) {
-            (None, None) => None,
-            (Some(bindings), None) | (None, Some(bindings)) => Some(bindings),
-            (Some(first), Some(second)) => Some(Self::new(
-                db,
-                first
-                    .bindings(db)
-                    .iter()
-                    .chain(second.bindings(db))
-                    .copied()
-                    .collect::<Box<[_]>>(),
-            )),
-        }
-    }
-
-    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
-        Self::new(
-            db,
-            self.bindings(db)
-                .iter()
-                .enumerate()
-                .map(|(index, binding)| {
-                    previous.bindings(db).get(index).map_or_else(
-                        || binding.recursive_type_normalized(db, cycle),
-                        |previous| binding.cycle_normalized(db, *previous, cycle),
-                    )
-                })
-                .collect::<Box<[_]>>(),
-        )
-    }
-
-    fn recursive_type_normalized_impl(
-        self,
-        db: &'db dyn Db,
-        div: Type<'db>,
-        nested: bool,
-    ) -> Option<Self> {
-        Some(Self::new(
-            db,
-            self.bindings(db)
-                .iter()
-                .map(|binding| binding.recursive_type_normalized_impl(db, div, nested))
-                .collect::<Option<Box<[_]>>>()?,
-        ))
-    }
-
-    fn apply_type_mapping_impl<'a>(
-        self,
-        db: &'db dyn Db,
-        type_mapping: &TypeMapping<'a, 'db>,
-        tcx: TypeContext<'db>,
-        visitor: &ApplyTypeMappingVisitor<'db>,
-    ) -> Self {
-        Self::new(
-            db,
-            self.bindings(db)
-                .iter()
-                .map(|binding| binding.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
-                .collect::<Box<[_]>>(),
-        )
-    }
-
-    fn apply_self_with_receiver(
-        self,
-        db: &'db dyn Db,
-        receiver_type: Type<'db>,
-        self_type: Type<'db>,
-        binding_context: Option<BindingContext<'db>>,
-    ) -> Self {
-        Self::new(
-            db,
-            self.bindings(db)
-                .iter()
-                .map(|binding| {
-                    binding.apply_self_with_receiver(db, receiver_type, self_type, binding_context)
-                })
-                .collect::<Box<[_]>>(),
-        )
-    }
-
-    fn types(self, db: &'db dyn Db) -> impl Iterator<Item = Type<'db>> + 'db {
-        self.bindings(db)
-            .iter()
-            .copied()
-            .flat_map(ReceiverBinding::types)
-    }
-
-    fn contains_typevar(self, db: &'db dyn Db) -> bool {
-        self.types(db)
-            .any(|ty| ty.has_typevar_or_typevar_instance(db))
-    }
-
-    fn when_satisfied<'c>(
-        self,
-        checker: &TypeRelationChecker<'_, 'c, 'db>,
-        db: &'db dyn Db,
-    ) -> ConstraintSet<'db, 'c> {
-        self.bindings(db)
-            .iter()
-            .when_all(db, checker.constraints, |binding| {
-                binding.when_satisfied(checker, db)
-            })
     }
 }
 
@@ -527,9 +316,11 @@ impl<'db> CallableSignature<'db> {
                             type_mapping.update_signature_generic_context(db, context)
                         }),
                         definition: self_signature.definition,
-                        receiver_bindings: self_signature.receiver_bindings.map(|bindings| {
-                            bindings.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
-                        }),
+                        receiver_constraints: self_signature.receiver_constraints.as_ref().map(
+                            |constraints| {
+                                constraints.apply_type_mapping(db, type_mapping, tcx, visitor)
+                            },
+                        ),
                         parameters,
                         return_ty: self_signature.return_ty.apply_type_mapping_impl(
                             db,
@@ -552,12 +343,20 @@ impl<'db> CallableSignature<'db> {
                                 }),
                             ),
                             definition: signature.definition,
-                            receiver_bindings: ReceiverBindings::merge_optional(
+                            receiver_constraints: merge_receiver_constraints(
                                 db,
-                                signature.receiver_bindings,
-                                self_signature.receiver_bindings.map(|bindings| {
-                                    bindings.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
-                                }),
+                                signature.receiver_constraints.clone(),
+                                self_signature
+                                    .receiver_constraints
+                                    .as_ref()
+                                    .map(|constraints| {
+                                        constraints.apply_type_mapping(
+                                            db,
+                                            type_mapping,
+                                            tcx,
+                                            visitor,
+                                        )
+                                    }),
                             ),
                             parameters: signature.parameters().with_prefix(
                                 prefix_parameters.iter().map(|param| {
@@ -660,19 +459,15 @@ impl<'db> CallableSignature<'db> {
             .any(|signature| !signature.parameters().as_slice().is_empty())
     }
 
-    /// Replaces `typing.Self` while supplying the runtime receiver for a previously bound
-    /// explicit receiver annotation. This does not bind a visible receiver parameter.
-    pub(crate) fn apply_self_with_receiver(
-        &self,
-        db: &'db dyn Db,
-        receiver_type: Type<'db>,
-        self_type: Type<'db>,
-    ) -> Self {
+    /// Replaces any occurrences of `typing.Self` in the parameter and return annotations with the
+    /// given type. (Does not bind the `self` parameter; to do that, use
+    /// [`bind_self`][Self::bind_self].)
+    pub(crate) fn apply_self(&self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
         Self {
             overloads: self
                 .overloads
                 .iter()
-                .map(|signature| signature.apply_self_with_receiver(db, receiver_type, self_type))
+                .map(|signature| signature.apply_self(db, self_type))
                 .collect(),
         }
     }
@@ -748,7 +543,7 @@ pub struct Signature<'db> {
     pub(crate) definition: Option<Definition<'db>>,
 
     /// The constraint introduced by binding an explicitly annotated receiver, if any.
-    receiver_bindings: Option<ReceiverBindings<'db>>,
+    receiver_constraints: Option<OwnedConstraintSet<'db>>,
 
     /// Parameters, in source order.
     ///
@@ -818,7 +613,7 @@ pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     if let Some(generic_context) = &signature.generic_context {
         walk_generic_context(db, *generic_context, visitor);
     }
-    for ty in signature.receiver_binding_types(db) {
+    for ty in signature.receiver_constraint_types() {
         visitor.visit_type(db, ty);
     }
     // By default we usually don't visit the type of the default value,
@@ -887,7 +682,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: None,
             definition: None,
-            receiver_bindings: None,
+            receiver_constraints: None,
             parameters,
             return_ty,
         }
@@ -901,7 +696,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context,
             definition: None,
-            receiver_bindings: None,
+            receiver_constraints: None,
             parameters,
             return_ty,
         }
@@ -912,7 +707,7 @@ impl<'db> Signature<'db> {
         Signature {
             generic_context: None,
             definition: None,
-            receiver_bindings: None,
+            receiver_constraints: None,
             parameters: Parameters::gradual_form(),
             return_ty: signature_type,
         }
@@ -965,7 +760,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context,
             definition: Some(definition),
-            receiver_bindings: None,
+            receiver_constraints: None,
             parameters,
             return_ty,
         }
@@ -1038,12 +833,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: self.generic_context,
             definition: self.definition,
-            receiver_bindings: match (self.receiver_bindings, previous.receiver_bindings) {
-                (Some(bindings), Some(previous)) => {
-                    Some(bindings.cycle_normalized(db, previous, cycle))
-                }
-                (bindings, _) => bindings,
-            },
+            receiver_constraints: self.receiver_constraints.clone(),
             parameters,
             return_ty,
         }
@@ -1073,10 +863,7 @@ impl<'db> Signature<'db> {
         Some(Self {
             generic_context: self.generic_context,
             definition: self.definition,
-            receiver_bindings: match self.receiver_bindings {
-                Some(bindings) => Some(bindings.recursive_type_normalized_impl(db, div, nested)?),
-                None => None,
-            },
+            receiver_constraints: self.receiver_constraints.clone(),
             parameters,
             return_ty,
         })
@@ -1094,9 +881,10 @@ impl<'db> Signature<'db> {
                 .generic_context
                 .map(|context| type_mapping.update_signature_generic_context(db, context)),
             definition: self.definition,
-            receiver_bindings: self
-                .receiver_bindings
-                .map(|bindings| bindings.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
+            receiver_constraints: self
+                .receiver_constraints
+                .as_ref()
+                .map(|constraints| constraints.apply_type_mapping(db, type_mapping, tcx, visitor)),
             parameters: self
                 .parameters
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
@@ -1136,7 +924,7 @@ impl<'db> Signature<'db> {
             std::iter::once(parameter.annotated_type()).chain(parameter.default_type())
         });
         let types = typevars
-            .chain(self.receiver_binding_types(db))
+            .chain(self.receiver_constraint_types())
             .chain(parameters)
             .chain(std::iter::once(self.return_ty));
 
@@ -1150,7 +938,7 @@ impl<'db> Signature<'db> {
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
-        for ty in self.receiver_binding_types(db) {
+        for ty in self.receiver_constraint_types() {
             ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
         }
         for param in &self.parameters {
@@ -1260,23 +1048,29 @@ impl<'db> Signature<'db> {
         };
         let mut return_ty = self.return_ty;
         let binding_context = self.definition.map(BindingContext::Definition);
-        let mut receiver_bindings = ReceiverBindings::merge_optional(
-            db,
-            self.receiver_bindings,
-            explicit_receiver.map(|parameter| {
-                ReceiverBindings::single(db, receiver_type, parameter.annotated_type())
-            }),
-        );
-        if let Some(typing_self_type) = typing_self_type {
-            receiver_bindings = receiver_bindings.map(|bindings| {
-                bindings.apply_self_with_receiver(
+        let receiver_constraint = explicit_receiver.map(|parameter| {
+            let receiver = receiver_type.unwrap_or_else(|| {
+                Type::TypeVar(BoundTypeVarInstance::synthetic_self(
                     db,
-                    receiver_type.unwrap_or(typing_self_type),
-                    typing_self_type,
-                    binding_context,
-                )
+                    Type::object(),
+                    binding_context.unwrap_or(BindingContext::Synthetic),
+                ))
             });
-        }
+            let annotation = if let Some(typing_self_type) = typing_self_type {
+                let mapping =
+                    TypeMapping::BindSelf(SelfBinding::new(db, typing_self_type, binding_context));
+                parameter
+                    .annotated_type()
+                    .apply_type_mapping(db, &mapping, TypeContext::default())
+            } else {
+                parameter.annotated_type()
+            };
+            receiver
+                .when_constraint_set_assignable_to_owned(db, annotation)
+                .into_owned()
+        });
+        let receiver_constraints =
+            merge_receiver_constraints(db, self.receiver_constraints.clone(), receiver_constraint);
         if let Some(self_type) = typing_self_type
             && self.needs_self_mapping(db, removed_receiver)
         {
@@ -1295,7 +1089,7 @@ impl<'db> Signature<'db> {
                 .generic_context
                 .map(|generic_context| generic_context.remove_self(db, binding_context)),
             definition: self.definition,
-            receiver_bindings,
+            receiver_constraints,
             parameters,
             return_ty,
         }
@@ -1380,29 +1174,25 @@ impl<'db> Signature<'db> {
             .is_some_and(|parameter| parameter.is_positional() && parameter.inferred_annotation)
     }
 
-    fn apply_self_with_receiver(
-        &self,
-        db: &'db dyn Db,
-        receiver_type: Type<'db>,
-        self_type: Type<'db>,
-    ) -> Self {
+    pub(crate) fn apply_self(&self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
         let binding_context = self.definition.map(BindingContext::Definition);
-        let receiver_bindings = self.receiver_bindings.map(|bindings| {
-            bindings.apply_self_with_receiver(db, receiver_type, self_type, binding_context)
+        let self_mapping = TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
+        let visitor = ApplyTypeMappingVisitor::default();
+        let receiver_constraints = self.receiver_constraints.as_ref().map(|constraints| {
+            constraints.apply_type_mapping(db, &self_mapping, TypeContext::default(), &visitor)
         });
         if !self.needs_self_mapping(db, false) {
             return Self {
-                receiver_bindings,
+                receiver_constraints,
                 ..self.clone()
             };
         }
 
-        let self_mapping = TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
         let parameters = self.parameters.apply_type_mapping_impl(
             db,
             &self_mapping,
             TypeContext::default(),
-            &ApplyTypeMappingVisitor::default(),
+            &visitor,
         );
         let return_ty =
             self.return_ty
@@ -1410,27 +1200,27 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: self.generic_context,
             definition: self.definition,
-            receiver_bindings,
+            receiver_constraints,
             parameters,
             return_ty,
         }
     }
 
-    fn receiver_bindings_when_satisfied<'c>(
+    fn receiver_constraints_when_satisfied<'c>(
         &self,
         checker: &TypeRelationChecker<'_, 'c, 'db>,
         db: &'db dyn Db,
     ) -> ConstraintSet<'db, 'c> {
-        let Some(bindings) = self.receiver_bindings else {
+        let Some(constraints) = self.receiver_constraints.as_ref() else {
             return checker.always();
         };
-        bindings.when_satisfied(checker, db)
+        checker.constraints.load(db, constraints)
     }
 
-    fn receiver_binding_types(&self, db: &'db dyn Db) -> impl Iterator<Item = Type<'db>> + 'db {
-        self.receiver_bindings
-            .into_iter()
-            .flat_map(|bindings| bindings.types(db))
+    fn receiver_constraint_types(&self) -> impl Iterator<Item = Type<'db>> + '_ {
+        self.receiver_constraints
+            .iter()
+            .flat_map(OwnedConstraintSet::types)
     }
 
     /// Returns this signature with the given specialization applied to parameters and return type.
@@ -1810,10 +1600,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Aggregation summarizes visible parameters and return types, but receiver bindings are
         // additional per-signature obligations. Leave those signatures to the ordinary relation,
         // which checks each receiver binding before comparing the visible signature.
-        if target_signature.receiver_bindings.is_some()
+        if target_signature.receiver_constraints.is_some()
             || source_signatures
                 .iter()
-                .any(|signature| signature.receiver_bindings.is_some())
+                .any(|signature| signature.receiver_constraints.is_some())
         {
             return None;
         }
@@ -2133,23 +1923,33 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
         if source
-            .receiver_bindings
-            .is_some_and(|bindings| bindings.contains_typevar(db))
+            .receiver_constraints
+            .as_ref()
+            .is_some_and(|constraints| {
+                constraints
+                    .types()
+                    .any(|ty| ty.has_typevar_or_typevar_instance(db))
+            })
             || target
-                .receiver_bindings
-                .is_some_and(|bindings| bindings.contains_typevar(db))
+                .receiver_constraints
+                .as_ref()
+                .is_some_and(|constraints| {
+                    constraints
+                        .types()
+                        .any(|ty| ty.has_typevar_or_typevar_instance(db))
+                })
         {
             checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         }
         let when = checker.with_signature_recursion_guard(source, target, || {
             source
-                .receiver_bindings_when_satisfied(&checker, db)
+                .receiver_constraints_when_satisfied(&checker, db)
                 .and(db, self.constraints, || {
-                    target.receiver_bindings_when_satisfied(&checker, db).and(
-                        db,
-                        self.constraints,
-                        || checker.check_signature_pair_inner(db, source, target),
-                    )
+                    target
+                        .receiver_constraints_when_satisfied(&checker, db)
+                        .and(db, self.constraints, || {
+                            checker.check_signature_pair_inner(db, source, target)
+                        })
                 })
         });
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -319,21 +319,12 @@ impl<'db> CallableSignature<'db> {
                             type_mapping.update_signature_generic_context(db, context)
                         }),
                         definition: self_signature.definition,
-                        receiver_constraints: self_signature
-                            .receiver_constraints
-                            .as_ref()
-                            .and_then(|constraints| {
-                                merge_receiver_constraints(
-                                    db,
-                                    None,
-                                    Some(constraints.apply_type_mapping(
-                                        db,
-                                        type_mapping,
-                                        tcx,
-                                        visitor,
-                                    )),
-                                )
-                            }),
+                        receiver_constraints: self_signature.map_receiver_constraints(
+                            db,
+                            type_mapping,
+                            tcx,
+                            visitor,
+                        ),
                         parameters,
                         return_ty: self_signature.return_ty.apply_type_mapping_impl(
                             db,
@@ -359,17 +350,12 @@ impl<'db> CallableSignature<'db> {
                             receiver_constraints: merge_receiver_constraints(
                                 db,
                                 signature.receiver_constraints.clone(),
-                                self_signature
-                                    .receiver_constraints
-                                    .as_ref()
-                                    .map(|constraints| {
-                                        constraints.apply_type_mapping(
-                                            db,
-                                            type_mapping,
-                                            tcx,
-                                            visitor,
-                                        )
-                                    }),
+                                self_signature.map_receiver_constraints(
+                                    db,
+                                    type_mapping,
+                                    tcx,
+                                    visitor,
+                                ),
                             ),
                             parameters: signature.parameters().with_prefix(
                                 prefix_parameters.iter().map(|param| {
@@ -894,13 +880,7 @@ impl<'db> Signature<'db> {
                 .generic_context
                 .map(|context| type_mapping.update_signature_generic_context(db, context)),
             definition: self.definition,
-            receiver_constraints: self.receiver_constraints.as_ref().and_then(|constraints| {
-                merge_receiver_constraints(
-                    db,
-                    None,
-                    Some(constraints.apply_type_mapping(db, type_mapping, tcx, visitor)),
-                )
-            }),
+            receiver_constraints: self.map_receiver_constraints(db, type_mapping, tcx, visitor),
             parameters: self
                 .parameters
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
@@ -1194,18 +1174,8 @@ impl<'db> Signature<'db> {
         let binding_context = self.definition.map(BindingContext::Definition);
         let self_mapping = TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
         let visitor = ApplyTypeMappingVisitor::default();
-        let receiver_constraints = self.receiver_constraints.as_ref().and_then(|constraints| {
-            merge_receiver_constraints(
-                db,
-                None,
-                Some(constraints.apply_type_mapping(
-                    db,
-                    &self_mapping,
-                    TypeContext::default(),
-                    &visitor,
-                )),
-            )
-        });
+        let receiver_constraints =
+            self.map_receiver_constraints(db, &self_mapping, TypeContext::default(), &visitor);
         if !self.needs_self_mapping(db, false) {
             return Self {
                 receiver_constraints,
@@ -1240,6 +1210,19 @@ impl<'db> Signature<'db> {
             return checker.always();
         };
         checker.constraints.load(db, constraints)
+    }
+
+    fn map_receiver_constraints(
+        &self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'_, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Option<OwnedConstraintSet<'db>> {
+        self.receiver_constraints
+            .as_ref()
+            .map(|constraints| constraints.apply_type_mapping(db, type_mapping, tcx, visitor))
+            .filter(|constraints| !constraints.is_always())
     }
 
     fn receiver_constraint_types(&self) -> impl Iterator<Item = Type<'db>> + '_ {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -458,15 +458,19 @@ impl<'db> CallableSignature<'db> {
             .any(|signature| !signature.parameters().as_slice().is_empty())
     }
 
-    /// Replaces any occurrences of `typing.Self` in the parameter and return annotations with the
-    /// given type. (Does not bind the `self` parameter; to do that, use
-    /// [`bind_self`][Self::bind_self].)
-    pub(crate) fn apply_self(&self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
+    /// Replaces `typing.Self` while supplying the runtime receiver for a previously bound
+    /// explicit receiver annotation. This does not bind a visible receiver parameter.
+    pub(crate) fn apply_self_with_receiver(
+        &self,
+        db: &'db dyn Db,
+        receiver_type: Type<'db>,
+        self_type: Type<'db>,
+    ) -> Self {
         Self {
             overloads: self
                 .overloads
                 .iter()
-                .map(|signature| signature.apply_self(db, self_type))
+                .map(|signature| signature.apply_self_with_receiver(db, receiver_type, self_type))
                 .collect(),
         }
     }
@@ -1049,7 +1053,7 @@ impl<'db> Signature<'db> {
                 Type::TypeVar(BoundTypeVarInstance::synthetic_self(
                     db,
                     Type::object(),
-                    binding_context.unwrap_or(BindingContext::Synthetic),
+                    BindingContext::Synthetic,
                 ))
             });
             let annotation = if let Some(typing_self_type) = typing_self_type {
@@ -1170,12 +1174,38 @@ impl<'db> Signature<'db> {
             .is_some_and(|parameter| parameter.is_positional() && parameter.inferred_annotation)
     }
 
-    pub(crate) fn apply_self(&self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
+    fn apply_self_with_receiver(
+        &self,
+        db: &'db dyn Db,
+        receiver_type: Type<'db>,
+        self_type: Type<'db>,
+    ) -> Self {
         let binding_context = self.definition.map(BindingContext::Definition);
+        let receiver_mapping = TypeMapping::BindSelf(SelfBinding::new(
+            db,
+            receiver_type,
+            Some(BindingContext::Synthetic),
+        ));
         let self_mapping = TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
-        let visitor = ApplyTypeMappingVisitor::default();
-        let receiver_constraints =
-            self.map_receiver_constraints(db, &self_mapping, TypeContext::default(), &visitor);
+        let receiver_visitor = ApplyTypeMappingVisitor::default();
+        let self_visitor = ApplyTypeMappingVisitor::default();
+        let receiver_constraints = self
+            .map_receiver_constraints(
+                db,
+                &receiver_mapping,
+                TypeContext::default(),
+                &receiver_visitor,
+            )
+            .map(|constraints| {
+                Self::map_constraints(
+                    db,
+                    &constraints,
+                    &self_mapping,
+                    TypeContext::default(),
+                    &self_visitor,
+                )
+            })
+            .filter(|constraints| !constraints.is_always());
         if !self.needs_self_mapping(db, false) {
             return Self {
                 receiver_constraints,
@@ -1187,11 +1217,14 @@ impl<'db> Signature<'db> {
             db,
             &self_mapping,
             TypeContext::default(),
-            &visitor,
+            &self_visitor,
         );
-        let return_ty =
-            self.return_ty
-                .apply_type_mapping(db, &self_mapping, TypeContext::default());
+        let return_ty = self.return_ty.apply_type_mapping_impl(
+            db,
+            &self_mapping,
+            TypeContext::default(),
+            &self_visitor,
+        );
         Self {
             generic_context: self.generic_context,
             definition: self.definition,
@@ -1219,10 +1252,36 @@ impl<'db> Signature<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Option<OwnedConstraintSet<'db>> {
-        self.receiver_constraints
-            .as_ref()
-            .map(|constraints| constraints.apply_type_mapping(db, type_mapping, tcx, visitor))
-            .filter(|constraints| !constraints.is_always())
+        let constraints = self.receiver_constraints.as_ref()?;
+        Some(Self::map_constraints(
+            db,
+            constraints,
+            type_mapping,
+            tcx,
+            visitor,
+        ))
+        .filter(|constraints| !constraints.is_always())
+    }
+
+    fn map_constraints(
+        db: &'db dyn Db,
+        constraints: &OwnedConstraintSet<'db>,
+        type_mapping: &TypeMapping<'_, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> OwnedConstraintSet<'db> {
+        if !constraints
+            .types()
+            .any(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor) != ty)
+        {
+            return constraints.clone();
+        }
+
+        constraints.query(|_builder, constraints| {
+            constraints
+                .apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                .into_owned(db)
+        })
     }
 
     fn receiver_constraint_types(&self) -> impl Iterator<Item = Type<'db>> + '_ {


### PR DESCRIPTION
## Summary

#26776 preserves the assignability relation introduced when an explicitly annotated method receiver is bound. It currently represents that relation using dedicated receiver-binding structs and reconstructs the corresponding constraints during each signature comparison.

This PR stores the relation directly as an `OwnedConstraintSet`. Binding a receiver snapshots its assignability obligation, signature transformations apply the same type mappings to the stored constraint set, and signature comparison loads the result into its active constraint builder. The implementation uses `ConstraintSet::apply_type_mapping_impl` from #26801 rather than maintaining a separate constraint-mapping implementation.

Deferred protocol receivers remain distinct from `typing.Self`: for a class method such as `cls: type[Self]`, the runtime receiver is the class object while `Self` denotes an instance. An internal deferred receiver is therefore mapped first, followed by the ordinary `Self` mapping.

This representation is intended as the bridge between bound-method handling and the universal signature relation in #26695: receiver obligations can participate directly in implication and quantification without a signature-specific parallel constraint model.

#26814 makes the owned relation used here cycle-aware when derived constraints recurse through protocols. This PR is stacked on that low-level fix.