### PR TITLE
[ty] Support class objects satisfying instance-method protocols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5043,7 +5043,7 @@ def _(cls: type[DecoratedMethods]) -> None:
     reveal_type(cls.class_)  # revealed: (value: int) -> str
 ```
 
-`Self` in a class method is bound to the class object being checked.
+`Self` in a class method names the instance constructed by the class object being checked.
 
 ```py
 class SelfFactory(Protocol):
@@ -5140,6 +5140,115 @@ class HiddenMethod(metaclass=HidingMeta):
         return b"foo"
 
 static_assert(not is_assignable_to(TypeOf[HiddenMethod], type[Foo]))
+```
+
+## Meta-protocols satisfying instance-method protocols
+
+A value of type `type[P]` is itself a class object, so it can satisfy another protocol through its
+directly accessible methods. An ordinary method on `P` remains unbound when accessed through
+`type[P]`, while class and static methods are bound. Generic specialization and overloads are
+preserved in either case.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Iterable, Iterator, Protocol, Self, overload
+
+class BoundMethod(Protocol):
+    def method(self, value: int) -> str: ...
+
+class InstanceMethodSource(Protocol):
+    def method(self, value: int) -> str: ...
+
+class UnboundMethod(Protocol):
+    def method(self, instance: InstanceMethodSource, /, value: int) -> str: ...
+
+class StaticMethodSource(Protocol):
+    @staticmethod
+    def method(value: int) -> str: ...
+
+class ClassMethodSource(Protocol):
+    @classmethod
+    def method(cls, value: int) -> str: ...
+
+def _(
+    instance_source: type[InstanceMethodSource],
+    static_source: type[StaticMethodSource],
+    class_source: type[ClassMethodSource],
+) -> None:
+    reveal_type(instance_source.method)  # revealed: (self, /, value: int) -> str
+    unbound: UnboundMethod = instance_source
+    bound: BoundMethod = instance_source  # error: [invalid-assignment]
+    reveal_type(static_source.method)  # revealed: (value: int) -> str
+    static_bound: BoundMethod = static_source
+    reveal_type(class_source.method)  # revealed: (value: int) -> str
+    class_bound: BoundMethod = class_source
+
+class GenericBoundMethod[T](Protocol):
+    def method(self, value: T) -> T: ...
+
+class GenericStaticMethodSource[T](Protocol):
+    @staticmethod
+    def method(value: T) -> T: ...
+
+def _(source: type[GenericStaticMethodSource[int]]) -> None:
+    reveal_type(source.method)  # revealed: (value: int) -> int
+    good: GenericBoundMethod[int] = source
+    bad: GenericBoundMethod[str] = source  # error: [invalid-assignment]
+
+class OverloadedBoundMethod(Protocol):
+    @overload
+    def method(self, value: int) -> int: ...
+    @overload
+    def method(self, value: str) -> str: ...
+
+class OverloadedStaticMethodSource(Protocol):
+    @overload
+    @staticmethod
+    def method(value: int) -> int: ...
+    @overload
+    @staticmethod
+    def method(value: str) -> str: ...
+
+def _(source: type[OverloadedStaticMethodSource]) -> None:
+    reveal_type(source.method)  # revealed: Overload[(value: int) -> int, (value: str) -> str]
+    overloaded: OverloadedBoundMethod = source
+
+class Copier(Protocol):
+    def copy(self) -> Self: ...
+
+class InstanceFactory(Protocol):
+    @classmethod
+    def copy(cls) -> Self: ...
+
+class ClassObjectFactory(Protocol):
+    @classmethod
+    def copy(cls) -> type[Self]: ...
+
+def _(instance_factory: type[InstanceFactory], class_object_factory: type[ClassObjectFactory]) -> None:
+    reveal_type(instance_factory.copy)  # revealed: () -> InstanceFactory
+    bad: Copier = instance_factory  # error: [invalid-assignment]
+    reveal_type(class_object_factory.copy)  # revealed: () -> type[ClassObjectFactory]
+    good: Copier = class_object_factory
+
+class IterableSource(Protocol):
+    def __iter__(self) -> Iterator[int]: ...
+
+class CustomSource(Protocol):
+    @classmethod
+    def __custom__(cls, value: int) -> str: ...
+
+class CustomConsumer(Protocol):
+    def __custom__(self, value: int) -> str: ...
+
+def _(iterable_source: type[IterableSource], custom_source: type[CustomSource]) -> None:
+    reveal_type(iterable_source.__iter__)  # revealed: (self, /) -> Iterator[int]
+    iterable: Iterable[int] = iterable_source  # error: [invalid-assignment]
+    reveal_type(custom_source.__custom__)  # revealed: (value: int) -> str
+    custom: CustomConsumer = custom_source
 ```
 
 ## Generic meta-protocols

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2930,9 +2930,9 @@ class Foo:
 static_assert(not is_assignable_to(Foo, Iterable[Any]))
 ```
 
-Because method members are always looked up on the meta-type of an object when testing assignability
-and subtyping, we understand that `IterableClass` here is a subtype of `Iterable[int]` even though
-`IterableClass.__iter__` has the wrong signature:
+Special method members are looked up on the meta-type of an object when testing assignability and
+subtyping, matching Python's special-method lookup. We therefore understand that `IterableClass`
+here is a subtype of `Iterable[int]` even though `IterableClass.__iter__` has the wrong signature:
 
 ```py
 from typing import Iterator, Iterable
