### PR TITLE
[ty] Preserve call gates and avoid quadratic evaluation

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1620,11 +1620,11 @@ impl PendingReachability {
         current_states: &mut IndexVec<I, PendingPlaceState>,
         branch_states: IndexVec<I, PendingPlaceState>,
         branch: PendingReachabilityId,
-        branch_ancestor: PendingReachabilityId,
         branch_reachability: ScopedReachabilityConstraintId,
         narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
+        let branch_ancestor = self.common_ancestor(self.current, branch);
         let mut branch_states = branch_states.into_iter();
         for current in current_states {
             let Some(mut branch_state) = branch_states.next() else {
@@ -2647,14 +2647,10 @@ impl<'db> UseDefMapBuilder<'db> {
         debug_assert!(self.member_states.len() >= snapshot.member_states.len());
 
         let branch = snapshot.pending_reachability;
-        let branch_ancestor = self
-            .pending_reachability
-            .common_ancestor(self.pending_reachability.current, branch);
         self.pending_reachability.merge_place_states(
             &mut self.symbol_states,
             snapshot.symbol_states,
             branch,
-            branch_ancestor,
             snapshot.reachability,
             &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
@@ -2663,7 +2659,6 @@ impl<'db> UseDefMapBuilder<'db> {
             &mut self.member_states,
             snapshot.member_states,
             branch,
-            branch_ancestor,
             snapshot.reachability,
             &mut self.narrowing_constraints,
             &mut self.reachability_constraints,

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1563,6 +1563,36 @@ impl PendingReachability {
         constraint
     }
 
+    /// Combines the call narrowing gates after `ancestor` through `target` into one constraint.
+    ///
+    /// `ancestor` must be an ancestor of `target`.
+    fn narrowing_constraint_between(
+        &self,
+        ancestor: PendingReachabilityId,
+        target: PendingReachabilityId,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+    ) -> ScopedNarrowingConstraint {
+        let mut unapplied = SmallVec::<[ScopedNarrowingConstraint; 4]>::new();
+        let mut current = target;
+        while current != ancestor {
+            let event = &self.constraints[current];
+            if event.narrowing_constraint != ScopedNarrowingConstraint::ALWAYS_TRUE {
+                unapplied.push(event.narrowing_constraint);
+            }
+            assert_ne!(
+                current, event.parent,
+                "pending narrowing must be an ancestor"
+            );
+            current = event.parent;
+        }
+
+        let mut constraint = ScopedNarrowingConstraint::ALWAYS_TRUE;
+        for pending in unapplied.into_iter().rev() {
+            constraint = narrowing_constraints.add_and_constraint(constraint, pending);
+        }
+        constraint
+    }
+
     /// Returns the lowest common ancestor of two nodes in the pending-constraint tree.
     fn common_ancestor(
         &self,
@@ -1625,6 +1655,12 @@ impl PendingReachability {
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
         let branch_ancestor = self.common_ancestor(self.current, branch);
+        let current_narrowing =
+            self.narrowing_constraint_between(branch_ancestor, self.current, narrowing_constraints);
+        let branch_narrowing =
+            self.narrowing_constraint_between(branch_ancestor, branch, narrowing_constraints);
+        let merged_narrowing =
+            narrowing_constraints.add_or_constraint(current_narrowing, branch_narrowing);
         let mut branch_states = branch_states.into_iter();
         for current in current_states {
             let Some(mut branch_state) = branch_states.next() else {
@@ -1653,9 +1689,14 @@ impl PendingReachability {
                     continue;
                 }
 
-                // Preserve call gates that precede the branch while discarding gates introduced
-                // inside either branch, which cannot be correlated with later narrowing.
+                // Preserve call gates that precede the branch, then merge gates introduced on the
+                // individual branch paths. If either path has no gate, the merged gate simplifies
+                // to `ALWAYS_TRUE` and can be discarded.
                 self.materialize_narrowing(current, branch_ancestor, narrowing_constraints);
+                if merged_narrowing != ScopedNarrowingConstraint::ALWAYS_TRUE {
+                    Rc::make_mut(&mut current.state)
+                        .record_narrowing_constraint(narrowing_constraints, merged_narrowing);
+                }
 
                 let current_constraint = self.constraint_between(
                     current.reachability,

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1437,7 +1437,17 @@ impl PendingReachability {
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) -> &'a mut PlaceState {
         self.materialize_reachability(pending, target, reachability_constraints);
+        self.materialize_narrowing(pending, target, narrowing_constraints);
 
+        Rc::make_mut(&mut pending.state)
+    }
+
+    fn materialize_narrowing(
+        &self,
+        pending: &mut PendingPlaceState,
+        target: PendingReachabilityId,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+    ) {
         if pending.narrowing != target {
             let mut unapplied = SmallVec::<[ScopedNarrowingConstraint; 4]>::new();
             let mut current = target;
@@ -1461,8 +1471,6 @@ impl PendingReachability {
             }
             pending.narrowing = target;
         }
-
-        Rc::make_mut(&mut pending.state)
     }
 
     fn materialize_reachability<'a>(
@@ -1554,6 +1562,22 @@ impl PendingReachability {
         }
         constraint
     }
+
+    /// Returns the lowest common ancestor of two nodes in the pending-constraint tree.
+    fn common_ancestor(
+        &self,
+        mut left: PendingReachabilityId,
+        mut right: PendingReachabilityId,
+    ) -> PendingReachabilityId {
+        while left != right {
+            if left.index() > right.index() {
+                left = self.constraints[left].parent;
+            } else {
+                right = self.constraints[right].parent;
+            }
+        }
+        left
+    }
 }
 
 /// A copy-on-write place state and the last reachability node materialized into it.
@@ -1596,6 +1620,7 @@ impl PendingReachability {
         current_states: &mut IndexVec<I, PendingPlaceState>,
         branch_states: IndexVec<I, PendingPlaceState>,
         branch: PendingReachabilityId,
+        branch_ancestor: PendingReachabilityId,
         branch_reachability: ScopedReachabilityConstraintId,
         narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
@@ -1628,6 +1653,10 @@ impl PendingReachability {
                     continue;
                 }
 
+                // Preserve call gates that precede the branch while discarding gates introduced
+                // inside either branch, which cannot be correlated with later narrowing.
+                self.materialize_narrowing(current, branch_ancestor, narrowing_constraints);
+
                 let current_constraint = self.constraint_between(
                     current.reachability,
                     self.current,
@@ -1646,9 +1675,6 @@ impl PendingReachability {
                         merged_constraint,
                     );
                 }
-                // Neither branch changed this place, so their pending narrowing gates cannot be
-                // correlated with branch-local narrowing and can be discarded. The merged
-                // reachability constraint above still excludes paths containing terminal calls.
                 current.reachability = self.current;
                 current.narrowing = self.current;
                 continue;
@@ -2621,10 +2647,14 @@ impl<'db> UseDefMapBuilder<'db> {
         debug_assert!(self.member_states.len() >= snapshot.member_states.len());
 
         let branch = snapshot.pending_reachability;
+        let branch_ancestor = self
+            .pending_reachability
+            .common_ancestor(self.pending_reachability.current, branch);
         self.pending_reachability.merge_place_states(
             &mut self.symbol_states,
             snapshot.symbol_states,
             branch,
+            branch_ancestor,
             snapshot.reachability,
             &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
@@ -2633,6 +2663,7 @@ impl<'db> UseDefMapBuilder<'db> {
             &mut self.member_states,
             snapshot.member_states,
             branch,
+            branch_ancestor,
             snapshot.reachability,
             &mut self.narrowing_constraints,
             &mut self.reachability_constraints,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -263,6 +263,25 @@ def _(x: int | None, outer: bool, inner: bool) -> None:
     reveal_type(x)  # revealed: None | int
 ```
 
+If every nested branch contains a call, their combined call constraint must be preserved:
+
+```py
+def _(x: int | None, outer: bool, inner: bool) -> None:
+    if outer:
+        if inner:
+            fail_nested_merge()
+        else:
+            fail_nested_merge()
+
+        if x is not None:
+            return
+    else:
+        if x is None:
+            return
+
+    reveal_type(x)  # revealed: int
+```
+
 And for elif branches:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -218,6 +218,51 @@ def _(x: int | None, flag: bool):
     reveal_type(x)  # revealed: int
 ```
 
+Call constraints that precede a nested merge must still gate narrowing later in the outer branch:
+
+```py
+from typing_extensions import Never
+
+def fail_nested_merge() -> Never:
+    raise RuntimeError
+
+def _(x: int | None, outer: bool, inner: bool) -> None:
+    if outer:
+        fail_nested_merge()
+
+        if inner:
+            pass
+        else:
+            pass
+
+        if x is not None:
+            return
+    else:
+        if x is None:
+            return
+
+    reveal_type(x)  # revealed: int
+```
+
+Call constraints introduced inside the nested branches are still discarded at that merge:
+
+```py
+def _(x: int | None, outer: bool, inner: bool) -> None:
+    if outer:
+        if inner:
+            pass
+        else:
+            fail_nested_merge()
+
+        if x is not None:
+            return
+    else:
+        if x is None:
+            return
+
+    reveal_type(x)  # revealed: None | int
+```
+
 And for elif branches:
 
 ```py

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -228,6 +228,7 @@ use ty_python_core::{
     },
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
     scope::ScopeId,
+    use_def_map,
 };
 
 /// Narrow `subject_ty` by all preceding unguarded match patterns.
@@ -526,6 +527,9 @@ std::thread_local! {
     static ACTIVE_NON_TERMINAL_CALL_PREFIXES: ActiveRecursionDetector<salsa::Id> = ActiveRecursionDetector::default();
 }
 
+const NON_TERMINAL_CALL_CHUNK_SIZE: usize = 16;
+const REACHABILITY_EVALUATION_CHUNK_SIZE: usize = 256;
+
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression) => expression.scope(db),
@@ -562,31 +566,146 @@ fn analyze_non_terminal_call_prefix<'db>(
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     root_predicate: ScopedPredicateId,
 ) {
-    let range = 0..=root_predicate.index();
-    if !range.clone().any(|index| {
-        matches!(
-            predicates[ScopedPredicateId::new(index)].node,
-            PredicateNode::IsNonTerminalCall(_)
-        )
-    }) {
-        return;
-    }
+    let scope = predicate_scope(db, &predicates[root_predicate]);
 
-    let key = predicate_scope(db, &predicates[root_predicate]).as_id();
     ACTIVE_NON_TERMINAL_CALL_PREFIXES.with(|active| {
         active.visit(
-            &key,
+            &scope.as_id(),
             || {},
             || {
-                for index in range {
-                    let predicate = &predicates[ScopedPredicateId::new(index)];
-                    if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
-                        analyze_single(db, predicate);
-                    }
+                let call_predicates = non_terminal_call_predicates(db, scope);
+                let call_count =
+                    call_predicates.partition_point(|predicate| *predicate <= root_predicate);
+                if call_count <= NON_TERMINAL_CALL_CHUNK_SIZE {
+                    analyze_non_terminal_calls(db, predicates, &call_predicates[..call_count]);
+                    return;
                 }
+
+                let mut start = 0;
+                let mut remaining = call_count / NON_TERMINAL_CALL_CHUNK_SIZE;
+
+                while remaining > 0 {
+                    let level = remaining.ilog2();
+                    let length = 1 << level;
+                    analyze_non_terminal_call_range(db, scope, level, start >> level);
+                    start += length;
+                    remaining -= length;
+                }
+
+                let tail_start =
+                    call_count / NON_TERMINAL_CALL_CHUNK_SIZE * NON_TERMINAL_CALL_CHUNK_SIZE;
+                analyze_non_terminal_calls(
+                    db,
+                    predicates,
+                    &call_predicates[tail_start..call_count],
+                );
             },
         );
     });
+}
+
+#[salsa::tracked(returns(deref), heap_size = get_size2::GetSize::get_heap_size)]
+fn non_terminal_call_predicates<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+) -> Box<[ScopedPredicateId]> {
+    use_def_map(db, scope)
+        .predicates()
+        .iter_enumerated()
+        .filter_map(|(id, predicate)| {
+            matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)).then_some(id)
+        })
+        .collect()
+}
+
+fn analyze_non_terminal_calls<'db>(
+    db: &'db dyn Db,
+    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
+    call_predicates: &[ScopedPredicateId],
+) {
+    for id in call_predicates {
+        analyze_single(db, &predicates[*id]);
+    }
+}
+
+/// Analyzes a power-of-two range of predicate blocks in source order.
+///
+/// Prefixes can be decomposed into these canonical ranges and reused by later expression-inference
+/// queries. Splitting ranges in half keeps the Salsa query stack logarithmic even when the first
+/// requested prefix contains thousands of calls. Each leaf handles multiple predicates iteratively
+/// to avoid retaining a Salsa argument and query result for every individual predicate.
+#[salsa::tracked(returns(copy), heap_size = get_size2::GetSize::get_heap_size)]
+fn analyze_non_terminal_call_range<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    level: u32,
+    index: usize,
+) {
+    if level == 0 {
+        let use_def = use_def_map(db, scope);
+        let call_predicates = non_terminal_call_predicates(db, scope);
+        let start = index * NON_TERMINAL_CALL_CHUNK_SIZE;
+        let end = start + NON_TERMINAL_CALL_CHUNK_SIZE;
+        analyze_non_terminal_calls(db, use_def.predicates(), &call_predicates[start..end]);
+        return;
+    }
+
+    let child_index = index * 2;
+    analyze_non_terminal_call_range(db, scope, level - 1, child_index);
+    analyze_non_terminal_call_range(db, scope, level - 1, child_index + 1);
+}
+
+fn evaluate_reachability_constraint<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    id: ScopedReachabilityConstraintId,
+) -> Truthiness {
+    if !id.is_terminal() {
+        let use_def = use_def_map(db, scope);
+        let root_predicate = use_def
+            .reachability_constraints()
+            .get_interior_node(id)
+            .atom();
+        analyze_non_terminal_call_prefix(db, use_def.predicates(), root_predicate);
+    }
+
+    evaluate_reachability_suffix(db, scope, id)
+}
+
+/// Evaluates a bounded portion of a reachability decision diagram.
+///
+/// Caching the suffix separately from expression-inference queries lets later statements reuse the
+/// result of the constraints accumulated by earlier statements. The bounded iterative chunk keeps
+/// a first evaluation of an unusually deep graph from creating one Rust stack frame per node.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial = |_, _, _, _| Truthiness::Ambiguous,
+    heap_size = get_size2::GetSize::get_heap_size
+)]
+fn evaluate_reachability_suffix<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    mut id: ScopedReachabilityConstraintId,
+) -> Truthiness {
+    let use_def = use_def_map(db, scope);
+    let constraints = use_def.reachability_constraints();
+    let predicates = use_def.predicates();
+
+    for _ in 0..REACHABILITY_EVALUATION_CHUNK_SIZE {
+        let node = match id {
+            ScopedReachabilityConstraintId::ALWAYS_TRUE => return Truthiness::AlwaysTrue,
+            ScopedReachabilityConstraintId::AMBIGUOUS => return Truthiness::Ambiguous,
+            ScopedReachabilityConstraintId::ALWAYS_FALSE => return Truthiness::AlwaysFalse,
+            _ => constraints.get_interior_node(id),
+        };
+        id = match analyze_single(db, &predicates[node.atom()]) {
+            Truthiness::AlwaysTrue => node.if_true(),
+            Truthiness::Ambiguous => node.if_ambiguous(),
+            Truthiness::AlwaysFalse => node.if_false(),
+        };
+    }
+
+    evaluate_reachability_suffix(db, scope, id)
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
@@ -609,28 +728,6 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
     ) -> Truthiness {
         type Id = ScopedReachabilityConstraintId;
 
-        // Analyze statement-level calls through this root one by one in source order, so any
-        // earlier call needed while inferring a later one is already cached instead of deepening
-        // the Salsa query stack. This avoids growing an excessive stack for deeply nested
-        // reachability queries.
-        //
-        // Without this prefix analysis, given:
-        //
-        //   call_a()  # predicate 0
-        //   call_b()  # predicate 1
-        //   call_c()  # predicate 2
-        //
-        // we'd analyze them backwards:
-        //
-        //   analyze call_c
-        //   └─ analyze call_b
-        //      └─ analyze call_a
-        //
-        // The prefix pass explicitly analyzes them forwards:
-        //
-        //   analyze call_a  → cached
-        //   analyze call_b  → call_a is already cached
-        //   analyze call_c  → call_b is already cached
         if !id.is_terminal() {
             let root_predicate = self.get_interior_node(id).atom();
             analyze_non_terminal_call_prefix(db, predicates, root_predicate);
@@ -1499,7 +1596,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
                 return result;
             }
 
-            let result = constraints.evaluate(db, predicates, id);
+            let result = evaluate_reachability_constraint(db, scope, id);
             self.other_entries.borrow_mut().insert(key, result);
             return result;
         }
@@ -1509,7 +1606,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
             return result;
         }
 
-        let result = constraints.evaluate(db, predicates, id);
+        let result = evaluate_reachability_constraint(db, self.primary_scope, id);
         let mut entries = self.primary_entries.borrow_mut();
         if entries.len() <= index {
             entries.resize(index + 1, None);
@@ -1605,6 +1702,222 @@ mod tests {
     use ty_python_core::narrowing_constraints::InteriorNode;
     use ty_python_core::predicate::Predicates;
     use ty_python_core::semantic_index;
+
+    #[test]
+    fn non_terminal_call_prefix_bypasses_ranges_for_small_scope() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        let source = format!(
+            "def noop() -> None: ...\n\ndef f(flag: bool) -> None:\n{}{}",
+            "    if flag:\n        value = 1\n    else:\n        value = 2\n"
+                .repeat(NON_TERMINAL_CALL_CHUNK_SIZE * 2),
+            "    noop()\n".repeat(7)
+        );
+        db.write_file("/src/test.py", &source)?;
+
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        {
+            let index = semantic_index(&db, file);
+            let function_scope = index
+                .child_scopes(FileScopeId::global())
+                .nth(1)
+                .unwrap()
+                .0
+                .to_scope_id(&db, file);
+            let use_def = use_def_map(&db, function_scope);
+            let predicates = use_def.predicates();
+            let call_predicates = predicates
+                .iter_enumerated()
+                .filter_map(|(id, predicate)| {
+                    matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)).then_some(id)
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(call_predicates.len(), 7);
+            assert!(predicates.len() > NON_TERMINAL_CALL_CHUNK_SIZE);
+
+            analyze_non_terminal_call_prefix(&db, predicates, call_predicates[3]);
+            analyze_non_terminal_call_prefix(&db, predicates, call_predicates[6]);
+        }
+
+        let events = db.take_salsa_events();
+        let range_executions = salsa::attach(&db, || {
+            events
+                .into_iter()
+                .filter(|event| {
+                    matches!(
+                        &event.kind,
+                        salsa::EventKind::WillExecute { database_key }
+                            if format!("{database_key:?}")
+                                .contains("analyze_non_terminal_call_range")
+                    )
+                })
+                .count()
+        });
+
+        assert_eq!(range_executions, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn non_terminal_call_prefix_reuses_ranges() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        let source = format!(
+            "def noop() -> None: ...\n\ndef f(flag: bool) -> None:\n    if flag:\n        noop()\n{}",
+            "    noop()\n".repeat(NON_TERMINAL_CALL_CHUNK_SIZE * 2)
+        );
+        db.write_file("/src/test.py", &source)?;
+
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        {
+            let index = semantic_index(&db, file);
+            let function_scope = index
+                .child_scopes(FileScopeId::global())
+                .nth(1)
+                .unwrap()
+                .0
+                .to_scope_id(&db, file);
+            let use_def = use_def_map(&db, function_scope);
+            let predicates = use_def.predicates();
+            let call_predicates = predicates
+                .iter_enumerated()
+                .filter_map(|(id, predicate)| {
+                    matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)).then_some(id)
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(call_predicates.len(), NON_TERMINAL_CALL_CHUNK_SIZE * 2 + 1);
+
+            analyze_non_terminal_call_prefix(
+                &db,
+                predicates,
+                call_predicates[NON_TERMINAL_CALL_CHUNK_SIZE - 1],
+            );
+            analyze_non_terminal_call_prefix(
+                &db,
+                predicates,
+                call_predicates[NON_TERMINAL_CALL_CHUNK_SIZE * 2],
+            );
+        }
+
+        let events = db.take_salsa_events();
+        let range_executions = salsa::attach(&db, || {
+            events
+                .into_iter()
+                .filter(|event| {
+                    matches!(
+                        &event.kind,
+                        salsa::EventKind::WillExecute { database_key }
+                            if format!("{database_key:?}")
+                                .contains("analyze_non_terminal_call_range")
+                    )
+                })
+                .count()
+        });
+
+        // The first prefix executes one leaf. The second prefix reuses that leaf and executes
+        // only the parent range and the next leaf.
+        assert_eq!(range_executions, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn reachability_suffixes_are_reused() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        let source = format!(
+            "def f() -> None:\n{}",
+            "    if 'reachable':\n        pass\n    else:\n        return\n"
+                .repeat(REACHABILITY_EVALUATION_CHUNK_SIZE * 2)
+        );
+        db.write_file("/src/test.py", &source)?;
+
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        let (function_scope, root) = {
+            let index = semantic_index(&db, file);
+            let function_scope = index.child_scopes(FileScopeId::global()).next().unwrap().0;
+            let scope = function_scope.to_scope_id(&db, file);
+            let use_def = index.use_def_map(function_scope);
+            let constraints = use_def.reachability_constraints();
+            let root = use_def.end_of_scope_reachability();
+            let mut suffix = root;
+
+            for _ in 0..REACHABILITY_EVALUATION_CHUNK_SIZE {
+                let node = constraints.get_interior_node(suffix);
+                suffix = node.if_true();
+            }
+            assert!(!suffix.is_terminal());
+            assert_eq!(
+                evaluate_reachability_suffix(&db, scope, suffix),
+                Truthiness::AlwaysTrue
+            );
+            (function_scope, root)
+        };
+        db.take_salsa_events();
+
+        {
+            let scope = function_scope.to_scope_id(&db, file);
+            assert_eq!(
+                evaluate_reachability_suffix(&db, scope, root),
+                Truthiness::AlwaysTrue
+            );
+        }
+        let events = db.take_salsa_events();
+        let suffix_executions = salsa::attach(&db, || {
+            events
+                .into_iter()
+                .filter(|event| {
+                    matches!(
+                        &event.kind,
+                        salsa::EventKind::WillExecute { database_key }
+                            if format!("{database_key:?}")
+                                .contains("evaluate_reachability_suffix")
+                    )
+                })
+                .count()
+        });
+
+        assert_eq!(suffix_executions, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn reachability_caches_invalidate_when_callable_changes() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        let source = format!(
+            "from dependency import callback\n\ndef f() -> None:\n{}",
+            "    callback()\n".repeat(NON_TERMINAL_CALL_CHUNK_SIZE + 1)
+        );
+        db.write_files([
+            ("/src/dependency.py", "def callback() -> None: ..."),
+            ("/src/test.py", source.as_str()),
+        ])?;
+
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        {
+            let index = semantic_index(&db, file);
+            let function_scope = index.child_scopes(FileScopeId::global()).next().unwrap().0;
+            let scope = function_scope.to_scope_id(&db, file);
+            let use_def = index.use_def_map(function_scope);
+            assert!(
+                evaluate_reachability_constraint(&db, scope, use_def.end_of_scope_reachability())
+                    .may_be_true()
+            );
+        }
+
+        db.write_file(
+            "/src/dependency.py",
+            "from typing import NoReturn\ndef callback() -> NoReturn: ...",
+        )?;
+
+        let index = semantic_index(&db, file);
+        let function_scope = index.child_scopes(FileScopeId::global()).next().unwrap().0;
+        let scope = function_scope.to_scope_id(&db, file);
+        let use_def = index.use_def_map(function_scope);
+        assert!(
+            evaluate_reachability_constraint(&db, scope, use_def.end_of_scope_reachability())
+                .is_always_false()
+        );
+        Ok(())
+    }
 
     #[test]
     fn deep_constraint_projection_does_not_overflow() -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

This follows the revert in #26793 and addresses the [post-merge finding on #26775](https://github.com/astral-sh/ruff/pull/26775#issuecomment-4964970253). The unchanged-place merge fast path introduced in #26775 dropped all pending call narrowing gates when a nested control-flow merge left a place untouched. That also dropped gates recorded before the branches diverged, so an unrelated nested `if` could allow later narrowing from an unreachable path to affect the merged type.

We now find the branch tips' shared ancestor once per flow merge and materialize call gates through that point before combining branch-local gates. This preserves gates shared by both branches while continuing to discard a gate that exists on only one path.

While validating the original performance issue, we also found that deferred gate construction alone did not remove the quadratic behavior: each standalone expression-inference query rescanned preceding call predicates and reevaluated the accumulated reachability decision diagram. We now index statement-call predicates once per scope, reuse canonical source-order ranges, and memoize bounded decision-diagram suffixes across inference queries. The memoized queries retain incremental invalidation and conservatively participate in cycle recovery.

On the 12,000-call reproducer, this reduces user CPU time in an optimized development build from about 8.5 seconds to 0.7 seconds. Regression coverage exercises both sides of the merge boundary, small-scope and range reuse, suffix reuse, and invalidation when a callable changes from returning `None` to `NoReturn`.

Closes https://github.com/astral-sh/ty/issues/3986.
