### PR TITLE
[ty] Parallelize subtype hierarchy search

### DIFF
--- a/crates/ty_ide/src/type_hierarchy.rs
+++ b/crates/ty_ide/src/type_hierarchy.rs
@@ -1,9 +1,11 @@
 use crate::Db;
 use crate::goto::find_goto_target;
+use rayon::prelude::*;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_text_size::{TextRange, TextSize};
+use ty_project::parallel::ParallelIteratorExt;
 use ty_python_semantic::SemanticModel;
 use ty_python_semantic::TypeHierarchyClass;
 use ty_python_semantic::types::Type;
@@ -56,6 +58,8 @@ pub fn type_hierarchy_supertypes(
 }
 
 /// Get the subtypes (derived classes) of a type hierarchy item.
+///
+/// This scans all available modules and can be expensive in large projects.
 pub fn type_hierarchy_subtypes(
     db: &dyn Db,
     file: File,
@@ -64,9 +68,16 @@ pub fn type_hierarchy_subtypes(
     let Some(ty) = resolve_type_at(db, file, offset) else {
         return vec![];
     };
-    ty_python_semantic::type_hierarchy_subtypes(db, ty)
-        .into_iter()
-        .map(|c| type_hierarchy_class_to_item(db, c))
+
+    ty_module_resolver::all_modules(db)
+        .into_par_iter()
+        .map_with_db(db, |db, module| {
+            ty_python_semantic::type_hierarchy_subtypes(db, ty, &[module])
+                .into_iter()
+                .map(|class| type_hierarchy_class_to_item(db, class))
+                .collect::<Vec<_>>()
+        })
+        .flat_map_iter(|items| items)
         .collect()
 }
 

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -19,6 +19,7 @@ use ruff_db::source::source_text;
 use ruff_python_ast::{self as ast, AnyNodeRef, name::Name};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
+use ty_module_resolver::Module;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::{attribute_scopes, global_scope, semantic_index, use_def_map};
 
@@ -1975,15 +1976,15 @@ pub fn type_hierarchy_supertypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchy
     supertypes
 }
 
-/// Get the direct subtypes of the class given.
+/// Get the direct subtypes of the class given in `modules`.
 ///
 /// When the type given doesn't correspond to a class literal, then this always
 /// returns an empty sequence.
-///
-/// Note that this scans all modules in `db` to find classes that directly
-/// inherit from the given class. This could be quite expensive in large
-/// projects.
-pub fn type_hierarchy_subtypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyClass> {
+pub fn type_hierarchy_subtypes(
+    db: &dyn Db,
+    ty: Type<'_>,
+    modules: &[Module<'_>],
+) -> Vec<TypeHierarchyClass> {
     let Some(target_class) = extract_class_literal(db, ty) else {
         return vec![];
     };
@@ -1991,8 +1992,7 @@ pub fn type_hierarchy_subtypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyCl
     let target_is_object = target_class.is_known(db, KnownClass::Object);
     let mut subtypes = vec![];
 
-    // Scan all modules in the workspace
-    for module in ty_module_resolver::all_modules(db) {
+    for &module in modules {
         let Some(file) = module.file(db) else {
             continue;
         };


### PR DESCRIPTION
## Summary

Parallelize subtype-hierarchy discovery across available modules while keeping semantic filtering and reachability checks unchanged.

## Test Plan

Testing: Focused IDE and language-server coverage passes, and Home Assistant cold subtype lookup improved roughly 7× with consistent results.

Rayon threads | Cold | Warm
-- | -- | --
1 | 11.14 s | 99 ms
8 | 2.47 s | 43 ms
16 | 1.83 s | 51 ms
64 | 1.50–1.61 s | 132–144 ms

