### PR TITLE
[ty] Cache sparse reachability checkpoints

### DIFF
--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -528,6 +528,7 @@ std::thread_local! {
 }
 
 const NON_TERMINAL_CALL_CHUNK_SIZE: usize = 16;
+const REACHABILITY_EVALUATION_CHUNK_SIZE: usize = 256;
 
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
@@ -564,7 +565,7 @@ fn analyze_non_terminal_call_prefix<'db>(
     db: &'db dyn Db,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     root_predicate: ScopedPredicateId,
-) {
+) -> bool {
     let scope = predicate_scope(db, &predicates[root_predicate]);
     let has_many_calls = predicates
         .iter()
@@ -615,6 +616,8 @@ fn analyze_non_terminal_call_prefix<'db>(
             },
         );
     });
+
+    has_many_calls
 }
 
 /// Returns the statement-call predicates for `scope` in source order.
@@ -672,6 +675,118 @@ fn analyze_non_terminal_call_range<'db>(
     analyze_non_terminal_call_range(db, scope, level - 1, child_index + 1);
 }
 
+/// Evaluates a reachability constraint after warming its statement-call prefix.
+///
+/// Large scopes reuse canonical call ranges and sparse decision-diagram checkpoints; small scopes
+/// retain the direct evaluation path without creating either cached index.
+fn evaluate_reachability_constraint<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    id: ScopedReachabilityConstraintId,
+) -> Truthiness {
+    if let Some(reachability) = terminal_reachability(id) {
+        return reachability;
+    }
+
+    let use_def = use_def_map(db, scope);
+    let constraints = use_def.reachability_constraints();
+    let predicates = use_def.predicates();
+    let root_predicate = constraints.get_interior_node(id).atom();
+    let has_many_calls = analyze_non_terminal_call_prefix(db, predicates, root_predicate);
+    let call_predicates = has_many_calls.then(|| non_terminal_call_predicates(db, scope));
+
+    evaluate_reachability_path(
+        db,
+        scope,
+        constraints,
+        predicates,
+        call_predicates,
+        id,
+        true,
+    )
+}
+
+fn terminal_reachability(id: ScopedReachabilityConstraintId) -> Option<Truthiness> {
+    match id {
+        ScopedReachabilityConstraintId::ALWAYS_TRUE => Some(Truthiness::AlwaysTrue),
+        ScopedReachabilityConstraintId::AMBIGUOUS => Some(Truthiness::Ambiguous),
+        ScopedReachabilityConstraintId::ALWAYS_FALSE => Some(Truthiness::AlwaysFalse),
+        _ => None,
+    }
+}
+
+fn is_reachability_checkpoint(
+    call_predicates: &[ScopedPredicateId],
+    predicate: ScopedPredicateId,
+) -> bool {
+    call_predicates
+        .binary_search(&predicate)
+        .is_ok_and(|index| (index + 1) % REACHABILITY_EVALUATION_CHUNK_SIZE == 0)
+}
+
+/// Walks a reachability decision diagram until it reaches a terminal or reusable checkpoint.
+///
+/// `use_checkpoint` is false only when entering from a checkpoint query. In that case, the first
+/// node is evaluated directly to prevent the query from immediately calling itself again.
+fn evaluate_reachability_path<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    constraints: &ReachabilityConstraints,
+    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
+    call_predicates: Option<&[ScopedPredicateId]>,
+    mut id: ScopedReachabilityConstraintId,
+    mut use_checkpoint: bool,
+) -> Truthiness {
+    loop {
+        if let Some(reachability) = terminal_reachability(id) {
+            return reachability;
+        }
+
+        let node = constraints.get_interior_node(id);
+        if use_checkpoint
+            && call_predicates.is_some_and(|call_predicates| {
+                is_reachability_checkpoint(call_predicates, node.atom())
+            })
+        {
+            return evaluate_reachability_checkpoint(db, scope, id);
+        }
+
+        id = match analyze_single(db, &predicates[node.atom()]) {
+            Truthiness::AlwaysTrue => node.if_true(),
+            Truthiness::Ambiguous => node.if_ambiguous(),
+            Truthiness::AlwaysFalse => node.if_false(),
+        };
+        use_checkpoint = true;
+    }
+}
+
+/// Evaluates a canonical suffix of a reachability decision diagram.
+///
+/// Only every [`REACHABILITY_EVALUATION_CHUNK_SIZE`]th non-terminal-call predicate is a checkpoint.
+/// This lets later statements reuse the constraints accumulated by earlier statements without
+/// retaining a Salsa query key and memo for every reachability constraint in the scope.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial = |_, _, _, _| Truthiness::Ambiguous,
+    heap_size = get_size2::GetSize::get_heap_size
+)]
+fn evaluate_reachability_checkpoint<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    id: ScopedReachabilityConstraintId,
+) -> Truthiness {
+    let use_def = use_def_map(db, scope);
+    evaluate_reachability_path(
+        db,
+        scope,
+        use_def.reachability_constraints(),
+        use_def.predicates(),
+        Some(non_terminal_call_predicates(db, scope)),
+        id,
+        false,
+    )
+}
+
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
     /// Analyze the statically known reachability for a given constraint.
     fn evaluate(
@@ -688,51 +803,23 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         &self,
         db: &'db dyn Db,
         predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-        mut id: ScopedReachabilityConstraintId,
+        id: ScopedReachabilityConstraintId,
     ) -> Truthiness {
-        type Id = ScopedReachabilityConstraintId;
-
-        // Analyze statement-level calls through this root one by one in source order, so any
-        // earlier call needed while inferring a later one is already cached instead of deepening
-        // the Salsa query stack. This avoids growing an excessive stack for deeply nested
-        // reachability queries.
-        //
-        // Without this prefix analysis, given:
-        //
-        //   call_a()  # predicate 0
-        //   call_b()  # predicate 1
-        //   call_c()  # predicate 2
-        //
-        // we'd analyze them backwards:
-        //
-        //   analyze call_c
-        //   └─ analyze call_b
-        //      └─ analyze call_a
-        //
-        // The prefix pass explicitly analyzes them forwards:
-        //
-        //   analyze call_a  → cached
-        //   analyze call_b  → call_a is already cached
-        //   analyze call_c  → call_b is already cached
-        if !id.is_terminal() {
-            let root_predicate = self.get_interior_node(id).atom();
-            analyze_non_terminal_call_prefix(db, predicates, root_predicate);
+        if let Some(reachability) = terminal_reachability(id) {
+            return reachability;
         }
 
-        loop {
-            let node = match id {
-                Id::ALWAYS_TRUE => return Truthiness::AlwaysTrue,
-                Id::AMBIGUOUS => return Truthiness::Ambiguous,
-                Id::ALWAYS_FALSE => return Truthiness::AlwaysFalse,
-                _ => self.get_interior_node(id),
-            };
-            let predicate = &predicates[node.atom()];
-            match analyze_single(db, predicate) {
-                Truthiness::AlwaysTrue => id = node.if_true(),
-                Truthiness::Ambiguous => id = node.if_ambiguous(),
-                Truthiness::AlwaysFalse => id = node.if_false(),
-            }
-        }
+        let root_predicate = self.get_interior_node(id).atom();
+        analyze_non_terminal_call_prefix(db, predicates, root_predicate);
+        evaluate_reachability_path(
+            db,
+            predicate_scope(db, &predicates[root_predicate]),
+            self,
+            predicates,
+            None,
+            id,
+            true,
+        )
     }
 }
 
@@ -1578,7 +1665,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
                 return result;
             }
 
-            let result = constraints.evaluate(db, predicates, id);
+            let result = evaluate_reachability_constraint(db, scope, id);
             self.other_entries.borrow_mut().insert(key, result);
             return result;
         }
@@ -1588,7 +1675,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
             return result;
         }
 
-        let result = constraints.evaluate(db, predicates, id);
+        let result = evaluate_reachability_constraint(db, self.primary_scope, id);
         let mut entries = self.primary_entries.borrow_mut();
         if entries.len() <= index {
             entries.resize(index + 1, None);


### PR DESCRIPTION
## Summary

#26810 avoids repeatedly scanning and inferring the statement-call prefix, but each standalone expression-inference query can still walk the complete accumulated reachability decision diagram. Repeating that walk after every statement remains quadratic even when the individual predicate analyses are already cached.

This change adds a Salsa-tracked checkpoint at every 256th statement-call predicate. Later evaluations can reuse the result of an earlier decision-diagram suffix while retaining only a sparse set of query keys and memos. Scopes with at most 16 calls continue to use the direct evaluator, and checkpoint queries conservatively participate in cycle recovery.

This is the second part of the fix for https://github.com/astral-sh/ty/issues/3986 and is stacked on #26810.
