### PR TITLE
[ty] Enforce declared TypeVar domains in constraint sets

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -211,7 +211,7 @@ static TANJUN: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    110,
+    113,
 );
 
 static STATIC_FRAME: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -329,7 +329,7 @@ class MetaBase(type):
         return self
 
 class Meta(MetaBase):
-    def __call__(cls: type[_TMeta], *args: Any, **kwargs: Any) -> _TMeta:
+    def __call__(cls: type[_TMeta], *args: Any, **kwargs: Any) -> _TMeta:  # error: [invalid-method-override]
         reveal_type(super(Meta, cls).meta_base_value)  # revealed: int
         reveal_type(super(Meta, cls).plain())  # revealed: type[_TMeta@__call__]
         return super().__call__(*args, **kwargs)
@@ -356,7 +356,7 @@ super(Meta, OtherBase)  # error: [invalid-super-argument]
 T = TypeVar("T", bound=int)
 
 class BoundIntMeta(type):
-    def __call__(cls: type[T]) -> T:
+    def __call__(cls: type[T]) -> T:  # error: [invalid-method-override]
         return super(BoundIntMeta, cls).__call__()  # error: [invalid-super-argument]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -104,9 +104,8 @@ valid_constraints: Callable[[], None] = ValidConstrainedReceiver().method
 
 invalid_aliased_bound: Callable[[], None] = InvalidAliasedBoundedReceiver().method  # error: [invalid-assignment]
 
-# TODO: Enforce valid specializations for TypeVars nested inside receiver annotations.
-invalid_nested_bound: Callable[[], None] = InvalidNestedBoundedReceiver().method  # TODO: error: [invalid-assignment]
-invalid_union_constraints: Callable[[], None] = InvalidUnionConstrainedReceiver().method  # TODO: error: [invalid-assignment]
+invalid_nested_bound: Callable[[], None] = InvalidNestedBoundedReceiver().method  # error: [invalid-assignment]
+invalid_union_constraints: Callable[[], None] = InvalidUnionConstrainedReceiver().method  # error: [invalid-assignment]
 ```
 
 When we coerce a generic callable into a `Callable` type, it remembers that it is generic:

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5123,6 +5123,26 @@ def _(t: TypeVarRecursive):
     reveal_type(t.y)  # revealed: TypeVarRecursive
 ```
 
+### Self-recursive TypeVar bounds
+
+Applying a recursive protocol's bound while comparing its generic method must not recursively
+re-enter the same signature relation:
+
+```py
+from typing import Protocol, TypeVar
+
+SelfT = TypeVar("SelfT", bound="Comparable")
+
+class Comparable(Protocol):
+    def __lt__(self: SelfT, other: SelfT) -> bool: ...
+
+class Concrete:
+    def __lt__(self, other: "Concrete") -> bool:
+        return False
+
+value: Comparable = Concrete()
+```
+
 ### Nested occurrences of self-reference
 
 Make sure that we handle self-reference correctly, even if the self-reference appears deeply nested

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5143,6 +5143,31 @@ class Concrete:
 value: Comparable = Concrete()
 ```
 
+### Recursive protocols and bounded generic methods
+
+Comparing a recursive protocol against a generic method whose receiver has a declared bound must not
+recursively re-enter constraint implication:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class Array(Protocol):
+    def __abs__(self) -> Array: ...
+
+class NDArray:
+    def __abs__[T: NDArray](self: T) -> T:
+        return self
+
+array: Array = NDArray()
+```
+
 ### Nested occurrences of self-reference
 
 Make sure that we handle self-reference correctly, even if the self-reference appears deeply nested

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3842,19 +3842,6 @@ static_assert(is_subtype_of(ValidConstrainedReceiver, ReceiverOnly))
 static_assert(is_assignable_to(RecursiveReceiverBound, ReceiverOnly))
 static_assert(is_subtype_of(RecursiveReceiverBound, ReceiverOnly))
 
-# Applying the declared domain of this F-bounded TypeVar while checking the protocol would re-enter
-# the same structural relation. We currently omit that recursive domain guard.
-SelfWeight = TypeVar("SelfWeight", bound="ImplementationWeight")
-
-class ImplementationWeight(Protocol):
-    def __lt__(self: SelfWeight, other: SelfWeight) -> bool: ...
-
-class NeutralWeight:
-    def __lt__(self, other: "NeutralWeight") -> bool:
-        return False
-
-weight: ImplementationWeight = NeutralWeight()
-
 # These test cases are taken from the typing conformance suite:
 class ShapeProtocolImplicitSelf(Protocol):
     def set_scale(self, scale: float) -> Self: ...

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3842,6 +3842,19 @@ static_assert(is_subtype_of(ValidConstrainedReceiver, ReceiverOnly))
 static_assert(is_assignable_to(RecursiveReceiverBound, ReceiverOnly))
 static_assert(is_subtype_of(RecursiveReceiverBound, ReceiverOnly))
 
+# Applying the declared domain of this F-bounded TypeVar while checking the protocol would re-enter
+# the same structural relation. We currently omit that recursive domain guard.
+SelfWeight = TypeVar("SelfWeight", bound="ImplementationWeight")
+
+class ImplementationWeight(Protocol):
+    def __lt__(self: SelfWeight, other: SelfWeight) -> bool: ...
+
+class NeutralWeight:
+    def __lt__(self, other: "NeutralWeight") -> bool:
+        return False
+
+weight: ImplementationWeight = NeutralWeight()
+
 # These test cases are taken from the typing conformance suite:
 class ShapeProtocolImplicitSelf(Protocol):
     def set_scale(self, scale: float) -> Self: ...

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Metaclasses_(faeb52a8cd1533b3).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/super.md_-_Super_-_Basic_Usage_-_Metaclasses_(faeb52a8cd1533b3).snap
@@ -24,7 +24,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
  9 |         return self
 10 | 
 11 | class Meta(MetaBase):
-12 |     def __call__(cls: type[_TMeta], *args: Any, **kwargs: Any) -> _TMeta:
+12 |     def __call__(cls: type[_TMeta], *args: Any, **kwargs: Any) -> _TMeta:  # error: [invalid-method-override]
 13 |         reveal_type(super(Meta, cls).meta_base_value)  # revealed: int
 14 |         reveal_type(super(Meta, cls).plain())  # revealed: type[_TMeta@__call__]
 15 |         return super().__call__(*args, **kwargs)
@@ -51,11 +51,27 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/class/super.md
 36 | T = TypeVar("T", bound=int)
 37 | 
 38 | class BoundIntMeta(type):
