### PR TITLE
Update Rust toolchain to 1.97 and MSRV to 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 # Please update rustfmt.toml when bumping the Rust edition
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 homepage = "https://docs.astral.sh/ruff"
 documentation = "https://docs.astral.sh/ruff"
 repository = "https://github.com/astral-sh/ruff"

--- a/crates/ruff/src/commands/config.rs
+++ b/crates/ruff/src/commands/config.rs
@@ -16,7 +16,7 @@ pub(crate) fn config(key: Option<&str>, format: HelpFormat) -> Result<()> {
                 }
 
                 HelpFormat::Json => {
-                    println!("{}", &serde_json::to_string_pretty(&metadata)?);
+                    println!("{}", serde_json::to_string_pretty(&metadata)?);
                 }
             }
         }
@@ -30,7 +30,7 @@ pub(crate) fn config(key: Option<&str>, format: HelpFormat) -> Result<()> {
                 }
 
                 HelpFormat::Json => {
-                    println!("{}", &serde_json::to_string_pretty(&entry)?);
+                    println!("{}", serde_json::to_string_pretty(&entry)?);
                 }
             },
         },

--- a/crates/ruff/src/commands/version.rs
+++ b/crates/ruff/src/commands/version.rs
@@ -11,7 +11,7 @@ pub(crate) fn version(output_format: HelpFormat) -> Result<()> {
 
     match output_format {
         HelpFormat::Text => {
-            writeln!(stdout, "ruff {}", &version_info)?;
+            writeln!(stdout, "ruff {version_info}")?;
         }
         HelpFormat::Json => {
             serde_json::to_writer_pretty(stdout, &version_info)?;

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -413,32 +413,27 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
         let mut pyproject_config = pyproject_config;
 
         loop {
-            match rx.recv() {
-                Ok(event) => {
-                    let Some(change_kind) = change_detected(&event?) else {
-                        continue;
-                    };
+            let Some(change_kind) = change_detected(&rx.recv()??) else {
+                continue;
+            };
 
-                    if matches!(change_kind, ChangeKind::Configuration) {
-                        pyproject_config =
-                            resolve::resolve(&config_arguments, cli.stdin_filename.as_deref())?;
-                    }
-                    Printer::clear_screen()?;
-                    printer.write_to_user("File change detected...\n");
-
-                    let diagnostics = commands::check::check(
-                        &files,
-                        &pyproject_config,
-                        &config_arguments,
-                        cache.into(),
-                        noqa.into(),
-                        fix_mode,
-                        unsafe_fixes,
-                    )?;
-                    printer.write_continuously(&mut writer, &diagnostics, preview)?;
-                }
-                Err(err) => return Err(err.into()),
+            if matches!(change_kind, ChangeKind::Configuration) {
+                pyproject_config =
+                    resolve::resolve(&config_arguments, cli.stdin_filename.as_deref())?;
             }
+            Printer::clear_screen()?;
+            printer.write_to_user("File change detected...\n");
+
+            let diagnostics = commands::check::check(
+                &files,
+                &pyproject_config,
+                &config_arguments,
+                cache.into(),
+                noqa.into(),
+                fix_mode,
+                unsafe_fixes,
+            )?;
+            printer.write_continuously(&mut writer, &diagnostics, preview)?;
         }
     } else {
         // Generate lint violations.

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1818,7 +1818,7 @@ fn check_input_from_argfile() -> Result<()> {
     )?;
 
     // Generate the args with the argfile notation
-    let argfile = format!("@{}", &input_file_path.display());
+    let argfile = format!("@{}", input_file_path.display());
     let mut cmd = RuffCheck::default().filename(argfile.as_ref()).build();
     insta::with_settings!({filters => vec![
         (file_a_path.display().to_string().as_str(), "/path/to/a.py"),

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -399,19 +399,17 @@ impl<'a> Dependency<'a> {
                         .map(|name| name.id.as_str())
                 })
                 .collect()
-        } else if let Some(method_def) = class_def
-            .body
-            .iter()
-            .filter_map(|stmt| stmt.as_function_def_stmt())
-            .find(|func_def| func_def.name.as_str() == method_name)
-        {
+        } else {
+            let method_def = class_def
+                .body
+                .iter()
+                .filter_map(|stmt| stmt.as_function_def_stmt())
+                .find(|func_def| func_def.name.as_str() == method_name)?;
             // Skip `self` parameter
             non_posonly_non_variadic_parameters(method_def)
                 .skip(1)
                 .map(|param| param.name().as_str())
                 .collect()
-        } else {
-            return None;
         };
 
         Some(Self::Class(parameter_names))

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/custom_type_var_for_self.rs
@@ -101,14 +101,14 @@ impl Violation for CustomTypeVarForSelf {
     fn message(&self) -> String {
         format!(
             "Use `Self` instead of custom TypeVar `{}`",
-            &self.typevar_name
+            self.typevar_name
         )
     }
 
     fn fix_title(&self) -> Option<String> {
         Some(format!(
             "Replace TypeVar `{}` with `Self`",
-            &self.typevar_name
+            self.typevar_name
         ))
     }
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -294,11 +294,11 @@ fn fix_always_false_branch(
                 range,
                 ..
             }) => {
-                debug_assert!(
+                debug_assert_eq!(
                     checker
                         .locator()
-                        .slice(TextRange::at(range.start(), "elif".text_len()))
-                        == "elif"
+                        .slice(TextRange::at(range.start(), "elif".text_len())),
+                    "elif"
                 );
                 let end_location = range.start() + ("elif".text_len() - "if".text_len());
                 Some(Fix::unsafe_edit(Edit::deletion(

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -133,7 +133,7 @@ fn replace_with_bytes_literal(locator: &Locator, call: &ast::ExprCall, tokens: &
                 let _ = write!(
                     &mut replacement,
                     "b{}",
-                    &string.trim_start_matches('u').trim_start_matches('U')
+                    string.trim_start_matches('u').trim_start_matches('U')
                 );
             }
             _ => {

--- a/crates/ruff_linter/src/rules/ruff/rules/sort_dunder_slots.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/sort_dunder_slots.rs
@@ -240,13 +240,9 @@ impl<'a> StringLiteralDisplay<'a> {
             ast::Expr::Dict(dict) => {
                 let mut narrowed_keys = Vec::with_capacity(dict.len());
                 for key in dict.iter_keys() {
-                    if let Some(key) = key {
-                        // This is somewhat unfortunate,
-                        // *but* using a dict for __slots__ is very rare
-                        narrowed_keys.push(key.to_owned());
-                    } else {
-                        return None;
-                    }
+                    // This is somewhat unfortunate,
+                    // *but* using a dict for __slots__ is very rare
+                    narrowed_keys.push(key?.to_owned());
                 }
                 // If `None` was present in the keys, it indicates a "** splat", .e.g
                 // `__slots__ = {"foo": "bar", **other_dict}`

--- a/crates/ruff_linter/src/source_kind.rs
+++ b/crates/ruff_linter/src/source_kind.rs
@@ -235,8 +235,8 @@ impl std::fmt::Display for SourceKindDiff<'_> {
                         || (format!("cell {idx}"), format!("cell {idx}")),
                         |path| {
                             (
-                                format!("{}:cell {}", &fs::relativize_path(path), idx),
-                                format!("{}:cell {}", &fs::relativize_path(path), idx),
+                                format!("{}:cell {}", fs::relativize_path(path), idx),
+                                format!("{}:cell {}", fs::relativize_path(path), idx),
                             )
                         },
                     );

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -310,18 +310,10 @@ where
                 range: _,
                 node_index: _,
             })
-            | Expr::List(ast::ExprList {
-                elts,
-                range: _,
-                node_index: _,
-                ..
-            })
-            | Expr::Tuple(ast::ExprTuple {
-                elts,
-                range: _,
-                node_index: _,
-                ..
-            }) => elts.iter().any(|expr| any_over_expr(expr, &mut *func)),
+            | Expr::List(ast::ExprList { elts, .. })
+            | Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                elts.iter().any(|expr| any_over_expr(expr, &mut *func))
+            }
             Expr::ListComp(ast::ExprListComp {
                 elt,
                 generators,
@@ -380,18 +372,8 @@ where
                 range: _,
                 node_index: _,
             })
-            | Expr::Attribute(ast::ExprAttribute {
-                value,
-                range: _,
-                node_index: _,
-                ..
-            })
-            | Expr::Starred(ast::ExprStarred {
-                value,
-                range: _,
-                node_index: _,
-                ..
-            }) => any_over_expr(value, func),
+            | Expr::Attribute(ast::ExprAttribute { value, .. })
+            | Expr::Starred(ast::ExprStarred { value, .. }) => any_over_expr(value, func),
             Expr::Yield(ast::ExprYield {
                 value,
                 range: _,

--- a/crates/ruff_python_formatter/src/range.rs
+++ b/crates/ruff_python_formatter/src/range.rs
@@ -541,32 +541,26 @@ impl NarrowRange<'_> {
             // The challenge here is that the second line of the multiline string uses a 4 space indentation. Using `dedent` would
             // dedent the second line to 0 spaces and the `indent` then adds a 2 space indentation to match the indentation in the source.
             // This is incorrect because the leading whitespace is the content of the string and not indentation, resulting in changed string content.
-            if let Some(indentation) =
-                indentation_at_offset(first_child.start(), self.context.source())
-            {
-                let relative_indent = indentation.strip_prefix(self.enclosing_indent).unwrap();
-                let expected_indents = self.level;
+            // Missing indentation indicates a simple-statement body of a compound statement (not a suite body).
+            // Don't narrow the range because the formatter must run `FormatClauseBody` to determine if the body should be collapsed or not.
+            let indentation = indentation_at_offset(first_child.start(), self.context.source())?;
+            let relative_indent = indentation.strip_prefix(self.enclosing_indent).unwrap();
+            let expected_indents = self.level;
 
-                // Each level must always add one level of indent. That's why an empty relative indent to the parent node tells us that the enclosing node is the Module.
-                let has_expected_indentation = match self.context.options().indent_style() {
-                    IndentStyle::Tab => {
-                        relative_indent.len() == expected_indents
-                            && relative_indent.chars().all(|c| c == '\t')
-                    }
-                    IndentStyle::Space => {
-                        relative_indent.len()
-                            == expected_indents
-                                * self.context.options().indent_width().value() as usize
-                            && relative_indent.chars().all(|c| c == ' ')
-                    }
-                };
-
-                if !has_expected_indentation {
-                    return None;
+            // Each level must always add one level of indent. That's why an empty relative indent to the parent node tells us that the enclosing node is the Module.
+            let has_expected_indentation = match self.context.options().indent_style() {
+                IndentStyle::Tab => {
+                    relative_indent.len() == expected_indents
+                        && relative_indent.chars().all(|c| c == '\t')
                 }
-            } else {
-                // Simple-statement body of a compound statement (not a suite body).
-                // Don't narrow the range because the formatter must run `FormatClauseBody` to determine if the body should be collapsed or not.
+                IndentStyle::Space => {
+                    relative_indent.len()
+                        == expected_indents * self.context.options().indent_width().value() as usize
+                        && relative_indent.chars().all(|c| c == ' ')
+                }
+            };
+
+            if !has_expected_indentation {
                 return None;
             }
         }

--- a/crates/ruff_python_formatter/tests/fixtures.rs
+++ b/crates/ruff_python_formatter/tests/fixtures.rs
@@ -425,7 +425,7 @@ Formatted once:
 Formatted twice:
 ---
 {reformatted}---"#,
-            options = &DisplayPyOptions(options),
+            options = DisplayPyOptions(options),
             reformatted = reformatted.as_code(),
         );
     }

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -30,7 +30,7 @@ impl std::error::Error for ParseError {
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{} at byte range {:?}", &self.error, self.location)
+        write!(f, "{} at byte range {:?}", self.error, self.location)
     }
 }
 

--- a/crates/ruff_python_semantic/src/cfg/visualize.rs
+++ b/crates/ruff_python_semantic/src/cfg/visualize.rs
@@ -24,7 +24,7 @@ trait MermaidGraph<'a>: DirectedGraph<'a> {
         let num_nodes = self.num_nodes();
         for idx in 0..num_nodes {
             let node = Self::Node::new(idx);
-            graph.push(format!("\tnode{}{}", idx, &self.draw_node(node)));
+            graph.push(format!("\tnode{}{}", idx, self.draw_node(node)));
         }
 
         // Draw edges

--- a/crates/ruff_server/tests/e2e/main.rs
+++ b/crates/ruff_server/tests/e2e/main.rs
@@ -521,7 +521,7 @@ impl TestServer {
             {
                 panic!(
                     "Received multiple publish diagnostic notifications for {uri}: ({existing:#?})",
-                    uri = &notification.uri
+                    uri = notification.uri
                 );
             }
         }

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -78,7 +78,7 @@ pub(crate) fn version(output_format: HelpFormat) -> Result<()> {
 
     match output_format {
         HelpFormat::Text => {
-            writeln!(stdout, "ty {}", &version_info)?;
+            writeln!(stdout, "ty {version_info}")?;
         }
         HelpFormat::Json => {
             serde_json::to_writer_pretty(&mut stdout, &version_info)?;

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -2511,7 +2511,7 @@ mod tests {
             Some(foo_real),
             path_to_module(&db, &FilePath::from(src.join("foo.py")))
         );
-        assert!(foo_real != foo);
+        assert_ne!(foo_real, foo);
     }
 
     #[test]

--- a/crates/ty_project/src/glob.rs
+++ b/crates/ty_project/src/glob.rs
@@ -108,7 +108,7 @@ impl Default for IncludeExcludeFilter {
 
 impl std::fmt::Display for IncludeExcludeFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "include={}, exclude={}", &self.include, &self.exclude)
+        write!(f, "include={}, exclude={}", self.include, self.exclude)
     }
 }
 

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -192,7 +192,7 @@ fn check_invalid_suppression(context: &mut CheckSuppressionsContext) {
             diag.into_diagnostic(format_args!(
                 "Invalid `{kind}` comment: {reason}",
                 kind = invalid.kind,
-                reason = &invalid.error
+                reason = invalid.error
             ));
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1745,7 +1745,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             {
                 builder.into_diagnostic(format_args!(
                     "Cyclic definition of `{}`",
-                    &type_alias.name.as_name_expr().unwrap().id,
+                    type_alias.name.as_name_expr().unwrap().id,
                 ));
             }
             // Replace with `Divergent`.
@@ -4262,7 +4262,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     {
                         let mut diag = builder.into_diagnostic(format_args!(
                             "Type annotation on enum member `{}` is not allowed",
-                            &name_expr.id
+                            name_expr.id
                         ));
                         diag.info(
                             "See: https://typing.python.org/en/latest/spec/enums.html#enum-members",

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -490,7 +490,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 };
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Useless body for `@overload`-decorated function `{}`",
-                    &function.name
+                    function.name
                 ));
                 diagnostic.set_primary_message("This statement will never be executed");
                 diagnostic.info(

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -111,7 +111,7 @@ pub(crate) fn check_overloaded_function<'db>(
         if let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name) {
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Overloaded function `{}` requires at least two overloads",
-                &function_node.name
+                function_node.name
             ));
             diagnostic.set_primary_message("Only one overload defined here");
             if let Some(decorator) =
@@ -158,11 +158,11 @@ pub(crate) fn check_overloaded_function<'db>(
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Overloads for function `{}` must be followed by a \
                     non-`@overload`-decorated implementation function",
-                    &function_node.name
+                    function_node.name
                 ));
                 diagnostic.info(format_args!(
                     "Attempting to call `{}` will raise `TypeError` at runtime",
-                    &function_node.name
+                    function_node.name
                 ));
                 diagnostic.info("Overloaded functions without implementations are only permitted:");
                 diagnostic.info(" - in stub files");
@@ -183,7 +183,7 @@ pub(crate) fn check_overloaded_function<'db>(
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Overloaded function `{}` does not use the `@{}` decorator \
                     consistently",
-                &function_node.name, inconsistency.decorator_name
+                function_node.name, inconsistency.decorator_name
             ));
             for function in inconsistency.missing {
                 diagnostic.annotate(

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/type_param_validation.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/type_param_validation.rs
@@ -48,7 +48,7 @@ pub(crate) fn check_no_default_after_typevar_tuple_pep695(
 
         diagnostic.set_concise_message(format_args!(
             "Type parameter `{single_name}` with a default follows TypeVarTuple `{}`",
-            &typevar_tuple.name
+            typevar_tuple.name
         ));
 
         diagnostic.set_primary_message(format_args!("`{single_name}` has a default"));
@@ -57,7 +57,7 @@ pub(crate) fn check_no_default_after_typevar_tuple_pep695(
 
         diagnostic.set_concise_message(format_args!(
             "Type parameters {names} with defaults follow TypeVarTuple `{}`",
-            &typevar_tuple.name
+            typevar_tuple.name
         ));
 
         diagnostic.set_primary_message(format_args!(
@@ -77,7 +77,7 @@ pub(crate) fn check_no_default_after_typevar_tuple_pep695(
     diagnostic.annotate(
         context
             .secondary(typevar_tuple)
-            .message(format_args!("`{}` is a TypeVarTuple", &typevar_tuple.name)),
+            .message(format_args!("`{}` is a TypeVarTuple", typevar_tuple.name)),
     );
 
     diagnostic.info("See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple");

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3983,11 +3983,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
                 if let Some(ref mut first) = first {
                     for rest_constraint in rest {
-                        if let Some(rest_constraint) = rest_constraint {
-                            merge_constraints_or(first, rest_constraint);
-                        } else {
-                            return None;
-                        }
+                        merge_constraints_or(first, rest_constraint?);
                     }
                 }
                 first

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -186,7 +186,7 @@ fn check_class_declaration<'db>(
             {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Cannot overwrite NamedTuple attribute `{}`",
-                    &member.name
+                    member.name
                 ));
                 diagnostic.info("This will cause the class creation to fail at runtime");
             }
@@ -300,7 +300,7 @@ fn check_class_declaration<'db>(
                         ) {
                             let mut diagnostic = builder.into_diagnostic(format_args!(
                                 "Enum member `{}` value is not assignable to expected type",
-                                &member.name
+                                member.name
                             ));
                             diagnostic.info(format_args!(
                                 "Expected `{}`, got `{}`",
@@ -1091,7 +1091,7 @@ fn check_explicit_overrides<'db>(
     }
     diagnostic.info(format_args!(
         "No `{member}` definitions were found on any superclasses of `{class}`",
-        member = &member.name,
+        member = member.name,
         class = class.name(db)
     ));
 }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -866,10 +866,10 @@ impl<'db> ProtocolMemberData<'db> {
                     ProtocolMemberKind::Property { read, write } => {
                         let mut d = f.debug_struct("PropertyMember");
                         if let Some(read) = read.and_then(|read| read.resolve(self.db)) {
-                            d.field("read", &format_args!("`{}`", &read.ty().display(self.db)));
+                            d.field("read", &format_args!("`{}`", read.ty().display(self.db)));
                         }
                         if let Some(write) = write.and_then(|write| write.resolve(self.db)) {
-                            d.field("write", &format_args!("`{}`", &write.ty().display(self.db)));
+                            d.field("write", &format_args!("`{}`", write.ty().display(self.db)));
                         }
                         d.finish()
                     }

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -580,7 +580,7 @@ impl TestServer {
             {
                 panic!(
                     "Received multiple publish diagnostic notifications for {uri}: ({existing:#?})",
-                    uri = &notification.uri
+                    uri = notification.uri
                 );
             }
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.0"


### PR DESCRIPTION
## Summary

Updates our pinned Rust toolchain from 1.96.1 to 1.97.0, and raises our MSRV 1.94 to 1.95, following our N-2 policy.

All code changes are driven by Clippy.
