### PR TITLE
[ty] Share structured docstring parsing components

### DIFF
--- a/crates/ty_ide/src/docstring/document.rs
+++ b/crates/ty_ide/src/docstring/document.rs
@@ -1,5 +1,8 @@
 use indexmap::IndexMap;
+use ruff_text_size::{TextRange, TextSize};
 use strum_macros::EnumIter;
+
+use self::syntax::{indentation, starts_with_markdown_list_item};
 
 pub(super) mod google;
 pub(super) mod preformatted;
@@ -52,4 +55,204 @@ impl SectionKind {
             SectionKind::Raises => "Raises",
         }
     }
+}
+
+/// A recognized structured docstring section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::docstring) struct Section<Name> {
+    kind: SectionKind,
+    range: TextRange,
+    body: SectionBody<Name>,
+}
+
+impl<Name> Section<Name> {
+    /// Returns the section kind.
+    pub(in crate::docstring) const fn kind(&self) -> SectionKind {
+        self.kind
+    }
+
+    /// Returns the section's source range.
+    pub(in crate::docstring) const fn range(&self) -> TextRange {
+        self.range
+    }
+
+    /// Consumes this section and returns its fragments when it can be rendered structurally.
+    pub(in crate::docstring) fn into_renderable_fragments(self) -> Option<Vec<BodyFragment<Name>>> {
+        let SectionBody::Parsed {
+            fragments,
+            has_structural_ambiguity,
+        } = self.body
+        else {
+            return None;
+        };
+        (!has_structural_ambiguity).then_some(fragments)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SectionBody<Name> {
+    /// A body parsed into semantic fragments.
+    Parsed {
+        fragments: Vec<BodyFragment<Name>>,
+        /// Whether the body's structure is ambiguous.
+        has_structural_ambiguity: bool,
+    },
+    /// A body whose contents were not parsed.
+    Opaque,
+}
+
+impl<Name> SectionBody<Name> {
+    /// Creates an unambiguous body containing the description as a single prose fragment.
+    fn from_prose(description: String) -> Self {
+        let fragments = (!description.is_empty())
+            .then_some(BodyFragment::Prose(description))
+            .into_iter()
+            .collect();
+        Self::Parsed {
+            fragments,
+            has_structural_ambiguity: false,
+        }
+    }
+
+    fn into_fragments(self) -> Vec<BodyFragment<Name>> {
+        match self {
+            Self::Parsed { fragments, .. } => fragments,
+            Self::Opaque => Vec::new(),
+        }
+    }
+}
+
+/// One parsed fragment in a structured section body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::docstring) enum BodyFragment<Name> {
+    /// Section-level prose that is not attached to an item.
+    Prose(String),
+    /// A named or anonymous section item.
+    Item(Item<Name>),
+}
+
+/// An item in a structured docstring section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::docstring) struct Item<Name> {
+    display_name: Name,
+    ty: Option<String>,
+    description: String,
+}
+
+impl<Name> Item<Name> {
+    /// Consumes this item and returns its display parts.
+    pub(in crate::docstring) fn into_display_name_type_and_description(
+        self,
+    ) -> (Name, Option<String>, String) {
+        (self.display_name, self.ty, self.description)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeaderKind {
+    Structured(SectionKind),
+    Opaque,
+}
+
+impl HeaderKind {
+    fn is_parameter_section(self) -> bool {
+        matches!(
+            self,
+            Self::Structured(
+                SectionKind::Parameters
+                    | SectionKind::KeywordArguments
+                    | SectionKind::OtherParameters
+            )
+        )
+    }
+}
+
+#[derive(Default)]
+struct DescriptionBuilder<'a> {
+    inline: Option<&'a str>,
+    continuation_lines: Vec<&'a str>,
+}
+
+impl<'a> DescriptionBuilder<'a> {
+    fn with_inline(inline: &'a str) -> Self {
+        let inline = inline.trim();
+        Self {
+            inline: (!inline.is_empty()).then_some(inline),
+            continuation_lines: Vec::new(),
+        }
+    }
+
+    fn push_line(&mut self, line: &'a str) {
+        // Keep a leading list item with the block so that its indentation establishes the baseline
+        // for nested items. Ordinary first lines use the allocation-free inline representation.
+        if self.inline.is_none()
+            && self.continuation_lines.is_empty()
+            && !starts_with_markdown_list_item(line.trim_start())
+        {
+            self.inline = Some(line.trim());
+        } else {
+            self.push_continuation(line);
+        }
+    }
+
+    fn push_continuation(&mut self, line: &'a str) {
+        self.continuation_lines.push(line);
+    }
+
+    fn finish(mut self) -> String {
+        if self.continuation_lines.is_empty() {
+            return self.inline.map_or_else(String::new, str::to_string);
+        }
+
+        let continuation_indent = self
+            .continuation_lines
+            .iter()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| indentation(line))
+            .min()
+            .unwrap_or_default();
+        for line in &mut self.continuation_lines {
+            *line = if line.trim().is_empty() {
+                ""
+            } else {
+                strip_indentation(line, continuation_indent).trim_end()
+            };
+        }
+
+        if let Some(inline) = self.inline {
+            self.continuation_lines.insert(0, inline);
+        }
+        let lines = self.continuation_lines;
+
+        let Some(start) = lines.iter().position(|line| !line.is_empty()) else {
+            return String::new();
+        };
+        let end = lines
+            .iter()
+            .rposition(|line| !line.is_empty())
+            .map_or(start, |index| index + 1);
+        lines[start..end].join("\n")
+    }
+}
+
+fn strip_indentation(line: &str, width: TextSize) -> &str {
+    let mut indentation_width = TextSize::default();
+    for (index, char) in line.char_indices() {
+        let next_indentation_width = match char {
+            ' ' => indentation_width + TextSize::new(1),
+            '\t' => TextSize::new((indentation_width.to_u32() / 8 + 1) * 8),
+            _ => return &line[index..],
+        };
+
+        if next_indentation_width > width {
+            return &line[index..];
+        }
+
+        indentation_width = next_indentation_width;
+        if indentation_width == width {
+            return &line[index + char.len_utf8()..];
+        }
+    }
+
+    ""
 }

