### PR TITLE
[ty] Prevent stack overflows when transforming recursive type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -698,6 +698,52 @@ def finite_alias_union(x: NonRecursiveId[NestedNoneAlias], condition: bool):
     reveal_type(x if condition else 1)  # revealed: None | Literal[1]
 ```
 
+### Generic self-recursive aliases with deeper specializations
+
+Regression test for <https://github.com/astral-sh/ty/issues/3452>.
+
+A recursive alias may refer to itself with a more deeply nested specialization. This should still
+terminate and preserve the alias at the recursive position.
+
+```py
+from typing import Callable, Concatenate
+
+type RecursiveParamspec[**P] = Callable[[], RecursiveParamspec[Concatenate[int, P]]]
+
+def paramspec_alias(func: RecursiveParamspec):
+    reveal_type(func)  # revealed: () -> RecursiveParamspec[(int, /, *args: Unknown, **kwargs: Unknown)]
+
+type RecursiveCallable[T] = Callable[[RecursiveCallable[T]], RecursiveCallable[T | RecursiveCallable[T]]]
+
+def callable_alias(x: RecursiveCallable[int]):
+    reveal_type(x)  # revealed: (RecursiveCallable[int], /) -> RecursiveCallable[int | RecursiveCallable[int]]
+
+type GrowingList[T] = list[GrowingList[T | GrowingList[T]]]
+
+def growing_list(x: GrowingList[int]):
+    reveal_type(x)  # revealed: list[GrowingList[int | GrowingList[int]]]
+
+type GrowingCallable[T] = Callable[[], GrowingCallable[T | GrowingCallable[T]] | None]
+
+def growing_callable(x: GrowingCallable[int]):
+    # revealed: (() -> GrowingCallable[int | GrowingCallable[int] | GrowingCallable[int | GrowingCallable[int]]] | None) | None
+    reveal_type(x())
+```
+
+Non-growing recursive aliases should continue to preserve distinct specializations.
+
+```py
+type StableWrapped[T] = list[StableWrapped[T]]
+
+def stable_wrapped(x: StableWrapped[int], y: StableWrapped[str]):
+    reveal_type(x)  # revealed: list[StableWrapped[int]]
+    reveal_type(y)  # revealed: list[StableWrapped[str]]
+    # error: [invalid-assignment] "Object of type `StableWrapped[str]` is not assignable to `StableWrapped[int]`"
+    x = y
+    # error: [invalid-assignment] "Object of type `StableWrapped[int]` is not assignable to `StableWrapped[str]`"
+    y = x
+```
+
 ### Subtyping of materializations of cyclic aliases
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -616,6 +616,116 @@ def contravariant(top: Top[ContravariantCallable], bottom: Bottom[ContravariantC
     reveal_type(bottom)  # revealed: (GenericContravariant[Never], /) -> None
 ```
 
