### PR TITLE
[ty] Avoid allocations during Salsa interned lookups

### DIFF
--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -151,6 +151,27 @@ impl salsa::Lookup<compact_str::CompactString> for &Name {
 }
 
 #[cfg(feature = "salsa")]
+impl salsa::Lookup<Name> for &str {
+    #[inline]
+    fn into_owned(self) -> Name {
+        Name::new(self)
+    }
+}
+
+#[cfg(feature = "salsa")]
+impl salsa::HashEqLike<&str> for Name {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(self.as_str(), state);
+    }
+
+    #[inline]
+    fn eq(&self, data: &&str) -> bool {
+        self.as_str() == *data
+    }
+}
+
+#[cfg(feature = "salsa")]
 impl salsa::HashEqLike<Name> for compact_str::CompactString {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/crates/ty_module_resolver/src/list.rs
+++ b/crates/ty_module_resolver/src/list.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::btree_map::{BTreeMap, Entry};
 
 use ruff_db::files::directory_listing;
@@ -178,7 +179,7 @@ impl<'db> Lister<'db> {
                         &module_path,
                         Module::file_module(
                             self.db,
-                            module_name,
+                            Cow::Owned(module_name),
                             ModuleKind::Package,
                             self.search_path.clone(),
                             file,
@@ -222,7 +223,7 @@ impl<'db> Lister<'db> {
                 if !self.search_path.is_standard_library() {
                     self.add_module(
                         &module_path,
-                        Module::namespace_package(self.db, module_name),
+                        Module::namespace_package(self.db, Cow::Owned(module_name)),
                     );
                 }
                 return;
@@ -250,7 +251,7 @@ impl<'db> Lister<'db> {
             &module_path,
             Module::file_module(
                 self.db,
-                module_name,
+                Cow::Owned(module_name),
                 ModuleKind::Module,
                 self.search_path.clone(),
                 file,

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Formatter;
 use std::str::FromStr;
 
@@ -25,7 +26,7 @@ impl get_size2::GetSize for Module<'_> {}
 impl<'db> Module<'db> {
     pub(crate) fn file_module(
         db: &'db dyn Db,
-        name: ModuleName,
+        name: Cow<'_, ModuleName>,
         kind: ModuleKind,
         search_path: SearchPath,
         file: File,
@@ -35,7 +36,7 @@ impl<'db> Module<'db> {
         Self::File(FileModule::new(db, name, kind, search_path, file, known))
     }
 
-    pub(crate) fn namespace_package(db: &'db dyn Db, name: ModuleName) -> Self {
+    pub(crate) fn namespace_package(db: &'db dyn Db, name: Cow<'_, ModuleName>) -> Self {
         Self::Namespace(NamespacePackage::new(db, name))
     }
 
@@ -204,7 +205,7 @@ fn all_submodule_names_for_package<'db>(
                     };
                     Some(Module::file_module(
                         db,
-                        name,
+                        Cow::Owned(name),
                         kind,
                         module.search_path(db).clone(),
                         file,
@@ -241,7 +242,7 @@ fn all_submodule_names_for_package<'db>(
                 };
                 Some(Module::file_module(
                     db,
-                    name,
+                    Cow::Owned(name),
                     kind,
                     module.search_path(db).clone(),
                     file,

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -222,7 +222,7 @@ fn resolve_module_query<'db>(
     resolved
         .into_iter()
         .next()
-        .map(|candidate| candidate.into_module(db, name.clone()))
+        .map(|candidate| candidate.into_module(db, name))
 }
 
 /// Like `resolve_module_query` but for cases where it failed to resolve the module
@@ -262,7 +262,7 @@ fn desperately_resolve_module<'db>(
     resolved
         .into_iter()
         .next()
-        .map(|candidate| candidate.into_module(db, name.clone()))
+        .map(|candidate| candidate.into_module(db, name))
 }
 
 /// Resolves the module for the given path.
@@ -1167,11 +1167,11 @@ impl ModuleResolutionCandidate {
     }
 
     // This is the module we were actually interested in resolving, complete the resolution
-    fn into_module(self, db: &'_ dyn Db, name: ModuleName) -> Module<'_> {
+    fn into_module<'db>(self, db: &'db dyn Db, name: &ModuleName) -> Module<'db> {
         match self.module {
             ResolvedModule::NamespacePackage => {
                 tracing::trace!("Resolve namespace package `{name}`");
-                Module::namespace_package(db, name)
+                Module::namespace_package(db, Cow::Borrowed(name))
             }
             ResolvedModule::LegacyNamespacePackage(file) => {
                 // legacy namespace packages behave like regular packages
@@ -1182,7 +1182,7 @@ impl ModuleResolutionCandidate {
                 );
                 Module::file_module(
                     db,
-                    name,
+                    Cow::Borrowed(name),
                     ModuleKind::Package,
                     self.path.into_search_path(),
                     file,
@@ -1195,7 +1195,7 @@ impl ModuleResolutionCandidate {
                 );
                 Module::file_module(
                     db,
-                    name,
+                    Cow::Borrowed(name),
                     ModuleKind::Package,
                     self.path.into_search_path(),
                     file,
@@ -1205,7 +1205,7 @@ impl ModuleResolutionCandidate {
                 tracing::trace!("Resolved module `{name}` to `{path}`", path = file.path(db));
                 Module::file_module(
                     db,
-                    name,
+                    Cow::Borrowed(name),
                     ModuleKind::Module,
                     self.path.into_search_path(),
                     file,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -873,7 +873,7 @@ impl<'db> DataclassParams<'db> {
             .ignore_possibly_undefined()
             .unwrap_or_else(Type::unknown);
 
-        Self::new(db, flags, vec![dataclasses_field].into_boxed_slice())
+        Self::new(db, flags, [dataclasses_field].as_slice())
     }
 
     fn from_transformer_params(db: &'db dyn Db, params: DataclassTransformerParams<'db>) -> Self {

--- a/crates/ty_python_semantic/src/types/class/enum_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/enum_literal.rs
@@ -248,7 +248,7 @@ impl<'db> DynamicEnumLiteral<'db> {
             && let Some(canonical_name) = enum_class.resolve_member(db, &Name::new(name))
         {
             let enum_lit =
-                crate::types::literal::EnumLiteralType::new(db, enum_class, canonical_name.clone());
+                crate::types::literal::EnumLiteralType::new(db, enum_class, canonical_name);
             return Member::definitely_declared(Type::enum_literal(enum_lit));
         }
         Member::unbound()

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -790,9 +790,7 @@ fn enum_literal_constraint<'db>(
     }
 
     let enum_class_literal = right.enum_class_literal(db);
-    let name = enum_class_literal
-        .resolve_member(db, right.name(db))?
-        .clone();
+    let name = enum_class_literal.resolve_member(db, right.name(db))?;
     let equal_to_right = Type::from(LiteralValueType::new(
         EnumLiteralType::new(db, enum_class_literal, name),
         right_literal.is_promotable(),

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -411,7 +411,7 @@ impl<'db> EnumValueSet<'db> {
                     Type::EnumComplement(EnumComplementType::new(
                         db,
                         self.enum_class,
-                        complement.excluded_names(db).clone(),
+                        complement.excluded_names(db),
                         FxOrderSet::default(),
                     ))
                 }
@@ -445,11 +445,7 @@ impl<'db> EnumValueSet<'db> {
     }
 
     fn member_type(&self, db: &'db dyn Db, name: &Name, promotable: bool) -> Type<'db> {
-        LiteralValueType::new(
-            EnumLiteralType::new(db, self.enum_class, name.clone()),
-            promotable,
-        )
-        .into()
+        LiteralValueType::new(EnumLiteralType::new(db, self.enum_class, name), promotable).into()
     }
 }
 
@@ -809,7 +805,7 @@ fn enum_class_key_profile<'db>(
             (
                 name.clone(),
                 semantics.and_then(|semantics| {
-                    enum_literal_value(db, EnumLiteralType::new(db, enum_class, name.clone()))
+                    enum_literal_value(db, EnumLiteralType::new(db, enum_class, name))
                         .and_then(|value| enum_comparison_key(semantics, value))
                 }),
             )

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1004,7 +1004,7 @@ impl<'db> GenericContext<'db> {
         element_type: Type<'db>,
         tuple: TupleType<'db>,
     ) -> Specialization<'db> {
-        Specialization::new(db, self, Box::from([element_type]), None, Some(tuple))
+        Specialization::new(db, self, [element_type].as_slice(), None, Some(tuple))
     }
 
     fn fill_in_defaults<I>(self, db: &'db dyn Db, types: I) -> Box<[Type<'db>]>

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3342,10 +3342,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.deferred.insert(definition);
 
         Type::KnownInstance(KnownInstanceType::NewType(NewType::new(
-            db,
-            ast::name::Name::from(name),
-            definition,
-            None,
+            db, name, definition, None,
         )))
     }
 
@@ -3678,11 +3675,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.deferred.insert(definition);
 
         Type::KnownInstance(KnownInstanceType::TypeAliasType(
-            TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(
-                db,
-                ast::name::Name::new(name),
-                definition,
-            )),
+            TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(db, name, definition)),
         ))
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -421,19 +421,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let name_ty = self.expression_type(name_arg);
         let name = name_ty
             .as_string_literal()
-            .map(|name_literal| Name::new(name_literal.value(db)));
+            .map(|name_literal| name_literal.value(db));
 
         if (name.is_some() || name_ty.is_assignable_to(db, KnownClass::Str.to_instance(db)))
             && let Some(definition) = definition
             && let Some(assigned_name) = definition.name(db)
-            && Some(assigned_name.as_str()) != name.as_deref()
+            && Some(assigned_name.as_str()) != name
         {
             report_mismatched_type_name(
                 &self.context,
                 name_arg,
                 base_name,
                 &assigned_name,
-                name.as_deref(),
+                name,
                 name_ty,
             );
         }
@@ -471,7 +471,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         &mut self,
         name_arg: &ast::Expr,
         base_class: KnownClass,
-    ) -> Option<Name> {
+    ) -> Option<&'db str> {
         let db = self.db();
         let base_name = base_class.name(db);
         let name_type = self.expression_type(name_arg);
@@ -491,7 +491,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return None;
         };
 
-        Some(Name::new(name_literal.value(db)))
+        Some(name_literal.value(db))
     }
 
     fn infer_enum_start_argument(&mut self, value: &ast::Expr) -> EnumStart {

--- a/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
@@ -325,7 +325,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // Extract name.
         let name = name_type
             .as_string_literal()
-            .map(|literal| Name::new(literal.value(db)));
+            .map(|literal| literal.value(db));
 
         if name.is_none()
             && !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
@@ -338,7 +338,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 "Expected `str`, found `{}`",
                 name_type.display(db)
             ));
-        } else if let Some(actual_name) = name.as_deref()
+        } else if let Some(actual_name) = name
             && let Some(definition) = definition
             && let Some(assigned_name) = definition.name(db)
             && assigned_name.as_str() != actual_name
@@ -353,7 +353,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             );
         }
 
-        let name = name.unwrap_or_else(|| Name::new_static("<unknown>"));
+        let name = name.unwrap_or("<unknown>");
 
         // Handle fields based on which namedtuple variant.
         let anchor = match definition {

--- a/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
@@ -71,7 +71,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .unwrap_or_else(Type::unknown);
 
         let name = if let Some(literal) = name_type.as_string_literal() {
-            ast::name::Name::new(literal.value(db))
+            literal.value(db)
         } else {
             if let Some(name_node) = name_node
                 && !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
@@ -85,7 +85,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     name_type.display(db)
                 ));
             }
-            ast::name::Name::new_static("<unknown>")
+            "<unknown>"
         };
 
         // For assigned `new_class()` calls, bases inference is deferred to handle forward
@@ -147,7 +147,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let has_exec_body = exec_body_arg.is_some_and(|arg| !arg.is_none_literal_expr());
         let members: Box<[(ast::name::Name, Type<'db>)]> = Box::new([]);
         let dynamic_class =
-            DynamicClassLiteral::new(db, &name, anchor, members, has_exec_body, None);
+            DynamicClassLiteral::new(db, name, anchor, members, has_exec_body, None);
 
         // For dangling calls, validate bases eagerly. For assigned calls, validation is
         // deferred along with bases inference.
@@ -157,7 +157,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let mut disjoint_bases = self.validate_dynamic_type_bases(
                 bases_arg,
                 explicit_bases,
-                &name,
+                dynamic_class.name(db),
                 DynamicClassKind::NewClass,
             );
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -12,7 +12,6 @@ use crate::types::infer::builder::{
     },
 };
 use crate::types::{KnownClass, SubclassOfType, Type, TypeContext, definition_expression_type};
-use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, HasNodeIndex, NodeIndex};
 use ty_python_core::definition::Definition;
 
@@ -193,7 +192,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         // Extract name and base classes.
         let name = if let Some(literal) = name_type.as_string_literal() {
-            Name::new(literal.value(db))
+            literal.value(db)
         } else {
             if !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
                 && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
@@ -205,7 +204,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     name_type.display(db)
                 ));
             }
-            Name::new_static("<unknown>")
+            "<unknown>"
         };
 
         let scope = self.scope();
@@ -254,7 +253,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         };
 
         let dynamic_class =
-            DynamicClassLiteral::new(db, &name, anchor, members, has_dynamic_namespace, None);
+            DynamicClassLiteral::new(db, name, anchor, members, has_dynamic_namespace, None);
 
         // For dangling calls, validate bases eagerly. For assigned calls, validation is
         // deferred along with bases inference.
@@ -263,7 +262,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let mut disjoint_bases = self.validate_dynamic_type_bases(
                 bases_arg,
                 explicit_bases,
-                &name,
+                dynamic_class.name(db),
                 DynamicClassKind::TypeCall,
             );
 

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -254,7 +254,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let name = name_type
             .as_string_literal()
-            .map(|literal| Name::new(literal.value(db)));
+            .map(|literal| literal.value(db));
 
         if name.is_none()
             && !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
@@ -269,19 +269,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ));
         } else if let Some(definition) = definition
             && let Some(assigned_name) = definition.name(db)
