### PR TITLE
[ty] Handle cycles in derived constraint relations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/derived_constraint_cycles.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/derived_constraint_cycles.md
@@ -27,6 +27,39 @@ def reduce[T](function: Callable[[T, T], T]) -> T:
 reduce(add)
 ```
 
+## Recursive relations between derived constraints
+
+Validating a derived constraint can require another relation check. If that relation recursively
+reaches the same pair of types, we assume that it holds until we find a contradiction elsewhere in
+the protocol. This lets the check terminate without accepting a protocol that has an incompatible
+non-recursive member.
+
+```py
+from __future__ import annotations
+
+from typing import Protocol, cast
+
+class Array(Protocol):
+    def __abs__(self) -> Array: ...
+    def __pos__(self) -> Array: ...
+    def marker(self) -> int: ...
+
+class Concrete[T]:
+    def __abs__[S](self: S) -> S:
+        return self
+
+    def __pos__[S](self: S) -> S:
+        return self
+
+    def marker(self) -> str:
+        return ""
+
+def convert[T](value: Concrete[T]) -> Array:
+    return cast(Array, value)
+
+invalid: Array = Concrete[int]()  # error: [invalid-assignment]
+```
+
 ## Independent nested substitutions can compose
 
 The repeat guard tracks substitution history separately for each derived constraint. This allows two

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -5442,10 +5442,13 @@ impl SequentMap {
     ) {
         // If the post constraint is unsatisfiable, then the antecedents contradict each other.
         let post_data = builder.constraint_data(post);
-        let when = post_data
-            .bounds
-            .materialized_lower()
-            .when_constraint_set_assignable_to(db, post_data.bounds.materialized_upper(), builder);
+        let when = builder.load(
+            db,
+            &post_data
+                .bounds
+                .materialized_lower()
+                .when_constraint_set_assignable_to_owned(db, post_data.bounds.materialized_upper()),
+        );
         if when.is_never_satisfied(db) {
             self.add_pair_impossibility(db, builder, ante1, ante2);
             return;
@@ -5562,7 +5565,10 @@ impl SequentMap {
             return;
         }
 
-        let when = lower.when_constraint_set_assignable_to(db, upper, builder);
+        let when = builder.load(
+            db,
+            &lower.when_constraint_set_assignable_to_owned(db, upper),
+        );
 
         // If L is _never_ assignable to U, this constraint would violate transitivity, and should
         // never have been added.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -454,6 +454,9 @@ impl<'db> Type<'db> {
 
     /// Returns an _owned_ (i.e. salsa-cached) constraint set that describes when `self` is
     /// constraint-set assignable to `target`.
+    ///
+    /// Recursive relations are evaluated coinductively: a cycle is provisionally satisfied until
+    /// another part of the relation produces a contradiction.
     pub(super) fn when_constraint_set_assignable_to_owned(
         self,
         db: &'db dyn Db,
@@ -461,7 +464,7 @@ impl<'db> Type<'db> {
     ) -> Cow<'db, OwnedConstraintSet<'db>> {
         #[salsa::tracked(
             returns(ref),
-            cycle_initial=|_, _, _, _| OwnedConstraintSet::default(),
+            cycle_initial=|_, _, _, _| OwnedConstraintSet::always(),
             heap_size=ruff_memory_usage::heap_size,
         )]
         fn when_constraint_set_assignable_to_owned_impl<'db>(


### PR DESCRIPTION
## Summary

While deriving implications from a constraint `L ≤ T ≤ U`, the sequent map checks when `L` is assignable to `U`. Running that relation directly in the active builder bypasses Salsa cycle recovery. Recursive protocols can therefore re-enter the same derived relation until stack overflow.

This PR routes both derived-relation checks through the existing owned, cached query and gives recursive assignability its coinductive initial result: provisionally true until another part of the relation contradicts it. The result is then loaded back into the active builder, preserving the existing sequent construction.

The regression combines two recursive members with an incompatible non-recursive member. It now terminates while still rejecting the invalid implementation.

This is split out of #26788 as its low-level base and is stacked on #26776.