### PR TITLE
[ruff/ty] [playground] Prevent playground save popup

### DIFF
--- a/playground/ruff/src/Editor/Chrome.tsx
+++ b/playground/ruff/src/Editor/Chrome.tsx
@@ -117,6 +117,20 @@ export default function Chrome() {
     return { pythonSource, settingsSource: settings };
   }, [settings, pythonSource]);
 
+  const handleKeyPress = (event: KeyboardEvent) => {
+    // Swallow command-s or ctrl-s to prevent browser save.
+    if (event.key === "s" && (event.ctrlKey || event.metaKey)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyPress);
+
+    return () => window.removeEventListener("keydown", handleKeyPress);
+  }, []);
+
   return (
     <main className="flex flex-col h-full bg-white dark:bg-ayu-background-dark">
       <Header

--- a/playground/ruff/src/Editor/Chrome.tsx
+++ b/playground/ruff/src/Editor/Chrome.tsx
@@ -1,5 +1,5 @@
 import ruffSchema from "../../../../ruff.schema.json";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState, useEffect } from "react";
 import { Header, useTheme, setupMonaco, downloadZip } from "shared";
 import {
   copyAsMarkdown,

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -241,6 +241,20 @@ export default function Playground() {
     restoreWorkspace(session, DEFAULT_WORKSPACE, dispatchFiles, setError);
   }, [session, files]);
 
+  const handleKeyPress = (event: KeyboardEvent) => {
+    // Swallow command-s or ctrl-s to prevent browser save.
+    if (event.key === "s" && (event.ctrlKey || event.metaKey)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyPress);
+
+    return () => window.removeEventListener("keydown", handleKeyPress);
+  }, []);
+
   return (
     <main className="flex flex-col h-full bg-white dark:bg-ayu-background-dark">
       <Header


### PR DESCRIPTION
## Summary

Inspired by/code stolen from https://github.com/erictraut/pyright-playground/commit/71bf884d082d200ea98eff536160fb091d93713d

In most browsers, if you press `ctrl+s`/`cmd+s` it opens a "save this page" popup dialog. This is very annoying if like me, you have muscle memory to save every time you finish typing. This change adds code to stop the browser from doing that in the playground.

## Test Plan

WARNING: Not tested locally as I can't build ruff/ty

Hopefully this just works/CI is fine with this, if not help would be appreciated.