+## Type aliases
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+### Non-recursive aliases
+
+Non-recursive aliases are materialized through nested specializations.
+
+```py
+from typing import Any
+from ty_extensions import Bottom, Top
+
+type Alias[T] = tuple[T, ...]
+
+def _(top: Top[Alias[Alias[Any]]], bottom: Bottom[Alias[Alias[Any]]]) -> None:
+    reveal_type(top)  # revealed: tuple[tuple[object, ...], ...]
+    reveal_type(bottom)  # revealed: tuple[tuple[()], ...]
+
+def triple(
+    top: Top[Alias[Alias[Alias[Any]]]],
+    bottom: Bottom[Alias[Alias[Alias[Any]]]],
+) -> None:
+    reveal_type(top)  # revealed: tuple[tuple[tuple[object, ...], ...], ...]
+    reveal_type(bottom)  # revealed: tuple[tuple[tuple[()], ...], ...]
+
+def generic[T](
+    top: Top[Alias[Alias[Any | T]]],
+    bottom: Bottom[Alias[Alias[Any | T]]],
+) -> None:
+    reveal_type(top)  # revealed: tuple[tuple[object, ...], ...]
+    reveal_type(bottom)  # revealed: tuple[tuple[T@generic, ...], ...]
+```
+
+### Recursive aliases
+
+The materialization of recursive aliases may stop midway. This is because a recursion guard
+activates to interrupt the handling halfway to ensure termination.
+
+TODO: The current behavior where dynamic types remain in types after materialization is undesirable.
+
+```py
+from collections.abc import Callable
+from typing import Any
+from ty_extensions import Bottom, Top
+
+type MaterializeShift[T1, T2, T3] = T1 | tuple[MaterializeShift[T2, T3, None]]
+
+def finite_recursive_materialization(
+    top: Top[MaterializeShift[int, str, Any]],
+    bottom: Bottom[MaterializeShift[int, str, Any]],
+) -> None:
+    reveal_type(top)  # revealed: int | tuple[str | tuple[object]]
+    reveal_type(bottom)  # revealed: int | tuple[str | tuple[tuple[MaterializeShift[None, None, None]]]]
+
+type MaterializeShift10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10] = tuple[
+    T1, MaterializeShift10[T2, T3, T4, T5, T6, T7, T8, T9, T10, None]
+]
+type MaterializeShift11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11] = tuple[
+    T1, MaterializeShift11[T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, None]
+]
+
+def recursive_materialization_within_limit(
+    bottom: Bottom[MaterializeShift10[None, None, None, None, None, None, None, None, None, Any]],
+) -> None:
+    reveal_type(bottom)  # revealed: Never
+
+def recursive_materialization_beyond_limit(
+    bottom: Bottom[MaterializeShift11[None, None, None, None, None, None, None, None, None, None, Any]],
+) -> None:
+    # revealed: tuple[None, MaterializeShift11[None, None, None, None, None, None, None, None, None, Any, None]]
+    reveal_type(bottom)
+
+type BranchOuter[T] = T | tuple[BranchInner[list[T]], BranchInner[list[T]]]
+type BranchInner[T] = T | tuple[BranchOuter[list[T]], BranchOuter[list[T]]]
+
+def branching_mutual_recursion(
+    top: Top[BranchOuter[Any]],
+    bottom: Bottom[BranchOuter[Any]],
+) -> None:
+    reveal_type(top)  # revealed: object
+    # revealed: tuple[BranchInner[list[Any]], BranchInner[list[Any]]]
+    reveal_type(bottom)
+
+type ContravariantBranchOuter[T] = (
+    T | tuple[Callable[[ContravariantBranchInner[list[T]], ContravariantBranchInner[list[T]]], None]]
+)
+type ContravariantBranchInner[T] = (
+    T | tuple[Callable[[ContravariantBranchOuter[list[T]], ContravariantBranchOuter[list[T]]], None]]
+)
+
+def wants_int(x: int): ...
+def branching_mutual_recursion_across_variance(
+    bottom: Bottom[ContravariantBranchOuter[Any]],
+) -> None:
+    wants_int(bottom)  # error: [invalid-argument-type]
+
+type Stable[T] = T | tuple[Stable[T]]
+
+def _(x: Bottom[Stable[Any]]) -> None:
+    reveal_type(x)  # revealed: tuple[Stable[Any]]
+
+type Grow[T] = T | tuple[Grow[list[T]]]
+
+def _(x: Bottom[Grow[Any]]) -> None:
+    reveal_type(x)  # revealed: tuple[Grow[list[Any]]]
+```
+
 ## Invalid use
 
 `Top[]` and `Bottom[]` are special forms that take a single argument.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4,7 +4,7 @@ use ruff_diagnostics::{Edit, Fix};
 use rustc_hash::FxHashMap;
 
 use std::borrow::Cow;
-use std::cell::OnceCell;
+use std::cell::{Cell, OnceCell};
 use std::iter;
 use std::rc::Rc;
 use std::time::Duration;
@@ -24,7 +24,7 @@ use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
 
 pub(crate) use self::callable::UpcastPolicy;
 pub use self::cyclic::CycleDetector;
-pub(crate) use self::cyclic::{ActiveRecursionDetector, TypeTransformer};
+pub(crate) use self::cyclic::{ActiveRecursionDetector, TransformerKind, TypeTransformer};
 pub(crate) use self::diagnostic::register_lints;
 pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
 pub(crate) use self::infer::{
@@ -290,7 +290,13 @@ fn definition_expression_annotation<'db>(
     }
 }
 
