### PR TITLE
[ty] Narrow tagged unions by tag truthiness

### DIFF
--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -627,9 +627,13 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
 
     fn expression_node(&self, expr: &ast::Expr) -> PossiblyNarrowedPlaces {
         match expr {
-            // Simple expressions that directly narrow a place
-            ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
-                self.simple_expr(expr)
+            // Simple expressions that directly narrow a place.
+            ast::Expr::Name(_) | ast::Expr::Attribute(_) => self.simple_expr(expr),
+            // Subscript truthiness can also narrow its base (`TypedDict` tagged unions).
+            ast::Expr::Subscript(subscript) => {
+                let mut places = self.simple_expr(expr);
+                places.extend(self.simple_expr(&subscript.value));
+                places
             }
             // Compare expressions can narrow places on either side
             ast::Expr::Compare(expr_compare) => self.expr_compare(expr_compare),

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -628,7 +628,13 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
     fn expression_node(&self, expr: &ast::Expr) -> PossiblyNarrowedPlaces {
         match expr {
             // Simple expressions that directly narrow a place.
-            ast::Expr::Name(_) | ast::Expr::Attribute(_) => self.simple_expr(expr),
+            ast::Expr::Name(_) => self.simple_expr(expr),
+            // Attribute truthiness can also narrow its base (nominal tagged unions).
+            ast::Expr::Attribute(attribute) => {
+                let mut places = self.simple_expr(expr);
+                places.extend(self.simple_expr(&attribute.value));
+                places
+            }
             // Subscript truthiness can also narrow its base (`TypedDict` tagged unions).
             ast::Expr::Subscript(subscript) => {
                 let mut places = self.simple_expr(expr);

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1548,6 +1548,48 @@ def _(x: A | B):
         reveal_type(x)  # revealed: A
 ```
 
+Nominal tagged unions can also be narrowed by attribute truthiness:
+
+```py
+from typing import Literal
+
+class Success:
+    success: Literal[True]
+    result: int
+
+class Failure:
+    success: Literal[False]
+    errors: list[str]
+
+def _(response: Success | Failure):
+    if response.success:
+        reveal_type(response)  # revealed: Success
+        reveal_type(response.result)  # revealed: int
+    else:
+        reveal_type(response)  # revealed: Failure
+        reveal_type(response.errors)  # revealed: list[str]
+
+    if not response.success:
+        reveal_type(response)  # revealed: Failure
+    else:
+        reveal_type(response)  # revealed: Success
+
+class TruthyIntTag:
+    success: Literal[1]
+
+class FalsyIntTag:
+    success: Literal[0]
+
+class AmbiguousTag:
+    success: bool
+
+def _(response: Success | Failure | TruthyIntTag | FalsyIntTag | AmbiguousTag):
+    if response.success:
+        reveal_type(response)  # revealed: Success | TruthyIntTag | AmbiguousTag
+    else:
+        reveal_type(response)  # revealed: Failure | FalsyIntTag | AmbiguousTag
+```
+
 Enum literals are also supported as attribute tags:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1548,48 +1548,6 @@ def _(x: A | B):
         reveal_type(x)  # revealed: A
 ```
 
-Nominal tagged unions can also be narrowed by attribute truthiness:
-
-```py
-from typing import Literal
-
-class Success:
-    success: Literal[True]
-    result: int
-
-class Failure:
-    success: Literal[False]
-    errors: list[str]
-
-def _(response: Success | Failure):
-    if response.success:
-        reveal_type(response)  # revealed: Success
-        reveal_type(response.result)  # revealed: int
-    else:
-        reveal_type(response)  # revealed: Failure
-        reveal_type(response.errors)  # revealed: list[str]
-
-    if not response.success:
-        reveal_type(response)  # revealed: Failure
-    else:
-        reveal_type(response)  # revealed: Success
-
-class TruthyIntTag:
-    success: Literal[1]
-
-class FalsyIntTag:
-    success: Literal[0]
-
-class AmbiguousTag:
-    success: bool
-
-def _(response: Success | Failure | TruthyIntTag | FalsyIntTag | AmbiguousTag):
-    if response.success:
-        reveal_type(response)  # revealed: Success | TruthyIntTag | AmbiguousTag
-    else:
-        reveal_type(response)  # revealed: Failure | FalsyIntTag | AmbiguousTag
-```
-
 Enum literals are also supported as attribute tags:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -71,7 +71,7 @@ if (foo1 := Foo()).val:
     reveal_type(foo1.val)  # revealed: int & ~AlwaysFalsy
 ```
 
-## Narrowing tagged unions by attribute truthiness
+## Narrowing tagged unions of nominal classes by attribute truthiness
 
 ```py
 from typing import Literal

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -71,6 +71,48 @@ if (foo1 := Foo()).val:
     reveal_type(foo1.val)  # revealed: int & ~AlwaysFalsy
 ```
 
+## Narrowing tagged unions by attribute truthiness
+
+```py
+from typing import Literal
+
+class Success:
+    success: Literal[True]
+    result: int
+
+class Failure:
+    success: Literal[False]
+    errors: list[str]
+
+def _(response: Success | Failure):
+    if response.success:
+        reveal_type(response)  # revealed: Success
+        reveal_type(response.result)  # revealed: int
+    else:
+        reveal_type(response)  # revealed: Failure
+        reveal_type(response.errors)  # revealed: list[str]
+
+    if not response.success:
+        reveal_type(response)  # revealed: Failure
+    else:
+        reveal_type(response)  # revealed: Success
+
+class TruthyIntTag:
+    success: Literal[1]
+
+class FalsyIntTag:
+    success: Literal[0]
+
+class AmbiguousTag:
+    success: bool
+
+def _(response: Success | Failure | TruthyIntTag | FalsyIntTag | AmbiguousTag):
+    if response.success:
+        reveal_type(response)  # revealed: Success | TruthyIntTag | AmbiguousTag
+    else:
+        reveal_type(response)  # revealed: Failure | FalsyIntTag | AmbiguousTag
+```
+
 ## Function Literals
 
 Basically functions are always truthy.

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5037,6 +5037,55 @@ def _(u: Foo | Bar):
         reveal_type(u)  # revealed: Bar
 ```
 
+Boolean tags can be narrowed by truthiness, including through a generic `TypedDict` and a type
+alias:
+
+```py
+import json
+from typing import Generic, TypeAlias, TypeVar
+
+T = TypeVar("T")
+
+class Success(TypedDict, Generic[T]):
+    success: Literal[True]
+    result: T
+
+class Failure(TypedDict):
+    success: Literal[False]
+    errors: list[str]
+
+Response: TypeAlias = Success[int] | Failure
+
+def _(response: Response):
+    if response["success"]:
+        reveal_type(response)  # revealed: Success[int]
+        reveal_type(response["result"])  # revealed: int
+    else:
+        reveal_type(response)  # revealed: Failure
+        reveal_type(response["errors"])  # revealed: list[str]
+
+response: Response = json.loads("{}")
+
+if not response["success"]:
+    reveal_type(response)  # revealed: Failure
+    reveal_type(response["errors"])  # revealed: list[str]
+else:
+    reveal_type(response)  # revealed: Success[int]
+    reveal_type(response["result"])  # revealed: int
+
+class TruthyIntTag(TypedDict):
+    success: Literal[1]
+
+class FalsyIntTag(TypedDict):
+    success: Literal[0]
+
+def _(response: Response | TruthyIntTag | FalsyIntTag):
+    if response["success"]:
+        reveal_type(response)  # revealed: Success[int] | TruthyIntTag
+    else:
+        reveal_type(response)  # revealed: Failure | FalsyIntTag
+```
+
 Enum literals are also supported as tags:
 
 ```py

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1115,7 +1115,22 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     constraints
                 }
             }
-            ast::Expr::Attribute(_) => self.evaluate_simple_expr(expression_node, is_positive),
+            ast::Expr::Attribute(attribute) => {
+                let constraints = self.evaluate_simple_expr(expression_node, is_positive);
+                let inference = infer_expression_types(self.db, expression, TypeContext::default());
+                let nominal_constraints = self
+                    .narrow_nominal_attribute_by_truthiness(
+                        inference.expression_type(&*attribute.value),
+                        &attribute.value,
+                        attribute.attr.id(),
+                        is_positive,
+                    )
+                    .map(|(place, constraint)| {
+                        NarrowingConstraints::from_iter([(place, constraint)])
+                    });
+
+                Self::merge_optional_constraints_and(constraints, nominal_constraints)
+            }
             ast::Expr::Subscript(subscript) => {
                 let constraints = self.evaluate_simple_expr(expression_node, is_positive);
                 let inference = infer_expression_types(self.db, expression, TypeContext::default());
@@ -4243,6 +4258,37 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         || !attribute_type.is_disjoint_from(self.db, rhs_type)
                 } else {
                     !attribute_type.is_subtype_of(self.db, rhs_type)
+                }
+            })
+        });
+
+        if narrowed == Type::Union(union) {
+            return None;
+        }
+
+        let attribute_value_place_expr = PlaceExpr::try_from_expr(attribute_value_expr)?;
+        let place = self.expect_place(&attribute_value_place_expr);
+        Some((place, NarrowingConstraint::replacement(narrowed)))
+    }
+
+    fn narrow_nominal_attribute_by_truthiness(
+        &self,
+        attribute_value_type: Type<'db>,
+        attribute_value_expr: &ast::Expr,
+        attribute_name: &str,
+        is_positive: bool,
+    ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
+        let Type::Union(union) = attribute_value_type.resolve_type_alias(self.db) else {
+            return None;
+        };
+
+        let narrowed = union.filter(self.db, |element| {
+            nominal_attribute_type(self.db, *element, attribute_name).is_none_or(|attribute_type| {
+                let truthiness = attribute_type.bool(self.db);
+                if is_positive {
+                    !truthiness.is_always_false()
+                } else {
+                    !truthiness.is_always_true()
                 }
             })
         });

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1115,8 +1115,22 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     constraints
                 }
             }
-            ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
-                self.evaluate_simple_expr(expression_node, is_positive)
+            ast::Expr::Attribute(_) => self.evaluate_simple_expr(expression_node, is_positive),
+            ast::Expr::Subscript(subscript) => {
+                let constraints = self.evaluate_simple_expr(expression_node, is_positive);
+                let inference = infer_expression_types(self.db, expression, TypeContext::default());
+                let typeddict_constraints = self
+                    .narrow_typeddict_subscript_by_truthiness(
+                        inference.expression_type(&*subscript.value),
+                        &subscript.value,
+                        inference.expression_type(&*subscript.slice),
+                        is_positive,
+                    )
+                    .map(|(place, constraint)| {
+                        NarrowingConstraints::from_iter([(place, constraint)])
+                    });
+
+                Self::merge_optional_constraints_and(constraints, typeddict_constraints)
             }
             ast::Expr::Compare(expr_compare) => {
                 self.evaluate_expr_compare(expr_compare, expression, is_positive)
@@ -4073,6 +4087,36 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let schema = TypedDictSchema::from_iter([(field_name, field)]);
         let synthesized_typeddict = TypedDictType::from_schema_items(self.db, schema);
         // As mentioned above, the synthesized `TypedDict` is always negated.
+        let intersection = Type::TypedDict(synthesized_typeddict).negate(self.db);
+        let place = self.expect_place(&subscript_place_expr);
+        Some((place, NarrowingConstraint::intersection(intersection)))
+    }
+
+    /// Narrow tagged unions of `TypedDict`s based on the truthiness of a `Literal` key.
+    fn narrow_typeddict_subscript_by_truthiness(
+        &self,
+        subscript_value_type: Type<'db>,
+        subscript_value_expr: &ast::Expr,
+        subscript_key_type: Type<'db>,
+        is_positive: bool,
+    ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
+        if !is_or_contains_typeddict(self.db, subscript_value_type) {
+            return None;
+        }
+        let subscript_place_expr = PlaceExpr::try_from_expr(subscript_value_expr)?;
+        let key_literal = subscript_key_type.as_string_literal()?;
+
+        let excluded_field_type = if is_positive {
+            Type::AlwaysFalsy
+        } else {
+            Type::AlwaysTruthy
+        };
+        let field = TypedDictFieldBuilder::new(excluded_field_type)
+            .required(false)
+            .read_only(true)
+            .build();
+        let schema = TypedDictSchema::from_iter([(Name::from(key_literal.value(self.db)), field)]);
+        let synthesized_typeddict = TypedDictType::from_schema_items(self.db, schema);
         let intersection = Type::TypedDict(synthesized_typeddict).negate(self.db);
         let place = self.expect_place(&subscript_place_expr);
         Some((place, NarrowingConstraint::intersection(intersection)))


### PR DESCRIPTION
## Summary

Narrow tagged unions when a discriminator is used directly as a truthiness condition, for both `TypedDict` subscripts and regular-class attributes.

The semantic-index pass previously recorded only the subscript or attribute place as potentially narrowed, so resolving the containing value never evaluated a narrowing constraint. Record the base as well, then exclude definitely-falsy variants on the truthy branch and definitely-truthy variants on the falsy branch. `TypedDict` unions use a negative synthesized-`TypedDict` constraint, while nominal unions use the existing arm-filtering strategy.

Truthiness is deliberately kept separate from equality semantics: the tests cover `Literal[True]`/`Literal[1]`, `Literal[False]`/`Literal[0]`, and ambiguous `bool` tags together so the correct alternatives are retained.

Closes https://github.com/astral-sh/ty/issues/4013.

## Test plan

Added mdtests.