@@ -3302,6 +3302,65 @@ class BadFactory:
 
 static_assert(is_assignable_to(TypeOf[Factory], FactoryProtocol))
 static_assert(not is_assignable_to(TypeOf[BadFactory], FactoryProtocol))
+```
+
+## Class objects and `Self`-returning instance-method protocol members
+
+A class object can satisfy a protocol with a regular instance-method member if the class object's
+directly accessible member has a compatible bound signature. Class and static methods therefore
+work, but a regular instance method does not: accessing it through the class produces an unbound
+function rather than a method bound to the class object.
+
+A custom dunder such as `__custom__` is an ordinary method: it is accessed directly on the class
+object and does not use Python's special-method lookup.
+
+```py
+from typing import Protocol
+from typing_extensions import Self
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_assignable_to
+
+class CopierProtocol(Protocol):
+    def copy(self) -> Self: ...
+
+class CustomCopierProtocol(Protocol):
+    def __custom__(self, value: int) -> str: ...
+
+class Copier:
+    def copy(self) -> Self:
+        return self
+
+class ClassCopier:
+    @classmethod
+    def copy(cls) -> Self:
+        return cls()
+
+class StaticCopier:
+    @staticmethod
+    def copy() -> "StaticCopier":
+        return StaticCopier()
+
+class CustomCopier:
+    @classmethod
+    def __custom__(cls, value: int) -> str:
+        return str(value)
+
+class CopierMeta(type):
+    def copy(cls) -> "BadDirectCopier":
+        return BadDirectCopier()
+
+class BadDirectCopier(metaclass=CopierMeta):
+    def copy(self, value: int) -> Self:
+        return self
+
+static_assert(is_assignable_to(Copier, CopierProtocol))
+static_assert(not is_assignable_to(TypeOf[Copier], CopierProtocol))
+static_assert(is_assignable_to(TypeOf[ClassCopier], CopierProtocol))
+static_assert(is_assignable_to(TypeOf[StaticCopier], CopierProtocol))
+static_assert(is_assignable_to(TypeOf[CustomCopier], CustomCopierProtocol))
+# The metaclass method is compatible, but ordinary protocol methods describe direct access on the
+# class object, where `BadDirectCopier.copy` is an incompatible unbound function.
+static_assert(not is_assignable_to(TypeOf[BadDirectCopier], CopierProtocol))
 ```
 
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3258,10 +3258,12 @@ parser: Parser = IntParser
 ## Class objects and `Self`-returning class-method protocol members
 
 When a class object is checked against a class-method protocol member, `Self` in the protocol
-signature is bound to instances of the class object rather than to the class object itself:
+signature names the class object. A class method that returns `Self` returns an instance and cannot
+satisfy that requirement; a class method that returns `type[Self]` can satisfy a `type[C]`
+candidate:
 
 ```py
-from typing import Protocol
+from typing import Protocol, TypeVar
 from typing_extensions import Self
 from ty_extensions import static_assert
 from ty_extensions._internal import TypeOf, is_assignable_to
