### PR TITLE
[ty] Prune receiver-mismatched overloads for class-level aliased methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -358,6 +358,16 @@ def union_receiver(reader: Reader[int | str]):
     reveal_type(reader.get)  # revealed: Overload[]
 ```
 
+A concrete union that matches *neither* overload on any branch prunes to the same empty
+`Overload[]`: with no type variable in the receiver, pruning confidently rejects every overload, and
+calling the result reports `no-matching-overload`.
+
+```py
+def union_receiver_no_match(reader: Reader[bytes | float]):
+    reveal_type(reader.get)  # revealed: Overload[]
+    reader.get(0)  # error: [no-matching-overload]
+```
+
 ## Constrained `TypeVar` receivers
 
 A `TypeVar` constrained to several types stands for exactly one of those constraints, but never for
@@ -378,6 +388,33 @@ T = TypeVar("T", A, B)
 
 def get_x(value: T) -> int | str:
     return value["x"]
+```
+
+The same guard applies to an overloaded method reached directly through a constrained `TypeVar`
+receiver. When none of the constraints matches any overload's explicit `self` annotation, pruning
+would remove every overload; because the receiver still contains a type variable, the overloads are
+kept instead of collapsing to a non-callable `Overload[]`, and normal overload resolution runs.
+
+```py
+from typing import TypeVar, overload
+
+class Widget:
+    @overload
+    def render(self: "Sub1") -> int: ...
+    @overload
+    def render(self: "Sub2") -> str: ...
+    def render(self) -> int | str:
+        return 0
+
+class Sub1(Widget): ...
+class Sub2(Widget): ...
+class OtherA(Widget): ...
+class OtherB(Widget): ...
+
+U = TypeVar("U", OtherA, OtherB)
+
+def constrained_no_match(widget: U):
+    reveal_type(widget.render)  # revealed: Overload[() -> int, () -> str]
 ```
 
 ## Aliased overloads through a union receiver

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -163,45 +163,90 @@ reveal_type(Base().narrowed)  # revealed: bound method Base.narrowed(x: int) -> 
 reveal_type(Child().narrowed)  # revealed: Overload[(x: int) -> int, (x: str) -> str]
 ```
 
-## Aliased overloaded methods
+## Class-level aliases
+
+### Bound method
 
 Accessing an overloaded method through a class-level alias (which is promoted to a `Callable`) must
-apply the same receiver-based overload pruning as accessing the original method. Here the overloads
-differ only in their `self` annotation, so an empty argument list cannot disambiguate them: without
-pruning, every call through the alias would incorrectly resolve to the first overload (`int`).
+apply the same receiver-based overload pruning as accessing the original method.
 
 ```py
-from typing import overload
+from typing import Awaitable, overload
+from typing_extensions import Literal, Protocol
 
-class Base:
+class SyncCommand(Protocol):
+    is_async: Literal[False]
+
+class AsyncCommand(Protocol):
+    is_async: Literal[True]
+
+class Command:
     @overload
-    def answer(self: "IntChild") -> int: ...
+    def execute(self: SyncCommand) -> int: ...
     @overload
-    def answer(self: "StrChild") -> str: ...
+    def execute(self: AsyncCommand) -> Awaitable[int]: ...
+    def execute(
+        self: SyncCommand | AsyncCommand,
+    ) -> int | Awaitable[int]:
+        raise NotImplementedError
+
+    alias = execute
+
+class ConcreteSyncCommand(Command):
+    is_async: Literal[False] = False
+
+class ConcreteAsyncCommand(Command):
+    is_async: Literal[True] = True
+
+reveal_type(ConcreteSyncCommand().alias())  # revealed: int
+reveal_type(ConcreteAsyncCommand().alias())  # revealed: Awaitable[int]
+```
+
+### `@classmethod`
+
+An aliased classmethod must use the owner class to filter explicit receiver annotations. This
+applies when the descriptor is accessed through either the class or an instance.
+
+```py
+from typing import Type, overload
+from typing_extensions import Self
+
+class Factory:
     @overload
-    def answer(self: "BoolChild") -> bool: ...
-    def answer(self) -> int | str | bool:
-        return 0
+    @classmethod
+    def create(cls: Type["Factory"], value: int) -> int: ...
+    @overload
+    @classmethod
+    def create(cls: Type["Factory"], value: str) -> str: ...
+    @classmethod
+    def create(cls, value: int | str) -> int | str:
+        return value
 
