### PR TITLE
[pycodestyle] Use the indent-width setting in E111 and E114

### DIFF
--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -1177,17 +1177,6 @@ pub(super) fn warn_incompatible_formatter_settings(resolver: &Resolver) {
             );
         }
 
-        // Validate all rules that rely on custom indent widths.
-        if setting.linter.rules.any_enabled(&[
-            Rule::IndentationWithInvalidMultiple,
-            Rule::IndentationWithInvalidMultipleComment,
-        ]) && setting.formatter.indent_width.value() != 4
-        {
-            warn_user_once!(
-                "The `format.indent-width` option with a value other than 4 is incompatible with `E111` and `E114`. We recommend disabling these rules when using the formatter, which enforces a consistent indentation width. Alternatively, set the `format.indent-width` option to `4`."
-            );
-        }
-
         // Validate all rules that rely on quote styles.
         if setting
             .linter

--- a/crates/ruff_linter/resources/test/fixtures/pycodestyle/E11_indent_width.py
+++ b/crates/ruff_linter/resources/test/fixtures/pycodestyle/E11_indent_width.py
@@ -1,0 +1,13 @@
+#: E111 with indent-width=4 or 8, ok with indent-width=2
+if x > 2:
+  print(x)
+#: E111 with any indent-width (3 is not a multiple of 2, 4, or 8)
+if x > 2:
+   print(x)
+#: E111 and E114 with indent-width=4 or 8, ok with indent-width=2
+if True:
+  # comment
+  print(x)
+#: E111 with indent-width=8, ok with indent-width=2 or 4
+if x > 2:
+    print(x)