@@ -3280,8 +3282,25 @@ class BadFactory:
     def make(cls) -> int:
         return 1
 
-static_assert(is_assignable_to(TypeOf[Factory], FactoryProtocol))
+class ClassObjectFactory:
+    @classmethod
+    def make(cls) -> type[Self]:
+        return cls
+
+static_assert(not is_assignable_to(TypeOf[Factory], FactoryProtocol))
 static_assert(not is_assignable_to(TypeOf[BadFactory], FactoryProtocol))
+static_assert(is_assignable_to(type[ClassObjectFactory], FactoryProtocol))
+
+T = TypeVar("T", bound=FactoryProtocol)
+
+def exact_factory(value: T) -> T:
+    return value.make()
+
+exact_factory(Factory)  # error: [invalid-argument-type]
+exact_factory(ClassObjectFactory)  # error: [invalid-argument-type]
+
+def _(factory: type[ClassObjectFactory]) -> None:
+    exact_factory(factory)
 ```
 
 ## Class objects and `Self`-returning instance-method protocol members
@@ -3289,16 +3308,20 @@ static_assert(not is_assignable_to(TypeOf[BadFactory], FactoryProtocol))
 A class object can satisfy a protocol with a regular instance-method member if the class object's
 directly accessible member has a compatible bound signature. Class and static methods therefore
 work, but a regular instance method does not: accessing it through the class produces an unbound
-function rather than a method bound to the class object.
+function rather than a method bound to the class object. If the protocol method returns `Self`, the
+implementation must return the class object, not an instance of the class.
 
 ```py
-from typing import Protocol
+from typing import Protocol, TypeVar
 from typing_extensions import Self
 from ty_extensions import static_assert
 from ty_extensions._internal import TypeOf, is_assignable_to
 
 class CopierProtocol(Protocol):
     def copy(self) -> Self: ...
+
+class PlainCopierProtocol(Protocol):
+    def copy(self) -> str: ...
 
 class Copier:
     def copy(self) -> Self:
@@ -3314,6 +3337,21 @@ class StaticCopier:
     def copy() -> "StaticCopier":
         return StaticCopier()
 
+class ClassObjectCopier:
+    @classmethod
+    def copy(cls) -> type[Self]:
+        return cls
+
+class PlainClassCopier:
+    @classmethod
+    def copy(cls) -> str:
+        return "copy"
+
+class PlainStaticCopier:
+    @staticmethod
+    def copy() -> str:
+        return "copy"
+
 class CopierMeta(type):
     def copy(cls) -> "BadDirectCopier":
         return BadDirectCopier()
@@ -3324,11 +3362,26 @@ class BadDirectCopier(metaclass=CopierMeta):
 
 static_assert(is_assignable_to(Copier, CopierProtocol))
 static_assert(not is_assignable_to(TypeOf[Copier], CopierProtocol))
-static_assert(is_assignable_to(TypeOf[ClassCopier], CopierProtocol))
-static_assert(is_assignable_to(TypeOf[StaticCopier], CopierProtocol))
+static_assert(not is_assignable_to(TypeOf[ClassCopier], CopierProtocol))
+static_assert(not is_assignable_to(TypeOf[StaticCopier], CopierProtocol))
+static_assert(is_assignable_to(type[ClassObjectCopier], CopierProtocol))
+static_assert(is_assignable_to(TypeOf[PlainClassCopier], PlainCopierProtocol))
+static_assert(is_assignable_to(TypeOf[PlainStaticCopier], PlainCopierProtocol))
 # The metaclass method is compatible, but ordinary protocol methods describe direct access on the
 # class object, where `BadDirectCopier.copy` is an incompatible unbound function.
 static_assert(not is_assignable_to(TypeOf[BadDirectCopier], CopierProtocol))