-    aliased = answer
+    aliased = create
 
-class IntChild(Base):
-    a: int = 0
+class ChildFactory(Factory): ...
 
-class StrChild(Base):
-    b: str = ""
+# Direct classmethod access already preserves receiver filtering.
+reveal_type(Factory.create(1))  # revealed: int
+reveal_type(ChildFactory.create(""))  # revealed: str
 
-class BoolChild(Base):
-    c: bytes = b""
+# Aliased classmethods must behave the same when accessed through a class or instance.
+reveal_type(Factory.aliased(1))  # revealed: int
+reveal_type(ChildFactory.aliased(""))  # revealed: str
+reveal_type(ChildFactory().aliased(1))  # revealed: int
 
-# Each receiver matches a single overload, so the alias prunes the other two.
-reveal_type(IntChild().aliased)  # revealed: () -> int
-reveal_type(StrChild().aliased)  # revealed: () -> str
-reveal_type(BoolChild().aliased)  # revealed: () -> bool
+class SelfFactory:
+    @classmethod
+    def create(cls) -> Self:
+        return cls()
 
-reveal_type(IntChild().aliased())  # revealed: int
-reveal_type(StrChild().aliased())  # revealed: str
-reveal_type(BoolChild().aliased())  # revealed: bool
+    aliased = create
+
+class ChildSelfFactory(SelfFactory): ...
+
+# Classmethod binding must continue to use the instance type to resolve `Self`.
+reveal_type(SelfFactory.aliased())  # revealed: SelfFactory
+reveal_type(ChildSelfFactory.aliased())  # revealed: ChildSelfFactory
 ```
 
 ## Specialized generic receivers

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -163,6 +163,47 @@ reveal_type(Base().narrowed)  # revealed: bound method Base.narrowed(x: int) -> 
 reveal_type(Child().narrowed)  # revealed: Overload[(x: int) -> int, (x: str) -> str]
 ```
 
