### PR TITLE
[`refurb`] Allow subclassing builtins in stub files (`FURB189`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/refurb/subclass-builtin.md
+++ b/crates/ruff_linter/resources/mdtest/refurb/subclass-builtin.md
@@ -1,0 +1,20 @@
+# `subclass-builtin` (`FURB189`)
+
+```toml
+[lint]
+preview = true
+select = ["FURB189"]
+```
+
+## Stub files
+
+Subclassing a builtin in a stub must be allowed so the stub can faithfully represent the runtime
+implementation.
+
+```pyi
+class D(dict): ...
+class L(list): ...
+class S(str): ...
+class SubscriptDict(dict[str, str]): ...
+class SubscriptList(list[str]): ...
+```

--- a/crates/ruff_linter/src/rules/refurb/rules/subclass_builtin.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/subclass_builtin.rs
@@ -15,6 +15,9 @@ use crate::{checkers::ast::Checker, importer::ImportRequest};
 /// Use the `UserDict`, `UserList`, and `UserString` objects from the `collections` module
 /// instead.
 ///
+/// This rule does not apply to stub files, which should faithfully represent the runtime
+/// implementation and may be out of the author's control.
+///
 /// ## Example
 ///
 /// ```python

--- a/crates/ruff_linter/src/rules/refurb/rules/subclass_builtin.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/subclass_builtin.rs
@@ -83,6 +83,10 @@ impl AlwaysFixableViolation for SubclassBuiltin {
 
 /// FURB189
 pub(crate) fn subclass_builtin(checker: &Checker, class: &StmtClassDef) {
+    if checker.source_type.is_stub() {
+        return;
+    }
+
     let Some(Arguments { args: bases, .. }) = class.arguments.as_deref() else {
         return;
     };


### PR DESCRIPTION
Summary
--

While looking at rule stabilization candidates for 0.16, I noticed that #15291 has been blocking
stabilization of this rule for quite a while despite being a one-line change. I decided to make that
one-line change since it seemed sensible to me. I'll still plan to hold off on stabilization until
this change has been in preview for a release cycle, but this should pave the way to stabilization
in 0.17.

Closed #15291

Test Plan
--

New mdtest showing that the rule is inactive in stub files
