### PR TITLE
Refactor TOML file linting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,7 +3435,6 @@ dependencies = [
  "ruff_linter",
  "ruff_python_ast",
  "ruff_ranged_value",
- "ruff_source_file",
  "ruff_workspace",
  "salsa",
 ]

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -225,8 +225,7 @@ pub(crate) fn lint_path(
                         return Ok(Diagnostics::from_source_error(&err, Some(path), settings));
                     }
                 };
-                let source_file = SourceFileBuilder::new(path.to_string_lossy(), contents).finish();
-                lint_pyproject_toml(&source_file, settings)
+                lint_pyproject_toml(path, &contents, settings)
             } else {
                 vec![]
             };
@@ -370,8 +369,6 @@ pub(crate) fn lint_stdin(
             }
 
             let path = path.unwrap();
-            let source_file =
-                SourceFileBuilder::new(path.to_string_lossy(), contents.clone()).finish();
 
             match fix_mode {
                 flags::FixMode::Diff | flags::FixMode::Generate => {}
@@ -379,7 +376,7 @@ pub(crate) fn lint_stdin(
             }
 
             return Ok(Diagnostics {
-                inner: lint_pyproject_toml(&source_file, &settings.linter),
+                inner: lint_pyproject_toml(path, &contents, &settings.linter),
                 fixed: FixMap::from_iter([(fs::relativize_path(path), FixTable::default())]),
                 notebook_indexes: FxHashMap::default(),
             });

--- a/crates/ruff_linter/resources/mdtest/ruff/invalid-pyproject-toml.md
+++ b/crates/ruff_linter/resources/mdtest/ruff/invalid-pyproject-toml.md
@@ -5,6 +5,8 @@
 select = ["RUF200"]
 ```
 
+## Reports an invalid `pyproject.toml`
+
 `pyproject.toml`:
 
 ```toml
@@ -19,4 +21,19 @@ error[RUF200]: Failed to parse pyproject.toml: invalid type: integer `1`, expect
 2 | name = 1 # snapshot: invalid-pyproject-toml
   |        ^
   |
+```
+
+## Respects per-file ignores
+
+```toml
+[lint]
+select = ["RUF200"]
+per-file-ignores = { "pyproject.toml" = ["RUF200"] }
+```
+
+`pyproject.toml`:
+
+```toml
+[project]
+name = 1
 ```

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -3549,6 +3549,11 @@ impl<'a> LintContext<'a> {
     }
 
     #[inline]
+    pub(crate) fn into_diagnostics(self) -> Vec<Diagnostic> {
+        self.diagnostics.into_inner()
+    }
+
+    #[inline]
     pub(crate) fn as_mut_vec(&mut self) -> &mut Vec<Diagnostic> {
         self.diagnostics.get_mut()
     }

--- a/crates/ruff_linter/src/pyproject_toml.rs
+++ b/crates/ruff_linter/src/pyproject_toml.rs
@@ -1,61 +1,9 @@
-use colored::Colorize;
-use log::warn;
-use pyproject_toml::PyProjectToml;
-use ruff_text_size::{TextRange, TextSize};
-
 use ruff_db::diagnostic::Diagnostic;
 use ruff_source_file::SourceFile;
 
-use crate::registry::Rule;
-use crate::rules::ruff::rules::InvalidPyprojectToml;
+use crate::rules::ruff::rules::invalid_pyproject_toml;
 use crate::settings::LinterSettings;
-use crate::{IOError, Violation};
 
-/// RUF200
 pub fn lint_pyproject_toml(source_file: &SourceFile, settings: &LinterSettings) -> Vec<Diagnostic> {
-    let Some(err) = toml::from_str::<PyProjectToml>(source_file.source_text()).err() else {
-        return Vec::default();
-    };
-
-    let mut messages = Vec::new();
-    let range = match err.span() {
-        // This is bad but sometimes toml and/or serde just don't give us spans
-        // TODO(konstin,micha): https://github.com/astral-sh/ruff/issues/4571
-        None => TextRange::default(),
-        Some(range) => {
-            let Ok(end) = TextSize::try_from(range.end) else {
-                let message = format!(
-                    "{} is larger than 4GB, but ruff assumes all files to be smaller",
-                    source_file.name(),
-                );
-                if settings.rules.enabled(Rule::IOError) {
-                    let diagnostic =
-                        IOError { message }.into_diagnostic(TextRange::default(), source_file);
-                    messages.push(diagnostic);
-                } else {
-                    warn!(
-                        "{}{}{} {message}",
-                        "Failed to lint ".bold(),
-                        source_file.name().bold(),
-                        ":".bold()
-                    );
-                }
-                return messages;
-            };
-            TextRange::new(
-                // start <= end, so if end < 4GB follows start < 4GB
-                TextSize::try_from(range.start).unwrap(),
-                end,
-            )
-        }
-    };
-
-    if settings.rules.enabled(Rule::InvalidPyprojectToml) {
-        let toml_err = err.message().to_string();
-        let diagnostic =
-            InvalidPyprojectToml { message: toml_err }.into_diagnostic(range, source_file);
-        messages.push(diagnostic);
-    }
-
-    messages
+    invalid_pyproject_toml(source_file, settings)
 }

--- a/crates/ruff_linter/src/pyproject_toml.rs
+++ b/crates/ruff_linter/src/pyproject_toml.rs
@@ -1,9 +1,22 @@
-use ruff_db::diagnostic::Diagnostic;
-use ruff_source_file::SourceFile;
+use std::path::Path;
 
+use ruff_db::diagnostic::Diagnostic;
+
+use crate::checkers::ast::LintContext;
+use crate::codes::Rule;
 use crate::rules::ruff::rules::invalid_pyproject_toml;
 use crate::settings::LinterSettings;
 
-pub fn lint_pyproject_toml(source_file: &SourceFile, settings: &LinterSettings) -> Vec<Diagnostic> {
-    invalid_pyproject_toml(source_file, settings)
+pub fn lint_pyproject_toml(
+    path: &Path,
+    contents: &str,
+    settings: &LinterSettings,
+) -> Vec<Diagnostic> {
+    let context = LintContext::new(path, contents, settings);
+
+    if context.is_rule_enabled(Rule::InvalidPyprojectToml) {
+        invalid_pyproject_toml(&context);
+    }
+
+    context.into_diagnostics()
 }

--- a/crates/ruff_linter/src/pyproject_toml.rs
+++ b/crates/ruff_linter/src/pyproject_toml.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use pyproject_toml::PyProjectToml;
 use ruff_db::diagnostic::Diagnostic;
 
 use crate::checkers::ast::LintContext;
@@ -14,8 +15,10 @@ pub fn lint_pyproject_toml(
 ) -> Vec<Diagnostic> {
     let context = LintContext::new(path, contents, settings);
 
-    if context.is_rule_enabled(Rule::InvalidPyprojectToml) {
-        invalid_pyproject_toml(&context);
+    if let Err(err) = toml::from_str::<PyProjectToml>(contents) {
+        if context.is_rule_enabled(Rule::InvalidPyprojectToml) {
+            invalid_pyproject_toml(&context, &err);
+        }
     }
 
     context.into_diagnostics()

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -13,7 +13,6 @@ mod tests {
     use anyhow::Result;
     use regex::Regex;
     use ruff_python_ast::PythonVersion;
-    use ruff_source_file::SourceFileBuilder;
     use rustc_hash::FxHashSet;
     use test_case::test_case;
 
@@ -795,9 +794,9 @@ mod tests {
             .join(path)
             .join("pyproject.toml");
         let contents = fs::read_to_string(path)?;
-        let source_file = SourceFileBuilder::new("pyproject.toml", contents).finish();
         let messages = lint_pyproject_toml(
-            &source_file,
+            Path::new("pyproject.toml"),
+            &contents,
             &settings::LinterSettings::for_rule(Rule::InvalidPyprojectToml),
         );
         assert_diagnostics!(snapshot, messages);

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_pyproject_toml.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_pyproject_toml.rs
@@ -1,5 +1,3 @@
-use pyproject_toml::PyProjectToml;
-
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::{TextRange, TextSize};
 
@@ -50,12 +48,7 @@ impl Violation for InvalidPyprojectToml {
 }
 
 /// RUF200
-pub(crate) fn invalid_pyproject_toml(context: &LintContext) {
-    let Some(err) = toml::from_str::<PyProjectToml>(context.source_file().source_text()).err()
-    else {
-        return;
-    };
-
+pub(crate) fn invalid_pyproject_toml(context: &LintContext, err: &toml::de::Error) {
     let range = match err.span() {
         // This is bad but sometimes toml and/or serde just don't give us spans
         // TODO(konstin,micha): https://github.com/astral-sh/ruff/issues/4571

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_pyproject_toml.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_pyproject_toml.rs
@@ -1,11 +1,9 @@
 use pyproject_toml::PyProjectToml;
 
-use ruff_db::diagnostic::Diagnostic;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::{FixAvailability, Violation, codes::Rule, settings::LinterSettings};
+use crate::{FixAvailability, Violation, checkers::ast::LintContext};
 
 /// ## What it does
 /// Checks for any pyproject.toml that does not conform to the schema from the relevant PEPs.
@@ -52,15 +50,12 @@ impl Violation for InvalidPyprojectToml {
 }
 
 /// RUF200
-pub(crate) fn invalid_pyproject_toml(
-    source_file: &SourceFile,
-    settings: &LinterSettings,
-) -> Vec<Diagnostic> {
-    let Some(err) = toml::from_str::<PyProjectToml>(source_file.source_text()).err() else {
-        return Vec::default();
+pub(crate) fn invalid_pyproject_toml(context: &LintContext) {
+    let Some(err) = toml::from_str::<PyProjectToml>(context.source_file().source_text()).err()
+    else {
+        return;
     };
 
-    let mut messages = Vec::new();
     let range = match err.span() {
         // This is bad but sometimes toml and/or serde just don't give us spans
         // TODO(konstin,micha): https://github.com/astral-sh/ruff/issues/4571
@@ -71,12 +66,6 @@ pub(crate) fn invalid_pyproject_toml(
         ),
     };
 
-    if settings.rules.enabled(Rule::InvalidPyprojectToml) {
-        let toml_err = err.message().to_string();
-        let diagnostic =
-            InvalidPyprojectToml { message: toml_err }.into_diagnostic(range, source_file);
-        messages.push(diagnostic);
-    }
-
-    messages
+    let toml_err = err.message().to_string();
+    context.report_diagnostic(InvalidPyprojectToml { message: toml_err }, range);
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_pyproject_toml.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_pyproject_toml.rs
@@ -1,6 +1,13 @@
-use ruff_macros::{ViolationMetadata, derive_message_formats};
+use colored::Colorize;
+use log::warn;
+use pyproject_toml::PyProjectToml;
 
-use crate::{FixAvailability, Violation};
+use ruff_db::diagnostic::Diagnostic;
+use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_source_file::SourceFile;
+use ruff_text_size::{TextRange, TextSize};
+
+use crate::{FixAvailability, IOError, Violation, codes::Rule, settings::LinterSettings};
 
 /// ## What it does
 /// Checks for any pyproject.toml that does not conform to the schema from the relevant PEPs.
@@ -44,4 +51,56 @@ impl Violation for InvalidPyprojectToml {
         let InvalidPyprojectToml { message } = self;
         format!("Failed to parse pyproject.toml: {message}")
     }
+}
+
+/// RUF200
+pub(crate) fn invalid_pyproject_toml(
+    source_file: &SourceFile,
+    settings: &LinterSettings,
+) -> Vec<Diagnostic> {
+    let Some(err) = toml::from_str::<PyProjectToml>(source_file.source_text()).err() else {
+        return Vec::default();
+    };
+
+    let mut messages = Vec::new();
+    let range = match err.span() {
+        // This is bad but sometimes toml and/or serde just don't give us spans
+        // TODO(konstin,micha): https://github.com/astral-sh/ruff/issues/4571
+        None => TextRange::default(),
+        Some(range) => {
+            let Ok(end) = TextSize::try_from(range.end) else {
+                let message = format!(
+                    "{} is larger than 4GB, but ruff assumes all files to be smaller",
+                    source_file.name(),
+                );
+                if settings.rules.enabled(Rule::IOError) {
+                    let diagnostic =
+                        IOError { message }.into_diagnostic(TextRange::default(), source_file);
+                    messages.push(diagnostic);
+                } else {
+                    warn!(
+                        "{}{}{} {message}",
+                        "Failed to lint ".bold(),
+                        source_file.name().bold(),
+                        ":".bold()
+                    );
+                }
+                return messages;
+            };
+            TextRange::new(
+                // start <= end, so if end < 4GB follows start < 4GB
+                TextSize::try_from(range.start).unwrap(),
+                end,
+            )
+        }
+    };
+
+    if settings.rules.enabled(Rule::InvalidPyprojectToml) {
+        let toml_err = err.message().to_string();
+        let diagnostic =
+            InvalidPyprojectToml { message: toml_err }.into_diagnostic(range, source_file);
+        messages.push(diagnostic);
+    }
+
+    messages
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_pyproject_toml.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_pyproject_toml.rs
@@ -1,5 +1,3 @@
-use colored::Colorize;
-use log::warn;
 use pyproject_toml::PyProjectToml;
 
 use ruff_db::diagnostic::Diagnostic;
@@ -7,7 +5,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_source_file::SourceFile;
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::{FixAvailability, IOError, Violation, codes::Rule, settings::LinterSettings};
+use crate::{FixAvailability, Violation, codes::Rule, settings::LinterSettings};
 
 /// ## What it does
 /// Checks for any pyproject.toml that does not conform to the schema from the relevant PEPs.
@@ -67,32 +65,10 @@ pub(crate) fn invalid_pyproject_toml(
         // This is bad but sometimes toml and/or serde just don't give us spans
         // TODO(konstin,micha): https://github.com/astral-sh/ruff/issues/4571
         None => TextRange::default(),
-        Some(range) => {
-            let Ok(end) = TextSize::try_from(range.end) else {
-                let message = format!(
-                    "{} is larger than 4GB, but ruff assumes all files to be smaller",
-                    source_file.name(),
-                );
-                if settings.rules.enabled(Rule::IOError) {
-                    let diagnostic =
-                        IOError { message }.into_diagnostic(TextRange::default(), source_file);
-                    messages.push(diagnostic);
-                } else {
-                    warn!(
-                        "{}{}{} {message}",
-                        "Failed to lint ".bold(),
-                        source_file.name().bold(),
-                        ":".bold()
-                    );
-                }
-                return messages;
-            };
-            TextRange::new(
-                // start <= end, so if end < 4GB follows start < 4GB
-                TextSize::try_from(range.start).unwrap(),
-                end,
-            )
-        }
+        Some(range) => TextRange::new(
+            TextSize::try_from(range.start).unwrap(),
+            TextSize::try_from(range.end).unwrap(),
+        ),
     };
 
     if settings.rules.enabled(Rule::InvalidPyprojectToml) {

--- a/crates/ruff_mdtest/Cargo.toml
+++ b/crates/ruff_mdtest/Cargo.toml
@@ -20,7 +20,6 @@ ruff_db = { workspace = true, features = ["os", "testing"] }
 ruff_linter = { workspace = true, features = ["testing"] }
 ruff_python_ast = { workspace = true }
 ruff_ranged_value = { workspace = true }
-ruff_source_file = { workspace = true }
 ruff_workspace = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/ruff_mdtest/src/lib.rs
+++ b/crates/ruff_mdtest/src/lib.rs
@@ -15,7 +15,6 @@ use ruff_linter::source_kind::SourceKind;
 use ruff_linter::test::test_contents;
 use ruff_python_ast::SourceType;
 use ruff_ranged_value::{ValueSource, ValueSourceGuard};
-use ruff_source_file::SourceFileBuilder;
 use ruff_workspace::configuration::Configuration;
 use ruff_workspace::options::Options;
 
@@ -128,10 +127,7 @@ fn run_test(
                             test_contents(&source_kind, path, &settings.linter).0
                         }
                         SourceType::Toml(source_type) if source_type.is_pyproject() => {
-                            let source_file =
-                                SourceFileBuilder::new(path.to_string_lossy(), source.as_str())
-                                    .finish();
-                            lint_pyproject_toml(&source_file, &settings.linter)
+                            lint_pyproject_toml(path, source.as_str(), &settings.linter)
                         }
                         SourceType::Toml(_) | SourceType::Markdown => Vec::new(),
                     }


### PR DESCRIPTION
Summary
--

This PR was spun off from #26772 to handle some of the refactors to RUF200. The first non-empty
commit is purely moving the implementation of RUF200 from the general `lint_pyproject_toml` function
into its own rule file. In #26772, `lint_pyproject_toml` will become `lint_toml` and invoke multiple
rules.

The second commit drops the overly defensive range check, as noted in https://github.com/astral-sh/ruff/pull/26772#discussion_r3576662265.

The third commit refactors the rule to use a `LintContext`. This not only sets up to run multiple
rules in this function, but also fixes a latent bug in rule suppression for RUF200. Because the rule
previously checked whether it was enabled via the `LinterSettings::rules.enabled` directly, it
didn't take into account settings like `per-file-ignores` (this also affects `unfixable` and other
fix-related settings for RUF201). The fourth commit contains a new mdtest for this that currently
fails on main.

Finally, the fifth commit moves parsing out of RUF200. We still parse into a `PyProjectToml` for
now, but at least this sets us up to share parsing between rules once we find the right shared
representation.

Test Plan
--

New mdtest mentioned above and then rebasing #26772 onto this.