-struct ApplyTypeMappingTag;
+struct ApplyDefaultTypeMapping;
+struct ApplyTopMaterialization;
+struct ApplyBottomMaterialization;
+struct ApplyTopSpecializationMaterialization;
+struct ApplyBottomSpecializationMaterialization;
+struct ApplyPromotion;
+struct ApplySkipPromotion;
 struct ApplyMaterializationEquivalence;
 
 type MaterializationEquivalenceVisitor<'db> =
@@ -303,14 +309,23 @@ type MaterializationEquivalenceVisitor<'db> =
 /// reuse the result of another.
 #[derive(Default)]
 pub(crate) struct ApplyTypeMappingVisitor<'db> {
-    default: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
-    top_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
-    bottom_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
-    top_specialization_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
-    bottom_specialization_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
-    promotion: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
-    skip_promotion: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
+    default: OnceCell<Box<TypeTransformer<'db, ApplyDefaultTypeMapping>>>,
+    top_materialization: OnceCell<Box<TypeTransformer<'db, ApplyTopMaterialization>>>,
+    bottom_materialization: OnceCell<Box<TypeTransformer<'db, ApplyBottomMaterialization>>>,
+    top_specialization_materialization:
+        OnceCell<Box<TypeTransformer<'db, ApplyTopSpecializationMaterialization>>>,
+    bottom_specialization_materialization:
+        OnceCell<Box<TypeTransformer<'db, ApplyBottomSpecializationMaterialization>>>,
+    promotion: OnceCell<Box<TypeTransformer<'db, ApplyPromotion>>>,
+    skip_promotion: OnceCell<Box<TypeTransformer<'db, ApplySkipPromotion>>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
+
+    /// The mapping mode whose transformer hit the recursive-alias unfold limit.
+    ///
+    /// This is shared because nested transformations can switch mapping modes. While it is set,
+    /// every mode must stop descending and caching until the initiating transformer reaches its
+    /// fallback frame.
+    unwinding_to_fallback: Cell<Option<TransformerKind>>,
 }
 
 impl<'db> ApplyTypeMappingVisitor<'db> {
@@ -326,24 +341,44 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
         type_mapping: &TypeMapping<'_, 'db>,
         func: impl FnOnce() -> Type<'db>,
     ) -> Type<'db> {
