### PR TITLE
[ty] Prefer existing union members in positive runtime narrowing

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -241,6 +241,66 @@ Defaults to `false`.
 
 ---
 
+### `strict-subclass-narrowing`
+
+Whether positive runtime narrowing should preserve intersections that can only be inhabited
+by an unrelated subclass when another union member already matches the runtime test.
+
+By default, a positive runtime check prefers union members that match through an existing
+inheritance or structural relationship. It discards remaining intersections whose only
+inhabitants would require a new subclass combining otherwise unrelated classes. This
+produces simpler types for annotations such as `T | list[T]` while retaining ordinary
+overlaps such as `Mapping[K, V] | Iterable[K]`.
+
+The policy applies to positive `isinstance`, `issubclass`, and builtin `callable` checks,
+along with class, mapping, and sequence patterns.
+
+This default is deliberately pragmatic rather than fully sound. Python permits an
+unannotated runtime class to inherit from otherwise unrelated bases, so a discarded
+intersection can still be inhabited. For example, a value reaching this function through
+the `Area` arm could be a `list[int]` subclass, even though the direct list arm is
+`list[str]`:
+
+```python
+class Area: ...
+class IntegerAreaList(Area, list[int]): ...
+
+def first(value: Area | list[str]) -> str:
+    if isinstance(value, list):
+        return value[0]  # Accepted by default, but can return an `int`.
+    return ""
+
+first(IntegerAreaList([1]))
+```
+
+Enable this option to preserve all possible subclass intersections.
+
+Defaults to `false`.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.analysis]
+    # Preserve intersections involving hypothetical unrelated subclasses
+    strict-subclass-narrowing = true
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [analysis]
+    # Preserve intersections involving hypothetical unrelated subclasses
+    strict-subclass-narrowing = true
+    ```
+
+---
+
 ## `environment`
 
 ### `extra-paths`
@@ -812,6 +872,66 @@ Defaults to `false`.
     [overrides.analysis]
     # Preserve broad builtin types instead of narrowing them to literals
     strict-literal-narrowing = true
+    ```
+
+---
+
+#### `strict-subclass-narrowing`
+
+Whether positive runtime narrowing should preserve intersections that can only be inhabited
+by an unrelated subclass when another union member already matches the runtime test.
+
+By default, a positive runtime check prefers union members that match through an existing
+inheritance or structural relationship. It discards remaining intersections whose only
+inhabitants would require a new subclass combining otherwise unrelated classes. This
+produces simpler types for annotations such as `T | list[T]` while retaining ordinary
+overlaps such as `Mapping[K, V] | Iterable[K]`.
+
+The policy applies to positive `isinstance`, `issubclass`, and builtin `callable` checks,
+along with class, mapping, and sequence patterns.
+
+This default is deliberately pragmatic rather than fully sound. Python permits an
+unannotated runtime class to inherit from otherwise unrelated bases, so a discarded
+intersection can still be inhabited. For example, a value reaching this function through
+the `Area` arm could be a `list[int]` subclass, even though the direct list arm is
+`list[str]`:
+
+```python
+class Area: ...
+class IntegerAreaList(Area, list[int]): ...
+
+def first(value: Area | list[str]) -> str:
+    if isinstance(value, list):
+        return value[0]  # Accepted by default, but can return an `int`.
+    return ""
+
+first(IntegerAreaList([1]))
+```
+
+Enable this option to preserve all possible subclass intersections.
+
+Defaults to `false`.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.overrides.analysis]
+    # Preserve intersections involving hypothetical unrelated subclasses
+    strict-subclass-narrowing = true
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [overrides.analysis]
+    # Preserve intersections involving hypothetical unrelated subclasses
+    strict-subclass-narrowing = true
     ```
 
 ---

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -1529,6 +1529,49 @@ pub struct AnalysisOptions {
     )]
     pub strict_literal_narrowing: Option<bool>,
 
+    /// Whether positive runtime narrowing should preserve intersections that can only be inhabited
+    /// by an unrelated subclass when another union member already matches the runtime test.
+    ///
+    /// By default, a positive runtime check prefers union members that match through an existing
+    /// inheritance or structural relationship. It discards remaining intersections whose only
+    /// inhabitants would require a new subclass combining otherwise unrelated classes. This
+    /// produces simpler types for annotations such as `T | list[T]` while retaining ordinary
+    /// overlaps such as `Mapping[K, V] | Iterable[K]`.
+    ///
+    /// The policy applies to positive `isinstance`, `issubclass`, and builtin `callable` checks,
+    /// along with class, mapping, and sequence patterns.
+    ///
+    /// This default is deliberately pragmatic rather than fully sound. Python permits an
+    /// unannotated runtime class to inherit from otherwise unrelated bases, so a discarded
+    /// intersection can still be inhabited. For example, a value reaching this function through
+    /// the `Area` arm could be a `list[int]` subclass, even though the direct list arm is
+    /// `list[str]`:
+    ///
+    /// ```python
+    /// class Area: ...
+    /// class IntegerAreaList(Area, list[int]): ...
+    ///
+    /// def first(value: Area | list[str]) -> str:
+    ///     if isinstance(value, list):
+    ///         return value[0]  # Accepted by default, but can return an `int`.
+    ///     return ""
+    ///
+    /// first(IntegerAreaList([1]))
+    /// ```
+    ///
+    /// Enable this option to preserve all possible subclass intersections.
+    ///
+    /// Defaults to `false`.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+        # Preserve intersections involving hypothetical unrelated subclasses
+        strict-subclass-narrowing = true
+        "#
+    )]
+    pub strict_subclass_narrowing: Option<bool>,
+
     /// Whether ty should respect `type: ignore` comments.
     ///
     /// When set to `false`, `type: ignore` comments are treated like any other normal