-39 |     def __call__(cls: type[T]) -> T:
+39 |     def __call__(cls: type[T]) -> T:  # error: [invalid-method-override]
 40 |         return super(BoundIntMeta, cls).__call__()  # error: [invalid-super-argument]
 ```
 
 # Diagnostics
+
+```
+error[invalid-method-override]: Invalid override of method `__call__`
+   --> src/mdtest_snippet.py:12:9
+    |
+ 12 |     def __call__(cls: type[_TMeta], *args: Any, **kwargs: Any) -> _TMeta:  # error: [invalid-method-override]
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `type.__call__`
+    |
+   ::: stdlib/builtins.pyi:284:9
+    |
+284 |     def __call__(self, *args: Any, **kwds: Any) -> Any:
+    |         ---------------------------------------------- `type.__call__` defined here
+    |
+info: This violates the Liskov Substitution Principle
+
+```
 
 ```
 error[invalid-super-argument]: `<class 'OtherBase'>` is not an instance or subclass of `<class 'Meta'>` in `super(<class 'Meta'>, <class 'OtherBase'>)` call
@@ -64,6 +80,22 @@ error[invalid-super-argument]: `<class 'OtherBase'>` is not an instance or subcl
 34 | super(Meta, OtherBase)  # error: [invalid-super-argument]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
+
+```
+
+```
+error[invalid-method-override]: Invalid override of method `__call__`
+   --> src/mdtest_snippet.py:39:9
+    |
+ 39 |     def __call__(cls: type[T]) -> T:  # error: [invalid-method-override]
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `type.__call__`
+    |
+   ::: stdlib/builtins.pyi:284:9
+    |
+284 |     def __call__(self, *args: Any, **kwds: Any) -> Any:
+    |         ---------------------------------------------- `type.__call__` defined here
+    |
+info: This violates the Liskov Substitution Principle
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/subscript/instance.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/instance.md
@@ -199,6 +199,15 @@ a = Identity()
 a[0] = 0
 ```
 
+## Subscript assignment on a negative-only intersection
+
+```py
+from ty_extensions import Not
+
+def assign(value: Not[None]) -> None:
+    value[:] = 1
+```
+
 ## `__setitem__` with invalid index argument
 
 ```py

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -590,8 +590,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// Reduces the set of inferable typevars for this constraint set. You provide the typevars that
     /// were inferable when this constraint set was created, and which should be abstracted away.
     /// Those typevars will be removed from the constraint set, and the constraint set will return
-    /// true whenever there was _any valid_ specialization of those typevars that returned true
-    /// before.
+    /// true whenever there was _any_ specialization of those typevars that returned true before.
     pub(crate) fn reduce_inferable(
         self,
         db: &'db dyn Db,
@@ -599,23 +598,38 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         to_remove: InferableTypeVars<'db>,
     ) -> Self {
         self.verify_builder(builder);
+        Self::from_node(builder, self.node.exists(db, builder, to_remove))
+    }
+
+    /// Intersects this set with the declared domain of every constrained type variable.
+    ///
+    /// Receiver constraints need this explicitly so that a nested type variable cannot be inferred
+    /// outside of its declared domain:
+    ///
+    /// ```python
+    /// class C:
+    ///     def method[T: int](self: list[T]) -> None: ...
+    /// ```
+    ///
+    /// This is separate from [`Self::reduce_inferable`], because applying domains during every
+    /// signature abstraction would recursively reapply self-referential protocol bounds.
+    pub(crate) fn and_valid_typevar_specializations(
+        self,
+        db: &'db dyn Db,
+        builder: &'c ConstraintSetBuilder<'db>,
+    ) -> Self {
+        self.verify_builder(builder);
         let mut constrained = self.node;
         let mut typevars = FxOrderSet::default();
-        // Existential abstraction must be restricted to each typevar's declared domain. Otherwise,
-        // a constraint such as `Receiver ≤ T` could be satisfied by `T = object` even when `T` is
-        // declared with an incompatible upper bound or set of constraints.
         self.node
             .for_each_unique_constraint(builder, &mut |constraint, _| {
-                let typevar = builder.constraint_data(constraint).typevar;
-                if typevar.is_inferable(db, to_remove) {
-                    typevars.insert(typevar);
-                }
+                typevars.insert(builder.constraint_data(constraint).typevar);
             });
         for typevar in typevars {
             constrained =
                 constrained.and_with_offset(builder, typevar.valid_specializations(db, builder));
         }
-        Self::from_node(builder, constrained.exists(db, builder, to_remove))
+        Self::from_node(builder, constrained)
     }
 
     /// Applies a type mapping to every constraint in this constraint set.

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -298,6 +298,7 @@ impl<'db> OwnedConstraintSet<'db> {
         };
         let builder = ConstraintSetBuilder {
             storage: RefCell::new(storage),
+            suppress_typevar_domains: Cell::new(false),
         };
         let set = ConstraintSet::from_node(&builder, self.node);
         f(&builder, set)