--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -35,12 +35,12 @@ use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_python_trivia::Cursor;
 use ruff_text_size::{TextRange, TextSize};
 
-use super::SectionKind;
 use super::preformatted::PreformattedBlockScanner;
 use super::syntax::{
-    ParsedLine, consume_quoted_string, container_block_end, indentation, parsed_lines,
-    split_once_at_top_level_colon, split_trailing_parenthetical, starts_with_markdown_list_item,
+    ParsedLine, consume_quoted_string, container_block_end, indentation, is_dotted_identifier,
+    parsed_lines, split_once_at_top_level_colon, split_trailing_parenthetical,
 };
+use super::{DescriptionBuilder, HeaderKind, SectionKind};
 
 /// Returns parameter documentation from recognized Google-style parameter sections.
 ///
@@ -73,95 +73,15 @@ pub(in crate::docstring) fn sections(source: &str) -> impl Iterator<Item = Secti
 }
 
 /// A recognized Google-style docstring section.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(in crate::docstring) struct Section {
-    kind: SectionKind,
-    range: TextRange,
-    body: SectionBody,
-}
+pub(in crate::docstring) type Section = super::Section<String>;
 
-impl Section {
-    /// Returns the section kind.
-    pub(in crate::docstring) const fn kind(&self) -> SectionKind {
-        self.kind
-    }
-
-    /// Returns the section's source range.
-    pub(in crate::docstring) const fn range(&self) -> TextRange {
-        self.range
-    }
-
-    /// Consumes this section and returns its fragments when it can be rendered structurally.
-    pub(in crate::docstring) fn into_renderable_fragments(self) -> Option<Vec<BodyFragment>> {
-        let SectionBody::Parsed {
-            fragments,
-            has_structural_ambiguity,
-        } = self.body
-        else {
-            return None;
-        };
-        (!has_structural_ambiguity).then_some(fragments)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum SectionBody {
-    /// A body parsed into semantic fragments.
-    Parsed {
-        fragments: Vec<BodyFragment>,
-        /// Whether the body's structure is ambiguous.
-        has_structural_ambiguity: bool,
-    },
-    /// A body whose contents were not parsed.
-    Opaque,
-}
-
-impl SectionBody {
-    /// Creates an unambiguous body containing the description as a single prose fragment.
-    fn from_prose(description: String) -> Self {
-        let fragments = (!description.is_empty())
-            .then_some(BodyFragment::Prose(description))
-            .into_iter()
-            .collect();
-        Self::Parsed {
-            fragments,
-            has_structural_ambiguity: false,
-        }
-    }
-
-    fn into_fragments(self) -> Vec<BodyFragment> {
-        match self {
-            Self::Parsed { fragments, .. } => fragments,
-            Self::Opaque => Vec::new(),
-        }
-    }
-}
+type SectionBody = super::SectionBody<String>;
 
 /// One parsed fragment in a Google section body.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(in crate::docstring) enum BodyFragment {
-    /// Section-level prose that is not attached to a named item.
-    Prose(String),
-    /// A named item and its description.
-    Item(Item),
-}
+pub(in crate::docstring) type BodyFragment = super::BodyFragment<String>;
 
 /// A named item in a Google section.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(in crate::docstring) struct Item {
-    display_name: String,
-    ty: Option<String>,
-    description: String,
-}
-
-impl Item {
-    /// Consumes this item and returns its display parts.
-    pub(in crate::docstring) fn into_display_name_type_and_description(
-        self,
-    ) -> (String, Option<String>, String) {
-        (self.display_name, self.ty, self.description)
-    }
-}
+pub(in crate::docstring) type Item = super::Item<String>;
 
 /// Splits a display name from a trailing parenthesized type.
 ///
@@ -552,11 +472,6 @@ impl<'a> SectionBuilder<'a> {
     }
 }
 
