### PR TITLE
[ty] Project exact-length narrowing through TypeVars

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/len.md
@@ -129,6 +129,55 @@ def _(x: Literal[b"", b"a"], y: Literal["a", "ab"]):
         reveal_type(y)  # revealed: Literal["ab"]
 ```
 
+Exact length narrowing projects through type-variable constraints and bounds while preserving the
+type variable:
+
+```py
+from typing import TypeVar, assert_never
+
+ConstrainedTuple = TypeVar(
+    "ConstrainedTuple",
+    tuple[int, int],
+    tuple[int, int, str],
+)
+
+def constrained_tuple(value: ConstrainedTuple) -> ConstrainedTuple:
+    if len(value) == 2:
+        reveal_type(value)  # revealed: ConstrainedTuple@constrained_tuple & tuple[int, int]
+        return value
+    elif len(value) == 3:
+        reveal_type(value)  # revealed: ConstrainedTuple@constrained_tuple & tuple[int, int, str]
+        return value
+    else:
+        assert_never(value)
+
+BoundTuple = TypeVar(
+    "BoundTuple",
+    bound=tuple[int, int] | tuple[int, int, str],
+)
+
+def bounded_tuple(value: BoundTuple) -> BoundTuple:
+    if len(value) == 2:
+        reveal_type(value)  # revealed: BoundTuple@bounded_tuple & tuple[int, int]
+        return value
+    elif len(value) == 3:
+        reveal_type(value)  # revealed: BoundTuple@bounded_tuple & tuple[int, int, str]
+        return value
+    else:
+        assert_never(value)
+
+VariableTuple = TypeVar(
+    "VariableTuple",
+    tuple[int, ...],
+    tuple[str],
+)
+
+def variable_tuple(value: VariableTuple) -> VariableTuple:
+    if len(value) == 2:
+        reveal_type(value)  # revealed: VariableTuple@variable_tuple & tuple[int, int]
+    return value
+```
+
 Tuple subclasses are filtered using their tuple spec while preserving the subclass:
 
 ```py

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2785,6 +2785,33 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             Type::Intersection(intersection) => intersection.map_positive(db, |element| {
                 Self::narrow_type_by_exact_len(db, *element, length, is_equality)
             }),
+            Type::TypeVar(typevar) => {
+                let Some(bound_or_constraints) = typevar.typevar(db).bound_or_constraints(db)
+                else {
+                    return ty;
+                };
+
+                let upper_bound = bound_or_constraints.as_type(db);
+                let narrowed_upper_bound = match bound_or_constraints {
+                    TypeVarBoundOrConstraints::UpperBound(bound) => {
+                        Self::narrow_type_by_exact_len(db, bound, length, is_equality)
+                    }
+                    TypeVarBoundOrConstraints::Constraints(constraints) => {
+                        UnionType::from_elements(
+                            db,
+                            constraints.elements(db).iter().map(|constraint| {
+                                Self::narrow_type_by_exact_len(db, *constraint, length, is_equality)
+                            }),
+                        )
+                    }
+                };
+
+                if narrowed_upper_bound == upper_bound {
+                    resolved
+                } else {
+                    IntersectionType::from_two_elements(db, resolved, narrowed_upper_bound)
+                }
+            }
             _ => {
                 if is_equality && let Some(tuple) = resolved.exact_tuple_instance_spec(db) {
                     match tuple.resize(db, TupleLength::Fixed(length)) {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary
Support exact length narrowing also for typevars. Code like this was previously rejected.
```python
T = TypeVar("T", tuple[int, int], tuple[int, int, str])

def f(x: T) -> None:
    if len(x) == 2: ...
    elif len(x) == 3: ...
    else: assert_never(x) # `Never` and `T@f_typevar` are not equivalent types
```

## Test Plan
New mdtests