-        let type_transformer = match type_mapping {
-            TypeMapping::Materialize(MaterializationKind::Top) => &self.top_materialization,
-            TypeMapping::Materialize(MaterializationKind::Bottom) => &self.bottom_materialization,
+        match type_mapping {
+            TypeMapping::Materialize(MaterializationKind::Top) => self
+                .top_materialization
+                .get_or_init(Box::default)
+                .visit_type(db, ty, &self.unwinding_to_fallback, func),
+            TypeMapping::Materialize(MaterializationKind::Bottom) => self
+                .bottom_materialization
+                .get_or_init(Box::default)
+                .visit_type(db, ty, &self.unwinding_to_fallback, func),
             TypeMapping::ApplySpecializationWithMaterialization {
                 materialization_kind: MaterializationKind::Top,
                 ..
-            } => &self.top_specialization_materialization,
+            } => self
+                .top_specialization_materialization
+                .get_or_init(Box::default)
+                .visit_type(db, ty, &self.unwinding_to_fallback, func),
             TypeMapping::ApplySpecializationWithMaterialization {
                 materialization_kind: MaterializationKind::Bottom,
                 ..
-            } => &self.bottom_specialization_materialization,
-            TypeMapping::Promote(PromotionMode::On, _) => &self.promotion,
-            TypeMapping::Promote(PromotionMode::Off, _) => &self.skip_promotion,
-            _ => &self.default,
-        };
-        type_transformer
-            .get_or_init(Box::default)
-            .visit_type(db, ty, func)
+            } => self
+                .bottom_specialization_materialization
+                .get_or_init(Box::default)
+                .visit_type(db, ty, &self.unwinding_to_fallback, func),
+            TypeMapping::Promote(PromotionMode::On, _) => self
+                .promotion
+                .get_or_init(Box::default)
+                .visit_type(db, ty, &self.unwinding_to_fallback, func),
+            TypeMapping::Promote(PromotionMode::Off, _) => self
+                .skip_promotion
+                .get_or_init(Box::default)
+                .visit_type(db, ty, &self.unwinding_to_fallback, func),
+            _ => self.default.get_or_init(Box::default).visit_type(
+                db,
+                ty,
+                &self.unwinding_to_fallback,
+                func,
+            ),
+        }
     }
 
     pub(crate) fn is_equivalent_to_materialization(

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -20,7 +20,8 @@
 //! avoid this is to prefer always calling `visitor.visit` only in the main recursive method on
 //! `Type`.
 
-use std::cell::RefCell;
+use std::any::TypeId;
+use std::cell::{Cell, RefCell};
 use std::cmp::Eq;
 use std::fmt;
 use std::hash::Hash;
@@ -34,6 +35,13 @@ use ty_python_core::definition::Definition;
 use crate::Db;
 use crate::types::Type;
 use crate::types::function::FunctionLiteral;
+
+/// Maximum number of recursive alias applications explored after the initial application.
+///
+/// Determining whether alias expansion eventually reaches a finite fixed point is possible in
+/// principle, but a general decision procedure is too expensive for normal type operations. Type
+/// transformations therefore use this operational limit.
+const MAX_RECURSIVE_TYPE_ALIAS_UNFOLDS: usize = 10;
 
 /// The type identity used for recursive checks/transformations.
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
@@ -239,7 +247,7 @@ pub(super) enum CycleDetectorVisit<T, R> {
 /// Guards recursive type transformations.
 pub(crate) struct TypeTransformer<'db, Tag> {
     /// The active transformation stack and its recursive identities.
-    /// Completed visits are removed from the end of the stack.
+    /// Recursive aliases may unfold up to [`MAX_RECURSIVE_TYPE_ALIAS_UNFOLDS`] times.
     seen: RefCell<SmallVec<[ActiveTypeTransformation<'db>; 3]>>,
 
     /// Memoized transformations from earlier visits in the current recursive operation.
@@ -247,6 +255,9 @@ pub(crate) struct TypeTransformer<'db, Tag> {
 
     _tag: PhantomData<fn() -> Tag>,
 }
+
+/// Identifies the [`TypeTransformer`] tag that initiated a shared fallback unwind.
+pub(crate) type TransformerKind = TypeId;
 
 impl<Tag> Default for TypeTransformer<'_, Tag> {
     fn default() -> Self {
@@ -258,34 +269,58 @@ impl<Tag> Default for TypeTransformer<'_, Tag> {
     }
 }
 
-impl<'db, Tag> TypeTransformer<'db, Tag> {
+impl<'db, Tag: 'static> TypeTransformer<'db, Tag> {
     #[inline]
     pub(crate) fn visit_type(
         &self,
         db: &'db dyn Db,
         ty: Type<'db>,
+        unwinding_to_fallback: &Cell<Option<TransformerKind>>,
         compute: impl FnOnce() -> Type<'db>,
     ) -> Type<'db> {
-        match self.begin_visit(db, ty) {
+        match self.begin_visit(db, ty, unwinding_to_fallback) {
             TypeTransformerVisit::Ready(result) => result,
             TypeTransformerVisit::Pending(ty) => {
                 let result = compute();
-                self.finish_visit(ty, result)
+                self.finish_visit(ty, result, unwinding_to_fallback)
             }
         }
     }
 
-    fn begin_visit(&self, db: &'db dyn Db, ty: Type<'db>) -> TypeTransformerVisit<'db> {
+    fn begin_visit(
+        &self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        unwinding_to_fallback: &Cell<Option<TransformerKind>>,
+    ) -> TypeTransformerVisit<'db> {
+        // Everything computed before the fallback frame finishes will be discarded.
+        if unwinding_to_fallback.get().is_some() {
+            return TypeTransformerVisit::Ready(ty);
+        }
+
         if let Some(result) = self.cache.borrow().get(&ty) {
             return TypeTransformerVisit::Ready(*result);
         }
 
         let identity = ty.to_type_identity(db);
         let seen = self.seen.borrow();
-        if seen
+        if seen.iter().any(|active| active.ty == ty) {
+            return TypeTransformerVisit::Ready(ty);
+        }
+        let active_occurrences = seen
             .iter()
-            .any(|active| active.ty == ty || active.identity == identity)
-        {
+            .filter(|active| active.identity == identity)
+            .count();
+        let should_stop = match identity {
+            TypeIdentity::RecursiveTypeAlias(_) => {
+                active_occurrences > MAX_RECURSIVE_TYPE_ALIAS_UNFOLDS
+            }
+            _ => active_occurrences > 0,
+        };
+        if should_stop {
+            if matches!(identity, TypeIdentity::RecursiveTypeAlias(_)) {
+                unwinding_to_fallback.set(Some(TypeId::of::<Tag>()));
+            }
             return TypeTransformerVisit::Ready(ty);
         }
         drop(seen);
@@ -296,10 +331,36 @@ impl<'db, Tag> TypeTransformer<'db, Tag> {
         TypeTransformerVisit::Pending(ty)
     }
 
-    fn finish_visit(&self, ty: Type<'db>, result: Type<'db>) -> Type<'db> {
+    fn finish_visit(
+        &self,
+        ty: Type<'db>,
+        mut result: Type<'db>,
+        unwinding_to_fallback: &Cell<Option<TransformerKind>>,
+    ) -> Type<'db> {
         let active = self.seen.borrow_mut().pop();
         debug_assert_eq!(active.map(|active| active.ty), Some(ty));
-        self.cache.borrow_mut().insert_completed(ty, result);
+
+        let active_recursive_aliases = self
+            .seen
+            .borrow()
+            .iter()
+            .filter(|active| matches!(active.identity, TypeIdentity::RecursiveTypeAlias(_)))
+            .count();
+
+        let unwinding = unwinding_to_fallback.get();
+        if unwinding == Some(TypeId::of::<Tag>())
+            && active.is_some_and(|active| {
+                matches!(active.identity, TypeIdentity::RecursiveTypeAlias(_))
+            })
+            && active_recursive_aliases == 1
+        {
+            result = ty;
+            unwinding_to_fallback.set(None);
+        }
+
+        if unwinding.is_none() {
+            self.cache.borrow_mut().insert_completed(ty, result);
+        }
         result
     }
 }

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -253,6 +253,9 @@ pub(crate) struct TypeTransformer<'db, Tag> {
     /// Memoized transformations from earlier visits in the current recursive operation.
     cache: RefCell<CycleDetectorCache<Type<'db>, Type<'db>>>,
 
+    /// Total recursive-alias reentries explored while transforming one recursive root.
+    recursive_type_alias_unfolds: Cell<usize>,
+
     _tag: PhantomData<fn() -> Tag>,
 }
 
