### PR TITLE
[ty] Avoid unsound TypedDict dictionary disjointness

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -176,6 +176,23 @@ def narrow_generic_alias[T: (Generic[int], Specialized)](klass: type[T]) -> None
         reveal_type(Generic[int])  # revealed: <class 'Generic[int]'>
 ```
 
+## `is` between a `TypedDict` and `dict`
+
+An optional `TypedDict` may be empty at runtime. It can therefore be the same object as an empty
+`dict[Never, Never]`, so the identity branch remains reachable:
+
+```py
+from typing import TypedDict
+from typing_extensions import Never
+
+class Movie(TypedDict, total=False):
+    title: str
+
+def _(x: Movie, y: dict[Never, Never]) -> None:
+    if x is y:
+        reveal_type(x)  # revealed: Movie & dict[Never, Never]
+```
+
 ## `is` where the other operand is a call expression
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -1008,6 +1008,23 @@ class MyDict(collections.defaultdict[str, float]):
                 self.add(text, item)
 ```
 
+A generic class-info can be instantiated with `dict`, so the branch must remain reachable even
+though the type variable's bound does not statically include `TypedDict`. The intersection retains
+the correlation with the unknown class-info type:
+
+```py
+from typing import TypeVar
+
+TDict = TypeVar("TDict", bound=dict[object, object])
+
+def narrow_with_generic_classinfo(value: A | int, cls: type[TDict]) -> None:
+    if isinstance(value, cls):
+        reveal_type(value)  # revealed: A & TDict@narrow_with_generic_classinfo
+
+def call_with_dict(value: A) -> None:
+    narrow_with_generic_classinfo(value, dict)
+```
+
 The negative branch removes a `TypedDict` member, making attributes from the remaining class
 available:
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4993,7 +4993,7 @@ subclass:
 
 ```py
 from collections.abc import MutableMapping
-from typing import Mapping, TypedDict
+from typing import Literal, Mapping, TypedDict
 from ty_extensions import static_assert
 from ty_extensions._internal import is_disjoint_from
 
@@ -5006,10 +5006,26 @@ class DictSubclass(dict[str, object]): ...
 static_assert(not is_disjoint_from(TD, object))
 static_assert(not is_disjoint_from(TD, Mapping[str, object]))
 static_assert(not is_disjoint_from(TD, MutableMapping[str, object]))
-static_assert(is_disjoint_from(TD, Mapping[int, object]))
+# TODO: Required string keys could prove this disjoint, but the gradual dictionary projection is
+# intentionally conservative about invariant key parameters.
+static_assert(not is_disjoint_from(TD, Mapping[int, object]))
 static_assert(is_disjoint_from(TD, RegularNonTD))
 static_assert(not is_disjoint_from(TD, dict[str, int]))
+static_assert(not is_disjoint_from(TD, dict[Literal["x"], object]))
+static_assert(not is_disjoint_from(dict[Literal["x"], object], TD))
+static_assert(not is_disjoint_from(TD, dict[str | int, object]))
+static_assert(not is_disjoint_from(TD, dict[object, object]))
 static_assert(is_disjoint_from(TD, DictSubclass))
+```
+
+A `TypedDict` with no required fields can be empty, so incompatible dictionary key types do not make
+the two types disjoint:
+
+```py
+class EmptyTypedDict(TypedDict):
+    pass
+
+static_assert(not is_disjoint_from(EmptyTypedDict, dict[str | int, object]))
 ```
 
 We do not yet use required field types to prove that a `TypedDict` and a dictionary have

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3298,15 +3298,15 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             }
 
             (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
-                // For any type `T`, if `dict[str, Any]` is not assignable to `T`, then all
-                // `TypedDict` types will always be disjoint from `T`. This doesn't cover all
-                // cases -- in fact `dict` *itself* is almost always disjoint from `TypedDict` --
-                // but it's a good approximation, and some false negatives are acceptable.
-                let dict_str_any = KnownClass::Dict
-                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
+                // Project to a gradual dictionary when proving disjointness. Using `str` for the
+                // key would be too precise here: invariant generic arguments would incorrectly
+                // prove disjointness from dictionaries whose key domain admits the TypedDict's
+                // literal keys, such as `dict[Literal["name"], object]`.
+                let dict =
+                    KnownClass::Dict.to_specialized_instance(db, &[Type::any(), Type::any()]);
 
                 self.as_relation_checker(TypeRelation::Assignability)
-                    .check_type_pair(db, dict_str_any, other)
+                    .check_type_pair(db, dict, other)
                     .negate(db, self.constraints)
             }
         }


### PR DESCRIPTION
## Summary

This is a focused follow-up to #25851.

When comparing a `TypedDict` with another type, we currently approximate every `TypedDict` as `dict[str, Any]`. Because dictionary key parameters are invariant, that can incorrectly prove a `TypedDict` disjoint from dictionary types whose key domains admit its actual string-literal keys, such as `dict[Literal["x"], object]` or `dict[object, object]`. Narrowing can then eliminate a reachable branch, including an `isinstance()` check whose generic class-info can instantiate to `dict`.

The same issue affects identity narrowing against empty dictionaries. An optional `TypedDict` can be empty at runtime, so comparing it with a `dict[Never, Never]` must not make the identity branch unreachable.

We now use the gradual projection `dict[Any, Any]` for this fallback. This deliberately refuses to prove disjointness unless we have stronger evidence, while preserving the fact that a `TypedDict` is disjoint from proper `dict` subclasses.

This remains intentionally conservative. We do not derive a precise dictionary projection from required fields, so `TypedDict` versus `Mapping[int, object]` remains non-disjoint, and required field value types are not used to prove disjointness from types such as `dict[str, str]`. The change also does not add broader materialization or correlation-aware refinement for generic class-info types.
