### PR TITLE
[ty] Avoid extending own-line suppressions in `--add-ignore`

### DIFF
--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -160,6 +160,54 @@ mod tests {
     }
 
     #[test]
+    fn add_code_existing_empty_ignore() {
+        let test = CodeActionTest::with_source(
+            r#"
+            b = <START>a<END> / 10  # ty:ignore[]
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions(&UNRESOLVED_REFERENCE), @"
+        info[code-action]: Ignore 'unresolved-reference' for this line
+         --> main.py:2:5
+          |
+        2 | b = a / 10  # ty:ignore[]
+          |     ^
+          |
+          |
+        1 |
+          - b = a / 10  # ty:ignore[]
+        2 + b = a / 10  # ty:ignore[unresolved-reference]
+          |
+        ");
+    }
+
+    #[test]
+    fn add_ignore_does_not_update_preceding_own_line_suppression() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            # ty:ignore[]
+            b = <START>a<END> / 10
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions(&UNRESOLVED_REFERENCE), @"
+        info[code-action]: Ignore 'unresolved-reference' for this line
+         --> main.py:4:5
+          |
+        4 | b = a / 10
+          |     ^
+          |
+          |
+        3 | # ty:ignore[]
+          - b = a / 10
+        4 + b = a / 10  # ty:ignore[unresolved-reference]
+          |
+        ");
+    }
+
+    #[test]
     fn add_code_existing_type_ignore() {
         let test = CodeActionTest::with_source(
             r#"

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1105,6 +1105,98 @@ class B(A):
     }
 
     #[test]
+    fn add_ignore_updates_empty_same_line_suppression() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                value = missing  # ty: ignore[]
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        value = missing  # ty: ignore[unresolved-reference]
+        ```
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_groups_diagnostics_for_same_line_suppression() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                def f() -> str: return ""
+
+                result: int = f(missing)  # ty: ignore[division-by-zero]
+                "#),
+            @r#"
+        Added 3 suppressions
+
+        ## Fixed source
+
+        ```py
+        def f() -> str: return ""
+
+        result: int = f(missing)  # ty: ignore[division-by-zero, invalid-assignment, too-many-positional-arguments, unresolved-reference]
+        ```
+
+        ## Diagnostics after applying fixes
+
+        warning[unused-ignore-comment]: Unused `ty: ignore` directive: 'division-by-zero'
+         --> test.py:3:40
+          |
+        1 | def f() -> str: return ""
+        2 |
+        3 | result: int = f(missing)  # ty: ignore[division-by-zero, invalid-assignment, too-many-positional-arguments, unresolved-reference]
+          |                                        ^^^^^^^^^^^^^^^^
+          |
+        help: Remove the unused suppression code
+        "#
+        );
+    }
+
+    #[test]
+    fn add_ignore_does_not_update_inner_own_line_suppression() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                values = [
+                    # ty: ignore[]
+                    missing,
+                ]
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        values = [
+            # ty: ignore[]
+            missing,  # ty:ignore[unresolved-reference]
+        ]
+        ```
+
+        ## Diagnostics after applying fixes
+
+        warning[unused-ignore-comment]: Unused `ty: ignore` without a code
+         --> test.py:3:5
+          |
+        1 | seen_code = True
+        2 | values = [
+        3 |     # ty: ignore[]
+          |     ^^^^^^^^^^^^^^
+        4 |     missing,  # ty:ignore[unresolved-reference]
+        5 | ]
+          |
+        help: Remove the unused suppression comment
+        "
+        );
+    }
+
+    #[test]
     fn add_ignore_does_not_update_preceding_own_line_suppressions() {
         assert_snapshot!(
             suppress_all_in(r#"

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1105,7 +1105,7 @@ class B(A):
     }
 
     #[test]
-    fn add_ignore_updates_own_line_suppressions() {
+    fn add_ignore_does_not_update_preceding_own_line_suppressions() {
         assert_snapshot!(
             suppress_all_in(r#"
                 seen_code = True
@@ -1127,17 +1127,29 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty: ignore[unresolved-reference]
-        value = missing
+        # ty: ignore[]
+        value = missing  # ty:ignore[unresolved-reference]
 
         def f(a: int, b: int) -> list[int]: return []
 
-        # ty: ignore[invalid-assignment, invalid-argument-type, unresolved-reference]
+        # ty: ignore[invalid-assignment]
         values: tuple[int] = f(
-            missing,
-            "bad",
+            missing,  # ty:ignore[unresolved-reference]
+            "bad",  # ty:ignore[invalid-argument-type]
         )
         ```
+
+        ## Diagnostics after applying fixes
+
+        warning[unused-ignore-comment]: Unused `ty: ignore` without a code
+         --> test.py:2:1
+          |
+        1 | seen_code = True
+        2 | # ty: ignore[]
+          | ^^^^^^^^^^^^^^
+        3 | value = missing  # ty:ignore[unresolved-reference]
+          |
+        help: Remove the unused suppression comment
         "#
         );
     }

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -818,6 +818,7 @@ mod tests {
     use crate::Db;
     use crate::db::tests::TestDbBuilder;
     use crate::fixes::{FixMode, fix_all};
+    use crate::is_unused_ignore_comment_lint;
 
     #[test]
     fn simple_suppression() {
@@ -1585,7 +1586,11 @@ class B(A):
             .iter()
             .filter(|diagnostic| FixMode::Suppress.is_fixable(diagnostic))
             .count();
-        let unsuppressible_diagnostics = total_diagnostics - suppressible_diagnostics;
+        let unsuppressible_diagnostics: Vec<_> = diagnostics
+            .iter()
+            .filter(|diagnostic| !FixMode::Suppress.is_fixable(diagnostic))
+            .cloned()
+            .collect();
         let cancellation_token_source = CancellationTokenSource::new();
         let fixes =
             suppress_all_diagnostics(&mut db, diagnostics, &cancellation_token_source.token())
@@ -1602,9 +1607,21 @@ class B(A):
                     .iter()
                     .all(|diagnostic| !FixMode::Suppress.is_fixable(diagnostic))
             );
-            // Adding a code to an empty suppression can also resolve its
-            // `unused-ignore-comment`.
-            assert!(fixes.diagnostics.len() <= unsuppressible_diagnostics);
+
+            let unexpected_diagnostics =
+                diff_diagnostics(&unsuppressible_diagnostics, &fixes.diagnostics);
+            assert!(unexpected_diagnostics.is_empty());
+
+            let incidentally_fixed_diagnostics =
+                diff_diagnostics(&fixes.diagnostics, &unsuppressible_diagnostics);
+            // Adding a code to an empty suppression also resolves its
+            // `unused-ignore-comment`, without adding another suppression.
+            assert!(incidentally_fixed_diagnostics.iter().all(|diagnostic| {
+                diagnostic
+                    .id()
+                    .as_lint()
+                    .is_some_and(is_unused_ignore_comment_lint)
+            }));
         }
 
         File::sync_path(&mut db, SystemPath::new("test.py"));

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1104,6 +1104,100 @@ class B(A):
         "#);
     }
 
+    #[test]
+    fn add_ignore_updates_own_line_suppressions() {
+        let mut db = TestDbBuilder::new()
+            .with_file(
+                "test.py",
+                "seen_code = True\n\
+                 # ty: ignore[]\n\
+                 value = missing\n\
+                 \n\
+                 def f(a: int, b: int) -> list[int]: return []\n\
+                 \n\
+                 # ty: ignore[invalid-assignment]\n\
+                 values: tuple[int] = f(\n\
+                     missing,\n\
+                     \"bad\",\n\
+                 )\n",
+            )
+            .build()
+            .unwrap();
+
+        let file = system_path_to_file(&db, "test.py").unwrap();
+        let diagnostics = db.check_file(file);
+        let planned_fixes = FixMode::Suppress.fixes(&db, file, &diagnostics);
+        assert_eq!(planned_fixes.len(), 2);
+        assert_eq!(planned_fixes[0].fixed_diagnostics, 1);
+        assert_eq!(planned_fixes[1].fixed_diagnostics, 2);
+
+        let cancellation_token_source = CancellationTokenSource::new();
+        let fixes = fix_all(
+            &mut db,
+            diagnostics,
+            FixMode::Suppress,
+            &cancellation_token_source.token(),
+            Db::check_file,
+        )
+        .expect("operation never gets cancelled");
+
+        assert_eq!(fixes.count, 3);
+        assert!(fixes.diagnostics.is_empty());
+        assert_eq!(
+            &*source_text(&db, file),
+            "seen_code = True\n\
+             # ty: ignore[unresolved-reference]\n\
+             value = missing\n\
+             \n\
+             def f(a: int, b: int) -> list[int]: return []\n\
+             \n\
+             # ty: ignore[invalid-assignment, invalid-argument-type, unresolved-reference]\n\
+             values: tuple[int] = f(\n\
+                 missing,\n\
+                 \"bad\",\n\
+             )\n"
+        );
+    }
+
+    #[test]
+    fn safe_fix_does_not_promote_nested_own_line_suppression() {
+        let mut db = TestDbBuilder::new()
+            .with_file(
+                "test.py",
+                "seen_code = True\n\
+                 # ty: ignore[division-by-zero] # ty: ignore[unresolved-reference]\n\
+                 value = missing\n",
+            )
+            .build()
+            .unwrap();
+
+        let file = system_path_to_file(&db, "test.py").unwrap();
+        let diagnostics = db.check_file(file);
+        let cancellation_token_source = CancellationTokenSource::new();
+        let fixes = fix_all(
+            &mut db,
+            diagnostics,
+            FixMode::ApplyFixes(Applicability::Safe),
+            &cancellation_token_source.token(),
+            Db::check_file,
+        )
+        .expect("operation never gets cancelled");
+
+        assert_eq!(fixes.count, 2);
+        assert_eq!(
+            &*source_text(&db, file),
+            "seen_code = True\n\
+             \n\
+             value = missing\n"
+        );
+        assert!(
+            fixes
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.id().as_str() == "unresolved-reference")
+        );
+    }
+
     /// Tests that the `fix_all` doesn't end up in an infinite loop
     /// if the fixes never converge and that it emits a diagnostic in that case.
     #[test]

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1246,43 +1246,6 @@ class B(A):
         );
     }
 
-    #[test]
-    fn safe_fix_preserves_nested_own_line_suppression() {
-        let mut db = TestDbBuilder::new()
-            .with_file(
-                "test.py",
-                r#"seen_code = True
-# ty: ignore[division-by-zero] # ty: ignore[unresolved-reference]
-value = missing
-"#,
-            )
-            .build()
-            .unwrap();
-
-        let file = system_path_to_file(&db, "test.py").unwrap();
-        let diagnostics = db.check_file(file);
-        let cancellation_token_source = CancellationTokenSource::new();
-        let fixes = fix_all(
-            &mut db,
-            diagnostics,
-            FixMode::ApplyFixes(Applicability::Safe),
-            &cancellation_token_source.token(),
-            Db::check_file,
-        )
-        .expect("operation never gets cancelled");
-
-        assert_eq!(fixes.count, 0);
-        assert_eq!(
-            &*source_text(&db, file),
-            r#"seen_code = True
-# ty: ignore[division-by-zero] # ty: ignore[unresolved-reference]
-value = missing
-"#
-        );
-        assert_eq!(fixes.diagnostics.len(), 1);
-        assert_eq!(fixes.diagnostics[0].id().as_str(), "unused-ignore-comment");
-    }
-
     /// Tests that the `fix_all` doesn't end up in an infinite loop
     /// if the fixes never converge and that it emits a diagnostic in that case.
     #[test]
@@ -1617,10 +1580,32 @@ value = missing
         let had_syntax_errors = parsed_before.load(&db).has_syntax_errors();
 
         let diagnostics = db.check_file(file);
+        let total_diagnostics = diagnostics.len();
+        let suppressible_diagnostics = diagnostics
+            .iter()
+            .filter(|diagnostic| FixMode::Suppress.is_fixable(diagnostic))
+            .count();
+        let unsuppressible_diagnostics = total_diagnostics - suppressible_diagnostics;
         let cancellation_token_source = CancellationTokenSource::new();
         let fixes =
             suppress_all_diagnostics(&mut db, diagnostics, &cancellation_token_source.token())
                 .expect("operation never gets cancelled");
+
+        if had_syntax_errors {
+            assert_eq!(fixes.count, 0);
+            assert_eq!(fixes.diagnostics.len(), total_diagnostics);
+        } else {
+            assert_eq!(fixes.count, suppressible_diagnostics);
+            assert!(
+                fixes
+                    .diagnostics
+                    .iter()
+                    .all(|diagnostic| !FixMode::Suppress.is_fixable(diagnostic))
+            );
+            // Adding a code to an empty suppression can also resolve its
+            // `unused-ignore-comment`.
+            assert!(fixes.diagnostics.len() <= unsuppressible_diagnostics);
+        }
 
         File::sync_path(&mut db, SystemPath::new("test.py"));
 

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1106,67 +1106,51 @@ class B(A):
 
     #[test]
     fn add_ignore_updates_own_line_suppressions() {
-        let mut db = TestDbBuilder::new()
-            .with_file(
-                "test.py",
-                "seen_code = True\n\
-                 # ty: ignore[]\n\
-                 value = missing\n\
-                 \n\
-                 def f(a: int, b: int) -> list[int]: return []\n\
-                 \n\
-                 # ty: ignore[invalid-assignment]\n\
-                 values: tuple[int] = f(\n\
-                     missing,\n\
-                     \"bad\",\n\
-                 )\n",
-            )
-            .build()
-            .unwrap();
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[]
+                value = missing
 
-        let file = system_path_to_file(&db, "test.py").unwrap();
-        let diagnostics = db.check_file(file);
-        let planned_fixes = FixMode::Suppress.fixes(&db, file, &diagnostics);
-        assert_eq!(planned_fixes.len(), 2);
-        assert_eq!(planned_fixes[0].fixed_diagnostics, 1);
-        assert_eq!(planned_fixes[1].fixed_diagnostics, 2);
+                def f(a: int, b: int) -> list[int]: return []
 
-        let cancellation_token_source = CancellationTokenSource::new();
-        let fixes = fix_all(
-            &mut db,
-            diagnostics,
-            FixMode::Suppress,
-            &cancellation_token_source.token(),
-            Db::check_file,
+                # ty: ignore[invalid-assignment]
+                values: tuple[int] = f(
+                    missing,
+                    "bad",
+                )
+                "#),
+            @r#"
+        Added 3 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # ty: ignore[unresolved-reference]
+        value = missing
+
+        def f(a: int, b: int) -> list[int]: return []
+
+        # ty: ignore[invalid-assignment, invalid-argument-type, unresolved-reference]
+        values: tuple[int] = f(
+            missing,
+            "bad",
         )
-        .expect("operation never gets cancelled");
-
-        assert_eq!(fixes.count, 3);
-        assert!(fixes.diagnostics.is_empty());
-        assert_eq!(
-            &*source_text(&db, file),
-            "seen_code = True\n\
-             # ty: ignore[unresolved-reference]\n\
-             value = missing\n\
-             \n\
-             def f(a: int, b: int) -> list[int]: return []\n\
-             \n\
-             # ty: ignore[invalid-assignment, invalid-argument-type, unresolved-reference]\n\
-             values: tuple[int] = f(\n\
-                 missing,\n\
-                 \"bad\",\n\
-             )\n"
+        ```
+        "#
         );
     }
 
     #[test]
-    fn safe_fix_does_not_promote_nested_own_line_suppression() {
+    fn safe_fix_preserves_nested_own_line_suppression() {
         let mut db = TestDbBuilder::new()
             .with_file(
                 "test.py",
-                "seen_code = True\n\
-                 # ty: ignore[division-by-zero] # ty: ignore[unresolved-reference]\n\
-                 value = missing\n",
+                r#"seen_code = True
+# ty: ignore[division-by-zero] # ty: ignore[unresolved-reference]
+value = missing
+"#,
             )
             .build()
             .unwrap();
@@ -1183,19 +1167,16 @@ class B(A):
         )
         .expect("operation never gets cancelled");
 
-        assert_eq!(fixes.count, 2);
+        assert_eq!(fixes.count, 0);
         assert_eq!(
             &*source_text(&db, file),
-            "seen_code = True\n\
-             \n\
-             value = missing\n"
+            r#"seen_code = True
+# ty: ignore[division-by-zero] # ty: ignore[unresolved-reference]
+value = missing
+"#
         );
-        assert!(
-            fixes
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.id().as_str() == "unresolved-reference")
-        );
+        assert_eq!(fixes.diagnostics.len(), 1);
+        assert_eq!(fixes.diagnostics[0].id().as_str(), "unused-ignore-comment");
     }
 
     /// Tests that the `fix_all` doesn't end up in an infinite loop
@@ -1532,13 +1513,10 @@ class B(A):
         let had_syntax_errors = parsed_before.load(&db).has_syntax_errors();
 
         let diagnostics = db.check_file(file);
-        let total_diagnostics = diagnostics.len();
         let cancellation_token_source = CancellationTokenSource::new();
         let fixes =
             suppress_all_diagnostics(&mut db, diagnostics, &cancellation_token_source.token())
                 .expect("operation never gets cancelled");
-
-        assert_eq!(fixes.count, total_diagnostics - fixes.diagnostics.len());
 
         File::sync_path(&mut db, SystemPath::new("test.py"));
 

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -367,6 +367,23 @@ impl Suppressions {
         })
     }
 
+    /// Returns the inline suppressions whose comments are on `line_range`.
+    fn inline_suppressions_on_line(
+        &self,
+        line_range: TextRange,
+    ) -> impl Iterator<Item = &Suppression> + '_ {
+        // The interval index retains source order, so comment ranges are also ordered by start.
+        let start = self
+            .inline
+            .entries
+            .partition_point(|entry| entry.value.comment_range.start() < line_range.start());
+
+        self.inline.entries[start..]
+            .iter()
+            .map(|entry| &entry.value)
+            .take_while(move |suppression| suppression.comment_range.start() < line_range.end())
+    }
+
     fn iter(&self) -> impl Iterator<Item = &Suppression> {
         self.file.iter().chain(self.inline.iter())
     }

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -55,16 +55,6 @@ pub fn suppress_all(
     // but also the diagnostic with the wider range (because the suppression is on its start line).
     ids_full_range.sort_unstable_by_key(|(_, range)| (range.start(), range.end()));
 
-    // 1. Group the diagnostics by their line-start position and try to add
-    //    the suppression to an existing `ty: ignore` comment on that line.
-    let mut by_start: BTreeMap<_, (BTreeSet<LintName>, usize)> = BTreeMap::new();
-
-    for &(id, range) in &ids_full_range {
-        let (lints, suppressed_diagnostics) = by_start.entry(range.start()).or_default();
-        lints.insert(id);
-        *suppressed_diagnostics += 1;
-    }
-
     let mut fixes = Vec::with_capacity(ids_full_range.len());
 
     // Tracks which lints get inserted by line. The offset is the line's start offset.
@@ -75,22 +65,36 @@ pub fn suppress_all(
     // (see the example with the wider range above).
     let mut by_line = BTreeMap::<TextSize, BTreeMap<LintName, SuppressionPosition>>::new();
 
-    for (start_offset, (lints, suppressed_diagnostics)) in by_start {
-        let codes: SmallVec<[LintName; 2]> = lints.into_iter().collect();
-        if let Some(add_to_start) =
-            add_to_existing_suppression(suppressions, &source, &codes, start_offset)
-        {
-            by_line.entry(start_offset).or_default().extend(
-                codes
-                    .iter()
-                    .copied()
-                    .map(|code| (code, SuppressionPosition::StartLine)),
-            );
-            fixes.push(SuppressFix {
-                fix: add_to_start,
-                suppressed_diagnostics,
-            });
+    let mut by_suppression = BTreeMap::<TextSize, ExistingSuppressionGroup>::new();
+
+    // 1. Try to add each diagnostic to an existing applicable `ty: ignore` comment, grouping
+    //    diagnostics that resolve to the same comment into a single fix.
+    for &(id, range) in &ids_full_range {
+        let start_offset = range.start();
+        if let Some(existing) = find_existing_suppression(suppressions, &source, start_offset) {
+            by_line
+                .entry(start_offset)
+                .or_default()
+                .insert(id, SuppressionPosition::StartLine);
+
+            let group = by_suppression
+                .entry(existing.insertion_offset)
+                .or_insert_with(|| ExistingSuppressionGroup {
+                    existing,
+                    codes: BTreeSet::new(),
+                    suppressed_diagnostics: 0,
+                });
+            group.codes.insert(id);
+            group.suppressed_diagnostics += 1;
         }
+    }
+
+    for group in by_suppression.into_values() {
+        let codes: SmallVec<[LintName; 2]> = group.codes.into_iter().collect();
+        fixes.push(SuppressFix {
+            fix: add_to_existing_suppression(group.existing, &codes),
+            suppressed_diagnostics: group.suppressed_diagnostics,
+        });
     }
 
     // 2. Group the diagnostics by their end position and try to add the code to an
@@ -152,6 +156,16 @@ enum SuppressionPosition {
     EndLine(TextSize),
 }
 
+/// Diagnostics that can be suppressed by a single edit to an existing suppression.
+///
+/// `codes` is deduplicated for insertion, while `suppressed_diagnostics` counts every diagnostic,
+/// including multiple diagnostics with the same lint code.
+struct ExistingSuppressionGroup {
+    existing: ExistingSuppression,
+    codes: BTreeSet<LintName>,
+    suppressed_diagnostics: usize,
+}
+
 /// Fix to suppress one or more diagnostics.
 pub struct SuppressFix {
     pub fix: Fix,
@@ -167,10 +181,10 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
     let source = source_text(db, file);
     let codes = &[id.name()];
 
-    if let Some(add_fix) =
-        add_to_existing_suppression(suppressions, &source, codes, suppression_range.start())
+    if let Some(existing) =
+        find_existing_suppression(suppressions, &source, suppression_range.start())
     {
-        return add_fix;
+        return add_to_existing_suppression(existing, codes);
     }
 
     append_to_existing_or_add_end_of_line_suppression(
@@ -240,8 +254,8 @@ fn append_to_existing_or_add_end_of_line_suppression(
     codes: &[LintName],
     line_end: TextSize,
 ) -> Fix {
-    if let Some(add_fix) = add_to_existing_suppression(suppressions, source, codes, line_end) {
-        return add_fix;
+    if let Some(existing) = find_existing_suppression(suppressions, source, line_end) {
+        return add_to_existing_suppression(existing, codes);
     }
 
     let up_to_line_end = &source[..line_end.to_usize()];
@@ -265,41 +279,63 @@ fn append_to_existing_or_add_end_of_line_suppression(
     })
 }
 
-fn add_to_existing_suppression(
+fn find_existing_suppression(
     suppressions: &Suppressions,
     source: &str,
-    codes: &[LintName],
     offset: TextSize,
-) -> Option<Fix> {
-    let mut existing_suppressions = suppressions
+) -> Option<ExistingSuppression> {
+    let existing = suppressions
         .inline_suppressions(TextRange::empty(offset))
-        .filter(|suppression| {
+        .find(|suppression| {
             matches!(
                 suppression.target,
                 SuppressionTarget::Lint(_) | SuppressionTarget::Empty,
             )
-        });
-
-    // If there's an existing `ty: ignore[]` comment, append the code to it instead of creating a new suppression comment.
-    let existing = existing_suppressions.next()?;
+        })?;
     let comment_text = &source[existing.comment_range];
 
     // Only add to the existing ignore comment if it has no reason.
-    let before_closing_paren = comment_text.trim_end().strip_suffix(']')?;
-    let up_to_last_code = before_closing_paren.trim_end();
-
-    let insertion = if up_to_last_code.ends_with(',') {
-        format!(" {codes}", codes = Codes(existing.kind, codes))
+    let before_closing_bracket = comment_text.trim_end().strip_suffix(']')?;
+    let up_to_last_code = before_closing_bracket.trim_end();
+    let separator = if up_to_last_code.ends_with('[') {
+        ""
+    } else if up_to_last_code.ends_with(',') {
+        " "
     } else {
-        format!(", {codes}", codes = Codes(existing.kind, codes))
+        ", "
     };
-
     let relative_offset_from_end = comment_text.text_len() - up_to_last_code.text_len();
 
-    Some(Fix::safe_edit(Edit::insertion(
-        insertion,
-        existing.comment_range.end() - relative_offset_from_end,
-    )))
+    Some(ExistingSuppression {
+        insertion_offset: existing.comment_range.end() - relative_offset_from_end,
+        kind: existing.kind,
+        separator,
+    })
+}
+
+/// Appends `codes` to an existing suppression comment.
+fn add_to_existing_suppression(existing: ExistingSuppression, codes: &[LintName]) -> Fix {
+    let separator = existing.separator;
+    let insertion = format!("{separator}{codes}", codes = Codes(existing.kind, codes));
+
+    Fix::safe_edit(Edit::insertion(insertion, existing.insertion_offset))
+}
+
+/// The location and formatting required to append lint codes to an existing suppression comment.
+///
+/// `kind` determines how codes are rendered, while `separator` preserves the syntax around the
+/// existing final code. For example:
+///
+/// ```python
+/// # ty: ignore[division-by-zero]
+/// ```
+///
+/// has an insertion offset before `]` and uses `", "` as the separator.
+#[derive(Copy, Clone)]
+struct ExistingSuppression {
+    insertion_offset: TextSize,
+    kind: SuppressionKind,
+    separator: &'static str,
 }
 
 struct Codes<'a>(SuppressionKind, &'a [LintName]);

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -56,6 +56,16 @@ pub fn suppress_all(
     // but also the diagnostic with the wider range (because the suppression is on its start line).
     ids_full_range.sort_unstable_by_key(|(_, range)| (range.start(), range.end()));
 
+    // 1. Group the diagnostics by their line-start position and try to add
+    //    the suppression to an existing `ty: ignore` comment on that line.
+    let mut by_start: BTreeMap<_, (BTreeSet<LintName>, usize)> = BTreeMap::new();
+
+    for &(id, range) in &ids_full_range {
+        let (lints, suppressed_diagnostics) = by_start.entry(range.start()).or_default();
+        lints.insert(id);
+        *suppressed_diagnostics += 1;
+    }
+
     let mut fixes = Vec::with_capacity(ids_full_range.len());
 
     // Tracks which lints get inserted by line. The offset is the line's start offset.
@@ -66,36 +76,20 @@ pub fn suppress_all(
     // (see the example with the wider range above).
     let mut by_line = BTreeMap::<TextSize, BTreeMap<LintName, SuppressionPosition>>::new();
 
-    let mut by_suppression = BTreeMap::<TextSize, ExistingSuppressionGroup>::new();
-
-    // 1. Try to add each diagnostic to an existing applicable `ty: ignore` comment, grouping
-    //    diagnostics that resolve to the same comment into a single fix.
-    for &(id, range) in &ids_full_range {
-        let start_offset = range.start();
+    for (start_offset, (lints, suppressed_diagnostics)) in by_start {
+        let codes: SmallVec<[LintName; 2]> = lints.into_iter().collect();
         if let Some(existing) = find_existing_suppression(suppressions, &source, start_offset) {
-            by_line
-                .entry(start_offset)
-                .or_default()
-                .insert(id, SuppressionPosition::StartLine);
-
-            let group = by_suppression
-                .entry(existing.insertion_offset)
-                .or_insert_with(|| ExistingSuppressionGroup {
-                    existing,
-                    codes: BTreeSet::new(),
-                    suppressed_diagnostics: 0,
-                });
-            group.codes.insert(id);
-            group.suppressed_diagnostics += 1;
+            by_line.entry(start_offset).or_default().extend(
+                codes
+                    .iter()
+                    .copied()
+                    .map(|code| (code, SuppressionPosition::StartLine)),
+            );
+            fixes.push(SuppressFix {
+                fix: add_to_existing_suppression(existing, &codes),
+                suppressed_diagnostics,
+            });
         }
-    }
-
-    for group in by_suppression.into_values() {
-        let codes: SmallVec<[LintName; 2]> = group.codes.into_iter().collect();
-        fixes.push(SuppressFix {
-            fix: add_to_existing_suppression(group.existing, &codes),
-            suppressed_diagnostics: group.suppressed_diagnostics,
-        });
     }
 
     // 2. Group the diagnostics by their end position and try to add the code to an
@@ -155,16 +149,6 @@ pub fn suppress_all(
 enum SuppressionPosition {
     StartLine,
     EndLine(TextSize),
-}
-
-/// Diagnostics that can be suppressed by a single edit to an existing suppression.
-///
-/// `codes` is deduplicated for insertion, while `suppressed_diagnostics` counts every diagnostic,
-/// including multiple diagnostics with the same lint code.
-struct ExistingSuppressionGroup {
-    existing: ExistingSuppression,
-    codes: BTreeSet<LintName>,
-    suppressed_diagnostics: usize,
 }
 
 /// Fix to suppress one or more diagnostics.
@@ -285,15 +269,13 @@ fn find_existing_suppression(
     source: &str,
     offset: TextSize,
 ) -> Option<ExistingSuppression> {
-    let line_start = source.line_start(offset);
     let existing = suppressions
-        .inline_suppressions(TextRange::empty(offset))
+        .inline_suppressions_on_line(source.line_range(offset))
         .find(|suppression| {
-            source.line_start(suppression.comment_range.start()) == line_start
-                && matches!(
-                    suppression.target,
-                    SuppressionTarget::Lint(_) | SuppressionTarget::Empty,
-                )
+            matches!(
+                suppression.target,
+                SuppressionTarget::Lint(_) | SuppressionTarget::Empty,
+            )
         })?;
     let comment_text = &source[existing.comment_range];
 

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -8,6 +8,7 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::token::TokenKind;
+use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use smallvec::SmallVec;
 
@@ -284,13 +285,15 @@ fn find_existing_suppression(
     source: &str,
     offset: TextSize,
 ) -> Option<ExistingSuppression> {
+    let line_start = source.line_start(offset);
     let existing = suppressions
         .inline_suppressions(TextRange::empty(offset))
         .find(|suppression| {
-            matches!(
-                suppression.target,
-                SuppressionTarget::Lint(_) | SuppressionTarget::Empty,
-            )
+            source.line_start(suppression.comment_range.start()) == line_start
+                && matches!(
+                    suppression.target,
+                    SuppressionTarget::Lint(_) | SuppressionTarget::Empty,
+                )
         })?;
     let comment_text = &source[existing.comment_range];
 

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -78,7 +78,9 @@ pub fn suppress_all(
 
     for (start_offset, (lints, suppressed_diagnostics)) in by_start {
         let codes: SmallVec<[LintName; 2]> = lints.into_iter().collect();
-        if let Some(existing) = find_existing_suppression(suppressions, &source, start_offset) {
+        if let Some(add_to_start) =
+            add_to_existing_suppression(suppressions, &source, &codes, start_offset)
+        {
             by_line.entry(start_offset).or_default().extend(
                 codes
                     .iter()
@@ -86,7 +88,7 @@ pub fn suppress_all(
                     .map(|code| (code, SuppressionPosition::StartLine)),
             );
             fixes.push(SuppressFix {
-                fix: add_to_existing_suppression(existing, &codes),
+                fix: add_to_start,
                 suppressed_diagnostics,
             });
         }
@@ -166,10 +168,10 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
     let source = source_text(db, file);
     let codes = &[id.name()];
 
-    if let Some(existing) =
-        find_existing_suppression(suppressions, &source, suppression_range.start())
+    if let Some(add_fix) =
+        add_to_existing_suppression(suppressions, &source, codes, suppression_range.start())
     {
-        return add_to_existing_suppression(existing, codes);
+        return add_fix;
     }
 
     append_to_existing_or_add_end_of_line_suppression(
@@ -239,8 +241,8 @@ fn append_to_existing_or_add_end_of_line_suppression(
     codes: &[LintName],
     line_end: TextSize,
 ) -> Fix {
-    if let Some(existing) = find_existing_suppression(suppressions, source, line_end) {
-        return add_to_existing_suppression(existing, codes);
+    if let Some(add_fix) = add_to_existing_suppression(suppressions, source, codes, line_end) {
+        return add_fix;
     }
 
     let up_to_line_end = &source[..line_end.to_usize()];
@@ -264,11 +266,12 @@ fn append_to_existing_or_add_end_of_line_suppression(
     })
 }
 
-fn find_existing_suppression(
+fn add_to_existing_suppression(
     suppressions: &Suppressions,
     source: &str,
+    codes: &[LintName],
     offset: TextSize,
-) -> Option<ExistingSuppression> {
+) -> Option<Fix> {
     let existing = suppressions
         .inline_suppressions_on_line(source.line_range(offset))
         .find(|suppression| {
@@ -291,36 +294,12 @@ fn find_existing_suppression(
     };
     let relative_offset_from_end = comment_text.text_len() - up_to_last_code.text_len();
 
-    Some(ExistingSuppression {
-        insertion_offset: existing.comment_range.end() - relative_offset_from_end,
-        kind: existing.kind,
-        separator,
-    })
-}
-
-/// Appends `codes` to an existing suppression comment.
-fn add_to_existing_suppression(existing: ExistingSuppression, codes: &[LintName]) -> Fix {
-    let separator = existing.separator;
     let insertion = format!("{separator}{codes}", codes = Codes(existing.kind, codes));
 
-    Fix::safe_edit(Edit::insertion(insertion, existing.insertion_offset))
-}
-
-/// The location and formatting required to append lint codes to an existing suppression comment.
-///
-/// `kind` determines how codes are rendered, while `separator` preserves the syntax around the
-/// existing final code. For example:
-///
-/// ```python
-/// # ty: ignore[division-by-zero]
-/// ```
-///
-/// has an insertion offset before `]` and uses `", "` as the separator.
-#[derive(Copy, Clone)]
-struct ExistingSuppression {
-    insertion_offset: TextSize,
-    kind: SuppressionKind,
-    separator: &'static str,
+    Some(Fix::safe_edit(Edit::insertion(
+        insertion,
+        existing.comment_range.end() - relative_offset_from_end,
+    )))
 }
 
 struct Codes<'a>(SuppressionKind, &'a [LintName]);


### PR DESCRIPTION
## Summary

This builds on #26785 by teaching `ty check --add-ignore` how to handle applicable own-line suppressions without broadening a preceding directive to cover additional diagnostics. In effect, we never use own-line comments for `--add-ignore`, whereas previously we may have applied them to more lines than intended.

Put differently, we now only extend an existing suppression when its comment is on the same physical line as the diagnostic's suppression range. If an applicable own-line suppression appears on a preceding line, we leave it unchanged and add an end-of-line suppression at the diagnostic instead:

```python
# ty: ignore[invalid-assignment]
values: tuple[int] = f(
    missing,  # ty:ignore[unresolved-reference]
    "bad",  # ty:ignore[invalid-argument-type]
)
```