-            && Some(assigned_name.as_str()) != name.as_deref()
+            && Some(assigned_name.as_str()) != name
         {
             report_mismatched_type_name(
                 &self.context,
                 name_arg,
                 "TypedDict",
                 &assigned_name,
-                name.as_deref(),
+                name,
                 name_type,
             );
         }
 
-        let name = name.unwrap_or_else(|| Name::new_static("<unknown>"));
+        let name = name.unwrap_or("<unknown>");
 
         self.validate_fields_arg(fields_arg);
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -521,14 +521,13 @@ impl<'db> TypeVarInstance<'db> {
                 let typevar_node = typevar.node(&module);
                 let bound =
                     definition_expression_type(db, definition, typevar_node.bound.as_ref()?);
-                let constraints = if let Some(tuple) = bound.tuple_instance_spec(db)
+                if let Some(tuple) = bound.tuple_instance_spec(db)
                     && let Tuple::Fixed(tuple) = tuple.into_owned()
                 {
-                    tuple.owned_elements()
+                    TypeVarConstraints::new(db, tuple.owned_elements())
                 } else {
-                    vec![Type::unknown()].into_boxed_slice()
-                };
-                TypeVarConstraints::new(db, constraints)
+                    TypeVarConstraints::new(db, [Type::unknown()].as_slice())
+                }
             }
             // legacy typevar
             DefinitionKind::Assignment(assignment) => {


### PR DESCRIPTION
## Summary

Avoid eager clones and one-element heap allocations during Salsa interned lookups, and allow borrowed strings for interned names. Keep owned module-name construction efficient with `Cow`; project benchmarks retire about 0.13% fewer instructions.

## Test Plan

Testing: Targeted Rust tests and repository hooks pass.
