### PR TITLE
[ty] Collect Pydantic field metadata through subscripted generic `Annotated` aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -940,6 +940,23 @@ class ModelWithAliasField(BaseModel):
 ModelWithAliasField()
 ```
 
+Field metadata is also collected through a generic alias, where the `Field(...)` default is carried
+on a type variable that is only specialized at the use site:
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T")
+GenericAliasField = Annotated[T, Field(default=0)]
+
+class ModelWithGenericAliasField(BaseModel):
+    value: GenericAliasField[int]
+
+# `value` is optional because the alias supplies `Field(default=0)`.
+ModelWithGenericAliasField()
+ModelWithGenericAliasField(value=1)
+```
+
 ## Frozen models and fields
 
 There are various ways to make a field immutable. A model can be globally frozen using a class

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -144,8 +144,15 @@ impl<'db> FieldMetadata<'db> {
             return;
         }
 
-        let Expr::Name(name) = annotation else {
-            return;
+        let name = match annotation {
+            Expr::Name(name) => name,
+            Expr::Subscript(subscript) => {
+                let Expr::Name(name) = subscript.value.as_ref() else {
+                    return;
+                };
+                name
+            }
+            _ => return,
         };
 
         // The following part is unfortunate. Pydantic defines `StrictInt` and the other aliases


### PR DESCRIPTION
## Summary

The bug: ty treats a Pydantic model field as a required constructor argument (`missing-argument`) when its default comes from a `Field(...)` that lives inside a generic `Annotated` type alias. For example:

```py
from typing import Annotated, TypeVar
from pydantic import BaseModel, Field

T = TypeVar("T")
MyField = Annotated[T, Field(default=0)]

class M(BaseModel):
    value: MyField[int]

M()  # before this change: error[missing-argument] for `value`
```

At runtime pydantic makes `value` optional (it defaults to 0), so the error is a false positive.

> AI assistance disclosure: I used AI to both draft the PR and the changes, while acknowledging your AI policy by carefully auditing the produced PR and changes. I understand them on a very narrow scoped basis (extending with the Subscript expression). Ofcourse I will reply to any comments on the PR myself, according to the policy.

I want to be careful about whether this really belongs in ty, so I checked pydantic's runtime behavior and cross checked two other type checkers. Pydantic makes the field optional at runtime, so pydantic is doing the right thing and there is nothing to fix on that side. ty already honors this default for the inline and bare alias forms (added in #26650); the only case it misses is the subscripted generic alias, which pydantic treats exactly the same as the others. So to me this reads as an internal gap in ty's existing pydantic handling, not new behavior.

The fix: in `FieldMetadata::collect_from_annotation`, the code that follows an alias back to its definition only ran when the annotation was a plain name (like `field: StrictInt`). A subscripted generic alias (`field: MyField[int]`) is an `Expr::Subscript`, so the function bailed out early and the default was lost. This change also handles `Expr::Subscript`: it takes the base name from `subscript.value` and then follows the alias the same way the plain name case already does.

There is no existing issue for this at the ty repo, if thats the preferred way, I'll gladly open an issue and link it here.

Scope: the metadata gets collected with the enclosing model's specialization rather than the alias's own subscript argument. From what I can tell that does not matter in practice, because a `Field` default is a runtime value, so its type cannot carry the alias's type variable, and I checked that a generic model using the alias still behaves correctly. There is a bigger direction hinted at in the existing comment and in astral-sh/ty#504 (keep the `Annotated` metadata through specialization instead of re-parsing the alias definition), but that is past what I understand and felt out of scope for this bug.

## Test Plan

- Added a regression test to `resources/mdtest/external/pydantic.md` (`ModelWithGenericAliasField`).
- Checked that it fails before the change (unexpected `missing-argument` for `value`) and passes after, run with `MDTEST_EXTERNAL=1` so real pydantic gets installed.
- Ran a standalone repro through a locally built `ty` CLI, including a generic model variant. It went from `missing-argument` to clean.
- Confirmed on pydantic 2.13.4 that all three forms above are optional at runtime, and that pyright and mypy (with the pydantic plugin) currently report all three as required.
- Ran the pre-PR checks locally and they all pass: `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean, the full `cargo test --workspace` passes with 0 failures (whole ruff plus ty suite), the external regression mdtest passes with `MDTEST_EXTERNAL=1`, and `prek` passes on the changed files. One note: the markdown hook rewrapped a single prose line in the test file, which is folded into the commit.


