### PR TITLE
[`pycodestyle`] Document `E731` fix safety

### DIFF
--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -34,6 +34,32 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 ///     return 2 * x
 /// ```
 ///
+/// ## Fix safety
+/// This fix is sometimes unsafe because converting a lambda assignment into a
+/// function definition changes observable properties of the callable.
+///
+/// In particular, a lambda function has the name `"<lambda>"`, while the
+/// generated function uses the name of the assigned variable. Code that relies
+/// on function metadata, such as logging, registration, or introspection, mayq
+/// therefore behave differently after the fix.
+///
+/// For example:
+/// ```python
+/// f = lambda value: value
+/// print(f.__name__)  # "<lambda>"
+/// ```
+///
+/// After applying the fix:
+/// ```python
+/// def f(value):
+///     return value
+///
+/// print(f.__name__)  # "f"
+/// ```
+///
+/// The callable returns the same value in this example, but the transformation
+/// does not preserve every observable property of the original function.
+///
 /// [PEP 8]: https://peps.python.org/pep-0008/#programming-recommendations
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.28")]

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -35,30 +35,13 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 /// ```
 ///
 /// ## Fix safety
-/// This fix is sometimes unsafe because converting a lambda assignment into a
+/// This fix is marked as unsafe because converting a lambda assignment into a
 /// function definition changes observable properties of the callable.
 ///
 /// In particular, a lambda function has the name `"<lambda>"`, while the
 /// generated function uses the name of the assigned variable. Code that relies
-/// on function metadata, such as logging, registration, or introspection, mayq
+/// on function metadata, such as logging, registration, or introspection, may
 /// therefore behave differently after the fix.
-///
-/// For example:
-/// ```python
-/// f = lambda value: value
-/// print(f.__name__)  # "<lambda>"
-/// ```
-///
-/// After applying the fix:
-/// ```python
-/// def f(value):
-///     return value
-///
-/// print(f.__name__)  # "f"
-/// ```
-///
-/// The callable returns the same value in this example, but the transformation
-/// does not preserve every observable property of the original function.
 ///
 /// [PEP 8]: https://peps.python.org/pep-0008/#programming-recommendations
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Adds a `Fix safety` section to the documentation for
`lambda-assignment` (`E731`).

The new section explains that converting a lambda assignment into a function
definition changes observable callable metadata. In particular, the function's
`__name__` changes from `"<lambda>"` to the assigned variable name, which can
affect code that relies on logging, registration, or introspection.

The E731 fix was changed from display-only to unsafe in #19700. Related
discussion: #19650.

Part of #15584.

## Test Plan

- `cargo fmt --all`
- `git diff --check`
- Manually verified the E731 unsafe fix and the resulting `__name__` change.