### PR TITLE
Document argfile support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -467,24 +467,6 @@ $ ruff check path/to/code/ --select F401 --select F403 --quiet
 All other configuration options can be set via the command line
 using the `--config` flag, detailed below.
 
-### Argfile support
-
-Ruff supports reading command-line arguments from a file, which is especially useful when passing a large number of file paths that might exceed your shell's command-line length limit. To use an argfile, prefix the file path with an `@` symbol:
-
-```console
-$ ruff check @path/to/args.txt
-```
-
-The arguments in the file must all be written on their own line. For example, `args.txt` might contain:
-
-```text
---select
-F401
---quiet
-path/to/code1/
-path/to/code2/
-```
-
 ### The `--config` CLI flag
 
 The `--config` flag has two uses. It is most often used to point to the
@@ -533,6 +515,24 @@ the same effect as specifying `--line-length=90`,
 which will similarly override the `line-length` setting from
 all configuration files detected by Ruff, regardless of where
 a specific configuration file is located.
+
+### Argfile support
+
+Ruff supports reading command-line arguments from a file, which is especially useful when passing a large number of file paths that might exceed your shell's command-line length limit. To use an argfile, prefix the file path with an `@` symbol:
+
+```console
+$ ruff check @path/to/args.txt
+```
+
+The arguments in the file must all be written on their own line. For example, `args.txt` might contain:
+
+```text
+--select
+F401
+--quiet
+path/to/code1/
+path/to/code2/
+```
 
 ### Full command-line interface
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -467,6 +467,24 @@ $ ruff check path/to/code/ --select F401 --select F403 --quiet
 All other configuration options can be set via the command line
 using the `--config` flag, detailed below.
 
+### Argfile support
+
+Ruff supports reading command-line arguments from a file, which is especially useful when passing a large number of file paths that might exceed your shell's command-line length limit. To use an argfile, prefix the file path with an `@` symbol:
+
+```console
+$ ruff check @path/to/args.txt
+```
+
+The arguments in the file must all be written on their own line. For example, `args.txt` might contain:
+
+```text
+--select
+F401
+--quiet
+path/to/code1/
+path/to/code2/
+```
+
 ### The `--config` CLI flag
 
 The `--config` flag has two uses. It is most often used to point to the


### PR DESCRIPTION
Closes #21894 by adding a section about argfile support (using `@`) to the configuration documentation.