### PR TITLE
[ty] Retain sequence pattern index observations until method calls

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1947,6 +1947,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         PossiblyNarrowedPlacesBuilder::new(self.db, place_table)
                             .pattern(pattern, module)
                     }
+                    PredicateNode::PatternObservation(pattern) => {
+                        let module = self.module;
+                        PossiblyNarrowedPlacesBuilder::new(self.db, place_table)
+                            .pattern(pattern, module)
+                    }
                     PredicateNode::SubjectElementPattern(_)
                     | PredicateNode::IsNonTerminalCall(_)
                     | PredicateNode::IsNonEmptyIterable(_)
@@ -2218,7 +2223,36 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
             predicate_id
         };
+
+        if !is_catchall
+            && !subject_targets.is_empty()
+            && Self::pattern_observes_sequence_shape(pattern_predicate.kind(self.db))
+        {
+            let observation_id = self
+                .current_use_def_map_mut()
+                .add_sequence_observation_predicate(PredicateOrLiteral::Predicate(Predicate {
+                    node: PredicateNode::PatternObservation(pattern_predicate),
+                    is_positive: true,
+                }));
+            for (place, bindings) in subject_targets {
+                self.current_use_def_map_mut()
+                    .record_narrowing_constraint_for_bindings(observation_id, *place, bindings);
+            }
+        }
         (predicate, predicate_id)
+    }
+
+    fn pattern_observes_sequence_shape(pattern: &PatternPredicateKind<'_>) -> bool {
+        match pattern {
+            PatternPredicateKind::Sequence(_) => true,
+            PatternPredicateKind::Or(patterns) => {
+                patterns.iter().any(Self::pattern_observes_sequence_shape)
+            }
+            PatternPredicateKind::As(Some(pattern), _) => {
+                Self::pattern_observes_sequence_shape(pattern)
+            }
+            _ => false,
+        }
     }
 
     /// Record an expression that needs to be a Salsa ingredient, because we need to infer its type
@@ -4648,6 +4682,19 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
             ast::Expr::Await(_) => {
                 self.mark_current_comprehension_async();
                 walk_expr(self, expr);
+            }
+            ast::Expr::Call(call) => {
+                walk_expr(self, expr);
+
+                if let Some(receiver) = call.func.as_attribute_expr().map(|attr| &*attr.value)
+                    && let Some(receiver_place) = PlaceExpr::try_from_expr(receiver)
+                    && let Some(receiver_id) = self
+                        .current_place_table()
+                        .place_id((&receiver_place).into())
+                {
+                    self.current_use_def_map_mut()
+                        .forget_sequence_observations_for_place(receiver_id);
+                }
             }
             _ => {
                 walk_expr(self, expr);

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -248,6 +248,50 @@ impl NarrowingConstraintsBuilder {
         }
     }
 
