### PR TITLE
[ty] Treat typing classes as disjoint bases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/async.md
@@ -174,10 +174,11 @@ If some intersection elements are not awaitable, we skip them and use the return
 awaitable elements:
 
 ```py
-from typing import Coroutine
+from typing import Coroutine, Protocol
 from ty_extensions import Intersection
 
-class NotAwaitable: ...
+class NotAwaitable(Protocol):
+    not_awaitable: int
 
 async def test(x: Intersection[Coroutine[object, object, str], NotAwaitable]):
     y = await x
@@ -200,12 +201,14 @@ When an intersection has three or more elements, some awaitable and some not, th
 elements are skipped:
 
 ```py
-from typing import Coroutine
+from typing import Coroutine, Protocol
 from ty_extensions import Intersection
 
 class A: ...
 class B: ...
-class NotAwaitable: ...
+
+class NotAwaitable(Protocol):
+    not_awaitable: int
 
 async def test(x: Intersection[Coroutine[object, object, A], Coroutine[object, object, B], NotAwaitable]):
     y = await x

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1189,14 +1189,18 @@ reveal_type(flatten_covariant(b"abc", ("x",)))  # revealed: tuple[int | Literal[
 ## Inferring typevars in intersections (formal type position)
 
 ```py
-from typing import TypeVar, Iterable
+from collections.abc import Iterator
+from typing import Protocol, TypeVar
 from ty_extensions import Intersection
 
 T = TypeVar("T")
 
+class IterableProtocol(Protocol[T]):
+    def __iter__(self) -> Iterator[T]: ...
+
 class Foo: ...
 
-def foo(x: Intersection[Iterable[T], Foo]) -> T:
+def foo(x: Intersection[IterableProtocol[T], Foo]) -> T:
     return next(iter(x))
 
 class Bar(list[int], Foo): ...

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -2,18 +2,26 @@
 
 Narrowing for `isinstance(object, classinfo)` expressions.
 
-## Builtins and typing protocols
+## Nominal classes and typing protocols
 
-Builtin classes are treated as disjoint from typing protocols they do not already satisfy.
+Nominal classes are treated as disjoint from typing protocols they do not already satisfy.
 
 ```py
 from typing import Awaitable
+
+class UserDefined: ...
 
 def _(value: int | Awaitable[str]) -> None:
     if isinstance(value, Awaitable):
         reveal_type(value)  # revealed: Awaitable[str]
     else:
         reveal_type(value)  # revealed: int
+
+def _(value: UserDefined | Awaitable[str]) -> None:
+    if isinstance(value, Awaitable):
+        reveal_type(value)  # revealed: Awaitable[str]
+    else:
+        reveal_type(value)  # revealed: UserDefined
 ```
 
 ## `classinfo` is a single type

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -335,11 +335,10 @@ static_assert(is_disjoint_from(D, B))
 static_assert(not is_disjoint_from(D, A))
 ```
 
-## Builtin classes, typing ABCs, and protocols
+## Classes defined in `typing` as disjoint bases
 
-Builtin classes are treated as disjoint from typing ABCs they do not already inherit from and typing
-protocols they do not already satisfy. This avoids retaining intersections that would require an
-unusual subclass.
+Classes defined in `typing` are treated as disjoint bases. They are disjoint from unrelated nominal
+classes and from nominal classes that do not satisfy them when they are protocols.
 
 ```py
 from collections.abc import Mapping, Sequence
@@ -352,10 +351,19 @@ static_assert(not is_disjoint_from(str, Sequence[str]))
 static_assert(is_disjoint_from(int, Awaitable[object]))
 static_assert(not is_disjoint_from(str, Iterable[str]))
 
+class Unrelated: ...
+class MappingSubclass(Mapping[str, object]): ...
+class AwaitableSubclass(Awaitable[object]): ...
+
+static_assert(is_disjoint_from(Unrelated, Mapping[str, object]))
+static_assert(not is_disjoint_from(MappingSubclass, Mapping[str, object]))
+static_assert(is_disjoint_from(Unrelated, Awaitable[object]))
+static_assert(not is_disjoint_from(AwaitableSubclass, Awaitable[object]))
+
 class CustomProtocol(Protocol):
     def custom(self) -> None: ...
 
-static_assert(not is_disjoint_from(int, CustomProtocol))
+static_assert(not is_disjoint_from(Unrelated, CustomProtocol))
 ```
 
 ## Strict subclass narrowing

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -239,10 +239,6 @@ impl<'db> NominalInstanceType<'db> {
         file_to_module(db, file).map(|module| module.name(db))
     }
 