--- a/crates/ruff_linter/src/checkers/logical_lines.rs
+++ b/crates/ruff_linter/src/checkers/logical_lines.rs
@@ -167,7 +167,7 @@ pub(crate) fn check_logical_lines(
 
         let indent_level = expand_indent(locator.slice(range), settings.tab_size);
 
-        let indent_size = 4;
+        let indent_width = settings.tab_size.as_usize();
 
         if enforce_indentation {
             indentation(
@@ -176,7 +176,7 @@ pub(crate) fn check_logical_lines(
                 indent_char,
                 indent_level,
                 prev_indent_level,
-                indent_size,
+                indent_width,
                 range,
                 context,
             );

--- a/crates/ruff_linter/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/mod.rs
@@ -485,4 +485,23 @@ mod tests {
         assert_diagnostics!(snapshot, diagnostics);
         Ok(())
     }
+
+    #[test_case(2)]
+    #[test_case(4)]
+    #[test_case(8)]
+    fn indent_width(indent_width: u8) -> Result<()> {
+        let snapshot = format!("indent_width_{indent_width}");
+        let diagnostics = test_path(
+            Path::new("pycodestyle/E11_indent_width.py"),
+            &settings::LinterSettings {
+                tab_size: NonZeroU8::new(indent_width).unwrap().into(),
+                ..settings::LinterSettings::for_rules([
+                    Rule::IndentationWithInvalidMultiple,
+                    Rule::IndentationWithInvalidMultipleComment,
+                ])
+            },
+        )?;
+        assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
 }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -8,7 +8,8 @@ use crate::checkers::ast::LintContext;
 use super::LogicalLine;
 
 /// ## What it does
-/// Checks for indentation with a non-multiple of 4 spaces.
+/// Checks for indentation with a non-multiple of the [`indent-width`] setting
+/// (4 by default).
 ///
 /// ## Why is this bad?
 /// According to [PEP 8], 4 spaces per indentation level should be preferred.
@@ -28,9 +29,6 @@ use super::LogicalLine;
 /// ## Formatter compatibility
 /// We recommend against using this rule alongside the [formatter]. The
 /// formatter enforces consistent indentation, making the rule redundant.
-///
-/// The rule is also incompatible with the [formatter] when using
-/// `indent-width` with a value other than `4`.
 ///
 /// ## Options
 /// - `indent-width`
@@ -52,7 +50,8 @@ impl Violation for IndentationWithInvalidMultiple {
 }
 
 /// ## What it does
-/// Checks for indentation of comments with a non-multiple of 4 spaces.
+/// Checks for indentation of comments with a non-multiple of the
+/// [`indent-width`] setting (4 by default).
 ///
 /// ## Why is this bad?
 /// According to [PEP 8], 4 spaces per indentation level should be preferred.
@@ -74,9 +73,6 @@ impl Violation for IndentationWithInvalidMultiple {
 /// ## Formatter compatibility
 /// We recommend against using this rule alongside the [formatter]. The
 /// formatter enforces consistent indentation, making the rule redundant.
-///
-/// The rule is also incompatible with the [formatter] when using
-/// `indent-width` with a value other than `4`.
 ///
 /// ## Options
 /// - `indent-width`
@@ -272,23 +268,19 @@ pub(crate) fn indentation(
     indent_char: char,
     indent_level: usize,
     prev_indent_level: Option<usize>,
-    indent_size: usize,
+    indent_width: usize,
     range: TextRange,
     context: &LintContext,
 ) {
-    if !indent_level.is_multiple_of(indent_size) {
+    if !indent_level.is_multiple_of(indent_width) {
         if logical_line.is_comment_only() {
             context.report_diagnostic_if_enabled(
-                IndentationWithInvalidMultipleComment {
-                    indent_width: indent_size,
-                },
+                IndentationWithInvalidMultipleComment { indent_width },
                 range,
             );
         } else {
             context.report_diagnostic_if_enabled(
-                IndentationWithInvalidMultiple {
-                    indent_width: indent_size,
-                },
+                IndentationWithInvalidMultiple { indent_width },
                 range,
             );
         }

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__indent_width_2.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__indent_width_2.snap
@@ -1,0 +1,13 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+E111 Indentation is not a multiple of 2
+ --> E11_indent_width.py:6:1
+  |
+4 | #: E111 with any indent-width (3 is not a multiple of 2, 4, or 8)
+5 | if x > 2:
+6 |    print(x)
+  | ^^^
+7 | #: E111 and E114 with indent-width=4 or 8, ok with indent-width=2
+8 | if True:
+  |

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__indent_width_4.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__indent_width_4.snap
@@ -1,0 +1,46 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+E111 Indentation is not a multiple of 4
+ --> E11_indent_width.py:3:1
+  |
+1 | #: E111 with indent-width=4 or 8, ok with indent-width=2
+2 | if x > 2:
+3 |   print(x)
+  | ^^
+4 | #: E111 with any indent-width (3 is not a multiple of 2, 4, or 8)
+5 | if x > 2:
+  |
+
+E111 Indentation is not a multiple of 4
+ --> E11_indent_width.py:6:1
+  |
+4 | #: E111 with any indent-width (3 is not a multiple of 2, 4, or 8)
+5 | if x > 2:
+6 |    print(x)
+  | ^^^
+7 | #: E111 and E114 with indent-width=4 or 8, ok with indent-width=2
+8 | if True:
+  |
+
+E114 Indentation is not a multiple of 4 (comment)
+  --> E11_indent_width.py:9:1
+   |
+ 7 | #: E111 and E114 with indent-width=4 or 8, ok with indent-width=2
+ 8 | if True:
+ 9 |   # comment
+   | ^^
+10 |   print(x)
+11 | #: E111 with indent-width=8, ok with indent-width=2 or 4
+   |
+
+E111 Indentation is not a multiple of 4
+  --> E11_indent_width.py:10:1
+   |
+ 8 | if True:
+ 9 |   # comment
+10 |   print(x)
+   | ^^
+11 | #: E111 with indent-width=8, ok with indent-width=2 or 4
+12 | if x > 2:
+   |

--- a/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__indent_width_8.snap
+++ b/crates/ruff_linter/src/rules/pycodestyle/snapshots/ruff_linter__rules__pycodestyle__tests__indent_width_8.snap
@@ -1,0 +1,55 @@
+---
+source: crates/ruff_linter/src/rules/pycodestyle/mod.rs
+---
+E111 Indentation is not a multiple of 8
+ --> E11_indent_width.py:3:1
+  |
+1 | #: E111 with indent-width=4 or 8, ok with indent-width=2
+2 | if x > 2:
+3 |   print(x)
+  | ^^
+4 | #: E111 with any indent-width (3 is not a multiple of 2, 4, or 8)
+5 | if x > 2:
+  |
+
+E111 Indentation is not a multiple of 8
+ --> E11_indent_width.py:6:1
+  |
+4 | #: E111 with any indent-width (3 is not a multiple of 2, 4, or 8)
+5 | if x > 2:
+6 |    print(x)
+  | ^^^
+7 | #: E111 and E114 with indent-width=4 or 8, ok with indent-width=2
+8 | if True:
+  |
+
+E114 Indentation is not a multiple of 8 (comment)
+  --> E11_indent_width.py:9:1
+   |
+ 7 | #: E111 and E114 with indent-width=4 or 8, ok with indent-width=2
+ 8 | if True:
+ 9 |   # comment
+   | ^^
+10 |   print(x)
+11 | #: E111 with indent-width=8, ok with indent-width=2 or 4
+   |
+
+E111 Indentation is not a multiple of 8
+  --> E11_indent_width.py:10:1
+   |
+ 8 | if True:
+ 9 |   # comment
+10 |   print(x)
+   | ^^
+11 | #: E111 with indent-width=8, ok with indent-width=2 or 4
+12 | if x > 2:
+   |
+
+E111 Indentation is not a multiple of 8
+  --> E11_indent_width.py:13:1
+   |
+11 | #: E111 with indent-width=8, ok with indent-width=2 or 4
+12 | if x > 2:
+13 |     print(x)
+   | ^^^^
+   |


### PR DESCRIPTION
##Summary
- Fixes #8705
- E111/E114 checked indentation against a hardcoded 4; now they use the indent-width setting
- Nobody on default config sees any change (the setting defaults to 4), and both rules are preview-only
- The CLI warning about indent-width ≠ 4 being incompatible with these rules is deleted and the linter and formatter read the same top-level setting, so they can't disagree anymore
- Renamed indent_size → indent_width internally

##Test Plan
- New fixture tested at indent-width 2, 4, and 8 with snapshots
- Full test suite passes; no existing snapshots changed
- Ran the built binary on a 2-space-indented file: flags by default, clean with indent-width = 2