+## Aliased overloaded methods
+
+Accessing an overloaded method through a class-level alias (which is promoted to a `Callable`) must
+apply the same receiver-based overload pruning as accessing the original method. Here the overloads
+differ only in their `self` annotation, so an empty argument list cannot disambiguate them: without
+pruning, every call through the alias would incorrectly resolve to the first overload (`int`).
+
+```py
+from typing import overload
+
+class Base:
+    @overload
+    def answer(self: "IntChild") -> int: ...
+    @overload
+    def answer(self: "StrChild") -> str: ...
+    @overload
+    def answer(self: "BoolChild") -> bool: ...
+    def answer(self) -> int | str | bool:
+        return 0
+
+    aliased = answer
+
+class IntChild(Base):
+    a: int = 0
+
+class StrChild(Base):
+    b: str = ""
+
+class BoolChild(Base):
+    c: bytes = b""
+
+# Each receiver matches a single overload, so the alias prunes the other two.
+reveal_type(IntChild().aliased)  # revealed: () -> int
+reveal_type(StrChild().aliased)  # revealed: () -> str
+reveal_type(BoolChild().aliased)  # revealed: () -> bool
+
+reveal_type(IntChild().aliased())  # revealed: int
+reveal_type(StrChild().aliased())  # revealed: str
+reveal_type(BoolChild().aliased())  # revealed: bool
+```
+
 ## Specialized generic receivers
 
 An explicit receiver annotation can also select overloads based on a generic class specialization.

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -358,6 +358,68 @@ def union_receiver(reader: Reader[int | str]):
     reveal_type(reader.get)  # revealed: Overload[]
 ```
 
+## Constrained `TypeVar` receivers
+
+A `TypeVar` constrained to several types stands for exactly one of those constraints, but never for
+a single one on its own. Receiver-based overload pruning must not discard every overload just
+because the unresolved `TypeVar` matches no individual concrete receiver; each constraint here
+supports subscription, so `value["x"]` stays callable.
+
+```py
+from typing import TypedDict, TypeVar
+
+class A(TypedDict):
+    x: int
+
+class B(TypedDict):
+    x: str
+
+T = TypeVar("T", A, B)
+
+def get_x(value: T) -> int | str:
+    return value["x"]
+```
+
+## Aliased overloads through a union receiver
+
+Accessing an overloaded method through a class-level alias (promoted to a `Callable`) prunes
+overloads by receiver just like direct access. When the receiver is a union that still carries a
+type variable, no single overload's explicit `self` annotation accepts the whole union, but pruning
+must not collapse the overload set to an empty (non-callable) `Overload[]`. The overloads are
+retained and normal overload resolution runs, so the unsupported `_sync` keyword is reported as
+`no-matching-overload` rather than `call-non-callable`.
+
+```py
+from typing import Generic, Literal, TypeVar, overload
+
+T = TypeVar("T")
+
+class State(Generic[T]):
+    @overload
+    def _result(self: "State[T]", flag: Literal[True] = True) -> T: ...
+    @overload
+    def _result(self: "State[T]", flag: Literal[False]) -> T | Exception: ...
+    def _result(self, flag: bool = True) -> T | Exception:
+        raise NotImplementedError
+    result = _result
+
+class Future(Generic[T]):
+    def __init__(self, value: T) -> None:
+        self.state: State[T] | None = None
+        self.value = value
+
+    def get_result(self) -> T:
+        if not self.state:
+            value = self.value
+            if isinstance(value, State):
+                self.state = value
+            else:
+                return value
+        # error: [no-matching-overload]
+        # error: [no-matching-overload]
+        return self.state.result(_sync=True)
+```
+
 ## Method type variables inferred from `self`
 
 Binding an overload whose explicit receiver introduces a method type variable should infer that

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3348,9 +3348,18 @@ impl<'db> Type<'db> {
                             // For classmethod-like callables, bind to the owner class.
                             owner.to_instance_approximation(db).unwrap_or(owner)
                         });
+                        let receiver_type = if callable.is_classmethod_like(db) {
+                            owner
+                        } else {
+                            self_type
+                        };
 
                         Some((
-                            Type::Callable(callable.bind_self(db, Some(self_type))),
+                            Type::Callable(callable.bind_self_with_receiver(
+                                db,
+                                Some(receiver_type),
+                                Some(self_type),
+                            )),
                             AttributeKind::NormalOrNonDataDescriptor,
                         ))
                     };

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -564,12 +564,27 @@ impl<'db> CallableType<'db> {
             return self.into_regular(db);
         }
 
-        CallableType::new(
-            db,
-            self.signatures(db).bind_self(db, self_type),
-            self.kind(db),
-            self.provenance(db),
-        )
+        let signatures = self.signatures(db);
+        // Mirror `BoundMethodType::bound_signatures`: when a promoted callable (such as an
+        // aliased method) carries multiple overloads with explicit `self` annotations, prune the
+        // overloads whose receiver annotation cannot accept the bound `self` before binding.
+        let bound = if let Some(self_type) = self_type
+            && signatures.overloads.len() > 1
+            && signatures
+                .iter()
+                .any(Signature::has_explicit_positional_receiver_annotation)
+        {
+            CallableSignature::from_overloads(
+                signatures
+                    .iter()
+                    .filter(|signature| signature.can_bind_self_to(db, self_type))
+                    .map(|signature| signature.bind_self(db, Some(self_type))),
+            )
+        } else {
+            signatures.bind_self(db, self_type)
+        };
+
+        CallableType::new(db, bound, self.kind(db), self.provenance(db))
     }
 
     pub(crate) fn into_function_like(self, db: &'db dyn Db) -> CallableType<'db> {

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -555,36 +555,41 @@ impl<'db> CallableType<'db> {
         ))
     }
 
+    /// Binds the first (presumably `self`) parameter of this callable.
+    ///
+    /// `self_type` is both used to select overloads with compatible explicit receiver annotations
+    /// and substituted for occurrences of `typing.Self`. Use [`Self::bind_self_with_receiver`] when
+    /// those types differ, as they do for classmethods.
     pub(crate) fn bind_self(
         self,
         db: &'db dyn Db,
+        self_type: Option<Type<'db>>,
+    ) -> CallableType<'db> {
+        self.bind_self_with_receiver(db, self_type, self_type)
+    }
+
+    /// Binds the first (presumably `self`) parameter of this callable.
+    ///
+    /// `receiver_type` is used to select overloads with compatible explicit receiver
+    /// annotations, while `self_type` replaces occurrences of `typing.Self`. These types differ
+    /// for classmethods: the receiver is a class object, but `Self` resolves to its instance type.
+    pub(crate) fn bind_self_with_receiver(
+        self,
+        db: &'db dyn Db,
+        receiver_type: Option<Type<'db>>,
         self_type: Option<Type<'db>>,
     ) -> CallableType<'db> {
         if self.is_dunder_paramspec(db) {
             return self.into_regular(db);
         }
 
-        let signatures = self.signatures(db);
-        // Mirror `BoundMethodType::bound_signatures`: when a promoted callable (such as an
-        // aliased method) carries multiple overloads with explicit `self` annotations, prune the
-        // overloads whose receiver annotation cannot accept the bound `self` before binding.
-        let bound = if let Some(self_type) = self_type
-            && signatures.overloads.len() > 1
-            && signatures
-                .iter()
-                .any(Signature::has_explicit_positional_receiver_annotation)
-        {
-            CallableSignature::from_overloads(
-                signatures
-                    .iter()
-                    .filter(|signature| signature.can_bind_self_to(db, self_type))
-                    .map(|signature| signature.bind_self(db, Some(self_type))),
-            )
-        } else {
-            signatures.bind_self(db, self_type)
-        };
-
-        CallableType::new(db, bound, self.kind(db), self.provenance(db))
+        CallableType::new(
+            db,
+            self.signatures(db)
+                .bind_self_with_receiver(db, receiver_type, self_type),
+            self.kind(db),
+            self.provenance(db),
+        )
     }
 
     pub(crate) fn into_function_like(self, db: &'db dyn Db) -> CallableType<'db> {

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -118,45 +118,11 @@ impl<'db> BoundMethodType<'db> {
         receiver_type: Type<'db>,
         typing_self_type: Type<'db>,
     ) -> CallableSignature<'db> {
-        let function_signature = self.function(db).signature(db);
-
-        let [signature] = function_signature.overloads.as_slice() else {
-            if !function_signature
-                .overloads
-                .iter()
-                .any(Signature::has_explicit_positional_receiver_annotation)
-            {
-                return CallableSignature::from_overloads(function_signature.overloads.iter().map(
-                    |signature| {
-                        signature.bind_self_with_receiver(
-                            db,
-                            Some(receiver_type),
-                            Some(typing_self_type),
-                        )
-                    },
-                ));
-            }
-
-            return CallableSignature::from_overloads(
-                function_signature
-                    .overloads
-                    .iter()
-                    .filter(|signature| signature.can_bind_self_to(db, receiver_type))
-                    .map(|signature| {
-                        signature.bind_self_with_receiver(
-                            db,
-                            Some(receiver_type),
-                            Some(typing_self_type),
-                        )
-                    }),
-            );
-        };
-
-        CallableSignature::single(signature.bind_self_with_receiver(
+        self.function(db).signature(db).bind_self_with_receiver(
             db,
             Some(receiver_type),
             Some(typing_self_type),
-        ))
+        )
     }
 
     pub(super) fn recursive_type_normalized_impl(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -449,18 +449,27 @@ impl<'db> CallableSignature<'db> {
                     .iter()
                     .any(Signature::has_explicit_positional_receiver_annotation)
             {
-                return Self::from_overloads(
-                    self.overloads
-                        .iter()
-                        .filter(|signature| signature.can_bind_self_to(db, receiver_type))
-                        .map(|signature| {
-                            signature.bind_self_with_receiver(
-                                db,
-                                Some(receiver_type),
-                                typing_self_type,
-                            )
-                        }),
-                );
+                let retained: Vec<_> = self
+                    .overloads
+                    .iter()
+                    .filter(|signature| signature.can_bind_self_to(db, receiver_type))
+                    .collect();
+
+                // A receiver that still contains a type variable (e.g. a constrained `TypeVar`, or a
+                // generic specialization such as `State[T]`) does not pin down a single concrete
+                // receiver, so receiver-based pruning cannot confidently reject an overload. When it
+                // would remove *every* overload we keep them all and defer to normal overload
+                // resolution, rather than exposing an empty (non-callable) `Overload[]`. Concrete
+                // receivers still prune to empty when nothing matches.
+                let overloads = if retained.is_empty() && receiver_type.has_typevar(db) {
+                    self.overloads.iter().collect()
+                } else {
+                    retained
+                };
+
+                return Self::from_overloads(overloads.into_iter().map(|signature| {
+                    signature.bind_self_with_receiver(db, Some(receiver_type), typing_self_type)
+                }));
             }
 
             return Self::from_overloads(self.overloads.iter().map(|signature| {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -442,26 +442,33 @@ impl<'db> CallableSignature<'db> {
         receiver_type: Option<Type<'db>>,
         typing_self_type: Option<Type<'db>>,
     ) -> Self {
-        if let Some(receiver_type) = receiver_type
-            && self.overloads.len() > 1
-            && self
-                .overloads
-                .iter()
-                .any(Signature::has_explicit_positional_receiver_annotation)
-        {
-            Self::from_overloads(
-                self.overloads
+        let [signature] = self.overloads.as_slice() else {
+            if let Some(receiver_type) = receiver_type
+                && self
+                    .overloads
                     .iter()
-                    .filter(|signature| signature.can_bind_self_to(db, receiver_type))
-                    .map(|signature| {
-                        signature.bind_self_with_receiver(db, Some(receiver_type), typing_self_type)
-                    }),
-            )
-        } else {
-            Self::from_overloads(self.overloads.iter().map(|signature| {
+                    .any(Signature::has_explicit_positional_receiver_annotation)
+            {
+                return Self::from_overloads(
+                    self.overloads
+                        .iter()
+                        .filter(|signature| signature.can_bind_self_to(db, receiver_type))
+                        .map(|signature| {
+                            signature.bind_self_with_receiver(
+                                db,
+                                Some(receiver_type),
+                                typing_self_type,
+                            )
+                        }),
+                );
+            }
+
+            return Self::from_overloads(self.overloads.iter().map(|signature| {
                 signature.bind_self_with_receiver(db, receiver_type, typing_self_type)
-            }))
-        }
+            }));
+        };
+
+        Self::single(signature.bind_self_with_receiver(db, receiver_type, typing_self_type))
     }
 
     pub(crate) fn has_parameters(&self) -> bool {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -430,32 +430,37 @@ impl<'db> CallableSignature<'db> {
         }
     }
 
-    /// Binds the first (presumably `self`) parameter of this signature. If a `self_type` is
-    /// provided, we will replace any occurrences of `typing.Self` in the parameter and return
-    /// annotations with that type.
-    pub(crate) fn bind_self(&self, db: &'db dyn Db, self_type: Option<Type<'db>>) -> Self {
-        self.bind_self_with_receiver(db, self_type, self_type)
-    }
-
-    /// Binds the receiver using its runtime type while using `typing_self_type` to replace
-    /// occurrences of `typing.Self`.
+    /// Binds the first (presumably `self`) parameter of this signature.
     ///
-    /// These differ for class methods: the runtime receiver is a class object, while
-    /// `typing.Self` denotes an instance of that class.
+    /// `receiver_type` is used to select overloads with compatible explicit receiver
+    /// annotations, while `typing_self_type` replaces occurrences of `typing.Self`. These types
+    /// differ for class methods: the receiver is a class object, but `Self` resolves to its
+    /// instance type.
     pub(crate) fn bind_self_with_receiver(
         &self,
         db: &'db dyn Db,
         receiver_type: Option<Type<'db>>,
         typing_self_type: Option<Type<'db>>,
     ) -> Self {
-        Self {
-            overloads: self
+        if let Some(receiver_type) = receiver_type
+            && self.overloads.len() > 1
+            && self
                 .overloads
                 .iter()
-                .map(|signature| {
-                    signature.bind_self_with_receiver(db, receiver_type, typing_self_type)
-                })
-                .collect(),
+                .any(Signature::has_explicit_positional_receiver_annotation)
+        {
+            Self::from_overloads(
+                self.overloads
+                    .iter()
+                    .filter(|signature| signature.can_bind_self_to(db, receiver_type))
+                    .map(|signature| {
+                        signature.bind_self_with_receiver(db, Some(receiver_type), typing_self_type)
+                    }),
+            )
+        } else {
+            Self::from_overloads(self.overloads.iter().map(|signature| {
+                signature.bind_self_with_receiver(db, receiver_type, typing_self_type)
+            }))
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

redis-py를 사용하다 `redis.asyncio.Redis.incr` 메서드의 return을 `Awaitable[int]`가 아닌 `int`라고 추정하는 문제를 발견했습니다.

> While using redis-py, I found that ty infers the return of `redis.asyncio.Redis.incr` as `int` instead of `Awaitable[int]`.

``` python
from typing import reveal_type
import redis

