### PR TITLE
[`flake8-comprehensions`] NFKC-normalize keyword names in `C408` fix

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C408.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C408.py
@@ -37,3 +37,12 @@ t"{dict(x='y') | dict(y='z')}"
 t"{ dict(x='y') | dict(y='z') }"
 t"a {dict(x='y') | dict(y='z')} b"
 t"a { dict(x='y') | dict(y='z') } b"
+
+# https://github.com/astral-sh/ruff/issues/16234
+# Python normalizes identifiers to NFKC, but does not normalize string literals, so the fix has to
+# normalize the keyword name to preserve the dictionary key at runtime. The character "ℼ" normalizes
+# to "π", and "ſ" normalizes to "s".
+dict(ℼ=3.14)
+dict(ſ=1)
+dict(𝕒=1, b=2)
+dict(a=1, b=2)  # already NFKC-normalized: unchanged

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
@@ -14,6 +14,7 @@ use ruff_python_ast::{self as ast, Expr, ExprCall};
 use ruff_python_codegen::Stylist;
 use ruff_python_semantic::SemanticModel;
 use ruff_text_size::{Ranged, TextRange};
+use unicode_normalization::UnicodeNormalization;
 
 use crate::Locator;
 use crate::cst::helpers::{negate, space};
@@ -241,6 +242,10 @@ pub(crate) fn fix_unnecessary_collection_call(
         .unwrap_or(stylist.quote());
 
     // Quote each argument.
+    //
+    // Python normalizes identifiers to NFKC, but string literals are not normalized. Emitting the
+    // raw source text of a keyword argument would change the dictionary key at runtime, so the
+    // name has to be normalized. See https://github.com/astral-sh/ruff/issues/16234.
     for arg in &call.args {
         let quoted = format!(
             "{}{}{}",
@@ -248,7 +253,9 @@ pub(crate) fn fix_unnecessary_collection_call(
             arg.keyword
                 .as_ref()
                 .expect("Expected dictionary argument to be kwarg")
-                .value,
+                .value
+                .nfkc()
+                .collect::<String>(),
             quote,
         );
         arena.push(quoted);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/fixes.rs
@@ -254,8 +254,7 @@ pub(crate) fn fix_unnecessary_collection_call(
                 .as_ref()
                 .expect("Expected dictionary argument to be kwarg")
                 .value
-                .nfkc()
-                .collect::<String>(),
+                .nfkc(),
             quote,
         );
         arena.push(quoted);

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C408_C408.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/snapshots/ruff_linter__rules__flake8_comprehensions__tests__C408_C408.py.snap
@@ -529,12 +529,15 @@ C408 [*] Unnecessary `dict()` call (rewrite as a literal)
 38 | t"a {dict(x='y') | dict(y='z')} b"
 39 | t"a { dict(x='y') | dict(y='z') } b"
    |       ^^^^^^^^^^^
+40 |
+41 | # https://github.com/astral-sh/ruff/issues/16234
    |
 help: Rewrite as a literal
    |
 38 | t"a {dict(x='y') | dict(y='z')} b"
    - t"a { dict(x='y') | dict(y='z') } b"
 39 + t"a { {'x': 'y'} | dict(y='z') } b"
+40 |
    |
 note: This is an unsafe fix and may change runtime behavior
 
@@ -545,11 +548,86 @@ C408 [*] Unnecessary `dict()` call (rewrite as a literal)
 38 | t"a {dict(x='y') | dict(y='z')} b"
 39 | t"a { dict(x='y') | dict(y='z') } b"
    |                     ^^^^^^^^^^^
+40 |
+41 | # https://github.com/astral-sh/ruff/issues/16234
    |
 help: Rewrite as a literal
    |
 38 | t"a {dict(x='y') | dict(y='z')} b"
    - t"a { dict(x='y') | dict(y='z') } b"
 39 + t"a { dict(x='y') | {'y': 'z'} } b"
+40 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+C408 [*] Unnecessary `dict()` call (rewrite as a literal)
+  --> C408.py:45:1
+   |
+43 | # normalize the keyword name to preserve the dictionary key at runtime. The character "ℼ" normalizes
+44 | # to "π", and "ſ" normalizes to "s".
+45 | dict(ℼ=3.14)
+   | ^^^^^^^^^^^^
+46 | dict(ſ=1)
+47 | dict(𝕒=1, b=2)
+   |
+help: Rewrite as a literal
+   |
+44 | # to "π", and "ſ" normalizes to "s".
+   - dict(ℼ=3.14)
+45 + {"π": 3.14}
+46 | dict(ſ=1)
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+C408 [*] Unnecessary `dict()` call (rewrite as a literal)
+  --> C408.py:46:1
+   |
+44 | # to "π", and "ſ" normalizes to "s".
+45 | dict(ℼ=3.14)
+46 | dict(ſ=1)
+   | ^^^^^^^^^
+47 | dict(𝕒=1, b=2)
+48 | dict(a=1, b=2)  # already NFKC-normalized: unchanged
+   |
+help: Rewrite as a literal
+   |
+45 | dict(ℼ=3.14)
+   - dict(ſ=1)
+46 + {"s": 1}
+47 | dict(𝕒=1, b=2)
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+C408 [*] Unnecessary `dict()` call (rewrite as a literal)
+  --> C408.py:47:1
+   |
+45 | dict(ℼ=3.14)
+46 | dict(ſ=1)
+47 | dict(𝕒=1, b=2)
+   | ^^^^^^^^^^^^^^
+48 | dict(a=1, b=2)  # already NFKC-normalized: unchanged
+   |
+help: Rewrite as a literal
+   |
+46 | dict(ſ=1)
+   - dict(𝕒=1, b=2)
+47 + {"a": 1, "b": 2}
+48 | dict(a=1, b=2)  # already NFKC-normalized: unchanged
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+C408 [*] Unnecessary `dict()` call (rewrite as a literal)
+  --> C408.py:48:1
+   |
+46 | dict(ſ=1)
+47 | dict(𝕒=1, b=2)
+48 | dict(a=1, b=2)  # already NFKC-normalized: unchanged
+   | ^^^^^^^^^^^^^^
+   |
+help: Rewrite as a literal
+   |
+47 | dict(𝕒=1, b=2)
+   - dict(a=1, b=2)  # already NFKC-normalized: unchanged
+48 + {"a": 1, "b": 2}  # already NFKC-normalized: unchanged
    |
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Python normalizes identifiers to NFKC, but does not normalize string literals. The fix for `unnecessary-collection-call` (C408) reparses the call with libcst, which — unlike Ruff's own parser — does not normalize identifiers, and then emits the raw source text of each keyword argument as a dictionary key. This changed the key at runtime: `dict(ℼ=3.14)` has the key `π`, but was rewritten to `{"ℼ": 3.14}`.

Normalize the keyword name before quoting it, matching what `fix::codemods` already does for qualified names built from libCST nodes.

Fixes #16234

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Python normalizes identifiers to NFKC, but not string literals. The C408 fix
re-parses the call with libcst, and that parser has a particular quirk: it does
not normalize (Ruff's own parser does). So libcst hands over the raw source text
of the kwarg as the key.

`dict(ℼ=3.14)` has the key `π` at RUNTIME, but was rewritten to `{"ℼ": 3.14}` >
this changes the behavior.

My fix normalizes the kwarg name before quoting it. I'm not creating anything
new, because `fix::codemods` already does the same thing.

I decided not to mark it as unsafe, because the C408 fix is already unsafe. And
unlike B009/B010/B043 (string > identifier, where preserving the behavior is
impossible), C408 goes identifier > string. So the correct key can be computed :)

## Test Plan

- 4 new cases at the end of `C408.py`: `ℼ`→`π`, `ſ`→`s`, `𝕒`→`a`, plus an ASCII control with no changes.
- The snapshot diff is essentially additive. No diagnostic was altered.
- The `allow_dict_calls_with_keyword_arguments` snapshot stayed INTACT.
- `cargo test -p ruff_linter`: 2811 passed, 0 failed :)
- `clippy --workspace --all-features -D warnings`: 100% clean. `generate-all`: up-to-date. And `prek run -a`: 14/14.

Fixes #16234