-/// Returns whether every component of `name` is a Python identifier.
-fn is_dotted_identifier(name: &str) -> bool {
-    !name.is_empty() && name.split('.').all(is_identifier)
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Header {
     kind: HeaderKind,
@@ -569,12 +484,6 @@ struct Header {
 enum HeaderForm {
     Section,
     Inline,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HeaderKind {
-    Structured(SectionKind),
-    Opaque,
 }
 
 impl HeaderKind {
@@ -754,74 +663,6 @@ impl<'a> ItemBuilder<'a> {
             ty: self.ty.map(str::to_string),
             description: self.description.finish(),
         }
-    }
-}
-
-#[derive(Default)]
-struct DescriptionBuilder<'a> {
-    inline: Option<&'a str>,
-    continuation_lines: Vec<&'a str>,
-}
-
-impl<'a> DescriptionBuilder<'a> {
-    fn with_inline(inline: &'a str) -> Self {
-        let inline = inline.trim();
-        Self {
-            inline: (!inline.is_empty()).then_some(inline),
-            continuation_lines: Vec::new(),
-        }
-    }
-
-    fn push_line(&mut self, line: &'a str) {
-        // Keep a leading list item with the block so that its indentation establishes the baseline
-        // for nested items. Ordinary first lines use the allocation-free inline representation.
-        if self.inline.is_none()
-            && self.continuation_lines.is_empty()
-            && !starts_with_markdown_list_item(line.trim_start())
-        {
-            self.inline = Some(line.trim());
-        } else {
-            self.push_continuation(line);
-        }
-    }
-
-    fn push_continuation(&mut self, line: &'a str) {
-        self.continuation_lines.push(line);
-    }
-
-    fn finish(mut self) -> String {
-        if self.continuation_lines.is_empty() {
-            return self.inline.map_or_else(String::new, str::to_string);
-        }
-
-        let continuation_indent = self
-            .continuation_lines
-            .iter()
-            .filter(|line| !line.trim().is_empty())
-            .map(|line| indentation(line))
-            .min()
-            .unwrap_or_default();
-        for line in &mut self.continuation_lines {
-            *line = if line.trim().is_empty() {
-                ""
-            } else {
-                strip_indentation(line, continuation_indent).trim_end()
-            };
-        }
-
-        if let Some(inline) = self.inline {
-            self.continuation_lines.insert(0, inline);
-        }
-        let lines = self.continuation_lines;
-
-        let Some(start) = lines.iter().position(|line| !line.is_empty()) else {
-            return String::new();
-        };
-        let end = lines
-            .iter()
-            .rposition(|line| !line.is_empty())
-            .map_or(start, |index| index + 1);
-        lines[start..end].join("\n")
     }
 }
 
@@ -1049,41 +890,6 @@ fn is_attribute_display_name(display_name: &str) -> bool {
     display_name
         .split(',')
         .all(|name| is_dotted_identifier(name.trim()))
-}
-
-fn strip_indentation(line: &str, width: TextSize) -> &str {
-    let mut indentation_width = TextSize::default();
-    for (index, char) in line.char_indices() {
-        let next_indentation_width = match char {
-            ' ' => indentation_width + TextSize::new(1),
-            '\t' => TextSize::new((indentation_width.to_u32() / 8 + 1) * 8),
-            _ => return &line[index..],
-        };
-
-        if next_indentation_width > width {
-            return &line[index..];
-        }
-
-        indentation_width = next_indentation_width;
-        if indentation_width == width {
-            return &line[index + char.len_utf8()..];
-        }
-    }
-
-    ""
-}
-
-impl HeaderKind {
-    fn is_parameter_section(self) -> bool {
-        matches!(
-            self,
-            Self::Structured(
-                SectionKind::Parameters
-                    | SectionKind::KeywordArguments
-                    | SectionKind::OtherParameters
-            )
-        )
-    }
 }
 
 #[cfg(test)]

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -1,3 +1,4 @@
+use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_python_trivia::{Cursor, leading_indentation, tab_offset_u32};
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{TextRange, TextSize};
@@ -28,6 +29,13 @@ pub(super) struct ParsedLine<'a> {
     pub(super) range: TextRange,
     /// The indentation in the source document.
     pub(super) indent: TextSize,
+}
+
+/// Returns whether every component of `name` is a Python identifier.
+///
+/// For example, this returns `true` for `"package.Type"` and `false` for `"package.1"`.
+pub(super) fn is_dotted_identifier(name: &str) -> bool {
+    !name.is_empty() && name.split('.').all(is_identifier)
 }
 
 /// Returns whether `line` starts with a `CommonMark` list-item marker.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Prior to [parsing a document model for NumPy-style docstrings](https://github.com/astral-sh/ruff/pull/25924), this moves a few parsing components that are currently only used for the Google-style docstring format to a shared location. This just helps reduce noise in that upcoming PR for using those same components for a new target.

## Test Plan

This is a behaviour-preserving refactor that is covered by existing tests.
<!-- How was it tested? -->