+
+T = TypeVar("T", bound=CopierProtocol)
+
+def exact_copy(value: T) -> T:
+    return value.copy()
+
+exact_copy(ClassCopier)  # error: [invalid-argument-type]
+exact_copy(StaticCopier)  # error: [invalid-argument-type]
+exact_copy(ClassObjectCopier)  # error: [invalid-argument-type]
+
+def _(copier: type[ClassObjectCopier]) -> None:
+    exact_copy(copier)
 ```
 
 ## Class objects and dunder instance-method protocol members
@@ -3351,6 +3404,27 @@ class IterableClass(metaclass=Meta):
         yield from "abc"
 
 static_assert(is_subtype_of(TypeOf[IterableClass], Iterable[int]))
+
+class DirectIterable:
+    @classmethod
+    def __iter__(cls) -> Iterator[int]:
+        yield from range(42)
+
+iterable: Iterable[int] = DirectIterable  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `<class 'DirectIterable'>` is not assignable to `Iterable[int]`
+  --> src/mdtest_snippet.py:20:11
+   |
+20 | iterable: Iterable[int] = DirectIterable  # snapshot
+   |           -------------   ^^^^^^^^^^^^^^ Incompatible value of type `<class 'DirectIterable'>`
+   |           |
+   |           Declared type
+   |
+info: type `<class 'DirectIterable'>` is not assignable to protocol `Iterable[int]`
+info: └── protocol member `__iter__` is not defined on type `<class 'DirectIterable'>`
+info:     └── special methods must be defined on the meta-type when matching a protocol
 ```
 
 A custom dunder such as `__custom__` is an ordinary method: it is accessed directly on the class

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2909,14 +2909,14 @@ static_assert(not is_assignable_to(Foo, SupportsFooMethod))
 static_assert(is_assignable_to(Foo, SupportsFooAttr))
 ```
 
-The reason for this is that some methods, such as dunder methods, are always looked up on the class
-directly. If a class with an `__iter__` instance attribute satisfied the `Iterable` protocol, for
-example, the `Iterable` protocol would not accurately describe the requirements Python has for a
-class to be iterable at runtime. Allowing callable instance attributes to satisfy method members of
-protocols would also make `issubclass()` narrowing of runtime-checkable protocols unsound, as the
-`issubclass()` mechanism at runtime for protocols only checks whether a method is accessible on the
-class object, not the instance. (Protocols with non-method members cannot be passed to
-`issubclass()` at all at runtime.)
+The reason for this is that some methods, such as Python's special methods, are always looked up on
+the class directly. If a class with an `__iter__` instance attribute satisfied the `Iterable`
+protocol, for example, the `Iterable` protocol would not accurately describe the requirements Python
+has for a class to be iterable at runtime. Allowing callable instance attributes to satisfy method
+members of protocols would also make `issubclass()` narrowing of runtime-checkable protocols
+unsound, as the `issubclass()` mechanism at runtime for protocols only checks whether a method is
+accessible on the class object, not the instance. (Protocols with non-method members cannot be
+passed to `issubclass()` at all at runtime.)
 
 ```py
 from typing import Iterable, Any
@@ -2928,26 +2928,6 @@ class Foo:
         self.__iter__: Callable[..., object] = lambda *args, **kwargs: None
 
 static_assert(not is_assignable_to(Foo, Iterable[Any]))
-```
-
-Special method members are looked up on the meta-type of an object when testing assignability and
-subtyping, matching Python's special-method lookup. We therefore understand that `IterableClass`
-here is a subtype of `Iterable[int]` even though `IterableClass.__iter__` has the wrong signature:
-
-```py
-from typing import Iterator, Iterable
-from ty_extensions import static_assert
-from ty_extensions._internal import TypeOf, is_subtype_of
-
-class Meta(type):
-    def __iter__(self) -> Iterator[int]:
-        yield from range(42)
-
-class IterableClass(metaclass=Meta):
-    def __iter__(self) -> Iterator[str]:
-        yield from "abc"
-
-static_assert(is_subtype_of(TypeOf[IterableClass], Iterable[int]))
 ```
 
 Enforcing that members must always be available on the class also means that it is safe to access a
@@ -3311,9 +3291,6 @@ directly accessible member has a compatible bound signature. Class and static me
 work, but a regular instance method does not: accessing it through the class produces an unbound
 function rather than a method bound to the class object.
 
-A custom dunder such as `__custom__` is an ordinary method: it is accessed directly on the class
-object and does not use Python's special-method lookup.
-
 ```py
 from typing import Protocol
 from typing_extensions import Self
