### PR TITLE
[ty] Separate type-mapping caches by transformation mode

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -378,7 +378,13 @@ def _(c: Consumer[Intersection[A, Not[AlwaysFalsy]]], p: Producer[Intersection[A
     reveal_type(p)  # revealed: Producer[A & ~AlwaysFalsy]
     reveal_type([c])  # revealed: list[Consumer[A & ~AlwaysFalsy]]
     reveal_type([p])  # revealed: list[Producer[A]]
+```
 
+A callable can use the same type in both a contravariant parameter and a covariant return. When the
+callable is promoted as a list element, these positions must be transformed independently: the
+parameter keeps the narrowed type, while the return type is promoted.
+
+```py
 type NarrowA = Intersection[A, Not[AlwaysFalsy]]
 
 def transform(value: NarrowA) -> NarrowA:

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -378,6 +378,13 @@ def _(c: Consumer[Intersection[A, Not[AlwaysFalsy]]], p: Producer[Intersection[A
     reveal_type(p)  # revealed: Producer[A & ~AlwaysFalsy]
     reveal_type([c])  # revealed: list[Consumer[A & ~AlwaysFalsy]]
     reveal_type([p])  # revealed: list[Producer[A]]
+
+type NarrowA = Intersection[A, Not[AlwaysFalsy]]
+
+def transform(value: NarrowA) -> NarrowA:
+    return value
+
+reveal_type([transform])  # revealed: list[(value: NarrowA) -> A]
 ```
 
 ## Literal annotations are respected

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -913,3 +913,26 @@ def _(top: Top[AliasedCallable[Any]], bottom: Bottom[AliasedCallable[Any]]) -> N
     reveal_type(top)  # revealed: (Never, /) -> object
     reveal_type(bottom)  # revealed: (object, /) -> Never
 ```
+
+When a materialized class specialization is applied to an attribute, the same function-literal type
+can be visited through both the parameter and return positions of a nested callable. Those positions
+use opposite materialization polarities and must not share a transformation cache.
+
+```py
+from ty_extensions import Top, Bottom
+from typing import Any, Callable
+from ty_extensions._internal import TypeOf
+
+class FunctionHolder[T]:
+    def shared(self, value: T) -> T:
+        raise NotImplementedError
+
+    nested: Callable[[TypeOf[shared]], TypeOf[shared]]
+
+def _(top: Top[FunctionHolder[Any]], bottom: Bottom[FunctionHolder[Any]]) -> None:
+    # revealed: (def shared(self, value: object) -> Never, /) -> def shared(self, value: Never) -> object
+    reveal_type(top.nested)
+
+    # revealed: (def shared(self, value: Never) -> object, /) -> def shared(self, value: object) -> Never
+    reveal_type(bottom.nested)
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -290,23 +290,35 @@ fn definition_expression_annotation<'db>(
     }
 }
 
-struct ApplyDefaultTypeMapping;
-struct ApplyTopMaterialization;
-struct ApplyBottomMaterialization;
+struct ApplyTypeMappingTag;
 struct ApplyMaterializationEquivalence;
+
+#[repr(usize)]
+enum ApplyTypeMappingCache {
+    Default,
+    TopMaterialization,
+    BottomMaterialization,
+    TopSpecializationMaterialization,
+    BottomSpecializationMaterialization,
+    Promotion,
+    SkipPromotion,
+}
+
+impl ApplyTypeMappingCache {
+    const COUNT: usize = Self::SkipPromotion as usize + 1;
+}
 
 type MaterializationEquivalenceVisitor<'db> =
     Rc<CycleDetector<ApplyMaterializationEquivalence, (Type<'db>, Type<'db>), bool, 1>>;
 
 /// A [`TypeTransformer`] that is used in `apply_type_mapping` methods.
 ///
-/// Materialization is the only mapping mode that needs to visit the same type under two different
-/// mappings within a single recursive call chain (`Top` and `Bottom`). Keep separate cycle caches
-/// for those modes so invariant checks can safely reuse one visitor.
+/// Some recursive transformations visit the same type under more than one mapping mode within a
+/// single call chain. Keep separate cycle caches for those modes so one transformation cannot
+/// reuse the result of another.
 pub(crate) struct ApplyTypeMappingVisitor<'db> {
-    default: OnceCell<TypeTransformer<'db, ApplyDefaultTypeMapping>>,
-    top_materialization: OnceCell<TypeTransformer<'db, ApplyTopMaterialization>>,
-    bottom_materialization: OnceCell<TypeTransformer<'db, ApplyBottomMaterialization>>,
+    type_transformers:
+        [OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>; ApplyTypeMappingCache::COUNT],
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
 }
 
@@ -323,20 +335,28 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
         type_mapping: &TypeMapping<'_, 'db>,
         func: impl FnOnce() -> Type<'db>,
     ) -> Type<'db> {
-        match type_mapping {
-            TypeMapping::Materialize(MaterializationKind::Top) => self
-                .top_materialization
-                .get_or_init(TypeTransformer::default)
-                .visit_type(db, ty, func),
-            TypeMapping::Materialize(MaterializationKind::Bottom) => self
-                .bottom_materialization
-                .get_or_init(TypeTransformer::default)
-                .visit_type(db, ty, func),
-            _ => self
-                .default
-                .get_or_init(TypeTransformer::default)
-                .visit_type(db, ty, func),
-        }
+        let cache = match type_mapping {
+            TypeMapping::Materialize(MaterializationKind::Top) => {
+                ApplyTypeMappingCache::TopMaterialization
+            }
+            TypeMapping::Materialize(MaterializationKind::Bottom) => {
+                ApplyTypeMappingCache::BottomMaterialization
+            }
+            TypeMapping::ApplySpecializationWithMaterialization {
+                materialization_kind: MaterializationKind::Top,
+                ..
+            } => ApplyTypeMappingCache::TopSpecializationMaterialization,
+            TypeMapping::ApplySpecializationWithMaterialization {
+                materialization_kind: MaterializationKind::Bottom,
+                ..
+            } => ApplyTypeMappingCache::BottomSpecializationMaterialization,
+            TypeMapping::Promote(PromotionMode::On, _) => ApplyTypeMappingCache::Promotion,
+            TypeMapping::Promote(PromotionMode::Off, _) => ApplyTypeMappingCache::SkipPromotion,
+            _ => ApplyTypeMappingCache::Default,
+        };
+        self.type_transformers[cache as usize]
+            .get_or_init(TypeTransformer::default)
+            .visit_type(db, ty, func)
     }
 
     pub(crate) fn is_equivalent_to_materialization(
@@ -357,9 +377,7 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
         debug_assert!(was_empty.is_ok());
 
         Self {
-            default: OnceCell::new(),
-            top_materialization: OnceCell::new(),
-            bottom_materialization: OnceCell::new(),
+            type_transformers: std::array::from_fn(|_| OnceCell::new()),
             materialization_equivalence,
         }
     }
@@ -368,9 +386,7 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
 impl Default for ApplyTypeMappingVisitor<'_> {
     fn default() -> Self {
         Self {
-            default: OnceCell::new(),
-            top_materialization: OnceCell::new(),
-            bottom_materialization: OnceCell::new(),
+            type_transformers: std::array::from_fn(|_| OnceCell::new()),
             materialization_equivalence: OnceCell::new(),
         }
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -293,21 +293,6 @@ fn definition_expression_annotation<'db>(
 struct ApplyTypeMappingTag;
 struct ApplyMaterializationEquivalence;
 
-#[repr(usize)]
-enum ApplyTypeMappingCache {
-    Default,
-    TopMaterialization,
-    BottomMaterialization,
-    TopSpecializationMaterialization,
-    BottomSpecializationMaterialization,
-    Promotion,
-    SkipPromotion,
-}
-
-impl ApplyTypeMappingCache {
-    const COUNT: usize = Self::SkipPromotion as usize + 1;
-}
-
 type MaterializationEquivalenceVisitor<'db> =
     Rc<CycleDetector<ApplyMaterializationEquivalence, (Type<'db>, Type<'db>), bool, 1>>;
 
@@ -316,9 +301,15 @@ type MaterializationEquivalenceVisitor<'db> =
 /// Some recursive transformations visit the same type under more than one mapping mode within a
 /// single call chain. Keep separate cycle caches for those modes so one transformation cannot
 /// reuse the result of another.
+#[derive(Default)]
 pub(crate) struct ApplyTypeMappingVisitor<'db> {
-    type_transformers:
-        [OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>; ApplyTypeMappingCache::COUNT],
+    default: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
+    top_materialization: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
+    bottom_materialization: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
+    top_specialization_materialization: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
+    bottom_specialization_materialization: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
+    promotion: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
+    skip_promotion: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
 }
 
@@ -335,26 +326,22 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
         type_mapping: &TypeMapping<'_, 'db>,
         func: impl FnOnce() -> Type<'db>,
     ) -> Type<'db> {
-        let cache = match type_mapping {
-            TypeMapping::Materialize(MaterializationKind::Top) => {
-                ApplyTypeMappingCache::TopMaterialization
-            }
-            TypeMapping::Materialize(MaterializationKind::Bottom) => {
-                ApplyTypeMappingCache::BottomMaterialization
-            }
+        let type_transformer = match type_mapping {
+            TypeMapping::Materialize(MaterializationKind::Top) => &self.top_materialization,
+            TypeMapping::Materialize(MaterializationKind::Bottom) => &self.bottom_materialization,
             TypeMapping::ApplySpecializationWithMaterialization {
                 materialization_kind: MaterializationKind::Top,
                 ..
-            } => ApplyTypeMappingCache::TopSpecializationMaterialization,
+            } => &self.top_specialization_materialization,
             TypeMapping::ApplySpecializationWithMaterialization {
                 materialization_kind: MaterializationKind::Bottom,
                 ..
-            } => ApplyTypeMappingCache::BottomSpecializationMaterialization,
-            TypeMapping::Promote(PromotionMode::On, _) => ApplyTypeMappingCache::Promotion,
-            TypeMapping::Promote(PromotionMode::Off, _) => ApplyTypeMappingCache::SkipPromotion,
-            _ => ApplyTypeMappingCache::Default,
+            } => &self.bottom_specialization_materialization,
+            TypeMapping::Promote(PromotionMode::On, _) => &self.promotion,
+            TypeMapping::Promote(PromotionMode::Off, _) => &self.skip_promotion,
+            _ => &self.default,
         };
-        self.type_transformers[cache as usize]
+        type_transformer
             .get_or_init(TypeTransformer::default)
             .visit_type(db, ty, func)
     }
@@ -377,17 +364,8 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
         debug_assert!(was_empty.is_ok());
 
         Self {
-            type_transformers: std::array::from_fn(|_| OnceCell::new()),
             materialization_equivalence,
-        }
-    }
-}
-
-impl Default for ApplyTypeMappingVisitor<'_> {
-    fn default() -> Self {
-        Self {
-            type_transformers: std::array::from_fn(|_| OnceCell::new()),
-            materialization_equivalence: OnceCell::new(),
+            ..Self::default()
         }
     }
 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -303,13 +303,13 @@ type MaterializationEquivalenceVisitor<'db> =
 /// reuse the result of another.
 #[derive(Default)]
 pub(crate) struct ApplyTypeMappingVisitor<'db> {
-    default: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
-    top_materialization: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
-    bottom_materialization: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
-    top_specialization_materialization: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
-    bottom_specialization_materialization: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
-    promotion: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
-    skip_promotion: OnceCell<TypeTransformer<'db, ApplyTypeMappingTag>>,
+    default: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
+    top_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
+    bottom_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
+    top_specialization_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
+    bottom_specialization_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
+    promotion: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
+    skip_promotion: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
 }
 
@@ -342,7 +342,7 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
             _ => &self.default,
         };
         type_transformer
-            .get_or_init(TypeTransformer::default)
+            .get_or_init(Box::default)
             .visit_type(db, ty, func)
     }
 

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -342,29 +342,6 @@ fn divergent_type() {
 }
 
 #[test]
-fn apply_type_mapping_visitor_separates_promotion_modes() {
-    let db = setup_db();
-    let visitor = ApplyTypeMappingVisitor::default();
-    let ty = Type::unknown();
-
-    let promoted = visitor.visit(
-        &db,
-        ty,
-        &TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular),
-        Type::object,
-    );
-    let unpromoted = visitor.visit(
-        &db,
-        ty,
-        &TypeMapping::Promote(PromotionMode::Off, PromotionKind::Regular),
-        || Type::Never,
-    );
-
-    assert_eq!(promoted, Type::object());
-    assert_eq!(unpromoted, Type::Never);
-}
-
-#[test]
 fn type_alias_variance() {
     use crate::db::tests::TestDb;
     use crate::place::global_symbol;

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -342,6 +342,29 @@ fn divergent_type() {
 }
 
 #[test]
+fn apply_type_mapping_visitor_separates_promotion_modes() {
+    let db = setup_db();
+    let visitor = ApplyTypeMappingVisitor::default();
+    let ty = Type::unknown();
+
+    let promoted = visitor.visit(
+        &db,
+        ty,
+        &TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular),
+        Type::object,
+    );
+    let unpromoted = visitor.visit(
+        &db,
+        ty,
+        &TypeMapping::Promote(PromotionMode::Off, PromotionKind::Regular),
+        || Type::Never,
+    );
+
+    assert_eq!(promoted, Type::object());
+    assert_eq!(unpromoted, Type::Never);
+}
+
+#[test]
 fn type_alias_variance() {
     use crate::db::tests::TestDb;
     use crate::place::global_symbol;


### PR DESCRIPTION
## Summary

`ApplyTypeMappingVisitor` caches each transformed `Type` so recursive type mappings terminate, but all mapping modes other than direct `Top` and `Bottom` materialization currently share one `TypeTransformer`. If the same type is visited with promotion enabled and disabled, or under top and bottom specialization-plus-materialization, the second visit can reuse a result computed under the opposite transformation.

This gives each mapping mode whose result can differ its own transformer cache.