@@ -264,6 +267,7 @@ impl<Tag> Default for TypeTransformer<'_, Tag> {
         Self {
             seen: RefCell::default(),
             cache: RefCell::default(),
+            recursive_type_alias_unfolds: Cell::default(),
             _tag: PhantomData,
         }
     }
@@ -312,8 +316,14 @@ impl<'db, Tag: 'static> TypeTransformer<'db, Tag> {
             .filter(|active| active.identity == identity)
             .count();
         let should_stop = match identity {
-            TypeIdentity::RecursiveTypeAlias(_) => {
-                active_occurrences > MAX_RECURSIVE_TYPE_ALIAS_UNFOLDS
+            TypeIdentity::RecursiveTypeAlias(_) if active_occurrences > 0 => {
+                let unfolds = self.recursive_type_alias_unfolds.get();
+                if unfolds >= MAX_RECURSIVE_TYPE_ALIAS_UNFOLDS {
+                    true
+                } else {
+                    self.recursive_type_alias_unfolds.set(unfolds + 1);
+                    false
+                }
             }
             _ => active_occurrences > 0,
         };
@@ -346,6 +356,10 @@ impl<'db, Tag: 'static> TypeTransformer<'db, Tag> {
             .iter()
             .filter(|active| matches!(active.identity, TypeIdentity::RecursiveTypeAlias(_)))
             .count();
+
+        if active_recursive_aliases == 0 {
+            self.recursive_type_alias_unfolds.set(0);
+        }
 
         let unwinding = unwinding_to_fallback.get();
         if unwinding == Some(TypeId::of::<Tag>())


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#3452

MRE:

```python
type GrowingList[T] = list[GrowingList[T | GrowingList[T]]]

def growing_list(x: GrowingList[int]):
    reveal_type(x)  # revealed: list[GrowingList[int | GrowingList[int]]]
```

This PR strengthens the recursion guard of `TypeTransformer`, allowing it to perform type mapping safely against growing recursive type aliases as reported in #26503.

Stacked on #26503

## Test Plan

mdtest updated
