### PR TITLE
[ty] Defer statement-call narrowing gates

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1415,25 +1415,47 @@ fn benchmark_typeis_narrowing(criterion: &mut Criterion) {
 
 /// Regression benchmark for <https://github.com/astral-sh/ty/issues/3986>.
 ///
-/// Each statement-level call creates a reachability predicate. Repeatedly scanning every preceding
-/// predicate while checking later expressions makes this pattern quadratic.
+/// Non-terminal-call predicates must gate later narrowing. Keeping these scope-wide constraints in
+/// an append-only tree avoids eagerly rewriting every live place state after each call. Exercise
+/// unnarrowed, already-narrowed, and fixed-reachability bindings because each takes a different
+/// path through reachability and narrowing evaluation.
 fn benchmark_repeated_statement_calls(criterion: &mut Criterion) {
     setup_rayon();
 
-    let mut code = String::from("def f() -> None:\n    value = 'abc'\n");
-    code.push_str(&"    value.upper()\n".repeat(1_500));
+    let cases = [
+        (
+            "ty_micro[repeated_statement_calls]",
+            String::from("def f() -> None:\n    value = 'abc'\n"),
+            "    value.upper()\n",
+        ),
+        (
+            "ty_micro[repeated_statement_calls_pre_narrowed]",
+            String::from(
+                "def f(value: str | None) -> None:\n    if value is None:\n        return\n",
+            ),
+            "    value.upper()\n",
+        ),
+        (
+            "ty_micro[repeated_statement_calls_fixed_reachability]",
+            String::from("def f(value: str, flag: bool) -> None:\n    if flag:\n"),
+            "        value.upper()\n",
+        ),
+    ];
 
-    criterion.bench_function("ty_micro[repeated_statement_calls]", |b| {
-        b.iter_batched_ref(
-            || setup_micro_case(&code),
-            |case| {
-                let Case { db, .. } = case;
-                let result = db.check();
-                assert_eq!(result.len(), 0);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    for (name, mut code, statement) in cases {
+        code.push_str(&statement.repeat(1_500));
+        criterion.bench_function(name, |b| {
+            b.iter_batched_ref(
+                || setup_micro_case(&code),
+                |case| {
+                    let Case { db, .. } = case;
+                    let result = db.check();
+                    assert_eq!(result.len(), 0);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
 }
 
 /// Benchmarks solving many union-bearing upper bounds while inferring a generic call.

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4199,15 +4199,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             .add_atom(predicate_id);
 
                         if self.in_function_scope() {
-                            self.record_reachability_constraint_id(predicate_id);
-
-                            // Also gate narrowing by this constraint: if the call returns
-                            // `Never`, any narrowing in the current branch should be
-                            // invalidated (since this path is unreachable). This enables
-                            // narrowing to be preserved after if-statements where one branch
-                            // calls a `NoReturn` function like `sys.exit()`.
+                            let reachability_constraint = self
+                                .current_reachability_constraints_mut()
+                                .add_atom(predicate_id);
                             self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
+                                .record_non_terminal_call_constraints(
+                                    reachability_constraint,
+                                    narrowing_constraint,
+                                );
                         } else {
                             // In non-function scopes, we only record a narrowing constraint
                             // (not a reachability constraint). Recording reachability for

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1382,14 +1382,14 @@ struct PendingReachabilityId;
 #[derive(Debug)]
 struct PendingReachabilityConstraint {
     parent: PendingReachabilityId,
-    constraint: ScopedReachabilityConstraintId,
+    reachability_constraint: ScopedReachabilityConstraintId,
+    narrowing_constraint: ScopedNarrowingConstraint,
 }
 
-/// An append-only tree of scope-wide reachability constraints.
+/// An append-only tree of scope-wide reachability constraints and call narrowing gates.
 ///
-/// Each [`PendingPlaceState`] remembers the last node applied to its place state, so snapshots can
-/// share place states and defer applying subsequent constraints until the place is observed or
-/// changed.
+/// Each [`PendingPlaceState`] remembers the last node applied for each constraint kind, so
+/// snapshots can share place states and defer applying subsequent constraints until needed.
 #[derive(Debug)]
 struct PendingReachability {
     constraints: IndexVec<PendingReachabilityId, PendingReachabilityConstraint>,
@@ -1402,7 +1402,8 @@ impl Default for PendingReachability {
         let root = constraints.next_index();
         constraints.push(PendingReachabilityConstraint {
             parent: root,
-            constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            reachability_constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            narrowing_constraint: ScopedNarrowingConstraint::ALWAYS_TRUE,
         });
         Self {
             constraints,
@@ -1412,18 +1413,67 @@ impl Default for PendingReachability {
 }
 
 impl PendingReachability {
-    fn push(&mut self, constraint: ScopedReachabilityConstraintId) {
+    fn push(
+        &mut self,
+        reachability_constraint: ScopedReachabilityConstraintId,
+        narrowing_constraint: ScopedNarrowingConstraint,
+    ) {
         self.current = self.constraints.push(PendingReachabilityConstraint {
             parent: self.current,
-            constraint,
+            reachability_constraint,
+            narrowing_constraint,
         });
     }
 
-    /// Applies the constraints between the place's last materialized node and `target`.
+    /// Applies both constraint kinds between the place's last materialized nodes and `target`.
     ///
     /// The place's node must be an ancestor of `target`. After materialization, the place is
     /// uniquely owned for mutation and records `target` as its last applied node.
     fn materialize<'a>(
+        &self,
+        pending: &'a mut PendingPlaceState,
+        target: PendingReachabilityId,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+    ) -> &'a mut PlaceState {
+        self.materialize_reachability(pending, target, reachability_constraints);
+        self.materialize_narrowing(pending, target, narrowing_constraints);
+
+        Rc::make_mut(&mut pending.state)
+    }
+
+    fn materialize_narrowing(
+        &self,
+        pending: &mut PendingPlaceState,
+        target: PendingReachabilityId,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+    ) {
+        if pending.narrowing != target {
+            let mut unapplied = SmallVec::<[ScopedNarrowingConstraint; 4]>::new();
+            let mut current = target;
+            while current != pending.narrowing {
+                let event = &self.constraints[current];
+                if event.narrowing_constraint != ScopedNarrowingConstraint::ALWAYS_TRUE {
+                    unapplied.push(event.narrowing_constraint);
+                }
+                assert_ne!(
+                    current, event.parent,
+                    "pending narrowing must be an ancestor"
+                );
+                current = event.parent;
+            }
+
+            if !unapplied.is_empty() {
+                let state = Rc::make_mut(&mut pending.state);
+                for constraint in unapplied.into_iter().rev() {
+                    state.record_narrowing_constraint(narrowing_constraints, constraint);
+                }
+            }
+            pending.narrowing = target;
+        }
+    }
+
+    fn materialize_reachability<'a>(
         &self,
         pending: &'a mut PendingPlaceState,
         target: PendingReachabilityId,
@@ -1434,7 +1484,7 @@ impl PendingReachability {
             let mut current = target;
             while current != pending.reachability {
                 let event = &self.constraints[current];
-                unapplied.push(event.constraint);
+                unapplied.push(event.reachability_constraint);
                 assert_ne!(
                     current, event.parent,
                     "pending reachability must be an ancestor"
@@ -1461,11 +1511,31 @@ impl PendingReachability {
         &self,
         pending: &'a mut PendingPlaceState,
         target: PendingReachabilityId,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) -> &'a PlaceState {
-        if pending.reachability != target {
-            self.materialize(pending, target, reachability_constraints);
+        if pending.reachability != target || pending.narrowing != target {
+            self.materialize(
+                pending,
+                target,
+                narrowing_constraints,
+                reachability_constraints,
+            );
         }
+        &pending.state
+    }
+
+    /// Returns the place state needed to resolve a use.
+    ///
+    /// A call's narrowing gate is only needed if the place is later changed or merged, so it is
+    /// not materialized here.
+    fn materialize_ref_at_use<'a>(
+        &self,
+        pending: &'a mut PendingPlaceState,
+        target: PendingReachabilityId,
+        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+    ) -> &'a PlaceState {
+        self.materialize_reachability(pending, target, reachability_constraints);
         &pending.state
     }
 
@@ -1482,7 +1552,8 @@ impl PendingReachability {
         let mut current = target;
         while current != ancestor {
             let event = &self.constraints[current];
-            constraint = reachability_constraints.add_and_constraint(constraint, event.constraint);
+            constraint = reachability_constraints
+                .add_and_constraint(constraint, event.reachability_constraint);
             assert_ne!(
                 current, event.parent,
                 "pending reachability must be an ancestor"
@@ -1491,6 +1562,52 @@ impl PendingReachability {
         }
         constraint
     }
+
+    /// Combines the call narrowing gates after `ancestor` through `target` into one constraint.
+    ///
+    /// `ancestor` must be an ancestor of `target`.
+    fn narrowing_constraint_between(
+        &self,
+        ancestor: PendingReachabilityId,
+        target: PendingReachabilityId,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+    ) -> ScopedNarrowingConstraint {
+        let mut unapplied = SmallVec::<[ScopedNarrowingConstraint; 4]>::new();
+        let mut current = target;
+        while current != ancestor {
+            let event = &self.constraints[current];
+            if event.narrowing_constraint != ScopedNarrowingConstraint::ALWAYS_TRUE {
+                unapplied.push(event.narrowing_constraint);
+            }
+            assert_ne!(
+                current, event.parent,
+                "pending narrowing must be an ancestor"
+            );
+            current = event.parent;
+        }
+
+        let mut constraint = ScopedNarrowingConstraint::ALWAYS_TRUE;
+        for pending in unapplied.into_iter().rev() {
+            constraint = narrowing_constraints.add_and_constraint(constraint, pending);
+        }
+        constraint
+    }
+
+    /// Returns the lowest common ancestor of two nodes in the pending-constraint tree.
+    fn common_ancestor(
+        &self,
+        mut left: PendingReachabilityId,
+        mut right: PendingReachabilityId,
+    ) -> PendingReachabilityId {
+        while left != right {
+            if left.index() > right.index() {
+                left = self.constraints[left].parent;
+            } else {
+                right = self.constraints[right].parent;
+            }
+        }
+        left
+    }
 }
 
 /// A copy-on-write place state and the last reachability node materialized into it.
@@ -1498,6 +1615,7 @@ impl PendingReachability {
 struct PendingPlaceState {
     state: Rc<PlaceState>,
     reachability: PendingReachabilityId,
+    narrowing: PendingReachabilityId,
 }
 
 impl PendingPlaceState {
@@ -1505,6 +1623,7 @@ impl PendingPlaceState {
         Self {
             state: Rc::new(state),
             reachability,
+            narrowing: reachability,
         }
     }
 }
@@ -1535,10 +1654,22 @@ impl PendingReachability {
         narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
+        let branch_ancestor = self.common_ancestor(self.current, branch);
+        let current_narrowing =
+            self.narrowing_constraint_between(branch_ancestor, self.current, narrowing_constraints);
+        let branch_narrowing =
+            self.narrowing_constraint_between(branch_ancestor, branch, narrowing_constraints);
+        let merged_narrowing =
+            narrowing_constraints.add_or_constraint(current_narrowing, branch_narrowing);
         let mut branch_states = branch_states.into_iter();
         for current in current_states {
             let Some(mut branch_state) = branch_states.next() else {
-                let current = self.materialize(current, self.current, reachability_constraints);
+                let current = self.materialize(
+                    current,
+                    self.current,
+                    narrowing_constraints,
+                    reachability_constraints,
+                );
                 current.merge(
                     PlaceState::undefined(branch_reachability),
                     narrowing_constraints,
@@ -1551,10 +1682,20 @@ impl PendingReachability {
             // common case is a truthy/falsy pair whose constraints cancel to `ALWAYS_TRUE`, leaving
             // the shared state untouched.
             if current.reachability == branch_state.reachability
+                && current.narrowing == branch_state.narrowing
                 && Rc::ptr_eq(&current.state, &branch_state.state)
             {
                 if self.current == branch {
                     continue;
+                }
+
+                // Preserve call gates that precede the branch, then merge gates introduced on the
+                // individual branch paths. If either path has no gate, the merged gate simplifies
+                // to `ALWAYS_TRUE` and can be discarded.
+                self.materialize_narrowing(current, branch_ancestor, narrowing_constraints);
+                if merged_narrowing != ScopedNarrowingConstraint::ALWAYS_TRUE {
+                    Rc::make_mut(&mut current.state)
+                        .record_narrowing_constraint(narrowing_constraints, merged_narrowing);
                 }
 
                 let current_constraint = self.constraint_between(
@@ -1576,12 +1717,23 @@ impl PendingReachability {
                     );
                 }
                 current.reachability = self.current;
+                current.narrowing = self.current;
                 continue;
             }
 
-            self.materialize(&mut branch_state, branch, reachability_constraints);
+            self.materialize(
+                &mut branch_state,
+                branch,
+                narrowing_constraints,
+                reachability_constraints,
+            );
             let branch_state = Rc::unwrap_or_clone(branch_state.state);
-            let current = self.materialize(current, self.current, reachability_constraints);
+            let current = self.materialize(
+                current,
+                self.current,
+                narrowing_constraints,
+                reachability_constraints,
+            );
             current.merge(
                 branch_state,
                 narrowing_constraints,
@@ -1763,6 +1915,7 @@ impl<'db> UseDefMapBuilder<'db> {
         let place_state = self.pending_reachability.materialize(
             place_state,
             pending,
+            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
         let definitions_at_definition = DefinitionsAtDefinition {
@@ -1856,6 +2009,7 @@ impl<'db> UseDefMapBuilder<'db> {
         let state = self.pending_reachability.materialize(
             state,
             pending,
+            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
         state.record_narrowing_constraint_for_bindings_at_use(
@@ -1885,6 +2039,7 @@ impl<'db> UseDefMapBuilder<'db> {
         let state = self.pending_reachability.materialize(
             state,
             pending,
+            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
         state.record_narrowing_constraint_for_bindings(
@@ -1931,6 +2086,7 @@ impl<'db> UseDefMapBuilder<'db> {
                         let state = self.pending_reachability.materialize(
                             state,
                             pending,
+                            &mut self.narrowing_constraints,
                             &mut self.reachability_constraints,
                         );
                         state.record_narrowing_constraint(
@@ -1944,6 +2100,7 @@ impl<'db> UseDefMapBuilder<'db> {
                         let state = self.pending_reachability.materialize(
                             state,
                             pending,
+                            &mut self.narrowing_constraints,
                             &mut self.reachability_constraints,
                         );
                         state.record_narrowing_constraint(
@@ -1973,6 +2130,7 @@ impl<'db> UseDefMapBuilder<'db> {
             .materialize_ref(
                 &mut self.symbol_states[symbol],
                 pending,
+                &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             )
             .clone();
@@ -1981,6 +2139,7 @@ impl<'db> UseDefMapBuilder<'db> {
             let state = self.pending_reachability.materialize_ref(
                 &mut self.member_states[member_id],
                 pending,
+                &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             );
             associated_member_states.insert(member_id, state.clone());
@@ -2034,6 +2193,7 @@ impl<'db> UseDefMapBuilder<'db> {
         let symbol_state = self.pending_reachability.materialize(
             &mut self.symbol_states[symbol],
             pending,
+            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
         let mut post_definition_state =
@@ -2062,6 +2222,7 @@ impl<'db> UseDefMapBuilder<'db> {
             let member_state = self.pending_reachability.materialize(
                 &mut self.member_states[member_id],
                 pending,
+                &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             );
             let mut post_definition_state =
@@ -2103,6 +2264,7 @@ impl<'db> UseDefMapBuilder<'db> {
             let state = self.pending_reachability.materialize(
                 state,
                 pending,
+                &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             );
             state.record_narrowing_constraint(&mut self.narrowing_constraints, constraint);
@@ -2113,10 +2275,34 @@ impl<'db> UseDefMapBuilder<'db> {
         &mut self,
         constraint: ScopedReachabilityConstraintId,
     ) {
+        self.record_reachability_constraint_impl(
+            constraint,
+            ScopedNarrowingConstraint::ALWAYS_TRUE,
+        );
+    }
+
+    /// Records a call's reachability predicate and its corresponding narrowing gate together.
+    ///
+    /// Reachability is materialized when a place is used, while the narrowing gate remains pending
+    /// until that place is changed or merged.
+    pub(super) fn record_non_terminal_call_constraints(
+        &mut self,
+        reachability_constraint: ScopedReachabilityConstraintId,
+        narrowing_constraint: ScopedNarrowingConstraint,
+    ) {
+        self.record_reachability_constraint_impl(reachability_constraint, narrowing_constraint);
+    }
+
+    fn record_reachability_constraint_impl(
+        &mut self,
+        reachability_constraint: ScopedReachabilityConstraintId,
+        narrowing_constraint: ScopedNarrowingConstraint,
+    ) {
         self.reachability = self
             .reachability_constraints
-            .add_and_constraint(self.reachability, constraint);
-        self.pending_reachability.push(constraint);
+            .add_and_constraint(self.reachability, reachability_constraint);
+        self.pending_reachability
+            .push(reachability_constraint, narrowing_constraint);
     }
 
     pub(super) fn record_declaration(
@@ -2131,6 +2317,7 @@ impl<'db> UseDefMapBuilder<'db> {
         let place_state = self.pending_reachability.materialize(
             place_state,
             pending,
+            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
 
@@ -2169,6 +2356,7 @@ impl<'db> UseDefMapBuilder<'db> {
         let place_state = self.pending_reachability.materialize(
             place_state,
             pending,
+            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
         place_state.record_declaration(def_id, self.reachability);
@@ -2209,6 +2397,7 @@ impl<'db> UseDefMapBuilder<'db> {
         let place_state = self.pending_reachability.materialize(
             place_state,
             pending,
+            &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
 
@@ -2226,11 +2415,12 @@ impl<'db> UseDefMapBuilder<'db> {
         let pending = self.pending_reachability.current;
         let place_state =
             pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
-        let bindings = self
-            .pending_reachability
-            .materialize_ref(place_state, pending, &mut self.reachability_constraints)
-            .bindings()
-            .clone();
+        let place_state = self.pending_reachability.materialize_ref_at_use(
+            place_state,
+            pending,
+            &mut self.reachability_constraints,
+        );
+        let bindings = place_state.bindings().clone();
 
         self.record_use_bindings(bindings, use_id);
     }
@@ -2244,11 +2434,12 @@ impl<'db> UseDefMapBuilder<'db> {
         for place in places {
             let place_state =
                 pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
-            let bindings = self
-                .pending_reachability
-                .materialize_ref(place_state, pending, &mut self.reachability_constraints)
-                .bindings()
-                .clone();
+            let place_state = self.pending_reachability.materialize_ref_at_use(
+                place_state,
+                pending,
+                &mut self.reachability_constraints,
+            );
+            let bindings = place_state.bindings().clone();
 
             let binding_definition_ids = bindings.iter().map(LiveBinding::binding);
             self.mark_definition_ids_used(binding_definition_ids);
@@ -2328,7 +2519,12 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let bindings = self
             .pending_reachability
-            .materialize_ref(place_state, pending, &mut self.reachability_constraints)
+            .materialize_ref(
+                place_state,
+                pending,
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+            )
             .bindings();
 
         let is_class_symbol = enclosing_scope.is_class() && enclosing_place.is_symbol();
@@ -2371,6 +2567,7 @@ impl<'db> UseDefMapBuilder<'db> {
             .materialize_ref(
                 &mut self.symbol_states[enclosing_symbol],
                 pending,
+                &mut self.narrowing_constraints,
                 &mut self.reachability_constraints,
             )
             .bindings()
@@ -2432,7 +2629,12 @@ impl<'db> UseDefMapBuilder<'db> {
             pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
         let bindings = self
             .pending_reachability
-            .materialize_ref(place_state, pending, &mut self.reachability_constraints)
+            .materialize_ref(
+                place_state,
+                pending,
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+            )
             .bindings();
 
         bindings.iter().copied()
@@ -2519,7 +2721,9 @@ impl<'db> UseDefMapBuilder<'db> {
             .iter_mut()
             .chain(self.member_states.iter_mut())
         {
-            self.pending_reachability.materialize(
+            // No later state change can require the correlation represented by pending call
+            // narrowing gates, so only reachability needs to be finalized here.
+            self.pending_reachability.materialize_reachability(
                 state,
                 pending,
                 &mut self.reachability_constraints,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -198,6 +198,90 @@ def _(val: int | None):
     reveal_type(val)  # revealed: int
 ```
 
+Narrowing that occurs after the `NoReturn` call must also be discarded with the unreachable branch:
+
+```py
+from typing_extensions import Never
+
+def fail() -> Never:
+    raise RuntimeError
+
+def _(x: int | None, flag: bool):
+    if flag:
+        fail()
+        if x is not None:
+            return
+    else:
+        if x is None:
+            return
+
+    reveal_type(x)  # revealed: int
+```
+
+Call constraints that precede a nested merge must still gate narrowing later in the outer branch:
+
+```py
+from typing_extensions import Never
+
+def fail_nested_merge() -> Never:
+    raise RuntimeError
+
+def _(x: int | None, outer: bool, inner: bool) -> None:
+    if outer:
+        fail_nested_merge()
+
+        if inner:
+            pass
+        else:
+            pass
+
+        if x is not None:
+            return
+    else:
+        if x is None:
+            return
+
+    reveal_type(x)  # revealed: int
+```
+
+Call constraints introduced inside the nested branches are still discarded at that merge:
+
+```py
+def _(x: int | None, outer: bool, inner: bool) -> None:
+    if outer:
+        if inner:
+            pass
+        else:
+            fail_nested_merge()
+
+        if x is not None:
+            return
+    else:
+        if x is None:
+            return
+
+    reveal_type(x)  # revealed: None | int
+```
+
+If every nested branch contains a call, their combined call constraint must be preserved:
+
+```py
+def _(x: int | None, outer: bool, inner: bool) -> None:
+    if outer:
+        if inner:
+            fail_nested_merge()
+        else:
+            fail_nested_merge()
+
+        if x is not None:
+            return
+    else:
+        if x is None:
+            return
+
+    reveal_type(x)  # revealed: int
+```
+
 And for elif branches:
 
 ```py


### PR DESCRIPTION
## Summary

This reapplies the deferred call-gate optimization from #26775 after it was reverted in #26792, and addresses the [post-merge finding on #26775](https://github.com/astral-sh/ruff/pull/26775#issuecomment-4964970253). It is stacked on the prefix and reachability-evaluation caches in #26810 and #26811.

Prior to this change, each statement-level call immediately applied an `IsNonTerminalCall` narrowing gate to every live place so calls returning `Never` could invalidate later narrowing. Repeated calls therefore rebuilt all live place states after every statement. We now store the narrowing gate alongside the pending scope-wide reachability constraint, materialize reachability when a place is used, and replay its narrowing gates only before that place changes or merges.

The previous implementation dropped all pending call gates when a nested control-flow merge left a place untouched. That also discarded gates recorded before the branches diverged, allowing narrowing from an unreachable path to affect the merged type. We now find the branch tips' shared ancestor once per flow merge, preserve the shared call gates through that point, and combine only the branch-local suffixes.

The repeated-call benchmark now covers unnarrowed, pre-narrowed, and fixed-reachability bindings, and the narrowing mdtests cover shared and branch-local gates across nested merges.

Closes https://github.com/astral-sh/ty/issues/3986.