-    pub(super) fn is_builtin_instance(self, db: &'db dyn Db) -> bool {
-        class_is_defined_in_known_module(db, self.class(db), KnownModule::Builtins)
-    }
-
     pub(super) fn class(&self, db: &'db dyn Db) -> ClassType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => tuple.to_class_type(db),
@@ -642,19 +638,18 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                 .filter_map(ClassBase::into_class)
                 .any(|mro_class| mro_class.class_literal(db) == base.class_literal(db))
         };
-        let builtin_and_typing_abc_are_disjoint =
-            |builtin: ClassType<'db>, typing_abc: ClassType<'db>| {
-                class_is_defined_in_known_module(db, builtin, KnownModule::Builtins)
-                    && class_is_defined_in_known_module(db, typing_abc, KnownModule::Typing)
-                    && !typing_abc.is_protocol(db)
-                    && !class_inherits_from(builtin, typing_abc)
-                    && !class_inherits_from(typing_abc, builtin)
+        let typing_class_is_disjoint_base =
+            |typing_class: ClassType<'db>, other: ClassType<'db>| {
+                class_is_defined_in_known_module(db, typing_class, KnownModule::Typing)
+                    && !typing_class.is_protocol(db)
+                    && !class_inherits_from(other, typing_class)
+                    && !class_inherits_from(typing_class, other)
             };
         if !db
             .analysis_settings(left_class.class_literal(db).file(db))
             .strict_subclass_narrowing
-            && (builtin_and_typing_abc_are_disjoint(left_class, right_class)
-                || builtin_and_typing_abc_are_disjoint(right_class, left_class))
+            && (typing_class_is_disjoint_base(left_class, right_class)
+                || typing_class_is_disjoint_base(right_class, left_class))
         {
             return self.always();
         }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2881,7 +2881,6 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 if !db
                     .analysis_settings(nominal.class(db).class_literal(db).file(db))
                     .strict_subclass_narrowing
-                    && nominal.is_builtin_instance(db)
                     && protocol.is_typing_protocol(db)
                     && !Type::ProtocolInstance(protocol).has_dynamic(db)
                     && !Type::ProtocolInstance(protocol).has_typevar_or_typevar_instance(db) =>


### PR DESCRIPTION
## Summary

This builds on #26416 and tries the broader heuristic proposed in the Slack discussion: for type disjointness, treat every class defined by `typing` as though it were decorated with `@disjoint_base`.

#26415 applies the heuristic to builtin classes intersected with nominal classes from `typing`, while #26416 extends it to builtin classes intersected with `typing` protocols. This PR removes the builtin restriction, so an unrelated user-defined nominal class is also considered disjoint from a `typing` class:

```python
from typing import Awaitable

class UserDefined: ...

def check(value: UserDefined | Awaitable[str]) -> None:
    if isinstance(value, Awaitable):
        reveal_type(value)  # Awaitable[str]
```

Classes that already inherit from a `typing` ABC or satisfy a `typing` protocol remain compatible. The protocol special case continues to require fully static arguments, and user-defined protocols keep the existing conservative behavior. This only changes type-disjointness reasoning; it does not introduce class-definition layout diagnostics.

This is stacked separately so its ecosystem results isolate the additional impact of treating all `typing` classes as disjoint bases.