@@ -403,6 +404,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         upper: Option<Type<'db>>,
     ) -> Self {
         let constraint = Constraint::new_node_with_bounds(db, builder, typevar, lower, upper);
+        if builder.typevar_domains_suppressed() {
+            return Self::from_node(builder, constraint);
+        }
         let valid_specializations = typevar.valid_specializations(db, builder);
         Self::from_node(
             builder,
@@ -831,6 +835,23 @@ impl Debug for ConstraintSet<'_, '_> {
 #[derive(Default)]
 pub(crate) struct ConstraintSetBuilder<'db> {
     storage: RefCell<ConstraintSetStorage<'db>>,
+    /// Temporarily omit declared `TypeVar` domains while checking recursive protocols.
+    ///
+    /// Recursive protocol member comparisons can re-enter constraint implication through a
+    /// fresh builder, bypassing the existing relation recursion guards. This escape hatch can be
+    /// removed once those recursive relations share a cycle detector.
+    suppress_typevar_domains: Cell<bool>,
+}
+
+struct TypeVarDomainSuppressionGuard<'a> {
+    suppress_typevar_domains: &'a Cell<bool>,
+    previous: bool,
+}
+
+impl Drop for TypeVarDomainSuppressionGuard<'_> {
+    fn drop(&mut self) {
+        self.suppress_typevar_domains.set(self.previous);
+    }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, get_size2::GetSize)]
@@ -942,6 +963,19 @@ impl ConstraintSetStorage<'_> {
 impl<'db> ConstraintSetBuilder<'db> {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    pub(super) fn typevar_domains_suppressed(&self) -> bool {
+        self.suppress_typevar_domains.get()
+    }
+
+    pub(super) fn with_typevar_domains_suppressed<R>(&self, work: impl FnOnce() -> R) -> R {
+        let previous = self.suppress_typevar_domains.replace(true);
+        let _guard = TypeVarDomainSuppressionGuard {
+            suppress_typevar_domains: &self.suppress_typevar_domains,
+            previous,
+        };
+        work()
     }
 
     /// Creates an [`OwnedConstraintSet`], consuming this builder in the process. You provide a
@@ -2101,6 +2135,12 @@ impl ConstraintId {
         builder: &ConstraintSetBuilder<'db>,
         other: Self,
     ) -> bool {
+        // Constraint implication is only a simplification. Conservatively skip it while checking
+        // recursive protocols because assignability between the bounds can re-enter the same
+        // protocol relation through a fresh builder.
+        if builder.typevar_domains_suppressed() {
+            return false;
+        }
         let self_constraint = builder.constraint_data(self);
         let other_constraint = builder.constraint_data(other);
         if !self_constraint

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -402,9 +402,11 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         lower: Option<Type<'db>>,
         upper: Option<Type<'db>>,
     ) -> Self {
+        let constraint = Constraint::new_node_with_bounds(db, builder, typevar, lower, upper);
+        let valid_specializations = typevar.valid_specializations(db, builder);
         Self::from_node(
             builder,
-            Constraint::new_node_with_bounds(db, builder, typevar, lower, upper),
+            constraint.and_with_offset(builder, valid_specializations),
         )
     }
 
@@ -601,37 +603,6 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         Self::from_node(builder, self.node.exists(db, builder, to_remove))
     }
 
