### PR TITLE
[ty] Replace type hierarchy callback with an enum

### DIFF
--- a/crates/ty_server/src/server/api/requests/type_hierarchy_subtypes.rs
+++ b/crates/ty_server/src/server/api/requests/type_hierarchy_subtypes.rs
@@ -4,7 +4,7 @@ use lsp_types::{TypeHierarchyItem, TypeHierarchySubtypesParams};
 use crate::server::api::traits::{
     BackgroundRequestHandler, RequestHandler, RetriableRequestHandler,
 };
-use crate::server::api::type_hierarchy::hierarchy_handler;
+use crate::server::api::type_hierarchy::{TypeHierarchyKind, hierarchy_handler};
 use crate::session::SessionSnapshot;
 use crate::session::client::Client;
 
@@ -28,7 +28,7 @@ impl BackgroundRequestHandler for TypeHierarchySubtypesRequestHandler {
         Ok(hierarchy_handler(
             snapshot,
             &params.item,
-            ty_ide::type_hierarchy_subtypes,
+            TypeHierarchyKind::Subtypes,
         ))
     }
 }

--- a/crates/ty_server/src/server/api/requests/type_hierarchy_supertypes.rs
+++ b/crates/ty_server/src/server/api/requests/type_hierarchy_supertypes.rs
@@ -4,7 +4,7 @@ use lsp_types::{TypeHierarchyItem, TypeHierarchySupertypesParams};
 use crate::server::api::traits::{
     BackgroundRequestHandler, RequestHandler, RetriableRequestHandler,
 };
-use crate::server::api::type_hierarchy::hierarchy_handler;
+use crate::server::api::type_hierarchy::{TypeHierarchyKind, hierarchy_handler};
 use crate::session::SessionSnapshot;
 use crate::session::client::Client;
 
@@ -28,7 +28,7 @@ impl BackgroundRequestHandler for TypeHierarchySupertypesRequestHandler {
         Ok(hierarchy_handler(
             snapshot,
             &params.item,
-            ty_ide::type_hierarchy_supertypes,
+            TypeHierarchyKind::Supertypes,
         ))
     }
 }

--- a/crates/ty_server/src/server/api/type_hierarchy.rs
+++ b/crates/ty_server/src/server/api/type_hierarchy.rs
@@ -1,6 +1,4 @@
 use lsp_types::{SymbolKind, TypeHierarchyItem};
-use ruff_db::files::File;
-use ruff_text_size::TextSize;
 use ty_project::ProjectDatabase;
 
 use crate::PositionEncoding;
@@ -8,14 +6,17 @@ use crate::document::{ToRangeExt, resolve_file_uri_range};
 use crate::session::SessionSnapshot;
 use crate::system::file_to_uri;
 
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum TypeHierarchyKind {
+    Subtypes,
+    Supertypes,
+}
+
 /// The subtype and supertype implementation.
-///
-/// `hierarchy_types` should be either `ty_ide::type_hierarchy_subtypes`
-/// or `ty_ide::type_hierarchy_supertypes`.
 pub(crate) fn hierarchy_handler(
     snapshot: &SessionSnapshot,
     requested_item: &TypeHierarchyItem,
-    hierarchy_types: fn(&dyn ty_project::Db, File, TextSize) -> Vec<ty_ide::TypeHierarchyItem>,
+    hierarchy_kind: TypeHierarchyKind,
 ) -> Option<Vec<TypeHierarchyItem>> {
     let encoding = snapshot.position_encoding();
 
@@ -32,8 +33,12 @@ pub(crate) fn hierarchy_handler(
         ) else {
             continue;
         };
+        let hierarchy_types = match hierarchy_kind {
+            TypeHierarchyKind::Subtypes => ty_ide::type_hierarchy_subtypes(db, file, offset),
+            TypeHierarchyKind::Supertypes => ty_ide::type_hierarchy_supertypes(db, file, offset),
+        };
         items.extend(
-            hierarchy_types(db, file, offset)
+            hierarchy_types
                 .into_iter()
                 .filter_map(|item| convert_to_lsp_item(db, item, encoding)),
         );


### PR DESCRIPTION
## Summary

Replace the type-hierarchy callback parameter with an explicit subtype/supertype enum and dispatch in the shared handler.

## Test Plan

Testing: Ran the focused type-hierarchy integration tests and repository hooks.
