### PR TITLE
[ty] Do not top-materialize (user) `TypeIs` return types

### DIFF
--- a/crates/ty_ide/src/type_hierarchy.rs
+++ b/crates/ty_ide/src/type_hierarchy.rs
@@ -221,7 +221,7 @@ mod tests {
         let supertypes = test.supertypes();
         insta::assert_snapshot!(
             snapshot(&test.db, &supertypes),
-            @"vendored://stdlib/builtins.pyi:3620:3626 object :: builtins",
+            @"vendored://stdlib/builtins.pyi:3650:3656 object :: builtins",
         );
     }
 
@@ -435,12 +435,12 @@ mod tests {
         let item = test.prepare().unwrap();
         insta::assert_snapshot!(
             snapshot(&test.db, &[item]),
-            @"vendored://stdlib/builtins.pyi:8520:8524 type :: builtins",
+            @"vendored://stdlib/builtins.pyi:8550:8554 type :: builtins",
         );
         let supertypes = test.supertypes();
         insta::assert_snapshot!(
             snapshot(&test.db, &supertypes),
-            @"vendored://stdlib/builtins.pyi:3620:3626 object :: builtins",
+            @"vendored://stdlib/builtins.pyi:3650:3656 object :: builtins",
         );
     }
 
@@ -492,7 +492,7 @@ mod tests {
         let supertypes = test.supertypes();
         insta::assert_snapshot!(
             snapshot(&test.db, &supertypes),
-            @"vendored://stdlib/builtins.pyi:104692:104697 tuple :: builtins",
+            @"vendored://stdlib/builtins.pyi:104722:104727 tuple :: builtins",
         );
     }
 

--- a/crates/ty_python_semantic/resources/mdtest/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/async.md
@@ -150,7 +150,7 @@ def get_any() -> Any:
 async def test():
     x = get_any()
     if inspect.isawaitable(x):
-        reveal_type(x)  # revealed: Any & Top[Awaitable[object]]
+        reveal_type(x)  # revealed: Any & Awaitable[object]
         y = await x
         reveal_type(y)  # revealed: Any
 ```

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -2223,7 +2223,8 @@ asdict(Foo)
 ## `dataclasses.is_dataclass`
 
 `is_dataclass` recognizes both dataclass instances and dataclass classes. A concrete dataclass
-instance always satisfies the `DataclassInstance` protocol, so the negative branch is unreachable:
+instance always satisfies the `DataclassInstance` protocol, but we do not currently recognize that
+the negative branch is unreachable:
 
 ```py
 from dataclasses import dataclass, is_dataclass
@@ -2234,7 +2235,8 @@ class Event:
 
 def check(event: Event) -> None:
     if not is_dataclass(event):
-        reveal_type(event)  # revealed: Never
+        # TODO: This should be `Never`.
+        reveal_type(event)  # revealed: Event & ~DataclassInstance & ~type[DataclassInstance]
 ```
 
 ## `dataclasses.KW_ONLY`

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1734,9 +1734,9 @@ error[invalid-method-override]: Invalid override of method `__eq__`
   3 |     def __eq__(self, other: "Bad") -> bool:  # snapshot: invalid-method-override
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `object.__eq__`
     |
-   ::: stdlib/builtins.pyi:136:9
+   ::: stdlib/builtins.pyi:137:9
     |
-136 |     def __eq__(self, value: object, /) -> bool: ...
+137 |     def __eq__(self, value: object, /) -> bool: ...
     |         -------------------------------------- `object.__eq__` defined here
 info: parameter `value` has an incompatible type: `object` is not assignable to `Bad`
 info: This violates the Liskov Substitution Principle

--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -2,7 +2,7 @@
 
 ## Basic narrowing
 
-The `callable()` builtin returns `TypeIs[Callable[..., object]]`, which narrows the type to the
+The `callable()` builtin returns `TypeIs[Top[Callable[..., object]]]`, which narrows the type to the
 intersection with `Top[Callable[..., object]]`. The `Top[...]` wrapper indicates this is a fully
 static type representing the top materialization of a gradual callable.
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -458,15 +458,14 @@ def _(x: Foo | Bar, is_bar: Callable[[object], TypeIs[Bar]]):
         reveal_type(x)  # revealed: Foo & ~Bar
 ```
 