def fn(r: redis.Redis, ar: redis.asyncio.Redis):
    reveal_type(r.incr("a")) # Revealed type: `int` [revealed-type]
    reveal_type(ar.incr("a")) # Revealed type: `int` [revealed-type]
```

그래서 redis-py의 구조를 그대로 축소해서 테스트 해보았을 때, `@overload` 메서드에 대한 alias를 처리하지 못하는 것을 확인했습니다.

> So when I reduced redis-py's structure down as-is and tested it, I confirmed that ty fails to handle the alias of an `@overload`-decorated method.

``` python
from typing import overload, Protocol, Literal, Any, reveal_type

class IntProtocol(Protocol):
    _type: Literal["Int"]

class StrProtocol(Protocol):
    _type: Literal["Str"]

class BoolProtocol(Protocol):
    _type: Literal["Bool"]

class Commands:
    @overload
    def answer(self: IntProtocol) -> int: ...
    @overload
    def answer(self: StrProtocol) -> str: ...
    @overload
    def answer(self: BoolProtocol) -> bool: ...
    def answer(self) -> int | str | bool: ...

    aliased_answer = answer

class IntClass(Commands):
    _type: Literal["Int"] = "Int"

class StrClass(Commands):
    _type: Literal["Str"] = "Str"

class BoolClass(Commands):
    _type: Literal["Bool"] = "Bool"

