### PR TITLE
[ty] Keep TypedDict fallback methods in sync

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/deprecated.md_-_Tests_for_the_`@depr…_-_Syntax_(142fa2948c3c6cf1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/deprecated.md_-_Tests_for_the_`@depr…_-_Syntax_(142fa2948c3c6cf1).snap
@@ -85,9 +85,9 @@ error[missing-argument]: No argument provided for required parameter `arg` of bo
   | ^^^^^^^^^^^^^^
   |
 info: Parameter declared here
-    --> stdlib/typing_extensions.pyi:1220:28
+    --> stdlib/typing_extensions.pyi:1229:28
      |
-1220 |         def __call__(self, arg: _T, /) -> _T: ...
+1229 |         def __call__(self, arg: _T, /) -> _T: ...
      |                            ^^^^^^^
      |
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2411,6 +2411,28 @@ def _(p: Person) -> None:
     reveal_type(p.setdefault("extraz", "value"))  # revealed: Unknown
 ```
 
+The fallback methods available on all `TypedDict` objects are the same whether the type was created
+with `typing.TypedDict` or `typing_extensions.TypedDict`:
+
+```py
+from typing import TypedDict as TypingTypedDict
+from typing_extensions import TypedDict as ExtensionsTypedDict
+
+class TypingMovie(TypingTypedDict):
+    title: str
+
+class ExtensionsMovie(ExtensionsTypedDict):
+    title: str
+
+def _(typing_movie: TypingMovie, extensions_movie: ExtensionsMovie, keys: list[str], value: int) -> None:
+    reveal_type(reversed(typing_movie))  # revealed: Iterator[str]
+    reveal_type(reversed(extensions_movie))  # revealed: Iterator[str]
+    reveal_type(typing_movie.fromkeys(keys))  # revealed: dict[str, Any | None]
+    reveal_type(extensions_movie.fromkeys(keys))  # revealed: dict[str, Any | None]
+    reveal_type(typing_movie.fromkeys(keys, value))  # revealed: dict[str, int]
+    reveal_type(extensions_movie.fromkeys(keys, value))  # revealed: dict[str, int]
+```
+
 Known-key `get()` calls also use the field type as bidirectional context when that produces a valid
 default:
 

--- a/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
@@ -12,7 +12,7 @@ from typing import Any, ClassVar, Generic, TypeVar, overload
 from typing_extensions import Never
 
 _T = TypeVar("_T")
-_S = TypeVar("_S")
+_ValueT = TypeVar("_ValueT")
 
 # Used for an undocumented mypy feature. Does not exist at runtime.
 promote = object()
@@ -40,7 +40,14 @@ class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
     def fromkeys(iterable: Iterable[_T], value: None = None, /) -> dict[_T, Any | None]: ...
     @staticmethod
     @overload
-    def fromkeys(iterable: Iterable[_T], value: _S, /) -> dict[_T, _S]: ...
+    def fromkeys(iterable: Iterable[_T], value: _ValueT, /) -> dict[_T, _ValueT]: ...
+    # Using Never so that only calls using mypy plugin hook that specialize the signature
+    # can go through.
+    def setdefault(self, k: Never, default: object) -> object: ...
+    # Mypy plugin hook for 'pop' expects that 'default' has a type variable type.
+    def pop(self, k: Never, default: _T = ...) -> object: ...  # pyright: ignore[reportInvalidTypeVarUse]
+    def update(self, m: typing_extensions.Self, /) -> None: ...
+    def __delitem__(self, k: Never) -> None: ...
     def items(self) -> dict_items[str, object]: ...
     def keys(self) -> dict_keys[str, object]: ...
     def values(self) -> dict_values[str, object]: ...
@@ -57,13 +64,6 @@ class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
     @overload
     def __ror__(self, value: dict[str, Any], /) -> dict[str, object]: ...
 
-    # Using Never so that only calls using mypy plugin hook that specialize the signature
-    # can go through.
-    def setdefault(self, k: Never, default: object) -> object: ...
-    # Mypy plugin hook for 'pop' expects that 'default' has a type variable type.
-    def pop(self, k: Never, default: _T = ...) -> object: ...  # pyright: ignore[reportInvalidTypeVarUse]
-    def update(self, m: typing_extensions.Self, /) -> None: ...
-    def __delitem__(self, k: Never) -> None: ...
     # supposedly incompatible definitions of __or__ and __ior__
     def __ior__(self, value: typing_extensions.Self, /) -> typing_extensions.Self: ...  # type: ignore[misc]
 
@@ -93,6 +93,7 @@ class NamedTupleFallback(tuple[Any, ...]):
         def __replace__(self, **kwargs: Any) -> typing_extensions.Self: ...
 
 # Non-default variations to accommodate couroutines, and `AwaitableGenerator` having a 4th type parameter.
+_S = TypeVar("_S")
 _YieldT_co = TypeVar("_YieldT_co", covariant=True)
 _SendT_nd_contra = TypeVar("_SendT_nd_contra", contravariant=True)
 _ReturnT_nd_co = TypeVar("_ReturnT_nd_co", covariant=True)

--- a/crates/ty_vendored/vendor/typeshed/stdlib/typing_extensions.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/typing_extensions.pyi
@@ -207,6 +207,7 @@ __all__ = [
 ]
 
 _T = _TypeVar("_T")
+_ValueT = _TypeVar("_ValueT")
 _F = _TypeVar("_F", bound=Callable[..., Any])
 _TC = _TypeVar("_TC", bound=type[object])
 _T_co = _TypeVar("_T_co", covariant=True)  # Any type covariant containers.
@@ -436,6 +437,12 @@ class _TypedDict(Mapping[str, object], metaclass=abc.ABCMeta):
     __closed__: ClassVar[bool | None]
     __extra_items__: ClassVar[AnnotationForm]
     def copy(self) -> Self: ...
+    @staticmethod
+    @overload
+    def fromkeys(iterable: Iterable[_T], value: None = None, /) -> dict[_T, Any | None]: ...
+    @staticmethod
+    @overload
+    def fromkeys(iterable: Iterable[_T], value: _ValueT, /) -> dict[_T, _ValueT]: ...
     # Using Never so that only calls using mypy plugin hook that specialize the signature
     # can go through.
     def setdefault(self, k: Never, default: object) -> object: ...
@@ -445,6 +452,8 @@ class _TypedDict(Mapping[str, object], metaclass=abc.ABCMeta):
     def items(self) -> dict_items[str, object]: ...
     def keys(self) -> dict_keys[str, object]: ...
     def values(self) -> dict_values[str, object]: ...
+    if sys.version_info >= (3, 8):
+        def __reversed__(self) -> Iterator[str]: ...
     def __delitem__(self, k: Never) -> None: ...
 
     @overload


### PR DESCRIPTION
## Summary

This is the fallback-provider follow-up in the #25851 stack, stacked on #26859.

`TypedDict` members come from different fallback definitions depending on whether the type was declared through `typing.TypedDict` or `typing_extensions.TypedDict`. After adding the dictionary operations needed by runtime narrowing, `fromkeys()` and `reversed()` were only available through the `typing` fallback, so otherwise equivalent `TypedDict` declarations exposed different method surfaces.

We add matching `fromkeys()` overloads and `__reversed__()` support to the `typing_extensions` fallback and cover both providers with the same assertions. We also align the organization and local type-variable naming of the two fallback definitions to make future drift easier to spot.

This only synchronizes operations common to every runtime `dict`. It does not make `TypedDict` assignable to mutable `dict`, relax schema-aware mutation rules, or change the specialized handling of methods such as `get()`, `pop()`, and `setdefault()`.