@@ -1606,6 +1649,7 @@ impl AnalysisOptions {
     ) -> AnalysisSettings {
         let Self {
             strict_literal_narrowing,
+            strict_subclass_narrowing,
             respect_type_ignore_comments,
             allowed_unresolved_imports,
             replace_imports_with_any,
@@ -1613,6 +1657,7 @@ impl AnalysisOptions {
 
         let AnalysisSettings {
             strict_literal_narrowing: strict_literal_narrowing_default,
+            strict_subclass_narrowing: strict_subclass_narrowing_default,
             respect_type_ignore_comments: respect_type_ignore_default,
             allowed_unresolved_imports: allowed_unresolved_imports_default,
             replace_imports_with_any: replace_imports_with_any_default,
@@ -1643,6 +1688,8 @@ impl AnalysisOptions {
         AnalysisSettings {
             strict_literal_narrowing: strict_literal_narrowing
                 .unwrap_or(strict_literal_narrowing_default),
+            strict_subclass_narrowing: strict_subclass_narrowing
+                .unwrap_or(strict_subclass_narrowing_default),
             respect_type_ignore_comments: respect_type_ignore_comments
                 .unwrap_or(respect_type_ignore_default),
             allowed_unresolved_imports,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -42,6 +42,50 @@ def h(x: Callable[..., int] | None):
         reveal_type(x)  # revealed: None
 ```
 
+## Union-relative callable narrowing
+
+Builtin `callable()` uses the same union-relative policy as `isinstance`. Dynamic arms remain
+possible, and user-defined `TypeIs` functions retain their specified intersection semantics.
+
+```py
+from collections.abc import Callable
+from typing import Any
+from typing_extensions import TypeIs
+
+def direct_callable(value: Callable[[], int] | int) -> int:
+    if callable(value):
+        reveal_type(value)  # revealed: () -> int
+        return value()
+    reveal_type(value)  # revealed: int & ~Top[(...) -> object]
+    return value
+
+def is_callable(value: object) -> TypeIs[Callable[..., object]]:
+    return callable(value)
+
+def user_typeis(value: Callable[[], int] | int) -> None:
+    if is_callable(value):
+        reveal_type(value)  # revealed: (() -> int) | (int & Top[(...) -> object])
+
+def dynamic_arm(value: Any | Callable[[], int]) -> None:
+    if callable(value):
+        reveal_type(value)  # revealed: (Any & Top[(...) -> object]) | (() -> int)
+```
+
+## Strict subclass narrowing for `callable()`
+
+```toml
+[analysis]
+strict-subclass-narrowing = true
+```
+
+```py
+from collections.abc import Callable
+
+def strict(value: Callable[[], int] | int) -> None:
+    if callable(value):
+        reveal_type(value)  # revealed: (() -> int) | (int & Top[(...) -> object])
+```
+
 ## Narrowing from object
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -868,7 +868,7 @@ class Direct(Base): ...
 
 def dynamic_arm(value: Any | Direct) -> None:
     if isinstance(value, Base):
-        # Dynamic arms never count as the direct witness, but remain possible once another arm
+        # Dynamic arms never count as a definite match, but remain possible once another arm
         # establishes the intended runtime branch.
         reveal_type(value)  # revealed: (Any & Base) | Direct
 
@@ -880,7 +880,7 @@ def typed_dict_arm(value: Payload | dict[str, int]) -> None:
         # A `TypedDict` is not a static subtype of `dict`, but all of its runtime values are dicts.
         reveal_type(value)  # revealed: Payload | dict[str, int]
 
-def typed_dict_witness(value: Payload | Area) -> None:
+def typed_dict_direct_match(value: Payload | Area) -> None:
     if isinstance(value, dict):
         reveal_type(value)  # revealed: Payload
     else:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -905,10 +905,6 @@ def known_overlap(
         # `Mapping` is already an `Iterable`, so both possibilities remain.
         reveal_type(value)  # revealed: Mapping[str, int] | (Iterable[tuple[str, int]] & Top[Mapping[Unknown, object]])
 
-def under_annotated(value: Iterable[Area]) -> None:
-    if isinstance(value, Mapping):
-        reveal_type(value)  # revealed: Iterable[Area] & Top[Mapping[Unknown, object]]
-
 class A: ...
 class B: ...
 class C: ...

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -722,12 +722,13 @@ def _(x: list[int] | set[str]):
         reveal_type(x)  # revealed: set[str]
 ```
 
-Though if the types involved are not disjoint bases, we necessarily keep a more complex type.
+When one union member directly matches, the positive branch drops unrelated subclass intersections
+while the negative branch remains conservative.
 
 ```py
 def _(x: Invariant[int] | Covariant[str]):
     if isinstance(x, Invariant):
-        reveal_type(x)  # revealed: Invariant[int] | (Covariant[str] & Top[Invariant[Unknown]])
+        reveal_type(x)  # revealed: Invariant[int]
     else:
         reveal_type(x)  # revealed: Covariant[str] & ~Top[Invariant[Unknown]]
 ```
@@ -848,4 +849,105 @@ def f():
         reveal_type(x)  # revealed: int
     else:
         reveal_type(x)  # revealed: str
+```
+
+## Union-relative subclass narrowing
+
+By default, a positive runtime check prefers union members that match through an existing
+inheritance relationship. It drops intersections whose only inhabitants would require a new,
+unrelated subclass. Without a matching union member, narrowing remains conservative.
+
+```py
+from collections.abc import Iterable, Mapping
+from typing import Any
+from typing_extensions import TypeGuard, TypedDict
+
+class Area: ...
+class Base: ...
+class Direct(Base): ...
+
+def dynamic_arm(value: Any | Direct) -> None:
+    if isinstance(value, Base):
+        # Dynamic arms never count as the direct witness, but remain possible once another arm
+        # establishes the intended runtime branch.
+        reveal_type(value)  # revealed: (Any & Base) | Direct
+
+class Payload(TypedDict):
+    key: int
+
+def typed_dict_arm(value: Payload | dict[str, int]) -> None:
+    if isinstance(value, dict):
+        # A `TypedDict` is not a static subtype of `dict`, but all of its runtime values are dicts.
+        reveal_type(value)  # revealed: Payload | dict[str, int]
+
+def typed_dict_witness(value: Payload | Area) -> None:
+    if isinstance(value, dict):
+        reveal_type(value)  # revealed: Payload
+    else:
+        # Negative narrowing remains conservative, even for runtime facts used by the positive
+        # union-arm preference.
+        reveal_type(value)  # revealed: (Payload & ~Top[dict[Unknown, Unknown]]) | (Area & ~Top[dict[Unknown, Unknown]])
+
+def direct_match(value: list[Area] | Area) -> None:
+    if isinstance(value, list):
+        reveal_type(value)  # revealed: list[Area]
+    else:
+        reveal_type(value)  # revealed: Area & ~Top[list[Unknown]]
+
+def lone_fallback(value: Area) -> None:
+    if isinstance(value, list):
+        reveal_type(value)  # revealed: Area & Top[list[Unknown]]
+
+def known_overlap(
+    value: Mapping[str, int] | Iterable[tuple[str, int]],
+) -> None:
+    if isinstance(value, Mapping):
+        # `Mapping` is already an `Iterable`, so both possibilities remain.
+        reveal_type(value)  # revealed: Mapping[str, int] | (Iterable[tuple[str, int]] & Top[Mapping[Unknown, object]])
+
+def under_annotated(value: Iterable[Area]) -> None:
+    if isinstance(value, Mapping):
+        reveal_type(value)  # revealed: Iterable[Area] & Top[Mapping[Unknown, object]]
+
+class A: ...
+class B: ...
+class C: ...
+
+def classinfo_union(value: A | B | C) -> None:
+    if isinstance(value, (A, B)):
+        reveal_type(value)  # revealed: A | B
+
+def combined_runtime_constraints(value: A | B) -> None:
+    if isinstance(value, A) and isinstance(value, B):
+        # Multiple runtime constraints use the conservative intersection semantics.
+        reveal_type(value)  # revealed: A & B
+
+def three_runtime_constraints(value: A | B | C) -> None:
+    if isinstance(value, A) and isinstance(value, B) and isinstance(value, C):
+        reveal_type(value)  # revealed: A & B & C
+
+def guard(value: object) -> TypeGuard[Area | list[Area]]:
+    return True
+
+def typeguard_then_runtime_test(value: object) -> None:
+    if guard(value) and isinstance(value, list):
+        # Runtime preference still applies after `TypeGuard` replaces the original type.
+        reveal_type(value)  # revealed: list[Area]
+```
+
+## Strict subclass narrowing
+
+```toml
+[analysis]
+strict-subclass-narrowing = true
+```
+
+```py
+class Area: ...
+
+def strict(value: list[Area] | Area) -> None:
+    if isinstance(value, list):
+        reveal_type(value)  # revealed: list[Area] | (Area & Top[list[Unknown]])
+    else:
+        reveal_type(value)  # revealed: Area & ~Top[list[Unknown]]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -93,6 +93,48 @@ def _(t: type[object]):
         reveal_type(t)  # revealed: type & ~type[A]
 ```
 
+### Union-relative subclass narrowing
+
+When a union contains a class that is already known to derive from the tested base, the positive
+branch drops intersections that would require an unrelated class to gain a new common subclass.
+
+```py
+from typing import Any
+
+class Base: ...
+class Derived(Base): ...
+class Unrelated: ...
+
+def _(t: type[Derived] | type[Unrelated]):
+    if issubclass(t, Base):
+        reveal_type(t)  # revealed: type[Derived]
+    else:
+        reveal_type(t)  # revealed: type[Unrelated] & ~type[Base]
+
+def dynamic_arm(t: type[Any] | type[Derived]) -> None:
+    if issubclass(t, Base):
+        reveal_type(t)  # revealed: (type[Any] & type[Base]) | type[Derived]
+```
+
+### Strict union-relative subclass narrowing
+
+The strict setting preserves the hypothetical subclass intersection:
+
+```toml
+[analysis]
+strict-subclass-narrowing = true
+```
+
+```py
+class Base: ...
+class Derived(Base): ...
+class Unrelated: ...
+
+def _(t: type[Derived] | type[Unrelated]):
+    if issubclass(t, Base):
+        reveal_type(t)  # revealed: type[Derived] | (type[Unrelated] & type[Base])
+```
+
 ### Handling of `None`
 
 `types.NoneType` is only available in Python 3.10 and later:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -141,35 +141,84 @@ def f(x: Covariant[int]):
 ## Mapping patterns
 
 ```py
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
+from typing_extensions import TypedDict
 
 def test_isinstance(x: dict[Any, Any] | int) -> None:
     if isinstance(x, Mapping):
-        reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
+        reveal_type(x)  # revealed: dict[Any, Any]
     else:
         reveal_type(x)  # revealed: int & ~Top[Mapping[Unknown, object]]
 
 def test_match(x: dict[Any, Any] | int) -> None:
     match x:
         case {}:
-            reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
+            reveal_type(x)  # revealed: dict[Any, Any]
         case _:
             reveal_type(x)  # revealed: int & ~Top[Mapping[Unknown, object]]
 
 def test_match_double_star(x: dict[Any, Any] | int) -> None:
     match x:
         case {**rest}:
-            reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
+            reveal_type(x)  # revealed: dict[Any, Any]
         case _:
             reveal_type(x)  # revealed: int & ~Top[Mapping[Unknown, object]]
 
 def test_match_refutable(x: dict[Any, Any] | int) -> None:
     match x:
         case {"k": _}:
-            reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
+            reveal_type(x)  # revealed: dict[Any, Any]
         case _:
             reveal_type(x)  # revealed: dict[Any, Any] | int
+
+def test_known_mapping_overlap(
+    x: Mapping[str, int] | Iterable[tuple[str, int]],
+) -> None:
+    match x:
+        case {}:
+            reveal_type(x)  # revealed: Mapping[str, int] | (Iterable[tuple[str, int]] & Top[Mapping[Unknown, object]])
+
+def test_synthetic_interface_overlap(
+    x: Mapping[str, int] | Sequence[int],
+) -> None:
+    match x:
+        case {}:
+            reveal_type(x)  # revealed: Mapping[str, int]
+
+class Payload(TypedDict):
+    key: int
+
+def test_typed_dict_mapping_pattern(x: Payload | dict[str, int]) -> None:
+    match x:
+        case {}:
+            reveal_type(x)  # revealed: Payload | dict[str, int]
+
+def test_typed_dict_class_pattern(x: Payload | dict[str, int]) -> None:
+    match x:
+        case dict():
+            reveal_type(x)  # revealed: Payload | dict[str, int]
+```
+
+## Mapping patterns with strict subclass narrowing
+
+```toml
+[analysis]
+strict-subclass-narrowing = true
+```
+
+```py
+from collections.abc import Mapping
+from typing import Any
+
+def test_isinstance(x: dict[Any, Any] | int) -> None:
+    if isinstance(x, Mapping):
+        reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
+
+def test_match(x: dict[Any, Any] | int) -> None:
+    match x:
+        case {}:
+            reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
 ```
 
 ## Sequence patterns
@@ -189,6 +238,12 @@ def test_match_star(x: Sequence[int] | int) -> None:
             # fixed, the `Sequence[int] & str` intersection should simplify to
             # `Never`.
             reveal_type(x)  # revealed: (Sequence[int] & str) | bytes | bytearray | (int & ~Sequence[object])
+
+def test_direct_sequence_arm(x: list[int] | int) -> None:
+    match x:
+        case [*rest]:
+            reveal_type(x)  # revealed: list[int]
+            reveal_type(rest)  # revealed: list[int]
 
 def test_match_star_excludes_text_and_bytes(x: str | bytes | bytearray | list[int]) -> None:
     match x:
@@ -269,6 +324,21 @@ def test_match_prefix_star_known_sequence(value: Sequence[int | str]) -> None:
             reveal_type(value[0])  # revealed: int | str
             reveal_type(value[1])  # revealed: int | str
             reveal_type(rest)  # revealed: list[int | str]
+```
+
+## Sequence patterns with strict subclass narrowing
+
+```toml
+[analysis]
+strict-subclass-narrowing = true
+```
+
+```py
+def test_match_star(x: list[int] | int) -> None:
+    match x:
+        case [*rest]:
+            reveal_type(x)  # revealed: list[int] | (int & Sequence[object])
+            reveal_type(rest)  # revealed: list[int] | list[object]
 ```
 
 ## Sequence capture types
@@ -755,6 +825,39 @@ def class_pattern_preserves_alias(value: Container) -> None:
             sequence.append("bad")  # error: [invalid-argument-type]
 ```
 
+## Union-relative class pattern narrowing
+
+Positive class patterns use the same union-relative subclass policy as `isinstance`.
+
+```py
+class Area: ...
+
+def direct_class_pattern(value: list[Area] | Area) -> None:
+    match value:
+        case list():
+            reveal_type(value)  # revealed: list[Area]
+        case _:
+            reveal_type(value)  # revealed: Area & ~Top[list[Unknown]]
+```
+
+## Strict subclass narrowing for class patterns
+
+```toml
+[analysis]
+strict-subclass-narrowing = true
+```
+
+```py
+class Area: ...
+
+def strict_class_pattern(value: list[Area] | Area) -> None:
+    match value:
+        case list():
+            reveal_type(value)  # revealed: list[Area] | (Area & Top[list[Unknown]])
+        case _:
+            reveal_type(value)  # revealed: Area & ~Top[list[Unknown]]
+```
+
 ## Binding overlapping classes with `as`
 
 Unrelated classes can share a subclass through multiple inheritance. Binding the whole class pattern
@@ -809,12 +912,24 @@ class ProtocolPayload(TypedDict):
 class SizedProtocol(Protocol):
     def __len__(self) -> int: ...
 
+@runtime_checkable
+class ClearProtocol(Protocol):
+    def clear(self) -> None: ...
+
 def test_match_typed_dict_alias_preserves_runtime_protocol_overlap(
     value: ProtocolPayload,
 ) -> None:
     match value:
         case SizedProtocol() as item:
             reveal_type(item)  # revealed: ProtocolPayload
+
+def test_match_typed_dict_alias_adds_hidden_runtime_protocol(
+    value: ProtocolPayload,
+) -> None:
+    match value:
+        case ClearProtocol() as item:
+            reveal_type(item)  # revealed: ProtocolPayload & ClearProtocol
+            item.clear()
 
 def test_match_typed_dict_alias_preserves_mapping_runtime_type(
     value: ProtocolPayload,
@@ -2715,8 +2830,8 @@ def match_named_expression_subject_capture(value: tuple[int]) -> None:
 
 Pattern captures can affect the type of a later match subject, including through a loop or a
 function defined before the capture. Direct, sequence, class, and built-in positional captures
-resolve to a concrete type. For a mapping capture, the recursive subject is known only to be a
-mapping, so its entry type is `object`.
+resolve to a concrete type. Union-relative narrowing also lets the mapping capture below reject the
+loop-carried non-mapping arm, so it resolves to the concrete value type of the original dictionary.
 
 ```py
 def match_loop_carried_capture(flag: bool, x: int) -> None:
@@ -2747,7 +2862,7 @@ def match_loop_carried_mapping_capture(flag: bool) -> None:
     while flag:
         match x:
             case {"value": x}:
-                reveal_type(x)  # revealed: object
+                reveal_type(x)  # revealed: int
 
 def match_loop_carried_match_self_capture(flag: bool, x: int) -> None:
     while flag:

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -95,6 +95,10 @@ pub struct AnalysisSettings {
     /// literal types.
     pub strict_literal_narrowing: bool,
 
+    /// Whether positive runtime narrowing preserves intersections that can only be inhabited by
+    /// an unrelated subclass when another union member already matches the runtime test.
+    pub strict_subclass_narrowing: bool,
+
     /// Whether errors can be suppressed with `type: ignore` comments.
     ///
     /// If set to false, ty won't:
@@ -113,6 +117,7 @@ impl Default for AnalysisSettings {
     fn default() -> Self {
         Self {
             strict_literal_narrowing: false,
+            strict_subclass_narrowing: false,
             respect_type_ignore_comments: true,
             allowed_unresolved_imports: ModuleGlobSet::empty(),
             replace_imports_with_any: ModuleGlobSet::empty(),

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -685,9 +685,7 @@ fn apply_accumulated_narrowing<'db>(
     accumulated: Option<NarrowingConstraint<'db>>,
 ) -> Type<'db> {
     match accumulated {
-        Some(constraint) => NarrowingConstraint::intersection(base_ty)
-            .merge_constraint_and(constraint)
-            .evaluate_constraint_type(db),
+        Some(constraint) => constraint.apply_to(db, base_ty),
         None => base_ty,
     }
 }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1972,6 +1972,8 @@ pub(super) enum FunctionBodyKind {
 #[strum(serialize_all = "snake_case")]
 #[cfg_attr(test, derive(strum_macros::EnumIter))]
 pub enum KnownFunction {
+    /// `builtins.callable`
+    Callable,
     /// `builtins.isinstance`
     #[strum(serialize = "isinstance")]
     IsInstance,
@@ -2127,7 +2129,8 @@ impl KnownFunction {
     /// Return `true` if `self` is defined in `module`
     const fn check_module(self, module: KnownModule) -> bool {
         match self {
-            Self::IsInstance
+            Self::Callable
+            | Self::IsInstance
             | Self::IsSubclass
             | Self::HasAttr
             | Self::Len
@@ -2674,7 +2677,8 @@ pub(crate) mod tests {
             let function_name = function.name();
 
             let module = match function {
-                KnownFunction::Len
+                KnownFunction::Callable
+                | KnownFunction::Len
                 | KnownFunction::Repr
                 | KnownFunction::IsInstance
                 | KnownFunction::HasAttr

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -614,15 +614,227 @@ impl ClassInfoConstraintFunction {
     }
 }
 
+/// Apply a positive runtime constraint to a union while preferring relationships that already
+/// exist in the declared types over intersections that require a hypothetical unrelated subclass.
+///
+/// This intentionally does not change global disjointness. If no union member definitely matches
+/// the runtime constraint, the fully conservative intersection is preserved.
+fn prefer_union_runtime_narrowing<'db>(
+    db: &'db dyn Db,
+    base_ty: Type<'db>,
+    runtime_constraint: Type<'db>,
+) -> Type<'db> {
+    let full_intersection = || {
+        IntersectionBuilder::new(db)
+            .add_positive(base_ty)
+            .add_positive(runtime_constraint)
+            .build()
+    };
+
+    let Type::Union(union) = base_ty.resolve_type_alias(db) else {
+        return full_intersection();
+    };
+
+    if !union
+        .elements(db)
+        .iter()
+        .any(|element| type_definitely_matches_runtime_constraint(db, *element, runtime_constraint))
+    {
+        return full_intersection();
+    }
+
+    union.map(db, |element| {
+        narrow_runtime_union_arm(db, *element, runtime_constraint)
+    })
+}
+
+fn narrow_runtime_union_arm<'db>(
+    db: &'db dyn Db,
+    base_ty: Type<'db>,
+    runtime_constraint: Type<'db>,
+) -> Type<'db> {
+    let intersect = || {
+        IntersectionBuilder::new(db)
+            .add_positive(base_ty)
+            .add_positive(runtime_constraint)
+            .build()
+    };
+
+    if base_ty.is_subtype_of(db, runtime_constraint) {
+        return base_ty;
+    }
+
+    if let Type::Union(union) = runtime_constraint.resolve_type_alias(db) {
+        return union.map(db, |element| {
+            narrow_runtime_union_arm(db, base_ty, *element)
+        });
+    }
+
+    if type_definitely_matches_runtime_constraint(db, base_ty, runtime_constraint) {
+        // A runtime `TypedDict` is a dictionary, but its static type intentionally hides mutating
+        // dictionary methods. Preserve that static interface for nominal class checks. Protocol
+        // checks still need the intersection to expose the members established by the check.
+        if matches!(base_ty.resolve_type_alias(db), Type::TypedDict(_))
+            && runtime_constraint
+                .nominal_class(db)
+                .is_some_and(|class| class.is_protocol(db))
+        {
+            return intersect();
+        }
+        return base_ty;
+    }
+
+    if !runtime_union_arm_is_relevant(db, base_ty, runtime_constraint) {
+        Type::Never
+    } else {
+        intersect()
+    }
+}
+
+/// Return whether every value in `ty` is known to satisfy the positive runtime constraint.
+///
+/// Dynamic types deliberately do not count as direct witnesses. A different union arm must
+/// establish that the runtime test describes an intended branch before arm preference applies.
+fn type_definitely_matches_runtime_constraint<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    runtime_constraint: Type<'db>,
+) -> bool {
+    let ty = ty.resolve_type_alias(db);
+    let runtime_constraint = runtime_constraint.resolve_type_alias(db);
+    if type_is_runtime_dynamic(ty) || type_is_runtime_dynamic(runtime_constraint) {
+        return false;
+    }
+    if matches!(ty, Type::TypedDict(_))
+        && typed_dict_matches_runtime_constraint(db, runtime_constraint)
+    {
+        return true;
+    }
+    ty.is_subtype_of(db, runtime_constraint)
+}
+
+fn type_is_runtime_dynamic(ty: Type<'_>) -> bool {
+    ty.is_dynamic() || matches!(ty, Type::SubclassOf(subclass_of) if subclass_of.is_dynamic())
+}
+
+/// `TypedDict` is structural in the static type system, but every runtime value is a dictionary.
+fn typed_dict_matches_runtime_constraint(db: &dyn Db, runtime_constraint: Type<'_>) -> bool {
+    match runtime_constraint.resolve_type_alias(db) {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .any(|element| typed_dict_matches_runtime_constraint(db, *element)),
+        Type::Intersection(intersection) => {
+            !intersection.positive(db).is_empty()
+                && intersection
+                    .positive(db)
+                    .iter()
+                    .all(|positive| typed_dict_matches_runtime_constraint(db, *positive))
+                && intersection
+                    .negative(db)
+                    .iter()
+                    .all(|negative| !typed_dict_matches_runtime_constraint(db, *negative))
+        }
+        constraint => constraint
+            .nominal_class(db)
+            .is_some_and(|class| typed_dict_matches_class_pattern(db, class.class_literal(db))),
+    }
+}
+
+/// Return whether an original union arm should remain in a positive runtime branch.
+fn runtime_union_arm_is_relevant<'db>(
+    db: &'db dyn Db,
+    arm: Type<'db>,
+    runtime_constraint: Type<'db>,
+) -> bool {
+    let arm = arm.resolve_type_alias(db);
+    type_is_runtime_dynamic(arm)
+        || type_definitely_matches_runtime_constraint(db, arm, runtime_constraint)
+        || (!arm.is_disjoint_from(db, runtime_constraint)
+            && types_have_existing_runtime_overlap(db, arm, runtime_constraint))
+}
+
+/// Return whether two types can overlap through an inheritance or structural relationship already
+/// present in the types, rather than only through a newly introduced common subclass.
+fn types_have_existing_runtime_overlap<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+) -> bool {
+    let left = left.resolve_type_alias(db);
+    let right = right.resolve_type_alias(db);
+
+    if type_is_runtime_dynamic(left) || type_is_runtime_dynamic(right) {
+        return true;
+    }
+    if (matches!(left, Type::TypedDict(_)) && typed_dict_matches_runtime_constraint(db, right))
+        || (matches!(right, Type::TypedDict(_)) && typed_dict_matches_runtime_constraint(db, left))
+    {
+        return true;
+    }
+    if left.is_subtype_of(db, right) || right.is_subtype_of(db, left) {
+        return true;
+    }
+
+    match (left, right) {
+        (Type::Union(union), right) => union
+            .elements(db)
+            .iter()
+            .any(|left| types_have_existing_runtime_overlap(db, *left, right)),
+        (left, Type::Union(union)) => union
+            .elements(db)
+            .iter()
+            .any(|right| types_have_existing_runtime_overlap(db, left, *right)),
+        (Type::Intersection(intersection), right) => intersection
+            .positive(db)
+            .iter()
+            .any(|left| types_have_existing_runtime_overlap(db, *left, right)),
+        (left, Type::Intersection(intersection)) => intersection
+            .positive(db)
+            .iter()
+            .any(|right| types_have_existing_runtime_overlap(db, left, *right)),
+        (left, right) => {
+            let runtime_class = |ty: Type<'db>| match ty {
+                Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
+                    SubclassOfInner::Class(class) => Some(class),
+                    SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => None,
+                },
+                _ => ty.nominal_class(db),
+            };
+            let Some(left_class) = runtime_class(left) else {
+                return false;
+            };
+            let Some(right_class) = runtime_class(right) else {
+                return false;
+            };
+            left_class.is_subtype_of_class_literal(db, right_class.class_literal(db))
+                || right_class.is_subtype_of_class_literal(db, left_class.class_literal(db))
+        }
+    }
+}
+
 #[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
 struct Conjunctions<'db> {
     conjuncts: SmallVec<[Type<'db>; 2]>,
+    /// Bits identifying positive runtime constraints in `conjuncts`.
+    ///
+    /// `u64::MAX` is also used as an overflow sentinel. Either multiple constraints or overflow
+    /// disables arm preference and falls back to the fully conservative intersection.
+    positive_runtime_conjuncts: u64,
 }
 
 impl<'db> Conjunctions<'db> {
     fn singleton(ty: Type<'db>) -> Self {
         Self {
             conjuncts: smallvec![ty],
+            positive_runtime_conjuncts: 0,
+        }
+    }
+
+    fn positive_runtime(ty: Type<'db>) -> Self {
+        Self {
+            conjuncts: smallvec![ty],
+            positive_runtime_conjuncts: 1,
         }
     }
 
@@ -631,12 +843,56 @@ impl<'db> Conjunctions<'db> {
             return Self::singleton(Type::Never);
         }
 
-        for conjunct in other.conjuncts {
-            if !self.conjuncts.contains(&conjunct) {
-                self.conjuncts.push(conjunct);
+        let runtime_count = self.positive_runtime_count() + other.positive_runtime_count();
+        if runtime_count != 1 {
+            for conjunct in other.conjuncts {
+                if !self.conjuncts.contains(&conjunct) {
+                    self.conjuncts.push(conjunct);
+                }
+            }
+            self.positive_runtime_conjuncts = if runtime_count == 0 { 0 } else { u64::MAX };
+            return self;
+        }
+
+        let other_runtime_conjuncts = other.positive_runtime_conjuncts;
+        for (other_index, conjunct) in other.conjuncts.into_iter().enumerate() {
+            let is_runtime = Self::runtime_mask_contains(other_runtime_conjuncts, other_index);
+            let already_present = self.conjuncts.iter().enumerate().any(|(index, existing)| {
+                *existing == conjunct
+                    && Self::runtime_mask_contains(self.positive_runtime_conjuncts, index)
+                        == is_runtime
+            });
+            if already_present {
+                continue;
+            }
+
+            let new_index = self.conjuncts.len();
+            self.conjuncts.push(conjunct);
+            if is_runtime {
+                if let Ok(new_index) = u32::try_from(new_index) {
+                    self.positive_runtime_conjuncts =
+                        1_u64.checked_shl(new_index).unwrap_or(u64::MAX);
+                } else {
+                    self.positive_runtime_conjuncts = u64::MAX;
+                }
             }
         }
         self
+    }
+
+    fn runtime_mask_contains(mask: u64, index: usize) -> bool {
+        u32::try_from(index)
+            .ok()
+            .and_then(|index| 1_u64.checked_shl(index))
+            .is_some_and(|bit| mask & bit != 0)
+    }
+
+    fn positive_runtime_count(&self) -> u32 {
+        if self.positive_runtime_conjuncts == u64::MAX {
+            2
+        } else {
+            self.positive_runtime_conjuncts.count_ones()
+        }
     }
 
     fn evaluate_constraint_type(self, db: &'db dyn Db) -> Type<'db> {
@@ -649,6 +905,42 @@ impl<'db> Conjunctions<'db> {
             intersection = intersection.add_positive(conjunct);
         }
         intersection.build()
+    }
+
+    fn evaluate_with_runtime_preference(
+        self,
+        db: &'db dyn Db,
+        base_ty: Option<Type<'db>>,
+    ) -> Type<'db> {
+        let mut constrained_base = IntersectionBuilder::new(db);
+        if let Some(base_ty) = base_ty {
+            constrained_base = constrained_base.add_positive(base_ty);
+        }
+        if self.positive_runtime_count() != 1 {
+            // Multiple runtime constraints can interact in ways that make arm preference
+            // order-dependent. Preserve the fully conservative intersection in that case.
+            return self
+                .conjuncts
+                .into_iter()
+                .fold(constrained_base, IntersectionBuilder::add_positive)
+                .build();
+        }
+
+        let runtime_index = self.positive_runtime_conjuncts.trailing_zeros() as usize;
+        let Some(&runtime_constraint) = self.conjuncts.get(runtime_index) else {
+            return self
+                .conjuncts
+                .into_iter()
+                .fold(constrained_base, IntersectionBuilder::add_positive)
+                .build();
+        };
+        for (index, conjunct) in self.conjuncts.into_iter().enumerate() {
+            if index != runtime_index {
+                constrained_base = constrained_base.add_positive(conjunct);
+            }
+        }
+        let constrained_base = constrained_base.build();
+        prefer_union_runtime_narrowing(db, constrained_base, runtime_constraint)
     }
 }
 
@@ -693,6 +985,14 @@ impl<'db> NarrowingConstraint<'db> {
     pub(crate) fn intersection(constraint: Type<'db>) -> Self {
         Self {
             intersection_disjuncts: smallvec_inline![Conjunctions::singleton(constraint)],
+            replacement_disjuncts: smallvec![],
+        }
+    }
+
+    /// Create an intersection constraint originating from a positive runtime type test.
+    fn positive_runtime_intersection(constraint: Type<'db>) -> Self {
+        Self {
+            intersection_disjuncts: smallvec_inline![Conjunctions::positive_runtime(constraint)],
             replacement_disjuncts: smallvec![],
         }
     }
@@ -778,6 +1078,19 @@ impl<'db> NarrowingConstraint<'db> {
             .chain(self.intersection_disjuncts)
         {
             union = union.add(conjunctions.evaluate_constraint_type(db));
+        }
+        union.build()
+    }
+
+    /// Apply this constraint to a previously known type, preserving the distinction between
+    /// ordinary intersections and relaxed positive runtime narrowing.
+    pub(crate) fn apply_to(self, db: &'db dyn Db, base_ty: Type<'db>) -> Type<'db> {
+        let mut union = UnionBuilder::new(db);
+        for conjunctions in self.replacement_disjuncts {
+            union = union.add(conjunctions.evaluate_with_runtime_preference(db, None));
+        }
+        for conjunctions in self.intersection_disjuncts {
+            union = union.add(conjunctions.evaluate_with_runtime_preference(db, Some(base_ty)));
         }
         union.build()
     }
@@ -1085,6 +1398,23 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         constraints.map(FrozenNarrowingConstraints::from)
     }
 
+    fn runtime_intersection_constraint(
+        &self,
+        constraint: Type<'db>,
+        is_positive: bool,
+    ) -> NarrowingConstraint<'db> {
+        if is_positive
+            && !self
+                .db
+                .analysis_settings(self.scope().file(self.db))
+                .strict_subclass_narrowing
+        {
+            NarrowingConstraint::positive_runtime_intersection(constraint)
+        } else {
+            NarrowingConstraint::intersection(constraint)
+        }
+    }
+
     fn evaluate_expression_predicate(
         &mut self,
         expression: Expression<'db>,
@@ -1366,6 +1696,38 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 .analysis_settings(self.scope.file(self.db))
                 .strict_literal_narrowing,
         )
+    }
+
+    fn strict_subclass_narrowing(&self) -> bool {
+        self.db
+            .analysis_settings(self.scope.file(self.db))
+            .strict_subclass_narrowing
+    }
+
+    fn prefer_existing_pattern_arms(
+        &self,
+        subject_ty: Type<'db>,
+        runtime_constraint: Type<'db>,
+    ) -> bool {
+        if self.strict_subclass_narrowing() {
+            return false;
+        }
+        let Type::Union(union) = subject_ty.resolve_type_alias(self.db) else {
+            return false;
+        };
+        union.elements(self.db).iter().any(|element| {
+            type_definitely_matches_runtime_constraint(self.db, *element, runtime_constraint)
+        })
+    }
+
+    fn runtime_pattern_arm_is_relevant(
+        &self,
+        subject_ty: Type<'db>,
+        runtime_constraint: Type<'db>,
+        prefer_existing_arms: bool,
+    ) -> bool {
+        !prefer_existing_arms
+            || runtime_union_arm_is_relevant(self.db, subject_ty, runtime_constraint)
     }
 
     fn merge_binding(
@@ -1652,9 +2014,23 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             Type::TypeAlias(alias) => {
                 self.filter_class_pattern_subject_type(class, class_ty, alias.value_type(self.db))
             }
-            Type::Union(union) => union.map(self.db, |element| {
-                self.filter_class_pattern_subject_type(class, class_ty, *element)
-            }),
+            Type::Union(union) => {
+                let prefer_existing_arms = !self.strict_subclass_narrowing()
+                    && union.elements(self.db).iter().any(|element| {
+                        type_definitely_matches_runtime_constraint(self.db, *element, class_ty)
+                    });
+                union.map(self.db, |element| {
+                    if !self.runtime_pattern_arm_is_relevant(
+                        *element,
+                        class_ty,
+                        prefer_existing_arms,
+                    ) {
+                        Type::Never
+                    } else {
+                        self.filter_class_pattern_subject_type(class, class_ty, *element)
+                    }
+                })
+            }
             Type::Intersection(intersection) if intersection.positive(self.db).is_empty() => {
                 self.intersect_types(subject_ty, class_ty)
             }
@@ -1677,7 +2053,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             Type::TypedDict(_)
                 if class.is_some_and(|class| typed_dict_matches_class_pattern(self.db, class)) =>
             {
-                subject_ty
+                if class.is_some_and(|class| class.is_protocol(self.db)) {
+                    self.intersect_types(subject_ty, class_ty)
+                } else {
+                    subject_ty
+                }
             }
             _ if subject_ty.is_subtype_of(self.db, class_ty) => subject_ty,
             _ if subject_ty.is_disjoint_from(self.db, class_ty) => Type::Never,
@@ -1972,10 +2352,18 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         context: &ClassPatternContext<'db>,
         subject_ty: Type<'db>,
     ) -> Type<'db> {
+        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, context.class_ty);
         self.analyze_matched_subject_arms(
             subject_ty,
             OriginalSubjectPreservation::EquivalentTypes,
             |analyzer, original_subject_ty, subject_ty| {
+                if !analyzer.runtime_pattern_arm_is_relevant(
+                    subject_ty,
+                    context.class_ty,
+                    prefer_existing_arms,
+                ) {
+                    return None;
+                }
                 let (narrowed_subject_ty, arguments) =
                     analyzer.class_pattern_arm(kind, context, original_subject_ty, subject_ty)?;
                 let mut matched_subject_ty = narrowed_subject_ty;
@@ -2026,10 +2414,18 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         context: &ClassPatternContext<'db>,
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
+        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, context.class_ty);
         self.analyze_pattern_subject_arms(
             subject_ty,
             OriginalSubjectPreservation::EquivalentTypes,
             |analyzer, original_subject_ty, subject_ty| {
+                if !analyzer.runtime_pattern_arm_is_relevant(
+                    subject_ty,
+                    context.class_ty,
+                    prefer_existing_arms,
+                ) {
+                    return None;
+                }
                 let (narrowed_subject_ty, arguments) =
                     analyzer.class_pattern_arm(kind, context, original_subject_ty, subject_ty)?;
                 let mut matched_subject_ty = narrowed_subject_ty;
@@ -2174,10 +2570,19 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         subject_ty: Type<'db>,
     ) -> Type<'db> {
         let key_types = self.mapping_pattern_key_types(kind);
+        let mapping_ty = mapping_pattern_type(self.db);
+        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, mapping_ty);
         self.analyze_matched_subject_arms(
             subject_ty,
             OriginalSubjectPreservation::EquivalentTypes,
             |analyzer, _, subject_ty| {
+                if !analyzer.runtime_pattern_arm_is_relevant(
+                    subject_ty,
+                    mapping_ty,
+                    prefer_existing_arms,
+                ) {
+                    return None;
+                }
                 let (narrowed_subject_ty, value_types) =
                     analyzer.mapping_pattern_arm(subject_ty, &key_types)?;
                 for (entry, value_ty) in kind.entries.iter().zip(value_types) {
@@ -2199,10 +2604,19 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
         let key_types = self.mapping_pattern_key_types(kind);
+        let mapping_ty = mapping_pattern_type(self.db);
+        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, mapping_ty);
         self.analyze_pattern_subject_arms(
             subject_ty,
             OriginalSubjectPreservation::EquivalentTypes,
             |analyzer, _, subject_ty| {
+                if !analyzer.runtime_pattern_arm_is_relevant(
+                    subject_ty,
+                    mapping_ty,
+                    prefer_existing_arms,
+                ) {
+                    return None;
+                }
                 let (narrowed_subject_ty, value_types) =
                     analyzer.mapping_pattern_arm(subject_ty, &key_types)?;
                 let mut bindings = BTreeMap::new();
@@ -2255,10 +2669,18 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> Type<'db> {
         let target_len = Self::sequence_pattern_target_len(kind);
         let sequence_ty = sequence_pattern_type_builder(self.db).build();
+        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, sequence_ty);
         self.analyze_matched_subject_arms(
             subject_ty,
             OriginalSubjectPreservation::TypeVariablesOnly,
             |analyzer, _, subject_ty| {
+                if !analyzer.runtime_pattern_arm_is_relevant(
+                    subject_ty,
+                    sequence_ty,
+                    prefer_existing_arms,
+                ) {
+                    return None;
+                }
                 let (narrowed_subject_ty, element_types) =
                     analyzer.sequence_pattern_arm(subject_ty, target_len, sequence_ty)?;
                 let mut persistent_element_types = Vec::with_capacity(kind.patterns.len());
@@ -2301,10 +2723,18 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> PatternSuccessResult<'db> {
         let target_len = Self::sequence_pattern_target_len(kind);
         let sequence_ty = sequence_pattern_type_builder(self.db).build();
+        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, sequence_ty);
         self.analyze_pattern_subject_arms(
             subject_ty,
             OriginalSubjectPreservation::TypeVariablesOnly,
             |analyzer, _, subject_ty| {
+                if !analyzer.runtime_pattern_arm_is_relevant(
+                    subject_ty,
+                    sequence_ty,
+                    prefer_existing_arms,
+                ) {
+                    return None;
+                }
                 let (narrowed_subject_ty, element_types) =
                     analyzer.sequence_pattern_arm(subject_ty, target_len, sequence_ty)?;
                 let mut bindings = BTreeMap::new();
@@ -3564,14 +3994,18 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
         let inference = infer_expression_types(self.db, expression, TypeContext::default());
+        let callable_ty = inference.expression_type(&*expr_call.func);
+        let is_builtin_callable = matches!(
+            callable_ty,
+            Type::FunctionLiteral(function)
+                if function.known(self.db) == Some(KnownFunction::Callable)
+        );
 
         if let Some(type_guard_call_constraints) =
-            self.evaluate_type_guard_call(inference, expr_call, is_positive)
+            self.evaluate_type_guard_call(inference, expr_call, is_positive, is_builtin_callable)
         {
             return Some(type_guard_call_constraints);
         }
-
-        let callable_ty = inference.expression_type(&*expr_call.func);
 
         match callable_ty {
             // For the expression `len(E)`, we narrow the type based on whether len(E) is truthy
@@ -3638,8 +4072,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     .map(|constraint| {
                         NarrowingConstraints::from_iter([(
                             place,
-                            NarrowingConstraint::intersection(
+                            self.runtime_intersection_constraint(
                                 constraint.negate_if(self.db, !is_positive),
+                                is_positive,
                             ),
                         )])
                     })
@@ -3667,19 +4102,23 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         inference: &ExpressionInference<'db>,
         expr_call: &ast::ExprCall,
         is_positive: bool,
+        is_builtin_callable: bool,
     ) -> Option<NarrowingConstraints<'db>> {
         let return_ty = inference.expression_type(expr_call);
 
         let place_and_constraint = match return_ty {
             Type::TypeIs(type_is) => {
                 let (_, place) = type_is.place_info(self.db)?;
+                let narrowed_ty = type_is
+                    .return_type(self.db)
+                    .negate_if(self.db, !is_positive);
                 Some((
                     place,
-                    NarrowingConstraint::intersection(
-                        type_is
-                            .return_type(self.db)
-                            .negate_if(self.db, !is_positive),
-                    ),
+                    if is_builtin_callable {
+                        self.runtime_intersection_constraint(narrowed_ty, is_positive)
+                    } else {
+                        NarrowingConstraint::intersection(narrowed_ty)
+                    },
                 ))
             }
             // TypeGuard only narrows in the positive case

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -619,6 +619,14 @@ impl ClassInfoConstraintFunction {
 ///
 /// This intentionally does not change global disjointness. If no union member definitely matches
 /// the runtime constraint, the fully conservative intersection is preserved.
+///
+/// ```python
+/// class Area: ...
+///
+/// def visit(value: Area | list[Area]) -> None:
+///     if isinstance(value, list):
+///         reveal_type(value)  # list[Area]
+/// ```
 fn prefer_union_runtime_narrowing<'db>(
     db: &'db dyn Db,
     base_ty: Type<'db>,
@@ -641,6 +649,8 @@ fn prefer_union_runtime_narrowing<'db>(
     .unwrap_or_else(full_intersection)
 }
 
+/// Narrow one union arm, preserving dynamic and existing structural or inheritance overlaps.
+/// Arms that could only match through a new unrelated subclass become `Never`.
 fn narrow_runtime_union_arm<'db>(
     db: &'db dyn Db,
     base_ty: Type<'db>,
@@ -698,12 +708,9 @@ fn is_definite_runtime_match<'db>(
     if type_is_runtime_dynamic(ty) || type_is_runtime_dynamic(runtime_constraint) {
         return false;
     }
-    if matches!(ty, Type::TypedDict(_))
-        && typed_dict_matches_runtime_constraint(db, runtime_constraint)
-    {
-        return true;
-    }
-    ty.is_subtype_of(db, runtime_constraint)
+    (matches!(ty, Type::TypedDict(_))
+        && typed_dict_matches_runtime_constraint(db, runtime_constraint))
+        || ty.is_subtype_of(db, runtime_constraint)
 }
 
 fn type_is_runtime_dynamic(ty: Type<'_>) -> bool {
@@ -734,6 +741,10 @@ fn typed_dict_matches_runtime_constraint(db: &dyn Db, runtime_constraint: Type<'
     }
 }
 
+/// Return whether a union arm should remain after preferring definite runtime matches.
+///
+/// Besides definite matches, this retains dynamic arms and overlaps already supported by the
+/// declared inheritance or structural relationships.
 fn runtime_union_arm_is_relevant<'db>(
     db: &'db dyn Db,
     arm: Type<'db>,
@@ -746,6 +757,10 @@ fn runtime_union_arm_is_relevant<'db>(
             && types_have_existing_runtime_overlap(db, arm, runtime_constraint))
 }
 
+/// Narrow the relevant arms of `union`, but only if at least one arm definitely matches.
+///
+/// Returning `None` preserves the conservative intersection when the runtime constraint would
+/// otherwise select arms based only on possible future subclass relationships.
 fn preferred_runtime_union<'db>(
     db: &'db dyn Db,
     union: UnionType<'db>,
@@ -826,6 +841,10 @@ struct Conjunctions<'db> {
     runtime_constraints: RuntimeConstraints<'db>,
 }
 
+/// Tracks whether a conjunction contains zero, one, or multiple positive runtime constraints.
+///
+/// Arm preference is only order-independent for a single constraint. Once constraints are
+/// `Multiple`, their types are stored in `Conjunctions::ordinary` and evaluated conservatively.
 #[derive(Hash, PartialEq, Debug, Eq, Clone, Copy, get_size2::GetSize, salsa::SalsaValue)]
 enum RuntimeConstraints<'db> {
     None,
@@ -908,6 +927,8 @@ impl<'db> Conjunctions<'db> {
             .build()
     }
 
+    /// Apply this conjunction to `base_ty`, using union-relative narrowing for a single runtime
+    /// constraint and conservative intersection semantics otherwise.
     fn evaluate_with_runtime_preference(
         self,
         db: &'db dyn Db,
@@ -1385,6 +1406,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         constraints.map(FrozenNarrowingConstraints::from)
     }
 
+    /// Record positive runtime provenance unless strict subclass narrowing requests the
+    /// conservative intersection behavior.
     fn runtime_intersection_constraint(
         &self,
         constraint: Type<'db>,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -823,25 +823,29 @@ fn types_have_existing_runtime_overlap<'db>(
 #[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
 struct Conjunctions<'db> {
     ordinary: SmallVec<[Type<'db>; 2]>,
-    runtime_constraint: Option<Type<'db>>,
-    /// If set, all runtime constraints have already been folded into `ordinary`.
-    has_multiple_runtime_constraints: bool,
+    runtime_constraints: RuntimeConstraints<'db>,
+}
+
+#[derive(Hash, PartialEq, Debug, Eq, Clone, Copy, get_size2::GetSize, salsa::SalsaValue)]
+enum RuntimeConstraints<'db> {
+    None,
+    Single(Type<'db>),
+    /// All runtime constraints have been folded into `Conjunctions::ordinary`.
+    Multiple,
 }
 
 impl<'db> Conjunctions<'db> {
     fn singleton(ty: Type<'db>) -> Self {
         Self {
             ordinary: smallvec![ty],
-            runtime_constraint: None,
-            has_multiple_runtime_constraints: false,
+            runtime_constraints: RuntimeConstraints::None,
         }
     }
 
     fn positive_runtime(ty: Type<'db>) -> Self {
         Self {
             ordinary: smallvec![],
-            runtime_constraint: Some(ty),
-            has_multiple_runtime_constraints: false,
+            runtime_constraints: RuntimeConstraints::Single(ty),
         }
     }
 
@@ -853,23 +857,23 @@ impl<'db> Conjunctions<'db> {
         for conjunct in other.ordinary {
             self.add_ordinary(conjunct);
         }
-        match (self.runtime_constraint.take(), other.runtime_constraint) {
-            (Some(left), Some(right)) => {
+        self.runtime_constraints = match (self.runtime_constraints, other.runtime_constraints) {
+            (RuntimeConstraints::None, runtime_constraints)
+            | (runtime_constraints, RuntimeConstraints::None) => runtime_constraints,
+            (RuntimeConstraints::Single(left), RuntimeConstraints::Single(right)) => {
                 self.add_ordinary(left);
                 self.add_ordinary(right);
-                self.has_multiple_runtime_constraints = true;
+                RuntimeConstraints::Multiple
             }
-            (runtime_constraint, None) | (None, runtime_constraint) => {
-                if self.has_multiple_runtime_constraints || other.has_multiple_runtime_constraints {
-                    if let Some(runtime_constraint) = runtime_constraint {
-                        self.add_ordinary(runtime_constraint);
-                    }
-                } else {
-                    self.runtime_constraint = runtime_constraint;
-                }
+            (RuntimeConstraints::Single(runtime_constraint), RuntimeConstraints::Multiple)
+            | (RuntimeConstraints::Multiple, RuntimeConstraints::Single(runtime_constraint)) => {
+                self.add_ordinary(runtime_constraint);
+                RuntimeConstraints::Multiple
             }
-        }
-        self.has_multiple_runtime_constraints |= other.has_multiple_runtime_constraints;
+            (RuntimeConstraints::Multiple, RuntimeConstraints::Multiple) => {
+                RuntimeConstraints::Multiple
+            }
+        };
         self
     }
 
@@ -881,13 +885,14 @@ impl<'db> Conjunctions<'db> {
 
     fn contains_never(&self) -> bool {
         self.ordinary.iter().any(Type::is_never)
-            || self
-                .runtime_constraint
-                .is_some_and(|constraint| constraint.is_never())
+            || matches!(
+                self.runtime_constraints,
+                RuntimeConstraints::Single(constraint) if constraint.is_never()
+            )
     }
 
     fn evaluate_constraint_type(mut self, db: &'db dyn Db) -> Type<'db> {
-        if let Some(runtime_constraint) = self.runtime_constraint {
+        if let RuntimeConstraints::Single(runtime_constraint) = self.runtime_constraints {
             self.add_ordinary(runtime_constraint);
         }
         if self.ordinary.len() == 1 {
@@ -908,6 +913,10 @@ impl<'db> Conjunctions<'db> {
         db: &'db dyn Db,
         base_ty: Option<Type<'db>>,
     ) -> Type<'db> {
+        let runtime_constraint = match self.runtime_constraints {
+            RuntimeConstraints::Single(runtime_constraint) => Some(runtime_constraint),
+            RuntimeConstraints::None | RuntimeConstraints::Multiple => None,
+        };
         let mut constrained_base = IntersectionBuilder::new(db);
         if let Some(base_ty) = base_ty {
             constrained_base = constrained_base.add_positive(base_ty);
@@ -916,10 +925,9 @@ impl<'db> Conjunctions<'db> {
             constrained_base = constrained_base.add_positive(conjunct);
         }
         let constrained_base = constrained_base.build();
-        self.runtime_constraint
-            .map_or(constrained_base, |runtime_constraint| {
-                prefer_union_runtime_narrowing(db, constrained_base, runtime_constraint)
-            })
+        runtime_constraint.map_or(constrained_base, |runtime_constraint| {
+            prefer_union_runtime_narrowing(db, constrained_base, runtime_constraint)
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -635,13 +635,10 @@ fn prefer_union_runtime_narrowing<'db>(
         return full_intersection();
     };
 
-    if !union_has_runtime_witness(db, union, runtime_constraint) {
-        return full_intersection();
-    }
-
-    union.map(db, |element| {
-        narrow_runtime_union_arm(db, *element, runtime_constraint)
+    preferred_runtime_union(db, union, runtime_constraint, |element| {
+        narrow_runtime_union_arm(db, element, runtime_constraint)
     })
+    .unwrap_or_else(full_intersection)
 }
 
 fn narrow_runtime_union_arm<'db>(
@@ -666,7 +663,7 @@ fn narrow_runtime_union_arm<'db>(
         });
     }
 
-    if type_definitely_matches_runtime_constraint(db, base_ty, runtime_constraint) {
+    if is_definite_runtime_match(db, base_ty, runtime_constraint) {
         // A runtime `TypedDict` is a dictionary, but its static type intentionally hides mutating
         // dictionary methods. Preserve that static interface for nominal class checks. Protocol
         // checks still need the intersection to expose the members established by the check.
@@ -689,9 +686,9 @@ fn narrow_runtime_union_arm<'db>(
 
 /// Return whether every value in `ty` is known to satisfy the positive runtime constraint.
 ///
-/// Dynamic types deliberately do not count as direct witnesses. A different union arm must
+/// Dynamic types deliberately do not count as definite matches. A different union arm must
 /// establish that the runtime test describes an intended branch before arm preference applies.
-fn type_definitely_matches_runtime_constraint<'db>(
+fn is_definite_runtime_match<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
     runtime_constraint: Type<'db>,
@@ -707,17 +704,6 @@ fn type_definitely_matches_runtime_constraint<'db>(
         return true;
     }
     ty.is_subtype_of(db, runtime_constraint)
-}
-
-fn union_has_runtime_witness<'db>(
-    db: &'db dyn Db,
-    union: UnionType<'db>,
-    runtime_constraint: Type<'db>,
-) -> bool {
-    union
-        .elements(db)
-        .iter()
-        .any(|element| type_definitely_matches_runtime_constraint(db, *element, runtime_constraint))
 }
 
 fn type_is_runtime_dynamic(ty: Type<'_>) -> bool {
@@ -748,17 +734,34 @@ fn typed_dict_matches_runtime_constraint(db: &dyn Db, runtime_constraint: Type<'
     }
 }
 
-/// Return whether an original union arm should remain in a positive runtime branch.
 fn runtime_union_arm_is_relevant<'db>(
     db: &'db dyn Db,
     arm: Type<'db>,
     runtime_constraint: Type<'db>,
 ) -> bool {
     let arm = arm.resolve_type_alias(db);
-    type_is_runtime_dynamic(arm)
-        || type_definitely_matches_runtime_constraint(db, arm, runtime_constraint)
+    is_definite_runtime_match(db, arm, runtime_constraint)
+        || type_is_runtime_dynamic(arm)
         || (!arm.is_disjoint_from(db, runtime_constraint)
             && types_have_existing_runtime_overlap(db, arm, runtime_constraint))
+}
+
+fn preferred_runtime_union<'db>(
+    db: &'db dyn Db,
+    union: UnionType<'db>,
+    runtime_constraint: Type<'db>,
+    mut narrow: impl FnMut(Type<'db>) -> Type<'db>,
+) -> Option<Type<'db>> {
+    let mut has_definite_match = false;
+    let preferred = UnionType::from_elements(
+        db,
+        union.elements(db).iter().filter_map(|element| {
+            has_definite_match |= is_definite_runtime_match(db, *element, runtime_constraint);
+            runtime_union_arm_is_relevant(db, *element, runtime_constraint)
+                .then(|| narrow(*element))
+        }),
+    );
+    has_definite_match.then_some(preferred)
 }
 
 /// Return whether two types can overlap through an inheritance or structural relationship already
@@ -802,10 +805,7 @@ fn types_have_existing_runtime_overlap<'db>(
             .any(|right| types_have_existing_runtime_overlap(db, left, *right)),
         (left, right) => {
             let runtime_class = |ty: Type<'db>| match ty {
-                Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
-                    SubclassOfInner::Class(class) => Some(class),
-                    SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => None,
-                },
+                Type::SubclassOf(subclass_of) => subclass_of.subclass_of().into_class(db),
                 _ => ty.nominal_class(db),
             };
             let Some(left_class) = runtime_class(left) else {
@@ -822,98 +822,85 @@ fn types_have_existing_runtime_overlap<'db>(
 
 #[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
 struct Conjunctions<'db> {
-    conjuncts: SmallVec<[Conjunct<'db>; 2]>,
-    /// Multiple runtime constraints can interact in ways that make arm preference order-dependent.
+    ordinary: SmallVec<[Type<'db>; 2]>,
+    runtime_constraint: Option<Type<'db>>,
+    /// If set, all runtime constraints have already been folded into `ordinary`.
     has_multiple_runtime_constraints: bool,
-}
-
-#[derive(Hash, PartialEq, Debug, Eq, Clone, Copy, get_size2::GetSize, salsa::SalsaValue)]
-enum Conjunct<'db> {
-    Ordinary(Type<'db>),
-    PositiveRuntime(Type<'db>),
-}
-
-impl<'db> Conjunct<'db> {
-    fn ty(self) -> Type<'db> {
-        match self {
-            Self::Ordinary(ty) | Self::PositiveRuntime(ty) => ty,
-        }
-    }
-
-    fn positive_runtime(self) -> Option<Type<'db>> {
-        match self {
-            Self::PositiveRuntime(ty) => Some(ty),
-            Self::Ordinary(_) => None,
-        }
-    }
 }
 
 impl<'db> Conjunctions<'db> {
     fn singleton(ty: Type<'db>) -> Self {
         Self {
-            conjuncts: smallvec![Conjunct::Ordinary(ty)],
+            ordinary: smallvec![ty],
+            runtime_constraint: None,
             has_multiple_runtime_constraints: false,
         }
     }
 
     fn positive_runtime(ty: Type<'db>) -> Self {
         Self {
-            conjuncts: smallvec![Conjunct::PositiveRuntime(ty)],
+            ordinary: smallvec![],
+            runtime_constraint: Some(ty),
             has_multiple_runtime_constraints: false,
         }
     }
 
     fn and_with(mut self, other: Self) -> Self {
-        if self
-            .conjuncts
-            .iter()
-            .any(|conjunct| conjunct.ty().is_never())
-            || other
-                .conjuncts
-                .iter()
-                .any(|conjunct| conjunct.ty().is_never())
-        {
+        if self.contains_never() || other.contains_never() {
             return Self::singleton(Type::Never);
         }
 
-        let runtime_count = self.runtime_constraint_count() + other.runtime_constraint_count();
-        self.has_multiple_runtime_constraints = runtime_count > 1;
-        for conjunct in other.conjuncts {
-            if !self.conjuncts.contains(&conjunct) {
-                self.conjuncts.push(conjunct);
+        for conjunct in other.ordinary {
+            self.add_ordinary(conjunct);
+        }
+        match (self.runtime_constraint.take(), other.runtime_constraint) {
+            (Some(left), Some(right)) => {
+                self.add_ordinary(left);
+                self.add_ordinary(right);
+                self.has_multiple_runtime_constraints = true;
+            }
+            (runtime_constraint, None) | (None, runtime_constraint) => {
+                if self.has_multiple_runtime_constraints || other.has_multiple_runtime_constraints {
+                    if let Some(runtime_constraint) = runtime_constraint {
+                        self.add_ordinary(runtime_constraint);
+                    }
+                } else {
+                    self.runtime_constraint = runtime_constraint;
+                }
             }
         }
+        self.has_multiple_runtime_constraints |= other.has_multiple_runtime_constraints;
         self
     }
 
-    fn runtime_constraint_count(&self) -> usize {
-        if self.has_multiple_runtime_constraints {
-            2
-        } else {
-            usize::from(self.single_runtime_constraint().is_some())
+    fn add_ordinary(&mut self, ty: Type<'db>) {
+        if !self.ordinary.contains(&ty) {
+            self.ordinary.push(ty);
         }
     }
 
-    fn single_runtime_constraint(&self) -> Option<Type<'db>> {
-        if self.has_multiple_runtime_constraints {
-            None
-        } else {
-            self.conjuncts
-                .iter()
-                .find_map(|conjunct| conjunct.positive_runtime())
-        }
+    fn contains_never(&self) -> bool {
+        self.ordinary.iter().any(Type::is_never)
+            || self
+                .runtime_constraint
+                .is_some_and(|constraint| constraint.is_never())
     }
 
-    fn evaluate_constraint_type(self, db: &'db dyn Db) -> Type<'db> {
-        if self.conjuncts.len() == 1 {
-            return self.conjuncts[0].ty();
+    fn evaluate_constraint_type(mut self, db: &'db dyn Db) -> Type<'db> {
+        if let Some(runtime_constraint) = self.runtime_constraint {
+            self.add_ordinary(runtime_constraint);
+        }
+        if self.ordinary.len() == 1 {
+            return self.ordinary[0];
         }
 
-        let mut intersection = IntersectionBuilder::new(db);
-        for conjunct in self.conjuncts {
-            intersection = intersection.add_positive(conjunct.ty());
-        }
-        intersection.build()
+        self.ordinary
+            .into_iter()
+            .fold(
+                IntersectionBuilder::new(db),
+                IntersectionBuilder::add_positive,
+            )
+            .build()
     }
 
     fn evaluate_with_runtime_preference(
@@ -925,22 +912,14 @@ impl<'db> Conjunctions<'db> {
         if let Some(base_ty) = base_ty {
             constrained_base = constrained_base.add_positive(base_ty);
         }
-        let Some(runtime_constraint) = self.single_runtime_constraint() else {
-            return self
-                .conjuncts
-                .into_iter()
-                .map(Conjunct::ty)
-                .fold(constrained_base, IntersectionBuilder::add_positive)
-                .build();
-        };
-
-        for conjunct in self.conjuncts {
-            if let Conjunct::Ordinary(ty) = conjunct {
-                constrained_base = constrained_base.add_positive(ty);
-            }
+        for conjunct in self.ordinary {
+            constrained_base = constrained_base.add_positive(conjunct);
         }
         let constrained_base = constrained_base.build();
-        prefer_union_runtime_narrowing(db, constrained_base, runtime_constraint)
+        self.runtime_constraint
+            .map_or(constrained_base, |runtime_constraint| {
+                prefer_union_runtime_narrowing(db, constrained_base, runtime_constraint)
+            })
     }
 }
 
@@ -1704,20 +1683,6 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             .strict_subclass_narrowing
     }
 
-    fn prefer_existing_pattern_arms(
-        &self,
-        subject_ty: Type<'db>,
-        runtime_constraint: Type<'db>,
-    ) -> bool {
-        if self.strict_subclass_narrowing() {
-            return false;
-        }
-        let Type::Union(union) = subject_ty.resolve_type_alias(self.db) else {
-            return false;
-        };
-        union_has_runtime_witness(self.db, union, runtime_constraint)
-    }
-
     fn merge_binding(
         bindings: &mut BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
         place: ScopedPlaceId,
@@ -2005,16 +1970,16 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 self.filter_class_pattern_subject_type(class, class_ty, alias.value_type(self.db))
             }
             Type::Union(union) => {
-                let prefer_existing_arms = !self.strict_subclass_narrowing()
-                    && union_has_runtime_witness(self.db, union, class_ty);
+                if !self.strict_subclass_narrowing()
+                    && let Some(filtered) =
+                        preferred_runtime_union(self.db, union, class_ty, |element| {
+                            self.filter_class_pattern_subject_type(class, class_ty, element)
+                        })
+                {
+                    return filtered;
+                }
                 union.map(self.db, |element| {
-                    if prefer_existing_arms
-                        && !runtime_union_arm_is_relevant(self.db, *element, class_ty)
-                    {
-                        Type::Never
-                    } else {
-                        self.filter_class_pattern_subject_type(class, class_ty, *element)
-                    }
+                    self.filter_class_pattern_subject_type(class, class_ty, *element)
                 })
             }
             Type::Intersection(intersection) if intersection.positive(self.db).is_empty() => {
@@ -2938,6 +2903,16 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         runtime_constraint: Option<Type<'db>>,
     ) -> SmallVec<[(Type<'db>, Type<'db>); 2]> {
         let subject_ty = subject_ty.resolve_type_alias(self.db);
+        let prefer_existing_arms = !self.strict_subclass_narrowing()
+            && runtime_constraint.is_some_and(|runtime_constraint| {
+                let Type::Union(union) = subject_ty else {
+                    return false;
+                };
+                union
+                    .elements(self.db)
+                    .iter()
+                    .any(|element| is_definite_runtime_match(self.db, *element, runtime_constraint))
+            });
         let mut arms = SmallVec::new();
         let mut add_arm = |original_subject_ty: Type<'db>| {
             let filtering_subject_ty = self.pattern_filtering_type(original_subject_ty);
@@ -2961,9 +2936,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             _ => add_arm(subject_ty),
         }
 
-        if let Some(runtime_constraint) = runtime_constraint
-            && self.prefer_existing_pattern_arms(subject_ty, runtime_constraint)
-        {
+        if prefer_existing_arms && let Some(runtime_constraint) = runtime_constraint {
             arms.retain(|(_, filtering_subject_ty)| {
                 runtime_union_arm_is_relevant(self.db, *filtering_subject_ty, runtime_constraint)
             });

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -635,11 +635,7 @@ fn prefer_union_runtime_narrowing<'db>(
         return full_intersection();
     };
 
-    if !union
-        .elements(db)
-        .iter()
-        .any(|element| type_definitely_matches_runtime_constraint(db, *element, runtime_constraint))
-    {
+    if !union_has_runtime_witness(db, union, runtime_constraint) {
         return full_intersection();
     }
 
@@ -711,6 +707,17 @@ fn type_definitely_matches_runtime_constraint<'db>(
         return true;
     }
     ty.is_subtype_of(db, runtime_constraint)
+}
+
+fn union_has_runtime_witness<'db>(
+    db: &'db dyn Db,
+    union: UnionType<'db>,
+    runtime_constraint: Type<'db>,
+) -> bool {
+    union
+        .elements(db)
+        .iter()
+        .any(|element| type_definitely_matches_runtime_constraint(db, *element, runtime_constraint))
 }
 
 fn type_is_runtime_dynamic(ty: Type<'_>) -> bool {
@@ -815,94 +822,96 @@ fn types_have_existing_runtime_overlap<'db>(
 
 #[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
 struct Conjunctions<'db> {
-    conjuncts: SmallVec<[Type<'db>; 2]>,
-    /// Bits identifying positive runtime constraints in `conjuncts`.
-    ///
-    /// `u64::MAX` is also used as an overflow sentinel. Either multiple constraints or overflow
-    /// disables arm preference and falls back to the fully conservative intersection.
-    positive_runtime_conjuncts: u64,
+    conjuncts: SmallVec<[Conjunct<'db>; 2]>,
+    /// Multiple runtime constraints can interact in ways that make arm preference order-dependent.
+    has_multiple_runtime_constraints: bool,
+}
+
+#[derive(Hash, PartialEq, Debug, Eq, Clone, Copy, get_size2::GetSize, salsa::SalsaValue)]
+enum Conjunct<'db> {
+    Ordinary(Type<'db>),
+    PositiveRuntime(Type<'db>),
+}
+
+impl<'db> Conjunct<'db> {
+    fn ty(self) -> Type<'db> {
+        match self {
+            Self::Ordinary(ty) | Self::PositiveRuntime(ty) => ty,
+        }
+    }
+
+    fn positive_runtime(self) -> Option<Type<'db>> {
+        match self {
+            Self::PositiveRuntime(ty) => Some(ty),
+            Self::Ordinary(_) => None,
+        }
+    }
 }
 
 impl<'db> Conjunctions<'db> {
     fn singleton(ty: Type<'db>) -> Self {
         Self {
-            conjuncts: smallvec![ty],
-            positive_runtime_conjuncts: 0,
+            conjuncts: smallvec![Conjunct::Ordinary(ty)],
+            has_multiple_runtime_constraints: false,
         }
     }
 
     fn positive_runtime(ty: Type<'db>) -> Self {
         Self {
-            conjuncts: smallvec![ty],
-            positive_runtime_conjuncts: 1,
+            conjuncts: smallvec![Conjunct::PositiveRuntime(ty)],
+            has_multiple_runtime_constraints: false,
         }
     }
 
     fn and_with(mut self, other: Self) -> Self {
-        if self.conjuncts.iter().any(Type::is_never) || other.conjuncts.iter().any(Type::is_never) {
+        if self
+            .conjuncts
+            .iter()
+            .any(|conjunct| conjunct.ty().is_never())
+            || other
+                .conjuncts
+                .iter()
+                .any(|conjunct| conjunct.ty().is_never())
+        {
             return Self::singleton(Type::Never);
         }
 
-        let runtime_count = self.positive_runtime_count() + other.positive_runtime_count();
-        if runtime_count != 1 {
-            for conjunct in other.conjuncts {
-                if !self.conjuncts.contains(&conjunct) {
-                    self.conjuncts.push(conjunct);
-                }
-            }
-            self.positive_runtime_conjuncts = if runtime_count == 0 { 0 } else { u64::MAX };
-            return self;
-        }
-
-        let other_runtime_conjuncts = other.positive_runtime_conjuncts;
-        for (other_index, conjunct) in other.conjuncts.into_iter().enumerate() {
-            let is_runtime = Self::runtime_mask_contains(other_runtime_conjuncts, other_index);
-            let already_present = self.conjuncts.iter().enumerate().any(|(index, existing)| {
-                *existing == conjunct
-                    && Self::runtime_mask_contains(self.positive_runtime_conjuncts, index)
-                        == is_runtime
-            });
-            if already_present {
-                continue;
-            }
-
-            let new_index = self.conjuncts.len();
-            self.conjuncts.push(conjunct);
-            if is_runtime {
-                if let Ok(new_index) = u32::try_from(new_index) {
-                    self.positive_runtime_conjuncts =
-                        1_u64.checked_shl(new_index).unwrap_or(u64::MAX);
-                } else {
-                    self.positive_runtime_conjuncts = u64::MAX;
-                }
+        let runtime_count = self.runtime_constraint_count() + other.runtime_constraint_count();
+        self.has_multiple_runtime_constraints = runtime_count > 1;
+        for conjunct in other.conjuncts {
+            if !self.conjuncts.contains(&conjunct) {
+                self.conjuncts.push(conjunct);
             }
         }
         self
     }
 
-    fn runtime_mask_contains(mask: u64, index: usize) -> bool {
-        u32::try_from(index)
-            .ok()
-            .and_then(|index| 1_u64.checked_shl(index))
-            .is_some_and(|bit| mask & bit != 0)
-    }
-
-    fn positive_runtime_count(&self) -> u32 {
-        if self.positive_runtime_conjuncts == u64::MAX {
+    fn runtime_constraint_count(&self) -> usize {
+        if self.has_multiple_runtime_constraints {
             2
         } else {
-            self.positive_runtime_conjuncts.count_ones()
+            usize::from(self.single_runtime_constraint().is_some())
+        }
+    }
+
+    fn single_runtime_constraint(&self) -> Option<Type<'db>> {
+        if self.has_multiple_runtime_constraints {
+            None
+        } else {
+            self.conjuncts
+                .iter()
+                .find_map(|conjunct| conjunct.positive_runtime())
         }
     }
 
     fn evaluate_constraint_type(self, db: &'db dyn Db) -> Type<'db> {
         if self.conjuncts.len() == 1 {
-            return self.conjuncts[0];
+            return self.conjuncts[0].ty();
         }
 
         let mut intersection = IntersectionBuilder::new(db);
         for conjunct in self.conjuncts {
-            intersection = intersection.add_positive(conjunct);
+            intersection = intersection.add_positive(conjunct.ty());
         }
         intersection.build()
     }
@@ -916,27 +925,18 @@ impl<'db> Conjunctions<'db> {
         if let Some(base_ty) = base_ty {
             constrained_base = constrained_base.add_positive(base_ty);
         }
-        if self.positive_runtime_count() != 1 {
-            // Multiple runtime constraints can interact in ways that make arm preference
-            // order-dependent. Preserve the fully conservative intersection in that case.
+        let Some(runtime_constraint) = self.single_runtime_constraint() else {
             return self
                 .conjuncts
                 .into_iter()
-                .fold(constrained_base, IntersectionBuilder::add_positive)
-                .build();
-        }
-
-        let runtime_index = self.positive_runtime_conjuncts.trailing_zeros() as usize;
-        let Some(&runtime_constraint) = self.conjuncts.get(runtime_index) else {
-            return self
-                .conjuncts
-                .into_iter()
+                .map(Conjunct::ty)
                 .fold(constrained_base, IntersectionBuilder::add_positive)
                 .build();
         };
-        for (index, conjunct) in self.conjuncts.into_iter().enumerate() {
-            if index != runtime_index {
-                constrained_base = constrained_base.add_positive(conjunct);
+
+        for conjunct in self.conjuncts {
+            if let Conjunct::Ordinary(ty) = conjunct {
+                constrained_base = constrained_base.add_positive(ty);
             }
         }
         let constrained_base = constrained_base.build();
@@ -1715,19 +1715,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let Type::Union(union) = subject_ty.resolve_type_alias(self.db) else {
             return false;
         };
-        union.elements(self.db).iter().any(|element| {
-            type_definitely_matches_runtime_constraint(self.db, *element, runtime_constraint)
-        })
-    }
-
-    fn runtime_pattern_arm_is_relevant(
-        &self,
-        subject_ty: Type<'db>,
-        runtime_constraint: Type<'db>,
-        prefer_existing_arms: bool,
-    ) -> bool {
-        !prefer_existing_arms
-            || runtime_union_arm_is_relevant(self.db, subject_ty, runtime_constraint)
+        union_has_runtime_witness(self.db, union, runtime_constraint)
     }
 
     fn merge_binding(
@@ -1892,6 +1880,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> Type<'db> {
         self.analyze_matched_subject_arms(
             subject_ty,
+            None,
             OriginalSubjectPreservation::TypeVariablesOnly,
             |analyzer, _, subject_ty| {
                 Some(UnionType::from_elements(
@@ -1941,6 +1930,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> PatternSuccessResult<'db> {
         self.analyze_pattern_subject_arms(
             subject_ty,
+            None,
             OriginalSubjectPreservation::TypeVariablesOnly,
             |analyzer, _, arm_ty| {
                 Some(analyzer.analyze_successful_or_pattern_arm(patterns, arm_ty))
@@ -2016,15 +2006,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             }
             Type::Union(union) => {
                 let prefer_existing_arms = !self.strict_subclass_narrowing()
-                    && union.elements(self.db).iter().any(|element| {
-                        type_definitely_matches_runtime_constraint(self.db, *element, class_ty)
-                    });
+                    && union_has_runtime_witness(self.db, union, class_ty);
                 union.map(self.db, |element| {
-                    if !self.runtime_pattern_arm_is_relevant(
-                        *element,
-                        class_ty,
-                        prefer_existing_arms,
-                    ) {
+                    if prefer_existing_arms
+                        && !runtime_union_arm_is_relevant(self.db, *element, class_ty)
+                    {
                         Type::Never
                     } else {
                         self.filter_class_pattern_subject_type(class, class_ty, *element)
@@ -2352,18 +2338,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         context: &ClassPatternContext<'db>,
         subject_ty: Type<'db>,
     ) -> Type<'db> {
-        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, context.class_ty);
         self.analyze_matched_subject_arms(
             subject_ty,
+            Some(context.class_ty),
             OriginalSubjectPreservation::EquivalentTypes,
             |analyzer, original_subject_ty, subject_ty| {
-                if !analyzer.runtime_pattern_arm_is_relevant(
-                    subject_ty,
-                    context.class_ty,
-                    prefer_existing_arms,
-                ) {
-                    return None;
-                }
                 let (narrowed_subject_ty, arguments) =
                     analyzer.class_pattern_arm(kind, context, original_subject_ty, subject_ty)?;
                 let mut matched_subject_ty = narrowed_subject_ty;
@@ -2414,18 +2393,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         context: &ClassPatternContext<'db>,
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
-        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, context.class_ty);
         self.analyze_pattern_subject_arms(
             subject_ty,
+            Some(context.class_ty),
             OriginalSubjectPreservation::EquivalentTypes,
             |analyzer, original_subject_ty, subject_ty| {
-                if !analyzer.runtime_pattern_arm_is_relevant(
-                    subject_ty,
-                    context.class_ty,
-                    prefer_existing_arms,
-                ) {
-                    return None;
-                }
                 let (narrowed_subject_ty, arguments) =
                     analyzer.class_pattern_arm(kind, context, original_subject_ty, subject_ty)?;
                 let mut matched_subject_ty = narrowed_subject_ty;
@@ -2571,18 +2543,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> Type<'db> {
         let key_types = self.mapping_pattern_key_types(kind);
         let mapping_ty = mapping_pattern_type(self.db);
-        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, mapping_ty);
         self.analyze_matched_subject_arms(
             subject_ty,
+            Some(mapping_ty),
             OriginalSubjectPreservation::EquivalentTypes,
             |analyzer, _, subject_ty| {
-                if !analyzer.runtime_pattern_arm_is_relevant(
-                    subject_ty,
-                    mapping_ty,
-                    prefer_existing_arms,
-                ) {
-                    return None;
-                }
                 let (narrowed_subject_ty, value_types) =
                     analyzer.mapping_pattern_arm(subject_ty, &key_types)?;
                 for (entry, value_ty) in kind.entries.iter().zip(value_types) {
@@ -2605,18 +2570,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> PatternSuccessResult<'db> {
         let key_types = self.mapping_pattern_key_types(kind);
         let mapping_ty = mapping_pattern_type(self.db);
-        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, mapping_ty);
         self.analyze_pattern_subject_arms(
             subject_ty,
+            Some(mapping_ty),
             OriginalSubjectPreservation::EquivalentTypes,
             |analyzer, _, subject_ty| {
-                if !analyzer.runtime_pattern_arm_is_relevant(
-                    subject_ty,
-                    mapping_ty,
-                    prefer_existing_arms,
-                ) {
-                    return None;
-                }
                 let (narrowed_subject_ty, value_types) =
                     analyzer.mapping_pattern_arm(subject_ty, &key_types)?;
                 let mut bindings = BTreeMap::new();
@@ -2669,18 +2627,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> Type<'db> {
         let target_len = Self::sequence_pattern_target_len(kind);
         let sequence_ty = sequence_pattern_type_builder(self.db).build();
-        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, sequence_ty);
         self.analyze_matched_subject_arms(
             subject_ty,
+            Some(sequence_ty),
             OriginalSubjectPreservation::TypeVariablesOnly,
             |analyzer, _, subject_ty| {
-                if !analyzer.runtime_pattern_arm_is_relevant(
-                    subject_ty,
-                    sequence_ty,
-                    prefer_existing_arms,
-                ) {
-                    return None;
-                }
                 let (narrowed_subject_ty, element_types) =
                     analyzer.sequence_pattern_arm(subject_ty, target_len, sequence_ty)?;
                 let mut persistent_element_types = Vec::with_capacity(kind.patterns.len());
@@ -2723,18 +2674,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> PatternSuccessResult<'db> {
         let target_len = Self::sequence_pattern_target_len(kind);
         let sequence_ty = sequence_pattern_type_builder(self.db).build();
-        let prefer_existing_arms = self.prefer_existing_pattern_arms(subject_ty, sequence_ty);
         self.analyze_pattern_subject_arms(
             subject_ty,
+            Some(sequence_ty),
             OriginalSubjectPreservation::TypeVariablesOnly,
             |analyzer, _, subject_ty| {
-                if !analyzer.runtime_pattern_arm_is_relevant(
-                    subject_ty,
-                    sequence_ty,
-                    prefer_existing_arms,
-                ) {
-                    return None;
-                }
                 let (narrowed_subject_ty, element_types) =
                     analyzer.sequence_pattern_arm(subject_ty, target_len, sequence_ty)?;
                 let mut bindings = BTreeMap::new();
@@ -2877,10 +2821,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     fn analyze_matched_subject_arms(
         &self,
         subject_ty: Type<'db>,
+        runtime_constraint: Option<Type<'db>>,
         preservation: OriginalSubjectPreservation,
         analyze_arm: impl Fn(&Self, Type<'db>, Type<'db>) -> Option<Type<'db>>,
     ) -> Type<'db> {
-        let subject_arms = self.match_pattern_subject_arms(subject_ty);
+        let subject_arms = self.match_pattern_subject_arms(subject_ty, runtime_constraint);
         let grouped_arms = subject_arms
             .into_iter()
             .chunk_by(|(original_subject_ty, _)| *original_subject_ty);
@@ -2906,10 +2851,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     fn analyze_pattern_subject_arms(
         &self,
         subject_ty: Type<'db>,
+        runtime_constraint: Option<Type<'db>>,
         preservation: OriginalSubjectPreservation,
         analyze_arm: impl Fn(&Self, Type<'db>, Type<'db>) -> Option<PatternSuccessResult<'db>>,
     ) -> PatternSuccessResult<'db> {
-        let subject_arms = self.match_pattern_subject_arms(subject_ty);
+        let subject_arms = self.match_pattern_subject_arms(subject_ty, runtime_constraint);
         let grouped_arms = subject_arms
             .into_iter()
             .chunk_by(|(original_subject_ty, _)| *original_subject_ty);
@@ -2989,6 +2935,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     fn match_pattern_subject_arms(
         &self,
         subject_ty: Type<'db>,
+        runtime_constraint: Option<Type<'db>>,
     ) -> SmallVec<[(Type<'db>, Type<'db>); 2]> {
         let subject_ty = subject_ty.resolve_type_alias(self.db);
         let mut arms = SmallVec::new();
@@ -3012,6 +2959,14 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 .copied()
                 .for_each(&mut add_arm),
             _ => add_arm(subject_ty),
+        }
+
+        if let Some(runtime_constraint) = runtime_constraint
+            && self.prefer_existing_pattern_arms(subject_ty, runtime_constraint)
+        {
+            arms.retain(|(_, filtering_subject_ty)| {
+                runtime_union_arm_is_relevant(self.db, *filtering_subject_ty, runtime_constraint)
+            });
         }
 
         arms

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -164,6 +164,7 @@ Settings: Settings {
     },
     analysis: AnalysisSettings {
         strict_literal_narrowing: false,
+        strict_subclass_narrowing: false,
         respect_type_ignore_comments: true,
         allowed_unresolved_imports: ModuleGlobSet {
             regex_set: RegexSet([]),

--- a/crates/ty_test/src/config.rs
+++ b/crates/ty_test/src/config.rs
@@ -124,6 +124,9 @@ pub(crate) struct Analysis {
     /// Whether equality comparisons should only narrow to literals when it is safe to do so.
     pub(crate) strict_literal_narrowing: Option<bool>,
 
+    /// Whether positive runtime narrowing should preserve hypothetical subclass intersections.
+    pub(crate) strict_subclass_narrowing: Option<bool>,
+
     /// Whether ty should support `type: ignore` comments.
     pub(crate) respect_type_ignore_comments: Option<bool>,
 

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -61,6 +61,7 @@ impl Db {
         let analysis = if let Some(options) = options {
             let AnalysisSettings {
                 strict_literal_narrowing: strict_literal_narrowing_default,
+                strict_subclass_narrowing: strict_subclass_narrowing_default,
                 respect_type_ignore_comments: respect_type_ignore_comments_default,
                 allowed_unresolved_imports: allowed_unresolved_imports_default,
                 replace_imports_with_any: replace_imports_with_any_default,
@@ -98,6 +99,9 @@ impl Db {
                 strict_literal_narrowing: options
                     .strict_literal_narrowing
                     .unwrap_or(strict_literal_narrowing_default),
+                strict_subclass_narrowing: options
+                    .strict_subclass_narrowing
+                    .unwrap_or(strict_subclass_narrowing_default),
                 respect_type_ignore_comments: options
                     .respect_type_ignore_comments
                     .unwrap_or(respect_type_ignore_comments_default),

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -105,6 +105,13 @@
             "boolean",
             "null"
           ]
+        },
+        "strict-subclass-narrowing": {
+          "description": "Whether positive runtime narrowing should preserve intersections that can only be inhabited\nby an unrelated subclass when another union member already matches the runtime test.\n\nBy default, a positive runtime check prefers union members that match through an existing\ninheritance or structural relationship. It discards remaining intersections whose only\ninhabitants would require a new subclass combining otherwise unrelated classes. This\nproduces simpler types for annotations such as `T | list[T]` while retaining ordinary\noverlaps such as `Mapping[K, V] | Iterable[K]`.\n\nThe policy applies to positive `isinstance`, `issubclass`, and builtin `callable` checks,\nalong with class, mapping, and sequence patterns.\n\nThis default is deliberately pragmatic rather than fully sound. Python permits an\nunannotated runtime class to inherit from otherwise unrelated bases, so a discarded\nintersection can still be inhabited. For example, a value reaching this function through\nthe `Area` arm could be a `list[int]` subclass, even though the direct list arm is\n`list[str]`:\n\n```python\nclass Area: ...\nclass IntegerAreaList(Area, list[int]): ...\n\ndef first(value: Area | list[str]) -> str:\n    if isinstance(value, list):\n        return value[0]  # Accepted by default, but can return an `int`.\n    return \"\"\n\nfirst(IntegerAreaList([1]))\n```\n\nEnable this option to preserve all possible subclass intersections.\n\nDefaults to `false`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

When a union contains an arm that is known to satisfy a positive runtime test, we now prefer the relationships already represented by the union. We discard other arms whose overlap with the tested type would require a hypothetical new common subclass, while retaining dynamic arms, `TypedDict` runtime matches, and existing subtype or structural overlaps. Without a known matching arm, narrowing remains conservative.

For example:

```python
class Area: ...

def visit(value: Area | list[Area]) -> None:
    if isinstance(value, list):
        reveal_type(value)  # list[Area]
```

Previously, we inferred `list[Area] | (Area & Top[list[Unknown]])`. We now infer `list[Area]` because the union already contains a definite `list[Area]` match. If no union member definitely matches, we retain the conservative intersection; negative narrowing and conjunctions of multiple runtime tests are also unchanged.

The policy applies to positive `isinstance`, `issubclass`, and builtin `callable` checks, along with class, mapping, and sequence patterns. It can also simplify a runtime check after a user-defined `TypeGuard`, but user-defined `TypeIs` functions keep their specified intersection semantics.

Like the existing literal-narrowing default, this is deliberately pragmatic rather than fully sound. A subclass accepted through the `Area` arm may also inherit from `list[int]`; if the direct union arm is `list[str]`, dropping the `Area` intersection can therefore infer `list[str]` for a value whose runtime class is a `list[int]` subclass. Users who prefer the conservative behavior can enable:

```toml
[tool.ty.analysis]
strict-subclass-narrowing = true
```

The option defaults to `false` and restores the prior conservative intersection behavior when enabled. The generated schema and configuration documentation describe the tradeoff and include a concrete unsoundness example. The implementation keeps runtime-test provenance local to narrowing constraints rather than changing global disjointness.

The regression coverage includes direct matches, conservative fallbacks, dynamic and `TypedDict` arms, `TypeGuard` composition, strict-mode parity, and all supported runtime-pattern forms.

This is an alternative to #26415, #26416, and #26790.

Related: https://github.com/astral-sh/ty/issues/1578
