### PR TITLE
[ty] Avoid redundant meta-protocol member checks

### DIFF
--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -500,6 +500,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         db: &'db dyn Db,
         ty: Type<'db>,
         protocol: ProtocolInstanceType<'db>,
+        check_class_access: bool,
     ) -> ConstraintSet<'db, 'c> {
         // `ty` might satisfy the protocol nominally, if `protocol` is a class-based protocol and
         // `ty` has the protocol class in its MRO. This is a much cheaper check than the
@@ -565,7 +566,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .interface(db)
                 .members(db)
                 .when_all(db, self.constraints, |member| {
-                    self.type_satisfies_protocol_member(db, ty, &member)
+                    self.type_satisfies_protocol_member(db, ty, &member, check_class_access)
                 })
         };
         if let Some(context) = self.report_context()
@@ -600,10 +601,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ));
 
         let constructed_ty = meta_ty.bindings(db).return_type(db);
-        self.check_type_pair(db, constructed_ty, Type::ProtocolInstance(protocol))
-            .and(db, self.constraints, || {
-                self.check_meta_protocol_members(db, constructed_ty, meta_ty, protocol)
-            })
+        self.check_type_pair_without_protocol_class_access(
+            db,
+            constructed_ty,
+            Type::ProtocolInstance(protocol),
+        )
+        .and(db, self.constraints, || {
+            self.check_meta_protocol_members(db, constructed_ty, meta_ty, protocol)
+        })
     }
 
     pub(super) fn check_nominal_instance_pair(
@@ -901,7 +906,7 @@ impl<'db> ProtocolInstanceType<'db> {
                 &materialization_visitor,
             );
             checker
-                .check_type_satisfies_protocol(db, Type::object(), protocol)
+                .check_type_satisfies_protocol(db, Type::object(), protocol, true)
                 .is_always_satisfied(db)
         }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -18,7 +18,7 @@ use crate::types::constraints::{
 use crate::types::enums::is_single_member_enum;
 use crate::types::generics::{InferableTypeVars, walk_specialization};
 use crate::types::protocol_class::{
-    ProtocolClass, has_all_protocol_members_defined, walk_protocol_interface,
+    ProtocolClass, ProtocolClassAccess, has_all_protocol_members_defined, walk_protocol_interface,
 };
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelationChecker,
@@ -500,7 +500,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         db: &'db dyn Db,
         ty: Type<'db>,
         protocol: ProtocolInstanceType<'db>,
-        check_class_access: bool,
+        class_access: ProtocolClassAccess,
     ) -> ConstraintSet<'db, 'c> {
         // `ty` might satisfy the protocol nominally, if `protocol` is a class-based protocol and
         // `ty` has the protocol class in its MRO. This is a much cheaper check than the
@@ -566,7 +566,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .interface(db)
                 .members(db)
                 .when_all(db, self.constraints, |member| {
-                    self.type_satisfies_protocol_member(db, ty, &member, check_class_access)
+                    self.type_satisfies_protocol_member(db, ty, &member, class_access)
                 })
         };
         if let Some(context) = self.report_context()
@@ -906,7 +906,12 @@ impl<'db> ProtocolInstanceType<'db> {
                 &materialization_visitor,
             );
             checker
-                .check_type_satisfies_protocol(db, Type::object(), protocol, true)
+                .check_type_satisfies_protocol(
+                    db,
+                    Type::object(),
+                    protocol,
+                    ProtocolClassAccess::Check,
+                )
                 .is_always_satisfied(db)
         }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1913,14 +1913,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         })
     }
 
