### PR TITLE
[ty] Use `let` guards more

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3931,8 +3931,10 @@ impl<'db> Type<'db> {
                 )
                 .into(),
 
-                Type::LiteralValue(literal) if literal.is_string() && name == "startswith" => {
-                    let string_literal = literal.as_string().unwrap();
+                Type::LiteralValue(literal)
+                    if name == "startswith"
+                        && let Some(string_literal) = literal.as_string() =>
+                {
                     Place::bound(Type::KnownBoundMethod(KnownBoundMethodType::StrStartswith(
                         string_literal,
                     )))
@@ -4114,9 +4116,9 @@ impl<'db> Type<'db> {
                 }
 
                 Type::LiteralValue(literal)
-                    if literal.is_bool() && matches!(name_str, "real" | "numerator") =>
+                    if matches!(name_str, "real" | "numerator")
+                        && let Some(bool_value) = literal.as_bool() =>
                 {
-                    let bool_value = literal.as_bool().unwrap();
                     Place::bound(Type::int_literal(i64::from(bool_value))).into()
                 }
 
@@ -4171,15 +4173,13 @@ impl<'db> Type<'db> {
 
                 Type::LiteralValue(literal)
                     if matches!(name_str, "name" | "_name_" | "value" | "_value_")
-                        && literal.as_enum().is_some_and(|enum_literal| {
-                            !enums::class_defines_property(
-                                db,
-                                enum_literal.enum_class(db),
-                                name_str,
-                            )
-                        }) =>
+                        && let Some(enum_literal) = literal.as_enum()
+                        && !enums::class_defines_property(
+                            db,
+                            enum_literal.enum_class(db),
+                            name_str,
+                        ) =>
                 {
-                    let enum_literal = literal.as_enum().unwrap();
                     let enum_class = enum_literal.enum_class_literal(db);
                     let is_enum_subclass = Type::ClassLiteral(enum_class.class_literal(db))
                         .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db));

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3003,10 +3003,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 | Type::GenericAlias(_)
                 | Type::SubclassOf(_)
                 | Type::Union(_)),
-            ) if matches!(formal_subclass.subclass_of(), SubclassOfInner::Protocol(_)) => {
-                let SubclassOfInner::Protocol(protocol) = formal_subclass.subclass_of() else {
-                    return Ok(());
-                };
+            ) if let SubclassOfInner::Protocol(protocol) = formal_subclass.subclass_of() => {
                 let formal_protocol = Type::ProtocolInstance(protocol);
                 if let Type::Union(union) = actual {
                     for element in union.elements(self.db) {
@@ -3028,12 +3025,15 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             (Type::SubclassOf(subclass_of), ty) | (ty, Type::SubclassOf(subclass_of))
-                if subclass_of.is_type_var() =>
+                if let Some(type_var) = subclass_of.into_type_var()
+                    && let Some(actual_instance) = ty.to_instance(self.db) =>
             {
-                let formal_instance = Type::TypeVar(subclass_of.into_type_var().unwrap());
-                if let Some(actual_instance) = ty.to_instance(self.db) {
-                    return self.infer_map_impl(formal_instance, actual_instance, polarity, seen);
-                }
+                return self.infer_map_impl(
+                    Type::TypeVar(type_var),
+                    actual_instance,
+                    polarity,
+                    seen,
+                );
             }
 
             (

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1107,8 +1107,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 })
         };
 
-        let bound_or_constraints;
-
         match (source, target) {
             // Everything is a subtype of `object`.
             (_, Type::NominalInstance(target)) if target.is_object() => self.always(),
@@ -1395,14 +1393,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // And vice versa. (No special metaclass handling is needed in this direction, since
             // "collapse to 'object'" in this case is a sound over-approximation.)
             (_, Type::SubclassOf(subclass_of))
-                if subclass_of.is_type_var() && source.to_instance(db).is_some() =>
+                if let Some(type_var) = subclass_of.into_type_var()
+                    && let Some(instance) = source.to_instance(db) =>
             {
-                subclass_of
-                    .into_type_var()
-                    .zip(source.to_instance(db))
-                    .when_some_and(db, self.constraints, |(target_i, source_i)| {
-                        self.check_type_pair(db, source_i, Type::TypeVar(target_i))
-                    })
+                self.check_type_pair(db, instance, Type::TypeVar(type_var))
             }
 
             // A gradual `ParamSpec` value (`...`) is assignability-consistent with any concrete
@@ -1433,23 +1427,21 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // the union of its constraints. An unbound, unconstrained, fully static typevar has an
             // implicit upper bound of `object` (which is handled above).
             (Type::TypeVar(bound_typevar), _)
-                if !bound_typevar.is_inferable(db, self.inferable) && {
-                    bound_or_constraints = bound_typevar.typevar(db).bound_or_constraints(db);
-                    bound_or_constraints.is_some()
-                } =>
+                if !bound_typevar.is_inferable(db, self.inferable)
+                    && let Some(bound_or_constraints) =
+                        bound_typevar.typevar(db).bound_or_constraints(db) =>
             {
                 match bound_or_constraints {
-                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                    TypeVarBoundOrConstraints::UpperBound(bound) => {
                         self.check_type_pair(db, bound, target)
                     }
-                    Some(TypeVarBoundOrConstraints::Constraints(typevar_constraints)) => {
+                    TypeVarBoundOrConstraints::Constraints(typevar_constraints) => {
                         typevar_constraints.elements(db).iter().when_all(
                             db,
                             self.constraints,
                             |constraint| self.check_type_pair(db, *constraint, target),
                         )
                     }
-                    None => unreachable!(),
                 }
             }
 
@@ -1458,7 +1450,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // disjoint, which means an lhs type might be a subtype of all of the constraints.
             (_, Type::TypeVar(bound_typevar))
                 if !bound_typevar.is_inferable(db, self.inferable)
-                    && !bound_typevar
+                    && let constraints = bound_typevar
                         .typevar(db)
                         .constraints(db)
                         .when_some_and(db, self.constraints, |constraints| {
@@ -1466,21 +1458,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                                 self.check_type_pair(db, source, *c)
                             })
                         })
-                        .is_never_satisfied(db) =>
+                    && !constraints.is_never_satisfied(db) =>
             {
-                // TODO: The repetition here isn't great, but we really need the fallthrough logic,
-                // where this arm only engages if it returns true (or in the world of constraints,
-                // not false). Once we're using real constraint sets instead of bool, we should be
-                // able to simplify the typevar logic.
-                bound_typevar.typevar(db).constraints(db).when_some_and(
-                    db,
-                    self.constraints,
-                    |constraints| {
-                        constraints.iter().when_all(db, self.constraints, |c| {
-                            self.check_type_pair(db, source, *c)
-                        })
-                    },
-                )
+                constraints
             }
 
             (Type::TypeVar(bound_typevar), _) if bound_typevar.is_inferable(db, self.inferable) => {
@@ -1953,9 +1933,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // A string literal `Literal["abc"]` is assignable to `str` *and* to
             // `Sequence[Literal["a", "b", "c"]]` because strings are sequences of their characters.
             (Type::LiteralValue(literal), Type::NominalInstance(instance))
-                if literal.is_string() =>
+                if let Some(value) = literal.as_string() =>
             {
-                let value = literal.as_string().unwrap();
                 let target_class = instance.class(db);
 
                 if target_class.is_known(db, KnownClass::Str) {
@@ -2001,9 +1980,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // A bytes literal `Literal[b"abc"]` is assignable to `bytes` *and* to
             // `Sequence[Literal[97, 98, 99]]` because bytes are sequences of integers.
             (Type::LiteralValue(literal), Type::NominalInstance(instance))
-                if literal.is_bytes() =>
+                if let Some(value) = literal.as_bytes() =>
             {
-                let value = literal.as_bytes().unwrap();
                 let target_class = instance.class(db);
 
                 if target_class.is_known(db, KnownClass::Bytes) {
@@ -2047,8 +2025,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // An instance is a subtype of an enum literal, if it is an instance of the enum class
             // and the enum has only one member.
-            (Type::NominalInstance(_), Type::LiteralValue(literal)) if literal.is_enum() => {
-                let target_enum_literal = literal.as_enum().unwrap();
+            (Type::NominalInstance(_), Type::LiteralValue(literal))
+                if let Some(target_enum_literal) = literal.as_enum() =>
+            {
                 if target_enum_literal.enum_class_instance(db) != source {
                     self.never()
                 } else {
@@ -2625,26 +2604,20 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             | (
                 other @ (Type::Callable(_) | Type::ProtocolInstance(_)),
                 Type::SubclassOf(subclass_of),
-            ) if subclass_of.is_type_var() => {
-                let type_var = subclass_of
-                    .subclass_of()
-                    .with_transposed_type_var(db)
-                    .into_type_var()
-                    .unwrap();
-
+            ) if let Some(type_var) = subclass_of
+                .subclass_of()
+                .with_transposed_type_var(db)
+                .into_type_var() =>
+            {
                 self.check_type_pair(db, Type::TypeVar(type_var), other)
             }
 
             // `type[T]` is disjoint from a class object `A` if every instance of `T` is disjoint from an instance of `A`.
             (Type::SubclassOf(subclass_of), other) | (other, Type::SubclassOf(subclass_of))
-                if subclass_of.is_type_var() && other.to_instance(db).is_some() =>
+                if let Some(type_var) = subclass_of.into_type_var()
+                    && let Some(instance) = other.to_instance(db) =>
             {
-                subclass_of
-                    .into_type_var()
-                    .zip(other.to_instance(db))
-                    .when_none_or(db, self.constraints, |(this_instance, other_instance)| {
-                        self.check_type_pair(db, Type::TypeVar(this_instance), other_instance)
-                    })
+                self.check_type_pair(db, Type::TypeVar(type_var), instance)
             }
 
             // A typevar is never disjoint from itself, since all occurrences of the typevar must

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -609,8 +609,9 @@ impl<'db> Type<'db> {
             }
 
             // Ex) Given `("a", "b", "c", "d")[1]`, return `"b"`
-            (Type::NominalInstance(nominal), Type::LiteralValue(literal)) if literal.is_int() => {
-                let i64_int = literal.as_int().unwrap();
+            (Type::NominalInstance(nominal), Type::LiteralValue(literal))
+                if let Some(i64_int) = literal.as_int() =>
+            {
                 nominal
                     .tuple_spec(db)
                     .and_then(|tuple| Some((tuple, i32::try_from(i64_int).ok()?)))
@@ -643,9 +644,10 @@ impl<'db> Type<'db> {
                 }),
 
             // Ex) Given `"value"[1]`, return `"a"`
-            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if lhs_literal.is_string() && rhs_literal.is_int() => {
-                let literal_ty = lhs_literal.as_string().unwrap();
-                let i64_int = rhs_literal.as_int().unwrap();
+            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal))
+                if let Some(literal_ty) = lhs_literal.as_string()
+                    && let Some(i64_int) = rhs_literal.as_int() =>
+            {
                 i32::try_from(i64_int).ok().map(|i32_int| {
                     let literal_value = literal_ty.value(db);
                     match (&mut literal_value.chars()).py_index(db, i32_int) {
@@ -664,8 +666,9 @@ impl<'db> Type<'db> {
             }
 
             // Ex) Given `"value"[1:3]`, return `"al"`
-            (Type::LiteralValue(literal), Type::NominalInstance(nominal)) if literal.is_string() => {
-                let literal_ty = literal.as_string().unwrap();
+            (Type::LiteralValue(literal), Type::NominalInstance(nominal))
+                if let Some(literal_ty) = literal.as_string() =>
+            {
                 nominal
                 .slice_literal(db)
                 .map(|SliceLiteral { start, stop, step }| {
@@ -696,9 +699,10 @@ impl<'db> Type<'db> {
             }
 
             // Ex) Given `b"value"[1]`, return `97` (i.e., `ord(b"a")`)
-            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if lhs_literal.is_bytes() && rhs_literal.is_int() => {
-                let literal_ty = lhs_literal.as_bytes().unwrap();
-                let i64_int = rhs_literal.as_int().unwrap();
+            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal))
+                if let Some(literal_ty) = lhs_literal.as_bytes()
+                    && let Some(i64_int) = rhs_literal.as_int() =>
+            {
                 i32::try_from(i64_int).ok().map(|i32_int| {
                     let literal_value = literal_ty.value(db);
                     match literal_value.py_index(db, i32_int) {
@@ -717,9 +721,9 @@ impl<'db> Type<'db> {
             }
 
             // Ex) Given `b"value"[1:3]`, return `b"al"`
-            (Type::LiteralValue(literal), Type::NominalInstance(nominal)) if literal.is_bytes() =>
+            (Type::LiteralValue(literal), Type::NominalInstance(nominal))
+                if let Some(literal_ty) = literal.as_bytes() =>
             {
-                let literal_ty = literal.as_bytes().unwrap();
                 nominal
                 .slice_literal(db)
                 .map(|SliceLiteral { start, stop, step }| {
@@ -739,15 +743,17 @@ impl<'db> Type<'db> {
             },
 
             // Ex) Given `"value"[True]`, return `"a"`
-            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if (lhs_literal.is_string() || lhs_literal.is_bytes()) && rhs_literal.is_bool() => {
-                let bool = rhs_literal.as_bool().unwrap();
+            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal))
+                if (lhs_literal.is_string() || lhs_literal.is_bytes())
+                    && let Some(bool) = rhs_literal.as_bool() =>
+            {
                 Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
             }
 
             (Type::NominalInstance(nominal), Type::LiteralValue(literal))
-                if literal.is_bool() && nominal.tuple_spec(db).is_some() =>
+                if let Some(bool) = literal.as_bool()
+                    && nominal.tuple_spec(db).is_some() =>
             {
-                let bool = literal.as_bool().unwrap();
                 Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
             }
 


### PR DESCRIPTION
## Summary

Now that we bumped our MSRV to 1.95, we can use `let` guards in `match` arms to remove quite a few `.unwrap()` calls and instances of duplicated computations

## Test Plan

existing tests