### PR TITLE
Reuse parser scratch buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,6 +3594,7 @@ dependencies = [
  "bstr",
  "compact_str",
  "datatest-stable",
+ "drop_bomb",
  "get-size2",
  "insta",
  "itertools 0.15.0",

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -20,6 +20,7 @@ ruff_text_size = { workspace = true, features = ["get-size"] }
 bitflags = { workspace = true }
 bstr = { workspace = true }
 compact_str = { workspace = true }
+drop_bomb = { workspace = true }
 get-size2 = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -28,7 +28,7 @@ use crate::{
     UnsupportedSyntaxErrorKind,
 };
 
-use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind, ScratchBufferExt};
+use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind};
 
 /// A token set consisting of a newline or end of file.
 const NEWLINE_EOF_SET: TokenSet = TokenSet::new([TokenKind::Newline, TokenKind::EndOfFile]);

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -28,7 +28,7 @@ use crate::{
     UnsupportedSyntaxErrorKind,
 };
 
-use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind};
+use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind, ScratchBufferExt};
 
 /// A token set consisting of a newline or end of file.
 const NEWLINE_EOF_SET: TokenSet = TokenSet::new([TokenKind::Newline, TokenKind::EndOfFile]);
@@ -815,8 +815,8 @@ impl<'src> Parser<'src> {
             };
         }
 
-        let args_start = self.expr_scratch.len();
-        let keywords_start = self.keyword_scratch.len();
+        let args_snapshot = self.expr_scratch.snapshot();
+        let keywords_snapshot = self.keyword_scratch.snapshot();
         let mut seen_keyword_argument = false; // foo = 1
         let mut seen_keyword_unpacking = false; // **foo
 
@@ -943,14 +943,11 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Rpar);
 
-        let keywords_len = self.keyword_scratch.len() - keywords_start;
-        let mut keywords = ThinVec::with_capacity(keywords_len);
-        keywords.extend(self.keyword_scratch.drain(keywords_start..));
-
+        let keywords = self.keyword_scratch.take_thin_vec(keywords_snapshot);
         let arguments = ast::Arguments {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
-            args: self.expr_scratch.drain(args_start..).collect(),
+            args: self.expr_scratch.take(args_snapshot),
             keywords,
         };
 