-For generics, we transform the argument passed into `TypeIs[]` from `X` to `Top[X]`. This helps
-especially when using various functions from typeshed that are annotated as returning
-`TypeIs[SomeCovariantGeneric[Any]]` to avoid false positives in other type checkers. For ty's
-purposes, it would usually lead to more intuitive results if `object` was used as the specialization
-for a covariant generic inside the `TypeIs` special form, but this is mitigated by our implicit
-transformation from `TypeIs[SomeCovariantGeneric[Any]]` to `TypeIs[Top[SomeCovariantGeneric[Any]]]`
-(which just simplifies to `TypeIs[SomeCovariantGeneric[object]]`).
+If a `TypeIs` function returns a gradual specialization of a generic class, we simply intersect with
+that generic type. This means that something like the following does not work like the user probably
+intended:
 
 ```py
+from typing import final
+
+@final
 class Unrelated: ...
 
 class Covariant[T]:
@@ -483,11 +482,28 @@ def _(x: Unrelated | Covariant[int]):
     if is_instance_of_covariant(x):
         raise RuntimeError("oh no")
 
-    reveal_type(x)  # revealed: Unrelated & ~Covariant[object]
+    reveal_type(x)  # revealed: Unrelated | (Covariant[int] & ~Covariant[Any])
 
-    # We would emit a false-positive diagnostic here if we didn't implicitly transform
-    # `TypeIs[Covariant[Any]]` to `TypeIs[Covariant[object]]`
-    needs_instance_of_unrelated(x)
+    needs_instance_of_unrelated(x)  # error: [invalid-argument-type]
+```
+
+If a user wants to select *all* instances of `Covariant`, they must use `Covariant[object]`, or more
+generally, `Top[C[Any]]`, which also works for invariant generic types:
+
+```py
+from ty_extensions import Top
+
+class Invariant[T]:
+    value: T  # make it invariant in `T`
+
+def is_instance_of_invariant(arg: object) -> TypeIs[Top[Invariant[Any]]]:
+    return isinstance(arg, Invariant)
+
+def _(x: Unrelated | Invariant[int]):
+    if is_instance_of_invariant(x):
+        reveal_type(x)  # revealed: Invariant[int]
+    else:
+        reveal_type(x)  # revealed: Unrelated
 ```
 
 ## `TypeGuard` special cases

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -458,22 +458,30 @@ def _(x: Foo | Bar, is_bar: Callable[[object], TypeIs[Bar]]):
         reveal_type(x)  # revealed: Foo & ~Bar
 ```
 
-If a `TypeIs` function returns a gradual specialization of a generic class, we simply intersect with
-that generic type. This means that something like the following does not work like the user probably
-intended:
+A `TypeIs` function that returns a gradual specialization of a generic class narrows to that generic
+type without replacing its gradual type argument:
 
 ```py
-from typing import final
-
-@final
-class Unrelated: ...
-
 class Covariant[T]:
     def get(self) -> T:
         raise NotImplementedError
 
 def is_instance_of_covariant(arg: object) -> TypeIs[Covariant[Any]]:
     return isinstance(arg, Covariant)
+
+def _(x: object):
+    if is_instance_of_covariant(x):
+        reveal_type(x)  # revealed: Covariant[Any]
+```
+
+However, intersecting with the declared gradual type does not necessarily exclude every other
+specialization in the negative branch:
+
+```py
+from typing import final
+
+@final
+class Unrelated: ...
 
 def needs_instance_of_unrelated(arg: Unrelated):
     pass
@@ -491,12 +499,15 @@ If a user wants to select *all* instances of `Covariant`, they must use `Covaria
 generally, `Top[C[Any]]`, which also works for invariant generic types:
 
 ```py
