### PR TITLE
docs(SIM107): replace misleading "use instead" example

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -26,17 +26,18 @@ use crate::checkers::ast::Checker;
 ///         return -1  # Always returns -1.
 /// ```
 ///
-/// Use instead:
+/// Use instead (avoid `return` in `try`/`except`/`finally`; keep cleanup free of returns):
 /// ```python
 /// def squared(n):
 ///     try:
-///         return_value = n**2
+///         return n**2
 ///     except Exception:
-///         return_value = "An exception occurred"
-///     finally:
-///         return_value = -1
-///     return return_value
+///         return "An exception occurred"
 /// ```
+///
+/// Using a variable that is overwritten in `finally` and returned afterward can still be
+/// surprising (the `finally` assignment always runs), so prefer returning from `try`/`except`
+/// only and keep `finally` for true cleanup without returns or result overrides.
 ///
 /// ## References
 /// - [Python documentation: Defining Clean-up Actions](https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions)


### PR DESCRIPTION
## Summary
- Fix SIM107 rule docs so the “use instead” sample no longer overwrites the result in `finally` (always-returned `-1`).
- Clarify that `finally` should not return or replace the function result.

Closes #22325.

## Test plan
- [x] Doc-only change to rustdoc on `ReturnInTryExceptFinally` (feeds docs.astral.sh rule page)