### PR TITLE
[ty] Diagnose invalid own-line type ignores

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -165,7 +165,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.57">0.0.57</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22blanket-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L61" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L62" target="_blank">View source</a>
 </small>
 
 
@@ -832,7 +832,7 @@ INITIALIZED_CONSTANT: Final[int] = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ignore-comment-unknown-rule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L43" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L44" target="_blank">View source</a>
 </small>
 
 
@@ -1838,7 +1838,7 @@ x: G[int]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L52" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L53" target="_blank">View source</a>
 </small>
 
 
@@ -5069,7 +5069,7 @@ async def main() -> None:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L25" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L26" target="_blank">View source</a>
 </small>
 
 
@@ -5110,7 +5110,7 @@ to `false` to prevent this rule from reporting unused `type: ignore` comments.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-type-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L34" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L35" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/type_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/type_ignore.md
@@ -258,11 +258,23 @@ File level suppressions must come before any non-trivia token,
 including module docstrings.
 """
 
-# error: [unused-type-ignore-comment] "Unused blanket `type: ignore` directive"
+# error: [invalid-ignore-comment] "Invalid `type: ignore` comment: own-line comments must appear before any Python statements"
 # type: ignore
 
 a = 10 / 0  # error: [division-by-zero]
 b = a / 0  # error: [division-by-zero]
+```
+
+An own-line `type: ignore` after the first Python statement is invalid and does not suppress the
+following line.
+
+```py
+seen_code = True
+
+# error: [invalid-ignore-comment] "own-line comments must appear before any Python statements"
+# type: ignore
+# error: [unresolved-reference]
+value = missing
 ```
 
 ## `respect-type-ignore-comments=false`

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -10,6 +10,7 @@ use ruff_db::diagnostic::{
 };
 use ruff_db::{files::File, parsed::parsed_module, source::source_text};
 use ruff_python_ast::token::TokenKind;
+use ruff_python_trivia::indentation_at_offset;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 use crate::diagnostic::DiagnosticGuard;
@@ -112,6 +113,11 @@ pub(crate) fn suppressions(db: &dyn Db, file: File) -> Suppressions {
                                 }
 
                                 builder.add_invalid_comment(kind, error);
+                            }
+                            ParseErrorKind::InvalidOwnLineTypeIgnore => {
+                                if respect_type_ignore {
+                                    builder.add_invalid_comment(SuppressionKind::TypeIgnore, error);
+                                }
                             }
                         },
                     }
@@ -544,6 +550,20 @@ impl<'a> SuppressionsBuilder<'a> {
         // > may precede the # type: ignore comment.
         // > https://typing.python.org/en/latest/spec/directives.html#type-ignore-comments
         let is_file_suppression = !self.seen_non_trivia_token;
+
+        if !is_file_suppression
+            && comment.kind().is_type_ignore()
+            && indentation_at_offset(comment.range().start(), self.source).is_some()
+        {
+            self.add_invalid_comment(
+                comment.kind(),
+                ParseError {
+                    kind: ParseErrorKind::InvalidOwnLineTypeIgnore,
+                    range: comment.range(),
+                },
+            );
+            return;
+        }
 
         let suppressed_range = if is_file_suppression {
             TextRange::new(0.into(), self.source.text_len())

--- a/crates/ty_python_semantic/src/suppression/parser.rs
+++ b/crates/ty_python_semantic/src/suppression/parser.rs
@@ -266,6 +266,9 @@ pub(super) enum ParseErrorKind {
     /// `ty: ignore[a, b`
     #[error("expected a closing bracket")]
     CodesMissingClosingBracket(SuppressionKind),
+
+    #[error("own-line comments must appear before any Python statements")]
+    InvalidOwnLineTypeIgnore,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

An own-line `type: ignore` that _doesn't_ precede Python code is a noop (i.e., it does _not_ suppress the following statement). We report it as an unused suppression today; this PR changes it to an `invalid-ignore-comment` with a targeted explanation:

```python
seen_code = True

# type: ignore
value = missing
# warning: Invalid `type: ignore` comment: own-line comments must appear before any Python statements
```
