### PR TITLE
[ty] Avoid expanding recursive protocol specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/3954_recursive_protocol_specialization_relation.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3954_recursive_protocol_specialization_relation.md
@@ -176,6 +176,68 @@ def convert(value: Source[int]) -> Target[int]:
     return value  # error: [invalid-return-type]
 ```
 
+## Transformed parameters retain structural solutions
+
+A structural relation can admit a narrower solution than relating the raw specialization arguments.
+The shortcut must not discard that solution before the protocol interface has been expanded once.
+
+`transformed.py`:
+
+```py
+from typing import Protocol
+
+class Inner[T](Protocol):
+    def get(self) -> T | int: ...
+
+class Outer[T](Protocol):
+    def inner(self) -> Inner[T]: ...
+
+def consume[T](value: Outer[T], exact: list[T]) -> T:
+    raise NotImplementedError
+
+def check(value: Outer[str | int], exact: list[str]) -> None:
+    reveal_type(consume(value, exact))  # revealed: str
+```
+
+## Lazy overload checks retain protocol-member context
+
+Overload implementation consistency uses lazy evaluation and still needs the structural mismatch
+context when a protocol member is incompatible.
+
+`overload_context.py`:
+
+```py
+from typing import Protocol, overload
+
+class P[T](Protocol):
+    def get(self) -> T: ...
+
+@overload
+def consume(value: int) -> None: ...
+@overload
+# snapshot: invalid-overload
+def consume(value: P[int]) -> None: ...
+def consume(value: P[str] | int) -> None: ...
+```
+
+```snapshot
+error[invalid-overload]: Implementation does not accept all arguments of this overload
+  --> src/overload_context.py:10:5
+   |
+10 | def consume(value: P[int]) -> None: ...
+   |     ^^^^^^^
+11 | def consume(value: P[str] | int) -> None: ...
+   |     ------- Implementation defined here
+   |
+info: Implementation signature `(value: P[str] | int) -> None` is not assignable to overload signature `(value: P[int]) -> None`
+info: parameter `value` has an incompatible type: `P[int]` is not assignable to `P[str] | int`
+info: └── type `P[int]` is not assignable to any element of the union `P[str] | int`
+info:     ├── protocol `P[int]` is not assignable to protocol `P[str]`
+info:     │   └── protocol member `get` is incompatible
+info:     │       └── incompatible return types: `int` is not assignable to `str`
+info:     └── ... omitted 1 union element without additional context
+```
+
 `attribute.py`:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/regression/3954_recursive_protocol_specialization_relation.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3954_recursive_protocol_specialization_relation.md
@@ -1,0 +1,204 @@
+# Recursive protocol specialization relations
+
+When two instances originate from the same generic protocol, their structural relation can be
+derived from the variance of the protocol interface. This avoids repeatedly expanding recursive
+members during inference while preserving constraints for type parameters that the interface
+actually exposes.
+
+This is a regression test for <https://github.com/astral-sh/ty/issues/3954>.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+## Recursive overload returns
+
+Generic overload returns introduce fresh method-local type variables on every unfolding. Relating
+the protocol specializations directly avoids that unbounded growth.
+
+`overloads.py`:
+
+```py
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Protocol, overload
+
+class TurnView(Protocol):
+    @property
+    def id(self) -> str: ...
+
+class Streamable[T](Protocol):
+    def __aiter__(self) -> AsyncIterator[T]: ...
+    @overload
+    def concat(self) -> Streamable[T]: ...
+    @overload
+    def concat[U1](self, other1: U1, /) -> Streamable[T | U1]: ...
+    @overload
+    def concat[U1, U2](self, other1: U1, other2: U2, /) -> Streamable[T | U1 | U2]: ...
+    @overload
+    def concat[U1, U2, U3](self, other1: U1, other2: U2, other3: U3, /) -> Streamable[T | U1 | U2 | U3]: ...
+    @overload
+    def concat[U1, U2, U3, U4](self, other1: U1, other2: U2, other3: U3, other4: U4, /) -> Streamable[T | U1 | U2 | U3 | U4]: ...
+    @overload
+    def concat[U1, U2, U3, U4, U5](
+        self, other1: U1, other2: U2, other3: U3, other4: U4, other5: U5, /
+    ) -> Streamable[T | U1 | U2 | U3 | U4 | U5]: ...
+    def concat(self, *others: object) -> Streamable[object]: ...
+
+class Connection[T](Streamable[T], Protocol): ...
+
+class TurnViewConnection[TurnT: TurnView](Connection[TurnT], Protocol):
+    def __aiter__(self) -> AsyncIterator[TurnT]: ...
+
+class Path:
+    @overload
+    def turns[TurnT: TurnView](self, *, type: type[TurnT]) -> TurnViewConnection[TurnT]: ...
+    @overload
+    def turns(self, *, type: None = None) -> TurnViewConnection[TurnView]: ...
+    def turns[TurnT: TurnView](
+        self, *, type: type[TurnT] | None = None
+    ) -> TurnViewConnection[TurnT] | TurnViewConnection[TurnView]:
+        raise NotImplementedError
+
+def element[TurnT: TurnView](turns: TurnViewConnection[TurnT]) -> TurnT:
+    raise NotImplementedError
+
+async def check(path: Path) -> None:
+    reveal_type(element(path.turns()))  # revealed: TurnView
+```
+
+## Recursive receiver constraints
+
+A receiver constraint can relate a specialization to a recursively transformed specialization.
+Computing the structural variance on the identity interface prevents `tuple[int, ...]` from growing
+on every relation step.
+
+`receiver.py`:
+
+```py
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterable
+from typing import Protocol
+
+class Streamable[T](Protocol):
+    def __aiter__(self) -> AsyncIterator[T]: ...
+    def enumerate(self) -> Streamable[tuple[int, T]]: ...
+    def flatten[U](self: Streamable[Streamable[U] | Iterable[U]]) -> Streamable[U]: ...
+
+def consume[T](items: Streamable[T]) -> None: ...
+def check(items: Streamable[int]) -> None:
+    consume(items)
+```
+
+## Recursive `ParamSpec` protocols
+
+`ParamSpec` specializations are callable-shaped, so their structural variance must still be flipped
+when relating the specialization arguments.
+
+`paramspec.py`:
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class Factory[**P](Protocol):
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> int: ...
+    def child(self) -> Factory[P]: ...
+
+def consume[**P](factory: Factory[P], *args: P.args, **kwargs: P.kwargs) -> int:
+    return factory(*args, **kwargs)
+
+def check(factory: Factory[[str]]) -> None:
+    reveal_type(consume(factory, "ok"))  # revealed: int
+    consume(factory, 1)  # error: [invalid-argument-type]
+```
+
+## Phantom parameters do not constrain structural relations
+
+The declared covariance of a legacy type variable is not enough to constrain a structural relation:
+if the interface never references that type variable, its structural variance is bivariant. In
+particular, a union containing the protocol must not infer nested instances of the same protocol for
+the surrounding type variable.
+
+`phantom.py`:
+
+```py
+from typing import Any, Protocol, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+class Recursive(Protocol[T_co]):
+    def method(self): ...
+
+def convert(value: Any | Recursive[T_co]) -> list[T_co]:
+    try:
+        raise Exception
+    except:
+        result = [value]
+        reveal_type(result)  # revealed: list[T_co@convert | Any | Recursive[T_co@convert]]
+        return result  # error: [invalid-return-type]
+```
+
+## Recursive properties and attributes retain finite mismatches
+
+A recursive property or mutable attribute cannot hide an incompatible overload member.
+
+`property.py`:
+
+```py
+from __future__ import annotations
+
+from typing import Protocol, overload
+
+class Source[T](Protocol):
+    @overload
+    def a_member(self, value: int) -> int: ...
+    @overload
+    def a_member(self, value: str) -> str: ...
+    def a_member(self, value: int | str) -> int | str: ...
+    @property
+    def z_child(self) -> Source[list[T]]: ...
+
+class Target[T](Protocol):
+    @overload
+    def a_member(self, value: int) -> str: ...
+    @overload
+    def a_member(self, value: str) -> int: ...
+    def a_member(self, value: int | str) -> int | str: ...
+    @property
+    def z_child(self) -> Target[list[T]]: ...
+
+def convert(value: Source[int]) -> Target[int]:
+    return value  # error: [invalid-return-type]
+```
+
+`attribute.py`:
+
+```py
+from __future__ import annotations
+
+from typing import Protocol, overload
+
+class Source[T](Protocol):
+    @overload
+    def a_member(self, value: int) -> int: ...
+    @overload
+    def a_member(self, value: str) -> str: ...
+    def a_member(self, value: int | str) -> int | str: ...
+    z_child: Source[list[T]]
+
+class Target[T](Protocol):
+    @overload
+    def a_member(self, value: int) -> str: ...
+    @overload
+    def a_member(self, value: str) -> int: ...
+    def a_member(self, value: int | str) -> int | str: ...
+    z_child: Target[list[T]]
+
+def convert(value: Source[int]) -> Target[int]:
+    return value  # error: [invalid-return-type]
+```

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1542,6 +1542,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: Specialization<'db>,
         target: Specialization<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        self.check_specialization_pair_with_variance(db, source, target, |typevar| {
+            specialization_variance(db, typevar)
+        })
+    }
+
+    /// Relates two specializations using the variance supplied for each type parameter.
+    ///
+    /// Protocol structural relations use their interface variance instead of the declared
+    /// variance, since parameters that do not occur in the interface cannot constrain that
+    /// relation.
+    pub(super) fn check_specialization_pair_with_variance(
+        &self,
+        db: &'db dyn Db,
+        source: Specialization<'db>,
+        target: Specialization<'db>,
+        mut variance: impl FnMut(BoundTypeVarInstance<'db>) -> TypeVarVariance,
+    ) -> ConstraintSet<'db, 'c> {
         let generic_context = source.generic_context(db);
         if generic_context != target.generic_context(db) {
             return self.never();
@@ -1572,7 +1589,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 //   - contravariant: verify that target_type <: source_type
                 //   - invariant: verify that source_type <: target_type AND target_type <: source_type
                 //   - bivariant: skip, can't make subtyping/assignability false
-                match specialization_variance(db, bound_typevar) {
+                match variance(bound_typevar) {
                     TypeVarVariance::Invariant => self.check_relation_in_invariant_position(
                         db,
                         *source_type,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1,6 +1,7 @@
 //! Instance types: both nominal and structural.
 
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::marker::PhantomData;
 
 use ruff_python_ast::name::Name;
@@ -9,7 +10,7 @@ use ty_module_resolver::{ModuleName, file_to_module};
 use super::protocol_class::ProtocolInterface;
 use super::{
     BoundTypeVarIdentity, BoundTypeVarInstance, ClassType, DivergentType, KnownClass,
-    MaterializationKind, SubclassOfType, Type, TypeVarVariance,
+    MaterializationKind, SubclassOfType, Type, TypeAliasType, TypeVarVariance,
 };
 use crate::place::PlaceAndQualifiers;
 use crate::types::constraints::{
@@ -18,7 +19,8 @@ use crate::types::constraints::{
 use crate::types::enums::is_single_member_enum;
 use crate::types::generics::{InferableTypeVars, walk_specialization};
 use crate::types::protocol_class::{
-    ProtocolClass, has_all_protocol_members_defined, walk_protocol_interface,
+    ProtocolClass, has_all_protocol_members_defined, walk_protocol_instance_interface,
+    walk_protocol_interface,
 };
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation,
@@ -26,6 +28,7 @@ use crate::types::relation::{
 };
 use crate::types::signatures::SignatureRelationVisitor;
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
+use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ErrorContext,
     FindLegacyTypeVarsVisitor, LiteralValueTypeKind, TypeContext, TypeMapping, VarianceInferable,
@@ -494,6 +497,55 @@ impl<'db> From<NominalInstanceType<'db>> for Type<'db> {
     }
 }
 
+/// Returns whether a protocol interface contains a recursive reference to its class-backed origin.
+#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+fn interface_references_protocol_origin<'db>(
+    db: &'db dyn Db,
+    interface: ProtocolInterface<'db>,
+    protocol: ProtocolClass<'db>,
+) -> bool {
+    struct ProtocolReferenceFinder<'db> {
+        origin: ClassLiteral<'db>,
+        found: Cell<bool>,
+        recursion_guard: TypeCollector<'db>,
+    }
+
+    impl<'db> TypeVisitor<'db> for ProtocolReferenceFinder<'db> {
+        fn should_visit_lazy_type_attributes(&self) -> bool {
+            false
+        }
+
+        fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
+            self.visit_type(db, type_alias.value_type(db));
+        }
+
+        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+            if self.found.get() {
+                return;
+            }
+
+            if ty
+                .as_protocol_instance()
+                .and_then(ProtocolInstanceType::to_nominal_instance)
+                .is_some_and(|instance| instance.class_literal(db) == self.origin)
+            {
+                self.found.set(true);
+                return;
+            }
+
+            walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+        }
+    }
+
+    let visitor = ProtocolReferenceFinder {
+        origin: protocol.class_literal(db),
+        found: Cell::new(false),
+        recursion_guard: TypeCollector::default(),
+    };
+    walk_protocol_instance_interface(db, interface, Type::instance(db, *protocol), &visitor);
+    visitor.found.get()
+}
+
 impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     /// Return `true` if `ty` conforms to the interface described by `protocol`.
     pub(super) fn check_type_satisfies_protocol(
@@ -530,6 +582,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
 
             if self.typevar_evaluation == TypeVarEvaluation::Lazy
+                && !self.is_context_collection_enabled()
                 && let Some(source_instance) = ty
                     .as_protocol_instance()
                     .and_then(ProtocolInstanceType::to_nominal_instance)
@@ -540,10 +593,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     .origin(db)
                     .identity_specialization(db)
                     .into_protocol_class(db)
+                && interface_references_protocol_origin(
+                    db,
+                    identity_protocol.interface(db),
+                    identity_protocol,
+                )
             {
-                // A protocol's structural relation is determined by its interface. Relating
-                // the arguments using the identity interface's variance avoids expanding
-                // recursive members (and their freshly bound method typevars) at every step.
+                // Non-recursive protocol members can yield solutions that cannot be inferred
+                // from the raw specialization arguments. For a recursive interface, use its
+                // variance to avoid repeatedly expanding members and their freshly bound method
+                // typevars.
                 let interface = identity_protocol.interface(db);
                 let structurally_satisfied = self.check_specialization_pair_with_variance(
                     db,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -21,7 +21,8 @@ use crate::types::protocol_class::{
     ProtocolClass, has_all_protocol_members_defined, walk_protocol_interface,
 };
 use crate::types::relation::{
-    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
+    DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation,
+    TypeRelationChecker, TypeVarEvaluation,
 };
 use crate::types::signatures::SignatureRelationVisitor;
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
@@ -526,6 +527,38 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .is_always_satisfied(db)
             {
                 return result;
+            }
+
+            if self.typevar_evaluation == TypeVarEvaluation::Lazy
+                && let Some(source_instance) = ty
+                    .as_protocol_instance()
+                    .and_then(ProtocolInstanceType::to_nominal_instance)
+                && let (ClassType::Generic(source_alias), ClassType::Generic(target_alias)) =
+                    (source_instance.class(db), nominal_instance.class(db))
+                && source_alias.origin(db) == target_alias.origin(db)
+                && let Some(identity_protocol) = target_alias
+                    .origin(db)
+                    .identity_specialization(db)
+                    .into_protocol_class(db)
+            {
+                // A protocol's structural relation is determined by its interface. Relating
+                // the arguments using the identity interface's variance avoids expanding
+                // recursive members (and their freshly bound method typevars) at every step.
+                let interface = identity_protocol.interface(db);
+                let structurally_satisfied = self.check_specialization_pair_with_variance(
+                    db,
+                    source_alias.specialization(db),
+                    target_alias.specialization(db),
+                    |typevar| {
+                        let variance = interface.variance_of(db, typevar.identity(db));
+                        if typevar.is_paramspec(db) {
+                            variance.flip()
+                        } else {
+                            variance
+                        }
+                    },
+                );
+                return result.or(db, self.constraints, || structurally_satisfied);
             }
 
             // For union simplification, failing the nominal relation between two


### PR DESCRIPTION
## Summary

Structural comparisons between two specializations of the same generic protocol currently expand the protocol interface on every inference step. Recursive members can introduce a fresh specialization (and fresh method-local type variables) on each unfolding, so exact-pair recursion guards never stabilize and the relation grows without bound.

This PR relates same-origin protocol specializations directly using the variance of the identity protocol interface. We retain the existing nominal result, apply the shortcut only during lazy type-variable evaluation, flip callable-shaped `ParamSpec` variance, and leave phantom parameters bivariant so the shortcut preserves the constraints actually exposed by the interface.

The regression covers recursive overload returns and receiver constraints, `ParamSpec` protocols, phantom parameters, and finite property/attribute mismatches.

Related: <https://github.com/astral-sh/ty/issues/3954>