-from ty_extensions import Top
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ty_extensions import Top
 
 class Invariant[T]:
     value: T  # make it invariant in `T`
 
-def is_instance_of_invariant(arg: object) -> TypeIs[Top[Invariant[Any]]]:
+def is_instance_of_invariant(arg: object) -> "TypeIs[Top[Invariant[Any]]]":
     return isinstance(arg, Invariant)
 
 def _(x: Unrelated | Invariant[int]):

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Basic_(f15db7dc447d0795).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Basic_(f15db7dc447d0795).snap
@@ -26,9 +26,9 @@ error[invalid-await]: `Literal[1]` is not awaitable
   2 |     await 1  # error: [invalid-await]
     |           ^
     |
-   ::: stdlib/builtins.pyi:349:7
+   ::: stdlib/builtins.pyi:350:7
     |
-349 | class int:
+350 | class int:
     |       --- type defined here
 info: `__await__` is missing
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elemen…_(39b614d4707c0661).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Equality_with_elemen…_(39b614d4707c0661).snap
@@ -41,9 +41,9 @@ error[invalid-method-override]: Invalid override of method `__eq__`
   6 |     def __eq__(self, other) -> NotBoolable:
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `object.__eq__`
     |
-   ::: stdlib/builtins.pyi:136:9
+   ::: stdlib/builtins.pyi:137:9
     |
-136 |     def __eq__(self, value: object, /) -> bool: ...
+137 |     def __eq__(self, value: object, /) -> bool: ...
     |         -------------------------------------- `object.__eq__` defined here
 info: incompatible return types: `NotBoolable` is not assignable to `bool`
 info: This violates the Liskov Substitution Principle

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Class_header_validat…_(25381f371caa1401).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Class_header_validat…_(25381f371caa1401).snap
@@ -46,9 +46,9 @@ error[invalid-typed-dict-header]: TypedDict class `Foo` can only inherit from Ty
   3 | class Foo(TypedDict, int): ...  # error: [invalid-typed-dict-header]
     |                      ^^^ `int` is not a `TypedDict` class
     |
-   ::: stdlib/builtins.pyi:349:7
+   ::: stdlib/builtins.pyi:350:7
     |
-349 | class int:
+350 | class int:
     |       --- `int` defined here
 
 ```
@@ -60,9 +60,9 @@ error[invalid-typed-dict-header]: TypedDict class `Foo2` can only inherit from T
   6 | class Foo2(TypedDict, object): ...  # error: [invalid-typed-dict-header]
     |                       ^^^^^^ `object` is not a `TypedDict` class
     |
-   ::: stdlib/builtins.pyi:113:7
+   ::: stdlib/builtins.pyi:114:7
     |
-113 | class object:
+114 | class object:
     |       ------ `object` defined here
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Union_with_overloade…_(4408ade1316b97c0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Union_with_overloade…_(4408ade1316b97c0).snap
@@ -41,9 +41,9 @@ info: ├── type `Literal[" "]` is not assignable to protocol `Buffer`
 info: │   └── protocol member `__buffer__` is not defined on type `Literal[" "]`
 info: └── ... omitted 1 union element without additional context
 info: Method defined here
-    --> stdlib/builtins.pyi:1843:9
+    --> stdlib/builtins.pyi:1844:9
      |
-1843 |     def split(self, sep: ReadableBuffer | None = None, maxsplit: SupportsIndex = -1) -> list[bytes]:
+1844 |     def split(self, sep: ReadableBuffer | None = None, maxsplit: SupportsIndex = -1) -> list[bytes]:
      |         ^^^^^       --------------------------------- Parameter declared here
 info: Union variant `bound method bytes.split(sep: Buffer | None = None, maxsplit: SupportsIndex = -1) -> list[bytes]` is incompatible with this call site
 info: Attempted to call union type `(bound method bytes.split(sep: Buffer | None = None, maxsplit: SupportsIndex = -1) -> list[bytes]) | (bound method str.split(sep: str | None = None, maxsplit: SupportsIndex = -1) -> list[str])`

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -8842,9 +8842,6 @@ impl<'db> TypeIsType<'db> {
 
     /// Construct an unbound `TypeIs` return type from the user-written type expression.
     ///
-    /// The user-written type is preserved for `TypeIs` invariance checks, while the return type
-    /// used for narrowing applies the top materialization on demand.
-    ///
     /// ```python
     /// from typing import TypeIs
     ///