-    /// Return `true` if `ty` provides every access required by this protocol member.
+    /// Return `true` if `ty` provides every requested access for this protocol member.
     pub(super) fn type_satisfies_protocol_member(
         &self,
         db: &'db dyn Db,
         ty: Type<'db>,
         member: &ProtocolMember<'_, 'db>,
+        check_class_access: bool,
     ) -> ConstraintSet<'db, 'c> {
-        let capabilities = member.implementation_capabilities(db, ty);
+        let mut capabilities = member.implementation_capabilities(db, ty);
+        if !check_class_access {
+            capabilities.class = ProtocolMemberAccess::NONE;
+        }
         if let Some(context) = self.report_context() {
             let instance_read_missing = capabilities.instance.read.is_some()
                 && protocol_member_read_type(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -678,6 +678,12 @@ enum ProtocolMemberAccessMode {
     Class,
 }
 
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub(super) enum ProtocolClassAccess {
+    Check,
+    Skip,
+}
+
 fn cycle_normalized_optional_type<'db>(
     db: &'db dyn Db,
     current: Option<ProtocolMemberType<'db>>,
@@ -1919,10 +1925,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         db: &'db dyn Db,
         ty: Type<'db>,
         member: &ProtocolMember<'_, 'db>,
-        check_class_access: bool,
+        class_access: ProtocolClassAccess,
     ) -> ConstraintSet<'db, 'c> {
         let mut capabilities = member.implementation_capabilities(db, ty);
-        if !check_class_access {
+        if class_access == ProtocolClassAccess::Skip {
             capabilities.class = ProtocolMemberAccess::NONE;
         }
         if let Some(context) = self.report_context() {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -13,6 +13,7 @@ use crate::types::constraints::{
 use crate::types::cyclic::PairVisitor;
 use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
+use crate::types::protocol_class::ProtocolClassAccess;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
 use crate::types::{
@@ -1034,7 +1035,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         source: Type<'db>,
         target: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        self.check_type_pair_impl(db, source, target, true)
+        self.check_type_pair_impl(db, source, target, ProtocolClassAccess::Check)
     }
 
     pub(super) fn check_type_pair_without_protocol_class_access(
@@ -1043,7 +1044,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         source: Type<'db>,
         target: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        self.check_type_pair_impl(db, source, target, false)
+        self.check_type_pair_impl(db, source, target, ProtocolClassAccess::Skip)
     }
 
     fn check_type_pair_impl(
@@ -1051,7 +1052,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         db: &'db dyn Db,
         source: Type<'db>,
         target: Type<'db>,
-        check_protocol_class_access: bool,
+        protocol_class_access: ProtocolClassAccess,
     ) -> ConstraintSet<'db, 'c> {
         if let Some(source) = source.materialized_divergent_fallback() {
             return self.check_type_pair(db, source, target);
@@ -1931,7 +1932,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         db,
                         source,
                         target_proto,
-                        check_protocol_class_access,
+                        protocol_class_access,
                     )
                 })
             }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1034,6 +1034,25 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         source: Type<'db>,
         target: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        self.check_type_pair_impl(db, source, target, true)
+    }
+
+    pub(super) fn check_type_pair_without_protocol_class_access(
+        &self,
+        db: &'db dyn Db,
+        source: Type<'db>,
+        target: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        self.check_type_pair_impl(db, source, target, false)
+    }
+
+    fn check_type_pair_impl(
+        &self,
+        db: &'db dyn Db,
+        source: Type<'db>,
+        target: Type<'db>,
+        check_protocol_class_access: bool,
+    ) -> ConstraintSet<'db, 'c> {
         if let Some(source) = source.materialized_divergent_fallback() {
             return self.check_type_pair(db, source, target);
         }
@@ -1908,7 +1927,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             (_, Type::ProtocolInstance(target_proto)) => {
                 self.with_recursion_guard(source, target, || {
-                    self.check_type_satisfies_protocol(db, source, target_proto)
+                    self.check_type_satisfies_protocol(
+                        db,
+                        source,
+                        target_proto,
+                        check_protocol_class_access,
+                    )
                 })
             }
 


### PR DESCRIPTION
## Summary

Follow up on [review feedback for `type[Protocol]`](https://github.com/astral-sh/ruff/pull/26649#discussion_r3576370805) to avoid checking the same protocol members twice when relating a class object to `type[P]`.

We first check that the class constructs an instance satisfying `P`, then check the class object against the protocol's class-side requirements. The instance check normally also performs class-side reads, writes, and method-presence checks, all of which the subsequent meta-protocol check repeats (with the stricter unbound-signature check for methods). This is unnecessary work for protocol-heavy projects such as DateType.

This skips the redundant class-side work only for the top-level constructed-instance relation. Recursive and nested protocol comparisons continue through the normal path, while the meta-protocol pass remains authoritative for `ClassVar`s and methods.

The existing `ty_python_semantic` suite, including the meta-protocol mdtests, passes unchanged.