### PR TITLE
[ty] Revert deferred call-gate optimization

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1413,31 +1413,6 @@ fn benchmark_typeis_narrowing(criterion: &mut Criterion) {
     });
 }
 
-/// Regression benchmark for <https://github.com/astral-sh/ty/issues/3986>.
-///
-/// Non-terminal-call predicates must gate later narrowing. Keeping these scope-wide constraints in
-/// an append-only tree avoids eagerly rewriting every live place state after each call.
-fn benchmark_repeated_statement_calls(criterion: &mut Criterion) {
-    setup_rayon();
-
-    let mut code = String::from("def f() -> None:\n    value = 'abc'\n");
-    for _ in 0..1_500 {
-        code.push_str("    value.upper()\n");
-    }
-
-    criterion.bench_function("ty_micro[repeated_statement_calls]", |b| {
-        b.iter_batched_ref(
-            || setup_micro_case(&code),
-            |case| {
-                let Case { db, .. } = case;
-                let result = db.check();
-                assert_eq!(result.len(), 0);
-            },
-            BatchSize::SmallInput,
-        );
-    });
-}
-
 /// Benchmarks solving many union-bearing upper bounds while inferring a generic call.
 ///
 /// Each callable argument places a distinct union upper bound on `T` through callable-parameter
@@ -1955,7 +1930,6 @@ criterion_group!(
     benchmark_literal_equality_fallthrough_guarded_any,
     benchmark_literal_or_pattern_reachability,
     benchmark_typeis_narrowing,
-    benchmark_repeated_statement_calls,
     benchmark_factored_upper_bounds,
     benchmark_pandas_tdd,
     benchmark_recursive_typed_dict_union_contextual_inference,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4188,14 +4188,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             .add_atom(predicate_id);
 
                         if self.in_function_scope() {
-                            let reachability_constraint = self
-                                .current_reachability_constraints_mut()
-                                .add_atom(predicate_id);
+                            self.record_reachability_constraint_id(predicate_id);
+
+                            // Also gate narrowing by this constraint: if the call returns
+                            // `Never`, any narrowing in the current branch should be
+                            // invalidated (since this path is unreachable). This enables
+                            // narrowing to be preserved after if-statements where one branch
+                            // calls a `NoReturn` function like `sys.exit()`.
                             self.current_use_def_map_mut()
-                                .record_non_terminal_call_constraints(
-                                    reachability_constraint,
-                                    narrowing_constraint,
-                                );
+                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
                         } else {
                             // In non-function scopes, we only record a narrowing constraint
                             // (not a reachability constraint). Recording reachability for

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1382,14 +1382,14 @@ struct PendingReachabilityId;
 #[derive(Debug)]
 struct PendingReachabilityConstraint {
     parent: PendingReachabilityId,
-    reachability_constraint: ScopedReachabilityConstraintId,
-    narrowing_constraint: ScopedNarrowingConstraint,
+    constraint: ScopedReachabilityConstraintId,
 }
 
-/// An append-only tree of scope-wide reachability constraints and call narrowing gates.
+/// An append-only tree of scope-wide reachability constraints.
 ///
-/// Each [`PendingPlaceState`] remembers the last node applied for each constraint kind, so
-/// snapshots can share place states and defer applying subsequent constraints until needed.
+/// Each [`PendingPlaceState`] remembers the last node applied to its place state, so snapshots can
+/// share place states and defer applying subsequent constraints until the place is observed or
+/// changed.
 #[derive(Debug)]
 struct PendingReachability {
     constraints: IndexVec<PendingReachabilityId, PendingReachabilityConstraint>,
@@ -1402,8 +1402,7 @@ impl Default for PendingReachability {
         let root = constraints.next_index();
         constraints.push(PendingReachabilityConstraint {
             parent: root,
-            reachability_constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
-            narrowing_constraint: ScopedNarrowingConstraint::ALWAYS_TRUE,
+            constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
         });
         Self {
             constraints,
@@ -1413,59 +1412,18 @@ impl Default for PendingReachability {
 }
 
 impl PendingReachability {
-    fn push(
-        &mut self,
-        reachability_constraint: ScopedReachabilityConstraintId,
-        narrowing_constraint: ScopedNarrowingConstraint,
-    ) {
+    fn push(&mut self, constraint: ScopedReachabilityConstraintId) {
         self.current = self.constraints.push(PendingReachabilityConstraint {
             parent: self.current,
-            reachability_constraint,
-            narrowing_constraint,
+            constraint,
         });
     }
 
-    /// Applies both constraint kinds between the place's last materialized nodes and `target`.
+    /// Applies the constraints between the place's last materialized node and `target`.
     ///
     /// The place's node must be an ancestor of `target`. After materialization, the place is
     /// uniquely owned for mutation and records `target` as its last applied node.
     fn materialize<'a>(
-        &self,
-        pending: &'a mut PendingPlaceState,
-        target: PendingReachabilityId,
-        narrowing_constraints: &mut NarrowingConstraintsBuilder,
-        reachability_constraints: &mut ReachabilityConstraintsBuilder,
-    ) -> &'a mut PlaceState {
-        self.materialize_reachability(pending, target, reachability_constraints);
-
-        if pending.narrowing != target {
-            let mut unapplied = SmallVec::<[ScopedNarrowingConstraint; 4]>::new();
-            let mut current = target;
-            while current != pending.narrowing {
-                let event = &self.constraints[current];
-                if event.narrowing_constraint != ScopedNarrowingConstraint::ALWAYS_TRUE {
-                    unapplied.push(event.narrowing_constraint);
-                }
-                assert_ne!(
-                    current, event.parent,
-                    "pending narrowing must be an ancestor"
-                );
-                current = event.parent;
-            }
-
-            if !unapplied.is_empty() {
-                let state = Rc::make_mut(&mut pending.state);
-                for constraint in unapplied.into_iter().rev() {
-                    state.record_narrowing_constraint(narrowing_constraints, constraint);
-                }
-            }
-            pending.narrowing = target;
-        }
-
-        Rc::make_mut(&mut pending.state)
-    }
-
-    fn materialize_reachability<'a>(
         &self,
         pending: &'a mut PendingPlaceState,
         target: PendingReachabilityId,
@@ -1476,7 +1434,7 @@ impl PendingReachability {
             let mut current = target;
             while current != pending.reachability {
                 let event = &self.constraints[current];
-                unapplied.push(event.reachability_constraint);
+                unapplied.push(event.constraint);
                 assert_ne!(
                     current, event.parent,
                     "pending reachability must be an ancestor"
@@ -1503,31 +1461,11 @@ impl PendingReachability {
         &self,
         pending: &'a mut PendingPlaceState,
         target: PendingReachabilityId,
-        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) -> &'a PlaceState {
-        if pending.reachability != target || pending.narrowing != target {
-            self.materialize(
-                pending,
-                target,
-                narrowing_constraints,
-                reachability_constraints,
-            );
+        if pending.reachability != target {
+            self.materialize(pending, target, reachability_constraints);
         }
-        &pending.state
-    }
-
-    /// Returns the place state needed to resolve a use.
-    ///
-    /// A call's narrowing gate is only needed if the place is later changed or merged, so it is
-    /// not materialized here.
-    fn materialize_ref_at_use<'a>(
-        &self,
-        pending: &'a mut PendingPlaceState,
-        target: PendingReachabilityId,
-        reachability_constraints: &mut ReachabilityConstraintsBuilder,
-    ) -> &'a PlaceState {
-        self.materialize_reachability(pending, target, reachability_constraints);
         &pending.state
     }
 
@@ -1544,8 +1482,7 @@ impl PendingReachability {
         let mut current = target;
         while current != ancestor {
             let event = &self.constraints[current];
-            constraint = reachability_constraints
-                .add_and_constraint(constraint, event.reachability_constraint);
+            constraint = reachability_constraints.add_and_constraint(constraint, event.constraint);
             assert_ne!(
                 current, event.parent,
                 "pending reachability must be an ancestor"
@@ -1561,7 +1498,6 @@ impl PendingReachability {
 struct PendingPlaceState {
     state: Rc<PlaceState>,
     reachability: PendingReachabilityId,
-    narrowing: PendingReachabilityId,
 }
 
 impl PendingPlaceState {
@@ -1569,7 +1505,6 @@ impl PendingPlaceState {
         Self {
             state: Rc::new(state),
             reachability,
-            narrowing: reachability,
         }
     }
 }
@@ -1603,12 +1538,7 @@ impl PendingReachability {
         let mut branch_states = branch_states.into_iter();
         for current in current_states {
             let Some(mut branch_state) = branch_states.next() else {
-                let current = self.materialize(
-                    current,
-                    self.current,
-                    narrowing_constraints,
-                    reachability_constraints,
-                );
+                let current = self.materialize(current, self.current, reachability_constraints);
                 current.merge(
                     PlaceState::undefined(branch_reachability),
                     narrowing_constraints,
@@ -1621,7 +1551,6 @@ impl PendingReachability {
             // common case is a truthy/falsy pair whose constraints cancel to `ALWAYS_TRUE`, leaving
             // the shared state untouched.
             if current.reachability == branch_state.reachability
-                && current.narrowing == branch_state.narrowing
                 && Rc::ptr_eq(&current.state, &branch_state.state)
             {
                 if self.current == branch {
@@ -1646,27 +1575,13 @@ impl PendingReachability {
                         merged_constraint,
                     );
                 }
-                // Neither branch changed this place, so their pending narrowing gates cannot be
-                // correlated with branch-local narrowing and can be discarded. The merged
-                // reachability constraint above still excludes paths containing terminal calls.
                 current.reachability = self.current;
-                current.narrowing = self.current;
                 continue;
             }
 
-            self.materialize(
-                &mut branch_state,
-                branch,
-                narrowing_constraints,
-                reachability_constraints,
-            );
+            self.materialize(&mut branch_state, branch, reachability_constraints);
             let branch_state = Rc::unwrap_or_clone(branch_state.state);
-            let current = self.materialize(
-                current,
-                self.current,
-                narrowing_constraints,
-                reachability_constraints,
-            );
+            let current = self.materialize(current, self.current, reachability_constraints);
             current.merge(
                 branch_state,
                 narrowing_constraints,
@@ -1848,7 +1763,6 @@ impl<'db> UseDefMapBuilder<'db> {
         let place_state = self.pending_reachability.materialize(
             place_state,
             pending,
-            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
         let definitions_at_definition = DefinitionsAtDefinition {
@@ -1942,7 +1856,6 @@ impl<'db> UseDefMapBuilder<'db> {
         let state = self.pending_reachability.materialize(
             state,
             pending,
-            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
         state.record_narrowing_constraint_for_bindings_at_use(
@@ -1972,7 +1885,6 @@ impl<'db> UseDefMapBuilder<'db> {
         let state = self.pending_reachability.materialize(
             state,
             pending,
-            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
         state.record_narrowing_constraint_for_bindings(
@@ -2019,7 +1931,6 @@ impl<'db> UseDefMapBuilder<'db> {
                         let state = self.pending_reachability.materialize(
                             state,
                             pending,
-                            &mut self.narrowing_constraints,
                             &mut self.reachability_constraints,
                         );
                         state.record_narrowing_constraint(
@@ -2033,7 +1944,6 @@ impl<'db> UseDefMapBuilder<'db> {
                         let state = self.pending_reachability.materialize(
                             state,
                             pending,
-                            &mut self.narrowing_constraints,
                             &mut self.reachability_constraints,
                         );
                         state.record_narrowing_constraint(
@@ -2063,7 +1973,6 @@ impl<'db> UseDefMapBuilder<'db> {
             .materialize_ref(
                 &mut self.symbol_states[symbol],
                 pending,
-                &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             )
             .clone();
@@ -2072,7 +1981,6 @@ impl<'db> UseDefMapBuilder<'db> {
             let state = self.pending_reachability.materialize_ref(
                 &mut self.member_states[member_id],
                 pending,
-                &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             );
             associated_member_states.insert(member_id, state.clone());
@@ -2126,7 +2034,6 @@ impl<'db> UseDefMapBuilder<'db> {
         let symbol_state = self.pending_reachability.materialize(
             &mut self.symbol_states[symbol],
             pending,
-            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
         let mut post_definition_state =
@@ -2155,7 +2062,6 @@ impl<'db> UseDefMapBuilder<'db> {
             let member_state = self.pending_reachability.materialize(
                 &mut self.member_states[member_id],
                 pending,
-                &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             );
             let mut post_definition_state =
@@ -2197,7 +2103,6 @@ impl<'db> UseDefMapBuilder<'db> {
             let state = self.pending_reachability.materialize(
                 state,
                 pending,
-                &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             );
             state.record_narrowing_constraint(&mut self.narrowing_constraints, constraint);
@@ -2208,30 +2113,10 @@ impl<'db> UseDefMapBuilder<'db> {
         &mut self,
         constraint: ScopedReachabilityConstraintId,
     ) {
-        self.record_reachability_constraint_impl(
-            constraint,
-            ScopedNarrowingConstraint::ALWAYS_TRUE,
-        );
-    }
-
-    pub(super) fn record_non_terminal_call_constraints(
-        &mut self,
-        reachability_constraint: ScopedReachabilityConstraintId,
-        narrowing_constraint: ScopedNarrowingConstraint,
-    ) {
-        self.record_reachability_constraint_impl(reachability_constraint, narrowing_constraint);
-    }
-
-    fn record_reachability_constraint_impl(
-        &mut self,
-        reachability_constraint: ScopedReachabilityConstraintId,
-        narrowing_constraint: ScopedNarrowingConstraint,
-    ) {
         self.reachability = self
             .reachability_constraints
-            .add_and_constraint(self.reachability, reachability_constraint);
-        self.pending_reachability
-            .push(reachability_constraint, narrowing_constraint);
+            .add_and_constraint(self.reachability, constraint);
+        self.pending_reachability.push(constraint);
     }
 
     pub(super) fn record_declaration(
@@ -2246,7 +2131,6 @@ impl<'db> UseDefMapBuilder<'db> {
         let place_state = self.pending_reachability.materialize(
             place_state,
             pending,
-            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
 
@@ -2285,7 +2169,6 @@ impl<'db> UseDefMapBuilder<'db> {
         let place_state = self.pending_reachability.materialize(
             place_state,
             pending,
-            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
         place_state.record_declaration(def_id, self.reachability);
@@ -2326,7 +2209,6 @@ impl<'db> UseDefMapBuilder<'db> {
         let place_state = self.pending_reachability.materialize(
             place_state,
             pending,
-            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
 
@@ -2344,12 +2226,11 @@ impl<'db> UseDefMapBuilder<'db> {
         let pending = self.pending_reachability.current;
         let place_state =
             pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
-        let place_state = self.pending_reachability.materialize_ref_at_use(
-            place_state,
-            pending,
-            &mut self.reachability_constraints,
-        );
-        let bindings = place_state.bindings().clone();
+        let bindings = self
+            .pending_reachability
+            .materialize_ref(place_state, pending, &mut self.reachability_constraints)
+            .bindings()
+            .clone();
 
         self.record_use_bindings(bindings, use_id);
     }
@@ -2363,12 +2244,11 @@ impl<'db> UseDefMapBuilder<'db> {
         for place in places {
             let place_state =
                 pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
-            let place_state = self.pending_reachability.materialize_ref_at_use(
-                place_state,
-                pending,
-                &mut self.reachability_constraints,
-            );
-            let bindings = place_state.bindings().clone();
+            let bindings = self
+                .pending_reachability
+                .materialize_ref(place_state, pending, &mut self.reachability_constraints)
+                .bindings()
+                .clone();
 
             let binding_definition_ids = bindings.iter().map(LiveBinding::binding);
             self.mark_definition_ids_used(binding_definition_ids);
@@ -2448,12 +2328,7 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let bindings = self
             .pending_reachability
-            .materialize_ref(
-                place_state,
-                pending,
-                &mut self.narrowing_constraints,
-                &mut self.reachability_constraints,
-            )
+            .materialize_ref(place_state, pending, &mut self.reachability_constraints)
             .bindings();
 
         let is_class_symbol = enclosing_scope.is_class() && enclosing_place.is_symbol();
@@ -2496,7 +2371,6 @@ impl<'db> UseDefMapBuilder<'db> {
             .materialize_ref(
                 &mut self.symbol_states[enclosing_symbol],
                 pending,
-                &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             )
             .bindings()
@@ -2558,12 +2432,7 @@ impl<'db> UseDefMapBuilder<'db> {
             pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
         let bindings = self
             .pending_reachability
-            .materialize_ref(
-                place_state,
-                pending,
-                &mut self.narrowing_constraints,
-                &mut self.reachability_constraints,
-            )
+            .materialize_ref(place_state, pending, &mut self.reachability_constraints)
             .bindings();
 
         bindings.iter().copied()
@@ -2650,9 +2519,7 @@ impl<'db> UseDefMapBuilder<'db> {
             .iter_mut()
             .chain(self.member_states.iter_mut())
         {
-            // No later state change can require the correlation represented by pending call
-            // narrowing gates, so only reachability needs to be finalized here.
-            self.pending_reachability.materialize_reachability(
+            self.pending_reachability.materialize(
                 state,
                 pending,
                 &mut self.reachability_constraints,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -198,26 +198,6 @@ def _(val: int | None):
     reveal_type(val)  # revealed: int
 ```
 
-Narrowing that occurs after the `NoReturn` call must also be discarded with the unreachable branch:
-
-```py
-from typing_extensions import Never
-
-def fail() -> Never:
-    raise RuntimeError
-
-def _(x: int | None, flag: bool):
-    if flag:
-        fail()
-        if x is not None:
-            return
-    else:
-        if x is None:
-            return
-
-    reveal_type(x)  # revealed: int
-```
-
 And for elif branches:
 
 ```py


### PR DESCRIPTION
## Summary

This reverts #26775 after [a post-merge finding](https://github.com/astral-sh/ruff/pull/26775#issuecomment-4964970253) showed that deferred call gates are dropped too early at nested control-flow merges. An unrelated nested `if` can therefore discard a preceding `Never` call gate and allow narrowing from an unreachable path to widen the final type.

We restore the previous eager call-gate materialization while we continue the optimization in a separate draft PR.
