### PR TITLE
[flake8-async] Allow configuring safe decorators for ASYNC119

### DIFF
--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_extend_from_shared_config.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_extend_from_shared_config.snap
@@ -108,6 +108,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool.snap
@@ -110,6 +110,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_preview_enabled.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_preview_enabled.snap
@@ -113,6 +113,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_target_version_override.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_target_version_override.snap
@@ -112,6 +112,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above.snap
@@ -109,6 +109,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above_with_tool.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above_with_tool.snap
@@ -110,6 +110,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above-2.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above-2.snap
@@ -108,6 +108,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above.snap
@@ -108,6 +108,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_no_target_fallback.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_no_target_fallback.snap
@@ -108,6 +108,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff/tests/cli/snapshots/cli__show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__show_settings__display_default_settings.snap
@@ -221,6 +221,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff/tests/cli/snapshots/cli__show_settings__display_settings_from_nested_directory.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__show_settings__display_settings_from_nested_directory.snap
@@ -229,6 +229,7 @@ linter.flake8_annotations.suppress_dummy_args = false
 linter.flake8_annotations.suppress_none_returning = false
 linter.flake8_annotations.allow_star_arg_any = false
 linter.flake8_annotations.ignore_fully_untyped = false
+linter.flake8_async.safe_async_generator_decorators = []
 linter.flake8_bandit.hardcoded_tmp_directory = [
 	/tmp,
 	/var/tmp,

--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC119_custom_decorators.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC119_custom_decorators.py
@@ -1,0 +1,21 @@
+import dishka
+from dishka import provide
+from dishka import Scope
+
+
+@provide(scope=Scope.REQUEST)
+async def safe_dishka_provide_call():
+    with open(""):
+        yield  # OK
+
+
+@dishka.provide
+async def safe_dishka_provide_reference():
+    with open(""):
+        yield  # OK
+
+
+@some_other_decorator
+async def unsafe_other_decorator():
+    with open(""):
+        yield  # ASYNC119

--- a/crates/ruff_linter/src/rules/flake8_async/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/mod.rs
@@ -1,6 +1,7 @@
 //! Rules from [flake8-async](https://pypi.org/project/flake8-async/).
 mod helpers;
 pub(crate) mod rules;
+pub mod settings;
 
 #[cfg(test)]
 mod tests {
@@ -53,6 +54,23 @@ mod tests {
             },
         )?;
         assert_diagnostics!(path.file_name().unwrap().to_str().unwrap(), diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn async119_custom_decorators() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("flake8_async")
+                .join("ASYNC119_custom_decorators.py")
+                .as_path(),
+            &LinterSettings {
+                flake8_async: super::settings::Settings {
+                    safe_async_generator_decorators: vec!["dishka.provide".to_string()],
+                },
+                ..LinterSettings::for_rule(Rule::YieldInContextManagerInAsyncGenerator)
+            },
+        )?;
+        assert_diagnostics!(diagnostics);
         Ok(())
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_async/rules/yield_in_context_manager_in_async_generator.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/yield_in_context_manager_in_async_generator.rs
@@ -1,5 +1,6 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::helpers::map_callable;
+use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::{self as ast, Expr, Stmt};
 use ruff_python_semantic::ScopeKind;
 use ruff_text_size::Ranged;
@@ -27,6 +28,9 @@ use crate::checkers::ast::Checker;
 /// The rule also suppresses diagnostics for functions decorated with
 /// `@pytest.fixture`, `@pytest_asyncio.fixture`, or `@trio.as_safe_channel`,
 /// as these handle async generator cleanup safely.
+///
+/// Additional safe decorators can be configured via the
+/// [`lint.flake8-async.safe-async-generator-decorators`] setting.
 ///
 /// ## Example
 ///
@@ -127,6 +131,11 @@ fn enclosing_async_function<'a>(checker: &Checker<'a>) -> Option<&'a ast::StmtFu
 /// `@pytest.fixture`, or `@trio.as_safe_channel`, which are known to handle
 /// async generator cleanup safely.
 fn has_safe_decorator(checker: &Checker, function_def: &ast::StmtFunctionDef) -> bool {
+    let safe_async_generator_decorators = &checker
+        .settings()
+        .flake8_async
+        .safe_async_generator_decorators;
+
     function_def.decorator_list.iter().any(|decorator| {
         checker
             .semantic()
@@ -137,7 +146,9 @@ fn has_safe_decorator(checker: &Checker, function_def: &ast::StmtFunctionDef) ->
                     ["contextlib", "asynccontextmanager"]
                         | ["pytest" | "pytest_asyncio", "fixture"]
                         | ["trio", "as_safe_channel"]
-                )
+                ) || safe_async_generator_decorators
+                    .iter()
+                    .any(|name| qualified_name == QualifiedName::from_dotted_name(name))
             })
     })
 }

