### PR TITLE
[ty] Use CharStr for interned string literals

### DIFF
--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -28,7 +28,7 @@ ty_site_packages = { workspace = true }
 ty_python_core = { workspace = true }
 
 bitflags = { workspace = true }
-char_str = { workspace = true }
+char_str = { workspace = true, features = ["get-size"] }
 compact_str = { workspace = true }
 drop_bomb = { workspace = true }
 get-size2 = { workspace = true, features = ["indexmap", "ordermap"] }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1,4 +1,4 @@
-use compact_str::{CompactString, ToCompactString};
+use compact_str::ToCompactString;
 use itertools::Itertools;
 use ruff_diagnostics::{Edit, Fix};
 use rustc_hash::FxHashMap;
@@ -1816,13 +1816,17 @@ impl<'db> Type<'db> {
     }
 
     /// Create a promotable string literal.
-    pub(crate) fn string_literal<T>(db: &'db dyn Db, string: T) -> Self
-    where
-        T: salsa::Lookup<CompactString> + std::hash::Hash,
-        CompactString: salsa::HashEqLike<T>,
-    {
-        Self::LiteralValue(LiteralValueType::promotable(StringLiteralType::new(
-            db, string,
+    pub(crate) fn string_literal(db: &'db dyn Db, string: impl AsRef<str>) -> Self {
+        Self::LiteralValue(LiteralValueType::promotable(StringLiteralType::from_str(
+            db,
+            string.as_ref(),
+        )))
+    }
+
+    /// Create a promotable string literal that shares an owned name's backing storage.
+    pub(crate) fn string_literal_from_name(db: &'db dyn Db, name: Name) -> Self {
+        Self::LiteralValue(LiteralValueType::promotable(StringLiteralType::from_name(
+            db, name,
         )))
     }
 
@@ -1838,10 +1842,7 @@ impl<'db> Type<'db> {
 
     /// Create a promotable single-character string literal.
     pub(crate) fn single_char_string_literal(db: &'db dyn Db, c: char) -> Self {
-        Self::LiteralValue(LiteralValueType::promotable(StringLiteralType::new(
-            db,
-            c.to_compact_string(),
-        )))
+        Self::string_literal(db, c.to_compact_string())
     }
 
     /// Create a promotable bytes literal.

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -68,12 +68,12 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
             }
 
             // __match_args__: tuple[Literal["field1"], Literal["field2"], ...]
-            let field_types = fields.map(|field| Type::string_literal(db, &field.name));
+            let field_types = fields.map(|field| Type::string_literal_from_name(db, field.name));
             Some(Type::heterogeneous_tuple(db, field_types))
         }
         "_fields" => {
             // _fields: tuple[Literal["field1"], Literal["field2"], ...]
-            let field_types = fields.map(|field| Type::string_literal(db, &field.name));
+            let field_types = fields.map(|field| Type::string_literal_from_name(db, field.name));
             Some(Type::heterogeneous_tuple(db, field_types))
         }
         "__slots__" => {

--- a/crates/ty_python_semantic/src/types/literal.rs
+++ b/crates/ty_python_semantic/src/types/literal.rs
@@ -1,5 +1,7 @@
+use std::hash::{Hash, Hasher};
+
 use bitflags::bitflags;
-use compact_str::CompactString;
+use char_str::CharStr;
 use ruff_python_ast::name::Name;
 
 use crate::Db;
@@ -344,16 +346,48 @@ impl std::cmp::PartialOrd for IntLiteralType {
     }
 }
 
+struct StringLiteralLookup<'a>(&'a str);
+
+impl Hash for StringLiteralLookup<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl salsa::Lookup<CharStr> for StringLiteralLookup<'_> {
+    fn into_owned(self) -> CharStr {
+        CharStr::from(self.0)
+    }
+}
+
+impl salsa::HashEqLike<StringLiteralLookup<'_>> for CharStr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Hash::hash(self, state);
+    }
+
+    fn eq(&self, data: &StringLiteralLookup<'_>) -> bool {
+        self.as_str() == data.0
+    }
+}
+
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct StringLiteralType<'db> {
     #[returns(deref)]
-    pub(crate) value: CompactString,
+    pub(crate) value: CharStr,
 }
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for StringLiteralType<'_> {}
 
 impl<'db> StringLiteralType<'db> {
+    pub(super) fn from_str(db: &'db dyn Db, value: &str) -> Self {
+        Self::new(db, StringLiteralLookup(value))
+    }
+
+    pub(super) fn from_name(db: &'db dyn Db, name: Name) -> Self {
+        Self::new(db, CharStr::from(name))
+    }
+
     /// The length of the string, as would be returned by Python's `len()`.
     pub(crate) fn python_len(self, db: &'db dyn Db) -> usize {
         self.value(db).chars().count()

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -5,7 +5,26 @@ use crate::types::type_alias::PEP695TypeAliasType;
 use ruff_db::system::DbWithWritableSystem as _;
 use ruff_python_ast as ast;
 use ruff_python_ast::PythonVersion;
+use ruff_python_ast::name::Name;
 use test_case::test_case;
+
+#[test]
+fn string_literal_shares_heap_backed_name() {
+    let db = setup_db();
+    let name = Name::new("a_named_tuple_field_longer_than_the_inline_capacity");
+    let name_pointer = name.as_str().as_ptr();
+
+    let literal = Type::string_literal_from_name(&db, name.clone());
+    let literal = literal
+        .as_string_literal()
+        .expect("the constructed type should be a string literal");
+
+    assert_eq!(literal.value(&db).as_ptr(), name_pointer);
+    assert_eq!(
+        Type::string_literal(&db, &name).as_string_literal(),
+        Some(literal)
+    );
+}
 
 /// Explicitly test for Python version <3.13 and >=3.13, to ensure that
 /// the fallback to `typing_extensions` is working correctly.


### PR DESCRIPTION
## Summary

This changes `StringLiteralType`'s Salsa key from a 24-byte `CompactString` to a 16-byte immutable `CharStr`.

As with `Name`, the tradeoff is that unique 17–24-byte values move from inline storage to the heap. The standard memory report includes that cost and remains positive across all four projects:

| Project | Old `StringLiteralType` | New `StringLiteralType` | Difference |
|---|---:|---:|---:|
| flake8 | 194.44 kB | 189.75 kB | -4.69 kB (-2.41%) |
| trio | 532.12 kB | 523.54 kB | -8.58 kB (-1.61%) |
| prefect | 5.90 MB | 5.89 MB | -12.54 kB (-0.21%) |
| sphinx | 2.04 MB | 2.00 MB | -46.55 kB (-2.23%) |