+    /// Existentially remove `predicates` from a narrowing formula.
+    ///
+    /// This preserves constraints established by every other predicate while forgetting facts
+    /// whose validity ended at the current control-flow point.
+    pub(crate) fn forget_predicates(
+        &mut self,
+        constraint: ScopedNarrowingConstraint,
+        predicates: &[ScopedPredicateId],
+    ) -> ScopedNarrowingConstraint {
+        fn forget(
+            builder: &mut NarrowingConstraintsBuilder,
+            constraint: ScopedNarrowingConstraint,
+            predicates: &[ScopedPredicateId],
+            cache: &mut FxHashMap<ScopedNarrowingConstraint, ScopedNarrowingConstraint>,
+        ) -> ScopedNarrowingConstraint {
+            if constraint.is_terminal() {
+                return constraint;
+            }
+            if let Some(result) = cache.get(&constraint) {
+                return *result;
+            }
+
+            let node = builder.interiors[constraint];
+            let if_true = forget(builder, node.if_true, predicates, cache);
+            let if_uncertain = forget(builder, node.if_uncertain, predicates, cache);
+            let if_false = forget(builder, node.if_false, predicates, cache);
+            let result = if predicates.contains(&node.atom) {
+                let either_value = builder.add_or_constraint(if_true, if_false);
+                builder.add_or_constraint(either_value, if_uncertain)
+            } else {
+                builder.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                })
+            };
+            cache.insert(constraint, result);
+            result
+        }
+
+        forget(self, constraint, predicates, &mut FxHashMap::default())
+    }
+
     pub(crate) fn add_negated_atom(
         &mut self,
         predicate: ScopedPredicateId,
@@ -462,6 +506,22 @@ mod tests {
                 evaluate(&constraints, formula, &values),
                 (values[0] || values[1]) && !values[2],
             );
+        }
+    }
+
+    #[test]
+    fn forgetting_a_predicate_preserves_other_constraints() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let a = predicate(0);
+        let b = predicate(1);
+        let a_constraint = constraints.add_atom(a);
+        let b_constraint = constraints.add_atom(b);
+        let formula = constraints.add_and_constraint(a_constraint, b_constraint);
+
+        let without_a = constraints.forget_predicates(formula, &[a]);
+        for mask in 0_u8..4 {
+            let values = [mask & 0b01 != 0, mask & 0b10 != 0];
+            assert_eq!(evaluate(&constraints, without_a, &values), values[1]);
         }
     }
 

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -135,6 +135,11 @@ pub enum PredicateNode<'db> {
     /// semantically during type checking, so calls to a shadowed `range` remain ambiguous.
     IsNonEmptyIterable(Expression<'db>),
     Pattern(PatternPredicate<'db>),
+    /// Flow-sensitive length and indexed-element facts observed by a sequence pattern.
+    ///
+    /// Unlike the ordinary pattern predicate, this constraint can be discarded after an operation
+    /// that may invalidate those observations.
+    PatternObservation(PatternPredicate<'db>),
     SubjectElementPattern(SubjectElementPatternPredicate<'db>),
     StarImportPlaceholder(StarImportPlaceholderPredicate<'db>),
 }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1611,6 +1611,9 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Builder of predicates.
     pub(super) predicates: PredicatesBuilder<'db>,
 
+    /// Pattern predicates whose sequence-shape observations can become stale.
+    sequence_observation_predicates: Vec<ScopedPredicateId>,
+
     /// Builder of reachability constraints.
     pub(super) reachability_constraints: ReachabilityConstraintsBuilder,
 
@@ -1671,6 +1674,7 @@ impl<'db> UseDefMapBuilder<'db> {
             all_definitions: IndexVec::from_iter([DefinitionState::Undefined]),
             used_bindings: IndexVec::from_iter([false]),
             predicates: PredicatesBuilder::default(),
+            sequence_observation_predicates: Vec::new(),
             reachability_constraints: ReachabilityConstraintsBuilder::default(),
             narrowing_constraints: NarrowingConstraintsBuilder::default(),
             bindings_by_use: IndexVec::new(),
@@ -1816,6 +1820,37 @@ impl<'db> UseDefMapBuilder<'db> {
             PredicateOrLiteral::Literal(true) => ScopedPredicateId::ALWAYS_TRUE,
             PredicateOrLiteral::Literal(false) => ScopedPredicateId::ALWAYS_FALSE,
         }
+    }
+
+    pub(super) fn add_sequence_observation_predicate(
+        &mut self,
+        predicate: PredicateOrLiteral<'db>,
+    ) -> ScopedPredicateId {
+        let predicate_id = self.add_predicate(predicate);
+        if predicate_id != ScopedPredicateId::ALWAYS_TRUE
+            && predicate_id != ScopedPredicateId::ALWAYS_FALSE
+        {
+            self.sequence_observation_predicates.push(predicate_id);
+        }
+        predicate_id
+    }
+
+    pub(super) fn forget_sequence_observations_for_place(&mut self, place: ScopedPlaceId) {
+        if self.sequence_observation_predicates.is_empty() {
+            return;
+        }
+        let pending = self.pending_reachability.current;
+        let state =
+            pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
+        let state = self.pending_reachability.materialize(
+            state,
+            pending,
+            &mut self.reachability_constraints,
+        );
+        state.forget_narrowing_predicates(
+            &mut self.narrowing_constraints,
+            &self.sequence_observation_predicates,
+        );
     }
 
     /// Records a narrowing constraint for only the specified places.

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -48,6 +48,7 @@ use smallvec::{SmallVec, smallvec};
 
 use crate::ReachabilityConstraintsBuilder;
 use crate::narrowing_constraints::{NarrowingConstraintsBuilder, ScopedNarrowingConstraint};
+use crate::predicate::ScopedPredicateId;
 use crate::reachability_constraints::ScopedReachabilityConstraintId;
 
 /// A newtype-index for a definition in a particular scope.
@@ -397,6 +398,17 @@ impl Bindings {
         }
     }
 
+    pub(super) fn forget_narrowing_predicates(
+        &mut self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        predicates: &[ScopedPredicateId],
+    ) {
+        for binding in &mut self.live_bindings {
+            binding.narrowing_constraint =
+                narrowing_constraints.forget_predicates(binding.narrowing_constraint, predicates);
+        }
+    }
+
     /// Add given reachability constraint to all live bindings.
     pub(super) fn record_reachability_constraint(
         &mut self,
@@ -512,6 +524,15 @@ impl PlaceState {
     ) {
         self.bindings
             .record_narrowing_constraint(narrowing_constraints, constraint);
+    }
+
+    pub(super) fn forget_narrowing_predicates(
+        &mut self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        predicates: &[ScopedPredicateId],
+    ) {
+        self.bindings
+            .forget_narrowing_predicates(narrowing_constraints, predicates);
     }
 
     /// Add the given constraint to live bindings that were also present at an earlier use.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -224,49 +224,95 @@ def test_match_exact_sequence_excludes_bytearray(x: bytearray | tuple[int, int])
 def test_match_exact_object_sequence(value: object) -> None:
     match value:
         case int(), str():
-            # revealed: Sequence[object] & ~str & ~bytes & ~bytearray
+            # revealed: Sequence[object] & <Protocol with members '__getitem__', '__len__'> & ~str & ~bytes & ~bytearray
             reveal_type(value)
-            reveal_type(len(value))  # revealed: int
-            reveal_type(value[0])  # revealed: object
-            reveal_type(value[1])  # revealed: object
+            reveal_type(len(value))  # revealed: Literal[2]
+            reveal_type(value[0])  # revealed: int
+            reveal_type(value[1])  # revealed: str
 
 def test_match_empty_object_sequence(value: object) -> None:
     match value:
         case []:
-            # revealed: Sequence[object] & ~str & ~bytes & ~bytearray
+            # revealed: Sequence[object] & <Protocol with members '__len__'> & ~str & ~bytes & ~bytearray
             reveal_type(value)
-            reveal_type(len(value))  # revealed: int
+            reveal_type(len(value))  # revealed: Literal[0]
 
 def test_match_singleton_object_sequence(value: object) -> None:
     match value:
         case [int()]:
-            # revealed: Sequence[object] & ~str & ~bytes & ~bytearray
+            # revealed: Sequence[object] & <Protocol with members '__getitem__', '__len__'> & ~bytearray & ~bytes
             reveal_type(value)
-            reveal_type(len(value))  # revealed: int
-            reveal_type(value[0])  # revealed: object
+            reveal_type(len(value))  # revealed: Literal[1]
+            reveal_type(value[0])  # revealed: int
+
+def test_match_singleton_object_sequence_capture(value: object) -> None:
+    match value:
+        case [int() as item]:
+            reveal_type(value[0])  # revealed: int
+            reveal_type(item)  # revealed: int
+
+def test_mutable_sequence_subject_discards_observations_after_method_call(
+    value: list[int | str] | None,
+) -> None:
+    match value:
+        case [int(), str()]:
+            reveal_type(value[0])  # revealed: int
+            value.reverse()
+            reveal_type(value)  # revealed: list[int | str]
+            reveal_type(value[0])  # revealed: int | str
+
+def reverse_sequence(value: list[int | str]) -> None:
+    value.reverse()
+
+# These tests deliberately document the current limits of the invalidation heuristic. The
+# revealed types are unsound because each operation can invalidate the observed first element.
+def test_sequence_observation_is_not_discarded_after_method_call_through_alias(
+    value: list[int | str],
+) -> None:
+    match value:
+        case [int(), str()]:
+            alias = value
+            alias.reverse()
+            reveal_type(value[0])  # revealed: int
+
+def test_sequence_observation_is_not_discarded_after_passing_to_function(
+    value: list[int | str],
+) -> None:
+    match value:
+        case [int(), str()]:
+            reverse_sequence(value)
+            reveal_type(value[0])  # revealed: int
+
+def test_sequence_observation_is_not_discarded_after_subscript_assignment(
+    value: list[int | str],
+) -> None:
+    match value:
+        case [int(), str()]:
+            value[0] = "replacement"
+            reveal_type(value[0])  # revealed: int
 
 def test_match_prefix_star_object_sequence(value: object) -> None:
     match value:
         case [int(), *rest]:
-            # revealed: Sequence[object] & ~str & ~bytes & ~bytearray
+            # revealed: Sequence[object] & <Protocol with members '__getitem__'> & ~str & ~bytes & ~bytearray
             reveal_type(value)
             reveal_type(len(value))  # revealed: int
-            reveal_type(value[0])  # revealed: object
+            reveal_type(value[0])  # revealed: int
             reveal_type(value[1])  # revealed: object
 
 def test_match_prefix_and_suffix_star_object_sequence(value: object) -> None:
     match value:
         case [int(), *rest, str()]:
-            # revealed: Sequence[object] & ~str & ~bytes & ~bytearray
+            # revealed: Sequence[object] & <Protocol with members '__getitem__'> & ~str & ~bytes & ~bytearray
             reveal_type(value)
-            reveal_type(value[0])  # revealed: object
-            reveal_type(value[-1])  # revealed: object
+            reveal_type(value[0])  # revealed: int
+            reveal_type(value[-1])  # revealed: str
             reveal_type(value[1])  # revealed: object
 
 def test_match_prefix_star_known_sequence(value: Sequence[int | str]) -> None:
     match value:
         case [int(), *rest]:
-            reveal_type(value[0])  # revealed: int | str
+            reveal_type(value[0])  # revealed: int
             reveal_type(value[1])  # revealed: int | str
             reveal_type(rest)  # revealed: list[int | str]
 ```
@@ -538,7 +584,8 @@ def failed_sequence_alternative_does_not_narrow_later_capture(
                 item.append(1)
                 match item:
                     case [only]:
-                        reveal_type(item)  # revealed: list[int]
+                        # revealed: list[int] & <Protocol with members '__getitem__', '__len__'>
+                        reveal_type(item)
 ```
 
 ## Declared pattern captures
@@ -678,7 +725,7 @@ def mutable_sequence_alias_does_not_keep_previous_shape_constraints(
             whole.clear()
             match whole:
                 case []:
-                    reveal_type(whole)  # revealed: list[int]
+                    reveal_type(whole)  # revealed: list[int] & <Protocol with members '__len__'>
 
 def failed_sequence_pattern_does_not_narrow_mutable_subject(
     value: list[int],
@@ -692,7 +739,7 @@ def failed_sequence_pattern_does_not_narrow_mutable_subject(
             value.clear()
             match value:
                 case []:
-                    reveal_type(value)  # revealed: list[int]
+                    reveal_type(value)  # revealed: list[int] & <Protocol with members '__len__'>
 ```
 
 ## Indirect class patterns

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -533,6 +533,7 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
             callable.scope(db)
         }
         PredicateNode::Pattern(pattern) => pattern.scope(db),
+        PredicateNode::PatternObservation(pattern) => pattern.scope(db),
         PredicateNode::SubjectElementPattern(subject_element) => subject_element.pattern.scope(db),
         PredicateNode::IsNonEmptyIterable(expression) => expression.scope(db),
         PredicateNode::StarImportPlaceholder(star_import) => star_import.scope(db),
@@ -1339,6 +1340,7 @@ fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {
         }) => analyze_non_terminal_call(db, callable, call_expr, is_await)
             .negate_if(!predicate.is_positive),
         PredicateNode::Pattern(inner) => analyze_pattern_predicate(db, inner),
+        PredicateNode::PatternObservation(inner) => analyze_pattern_predicate(db, inner),
         PredicateNode::SubjectElementPattern(subject_element) => {
             analyze_pattern_predicate(db, subject_element.pattern)
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -95,6 +95,11 @@ pub(crate) fn infer_narrowing_constraints<'db>(
                 .and_then(|constraints| constraints.get(&place).cloned());
             (positive, negative)
         }
+        PredicateNode::PatternObservation(pattern) => {
+            let positive = all_sequence_observation_constraints_for_pattern(db, pattern)
+                .and_then(|constraints| constraints.get(&place).cloned());
+            (positive, None)
+        }
         PredicateNode::SubjectElementPattern(subject_element) => {
             let positive = all_narrowing_constraints_for_subject_element_pattern(
                 db,
@@ -123,6 +128,21 @@ fn all_narrowing_constraints_for_pattern<'db>(
 ) -> Option<FrozenNarrowingConstraints<'db>> {
     let module = parsed_module(db, pattern.file(db)).load(db);
     NarrowingConstraintsBuilder::new(db, &module, PredicateNode::Pattern(pattern), true).finish()
+}
+
+#[salsa::tracked(returns(as_ref), heap_size=ruff_memory_usage::heap_size)]
+fn all_sequence_observation_constraints_for_pattern<'db>(
+    db: &'db dyn Db,
+    pattern: PatternPredicate<'db>,
+) -> Option<FrozenNarrowingConstraints<'db>> {
+    let module = parsed_module(db, pattern.file(db)).load(db);
+    NarrowingConstraintsBuilder::new(
+        db,
+        &module,
+        PredicateNode::PatternObservation(pattern),
+        true,
+    )
+    .finish()
 }
 
 #[salsa::tracked(
@@ -1063,6 +1083,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PredicateNode::Pattern(pattern) => {
                 self.evaluate_pattern_predicate(pattern, self.is_positive)
             }
+            PredicateNode::PatternObservation(pattern) => {
+                self.evaluate_pattern_observation(pattern)
+            }
             PredicateNode::SubjectElementPattern(subject_element) => {
                 self.evaluate_subject_element_pattern(subject_element)
             }
@@ -1254,6 +1277,33 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             constraints.insert(place, subject_constraint);
         }
         (!constraints.is_empty()).then_some(constraints)
+    }
+
+    fn evaluate_pattern_observation(
+        &mut self,
+        pattern: PatternPredicate<'db>,
+    ) -> Option<NarrowingConstraints<'db>> {
+        let subject = pattern.subject(self.db);
+        let subject_node = subject.node_ref(self.db).node(self.module);
+        let subject_place = PlaceExpr::try_from_expr(subject_node)?;
+        let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
+        if subject_ty.exact_tuple_instance_spec(self.db).is_some() {
+            return None;
+        }
+
+        let observation = necessary_match_pattern_type(self.db, pattern.kind(self.db));
+        let observed_subject_ty = IntersectionBuilder::new(self.db)
+            .add_positive(subject_ty)
+            .add_positive(observation)
+            .build();
+        if observed_subject_ty.is_equivalent_to(self.db, subject_ty) {
+            return None;
+        }
+
+        Some(NarrowingConstraints::from_iter([(
+            self.expect_place(&subject_place),
+            NarrowingConstraint::intersection(observation),
+        )]))
     }
 
     fn evaluate_positive_pattern_related_expressions(
@@ -2632,6 +2682,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         match self.predicate {
             PredicateNode::Expression(expression) => expression.scope(self.db),
             PredicateNode::Pattern(pattern) => pattern.scope(self.db),
+            PredicateNode::PatternObservation(pattern) => pattern.scope(self.db),
             PredicateNode::SubjectElementPattern(subject_element) => {
                 subject_element.pattern.scope(self.db)
             }


### PR DESCRIPTION
## Summary

Prior to this change, when a sequence-pattern subject did not have a statically known exact-tuple shape, we kept the general sequence narrowing but discarded the pattern's length and indexed-element observations:

```python
def f(value: object) -> None:
    match value:
        case [int()]:
            reveal_type(value[0])  # object
```

We now represent those observations as a separate flow-sensitive pattern predicate. The predicate intersects the subject with the synthesized `__len__` and literal-index `__getitem__` protocol implied by the pattern, so the example above reveals `int` and `len(value)` reveals `Literal[1]`.

Unlike ordinary pattern narrowing, the observation predicate is removed from the receiver's live bindings after a direct method call. This retains stable narrowing while discarding the indexed facts that the call may have invalidated:

```python
def f(value: list[int | str] | None) -> None:
    match value:
        case [int(), str()]:
            value.reverse()
            reveal_type(value)  # list[int | str]
            reveal_type(value[0])  # int | str
```