@@ -3322,9 +3299,6 @@ from ty_extensions._internal import TypeOf, is_assignable_to
 
 class CopierProtocol(Protocol):
     def copy(self) -> Self: ...
-
-class CustomCopierProtocol(Protocol):
-    def __custom__(self, value: int) -> str: ...
 
 class Copier:
     def copy(self) -> Self:
@@ -3340,11 +3314,6 @@ class StaticCopier:
     def copy() -> "StaticCopier":
         return StaticCopier()
 
-class CustomCopier:
-    @classmethod
-    def __custom__(cls, value: int) -> str:
-        return str(value)
-
 class CopierMeta(type):
     def copy(cls) -> "BadDirectCopier":
         return BadDirectCopier()
@@ -3357,10 +3326,50 @@ static_assert(is_assignable_to(Copier, CopierProtocol))
 static_assert(not is_assignable_to(TypeOf[Copier], CopierProtocol))
 static_assert(is_assignable_to(TypeOf[ClassCopier], CopierProtocol))
 static_assert(is_assignable_to(TypeOf[StaticCopier], CopierProtocol))
-static_assert(is_assignable_to(TypeOf[CustomCopier], CustomCopierProtocol))
 # The metaclass method is compatible, but ordinary protocol methods describe direct access on the
 # class object, where `BadDirectCopier.copy` is an incompatible unbound function.
 static_assert(not is_assignable_to(TypeOf[BadDirectCopier], CopierProtocol))
