### PR TITLE
[ty] Resolve PEP 695 aliases in type[...] annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -23,6 +23,51 @@ def f() -> None:
     reveal_type(x)  # revealed: int | str
 ```
 
+## Type aliases in `type[...]`
+
+```py
+from typing import Type, TypeAliasType, assert_never
+
+class A: ...
+class B: ...
+
+type IntAlias = int
+type ChainedIntAlias = IntAlias
+type UnionAlias = A | B
+type NestedUnionAlias = IntAlias | str
+type GenericAlias[T] = T
+ManualIntAlias = TypeAliasType("ManualIntAlias", int)
+
+def _(
+    simple: type[IntAlias],
+    chained: type[ChainedIntAlias],
+    union: type[UnionAlias],
+    nested_union: type[NestedUnionAlias],
+    direct_union: type[IntAlias | str],
+    generic: type[GenericAlias[int]],
+    manual: type[ManualIntAlias],
+    typing_type: Type[IntAlias],
+):
+    reveal_type(simple)  # revealed: type[int]
+    reveal_type(chained)  # revealed: type[int]
+    reveal_type(union)  # revealed: type[A | B]
+    reveal_type(nested_union)  # revealed: type[int | str]
+    reveal_type(direct_union)  # revealed: type[int | str]
+    reveal_type(generic)  # revealed: type[int]
+    reveal_type(manual)  # revealed: type[int]
+    reveal_type(typing_type)  # revealed: type[int]
+
+# error: [invalid-assignment]
+bad: type[IntAlias] = str
+
+def exhaust_union(value: type[UnionAlias]) -> str:
+    if issubclass(value, A):
+        return "A"
+    if issubclass(value, B):
+        return "B"
+    assert_never(value)
+```
+
 ## `__value__` attribute
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1224,14 +1224,25 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             SubclassOfType::subclass_of_unknown()
         };
 
-        let infer_type_argument = |builder: &mut Self, slice: &ast::Expr| {
-            let slice_ty = builder.infer_type_expression(slice);
+        let subclass_of_type_argument = |builder: &Self, slice: &ast::Expr, slice_ty: Type<'db>| {
+            let slice_ty = slice_ty.resolve_type_alias(builder.db());
+            let slice_ty = match slice_ty {
+                Type::Union(union) if union.has_aliases(builder.db()) => {
+                    union.expand_aliases(builder.db())
+                }
+                _ => slice_ty,
+            };
             SubclassOfType::try_from_instance(builder.db(), slice_ty).unwrap_or_else(|| {
                 match slice_ty {
                     Type::Callable(_) => invalid_type_argument(builder, slice),
                     _ => todo_type!("unsupported type[X] special form"),
                 }
             })
+        };
+
+        let infer_type_argument = |builder: &mut Self, slice: &ast::Expr| {
+            let slice_ty = builder.infer_type_expression(slice);
+            subclass_of_type_argument(builder, slice, slice_ty)
         };
 
         match slice {
@@ -1326,6 +1337,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             special_form,
                         );
                         invalid_type_argument(self, slice)
+                    }
+                    value_ty @ Type::KnownInstance(KnownInstanceType::TypeAliasType(
+                        TypeAliasType::PEP695(_),
+                    )) => {
+                        let slice_ty = self.infer_subscript_type_expression(subscript, value_ty);
+                        subclass_of_type_argument(self, slice, slice_ty)
                     }
                     _ => {
                         self.infer_expression(parameters, TypeContext::default());


### PR DESCRIPTION
## Summary

Resolve PEP 695 type aliases, including aliases preserved inside unions, before converting `type[...]` arguments to subclass types.

Previously, a lazy `Type::TypeAlias` reached subclass conversion unchanged and fell back to `@Todo`, which also suppressed valid assignment and exhaustiveness diagnostics.

Closes astral-sh/ty#3996.

## Test Plan

Added mdtests.
