### PR TITLE
[`pyupgrade`] Fix false positive with `TypeVar` default before Python 3.13 (`UP040`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pyupgrade/non-pep695-type-alias.md
+++ b/crates/ruff_linter/resources/mdtest/pyupgrade/non-pep695-type-alias.md
@@ -21,25 +21,7 @@ from typing import TypeAlias
 from typing_extensions import TypeVar
 
 T = TypeVar("T", default=int)
-# TODO
-# snapshot: non-pep695-type-alias
 Alias: TypeAlias = list[T]
-```
-
-```snapshot
-error[UP040]: Type alias `Alias` uses `TypeAlias` annotation instead of the `type` keyword
- --> src/mdtest_snippet.py:7:1
-  |
-7 | Alias: TypeAlias = list[T]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-help: Use the `type` keyword
-  |
-6 | # snapshot: non-pep695-type-alias
-  - Alias: TypeAlias = list[T]
-7 + type Alias[T = int] = list[T]
-  |
-note: This is an unsafe fix and may change runtime behavior
 ```
 
 ### `TypeAliasType`
@@ -48,22 +30,5 @@ note: This is an unsafe fix and may change runtime behavior
 from typing_extensions import TypeAliasType, TypeVar
 
 T = TypeVar("T", default=int)
-# TODO
-# snapshot: non-pep695-type-alias
 Alias = TypeAliasType("Alias", list[T], type_params=(T,))
-```
-
-```snapshot
-error[UP040]: Type alias `Alias` uses `TypeAliasType` assignment instead of the `type` keyword
- --> src/mdtest_snippet.py:6:1
-  |
-6 | Alias = TypeAliasType("Alias", list[T], type_params=(T,))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-help: Use the `type` keyword
-  |
-5 | # snapshot: non-pep695-type-alias
-  - Alias = TypeAliasType("Alias", list[T], type_params=(T,))
-6 + type Alias[T = int] = list[T]
-  |
 ```

--- a/crates/ruff_linter/resources/mdtest/pyupgrade/non-pep695-type-alias.md
+++ b/crates/ruff_linter/resources/mdtest/pyupgrade/non-pep695-type-alias.md
@@ -1,0 +1,69 @@
+# `non-pep695-type-alias` (`UP040`)
+
+## `TypeVar` defaults before Python 3.13
+
+`typing_extensions` backports the `default` argument to Python 3.12 and earlier, but the PEP-695
+syntax enforced by the rule is only available on 3.13 and later, so we have to avoid a diagnostic in
+both of these cases.
+
+```toml
+target-version = "py312"
+
+[lint]
+preview = true
+select = ["non-pep695-type-alias"]
+```
+
+### `TypeAlias`
+
+```py
+from typing import TypeAlias
+from typing_extensions import TypeVar
+
+T = TypeVar("T", default=int)
+# TODO
+# snapshot: non-pep695-type-alias
+Alias: TypeAlias = list[T]
+```
+
+```snapshot
+error[UP040]: Type alias `Alias` uses `TypeAlias` annotation instead of the `type` keyword
+ --> src/mdtest_snippet.py:7:1
+  |
+7 | Alias: TypeAlias = list[T]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+help: Use the `type` keyword
+  |
+6 | # snapshot: non-pep695-type-alias
+  - Alias: TypeAlias = list[T]
+7 + type Alias[T = int] = list[T]
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+### `TypeAliasType`
+
+```py
+from typing_extensions import TypeAliasType, TypeVar
+
+T = TypeVar("T", default=int)
+# TODO
+# snapshot: non-pep695-type-alias
+Alias = TypeAliasType("Alias", list[T], type_params=(T,))
+```
+
+```snapshot
+error[UP040]: Type alias `Alias` uses `TypeAliasType` assignment instead of the `type` keyword
+ --> src/mdtest_snippet.py:6:1
+  |
+6 | Alias = TypeAliasType("Alias", list[T], type_params=(T,))
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+help: Use the `type` keyword
+  |
+5 | # snapshot: non-pep695-type-alias
+  - Alias = TypeAliasType("Alias", list[T], type_params=(T,))
+6 + type Alias[T = int] = list[T]
+  |
+```

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -259,9 +259,9 @@ fn create_diagnostic(
 ) {
     // If any type variables have defaults, skip the rule unless
     // running with preview mode enabled and targeting Python 3.13+.
-    if type_vars.iter().any(|type_var| type_var.default.is_some())
-        && (checker.target_version() < PythonVersion::PY313
-            || !is_type_var_default_enabled(checker.settings()))
+    if (checker.target_version() < PythonVersion::PY313
+        || !is_type_var_default_enabled(checker.settings()))
+        && type_vars.iter().any(|type_var| type_var.default.is_some())
     {
         return;
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -238,13 +238,6 @@ pub(crate) fn non_pep695_type_alias(checker: &Checker, stmt: &StmtAnnAssign) {
         .unique_by(|tvar| tvar.name)
         .collect::<Vec<_>>();
 
-    // Skip if any TypeVar has defaults and preview mode is not enabled
-    if vars.iter().any(|tv| tv.default.is_some())
-        && !is_type_var_default_enabled(checker.settings())
-    {
-        return;
-    }
-
     create_diagnostic(
         checker,
         stmt.into(),
@@ -264,6 +257,15 @@ fn create_diagnostic(
     type_vars: &[TypeVar],
     type_alias_kind: TypeAliasKind,
 ) {
+    // If any type variables have defaults, skip the rule unless
+    // running with preview mode enabled and targeting Python 3.13+.
+    if type_vars.iter().any(|type_var| type_var.default.is_some())
+        && (checker.target_version() < PythonVersion::PY313
+            || !is_type_var_default_enabled(checker.settings()))
+    {
+        return;
+    }
+
     let source = checker.source();
     let tokens = checker.tokens();
     let comment_ranges = checker.comment_ranges();

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
@@ -321,24 +321,6 @@ help: Use the `type` keyword
 86 |
    |
 
-UP040 [*] Type alias `AnyList` uses `TypeAliasType` assignment instead of the `type` keyword
-  --> UP040.py:95:1
-   |
-93 | # `default` was added in Python 3.13
-94 | T = typing.TypeVar("T", default=Any)
-95 | AnyList = TypeAliasType("AnyList", list[T], type_params=(T,))
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-96 |
-97 | # unsafe fix if comments within the fix
-   |
-help: Use the `type` keyword
-   |
-94 | T = typing.TypeVar("T", default=Any)
-   - AnyList = TypeAliasType("AnyList", list[T], type_params=(T,))
-95 + type AnyList[T = Any] = list[T]
-96 |
-   |
-
 UP040 [*] Type alias `PositiveList` uses `TypeAliasType` assignment instead of the `type` keyword
    --> UP040.py:99:1
     |

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py__preview_diff.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py__preview_diff.snap
@@ -7,7 +7,7 @@ source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 
 --- Summary ---
 Removed: 0
-Added: 2
+Added: 3
 
 --- Added ---
 UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
@@ -28,6 +28,25 @@ help: Use the `type` keyword
 49 |
    |
 note: This is an unsafe fix and may change runtime behavior
+
+
+UP040 [*] Type alias `AnyList` uses `TypeAliasType` assignment instead of the `type` keyword
+  --> UP040.py:95:1
+   |
+93 | # `default` was added in Python 3.13
+94 | T = typing.TypeVar("T", default=Any)
+95 | AnyList = TypeAliasType("AnyList", list[T], type_params=(T,))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+96 |
+97 | # unsafe fix if comments within the fix
+   |
+help: Use the `type` keyword
+   |
+94 | T = typing.TypeVar("T", default=Any)
+   - AnyList = TypeAliasType("AnyList", list[T], type_params=(T,))
+95 + type AnyList[T = Any] = list[T]
+96 |
+   |
 
 
 UP040 [*] Type alias `DefaultList` uses `TypeAlias` annotation instead of the `type` keyword


### PR DESCRIPTION
Summary
--

This PR fixes a latent bug in `UP040` related to the similar changes to the other PEP-695 rules
`UP046` and `UP047` in #21045. In short, `typing_extensions` backports the `default` argument for
`TypeVar`s to earlier versions of Python, so checking preview alone isn't sufficient. Even the
existing preview check only applied to the `TypeAlias` part of `UP040`, not the `TypeAliasType`
part, so I moved the check into `create_diagnostic`, which is shared by both paths.

This was never reported, so I'm planning to stabilize the preview feature in 0.16 anyway.

Test Plan
--

New mdtests and updates to existing snapshots