+```
+
+## Class objects and dunder instance-method protocol members
+
+Special methods are looked up on the meta-type of an object when testing assignability and
+subtyping, matching Python's special-method lookup. We therefore understand that `IterableClass`
+here is a subtype of `Iterable[int]` even though `IterableClass.__iter__` has the wrong signature:
+
+```py
+from typing import Iterable, Iterator
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_subtype_of
+
+class Meta(type):
+    def __iter__(self) -> Iterator[int]:
+        yield from range(42)
+
+class IterableClass(metaclass=Meta):
+    def __iter__(self) -> Iterator[str]:
+        yield from "abc"
+
+static_assert(is_subtype_of(TypeOf[IterableClass], Iterable[int]))
+```
+
+A custom dunder such as `__custom__` is an ordinary method: it is accessed directly on the class
+object and does not use Python's special-method lookup.
+
+```py
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_assignable_to
+
+class CustomProtocol(Protocol):
+    def __custom__(self, value: int) -> str: ...
+
+class Custom:
+    @classmethod
+    def __custom__(cls, value: int) -> str:
+        return str(value)
+
+static_assert(is_assignable_to(TypeOf[Custom], CustomProtocol))
 ```
 
 ## Subtyping of protocols with `@classmethod` or `@staticmethod` members

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1745,12 +1745,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return self.never();
         };
 
-        // For a method on a class object, `Self` names instances of that class: a
-        // `@classmethod` returning `Self` returns `Factory`, not `type[Factory]`. For a
-        // non-method member, `Self` names the object whose attribute is being checked, so a
-        // class object must stay a class object.
-        let non_method_self_binding_ty = ty.literal_fallback_instance(db).unwrap_or(ty);
-        let method_self_binding_ty = ty
+        // `Self` in a protocol member names the value satisfying the protocol. `Self` in a
+        // method on a class object names instances of that class: a `@classmethod` returning
+        // `Self` returns `Factory`, not `type[Factory]`. Keep the bindings separate so a method
+        // that returns an instance cannot satisfy a protocol that promises the class object.
+        let protocol_self_binding_ty = ty.literal_fallback_instance(db).unwrap_or(ty);
+        let implementation_self_binding_ty = ty
             .to_instance(db)
             .or_else(|| ty.literal_fallback_instance(db))
             .unwrap_or(ty);
@@ -1776,8 +1776,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .when_some_and(db, self.constraints, |callables| {
                     self.check_callables_vs_callable(
                         db,
-                        &callables.map(|callable| callable.apply_self(db, method_self_binding_ty)),
-                        required_callable.apply_self(db, method_self_binding_ty),
+                        &callables.map(|callable| {
+                            callable.apply_self(db, implementation_self_binding_ty)
+                        }),
+                        required_callable.apply_self(db, protocol_self_binding_ty),
                     )
                 })
         } else if member.is_instance_method() {
@@ -1794,11 +1796,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         if callable.is_function_like(db) {
                             self.check_callable_pair(
                                 db,
-                                callable.bind_self(db, Some(method_self_binding_ty)),
+                                callable.bind_self(db, Some(implementation_self_binding_ty)),
                                 protocol_bind_self(
                                     db,
                                     required_callable,
-                                    Some(method_self_binding_ty),
+                                    Some(protocol_self_binding_ty),
                                 ),
                             )
                         } else {
@@ -1816,11 +1818,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             self.check_type_pair(
                 db,
                 attribute_type,
-                Type::Callable(required_callable.apply_self(db, method_self_binding_ty)),
+                Type::Callable(required_callable.apply_self(db, protocol_self_binding_ty)),
             )
         } else {
             required_ty
-                .bind_self(db, non_method_self_binding_ty)
+                .bind_self(db, protocol_self_binding_ty)
                 .when_some_and(db, self.constraints, |required_ty| {
                     let result = self.check_type_pair(db, attribute_type, required_ty);
                     if let Some(context) = self.report_context()
@@ -1940,6 +1942,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 )
                 .is_none();
             if instance_read_missing || class_read_missing {
+                if instance_read_missing
+                    && is_class_object_type(ty)
+                    && member.is_instance_method()
+                    && member.uses_special_method_lookup()
+                {
+                    context.push(ErrorContext::ProtocolSpecialMethodNotDefinedOnMetaType);
+                }
                 context.push(ErrorContext::ProtocolMemberNotDefined {
                     member_name: member.name.into(),
                     ty,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1053,6 +1053,121 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         )
     }
 
+    /// Returns whether this member is dispatched through special-method lookup on the type.
+    ///
+    /// The names are the methods registered in CPython's `slotdefs` table or explicitly looked
+    /// up on the type by Python or its standard library.
+    fn uses_special_method_lookup(&self) -> bool {
+        matches!(
+            self.name,
+            "__abs__"
+                | "__add__"
+                | "__aenter__"
+                | "__aexit__"
+                | "__aiter__"
+                | "__and__"
+                | "__anext__"
+                | "__await__"
+                | "__bool__"
+                | "__buffer__"
+                | "__bytes__"
+                | "__call__"
+                | "__ceil__"
+                | "__complex__"
+                | "__contains__"
+                | "__copy__"
+                | "__del__"
+                | "__delattr__"
+                | "__delete__"
+                | "__delitem__"
+                | "__dir__"
+                | "__divmod__"
+                | "__enter__"
+                | "__eq__"
+                | "__exit__"
+                | "__float__"
+                | "__floor__"
+                | "__floordiv__"
+                | "__format__"
+                | "__fspath__"
+                | "__ge__"
+                | "__get__"
+                | "__getattr__"
+                | "__getattribute__"
+                | "__getitem__"
+                | "__getnewargs__"
+                | "__getnewargs_ex__"
+                | "__gt__"
+                | "__hash__"
+                | "__iadd__"
+                | "__iand__"
+                | "__ifloordiv__"
+                | "__ilshift__"
+                | "__imatmul__"
+                | "__imod__"
+                | "__imul__"
+                | "__index__"
+                | "__init__"
+                | "__instancecheck__"
+                | "__int__"
+                | "__invert__"
+                | "__ior__"
+                | "__ipow__"
+                | "__irshift__"
+                | "__isub__"
+                | "__iter__"
+                | "__itruediv__"
+                | "__ixor__"
+                | "__le__"
+                | "__len__"
+                | "__length_hint__"
+                | "__lshift__"
+                | "__lt__"
+                | "__matmul__"
+                | "__missing__"
+                | "__mod__"
+                | "__mul__"
+                | "__ne__"
+                | "__neg__"
+                | "__new__"
+                | "__next__"
+                | "__or__"
+                | "__pos__"
+                | "__pow__"
+                | "__radd__"
+                | "__rand__"
+                | "__rdivmod__"
+                | "__release_buffer__"
+                | "__replace__"
+                | "__repr__"
+                | "__reversed__"
+                | "__rfloordiv__"
+                | "__rlshift__"
+                | "__rmatmul__"
+                | "__rmod__"
+                | "__rmul__"
+                | "__ror__"
+                | "__round__"
+                | "__rpow__"
+                | "__rrshift__"
+                | "__rshift__"
+                | "__rsub__"
+                | "__rtruediv__"
+                | "__rxor__"
+                | "__set__"
+                | "__set_name__"
+                | "__setattr__"
+                | "__setitem__"
+                | "__sizeof__"
+                | "__str__"
+                | "__sub__"
+                | "__subclasscheck__"
+                | "__truediv__"
+                | "__trunc__"
+                | "__xor__"
+        )
+    }
+
     fn is_property(&self) -> bool {
         matches!(self.data.kind, ProtocolMemberKind::Property { .. })
     }
@@ -1068,8 +1183,9 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
     /// Returns the accesses that a candidate value must provide for this member.
     ///
     /// A module-level callable can satisfy an ordinary or static method through direct member
-    /// access. A class object can likewise satisfy a class or static method. The member does not
-    /// also need to exist on the value's meta-type.
+    /// access. A class object can likewise satisfy a class, static, or ordinary instance method;
+    /// special instance methods instead use special-method lookup through the meta-type. Neither
+    /// case needs a separate class-side check for the same member.
     fn implementation_capabilities(
         &self,
         db: &'db dyn Db,
@@ -1084,14 +1200,9 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
                     _,
                     ProtocolMethodKind::Instance | ProtocolMethodKind::Static
                 )
-            ) | (
-                Type::ClassLiteral(_),
-                ProtocolMemberKind::Method(
-                    _,
-                    ProtocolMethodKind::Class | ProtocolMethodKind::Static
-                )
             )
-        ) {
+        ) || (is_class_object_type(ty) && self.is_method())
+        {
             ProtocolMemberCapabilities {
                 class: ProtocolMemberAccess::NONE,
                 ..capabilities
@@ -1263,6 +1374,13 @@ fn property_set_type<'db>(
     property_set_member_type(db, property.setter(db)?)?.bind_self(db, receiver_ty)
 }
 
+fn is_class_object_type(ty: Type<'_>) -> bool {
+    matches!(
+        ty,
+        Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_)
+    )
+}
+
 fn protocol_member_read_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -1279,10 +1397,12 @@ fn protocol_member_read_type<'db>(
         return Some(ty);
     }
 
-    // PEP 544 matches module-level functions directly, without descriptor binding on `ModuleType`.
+    // Module-level functions and ordinary methods on class objects are matched through direct
+    // member access. Special instance methods still use special-method lookup on the meta-type.
     let place = if access == ProtocolMemberAccessMode::Instance
         && member.is_instance_method()
         && !matches!(ty, Type::ModuleLiteral(_))
+        && (!is_class_object_type(ty) || member.uses_special_method_lookup())
     {
         ty.invoke_descriptor_protocol(
             db,

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -136,6 +136,7 @@ pub(crate) enum ErrorContext<'db> {
         member_name: Name,
         ty: Type<'db>,
     },
+    ProtocolSpecialMethodNotDefinedOnMetaType,
     ProtocolMemberIncompatible {
         member_name: Name,
     },
@@ -355,6 +356,10 @@ impl<'db> ErrorContext<'db> {
                 "protocol member `{member_name}` is not defined on type `{}`",
                 ty.display(db),
             ),
+            Self::ProtocolSpecialMethodNotDefinedOnMetaType => {
+                "special methods must be defined on the meta-type when matching a protocol"
+                    .to_string()
+            }
             Self::ProtocolMemberIncompatible { member_name } => {
                 format!("protocol member `{member_name}` is incompatible")
             }


### PR DESCRIPTION
## Summary

Allow a class object to satisfy an instance-method protocol member through a directly accessible bound classmethod or staticmethod. This matches mypy and pyright behavior, fixes one conformance test assertion, and seems correct to me. Ecosystem looks good, too.

Special dunder methods which are looked up on the meta-type still must exist on the meta-type to match a protocol; we add extra diagnostic context to clarify this rule when it applies.

`Self` handling in protocols requires a fix so that we don't unsoundly allow a `Self` returning method on a class object to wrongly match a `Self` returning method on a protocol.

## Test plan

Added mdtests.