reveal_type(IntClass().answer())  # 1. Revealed type: `int` [revealed-type]
reveal_type(StrClass().answer())  # 1. Revealed type: `str` [revealed-type]
reveal_type(BoolClass().answer())  # 1. Revealed type: `str` [revealed-type]

reveal_type(IntClass().aliased_answer())  # 1. Revealed type: `int` [revealed-type]
reveal_type(StrClass().aliased_answer())  # 1. Revealed type: `int` [revealed-type]
reveal_type(BoolClass().aliased_answer())  # 1. Revealed type: `int` [revealed-type]
```

오버로드된 메서드를 클래스 레벨 alias로 접근하는 경우 Callable로 처리하는데, 이 과정에서 BoundMethod로 처리할 때는 존재하던 필터링이 없어서 그대로 타입이 통과된다는 것을 발견했습니다.

> When an overloaded method is accessed through a class-level alias, it is handled as a `Callable`. I found that this path lacks the filtering that exists when the method is handled as a `BoundMethod`, so the type passes through without being pruned.

---

> **Claude Summary** 
> Accessing an overloaded method through a class-level alias (which is promoted to a `Callable`) went through `CallableType::bind_self`, which bound every overload without pruning those whose explicit `self` annotation cannot accept the bound receiver. A no-argument call through the alias therefore resolved to the first overload regardless of the receiver (e.g. `StrClass().aliased_answer()` revealed `int` instead of `str`).
>
> Mirror `BoundMethodType::bound_signatures`: when the callable carries multiple overloads with explicit receiver annotations, filter with `can_bind_self_to` before binding `self`.

## Test Plan

<!-- How was it tested? -->

테스트는 redis-py 구현에서 검증을 위해 불필요한 부분을 걷어내는 방향으로 진행되었습니다.

> The test was written by stripping the redis-py reproduction down to only what is needed for verification.

```py
from typing import overload

class Base:
    @overload
    def answer(self: "IntChild") -> int: ...
    @overload
    def answer(self: "StrChild") -> str: ...
    @overload
    def answer(self: "BoolChild") -> bool: ...
    def answer(self) -> int | str | bool:
        return 0

    aliased = answer

class IntChild(Base):
    a: int = 0

class StrChild(Base):
    b: str = ""

class BoolChild(Base):
    c: bytes = b""

# Each receiver matches a single overload, so the alias prunes the other two.
reveal_type(IntChild().aliased)  # revealed: () -> int
reveal_type(StrChild().aliased)  # revealed: () -> str
reveal_type(BoolChild().aliased)  # revealed: () -> bool

reveal_type(IntChild().aliased())  # revealed: int
reveal_type(StrChild().aliased())  # revealed: str
reveal_type(BoolChild().aliased())  # revealed: bool
```
