### PR TITLE
[ty] Cache non-terminal-call reachability prefixes

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1413,6 +1413,29 @@ fn benchmark_typeis_narrowing(criterion: &mut Criterion) {
     });
 }
 
+/// Regression benchmark for <https://github.com/astral-sh/ty/issues/3986>.
+///
+/// Each statement-level call creates a reachability predicate. Repeatedly scanning every preceding
+/// predicate while checking later expressions makes this pattern quadratic.
+fn benchmark_repeated_statement_calls(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let mut code = String::from("def f() -> None:\n    value = 'abc'\n");
+    code.push_str(&"    value.upper()\n".repeat(1_500));
+
+    criterion.bench_function("ty_micro[repeated_statement_calls]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 /// Benchmarks solving many union-bearing upper bounds while inferring a generic call.
 ///
 /// Each callable argument places a distinct union upper bound on `T` through callable-parameter
@@ -1930,6 +1953,7 @@ criterion_group!(
     benchmark_literal_equality_fallthrough_guarded_any,
     benchmark_literal_or_pattern_reachability,
     benchmark_typeis_narrowing,
+    benchmark_repeated_statement_calls,
     benchmark_factored_upper_bounds,
     benchmark_pandas_tdd,
     benchmark_recursive_typed_dict_union_contextual_inference,

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -228,6 +228,7 @@ use ty_python_core::{
     },
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
     scope::ScopeId,
+    use_def_map,
 };
 
 /// Narrow `subject_ty` by all preceding unguarded match patterns.
@@ -526,6 +527,8 @@ std::thread_local! {
     static ACTIVE_NON_TERMINAL_CALL_PREFIXES: ActiveRecursionDetector<salsa::Id> = ActiveRecursionDetector::default();
 }
 
+const NON_TERMINAL_CALL_CHUNK_SIZE: usize = 16;
+
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression) => expression.scope(db),
@@ -562,31 +565,111 @@ fn analyze_non_terminal_call_prefix<'db>(
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     root_predicate: ScopedPredicateId,
 ) {
-    let range = 0..=root_predicate.index();
-    if !range.clone().any(|index| {
-        matches!(
-            predicates[ScopedPredicateId::new(index)].node,
-            PredicateNode::IsNonTerminalCall(_)
-        )
-    }) {
-        return;
-    }
+    let scope = predicate_scope(db, &predicates[root_predicate]);
+    let has_many_calls = predicates
+        .iter()
+        .filter(|predicate| matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)))
+        .nth(NON_TERMINAL_CALL_CHUNK_SIZE)
+        .is_some();
 
-    let key = predicate_scope(db, &predicates[root_predicate]).as_id();
     ACTIVE_NON_TERMINAL_CALL_PREFIXES.with(|active| {
         active.visit(
-            &key,
+            &scope.as_id(),
             || {},
             || {
-                for index in range {
-                    let predicate = &predicates[ScopedPredicateId::new(index)];
-                    if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
-                        analyze_single(db, predicate);
+                if !has_many_calls {
+                    for predicate in &predicates.raw[..=root_predicate.index()] {
+                        if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
+                            analyze_single(db, predicate);
+                        }
                     }
+                    return;
                 }
+
+                let call_predicates = non_terminal_call_predicates(db, scope);
+                let call_count =
+                    call_predicates.partition_point(|predicate| *predicate <= root_predicate);
+                if call_count <= NON_TERMINAL_CALL_CHUNK_SIZE {
+                    analyze_non_terminal_calls(db, predicates, &call_predicates[..call_count]);
+                    return;
+                }
+
+                let mut start = 0;
+                let mut remaining = call_count / NON_TERMINAL_CALL_CHUNK_SIZE;
+
+                while remaining > 0 {
+                    let level = remaining.ilog2();
+                    let length = 1 << level;
+                    analyze_non_terminal_call_range(db, scope, level, start >> level);
+                    start += length;
+                    remaining -= length;
+                }
+
+                let tail_start =
+                    call_count / NON_TERMINAL_CALL_CHUNK_SIZE * NON_TERMINAL_CALL_CHUNK_SIZE;
+                analyze_non_terminal_calls(
+                    db,
+                    predicates,
+                    &call_predicates[tail_start..call_count],
+                );
             },
         );
     });
+}
+
+/// Returns the statement-call predicates for `scope` in source order.
+///
+/// This tracked index is used only once a scope exceeds [`NON_TERMINAL_CALL_CHUNK_SIZE`], avoiding
+/// a persistent allocation for the common case of scopes with few calls.
+#[salsa::tracked(returns(deref), heap_size = get_size2::GetSize::get_heap_size)]
+fn non_terminal_call_predicates<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+) -> Box<[ScopedPredicateId]> {
+    use_def_map(db, scope)
+        .predicates()
+        .iter_enumerated()
+        .filter_map(|(id, predicate)| {
+            matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)).then_some(id)
+        })
+        .collect()
+}
+
+fn analyze_non_terminal_calls<'db>(
+    db: &'db dyn Db,
+    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
+    call_predicates: &[ScopedPredicateId],
+) {
+    for id in call_predicates {
+        analyze_single(db, &predicates[*id]);
+    }
+}
+
+/// Analyzes a power-of-two range of call-predicate blocks in source order.
+///
+/// Prefixes can be decomposed into these canonical ranges and reused by later expression-inference
+/// queries. Splitting ranges in half keeps the Salsa query stack logarithmic even when the first
+/// requested prefix contains thousands of calls. Each leaf handles multiple calls iteratively to
+/// avoid retaining a Salsa argument and query result for every individual predicate.
+#[salsa::tracked(returns(copy), heap_size = get_size2::GetSize::get_heap_size)]
+fn analyze_non_terminal_call_range<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    level: u32,
+    index: usize,
+) {
+    if level == 0 {
+        let use_def = use_def_map(db, scope);
+        let call_predicates = non_terminal_call_predicates(db, scope);
+        let start = index * NON_TERMINAL_CALL_CHUNK_SIZE;
+        let end = start + NON_TERMINAL_CALL_CHUNK_SIZE;
+        analyze_non_terminal_calls(db, use_def.predicates(), &call_predicates[start..end]);
+        return;
+    }
+
+    let child_index = index * 2;
+    analyze_non_terminal_call_range(db, scope, level - 1, child_index);
+    analyze_non_terminal_call_range(db, scope, level - 1, child_index + 1);
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {


### PR DESCRIPTION
## Summary

Statement-level call predicates are assigned in source order but appear in reverse order in reachability decision diagrams. We warm preceding calls in source order to avoid a deeply recursive Salsa query chain, but the existing implementation rescans the entire predicate prefix for every later expression-inference query. With `n` statement calls, the query for call `i` scans the first `i` predicates, producing `1 + 2 + ... + n = O(n²)` total scanning even though the individual call analyses are cached.

This change indexes statement-call predicates once for scopes with more than 16 calls and decomposes each requested prefix into reusable power-of-two ranges. Each leaf analyzes 16 actual calls iteratively, while smaller scopes retain the direct path without allocating the tracked index.

This revisits the approach from #26763, using call-based rather than raw-predicate-based chunks so the cached work remains proportional to the expensive predicates.

This is the first of three related PRs. [#26811](https://github.com/astral-sh/ruff/pull/26811) caches sparse reachability checkpoints, and [#26793](https://github.com/astral-sh/ruff/pull/26793) defers statement-call narrowing gates.