--- a/crates/ruff_linter/src/rules/flake8_async/settings.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/settings.rs
@@ -1,0 +1,23 @@
+//! Settings for the `flake8-async` plugin.
+
+use crate::display_settings;
+use ruff_macros::CacheKey;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, Default, CacheKey)]
+pub struct Settings {
+    pub safe_async_generator_decorators: Vec<String>,
+}
+
+impl Display for Settings {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        display_settings! {
+            formatter = f,
+            namespace = "linter.flake8_async",
+            fields = [
+                self.safe_async_generator_decorators | array
+            ]
+        }
+        Ok(())
+    }
+}

--- a/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__async119_custom_decorators.snap
+++ b/crates/ruff_linter/src/rules/flake8_async/snapshots/ruff_linter__rules__flake8_async__tests__async119_custom_decorators.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff_linter/src/rules/flake8_async/mod.rs
+---
+ASYNC119 Yield in context manager in async generator may not trigger cleanup
+  --> ASYNC119_custom_decorators.py:21:9
+   |
+19 | async def unsafe_other_decorator():
+20 |     with open(""):
+21 |         yield  # ASYNC119
+   |         ^^^^^
+   |
+help: Use `@asynccontextmanager` if appropriate, or refactor

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -16,8 +16,8 @@ use ruff_python_ast::PythonVersion;
 use crate::line_width::LineLength;
 use crate::registry::{Linter, Rule};
 use crate::rules::{
-    flake8_annotations, flake8_bandit, flake8_boolean_trap, flake8_bugbear, flake8_builtins,
-    flake8_comprehensions, flake8_copyright, flake8_errmsg, flake8_gettext,
+    flake8_annotations, flake8_async, flake8_bandit, flake8_boolean_trap, flake8_bugbear,
+    flake8_builtins, flake8_comprehensions, flake8_copyright, flake8_errmsg, flake8_gettext,
     flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style, flake8_quotes,
     flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, isort, mccabe,
     pep8_naming, pycodestyle, pydoclint, pydocstyle, pyflakes, pylint, pyupgrade, ruff,
@@ -256,6 +256,7 @@ pub struct LinterSettings {
 
     // Plugins
     pub flake8_annotations: flake8_annotations::settings::Settings,
+    pub flake8_async: flake8_async::settings::Settings,
     pub flake8_bandit: flake8_bandit::settings::Settings,
     pub flake8_boolean_trap: flake8_boolean_trap::settings::Settings,
     pub flake8_bugbear: flake8_bugbear::settings::Settings,
@@ -325,6 +326,7 @@ impl Display for LinterSettings {
             namespace = "linter",
             fields = [
                 self.flake8_annotations | nested,
+                self.flake8_async | nested,
                 self.flake8_bandit | nested,
                 self.flake8_bugbear | nested,
                 self.flake8_builtins | nested,
@@ -836,6 +838,7 @@ impl LinterSettings {
             task_tags: TASK_TAGS.iter().map(ToString::to_string).collect(),
             typing_modules: vec![],
             flake8_annotations: flake8_annotations::settings::Settings::default(),
+            flake8_async: flake8_async::settings::Settings::default(),
             flake8_bandit: flake8_bandit::settings::Settings::default(),
             flake8_boolean_trap: flake8_boolean_trap::settings::Settings::default(),
             flake8_bugbear: flake8_bugbear::settings::Settings::default(),

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -47,9 +47,9 @@ use ruff_python_formatter::{
 };
 
 use crate::options::{
-    AnalyzeOptions, Flake8AnnotationsOptions, Flake8BanditOptions, Flake8BooleanTrapOptions,
-    Flake8BugbearOptions, Flake8BuiltinsOptions, Flake8ComprehensionsOptions,
-    Flake8CopyrightOptions, Flake8ErrMsgOptions, Flake8GetTextOptions,
+    AnalyzeOptions, Flake8AnnotationsOptions, Flake8AsyncOptions, Flake8BanditOptions,
+    Flake8BooleanTrapOptions, Flake8BugbearOptions, Flake8BuiltinsOptions,
+    Flake8ComprehensionsOptions, Flake8CopyrightOptions, Flake8ErrMsgOptions, Flake8GetTextOptions,
     Flake8ImplicitStrConcatOptions, Flake8ImportConventionsOptions, Flake8PytestStyleOptions,
     Flake8QuotesOptions, Flake8SelfOptions, Flake8TidyImportsOptions, Flake8TypeCheckingOptions,
     Flake8UnusedArgumentsOptions, FormatOptions, IsortOptions, LintCommonOptions, LintOptions,
@@ -491,6 +491,10 @@ impl Configuration {
                         ..pycodestyle::settings::Settings::default()
                     }
                 },
+                flake8_async: lint
+                    .flake8_async
+                    .map(Flake8AsyncOptions::into_settings)
+                    .unwrap_or_default(),
                 pydoclint: lint
                     .pydoclint
                     .map(PydoclintOptions::into_settings)
@@ -769,6 +773,7 @@ pub struct LintConfiguration {
     pub mccabe: Option<McCabeOptions>,
     pub pep8_naming: Option<Pep8NamingOptions>,
     pub pycodestyle: Option<PycodestyleOptions>,
+    pub flake8_async: Option<Flake8AsyncOptions>,
     pub pydoclint: Option<PydoclintOptions>,
     pub pydocstyle: Option<PydocstyleOptions>,
     pub pyflakes: Option<PyflakesOptions>,
@@ -886,6 +891,7 @@ impl LintConfiguration {
             mccabe: options.common.mccabe,
             pep8_naming: options.common.pep8_naming,
             pycodestyle: options.common.pycodestyle,
+            flake8_async: options.flake8_async,
             pydoclint: options.pydoclint,
             pydocstyle: options.common.pydocstyle,
             pyflakes: options.common.pyflakes,
@@ -1303,6 +1309,7 @@ impl LintConfiguration {
             mccabe: self.mccabe.combine(config.mccabe),
             pep8_naming: self.pep8_naming.combine(config.pep8_naming),
             pycodestyle: self.pycodestyle.combine(config.pycodestyle),
+            flake8_async: self.flake8_async.combine(config.flake8_async),
             pydoclint: self.pydoclint.combine(config.pydoclint),
             pydocstyle: self.pydocstyle.combine(config.pydocstyle),
             pyflakes: self.pyflakes.combine(config.pyflakes),

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -528,6 +528,10 @@ pub struct LintOptions {
     )]
     pub exclude: Option<Vec<String>>,
 
+    /// Options for the `flake8-async` plugin.
+    #[option_group]
+    pub flake8_async: Option<Flake8AsyncOptions>,
+
     /// Options for the `pydoclint` plugin.
     #[option_group]
     pub pydoclint: Option<PydoclintOptions>,
@@ -1145,6 +1149,45 @@ impl Flake8AnnotationsOptions {
             suppress_none_returning: self.suppress_none_returning.unwrap_or(false),
             allow_star_arg_any: self.allow_star_arg_any.unwrap_or(false),
             ignore_fully_untyped: self.ignore_fully_untyped.unwrap_or(false),
+        }
+    }
+}
+
+/// Options for the `flake8-async` plugin.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, OptionsMetadata, CombineOptions,
+)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Flake8AsyncOptions {
+    /// Additional decorators that mark an async generator as safe to yield
+    /// inside a context manager, suppressing the `yield-in-context-manager-in-async-generator`
+    /// rule (`ASYNC119`).
+    ///
+    /// The built-in safe decorators (`contextlib.asynccontextmanager`, `pytest.fixture`,
+    /// `pytest_asyncio.fixture`, and `trio.as_safe_channel`) are always recognized.
+    /// Use this setting to add framework-specific decorators that handle async generator
+    /// cleanup safely.
+    ///
+    /// Expects to receive a list of fully-qualified names (e.g., `dishka.provide`, rather than
+    /// `provide`).
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[str]",
+        example = r#"
+            # Mark `dishka.provide` as a safe async generator decorator.
+            safe-async-generator-decorators = ["dishka.provide"]
+        "#
+    )]
+    pub safe_async_generator_decorators: Option<Vec<String>>,
+}
+
+impl Flake8AsyncOptions {
+    pub fn into_settings(self) -> ruff_linter::rules::flake8_async::settings::Settings {
+        ruff_linter::rules::flake8_async::settings::Settings {
+            safe_async_generator_decorators: self
+                .safe_async_generator_decorators
+                .unwrap_or_default(),
         }
     }
 }
@@ -4271,6 +4314,7 @@ pub struct LintOptionsWire {
     extend_per_file_ignores: Option<FxHashMap<String, Vec<UnresolvedRuleSelector>>>,
 
     exclude: Option<Vec<String>>,
+    flake8_async: Option<Flake8AsyncOptions>,
     pydoclint: Option<PydoclintOptions>,
     ruff: Option<RuffOptions>,
     preview: Option<bool>,
@@ -4327,6 +4371,7 @@ impl From<LintOptionsWire> for LintOptions {
             per_file_ignores,
             extend_per_file_ignores,
             exclude,
+            flake8_async,
             pydoclint,
             ruff,
             preview,
@@ -4384,6 +4429,7 @@ impl From<LintOptionsWire> for LintOptions {
                 extend_per_file_ignores,
             },
             exclude,
+            flake8_async,
             pydoclint,
             ruff,
             preview,

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -965,6 +965,23 @@
       },
       "additionalProperties": false
     },
+    "Flake8AsyncOptions": {
+      "description": "Options for the `flake8-async` plugin.",
+      "type": "object",
+      "properties": {
+        "safe-async-generator-decorators": {
+          "description": "Additional decorators that mark an async generator as safe to yield\ninside a context manager, suppressing the `yield-in-context-manager-in-async-generator`\nrule (`ASYNC119`).\n\nThe built-in safe decorators (`contextlib.asynccontextmanager`, `pytest.fixture`,\n`pytest_asyncio.fixture`, and `trio.as_safe_channel`) are always recognized.\nUse this setting to add framework-specific decorators that handle async generator\ncleanup safely.\n\nExpects to receive a list of fully-qualified names (e.g., `dishka.provide`, rather than\n`provide`).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "Flake8BanditOptions": {
       "description": "Options for the `flake8-bandit` plugin.",
       "type": "object",
@@ -2254,6 +2271,17 @@
           "anyOf": [
             {
               "$ref": "#/definitions/Flake8AnnotationsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flake8-async": {
+          "description": "Options for the `flake8-async` plugin.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Flake8AsyncOptions"
             },
             {
               "type": "null"


### PR DESCRIPTION
## Summary

ASYNC119 (`yield-in-context-manager-in-async-generator`) currently uses a hard-coded
allowlist of decorators known to handle async generator cleanup safely:
`@contextlib.asynccontextmanager`, `@pytest.fixture` / `@pytest_asyncio.fixture`,
and `@trio.as_safe_channel`.

Other frameworks can provide the same guarantee but aren't recognized. Dishka,
for example, finalizes generator-based providers when their scope exits, which
can trigger a false positive on `@provide(scope=Scope.REQUEST)`-decorated
generators.

This PR adds a `lint.flake8-async.safe-async-generator-decorators` setting so
users can extend the allowlist without Ruff needing to hard-code additional
framework-specific decorators.

```toml
[tool.ruff.lint.flake8-async]
safe-async-generator-decorators = ["dishka.provide"]
```

Configured entries are resolved using Ruff's semantic model, so both decorator
references (for example, `@dishka.provide`) and decorator calls (for example,
`@provide(scope=Scope.REQUEST)`) are supported.

Closes #26756.

## Test Plan

- Added `ASYNC119_custom_decorators.py` fixture and corresponding snapshot.
- Added a rule test covering `dishka.provide`.
- Updated CLI snapshots for the new configuration option.
- Ran:
  - `cargo test`
  - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
  - `cargo fmt --all`
  - `cargo dev generate-all`