### PR TITLE
[ty] Experiment: remove type-mapping visitor cache

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -299,8 +299,8 @@ type MaterializationEquivalenceVisitor<'db> =
 /// A [`TypeTransformer`] that is used in `apply_type_mapping` methods.
 ///
 /// Some recursive transformations visit the same type under more than one mapping mode within a
-/// single call chain. Keep separate cycle caches for those modes so one transformation cannot
-/// reuse the result of another.
+/// single call chain. Keep separate recursion stacks for those modes so one transformation is not
+/// mistaken for a cycle in another.
 #[derive(Default)]
 pub(crate) struct ApplyTypeMappingVisitor<'db> {
     default: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -106,9 +106,6 @@ pub(crate) struct TypeTransformer<'db, Tag> {
     /// Completed visits are removed from the end of the stack.
     seen: RefCell<SmallVec<[Type<'db>; 3]>>,
 
-    /// Memoized transformations from earlier visits in the current recursive operation.
-    cache: RefCell<CycleDetectorCache<Type<'db>, Type<'db>>>,
-
     _tag: PhantomData<fn() -> Tag>,
 }
 
@@ -116,7 +113,6 @@ impl<Tag> Default for TypeTransformer<'_, Tag> {
     fn default() -> Self {
         Self {
             seen: RefCell::default(),
-            cache: RefCell::default(),
             _tag: PhantomData,
         }
     }
@@ -131,19 +127,16 @@ impl<'db, Tag> TypeTransformer<'db, Tag> {
         compute: impl FnOnce() -> Type<'db>,
     ) -> Type<'db> {
         match self.begin_visit(db, ty) {
-            BeginVisit::Ready(result) => result,
-            BeginVisit::Pending(ty) => {
+            Some(result) => result,
+            None => {
                 let result = compute();
-                self.finish_visit(ty, result)
+                self.seen.borrow_mut().pop();
+                result
             }
         }
     }
 
-    fn begin_visit(&self, db: &'db dyn Db, ty: Type<'db>) -> BeginVisit<Type<'db>, Type<'db>> {
-        if let Some(result) = self.cache.borrow().get(&ty) {
-            return BeginVisit::Ready(*result);
-        }
-
+    fn begin_visit(&self, db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
         if self
             .seen
             .borrow()
@@ -152,17 +145,11 @@ impl<'db, Tag> TypeTransformer<'db, Tag> {
         {
             // When a cycle is encountered, the type being visited is returned as a fallback
             // (typically a recursive type alias).
-            return BeginVisit::Ready(ty);
+            return Some(ty);
         }
 
         self.seen.borrow_mut().push(ty);
-        BeginVisit::Pending(ty)
-    }
-
-    fn finish_visit(&self, ty: Type<'db>, result: Type<'db>) -> Type<'db> {
-        self.seen.borrow_mut().pop();
-        self.cache.borrow_mut().insert_new(ty, result);
-        result
+        None
     }
 
     fn same_type_identity(db: &'db dyn Db, left: Type<'db>, right: Type<'db>) -> bool {


### PR DESCRIPTION
## Summary

This removes completed-result memoization from `TypeTransformer` while preserving the active recursion stacks (one per mode).

The cached implementation was instrumented to count `TypeTransformer::visit_type` calls and completed-result cache hits.

Overall, there was a 13.35% hit rate:

| Coverage | Result |
| --- | ---: |
| Visits | 1,250,351 |
| Cache hits | 166,967 (13.35%) |
| Projects with at least one hit | 133/157 |
| Projects with a hit rate >= 1% | 91/157 |
| Projects with a hit rate >= 10% | 14/157 |

The largest hit contributors were:

| Project | Visits | Cache hits |
| --- | ---: | ---: |
| pandas | 189,628 | 68,650 (36.20%) |
| pandas-stubs | 43,779 | 24,175 (55.22%) |
| scikit-learn | 62,074 | 11,571 (18.64%) |
| static-frame | 33,965 | 10,340 (30.44%) |
| Colour | 39,642 | 6,896 (17.40%) |
| Prefect | 36,985 | 6,128 (16.57%) |
| xarray | 37,764 | 4,936 (13.07%) |
| Home Assistant Core | 111,594 | 4,576 (4.10%) |
| scipy-stubs | 33,858 | 4,375 (12.92%) |
| Rotki | 41,698 | 3,048 (7.31%) |

I then looked at timing changes for pandas, pandas-stubs, and scikit-learn:

| Pair | Cached | Uncached | Uncached delta |
| --- | ---: | ---: | ---: |
| 1 | 11.126s | 12.314s | +10.7% |
| 2 | 11.197s | 11.648s | +4.0% |
| 3 | 11.399s | 11.438s | +0.3% |
| 4 | 11.026s | 11.786s | +6.9% |
| 5 | 11.246s | 12.417s | +10.4% |