@@ -1004,7 +1001,7 @@ impl<'src> Parser<'src> {
         // If there are more than one element in the slice, we need to create a tuple
         // expression to represent it.
         if self.eat(TokenKind::Comma) {
-            let slices_start = self.expr_scratch.len();
+            let slices_snapshot = self.expr_scratch.snapshot();
             self.expr_scratch.push(slice);
 
             self.parse_comma_separated_list(RecoveryContextKind::Slices, |parser| {
@@ -1013,7 +1010,7 @@ impl<'src> Parser<'src> {
             });
 
             slice = Expr::Tuple(ast::ExprTuple {
-                elts: self.expr_scratch.drain(slices_start..).collect(),
+                elts: self.expr_scratch.take(slices_snapshot),
                 ctx: ExprContext::Load,
                 range: self.node_range(slice_start),
                 parenthesized: false,
@@ -1251,7 +1248,7 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprBoolOp {
         self.bump(TokenKind::from(op));
 
-        let values_start = self.expr_scratch.len();
+        let values_snapshot = self.expr_scratch.snapshot();
         self.expr_scratch.push(lhs);
         let mut progress = ParserProgress::default();
 
@@ -1270,7 +1267,7 @@ impl<'src> Parser<'src> {
         }
 
         ast::ExprBoolOp {
-            values: self.expr_scratch.drain(values_start..).collect(),
+            values: self.expr_scratch.take(values_snapshot),
             op,
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
@@ -1319,7 +1316,7 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprCompare {
         self.bump_cmp_op(op);
 
-        let comparators_start = self.expr_scratch.len();
+        let comparators_snapshot = self.expr_scratch.snapshot();
         let mut operators = vec![op];
 
         let mut progress = ParserProgress::default();
@@ -1353,7 +1350,7 @@ impl<'src> Parser<'src> {
         ast::ExprCompare {
             left: Box::new(lhs),
             ops: operators.into_boxed_slice(),
-            comparators: self.expr_scratch.drain(comparators_start..).collect(),
+            comparators: self.expr_scratch.take(comparators_snapshot),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }
@@ -2452,7 +2449,7 @@ impl<'src> Parser<'src> {
             self.expect(TokenKind::Comma);
         }
 
-        let elts_start = self.expr_scratch.len();
+        let elts_snapshot = self.expr_scratch.snapshot();
         self.expr_scratch.push(first_element);
 
         self.parse_comma_separated_list(RecoveryContextKind::TupleElements(parenthesized), |p| {
@@ -2465,7 +2462,7 @@ impl<'src> Parser<'src> {
         }
 
         ast::ExprTuple {
-            elts: self.expr_scratch.drain(elts_start..).collect(),
+            elts: self.expr_scratch.take(elts_snapshot),
             ctx: ExprContext::Load,
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
@@ -2481,7 +2478,7 @@ impl<'src> Parser<'src> {
             self.expect(TokenKind::Comma);
         }
 
-        let elts_start = self.expr_scratch.len();
+        let elts_snapshot = self.expr_scratch.snapshot();
         self.expr_scratch.push(first_element);
 
         self.parse_comma_separated_list(RecoveryContextKind::ListElements, |parser| {
@@ -2494,7 +2491,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::Rsqb);
 
         ast::ExprList {
-            elts: self.expr_scratch.drain(elts_start..).collect(),
+            elts: self.expr_scratch.take(elts_snapshot),
             ctx: ExprContext::Load,
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
@@ -2524,7 +2521,7 @@ impl<'src> Parser<'src> {
             );
         }
 
-        let elts_start = self.expr_scratch.len();
+        let elts_snapshot = self.expr_scratch.snapshot();
         self.expr_scratch.push(first_element.expr);
 
         self.parse_comma_separated_list(RecoveryContextKind::SetElements, |parser| {
@@ -2548,7 +2545,7 @@ impl<'src> Parser<'src> {
         ast::ExprSet {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
-            elts: self.expr_scratch.drain(elts_start..).collect(),
+            elts: self.expr_scratch.take(elts_snapshot),
         }
     }
 
@@ -2649,7 +2646,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::In);
         let iter = self.parse_simple_expression(ExpressionContext::default());
 
-        let ifs_start = self.expr_scratch.len();
+        let ifs_snapshot = self.expr_scratch.snapshot();
         let mut progress = ParserProgress::default();
 
         while self.eat(TokenKind::If) {
@@ -2665,7 +2662,7 @@ impl<'src> Parser<'src> {
             node_index: AtomicNodeIndex::NONE,
             target: target.expr,
             iter: iter.expr,
-            ifs: self.expr_scratch.drain(ifs_start..).collect(),
+            ifs: self.expr_scratch.take(ifs_snapshot),
             is_async,
         }
     }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -816,7 +816,7 @@ impl<'src> Parser<'src> {
         }
 
         let args_start = self.expr_scratch.len();
-        let mut keywords = vec![];
+        let keywords_start = self.keyword_scratch.len();
         let mut seen_keyword_argument = false; // foo = 1
         let mut seen_keyword_unpacking = false; // **foo
 
@@ -826,7 +826,7 @@ impl<'src> Parser<'src> {
                 if parser.eat(TokenKind::DoubleStar) {
                     let value = parser.parse_conditional_expression_or_higher();
 
-                    keywords.push(ast::Keyword {
+                    parser.keyword_scratch.push(ast::Keyword {
                         arg: None,
                         value: value.expr,
                         range: parser.node_range(argument_start),
@@ -916,7 +916,7 @@ impl<'src> Parser<'src> {
 
                         let value = parser.parse_conditional_expression_or_higher();
 
-                        keywords.push(ast::Keyword {
+                        parser.keyword_scratch.push(ast::Keyword {
                             arg: Some(arg),
                             value: value.expr,
                             range: parser.node_range(argument_start),
@@ -943,11 +943,15 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Rpar);
 
+        let keywords_len = self.keyword_scratch.len() - keywords_start;
+        let mut keywords = ThinVec::with_capacity(keywords_len);
+        keywords.extend(self.keyword_scratch.drain(keywords_start..));
+
         let arguments = ast::Arguments {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
             args: self.expr_scratch.drain(args_start..).collect(),
-            keywords: keywords.into(),
+            keywords,
         };
 
         self.validate_arguments(&arguments, has_trailing_comma, context);

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -815,7 +815,7 @@ impl<'src> Parser<'src> {
             };
         }
 
-        let mut args = vec![];
+        let args_start = self.expr_scratch.len();
         let mut keywords = vec![];
         let mut seen_keyword_argument = false; // foo = 1
         let mut seen_keyword_unpacking = false; // **foo
@@ -936,12 +936,7 @@ impl<'src> Parser<'src> {
                                 );
                             }
                         }
-                        // Reserve exactly one slot for the first positional argument, while
-                        // avoiding any allocation for keyword-only calls.
-                        if args.is_empty() {
-                            args.reserve_exact(1);
-                        }
-                        args.push(parsed_expr.expr);
+                        parser.expr_scratch.push(parsed_expr.expr);
                     }
                 }
             });
@@ -951,7 +946,7 @@ impl<'src> Parser<'src> {
         let arguments = ast::Arguments {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
-            args: args.into_boxed_slice(),
+            args: self.expr_scratch.drain(args_start..).collect(),
             keywords: keywords.into(),
         };
 
@@ -1005,16 +1000,16 @@ impl<'src> Parser<'src> {
         // If there are more than one element in the slice, we need to create a tuple
         // expression to represent it.
         if self.eat(TokenKind::Comma) {
-            let mut slices = vec![slice];
+            let slices_start = self.expr_scratch.len();
+            self.expr_scratch.push(slice);
 
             self.parse_comma_separated_list(RecoveryContextKind::Slices, |parser| {
-                slices.push(parser.parse_slice());
+                let slice = parser.parse_slice();
+                parser.expr_scratch.push(slice);
             });
 
-            slices.shrink_to_fit();
-
             slice = Expr::Tuple(ast::ExprTuple {
-                elts: slices,
+                elts: self.expr_scratch.drain(slices_start..).collect(),
                 ctx: ExprContext::Load,
                 range: self.node_range(slice_start),
                 parenthesized: false,
@@ -1252,8 +1247,8 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprBoolOp {
         self.bump(TokenKind::from(op));
 
-        let mut values = Vec::with_capacity(2);
-        values.push(lhs);
+        let values_start = self.expr_scratch.len();
+        self.expr_scratch.push(lhs);
         let mut progress = ParserProgress::default();
 
         // Keep adding the expression to `values` until we see a different
@@ -1263,17 +1258,15 @@ impl<'src> Parser<'src> {
 
             let parsed_expr =
                 self.parse_binary_expression_or_higher(OperatorPrecedence::from(op), context);
-            values.push(parsed_expr.expr);
+            self.expr_scratch.push(parsed_expr.expr);
 
             if !self.eat(TokenKind::from(op)) {
                 break;
             }
         }
 
-        values.shrink_to_fit();
-
         ast::ExprBoolOp {
-            values,
+            values: self.expr_scratch.drain(values_start..).collect(),
             op,
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
@@ -1322,7 +1315,7 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprCompare {
         self.bump_cmp_op(op);
 
-        let mut comparators = vec![];
+        let comparators_start = self.expr_scratch.len();
         let mut operators = vec![op];
 
         let mut progress = ParserProgress::default();
@@ -1330,13 +1323,13 @@ impl<'src> Parser<'src> {
         loop {
             progress.assert_progressing(self);
 
-            comparators.push(
-                self.parse_binary_expression_or_higher(
+            let comparator = self
+                .parse_binary_expression_or_higher(
                     OperatorPrecedence::ComparisonsMembershipIdentity,
                     context,
                 )
-                .expr,
-            );
+                .expr;
+            self.expr_scratch.push(comparator);
 
             let next_token = self.current_token_kind();
             if matches!(next_token, TokenKind::In) && context.is_in_excluded() {
@@ -1356,7 +1349,7 @@ impl<'src> Parser<'src> {
         ast::ExprCompare {
             left: Box::new(lhs),
             ops: operators.into_boxed_slice(),
-            comparators: comparators.into_boxed_slice(),
+            comparators: self.expr_scratch.drain(comparators_start..).collect(),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }
@@ -2455,20 +2448,20 @@ impl<'src> Parser<'src> {
             self.expect(TokenKind::Comma);
         }
 
-        let mut elts = vec![first_element];
+        let elts_start = self.expr_scratch.len();
+        self.expr_scratch.push(first_element);
 
         self.parse_comma_separated_list(RecoveryContextKind::TupleElements(parenthesized), |p| {
-            elts.push(parse_func(p).expr);
+            let element = parse_func(p).expr;
+            p.expr_scratch.push(element);
         });
 
         if parenthesized.is_yes() {
             self.expect(TokenKind::Rpar);
         }
 
-        elts.shrink_to_fit();
-
         ast::ExprTuple {
-            elts,
+            elts: self.expr_scratch.drain(elts_start..).collect(),
             ctx: ExprContext::Load,
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
@@ -2484,22 +2477,20 @@ impl<'src> Parser<'src> {
             self.expect(TokenKind::Comma);
         }
 
-        let mut elts = vec![first_element];
+        let elts_start = self.expr_scratch.len();
+        self.expr_scratch.push(first_element);
 
         self.parse_comma_separated_list(RecoveryContextKind::ListElements, |parser| {
-            elts.push(
-                parser
-                    .parse_named_expression_or_higher(ExpressionContext::starred_bitwise_or())
-                    .expr,
-            );
+            let element = parser
+                .parse_named_expression_or_higher(ExpressionContext::starred_bitwise_or())
+                .expr;
+            parser.expr_scratch.push(element);
         });
 
         self.expect(TokenKind::Rsqb);
 
-        elts.shrink_to_fit();
-
         ast::ExprList {
-            elts,
+            elts: self.expr_scratch.drain(elts_start..).collect(),
             ctx: ExprContext::Load,
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
@@ -2529,7 +2520,8 @@ impl<'src> Parser<'src> {
             );
         }
 
-        let mut elts = vec![first_element.expr];
+        let elts_start = self.expr_scratch.len();
+        self.expr_scratch.push(first_element.expr);
 
         self.parse_comma_separated_list(RecoveryContextKind::SetElements, |parser| {
             let parsed_expr =
@@ -2544,7 +2536,7 @@ impl<'src> Parser<'src> {
                 );
             }
 
-            elts.push(parsed_expr.expr);
+            parser.expr_scratch.push(parsed_expr.expr);
         });
 
         self.expect(TokenKind::Rbrace);
@@ -2552,7 +2544,7 @@ impl<'src> Parser<'src> {
         ast::ExprSet {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
-            elts,
+            elts: self.expr_scratch.drain(elts_start..).collect(),
         }
     }
 
@@ -2653,7 +2645,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::In);
         let iter = self.parse_simple_expression(ExpressionContext::default());
 
-        let mut ifs = Vec::new();
+        let ifs_start = self.expr_scratch.len();
         let mut progress = ParserProgress::default();
 
         while self.eat(TokenKind::If) {
@@ -2661,20 +2653,15 @@ impl<'src> Parser<'src> {
 
             let parsed_expr = self.parse_simple_expression(ExpressionContext::default());
 
-            if ifs.is_empty() {
-                ifs.reserve_exact(1);
-            }
-            ifs.push(parsed_expr.expr);
+            self.expr_scratch.push(parsed_expr.expr);
         }
-
-        ifs.shrink_to_fit();
 
         ast::Comprehension {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
             target: target.expr,
             iter: iter.expr,
-            ifs,
+            ifs: self.expr_scratch.drain(ifs_start..).collect(),
             is_async,
         }
     }

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -17,7 +17,7 @@ use unicode_normalization::UnicodeNormalization;
 use crate::error::UnsupportedSyntaxError;
 use crate::parser::expression::ExpressionContext;
 use crate::parser::progress::{ParserProgress, TokenId};
-use crate::parser::scratch_buffer::ScratchBufferExt;
+use crate::parser::scratch_buffer::ScratchBuffer;
 use crate::string::InterpolatedStringKind;
 use crate::token_set::TokenSet;
 use crate::token_source::{TokenSource, TokenSourceCheckpoint};
@@ -73,22 +73,22 @@ pub(crate) struct Parser<'src> {
     max_nesting_depth: u32,
 
     /// Reusable, nesting-safe scratch storage for expression lists.
-    expr_scratch: Vec<Expr>,
+    expr_scratch: ScratchBuffer<Expr>,
 
     /// Reusable, nesting-safe scratch storage for call keywords.
-    keyword_scratch: Vec<Keyword>,
+    keyword_scratch: ScratchBuffer<Keyword>,
 
     /// Reusable, nesting-safe scratch storage for function and lambda parameters.
-    parameter_scratch: Vec<ParameterWithDefault>,
+    parameter_scratch: ScratchBuffer<ParameterWithDefault>,
 
     /// Reusable, nesting-safe scratch storage for statement lists.
-    stmt_scratch: Vec<Stmt>,
+    stmt_scratch: ScratchBuffer<Stmt>,
 
     /// Reusable scratch storage for import aliases.
-    alias_scratch: Vec<Alias>,
+    alias_scratch: ScratchBuffer<Alias>,
 
     /// Reusable, nesting-safe scratch storage for `elif` and `else` clauses.
-    elif_else_scratch: Vec<ElifElseClause>,
+    elif_else_scratch: ScratchBuffer<ElifElseClause>,
 }
 
 impl<'src> Parser<'src> {
@@ -119,12 +119,12 @@ impl<'src> Parser<'src> {
             current_token_id: TokenId::default(),
             depth_remaining,
             max_nesting_depth,
-            expr_scratch: Vec::with_capacity(16),
-            keyword_scratch: Vec::new(),
-            parameter_scratch: Vec::new(),
-            stmt_scratch: Vec::with_capacity(32),
-            alias_scratch: Vec::new(),
-            elif_else_scratch: Vec::new(),
+            expr_scratch: ScratchBuffer::with_capacity(16),
+            keyword_scratch: ScratchBuffer::new(),
+            parameter_scratch: ScratchBuffer::new(),
+            stmt_scratch: ScratchBuffer::with_capacity(32),
+            alias_scratch: ScratchBuffer::new(),
+            elif_else_scratch: ScratchBuffer::new(),
         }
     }
 

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -234,13 +234,6 @@ impl<'src> Parser<'src> {
             TokenKind::EndOfFile,
             "Parser should be at the end of the file."
         );
-        debug_assert!(self.expr_scratch.is_empty());
-        debug_assert!(self.keyword_scratch.is_empty());
-        debug_assert!(self.parameter_scratch.is_empty());
-        debug_assert!(self.stmt_scratch.is_empty());
-        debug_assert!(self.alias_scratch.is_empty());
-        debug_assert!(self.elif_else_scratch.is_empty());
-
         // TODO consider re-integrating lexical error handling into the parser?
         let parse_errors = self.errors;
         let (tokens, lex_errors) = self.tokens.finish();

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -6,8 +6,8 @@ use bitflags::bitflags;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{
-    AtomicNodeIndex, Expr, Int, IpyEscapeKind, Keyword, Mod, ModExpression, ModModule,
-    ParameterWithDefault, Stmt, StringFlags,
+    Alias, AtomicNodeIndex, ElifElseClause, Expr, Int, IpyEscapeKind, Keyword, Mod, ModExpression,
+    ModModule, ParameterWithDefault, Stmt, StringFlags,
 };
 use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -83,6 +83,12 @@ pub(crate) struct Parser<'src> {
 
     /// Reusable, nesting-safe scratch storage for statement lists.
     stmt_scratch: Vec<Stmt>,
+
+    /// Reusable scratch storage for import aliases.
+    alias_scratch: Vec<Alias>,
+
+    /// Reusable, nesting-safe scratch storage for `elif` and `else` clauses.
+    elif_else_scratch: Vec<ElifElseClause>,
 }
 
 impl<'src> Parser<'src> {
@@ -117,6 +123,8 @@ impl<'src> Parser<'src> {
             keyword_scratch: Vec::new(),
             parameter_scratch: Vec::new(),
             stmt_scratch: Vec::with_capacity(32),
+            alias_scratch: Vec::new(),
+            elif_else_scratch: Vec::new(),
         }
     }
 
@@ -230,6 +238,8 @@ impl<'src> Parser<'src> {
         debug_assert!(self.keyword_scratch.is_empty());
         debug_assert!(self.parameter_scratch.is_empty());
         debug_assert!(self.stmt_scratch.is_empty());
+        debug_assert!(self.alias_scratch.is_empty());
+        debug_assert!(self.elif_else_scratch.is_empty());
 
         // TODO consider re-integrating lexical error handling into the parser?
         let parse_errors = self.errors;

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -113,10 +113,10 @@ impl<'src> Parser<'src> {
             current_token_id: TokenId::default(),
             depth_remaining,
             max_nesting_depth,
-            expr_scratch: Vec::new(),
+            expr_scratch: Vec::with_capacity(16),
             keyword_scratch: Vec::new(),
             parameter_scratch: Vec::new(),
-            stmt_scratch: Vec::new(),
+            stmt_scratch: Vec::with_capacity(32),
         }
     }
 

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -226,6 +226,10 @@ impl<'src> Parser<'src> {
             TokenKind::EndOfFile,
             "Parser should be at the end of the file."
         );
+        debug_assert!(self.expr_scratch.is_empty());
+        debug_assert!(self.keyword_scratch.is_empty());
+        debug_assert!(self.parameter_scratch.is_empty());
+        debug_assert!(self.stmt_scratch.is_empty());
 
         // TODO consider re-integrating lexical error handling into the parser?
         let parse_errors = self.errors;

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -6,7 +6,8 @@ use bitflags::bitflags;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{
-    AtomicNodeIndex, Expr, Int, IpyEscapeKind, Mod, ModExpression, ModModule, Stmt, StringFlags,
+    AtomicNodeIndex, Expr, Int, IpyEscapeKind, Keyword, Mod, ModExpression, ModModule, Stmt,
+    StringFlags,
 };
 use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -72,6 +73,9 @@ pub(crate) struct Parser<'src> {
     /// Reusable, nesting-safe scratch storage for expression lists.
     expr_scratch: Vec<Expr>,
 
+    /// Reusable, nesting-safe scratch storage for call keywords.
+    keyword_scratch: Vec<Keyword>,
+
     /// Reusable, nesting-safe scratch storage for statement lists.
     stmt_scratch: Vec<Stmt>,
 }
@@ -105,6 +109,7 @@ impl<'src> Parser<'src> {
             depth_remaining,
             max_nesting_depth,
             expr_scratch: Vec::new(),
+            keyword_scratch: Vec::new(),
             stmt_scratch: Vec::new(),
         }
     }

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -6,7 +6,7 @@ use bitflags::bitflags;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{
-    AtomicNodeIndex, Int, IpyEscapeKind, Mod, ModExpression, ModModule, StringFlags,
+    AtomicNodeIndex, Expr, Int, IpyEscapeKind, Mod, ModExpression, ModModule, Stmt, StringFlags,
 };
 use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -68,6 +68,12 @@ pub(crate) struct Parser<'src> {
 
     /// Maximum lexer nesting depth before postfix calls and subscripts should stop recursing.
     max_nesting_depth: u32,
+
+    /// Reusable, nesting-safe scratch storage for expression lists.
+    expr_scratch: Vec<Expr>,
+
+    /// Reusable, nesting-safe scratch storage for statement lists.
+    stmt_scratch: Vec<Stmt>,
 }
 
 impl<'src> Parser<'src> {
@@ -98,6 +104,8 @@ impl<'src> Parser<'src> {
             current_token_id: TokenId::default(),
             depth_remaining,
             max_nesting_depth,
+            expr_scratch: Vec::new(),
+            stmt_scratch: Vec::new(),
         }
     }
 

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -17,6 +17,7 @@ use unicode_normalization::UnicodeNormalization;
 use crate::error::UnsupportedSyntaxError;
 use crate::parser::expression::ExpressionContext;
 use crate::parser::progress::{ParserProgress, TokenId};
+use crate::parser::scratch_buffer::ScratchBufferExt;
 use crate::string::InterpolatedStringKind;
 use crate::token_set::TokenSet;
 use crate::token_source::{TokenSource, TokenSourceCheckpoint};
@@ -31,6 +32,7 @@ mod options;
 mod pattern;
 mod progress;
 mod recovery;
+mod scratch_buffer;
 mod statement;
 #[cfg(test)]
 mod tests;

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -6,8 +6,8 @@ use bitflags::bitflags;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{
-    AtomicNodeIndex, Expr, Int, IpyEscapeKind, Keyword, Mod, ModExpression, ModModule, Stmt,
-    StringFlags,
+    AtomicNodeIndex, Expr, Int, IpyEscapeKind, Keyword, Mod, ModExpression, ModModule,
+    ParameterWithDefault, Stmt, StringFlags,
 };
 use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -78,6 +78,9 @@ pub(crate) struct Parser<'src> {
     /// Reusable, nesting-safe scratch storage for call keywords.
     keyword_scratch: Vec<Keyword>,
 
+    /// Reusable, nesting-safe scratch storage for function and lambda parameters.
+    parameter_scratch: Vec<ParameterWithDefault>,
+
     /// Reusable, nesting-safe scratch storage for statement lists.
     stmt_scratch: Vec<Stmt>,
 }
@@ -112,6 +115,7 @@ impl<'src> Parser<'src> {
             max_nesting_depth,
             expr_scratch: Vec::new(),
             keyword_scratch: Vec::new(),
+            parameter_scratch: Vec::new(),
             stmt_scratch: Vec::new(),
         }
     }

--- a/crates/ruff_python_parser/src/parser/scratch_buffer.rs
+++ b/crates/ruff_python_parser/src/parser/scratch_buffer.rs
@@ -1,3 +1,5 @@
+use std::vec::Drain;
+
 use drop_bomb::DebugDropBomb;
 use thin_vec::ThinVec;
 
@@ -8,6 +10,8 @@ pub(super) trait ScratchBufferExt<T> {
     fn take<C: FromIterator<T>>(&mut self, snapshot: ScratchSnapshot) -> C;
 
     fn take_thin_vec(&mut self, snapshot: ScratchSnapshot) -> ThinVec<T>;
+
+    fn drain_snapshot(&mut self, snapshot: ScratchSnapshot) -> Drain<'_, T>;
 }
 
 impl<T> ScratchBufferExt<T> for Vec<T> {
@@ -21,21 +25,30 @@ impl<T> ScratchBufferExt<T> for Vec<T> {
 
     #[inline]
     fn take<C: FromIterator<T>>(&mut self, snapshot: ScratchSnapshot) -> C {
-        let start = snapshot.restore(self.len());
-        self.drain(start..).collect()
+        self.drain_snapshot(snapshot).collect()
     }
 
     #[inline]
-    fn take_thin_vec(&mut self, snapshot: ScratchSnapshot) -> ThinVec<T> {
-        let start = snapshot.restore(self.len());
-        let len = self.len() - start;
-        if len == 0 {
+    fn take_thin_vec(&mut self, mut snapshot: ScratchSnapshot) -> ThinVec<T> {
+        if snapshot.is_empty(self) {
+            snapshot.bomb.defuse();
             return ThinVec::new();
         }
 
-        let mut result = ThinVec::with_capacity(len);
-        result.extend(self.drain(start..));
+        let drain = self.drain_snapshot(snapshot);
+        let mut result = ThinVec::with_capacity(drain.len());
+        result.extend(drain);
         result
+    }
+
+    #[inline]
+    fn drain_snapshot(&mut self, mut snapshot: ScratchSnapshot) -> Drain<'_, T> {
+        debug_assert!(
+            self.len() >= snapshot.len,
+            "Scratch buffer snapshots must be restored in reverse order of creation."
+        );
+        snapshot.bomb.defuse();
+        self.drain(snapshot.len..)
     }
 }
 
@@ -45,13 +58,12 @@ pub(super) struct ScratchSnapshot {
 }
 
 impl ScratchSnapshot {
-    fn restore(mut self, buffer_len: usize) -> usize {
+    pub(super) fn is_empty<T>(&self, buffer: &[T]) -> bool {
         debug_assert!(
-            buffer_len >= self.len,
-            "Scratch buffers must not shrink before a snapshot is restored."
+            buffer.len() >= self.len,
+            "Scratch buffer snapshots must be restored in reverse order of creation."
         );
-        self.bomb.defuse();
-        self.len
+        buffer.len() == self.len
     }
 }
 
@@ -69,11 +81,25 @@ mod tests {
 
     #[test]
     #[cfg(debug_assertions)]
-    #[should_panic(expected = "Scratch buffers must not shrink before a snapshot is restored.")]
-    fn buffer_must_not_shrink_before_restore() {
+    #[should_panic(
+        expected = "Scratch buffer snapshots must be restored in reverse order of creation."
+    )]
+    fn snapshot_must_be_restored_in_reverse_order() {
         let mut buffer = vec![1];
         let snapshot = buffer.snapshot();
         buffer.clear();
+
+        let _: Vec<_> = buffer.take(snapshot);
+    }
+
+    #[test]
+    fn snapshot_is_empty_relative_to_its_buffer() {
+        let mut buffer = vec![1];
+        let snapshot = buffer.snapshot();
+        assert!(snapshot.is_empty(&buffer));
+
+        buffer.push(2);
+        assert!(!snapshot.is_empty(&buffer));
 
         let _: Vec<_> = buffer.take(snapshot);
     }

--- a/crates/ruff_python_parser/src/parser/scratch_buffer.rs
+++ b/crates/ruff_python_parser/src/parser/scratch_buffer.rs
@@ -3,34 +3,57 @@ use std::vec::Drain;
 use drop_bomb::DebugDropBomb;
 use thin_vec::ThinVec;
 
-/// Operations for reusable scratch storage that preserve entries belonging to outer parser frames.
-pub(super) trait ScratchBufferExt<T> {
-    fn snapshot(&self) -> ScratchSnapshot;
-
-    fn take<C: FromIterator<T>>(&mut self, snapshot: ScratchSnapshot) -> C;
-
-    fn take_thin_vec(&mut self, snapshot: ScratchSnapshot) -> ThinVec<T>;
-
-    fn drain_snapshot(&mut self, snapshot: ScratchSnapshot) -> Drain<'_, T>;
+/// Reusable scratch storage that preserves entries belonging to outer parser frames.
+#[derive(Debug)]
+pub(super) struct ScratchBuffer<T> {
+    buffer: Vec<T>,
 }
 
-impl<T> ScratchBufferExt<T> for Vec<T> {
+impl<T> ScratchBuffer<T> {
+    pub(super) fn new() -> Self {
+        Self { buffer: Vec::new() }
+    }
+
+    pub(super) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            buffer: Vec::with_capacity(capacity),
+        }
+    }
+
     #[inline]
-    fn snapshot(&self) -> ScratchSnapshot {
+    pub(super) fn push(&mut self, value: T) {
+        self.buffer.push(value);
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    #[inline]
+    pub(super) fn is_empty_since(&self, snapshot: &ScratchSnapshot) -> bool {
+        debug_assert!(
+            self.buffer.len() >= snapshot.len,
+            "Scratch buffer snapshots must be restored in reverse order of creation."
+        );
+        self.buffer.len() == snapshot.len
+    }
+
+    #[inline]
+    pub(super) fn snapshot(&self) -> ScratchSnapshot {
         ScratchSnapshot {
-            len: self.len(),
+            len: self.buffer.len(),
             bomb: DebugDropBomb::new("Scratch buffer snapshots must be restored."),
         }
     }
 
     #[inline]
-    fn take<C: FromIterator<T>>(&mut self, snapshot: ScratchSnapshot) -> C {
+    pub(super) fn take<C: FromIterator<T>>(&mut self, snapshot: ScratchSnapshot) -> C {
         self.drain_snapshot(snapshot).collect()
     }
 
     #[inline]
-    fn take_thin_vec(&mut self, mut snapshot: ScratchSnapshot) -> ThinVec<T> {
-        if snapshot.is_empty(self) {
+    pub(super) fn take_thin_vec(&mut self, mut snapshot: ScratchSnapshot) -> ThinVec<T> {
+        if self.is_empty_since(&snapshot) {
             snapshot.bomb.defuse();
             return ThinVec::new();
         }
@@ -44,11 +67,11 @@ impl<T> ScratchBufferExt<T> for Vec<T> {
     #[inline]
     fn drain_snapshot(&mut self, mut snapshot: ScratchSnapshot) -> Drain<'_, T> {
         debug_assert!(
-            self.len() >= snapshot.len,
+            self.buffer.len() >= snapshot.len,
             "Scratch buffer snapshots must be restored in reverse order of creation."
         );
         snapshot.bomb.defuse();
-        self.drain(snapshot.len..)
+        self.buffer.drain(snapshot.len..)
     }
 }
 
@@ -57,25 +80,15 @@ pub(super) struct ScratchSnapshot {
     bomb: DebugDropBomb,
 }
 
-impl ScratchSnapshot {
-    pub(super) fn is_empty<T>(&self, buffer: &[T]) -> bool {
-        debug_assert!(
-            buffer.len() >= self.len,
-            "Scratch buffer snapshots must be restored in reverse order of creation."
-        );
-        buffer.len() == self.len
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::ScratchBufferExt;
+    use super::ScratchBuffer;
 
     #[test]
     #[cfg(debug_assertions)]
     #[should_panic(expected = "Scratch buffer snapshots must be restored.")]
     fn snapshot_must_be_restored() {
-        let buffer = Vec::<u8>::new();
+        let buffer = ScratchBuffer::<u8>::new();
         let _snapshot = buffer.snapshot();
     }
 
@@ -85,21 +98,23 @@ mod tests {
         expected = "Scratch buffer snapshots must be restored in reverse order of creation."
     )]
     fn snapshot_must_be_restored_in_reverse_order() {
-        let mut buffer = vec![1];
+        let mut buffer = ScratchBuffer::new();
+        buffer.push(1);
         let snapshot = buffer.snapshot();
-        buffer.clear();
+        buffer.buffer.clear();
 
         let _: Vec<_> = buffer.take(snapshot);
     }
 
     #[test]
     fn snapshot_is_empty_relative_to_its_buffer() {
-        let mut buffer = vec![1];
+        let mut buffer = ScratchBuffer::new();
+        buffer.push(1);
         let snapshot = buffer.snapshot();
-        assert!(snapshot.is_empty(&buffer));
+        assert!(buffer.is_empty_since(&snapshot));
 
         buffer.push(2);
-        assert!(!snapshot.is_empty(&buffer));
+        assert!(!buffer.is_empty_since(&snapshot));
 
         let _: Vec<_> = buffer.take(snapshot);
     }

--- a/crates/ruff_python_parser/src/parser/scratch_buffer.rs
+++ b/crates/ruff_python_parser/src/parser/scratch_buffer.rs
@@ -25,12 +25,8 @@ impl<T> ScratchBuffer<T> {
         self.buffer.push(value);
     }
 
-    pub(super) fn is_empty(&self) -> bool {
-        self.buffer.is_empty()
-    }
-
     #[inline]
-    pub(super) fn is_empty_since(&self, snapshot: &ScratchSnapshot) -> bool {
+    pub(super) fn is_empty(&self, snapshot: &ScratchSnapshot) -> bool {
         debug_assert!(
             self.buffer.len() >= snapshot.len,
             "Scratch buffer snapshots must be restored in reverse order of creation."
@@ -53,7 +49,7 @@ impl<T> ScratchBuffer<T> {
 
     #[inline]
     pub(super) fn take_thin_vec(&mut self, mut snapshot: ScratchSnapshot) -> ThinVec<T> {
-        if self.is_empty_since(&snapshot) {
+        if self.is_empty(&snapshot) {
             snapshot.bomb.defuse();
             return ThinVec::new();
         }
@@ -75,6 +71,15 @@ impl<T> ScratchBuffer<T> {
     }
 }
 
+impl<T> Drop for ScratchBuffer<T> {
+    fn drop(&mut self) {
+        debug_assert!(
+            self.buffer.is_empty() || std::thread::panicking(),
+            "Scratch buffers must be empty when dropped."
+        );
+    }
+}
+
 pub(super) struct ScratchSnapshot {
     len: usize,
     bomb: DebugDropBomb,
@@ -83,6 +88,14 @@ pub(super) struct ScratchSnapshot {
 #[cfg(test)]
 mod tests {
     use super::ScratchBuffer;
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Scratch buffers must be empty when dropped.")]
+    fn buffer_must_be_empty_when_dropped() {
+        let mut buffer = ScratchBuffer::new();
+        buffer.push(1);
+    }
 
     #[test]
     #[cfg(debug_assertions)]
@@ -109,13 +122,15 @@ mod tests {
     #[test]
     fn snapshot_is_empty_relative_to_its_buffer() {
         let mut buffer = ScratchBuffer::new();
+        let outer_snapshot = buffer.snapshot();
         buffer.push(1);
         let snapshot = buffer.snapshot();
-        assert!(buffer.is_empty_since(&snapshot));
+        assert!(buffer.is_empty(&snapshot));
 
         buffer.push(2);
-        assert!(!buffer.is_empty_since(&snapshot));
+        assert!(!buffer.is_empty(&snapshot));
 
         let _: Vec<_> = buffer.take(snapshot);
+        let _: Vec<_> = buffer.take(outer_snapshot);
     }
 }

--- a/crates/ruff_python_parser/src/parser/scratch_buffer.rs
+++ b/crates/ruff_python_parser/src/parser/scratch_buffer.rs
@@ -1,3 +1,4 @@
+use drop_bomb::DebugDropBomb;
 use thin_vec::ThinVec;
 
 /// Operations for reusable scratch storage that preserve entries belonging to outer parser frames.
@@ -12,26 +13,68 @@ pub(super) trait ScratchBufferExt<T> {
 impl<T> ScratchBufferExt<T> for Vec<T> {
     #[inline]
     fn snapshot(&self) -> ScratchSnapshot {
-        ScratchSnapshot(self.len())
+        ScratchSnapshot {
+            len: self.len(),
+            bomb: DebugDropBomb::new("Scratch buffer snapshots must be restored."),
+        }
     }
 
     #[inline]
     fn take<C: FromIterator<T>>(&mut self, snapshot: ScratchSnapshot) -> C {
-        self.drain(snapshot.0..).collect()
+        let start = snapshot.restore(self.len());
+        self.drain(start..).collect()
     }
 
     #[inline]
     fn take_thin_vec(&mut self, snapshot: ScratchSnapshot) -> ThinVec<T> {
-        let len = self.len() - snapshot.0;
+        let start = snapshot.restore(self.len());
+        let len = self.len() - start;
         if len == 0 {
             return ThinVec::new();
         }
 
         let mut result = ThinVec::with_capacity(len);
-        result.extend(self.drain(snapshot.0..));
+        result.extend(self.drain(start..));
         result
     }
 }
 
-#[derive(Clone, Copy)]
-pub(super) struct ScratchSnapshot(usize);
+pub(super) struct ScratchSnapshot {
+    len: usize,
+    bomb: DebugDropBomb,
+}
+
+impl ScratchSnapshot {
+    fn restore(mut self, buffer_len: usize) -> usize {
+        debug_assert!(
+            buffer_len >= self.len,
+            "Scratch buffers must not shrink before a snapshot is restored."
+        );
+        self.bomb.defuse();
+        self.len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScratchBufferExt;
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Scratch buffer snapshots must be restored.")]
+    fn snapshot_must_be_restored() {
+        let buffer = Vec::<u8>::new();
+        let _snapshot = buffer.snapshot();
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Scratch buffers must not shrink before a snapshot is restored.")]
+    fn buffer_must_not_shrink_before_restore() {
+        let mut buffer = vec![1];
+        let snapshot = buffer.snapshot();
+        buffer.clear();
+
+        let _: Vec<_> = buffer.take(snapshot);
+    }
+}

--- a/crates/ruff_python_parser/src/parser/scratch_buffer.rs
+++ b/crates/ruff_python_parser/src/parser/scratch_buffer.rs
@@ -1,0 +1,37 @@
+use thin_vec::ThinVec;
+
+/// Operations for reusable scratch storage that preserve entries belonging to outer parser frames.
+pub(super) trait ScratchBufferExt<T> {
+    fn snapshot(&self) -> ScratchSnapshot;
+
+    fn take<C: FromIterator<T>>(&mut self, snapshot: ScratchSnapshot) -> C;
+
+    fn take_thin_vec(&mut self, snapshot: ScratchSnapshot) -> ThinVec<T>;
+}
+
+impl<T> ScratchBufferExt<T> for Vec<T> {
+    #[inline]
+    fn snapshot(&self) -> ScratchSnapshot {
+        ScratchSnapshot(self.len())
+    }
+
+    #[inline]
+    fn take<C: FromIterator<T>>(&mut self, snapshot: ScratchSnapshot) -> C {
+        self.drain(snapshot.0..).collect()
+    }
+
+    #[inline]
+    fn take_thin_vec(&mut self, snapshot: ScratchSnapshot) -> ThinVec<T> {
+        let len = self.len() - snapshot.0;
+        if len == 0 {
+            return ThinVec::new();
+        }
+
+        let mut result = ThinVec::with_capacity(len);
+        result.extend(self.drain(snapshot.0..));
+        result
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ScratchSnapshot(usize);

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -19,8 +19,8 @@ use crate::parser::{
 use crate::token_set::TokenSet;
 use crate::{Mode, ParseErrorType, UnsupportedSyntaxErrorKind};
 
+use super::Parenthesized;
 use super::expression::ExpressionContext;
-use super::{Parenthesized, ScratchBufferExt};
 
 /// Tokens that represent compound statements.
 const COMPOUND_STMT_SET: TokenSet = TokenSet::new([
@@ -3454,7 +3454,7 @@ impl<'src> Parser<'src> {
                     let slash_range = parser.current_token_range();
                     parser.bump(TokenKind::Slash);
 
-                    if parameters_snapshot.is_empty(&parser.parameter_scratch)
+                    if parser.parameter_scratch.is_empty_since(&parameters_snapshot)
                         && parameters.vararg.is_none()
                         && parameters.kwarg.is_none()
                     {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -195,13 +195,14 @@ impl<'src> Parser<'src> {
     ///
     /// [Python grammar]: https://docs.python.org/3/reference/grammar.html
     fn parse_simple_statements(&mut self) -> Suite {
-        let mut stmts = Suite::with_capacity(1);
+        let stmts_snapshot = self.stmt_scratch.snapshot();
         let mut progress = ParserProgress::default();
 
         loop {
             progress.assert_progressing(self);
 
-            stmts.push(self.parse_simple_statement());
+            let stmt = self.parse_simple_statement();
+            self.stmt_scratch.push(stmt);
 
             if !self.eat(TokenKind::Semi) {
                 if self.at_simple_stmt() {
@@ -258,8 +259,7 @@ impl<'src> Parser<'src> {
 
         // test_ok simple_stmts_with_semicolons
         // return; import a; from x import y; z; type T = int
-        stmts.shrink_to_fit();
-        stmts
+        self.stmt_scratch.take_thin_vec(stmts_snapshot)
     }
 
     /// Parses a simple statement.
@@ -620,19 +620,18 @@ impl<'src> Parser<'src> {
         // import ,
         // import x, y,
 
-        let mut names = self.parse_comma_separated_list_into_vec_with_capacity(
-            RecoveryContextKind::ImportNames,
-            |p| p.parse_alias(ImportStyle::Import),
-            1,
-        );
+        let names_snapshot = self.alias_scratch.snapshot();
+        self.parse_comma_separated_list(RecoveryContextKind::ImportNames, |parser| {
+            let alias = parser.parse_alias(ImportStyle::Import);
+            parser.alias_scratch.push(alias);
+        });
+        let names: Vec<_> = self.alias_scratch.take(names_snapshot);
 
         if names.is_empty() {
             // test_err import_stmt_empty
             // import
             self.add_error(ParseErrorType::EmptyImportNames, self.current_token_range());
         }
-
-        names.shrink_to_fit();
 
         ast::StmtImport {
             names,
@@ -698,7 +697,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::Import);
 
         let names_start = self.node_start();
-        let mut names = Vec::new();
+        let names_snapshot = self.alias_scratch.snapshot();
         let mut seen_star_import = false;
 
         let parenthesized = Parenthesized::from(self.eat(TokenKind::Lpar));
@@ -716,9 +715,10 @@ impl<'src> Parser<'src> {
                 // from x import a, b.c, d, e.f, g
                 let alias = parser.parse_alias(ImportStyle::ImportFrom);
                 seen_star_import |= alias.name.id == "*";
-                names.push(alias);
+                parser.alias_scratch.push(alias);
             },
         );
+        let names: Vec<_> = self.alias_scratch.take(names_snapshot);
 
         if names.is_empty() {
             // test_err from_import_empty_names
@@ -757,8 +757,6 @@ impl<'src> Parser<'src> {
             // 2 + 2
             self.expect(TokenKind::Rpar);
         }
-
-        names.shrink_to_fit();
 
         ast::StmtImportFrom {
             module,
@@ -1452,18 +1450,18 @@ impl<'src> Parser<'src> {
         //     pass
         // else:
         //     pass
-        let mut elif_else_clauses = self.parse_clauses(Clause::ElIf, |p| {
-            p.parse_elif_or_else_clause(ElifOrElse::Elif)
+        let elif_else_snapshot = self.elif_else_scratch.snapshot();
+        self.parse_clauses(Clause::ElIf, |parser| {
+            let clause = parser.parse_elif_or_else_clause(ElifOrElse::Elif);
+            parser.elif_else_scratch.push(clause);
         });
 
         if self.at(TokenKind::Else) {
-            if elif_else_clauses.is_empty() {
-                elif_else_clauses.reserve_exact(1);
-            }
-            elif_else_clauses.push(self.parse_elif_or_else_clause(ElifOrElse::Else));
+            let clause = self.parse_elif_or_else_clause(ElifOrElse::Else);
+            self.elif_else_scratch.push(clause);
         }
 
-        elif_else_clauses.shrink_to_fit();
+        let elif_else_clauses = self.elif_else_scratch.take(elif_else_snapshot);
 
         ast::StmtIf {
             test: Box::new(test.expr),
@@ -1560,7 +1558,8 @@ impl<'src> Parser<'src> {
         // except* ExceptionGroup:
         //     pass
         let mut mixed_except_ranges = Vec::new();
-        let mut handlers = self.parse_clauses(Clause::Except, |p| {
+        let mut handlers = Vec::new();
+        self.parse_clauses(Clause::Except, |p| {
             let (handler, kind) = p.parse_except_clause();
             if let ExceptClauseKind::Star(range) = kind {
                 p.add_unsupported_syntax_error(UnsupportedSyntaxErrorKind::ExceptStar, range);
@@ -1570,7 +1569,10 @@ impl<'src> Parser<'src> {
             } else if is_star != Some(kind.is_star()) {
                 mixed_except_ranges.push(handler.range());
             }
-            handler
+            if handlers.is_empty() {
+                handlers.reserve_exact(1);
+            }
+            handlers.push(handler);
         });
         handlers.shrink_to_fit();
 
@@ -3317,7 +3319,6 @@ impl<'src> Parser<'src> {
         let parameters_snapshot = self.parameter_scratch.snapshot();
         let mut args_snapshot = None;
         let mut kwonlyargs_snapshot = None;
-        let mut seen_non_variadic_param = false;
 
         let mut seen_default_param = false; // `a=10`
         let mut seen_positional_only_separator = false; // `/`
@@ -3459,7 +3460,7 @@ impl<'src> Parser<'src> {
                     let slash_range = parser.current_token_range();
                     parser.bump(TokenKind::Slash);
 
-                    if !seen_non_variadic_param
+                    if parameters_snapshot.is_empty(&parser.parameter_scratch)
                         && parameters.vararg.is_none()
                         && parameters.kwarg.is_none()
                     {
@@ -3554,7 +3555,6 @@ impl<'src> Parser<'src> {
                     }
 
                     parser.parameter_scratch.push(param);
-                    seen_non_variadic_param = true;
                     last_keyword_only_separator_range = None;
                 }
                 _ => {
@@ -4024,12 +4024,7 @@ impl<'src> Parser<'src> {
     /// For now, don't recover when parsing clause headers, but add the terminator tokens (e.g.
     /// `Else`) to the recovery context so that expression recovery stops when it encounters an
     /// `else` token.
-    fn parse_clauses<T>(
-        &mut self,
-        clause: Clause,
-        mut parse_clause: impl FnMut(&mut Parser<'src>) -> T,
-    ) -> Vec<T> {
-        let mut clauses = Vec::new();
+    fn parse_clauses(&mut self, clause: Clause, mut parse_clause: impl FnMut(&mut Parser<'src>)) {
         let mut progress = ParserProgress::default();
 
         let recovery_kind = match clause {
@@ -4046,15 +4041,10 @@ impl<'src> Parser<'src> {
         while recovery_kind.is_list_element(self) {
             progress.assert_progressing(self);
 
-            if clauses.is_empty() {
-                clauses.reserve_exact(1);
-            }
-            clauses.push(parse_clause(self));
+            parse_clause(self);
         }
 
         self.recovery_context = saved_context;
-
-        clauses
     }
 }
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -1461,12 +1461,10 @@ impl<'src> Parser<'src> {
             self.elif_else_scratch.push(clause);
         }
 
-        let elif_else_clauses = self.elif_else_scratch.take(elif_else_snapshot);
-
         ast::StmtIf {
             test: Box::new(test.expr),
             body,
-            elif_else_clauses,
+            elif_else_clauses: self.elif_else_scratch.take(elif_else_snapshot),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }
@@ -3126,27 +3124,24 @@ impl<'src> Parser<'src> {
     fn parse_block(&mut self) -> Suite {
         self.bump(TokenKind::Indent);
 
-        let statements =
-            if let Some(statements) = self.with_recursion(Parser::parse_block_statements) {
-                statements
-            } else {
-                self.report_recursion_limit_exceeded(self.current_token_range());
-                Suite::new()
-            };
+        let statements = if let Some(statements) = self.with_recursion(|parser| {
+            let snapshot = parser.stmt_scratch.snapshot();
+            parser.parse_list(RecoveryContextKind::BlockStatements, |parser| {
+                let statement = parser.parse_statement();
+                parser.stmt_scratch.push(statement);
+            });
+
+            parser.stmt_scratch.take_thin_vec(snapshot)
+        }) {
+            statements
+        } else {
+            self.report_recursion_limit_exceeded(self.current_token_range());
+            Suite::new()
+        };
 
         self.expect(TokenKind::Dedent);
 
         statements
-    }
-
-    fn parse_block_statements(&mut self) -> Suite {
-        let snapshot = self.stmt_scratch.snapshot();
-        self.parse_list(RecoveryContextKind::BlockStatements, |parser| {
-            let statement = parser.parse_statement();
-            parser.stmt_scratch.push(statement);
-        });
-
-        self.stmt_scratch.take_thin_vec(snapshot)
     }
 
     /// Parses a single parameter for the given function kind.
@@ -3345,9 +3340,8 @@ impl<'src> Parser<'src> {
                     let star_range = parser.current_token_range();
                     parser.bump(TokenKind::Star);
 
-                    if kwonlyargs_snapshot.is_none() {
-                        kwonlyargs_snapshot = Some(parser.parameter_scratch.snapshot());
-                    }
+                    kwonlyargs_snapshot
+                        .get_or_insert_with(|| parser.parameter_scratch.snapshot());
 
                     if parser.at_name_or_soft_keyword() {
                         let param = parser.parse_parameter(param_start, function_kind, AllowStarAnnotation::Yes);

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3454,7 +3454,7 @@ impl<'src> Parser<'src> {
                     let slash_range = parser.current_token_range();
                     parser.bump(TokenKind::Slash);
 
-                    if parser.parameter_scratch.is_empty_since(&parameters_snapshot)
+                    if parser.parameter_scratch.is_empty(&parameters_snapshot)
                         && parameters.vararg.is_none()
                         && parameters.kwarg.is_none()
                     {

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3124,20 +3124,29 @@ impl<'src> Parser<'src> {
     fn parse_block(&mut self) -> Suite {
         self.bump(TokenKind::Indent);
 
-        let statements = if let Some(statements) = self.with_recursion(|parser| {
-            parser.parse_list_into_thin_vec(
-                RecoveryContextKind::BlockStatements,
-                Parser::parse_statement,
-            )
-        }) {
-            statements
-        } else {
-            self.report_recursion_limit_exceeded(self.current_token_range());
-            Suite::new()
-        };
+        let statements =
+            if let Some(statements) = self.with_recursion(Parser::parse_block_statements) {
+                statements
+            } else {
+                self.report_recursion_limit_exceeded(self.current_token_range());
+                Suite::new()
+            };
 
         self.expect(TokenKind::Dedent);
 
+        statements
+    }
+
+    fn parse_block_statements(&mut self) -> Suite {
+        let start = self.stmt_scratch.len();
+        self.parse_list(RecoveryContextKind::BlockStatements, |parser| {
+            let statement = parser.parse_statement();
+            parser.stmt_scratch.push(statement);
+        });
+
+        let len = self.stmt_scratch.len() - start;
+        let mut statements = Suite::with_capacity(len);
+        statements.extend(self.stmt_scratch.drain(start..));
         statements
     }
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3315,7 +3315,7 @@ impl<'src> Parser<'src> {
         // recover well from `*args=(1, 2)`.
         let mut parameters = ast::Parameters::default();
         let parameters_snapshot = self.parameter_scratch.snapshot();
-        let mut args_snapshot = parameters_snapshot;
+        let mut args_snapshot = None;
         let mut kwonlyargs_snapshot = None;
         let mut seen_non_variadic_param = false;
 
@@ -3504,8 +3504,9 @@ impl<'src> Parser<'src> {
                     if !seen_positional_only_separator {
                         // We should only split if we're seeing the separator for the
                         // first time, otherwise it's a user error.
-                        args_snapshot = kwonlyargs_snapshot
-                            .unwrap_or_else(|| parser.parameter_scratch.snapshot());
+                        if kwonlyargs_snapshot.is_none() {
+                            args_snapshot = Some(parser.parameter_scratch.snapshot());
+                        }
                         seen_positional_only_separator = true;
 
                         // test_ok pos_only_py38
@@ -3580,8 +3581,14 @@ impl<'src> Parser<'src> {
         if let Some(kwonlyargs_snapshot) = kwonlyargs_snapshot {
             parameters.kwonlyargs = self.parameter_scratch.take_thin_vec(kwonlyargs_snapshot);
         }
-        parameters.args = self.parameter_scratch.take_thin_vec(args_snapshot);
-        parameters.posonlyargs = self.parameter_scratch.take_thin_vec(parameters_snapshot);
+        if let Some(args_snapshot) = args_snapshot {
+            parameters.args = self.parameter_scratch.take_thin_vec(args_snapshot);
+            parameters.posonlyargs = self.parameter_scratch.take_thin_vec(parameters_snapshot);
+        } else if seen_positional_only_separator {
+            parameters.posonlyargs = self.parameter_scratch.take_thin_vec(parameters_snapshot);
+        } else {
+            parameters.args = self.parameter_scratch.take_thin_vec(parameters_snapshot);
+        }
 
         parameters.range = self.node_range(start);
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -19,8 +19,8 @@ use crate::parser::{
 use crate::token_set::TokenSet;
 use crate::{Mode, ParseErrorType, UnsupportedSyntaxErrorKind};
 
-use super::Parenthesized;
 use super::expression::ExpressionContext;
+use super::{Parenthesized, ScratchBufferExt};
 
 /// Tokens that represent compound statements.
 const COMPOUND_STMT_SET: TokenSet = TokenSet::new([
@@ -3138,16 +3138,13 @@ impl<'src> Parser<'src> {
     }
 
     fn parse_block_statements(&mut self) -> Suite {
-        let start = self.stmt_scratch.len();
+        let snapshot = self.stmt_scratch.snapshot();
         self.parse_list(RecoveryContextKind::BlockStatements, |parser| {
             let statement = parser.parse_statement();
             parser.stmt_scratch.push(statement);
         });
 
-        let len = self.stmt_scratch.len() - start;
-        let mut statements = Suite::with_capacity(len);
-        statements.extend(self.stmt_scratch.drain(start..));
-        statements
+        self.stmt_scratch.take_thin_vec(snapshot)
     }
 
     /// Parses a single parameter for the given function kind.

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3314,6 +3314,10 @@ impl<'src> Parser<'src> {
         // uses `Parameter` (not `ParameterWithDefault`) which means that the parser cannot
         // recover well from `*args=(1, 2)`.
         let mut parameters = ast::Parameters::default();
+        let parameters_snapshot = self.parameter_scratch.snapshot();
+        let mut args_snapshot = parameters_snapshot;
+        let mut kwonlyargs_snapshot = None;
+        let mut seen_non_variadic_param = false;
 
         let mut seen_default_param = false; // `a=10`
         let mut seen_positional_only_separator = false; // `/`
@@ -3339,6 +3343,10 @@ impl<'src> Parser<'src> {
                 TokenKind::Star => {
                     let star_range = parser.current_token_range();
                     parser.bump(TokenKind::Star);
+
+                    if kwonlyargs_snapshot.is_none() {
+                        kwonlyargs_snapshot = Some(parser.parameter_scratch.snapshot());
+                    }
 
                     if parser.at_name_or_soft_keyword() {
                         let param = parser.parse_parameter(param_start, function_kind, AllowStarAnnotation::Yes);
@@ -3451,7 +3459,10 @@ impl<'src> Parser<'src> {
                     let slash_range = parser.current_token_range();
                     parser.bump(TokenKind::Slash);
 
-                    if parameters.is_empty() {
+                    if !seen_non_variadic_param
+                        && parameters.vararg.is_none()
+                        && parameters.kwarg.is_none()
+                    {
                         // test_err params_no_arg_before_slash
                         // def foo(/): ...
                         // def foo(/, a): ...
@@ -3491,9 +3502,10 @@ impl<'src> Parser<'src> {
                     }
 
                     if !seen_positional_only_separator {
-                        // We should only swap if we're seeing the separator for the
+                        // We should only split if we're seeing the separator for the
                         // first time, otherwise it's a user error.
-                        std::mem::swap(&mut parameters.args, &mut parameters.posonlyargs);
+                        args_snapshot = kwonlyargs_snapshot
+                            .unwrap_or_else(|| parser.parameter_scratch.snapshot());
                         seen_positional_only_separator = true;
 
                         // test_ok pos_only_py38
@@ -3540,11 +3552,8 @@ impl<'src> Parser<'src> {
                         seen_keyword_only_param_after_separator = true;
                     }
 
-                    if seen_keyword_only_separator || parameters.vararg.is_some() {
-                        parameters.kwonlyargs.push(param);
-                    } else {
-                        parameters.args.push(param);
-                    }
+                    parser.parameter_scratch.push(param);
+                    seen_non_variadic_param = true;
                     last_keyword_only_separator_range = None;
                 }
                 _ => {
@@ -3568,9 +3577,11 @@ impl<'src> Parser<'src> {
             self.expect(TokenKind::Rpar);
         }
 
-        parameters.args.shrink_to_fit();
-        parameters.kwonlyargs.shrink_to_fit();
-        parameters.posonlyargs.shrink_to_fit();
+        if let Some(kwonlyargs_snapshot) = kwonlyargs_snapshot {
+            parameters.kwonlyargs = self.parameter_scratch.take_thin_vec(kwonlyargs_snapshot);
+        }
+        parameters.args = self.parameter_scratch.take_thin_vec(args_snapshot);
+        parameters.posonlyargs = self.parameter_scratch.take_thin_vec(parameters_snapshot);
 
         parameters.range = self.node_range(start);
 

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -72,32 +72,6 @@ fn nfkc_normalizes_names() {
 }
 
 #[test]
-fn import_aliases() {
-    let suite = parse_module(
-        r"
-import first, second as renamed
-from package import third, fourth as other, fifth
-import last
-",
-    )
-    .unwrap()
-    .into_suite();
-
-    let Stmt::Import(first) = &suite[0] else {
-        panic!("expected import statement");
-    };
-    assert_eq!(first.names.len(), 2);
-    let Stmt::ImportFrom(second) = &suite[1] else {
-        panic!("expected from-import statement");
-    };
-    assert_eq!(second.names.len(), 3);
-    let Stmt::Import(last) = &suite[2] else {
-        panic!("expected import statement");
-    };
-    assert_eq!(last.names.len(), 1);
-}
-
-#[test]
 fn number_values() {
     let cases = [
         ("1E400", Number::Float(f64::INFINITY)),

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -72,162 +72,29 @@ fn nfkc_normalizes_names() {
 }
 
 #[test]
-fn nested_expression_lists() {
-    let parsed = parse_expression(
-        r#"outer(first, inner(one, two), f"{nested(three, four)}", left < nested(five < six, seven) < right, (one, [two, {three, four}], target[one:two, three:four]), [x for x in values if one and inner(two, three) if other < thing], last)"#,
-    )
-    .unwrap();
-    let Expr::Call(outer) = parsed.expr() else {
-        panic!("expected call expression, got {:?}", parsed.expr());
-    };
-
-    assert_eq!(outer.arguments.args.len(), 7);
-    let Expr::Call(inner) = &outer.arguments.args[1] else {
-        panic!("expected nested call expression");
-    };
-    assert_eq!(inner.arguments.args.len(), 2);
-    let Expr::Compare(compare) = &outer.arguments.args[3] else {
-        panic!("expected comparison expression");
-    };
-    assert_eq!(compare.comparators.len(), 2);
-    let Expr::Tuple(tuple) = &outer.arguments.args[4] else {
-        panic!("expected tuple expression");
-    };
-    assert_eq!(tuple.elts.len(), 3);
-    let Expr::ListComp(comprehension) = &outer.arguments.args[5] else {
-        panic!("expected list comprehension");
-    };
-    assert_eq!(comprehension.generators[0].ifs.len(), 2);
-}
-
-#[test]
-fn nested_call_keywords() {
-    let parsed = parse_expression(
-        "outer(alpha=first, beta=inner(gamma=value, delta=nested(epsilon=value), **mapping), zeta=last, **tail)",
-    )
-    .unwrap();
-    let Expr::Call(outer) = parsed.expr() else {
-        panic!("expected call expression, got {:?}", parsed.expr());
-    };
-
-    assert_eq!(outer.arguments.args.len(), 0);
-    assert_eq!(outer.arguments.keywords.len(), 4);
-    let Expr::Call(inner) = &outer.arguments.keywords[1].value else {
-        panic!("expected nested call expression");
-    };
-    assert_eq!(inner.arguments.keywords.len(), 3);
-    let Expr::Call(nested) = &inner.arguments.keywords[1].value else {
-        panic!("expected doubly nested call expression");
-    };
-    assert_eq!(nested.arguments.keywords.len(), 1);
-}
-
-#[test]
-fn nested_parameters() {
+fn import_aliases() {
     let suite = parse_module(
         r"
-def outer(
-    before,
-    annotated: (lambda left, /, *, right, **rest: right),
-    /,
-    middle=(lambda nested, /, value=(lambda deep, /, *, kw, **tail: kw), *, only, **more: only),
-    *,
-    final=(lambda last, /, *, named, **extra: named),
-    **remaining,
-):
-    pass
-",
-    )
-    .unwrap()
-    .into_suite();
-    let Stmt::FunctionDef(outer) = &suite[0] else {
-        panic!("expected function definition");
-    };
-
-    assert_eq!(outer.parameters.posonlyargs.len(), 2);
-    assert_eq!(outer.parameters.args.len(), 1);
-    assert_eq!(outer.parameters.kwonlyargs.len(), 1);
-    assert!(outer.parameters.kwarg.is_some());
-    assert_eq!(outer.parameters.posonlyargs[0].name().as_str(), "before");
-    assert_eq!(outer.parameters.posonlyargs[1].name().as_str(), "annotated");
-    assert_eq!(outer.parameters.args[0].name().as_str(), "middle");
-    assert_eq!(outer.parameters.kwonlyargs[0].name().as_str(), "final");
-
-    let Some(Expr::Lambda(annotation)) = outer.parameters.posonlyargs[1]
-        .parameter
-        .annotation
-        .as_deref()
-    else {
-        panic!("expected lambda annotation");
-    };
-    let Some(annotation_parameters) = annotation.parameters.as_ref() else {
-        panic!("expected annotation parameters");
-    };
-    assert_eq!(annotation_parameters.posonlyargs.len(), 1);
-    assert_eq!(annotation_parameters.kwonlyargs.len(), 1);
-    assert!(annotation_parameters.kwarg.is_some());
-    assert_eq!(annotation_parameters.posonlyargs[0].name().as_str(), "left");
-    assert_eq!(annotation_parameters.kwonlyargs[0].name().as_str(), "right");
-
-    let Some(Expr::Lambda(default)) = outer.parameters.args[0].default.as_deref() else {
-        panic!("expected lambda default");
-    };
-    let Some(default_parameters) = default.parameters.as_ref() else {
-        panic!("expected default parameters");
-    };
-    assert_eq!(default_parameters.posonlyargs.len(), 1);
-    assert_eq!(default_parameters.args.len(), 1);
-    assert_eq!(default_parameters.kwonlyargs.len(), 1);
-    assert!(default_parameters.kwarg.is_some());
-    assert_eq!(default_parameters.posonlyargs[0].name().as_str(), "nested");
-    assert_eq!(default_parameters.args[0].name().as_str(), "value");
-    assert_eq!(default_parameters.kwonlyargs[0].name().as_str(), "only");
-
-    let Some(Expr::Lambda(deep)) = default_parameters.args[0].default.as_deref() else {
-        panic!("expected nested lambda default");
-    };
-    let Some(deep_parameters) = deep.parameters.as_ref() else {
-        panic!("expected nested default parameters");
-    };
-    assert_eq!(deep_parameters.posonlyargs[0].name().as_str(), "deep");
-    assert_eq!(deep_parameters.kwonlyargs[0].name().as_str(), "kw");
-}
-
-#[test]
-fn nested_statement_lists() {
-    let suite = parse_module(
-        r"
-def outer():
-    first
-    if condition:
-        nested_one
-        if other:
-            deep
-            deeper
-        nested_two
-    else:
-        alternative
-    last
-after
+import first, second as renamed
+from package import third, fourth as other, fifth
+import last
 ",
     )
     .unwrap()
     .into_suite();
 
-    assert_eq!(suite.len(), 2);
-    let Stmt::FunctionDef(outer) = &suite[0] else {
-        panic!("expected function definition");
+    let Stmt::Import(first) = &suite[0] else {
+        panic!("expected import statement");
     };
-    assert_eq!(outer.body.len(), 3);
-    let Stmt::If(outer_if) = &outer.body[1] else {
-        panic!("expected if statement");
+    assert_eq!(first.names.len(), 2);
+    let Stmt::ImportFrom(second) = &suite[1] else {
+        panic!("expected from-import statement");
     };
-    assert_eq!(outer_if.body.len(), 3);
-    assert_eq!(outer_if.elif_else_clauses[0].body.len(), 1);
-    let Stmt::If(inner_if) = &outer_if.body[1] else {
-        panic!("expected nested if statement");
+    assert_eq!(second.names.len(), 3);
+    let Stmt::Import(last) = &suite[2] else {
+        panic!("expected import statement");
     };
-    assert_eq!(inner_if.body.len(), 2);
+    assert_eq!(last.names.len(), 1);
 }
 
 #[test]

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -101,6 +101,28 @@ fn nested_expression_lists() {
 }
 
 #[test]
+fn nested_call_keywords() {
+    let parsed = parse_expression(
+        "outer(alpha=first, beta=inner(gamma=value, delta=nested(epsilon=value), **mapping), zeta=last, **tail)",
+    )
+    .unwrap();
+    let Expr::Call(outer) = parsed.expr() else {
+        panic!("expected call expression, got {:?}", parsed.expr());
+    };
+
+    assert_eq!(outer.arguments.args.len(), 0);
+    assert_eq!(outer.arguments.keywords.len(), 4);
+    let Expr::Call(inner) = &outer.arguments.keywords[1].value else {
+        panic!("expected nested call expression");
+    };
+    assert_eq!(inner.arguments.keywords.len(), 3);
+    let Expr::Call(nested) = &inner.arguments.keywords[1].value else {
+        panic!("expected doubly nested call expression");
+    };
+    assert_eq!(nested.arguments.keywords.len(), 1);
+}
+
+#[test]
 fn nested_statement_lists() {
     let suite = parse_module(
         r"

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -123,6 +123,77 @@ fn nested_call_keywords() {
 }
 
 #[test]
+fn nested_parameters() {
+    let suite = parse_module(
+        r"
+def outer(
+    before,
+    annotated: (lambda left, /, *, right, **rest: right),
+    /,
+    middle=(lambda nested, /, value=(lambda deep, /, *, kw, **tail: kw), *, only, **more: only),
+    *,
+    final=(lambda last, /, *, named, **extra: named),
+    **remaining,
+):
+    pass
+",
+    )
+    .unwrap()
+    .into_suite();
+    let Stmt::FunctionDef(outer) = &suite[0] else {
+        panic!("expected function definition");
+    };
+
+    assert_eq!(outer.parameters.posonlyargs.len(), 2);
+    assert_eq!(outer.parameters.args.len(), 1);
+    assert_eq!(outer.parameters.kwonlyargs.len(), 1);
+    assert!(outer.parameters.kwarg.is_some());
+    assert_eq!(outer.parameters.posonlyargs[0].name().as_str(), "before");
+    assert_eq!(outer.parameters.posonlyargs[1].name().as_str(), "annotated");
+    assert_eq!(outer.parameters.args[0].name().as_str(), "middle");
+    assert_eq!(outer.parameters.kwonlyargs[0].name().as_str(), "final");
+
+    let Some(Expr::Lambda(annotation)) = outer.parameters.posonlyargs[1]
+        .parameter
+        .annotation
+        .as_deref()
+    else {
+        panic!("expected lambda annotation");
+    };
+    let Some(annotation_parameters) = annotation.parameters.as_ref() else {
+        panic!("expected annotation parameters");
+    };
+    assert_eq!(annotation_parameters.posonlyargs.len(), 1);
+    assert_eq!(annotation_parameters.kwonlyargs.len(), 1);
+    assert!(annotation_parameters.kwarg.is_some());
+    assert_eq!(annotation_parameters.posonlyargs[0].name().as_str(), "left");
+    assert_eq!(annotation_parameters.kwonlyargs[0].name().as_str(), "right");
+
+    let Some(Expr::Lambda(default)) = outer.parameters.args[0].default.as_deref() else {
+        panic!("expected lambda default");
+    };
+    let Some(default_parameters) = default.parameters.as_ref() else {
+        panic!("expected default parameters");
+    };
+    assert_eq!(default_parameters.posonlyargs.len(), 1);
+    assert_eq!(default_parameters.args.len(), 1);
+    assert_eq!(default_parameters.kwonlyargs.len(), 1);
+    assert!(default_parameters.kwarg.is_some());
+    assert_eq!(default_parameters.posonlyargs[0].name().as_str(), "nested");
+    assert_eq!(default_parameters.args[0].name().as_str(), "value");
+    assert_eq!(default_parameters.kwonlyargs[0].name().as_str(), "only");
+
+    let Some(Expr::Lambda(deep)) = default_parameters.args[0].default.as_deref() else {
+        panic!("expected nested lambda default");
+    };
+    let Some(deep_parameters) = deep.parameters.as_ref() else {
+        panic!("expected nested default parameters");
+    };
+    assert_eq!(deep_parameters.posonlyargs[0].name().as_str(), "deep");
+    assert_eq!(deep_parameters.kwonlyargs[0].name().as_str(), "kw");
+}
+
+#[test]
 fn nested_statement_lists() {
     let suite = parse_module(
         r"

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -72,6 +72,72 @@ fn nfkc_normalizes_names() {
 }
 
 #[test]
+fn nested_expression_lists() {
+    let parsed = parse_expression(
+        r#"outer(first, inner(one, two), f"{nested(three, four)}", left < nested(five < six, seven) < right, (one, [two, {three, four}], target[one:two, three:four]), [x for x in values if one and inner(two, three) if other < thing], last)"#,
+    )
+    .unwrap();
+    let Expr::Call(outer) = parsed.expr() else {
+        panic!("expected call expression, got {:?}", parsed.expr());
+    };
+
+    assert_eq!(outer.arguments.args.len(), 7);
+    let Expr::Call(inner) = &outer.arguments.args[1] else {
+        panic!("expected nested call expression");
+    };
+    assert_eq!(inner.arguments.args.len(), 2);
+    let Expr::Compare(compare) = &outer.arguments.args[3] else {
+        panic!("expected comparison expression");
+    };
+    assert_eq!(compare.comparators.len(), 2);
+    let Expr::Tuple(tuple) = &outer.arguments.args[4] else {
+        panic!("expected tuple expression");
+    };
+    assert_eq!(tuple.elts.len(), 3);
+    let Expr::ListComp(comprehension) = &outer.arguments.args[5] else {
+        panic!("expected list comprehension");
+    };
+    assert_eq!(comprehension.generators[0].ifs.len(), 2);
+}
+
+#[test]
+fn nested_statement_lists() {
+    let suite = parse_module(
+        r"
+def outer():
+    first
+    if condition:
+        nested_one
+        if other:
+            deep
+            deeper
+        nested_two
+    else:
+        alternative
+    last
+after
+",
+    )
+    .unwrap()
+    .into_suite();
+
+    assert_eq!(suite.len(), 2);
+    let Stmt::FunctionDef(outer) = &suite[0] else {
+        panic!("expected function definition");
+    };
+    assert_eq!(outer.body.len(), 3);
+    let Stmt::If(outer_if) = &outer.body[1] else {
+        panic!("expected if statement");
+    };
+    assert_eq!(outer_if.body.len(), 3);
+    assert_eq!(outer_if.elif_else_clauses[0].body.len(), 1);
+    let Stmt::If(inner_if) = &outer_if.body[1] else {
+        panic!("expected nested if statement");
+    };
+    assert_eq!(inner_if.body.len(), 2);
+}
+
+#[test]
 fn number_values() {
     let cases = [
         ("1E400", Number::Float(f64::INFINITY)),


### PR DESCRIPTION
## Summary

Use scratch buffers instead of allocating new `Vec`s and shrinking them when constructing the AST node. While this doesn't remove the need for copying the elements, it reduces the allocations within our parser (`shrink_to_fit` often needs to allocate a new buffer and move all elements). One shared scratch buffer per node type is sufficient, because our parser is recursive (more nested parse rule always push to the end, and parse function drain from the end as they complete). 


## Performance

Very consistent perf improvement

## Codspeed memory regression

This can cause the parser's peak memory to increase, because we retain the scratch buffer allocation after parsing a clause completed. However, that memory is only temporary and released as soon as the parser completes. Most project-level memory reports show a memory reduction. It's only specific parser benchmarks that show a memory increase