@@ -8856,12 +8853,7 @@ impl<'db> TypeIsType<'db> {
     }
 
     pub(crate) fn return_type(self, db: &'db dyn Db) -> Type<'db> {
-        // N.B. Using the top materialization here is a pragmatic decision that
-        // makes us produce more intuitive results given how `TypeIs` is used in
-        // the real world (in particular, in typeshed). However, there's some
-        // debate about whether this is really fully correct. See
-        // <https://github.com/astral-sh/ruff/pull/20591> for more discussion.
-        self.type_argument(db).top_materialization(db)
+        self.type_argument(db)
     }
 
     #[must_use]

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2393,12 +2393,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                     Type::unknown()
                 }
-                _ => TypeGuardType::unbound(
-                    self.db(),
-                    // Unlike `TypeIs`, don't use top materialization, because
-                    // `TypeGuard` clobbering behavior makes it counterintuitive
-                    self.infer_type_expression(arguments_slice),
-                ),
+                _ => TypeGuardType::unbound(self.db(), self.infer_type_expression(arguments_slice)),
             },
             SpecialFormType::Concatenate => {
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {

--- a/crates/ty_vendored/typeshed_patches/0005-inspect-isawaitable-object.patch
+++ b/crates/ty_vendored/typeshed_patches/0005-inspect-isawaitable-object.patch
@@ -1,0 +1,26 @@
+--- a/stdlib/inspect.pyi
++++ b/stdlib/inspect.pyi
+@@ -345,10 +345,10 @@ def isgenerator(object: object) -> TypeIs[GeneratorType[object, Never, object]]:
+         throw()         used to raise an exception inside the generator
+     """
+ 
+-def iscoroutine(object: object) -> TypeIs[CoroutineType[Any, Any, Any]]:
++def iscoroutine(object: object) -> TypeIs[CoroutineType[object, Never, object]]:
+     """Return true if the object is a coroutine."""
+ 
+-def isawaitable(object: object) -> TypeIs[Awaitable[Any]]:
++def isawaitable(object: object) -> TypeIs[Awaitable[object]]:
+     """Return true if object can be passed to an ``await`` expression."""
+ 
+ @overload
+--- a/stdlib/typing_extensions.pyi
++++ b/stdlib/typing_extensions.pyi
+@@ -1337,7 +1337,7 @@ else:
+ 
+     For example::
+ 
+-        def is_awaitable(val: object) -> TypeIs[Awaitable[Any]]:
++        def is_awaitable(val: object) -> TypeIs[Awaitable[object]]:
+             return hasattr(val, '__await__')
+ 
+         def f(val: Union[int, Awaitable[int]]) -> int:

--- a/crates/ty_vendored/typeshed_patches/0006-stdlib-typeis-static-types.patch
+++ b/crates/ty_vendored/typeshed_patches/0006-stdlib-typeis-static-types.patch
@@ -1,0 +1,58 @@
+--- a/stdlib/builtins.pyi
++++ b/stdlib/builtins.pyi
+@@ -78,6 +78,7 @@ from typing import (  # noqa: Y022,UP035
+ 
+ # we can't import `Literal` from typing or mypy crashes: see #11247
+ from typing_extensions import Literal, LiteralString, Self, TypeIs, TypeVarTuple, deprecated, disjoint_base  # noqa: Y023, UP035
++from ty_extensions import Top
+ 
+ if sys.version_info >= (3, 14):
+     from _typeshed import AnnotateFunc
+@@ -3667,7 +3668,7 @@ def breakpoint(*args: Any, **kws: Any) -> None:
+     By default, this drops you into the pdb debugger.
+     """
+ 
+-def callable(obj: object, /) -> TypeIs[Callable[..., object]]:
++def callable(obj: object, /) -> TypeIs[Top[Callable[..., object]]]:
+     """Return whether the object is callable (i.e., some kind of function).
+ 
+     Note that classes are callable, as are instances of classes with a
+--- a/stdlib/asyncio/base_futures.pyi
++++ b/stdlib/asyncio/base_futures.pyi
+@@ -3,6 +3,7 @@ from collections.abc import Callable, Sequence
+ from contextvars import Context
+ from typing import Any, Final
+ from typing_extensions import TypeIs
++from ty_extensions import Top
+ 
+ from . import futures
+ 
+@@ -12,7 +13,7 @@ _PENDING: Final = "PENDING"  # undocumented
+ _CANCELLED: Final = "CANCELLED"  # undocumented
+ _FINISHED: Final = "FINISHED"  # undocumented
+ 
+-def isfuture(obj: object) -> TypeIs[Future[Any]]:
++def isfuture(obj: object) -> TypeIs[Top[Future[Any]]]:
+     """Check for a Future.
+ 
+     This returns True when obj is a Future instance or is advertising
+--- a/stdlib/asyncio/coroutines.pyi
++++ b/stdlib/asyncio/coroutines.pyi
+@@ -1,6 +1,6 @@
+ import sys
+ from collections.abc import Awaitable, Callable, Coroutine
+ from typing import Any, ParamSpec, TypeGuard, TypeVar, overload
+-from typing_extensions import TypeIs, deprecated
++from typing_extensions import Never, TypeIs, deprecated
+ 
+ # Keep asyncio.__all__ updated with any changes to __all__ here
+@@ -22,7 +22,7 @@ if sys.version_info < (3, 11):
+         If the coroutine is not yielded from before it is destroyed,
+         an error message is logged.
+         """
+ 
+-def iscoroutine(obj: object) -> TypeIs[Coroutine[Any, Any, Any]]:
++def iscoroutine(obj: object) -> TypeIs[Coroutine[object, Never, object]]:
+     """Return True if obj is a coroutine object."""
+ 
+ if sys.version_info >= (3, 11):

--- a/crates/ty_vendored/vendor/typeshed/stdlib/asyncio/base_futures.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/asyncio/base_futures.pyi
@@ -3,6 +3,7 @@ from collections.abc import Callable, Sequence
 from contextvars import Context
 from typing import Any, Final
 from typing_extensions import TypeIs
+from ty_extensions import Top
 
 from . import futures
 
@@ -12,7 +13,7 @@ _PENDING: Final = "PENDING"  # undocumented
 _CANCELLED: Final = "CANCELLED"  # undocumented
 _FINISHED: Final = "FINISHED"  # undocumented
 
-def isfuture(obj: object) -> TypeIs[Future[Any]]:
+def isfuture(obj: object) -> TypeIs[Top[Future[Any]]]:
     """Check for a Future.
 
     This returns True when obj is a Future instance or is advertising

--- a/crates/ty_vendored/vendor/typeshed/stdlib/asyncio/coroutines.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/asyncio/coroutines.pyi
@@ -1,7 +1,7 @@
 import sys
 from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any, ParamSpec, TypeGuard, TypeVar, overload
-from typing_extensions import TypeIs, deprecated
+from typing_extensions import Never, TypeIs, deprecated
 
 # Keep asyncio.__all__ updated with any changes to __all__ here
 if sys.version_info >= (3, 11):
@@ -22,7 +22,7 @@ if sys.version_info < (3, 11):
         an error message is logged.
         """
 
-def iscoroutine(obj: object) -> TypeIs[Coroutine[Any, Any, Any]]:
+def iscoroutine(obj: object) -> TypeIs[Coroutine[object, Never, object]]:
     """Return True if obj is a coroutine object."""
 
 if sys.version_info >= (3, 11):

--- a/crates/ty_vendored/vendor/typeshed/stdlib/builtins.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/builtins.pyi
@@ -78,6 +78,7 @@ from typing import (  # noqa: Y022,UP035
 
 # we can't import `Literal` from typing or mypy crashes: see #11247
 from typing_extensions import Literal, LiteralString, Self, TypeIs, TypeVarTuple, deprecated, disjoint_base  # noqa: Y023, UP035
+from ty_extensions import Top
 
 if sys.version_info >= (3, 14):
     from _typeshed import AnnotateFunc
@@ -3666,7 +3667,7 @@ def breakpoint(*args: Any, **kws: Any) -> None:
     By default, this drops you into the pdb debugger.
     """
 
-def callable(obj: object, /) -> TypeIs[Callable[..., object]]:
+def callable(obj: object, /) -> TypeIs[Top[Callable[..., object]]]:
     """Return whether the object is callable (i.e., some kind of function).
 
     Note that classes are callable, as are instances of classes with a

--- a/crates/ty_vendored/vendor/typeshed/stdlib/inspect.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/inspect.pyi
@@ -345,10 +345,10 @@ def isgenerator(object: object) -> TypeIs[GeneratorType[object, Never, object]]:
         throw()         used to raise an exception inside the generator
     """
 
-def iscoroutine(object: object) -> TypeIs[CoroutineType[Any, Any, Any]]:
+def iscoroutine(object: object) -> TypeIs[CoroutineType[object, Never, object]]:
     """Return true if the object is a coroutine."""
 
-def isawaitable(object: object) -> TypeIs[Awaitable[Any]]:
+def isawaitable(object: object) -> TypeIs[Awaitable[object]]:
     """Return true if object can be passed to an ``await`` expression."""
 
 @overload

--- a/crates/ty_vendored/vendor/typeshed/stdlib/typing_extensions.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/typing_extensions.pyi
@@ -1337,7 +1337,7 @@ else:
 
     For example::
 
-        def is_awaitable(val: object) -> TypeIs[Awaitable[Any]]:
+        def is_awaitable(val: object) -> TypeIs[Awaitable[object]]:
             return hasattr(val, '__await__')
 
         def f(val: Union[int, Awaitable[int]]) -> int:


### PR DESCRIPTION
## Summary

We currently top-materialize `TypeIs` types to work around the fact that typeshed annotates some standard library functions like `isawaitable` with a gradual `TypeIs[Awaitable[Any]]` return type. This is problematic when taken verbatim, since that instructs us to intersect with a gradual `Awaitable[Any]` type instead of truly selecting *all* awaitables (`Awaitable[object]`). For example, narrowing `Item | Awaitable[Item]` with a final `Item` class using `isawaitable` would result in `Awaitable[Item] & Awaitable[Any] = Awaitable[Item & Any]`, instead of just `Awaitable[Item]`.

However, the current behavior is problematic for user-defined `TypeIs` functions, since we don't respect their declared return type.

Here, we fix this by patching typeshed while dropping the top-materialization. This leads to an unchanged behavior for standard-library functions like `isawaitable`, `iscallable`, etc, but respects users annotations for custom `TypeIs` functions:

```py
def is_list(arg: object) -> TypeIs[list[Any]]:
    return isinstance(arg, list)

def _(x: object):
    if is_list(x):
        reveal_type(x)  # list[Any], previously: Top[list[Any]]
```

relates to https://github.com/astral-sh/ty/issues/3375

## Ecosystem report

Looks mostly good: Removed false positives, new unused ignore comment diagnostics

Some expected problems, e.g. with this user-defined function in beartype, leading to unfortunate types like `((...) -> Unknown) & ~((...) -> Unknown)`, which are technically correct (and could maybe be simplified), but certainly unintended:
```py
def is_callable_like(value: Any) -> TypeIs[Callable]:
    return callable(value)
```

## Conformance results

- One false positive removed, which is expected.
- One new false positive, which looks like it's due to a generic solver gap.

## Test Plan

Adapted tests