-    /// Intersects this set with the declared domain of every constrained type variable.
-    ///
-    /// Receiver constraints need this explicitly so that a nested type variable cannot be inferred
-    /// outside of its declared domain:
-    ///
-    /// ```python
-    /// class C:
-    ///     def method[T: int](self: list[T]) -> None: ...
-    /// ```
-    ///
-    /// This is separate from [`Self::reduce_inferable`], because applying domains during every
-    /// signature abstraction would recursively reapply self-referential protocol bounds.
-    pub(crate) fn and_valid_typevar_specializations(
-        self,
-        db: &'db dyn Db,
-        builder: &'c ConstraintSetBuilder<'db>,
-    ) -> Self {
-        self.verify_builder(builder);
-        let mut constrained = self.node;
-        let mut typevars = FxOrderSet::default();
-        self.node
-            .for_each_unique_constraint(builder, &mut |constraint, _| {
-                typevars.insert(builder.constraint_data(constraint).typevar);
-            });
-        for typevar in typevars {
-            constrained =
-                constrained.and_with_offset(builder, typevar.valid_specializations(db, builder));
-        }
-        Self::from_node(builder, constrained)
-    }
-
     /// Applies a type mapping to every constraint in this constraint set.
     pub(crate) fn apply_type_mapping_impl(
         self,
@@ -704,7 +675,14 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                     .map(|upper| upper.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
 
                 let mapped = if let Type::TypeVar(typevar) = subject {
-                    Constraint::new_node_with_bounds(db, builder, typevar, lower, upper)
+                    Constraint::new_node_with_kind(
+                        db,
+                        builder,
+                        typevar,
+                        lower,
+                        upper,
+                        constraint.kind,
+                    )
                 } else {
                     let lower_holds = lower.map_or(ALWAYS_TRUE, |lower| {
                         builder
@@ -1401,6 +1379,28 @@ pub struct ConstraintId;
 pub(crate) struct Constraint<'db> {
     pub(crate) typevar: BoundTypeVarInstance<'db>,
     pub(crate) bounds: ConstraintBounds<'db>,
+    kind: ConstraintKind,
+}
+
+/// Whether a constraint provides inference evidence or only restricts the valid domain.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+enum ConstraintKind {
+    Inference,
+    TypeVarDomain,
+}
+
+impl ConstraintKind {
+    /// Combines the roles of two antecedents for a constraint derived from both.
+    ///
+    /// A fact derived only from domain guards remains a guard. Once an inference constraint
+    /// participates, the derived fact can carry that evidence to another type variable.
+    fn derived_with(self, other: Self) -> Self {
+        if matches!(self, Self::TypeVarDomain) && matches!(other, Self::TypeVarDomain) {
+            Self::TypeVarDomain
+        } else {
+            Self::Inference
+        }
+    }
 }
 
 /// The explicit lower and upper bounds inferred for a typevar on one constraint path.
@@ -1577,6 +1577,7 @@ impl<'db> UpperBound<'db> {
 }
 
 impl ConstraintId {
+    #[cfg(test)]
     fn new<'db>(
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
@@ -1587,6 +1588,7 @@ impl ConstraintId {
         Self::new_with_bounds(db, builder, typevar, Some(lower), Some(upper))
     }
 
+    #[cfg(test)]
     fn new_with_bounds<'db>(
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
@@ -1594,11 +1596,31 @@ impl ConstraintId {
         lower: Option<Type<'db>>,
         upper: Option<Type<'db>>,
     ) -> ConstraintId {
+        Self::new_with_kind(
+            db,
+            builder,
+            typevar,
+            lower,
+            upper,
+            ConstraintKind::Inference,
+        )
+    }
+
+    /// Interns a range constraint with its role in solution inference.
+    fn new_with_kind<'db>(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        typevar: BoundTypeVarInstance<'db>,
+        lower: Option<Type<'db>>,
+        upper: Option<Type<'db>>,
+        kind: ConstraintKind,
+    ) -> ConstraintId {
         builder.intern_constraint(
             db,
             Constraint {
                 typevar,
                 bounds: ConstraintBounds::new(lower, upper),
+                kind,
             },
         )
     }
@@ -1712,6 +1734,24 @@ impl<'db> Constraint<'db> {
         Self::new_node_with_bounds(db, builder, typevar, Some(lower), Some(upper))
     }
 
+    /// Returns an exact range that restricts a type variable's declared domain.
+    fn new_domain_node(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        typevar: BoundTypeVarInstance<'db>,
+        lower: Type<'db>,
+        upper: Type<'db>,
+    ) -> NodeId {
+        Self::new_node_with_kind(
+            db,
+            builder,
+            typevar,
+            Some(lower),
+            Some(upper),
+            ConstraintKind::TypeVarDomain,
+        )
+    }
+
     /// Returns a new range constraint, preserving whether each bound was present explicitly.
     ///
     /// Panics if present `lower` and `upper` bounds are not fully static.
@@ -1719,8 +1759,45 @@ impl<'db> Constraint<'db> {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
+        lower: Option<Type<'db>>,
+        upper: Option<Type<'db>>,
+    ) -> NodeId {
+        Self::new_node_with_kind(
+            db,
+            builder,
+            typevar,
+            lower,
+            upper,
+            ConstraintKind::Inference,
+        )
+    }
+
+    /// Returns a declared-domain range while preserving which bounds are explicit.
+    fn new_domain_node_with_bounds(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        typevar: BoundTypeVarInstance<'db>,
+        lower: Option<Type<'db>>,
+        upper: Option<Type<'db>>,
+    ) -> NodeId {
+        Self::new_node_with_kind(
+            db,
+            builder,
+            typevar,
+            lower,
+            upper,
+            ConstraintKind::TypeVarDomain,
+        )
+    }
+
+    /// Returns a range constraint with its role in solution inference.
+    fn new_node_with_kind(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        typevar: BoundTypeVarInstance<'db>,
         mut lower: Option<Type<'db>>,
         mut upper: Option<Type<'db>>,
+        kind: ConstraintKind,
     ) -> NodeId {
         if lower.is_none() && upper.is_none() {
             return ALWAYS_TRUE;
@@ -1739,12 +1816,13 @@ impl<'db> Constraint<'db> {
             for lower_element in lower_union.elements(db) {
                 result = result.and_with_offset(
                     builder,
-                    Constraint::new_node_with_bounds(
+                    Constraint::new_node_with_kind(
                         db,
                         builder,
                         typevar,
                         Some(*lower_element),
                         upper,
+                        kind,
                     ),
                 );
             }
@@ -1760,24 +1838,26 @@ impl<'db> Constraint<'db> {
             for upper_element in upper_intersection.iter_positive(db) {
                 result = result.and_with_offset(
                     builder,
-                    Constraint::new_node_with_bounds(
+                    Constraint::new_node_with_kind(
                         db,
                         builder,
                         typevar,
                         lower,
                         Some(upper_element),
+                        kind,
                     ),
                 );
             }
             for upper_element in upper_intersection.iter_negative(db) {
                 result = result.and_with_offset(
                     builder,
-                    Constraint::new_node_with_bounds(
+                    Constraint::new_node_with_kind(
                         db,
                         builder,
                         typevar,
                         lower,
                         Some(upper_element.negate(db)),
+                        kind,
                     ),
                 );
             }
@@ -1810,7 +1890,14 @@ impl<'db> Constraint<'db> {
             {
                 return Node::new_constraint(
                     builder,
-                    ConstraintId::new(db, builder, typevar, Type::Never, Type::object()),
+                    ConstraintId::new_with_kind(
+                        db,
+                        builder,
+                        typevar,
+                        Some(Type::Never),
+                        Some(Type::object()),
+                        kind,
+                    ),
                     1,
                 )
                 .negate(builder);
@@ -1866,12 +1953,13 @@ impl<'db> Constraint<'db> {
                 };
                 Node::new_constraint(
                     builder,
-                    ConstraintId::new(
+                    ConstraintId::new_with_kind(
                         db,
                         builder,
                         typevar,
-                        Type::TypeVar(bound),
-                        Type::TypeVar(bound),
+                        Some(Type::TypeVar(bound)),
+                        Some(Type::TypeVar(bound)),
+                        kind,
                     ),
                     1,
                 )
@@ -1884,23 +1972,25 @@ impl<'db> Constraint<'db> {
             {
                 let lower = Node::new_constraint(
                     builder,
-                    ConstraintId::new_with_bounds(
+                    ConstraintId::new_with_kind(
                         db,
                         builder,
                         lower,
                         None,
                         Some(Type::TypeVar(typevar)),
+                        kind,
                     ),
                     1,
                 );
                 let upper = Node::new_constraint(
                     builder,
-                    ConstraintId::new_with_bounds(
+                    ConstraintId::new_with_kind(
                         db,
                         builder,
                         upper,
                         Some(Type::TypeVar(typevar)),
                         None,
+                        kind,
                     ),
                     1,
                 );
@@ -1911,19 +2001,20 @@ impl<'db> Constraint<'db> {
             (Type::TypeVar(lower), _) if typevar.can_be_bound_for(db, builder, lower) => {
                 let lower = Node::new_constraint(
                     builder,
-                    ConstraintId::new_with_bounds(
+                    ConstraintId::new_with_kind(
                         db,
                         builder,
                         lower,
                         None,
                         Some(Type::TypeVar(typevar)),
+                        kind,
                     ),
                     1,
                 );
                 let upper = if upper.is_none() {
                     ALWAYS_TRUE
                 } else {
-                    Constraint::new_node_with_bounds(db, builder, typevar, None, upper)
+                    Constraint::new_node_with_kind(db, builder, typevar, None, upper, kind)
                 };
                 lower.and(builder, upper)
             }
@@ -1933,16 +2024,17 @@ impl<'db> Constraint<'db> {
                 let lower = if lower.is_none() {
                     ALWAYS_TRUE
                 } else {
-                    Constraint::new_node_with_bounds(db, builder, typevar, lower, None)
+                    Constraint::new_node_with_kind(db, builder, typevar, lower, None, kind)
                 };
                 let upper = Node::new_constraint(
                     builder,
-                    ConstraintId::new_with_bounds(
+                    ConstraintId::new_with_kind(
                         db,
                         builder,
                         upper,
                         Some(Type::TypeVar(typevar)),
                         None,
+                        kind,
                     ),
                     1,
                 );
@@ -1951,7 +2043,7 @@ impl<'db> Constraint<'db> {
 
             _ => Node::new_constraint(
                 builder,
-                ConstraintId::new_with_bounds(db, builder, typevar, lower, upper),
+                ConstraintId::new_with_kind(db, builder, typevar, lower, upper, kind),
                 1,
             ),
         }
@@ -2063,6 +2155,12 @@ impl ConstraintId {
             return IntersectionResult::Disjoint;
         }
 
+        // Keep declared-domain guards separate from inference evidence. We still perform the
+        // satisfiability check above so incompatible evidence makes the pair impossible.
+        if self_constraint.kind != other_constraint.kind {
+            return IntersectionResult::CannotSimplify;
+        }
+
         // We do not create lower bounds that are unions, or upper bounds that are factored
         // intersections, since those can be broken apart into BDDs over simpler constraints. If the
         // merged upper contains a union clause, keep any useful disjointness result from above but
@@ -2080,6 +2178,7 @@ impl ConstraintId {
         IntersectionResult::Simplified(Constraint {
             typevar: self_constraint.typevar,
             bounds: ConstraintBounds::new(lower, upper),
+            kind: self_constraint.kind,
         })
     }
 
@@ -3654,6 +3753,10 @@ impl<'db> ConstraintBoundsBuilder<'db> {
 }
 
 /// The explicit lower and upper bounds inferred for one typevar on one BDD path.
+///
+/// Declared-domain guards determine whether the path is valid, but are not included here as
+/// inference evidence. [`PathBounds::default_solve`] validates the inferred result against the
+/// type variable's declared bound or constraints.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct PathBound<'db> {
     pub(crate) bound_typevar: BoundTypeVarInstance<'db>,
@@ -3792,6 +3895,9 @@ impl<'db> PathBounds<'db> {
             mappings.clear();
             for (constraint, _) in path {
                 let constraint = builder.constraint_data(constraint);
+                if constraint.kind == ConstraintKind::TypeVarDomain {
+                    continue;
+                }
                 let typevar = constraint.typevar;
                 if let Some(lower) = constraint.bounds.lower {
                     let bounds = mappings.entry(typevar).or_default();
@@ -3866,11 +3972,13 @@ impl<'db> PathBounds<'db> {
                     }
 
                     current = interior.if_true;
-                    constraints.push((
-                        constraint.typevar,
-                        constraint.bounds,
-                        interior.source_order,
-                    ));
+                    if constraint.kind == ConstraintKind::Inference {
+                        constraints.push((
+                            constraint.typevar,
+                            constraint.bounds,
+                            interior.source_order,
+                        ));
+                    }
                 }
             }
         }
@@ -4790,12 +4898,15 @@ impl InteriorNode {
                     _ => continue,
                 };
 
-                let new_constraint = ConstraintId::new_with_bounds(
+                let new_constraint = ConstraintId::new_with_kind(
                     db,
                     builder,
                     constrained_typevar,
                     new_lower,
                     new_upper,
+                    left_constraint_data
+                        .kind
+                        .derived_with(right_constraint_data.kind),
                 );
                 if seen_constraints.contains(&new_constraint) {
                     continue;
@@ -5814,6 +5925,9 @@ impl SequentMap {
         let bound_typevar = bound_constraint_data.typevar;
         let constrained_constraint_data = builder.constraint_data(constrained_constraint);
         let constrained_typevar = constrained_constraint_data.typevar;
+        let derived_kind = bound_constraint_data
+            .kind
+            .derived_with(constrained_constraint_data.kind);
 
         // Transitive pivots require subtyping; classes with dynamic bases can be assignable to
         // unrelated types without being subtypes.
@@ -5907,12 +6021,13 @@ impl SequentMap {
         if let Some(Type::TypeVar(lower_bound_typevar)) = new_lower
             && !lower_bound_typevar.can_be_bound_for(db, builder, constrained_typevar)
         {
-            post_constraints.push(ConstraintId::new_with_bounds(
+            post_constraints.push(ConstraintId::new_with_kind(
                 db,
                 builder,
                 lower_bound_typevar,
                 None,
                 Some(Type::TypeVar(constrained_typevar)),
+                derived_kind,
             ));
             constrained_lower = None;
         }
@@ -5920,12 +6035,13 @@ impl SequentMap {
         if let Some(Type::TypeVar(upper_bound_typevar)) = new_upper
             && !upper_bound_typevar.can_be_bound_for(db, builder, constrained_typevar)
         {
-            post_constraints.push(ConstraintId::new_with_bounds(
+            post_constraints.push(ConstraintId::new_with_kind(
                 db,
                 builder,
                 upper_bound_typevar,
                 Some(Type::TypeVar(constrained_typevar)),
                 None,
+                derived_kind,
             ));
             constrained_upper = None;
         }
@@ -5933,12 +6049,13 @@ impl SequentMap {
         if !(constrained_lower.is_none_or(|ty| ty.is_never())
             && constrained_upper.is_none_or(|ty| ty.is_object()))
         {
-            post_constraints.push(ConstraintId::new_with_bounds(
+            post_constraints.push(ConstraintId::new_with_kind(
                 db,
                 builder,
                 constrained_typevar,
                 constrained_lower,
                 constrained_upper,
+                derived_kind,
             ));
         }
 
@@ -5994,6 +6111,7 @@ impl SequentMap {
                 let constrained_identity = constrained_typevar.identity(db);
                 let constrained_lower = constrained_data.bounds.materialized_lower();
                 let constrained_upper = constrained_data.bounds.materialized_upper();
+                let derived_kind = bound_data.kind.derived_with(constrained_data.kind);
 
                 // If the replacement contains the bound typevar itself (e.g., the bound
                 // constraint is `_V ≤ G[_V]`), or the constrained typevar (e.g., the bound
@@ -6064,12 +6182,13 @@ impl SequentMap {
                     let new_upper =
                         constrained_upper.substitute_one_typevar(db, bound_typevar, replacement);
                     if new_upper != constrained_upper {
-                        let post = ConstraintId::new_with_bounds(
+                        let post = ConstraintId::new_with_kind(
                             db,
                             builder,
                             constrained_typevar,
                             constrained_data.bounds.lower,
                             Some(new_upper),
+                            derived_kind,
                         );
                         self.add_pair_implication(
                             db,
@@ -6125,12 +6244,13 @@ impl SequentMap {
                     let new_lower =
                         constrained_lower.substitute_one_typevar(db, bound_typevar, replacement);
                     if new_lower != constrained_lower {
-                        let post = ConstraintId::new_with_bounds(
+                        let post = ConstraintId::new_with_kind(
                             db,
                             builder,
                             constrained_typevar,
                             Some(new_lower),
                             constrained_data.bounds.upper,
+                            derived_kind,
                         );
                         self.add_pair_implication(
                             db,
@@ -6176,6 +6296,7 @@ impl SequentMap {
                 let constrained_typevar = constrained_data.typevar;
                 let constrained_lower = constrained_data.bounds.materialized_lower();
                 let constrained_upper = constrained_data.bounds.materialized_upper();
+                let derived_kind = bound_data.kind.derived_with(constrained_data.kind);
 
                 let mut try_one_bound = |bound: Type<'db>, is_upper_bound: bool| {
                     let Some(nested_typevar) = bound.as_typevar() else {
@@ -6218,12 +6339,13 @@ impl SequentMap {
                             replacement,
                         );
                         if new_upper != constrained_upper {
-                            let post = ConstraintId::new_with_bounds(
+                            let post = ConstraintId::new_with_kind(
                                 db,
                                 builder,
                                 constrained_typevar,
                                 constrained_data.bounds.lower,
                                 Some(new_upper),
+                                derived_kind,
                             );
                             self.add_pair_implication(
                                 db,
@@ -6256,12 +6378,13 @@ impl SequentMap {
                             replacement,
                         );
                         if new_lower != constrained_lower {
-                            let post = ConstraintId::new_with_bounds(
+                            let post = ConstraintId::new_with_kind(
                                 db,
                                 builder,
                                 constrained_typevar,
                                 Some(new_lower),
                                 constrained_data.bounds.upper,
+                                derived_kind,
                             );
                             self.add_pair_implication(
                                 db,
@@ -6305,6 +6428,9 @@ impl SequentMap {
                 let right_constraint_data = builder.constraint_data(right_constraint);
                 let right_lower = right_constraint_data.bounds.lower;
                 let right_upper = right_constraint_data.bounds.upper;
+                let derived_kind = left_constraint_data
+                    .kind
+                    .derived_with(right_constraint_data.kind);
                 let new_constraints =
                     |bound_typevar: BoundTypeVarInstance<'db>,
                      mut right_lower: Option<Type<'db>>,
@@ -6335,12 +6461,13 @@ impl SequentMap {
                         if let Some(Type::TypeVar(lower_bound_typevar)) = right_lower
                             && !lower_bound_typevar.can_be_bound_for(db, builder, bound_typevar)
                         {
-                            post_constraints.push(ConstraintId::new_with_bounds(
+                            post_constraints.push(ConstraintId::new_with_kind(
                                 db,
                                 builder,
                                 lower_bound_typevar,
                                 None,
                                 Some(Type::TypeVar(bound_typevar)),
+                                derived_kind,
                             ));
                             constrained_lower = None;
                         }
@@ -6348,12 +6475,13 @@ impl SequentMap {
                         if let Some(Type::TypeVar(upper_bound_typevar)) = right_upper
                             && !upper_bound_typevar.can_be_bound_for(db, builder, bound_typevar)
                         {
-                            post_constraints.push(ConstraintId::new_with_bounds(
+                            post_constraints.push(ConstraintId::new_with_kind(
                                 db,
                                 builder,
                                 upper_bound_typevar,
                                 Some(Type::TypeVar(bound_typevar)),
                                 None,
+                                derived_kind,
                             ));
                             constrained_upper = None;
                         }
@@ -6361,12 +6489,13 @@ impl SequentMap {
                         if !(constrained_lower.unwrap_or(Type::Never).is_never()
                             && constrained_upper.unwrap_or(Type::object()).is_object())
                         {
-                            post_constraints.push(ConstraintId::new_with_bounds(
+                            post_constraints.push(ConstraintId::new_with_kind(
                                 db,
                                 builder,
                                 bound_typevar,
                                 constrained_lower,
                                 constrained_upper,
+                                derived_kind,
                             ));
                         }
 
@@ -7224,6 +7353,12 @@ impl<'db> BoundTypeVarInstance<'db> {
             // P.args and P.kwargs are variadic, and do not have an upper bound or constraints.
             return ALWAYS_TRUE;
         }
+        if self.typevar(db).is_self(db) {
+            // `typing.Self` is specialized by receiver binding. Its synthetic upper bound is not
+            // a declared TypeVar domain and can be recursively parameterized by the class's own
+            // type variables.
+            return ALWAYS_TRUE;
+        }
 
         // For gradual upper bounds and constraints, we are free to choose any materialization that
         // makes the check succeed. In inferable positions, it is most helpful to choose a
@@ -7238,8 +7373,20 @@ impl<'db> BoundTypeVarInstance<'db> {
         match self.typevar(db).bound_or_constraints(db) {
             None => ALWAYS_TRUE,
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                // Intersecting an F-bounded protocol domain at construction time re-enters the
+                // same structural protocol relation while its constraint set is being checked.
+                // Omit that domain for now; all other constrained typevars still carry their
+                // declared domains in every constraint set.
+                if matches!(bound, Type::ProtocolInstance(_))
+                    && any_over_type(db, bound, true, |ty| {
+                        ty.as_typevar()
+                            .is_some_and(|candidate| candidate.typevar(db) == self.typevar(db))
+                    })
+                {
+                    return ALWAYS_TRUE;
+                }
                 let bound = bound.top_materialization(db);
-                Constraint::new_node_with_bounds(db, builder, self, None, Some(bound))
+                Constraint::new_domain_node_with_bounds(db, builder, self, None, Some(bound))
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                 let mut specializations = ALWAYS_FALSE;
@@ -7248,7 +7395,13 @@ impl<'db> BoundTypeVarInstance<'db> {
                     let constraint_upper = constraint.top_materialization(db);
                     specializations = specializations.or_with_offset(
                         builder,
-                        Constraint::new_node(db, builder, self, constraint_lower, constraint_upper),
+                        Constraint::new_domain_node(
+                            db,
+                            builder,
+                            self,
+                            constraint_lower,
+                            constraint_upper,
+                        ),
                     );
                 }
                 specializations
@@ -7318,6 +7471,7 @@ mod tests {
 
     use crate::db::tests::setup_db;
     use crate::types::generics::ApplySpecialization;
+    use crate::types::typevar::TypeVarConstraints;
     use crate::types::{BoundTypeVarInstance, KnownClass, TypeVarVariance};
     use ruff_python_ast::name::Name;
 
@@ -7452,6 +7606,49 @@ mod tests {
         let storage = builder.storage.borrow();
         assert_eq!(storage.single_sequent_cache.len(), single_sequents);
         assert_eq!(storage.pair_sequent_cache.len(), pair_sequents);
+    }
+
+    #[test]
+    fn typevar_domain_restricts_without_providing_inference_evidence() {
+        let db = setup_db();
+        let str = known_instance(&db, KnownClass::Str);
+        let bytes = known_instance(&db, KnownClass::Bytes);
+        let str_or_bytes = UnionType::from_two_elements(&db, str, bytes);
+        let typevar = create_typevar(&db, "T").map_bound_or_constraints(&db, |_| {
+            Some(TypeVarBoundOrConstraints::Constraints(
+                TypeVarConstraints::new(
+                    &db,
+                    Vec::from([str_or_bytes, str, bytes]).into_boxed_slice(),
+                ),
+            ))
+        });
+        let builder = ConstraintSetBuilder::new();
+        let inferable =
+            InferableTypeVars::from_typevars(&db, std::iter::once(typevar.identity(&db)).collect());
+
+        let valid = ConstraintSet::constrain_typevar_lower_bound(&db, &builder, typevar, str)
+            .solutions(&db, &builder, inferable);
+        let Solutions::Constrained(solutions) = valid else {
+            panic!("expected constrained solutions");
+        };
+        assert!(
+            solutions
+                .iter()
+                .flatten()
+                .all(|binding| { binding.bound_typevar == typevar && binding.solution == str })
+        );
+
+        let invalid = ConstraintSet::constrain_typevar_lower_bound(
+            &db,
+            &builder,
+            typevar,
+            known_instance(&db, KnownClass::Int),
+        );
+        assert!(invalid.is_never_satisfied(&db));
+        assert_eq!(
+            invalid.solutions(&db, &builder, inferable),
+            Solutions::Unsatisfiable
+        );
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -590,7 +590,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// Reduces the set of inferable typevars for this constraint set. You provide the typevars that
     /// were inferable when this constraint set was created, and which should be abstracted away.
     /// Those typevars will be removed from the constraint set, and the constraint set will return
-    /// true whenever there was _any_ specialization of those typevars that returned true before.
+    /// true whenever there was _any valid_ specialization of those typevars that returned true
+    /// before.
     pub(crate) fn reduce_inferable(
         self,
         db: &'db dyn Db,
@@ -598,7 +599,23 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         to_remove: InferableTypeVars<'db>,
     ) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.exists(db, builder, to_remove))
+        let mut constrained = self.node;
+        let mut typevars = FxOrderSet::default();
+        // Existential abstraction must be restricted to each typevar's declared domain. Otherwise,
+        // a constraint such as `Receiver ≤ T` could be satisfied by `T = object` even when `T` is
+        // declared with an incompatible upper bound or set of constraints.
+        self.node
+            .for_each_unique_constraint(builder, &mut |constraint, _| {
+                let typevar = builder.constraint_data(constraint).typevar;
+                if typevar.is_inferable(db, to_remove) {
+                    typevars.insert(typevar);
+                }
+            });
+        for typevar in typevars {
+            constrained =
+                constrained.and_with_offset(builder, typevar.valid_specializations(db, builder));
+        }
+        Self::from_node(builder, constrained.exists(db, builder, to_remove))
     }
 
     /// Applies a type mapping to every constraint in this constraint set.

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1685,6 +1685,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if !valid {
                     check_positive_elements(true);
                 }
+                #[expect(
+                    clippy::drop_non_drop,
+                    reason = "release the inference-guard borrows before finalizing them"
+                )]
+                drop(check_positive_elements);
+
+                // A negative-only intersection has no candidate arm from which to select a type
+                // context, but these expressions still need one committed inference.
+                if intersection.positive(db).is_empty() {
+                    infer_slice_ty.infer_loud(self, TypeContext::default());
+                    infer_rhs_value.infer_loud(self, TypeContext::default());
+                }
 
                 valid
             }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1,6 +1,7 @@
 //! Instance types: both nominal and structural.
 
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::marker::PhantomData;
 
 use ruff_python_ast::name::Name;
@@ -25,6 +26,7 @@ use crate::types::relation::{
 };
 use crate::types::signatures::SignatureRelationVisitor;
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
+use crate::types::visitor::any_over_type;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ErrorContext,
     FindLegacyTypeVarsVisitor, LiteralValueTypeKind, TypeContext, TypeMapping, VarianceInferable,
@@ -493,6 +495,28 @@ impl<'db> From<NominalInstanceType<'db>> for Type<'db> {
     }
 }
 
+/// Returns whether a class-based protocol refers back to its own origin.
+fn is_recursive_protocol<'db>(db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) -> bool {
+    let Some((origin, _)) = protocol
+        .as_class_based()
+        .and_then(|class| class.static_class_literal(db))
+    else {
+        return false;
+    };
+
+    // The walk visits the root first. A second visit to the same origin is an interface back-edge.
+    let seen_origin = Cell::new(false);
+    any_over_type(db, Type::ProtocolInstance(protocol), true, |nested| {
+        let Type::ProtocolInstance(nested) = nested else {
+            return false;
+        };
+        nested
+            .as_class_based()
+            .and_then(|class| class.static_class_literal(db))
+            .is_some_and(|(nested_origin, _)| nested_origin == origin && seen_origin.replace(true))
+    })
+}
+
 impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     /// Return `true` if `ty` conforms to the interface described by `protocol`.
     pub(super) fn check_type_satisfies_protocol(
@@ -569,21 +593,33 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return result;
         }
 
-        let structurally_satisfied = if let Type::ProtocolInstance(source_protocol) = ty {
-            self.check_protocol_interface_pair(
-                db,
-                ty,
-                source_protocol.interface(db),
-                protocol.interface(db),
-            )
+        let check_structurally =
+            || match ty {
+                Type::ProtocolInstance(source_protocol) => self.check_protocol_interface_pair(
+                    db,
+                    ty,
+                    source_protocol.interface(db),
+                    protocol.interface(db),
+                ),
+                _ => protocol.inner.interface(db).members(db).when_all(
+                    db,
+                    self.constraints,
+                    |member| self.type_satisfies_protocol_member(db, ty, &member),
+                ),
+            };
+        // Declared TypeVar domains can make recursive member-signature comparisons re-enter the
+        // same protocol relation through constraint implication. Omit the domains for recursive
+        // structural comparisons until those relations can share a recursion guard.
+        let structurally_satisfied = if !self.constraints.typevar_domains_suppressed()
+            && (is_recursive_protocol(db, protocol)
+                || ty
+                    .as_protocol_instance()
+                    .is_some_and(|source| is_recursive_protocol(db, source)))
+        {
+            self.constraints
+                .with_typevar_domains_suppressed(check_structurally)
         } else {
-            protocol
-                .inner
-                .interface(db)
-                .members(db)
-                .when_all(db, self.constraints, |member| {
-                    self.type_satisfies_protocol_member(db, ty, &member)
-                })
+            check_structurally()
         };
         if let Some(context) = self.report_context()
             && structurally_satisfied.is_never_satisfied(db)

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1072,7 +1072,17 @@ impl<'db> Signature<'db> {
             } else {
                 parameter.annotated_type()
             };
-            receiver.when_constraint_set_assignable_to_owned(db, annotation)
+            let receiver_constraint =
+                receiver.when_constraint_set_assignable_to_owned(db, annotation);
+            if receiver_constraint.is_trivially_always_satisfied() {
+                return receiver_constraint;
+            }
+            let builder = ConstraintSetBuilder::new();
+            std::borrow::Cow::Owned(builder.into_owned(|builder| {
+                builder
+                    .load(db, receiver_constraint.as_ref())
+                    .and_valid_typevar_specializations(db, builder)
+            }))
         });
         let receiver_constraints = merge_receiver_constraints(
             db,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1072,17 +1072,7 @@ impl<'db> Signature<'db> {
             } else {
                 parameter.annotated_type()
             };
-            let receiver_constraint =
-                receiver.when_constraint_set_assignable_to_owned(db, annotation);
-            if receiver_constraint.is_trivially_always_satisfied() {
-                return receiver_constraint;
-            }
-            let builder = ConstraintSetBuilder::new();
-            std::borrow::Cow::Owned(builder.into_owned(|builder| {
-                builder
-                    .load(db, receiver_constraint.as_ref())
-                    .and_valid_typevar_specializations(db, builder)
-            }))
+            receiver.when_constraint_set_assignable_to_owned(db, annotation)
         });
         let receiver_constraints = merge_receiver_constraints(
             db,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -39,8 +39,8 @@ use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
     CallableType, ErrorContext, ErrorContextTree, FindLegacyTypeVarsVisitor, KnownClass,
     MaterializationKind, ParamSpecAttrKind, ParameterDescription, SelfBinding, TypeContext,
-    TypeMapping, TypeVarBoundOrConstraints, TypeVarNonce, TypedDictType, UnionBuilder,
-    VarianceInferable, infer_complete_scope_types, todo_type,
+    TypeMapping, TypeVarNonce, TypedDictType, UnionBuilder, VarianceInferable,
+    infer_complete_scope_types, todo_type,
 };
 use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
@@ -1072,19 +1072,6 @@ impl<'db> Signature<'db> {
             } else {
                 parameter.annotated_type()
             };
-            // TODO: Also intersect nested receiver type variables, such as the `T` in
-            // `self: list[T]`, with their valid specializations when constructing or solving the
-            // receiver constraint set.
-            let receiver_typevar = match annotation {
-                Type::TypeVar(typevar) => Some(typevar),
-                Type::TypeAlias(_) => annotation.resolve_type_alias(db).as_typevar(),
-                _ => None,
-            };
-            if receiver_typevar.is_some_and(|typevar| {
-                Self::receiver_violates_typevar_domain(db, receiver, typevar)
-            }) {
-                return std::borrow::Cow::Owned(OwnedConstraintSet::default());
-            }
             receiver.when_constraint_set_assignable_to_owned(db, annotation)
         });
         let receiver_constraints = merge_receiver_constraints(
@@ -1113,40 +1100,6 @@ impl<'db> Signature<'db> {
             receiver_constraints,
             parameters,
             return_ty,
-        }
-    }
-
-    /// Returns whether a concrete receiver violates a direct receiver type variable's domain.
-    ///
-    /// Unbounded or non-concrete receivers do not provably violate the domain and return `false`,
-    /// leaving the original receiver relation available to normal inference. Transparent PEP 695
-    /// receiver aliases are resolved by the caller before this check.
-    ///
-    /// ```python
-    /// class C:
-    ///     def method[T: int](self: T) -> None: ...
-    /// ```
-    fn receiver_violates_typevar_domain(
-        db: &'db dyn Db,
-        receiver: Type<'db>,
-        typevar: BoundTypeVarInstance<'db>,
-    ) -> bool {
-        let Some(domain) = typevar.typevar(db).bound_or_constraints(db) else {
-            return false;
-        };
-        if receiver.has_typevar(db) {
-            return false;
-        }
-
-        !match domain {
-            TypeVarBoundOrConstraints::UpperBound(bound) => {
-                receiver.is_assignable_to(db, bound.top_materialization(db))
-            }
-            TypeVarBoundOrConstraints::Constraints(constraints) => {
-                constraints.elements(db).iter().any(|constraint| {
-                    receiver.is_assignable_to(db, constraint.top_materialization(db))
-                })
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

This is a follow-up to #26863. That PR validates TypeVar domains directly when binding a receiver, but the receiver-specific check only sees a bare TypeVar or transparent alias. It therefore cannot enforce a TypeVar nested in annotations like `list[T]` or `T | None`.

This draft moves the invariant into `ConstraintSet::constrain_typevar_with_bounds`: every constructed TypeVar constraint is intersected with the TypeVar's declared upper bound or constraints. All variables in a constraint set must therefore remain within their declared domains, including variables that are not later existentially abstracted.

Declared-domain branches are tagged as guards. They participate in satisfiability and prune invalid paths, but are omitted from the bounds used as inference evidence. This preserves existing constrained-TypeVar selection while still rejecting solutions outside the declared domain.

```python
from typing import Callable

class C(list[str]):
    def method[T: int](self: list[T]) -> None: ...

callback: Callable[[], None] = C().method  # error
```

The receiver relation can now stay structural: nested relations produce ordinary constraints for `T`, and the construction-time invariant prevents those constraints from choosing an invalid specialization.

There are two narrow recursion exceptions. We omit the synthetic upper bound of `typing.Self`, because it is supplied by receiver binding rather than declared by the user. During a structural comparison involving a recursive class-based protocol, we also temporarily omit declared TypeVar domains and constraint-implication simplification. Otherwise, a member-signature relation can re-enter the same protocol comparison through a fresh constraint builder. Nominal checks, non-recursive protocols, and every constraint constructed outside that structural comparison still enforce all declared TypeVar domains.

The broader invariant exposes two invalid metaclass `__call__` overrides in the existing `super()` coverage, where the declared receiver narrows `type.__call__`; those diagnostics are now expected.

It also exposed an existing inference-finalization bug for subscript assignment on a negative-only intersection. The inference guards now receive a default context when there is no positive candidate arm, with a focused regression test. Tanjun's walltime benchmark cap is updated from 110 to 113 diagnostics for the three newly enforced domain errors.
