### PR TITLE
[ty] Project intersections in to_instance

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -670,6 +670,7 @@ class ResourceEnabled(Protocol):
 SchemaT = TypeVar("SchemaT")
 
 def register(cls: type[SchemaT]) -> Intersection[type[SchemaT], ResourceEnabled]:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `type[SchemaT@register] & ResourceEnabled`, found `type[SchemaT@register]`"
     return cls
 
 @register
@@ -699,6 +700,7 @@ class ResourceEnabled(Protocol):
 SchemaT = TypeVar("SchemaT")
 
 def register(cls: type[SchemaT]) -> Intersection[type[SchemaT], ResourceEnabled]:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `type[SchemaT@register] & ResourceEnabled`, found `type[SchemaT@register]`"
     return cls
 
 @dataclass
@@ -729,6 +731,7 @@ class ResourceEnabled(Protocol):
 SchemaT = TypeVar("SchemaT")
 
 def register(cls: type[SchemaT]) -> Intersection[type[SchemaT], ResourceEnabled]:
+    # error: [invalid-return-type] "Return type does not match returned value: expected `type[SchemaT@register] & ResourceEnabled`, found `type[SchemaT@register]`"
     return cls
 
 def identity(cls: type[SchemaT]) -> type[SchemaT]:

--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -65,6 +65,39 @@ def foo(
         reveal_type(j)  # revealed: ValueError
 ```
 
+## Intersected exception types
+
+An intersected exception class projects its positive class-object constraints into the caught
+instance type. Unmappable positive constraints and exact-class negatives do not exclude valid
+subclass instances.
+
+```py
+from typing import Any
+from ty_extensions import Intersection
+
+class FirstError(Exception): ...
+class SecondError(Exception): ...
+
+def catch_intersection(exc: Intersection[type[FirstError], type[SecondError]]) -> None:
+    try:
+        help()
+    except exc as caught:
+        reveal_type(caught)  # revealed: FirstError & SecondError
+
+def catch_proper_subclass(exc: Any) -> None:
+    if exc != ValueError and issubclass(exc, ValueError):
+        reveal_type(exc)  # revealed: Any & type[ValueError] & ~<class 'ValueError'>
+        try:
+            help()
+        except exc as caught:
+            reveal_type(caught)  # revealed: Any & ValueError
+
+try:
+    help()
+except ZeroDivisionError and ValueError as caught:
+    reveal_type(caught)  # revealed: ZeroDivisionError | ValueError
+```
+
 We do not emit an `invalid-exception-caught` if a class is caught that has `Any` or `Unknown` in its
 MRO, as the dynamic element in the MRO could materialize to some subclass of `BaseException`:
 

--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -65,11 +65,11 @@ def foo(
         reveal_type(j)  # revealed: ValueError
 ```
 
-## Intersected exception types
+## Exception-class expressions
 
-An intersected exception class projects its positive class-object constraints into the caught
-instance type. Unmappable positive constraints and exact-class negatives do not exclude valid
-subclass instances.
+Exception-class expressions can produce intersections, gradual refinements, or unions. Positive
+class-object constraints project into the caught instance type; unmappable positive constraints and
+exact-class negatives do not exclude valid subclass instances.
 
 ```py
 from typing import Any

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -146,6 +146,21 @@ def pep695_typevar_narrowing[T: (int, str)](x: int | str, t: type[T]) -> T:
     return x
 ```
 
+Narrowing a union of `type[T]` and a callable factory must preserve the `type[T]` alternative:
+
+```py
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+class Holder(Generic[T]):
+    value: type[T] | Callable[[], type[T]]
+
+    def narrow(self) -> None:
+        if isinstance(self.value, type):
+            reveal_type(self.value)  # revealed: type[T@Holder] | ((() -> type[T@Holder]) & type)
+```
+
 ## `__class__`
 
 ```py
@@ -181,7 +196,7 @@ A class `A` is a subtype of `type[T]` if any instance of `A` is a subtype of `T`
 
 ```py
 from typing import Any, Callable, Protocol
-from ty_extensions import static_assert
+from ty_extensions import Intersection, static_assert
 from ty_extensions._internal import is_assignable_to, is_subtype_of, is_disjoint_from
 
 class Callback[T](Protocol):
@@ -201,6 +216,9 @@ def _[T](_: T):
 
     static_assert(is_assignable_to(type[T], Callable[..., T] | Callable[..., Any]))
     static_assert(not is_disjoint_from(type[T], Callable[..., T] | Callable[..., Any]))
+
+    static_assert(not is_subtype_of(type[T], Intersection[Callable[[], type[T]], type]))
+    static_assert(not is_subtype_of(type[T], Intersection[Callable[[], type[T]], type] | type[int]))
 
     static_assert(not is_assignable_to(type[T], Callback[int]))
     static_assert(not is_disjoint_from(type[T], Callback[int]))
@@ -277,12 +295,17 @@ def _[T: (int, str)](_: T):
 
     static_assert(is_subtype_of(type[T], type[int] | type[str]))
     static_assert(is_subtype_of(type[T], type[int | str]))
+    static_assert(is_subtype_of(type[T], Intersection[Callable[[], type[T]], type] | type[int] | type[str]))
     static_assert(not is_disjoint_from(type[T], type[int | str]))
     static_assert(not is_disjoint_from(type[T], type[int] | type[str]))
 
 def _[T: (int | str, int)](_: T):
     static_assert(is_subtype_of(type[int], type[T]))
     static_assert(not is_disjoint_from(type[int], type[T]))
+
+def _[T, U: (Intersection[Callable[[], type], type], type)](_: T):
+    static_assert(not is_subtype_of(type[T], U))
+    static_assert(not is_subtype_of(type[T], U | type[int]))
 ```
 
 ## Type aliases in final upper bounds

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -195,9 +195,9 @@ class B:
 A class `A` is a subtype of `type[T]` if any instance of `A` is a subtype of `T`.
 
 ```py
-from typing import Any, Callable, Protocol
+from typing import Any, Callable, NewType, Protocol, TypeVar
 from ty_extensions import Intersection, static_assert
-from ty_extensions._internal import is_assignable_to, is_subtype_of, is_disjoint_from
+from ty_extensions._internal import TypeOf, is_assignable_to, is_subtype_of, is_disjoint_from
 
 class Callback[T](Protocol):
     def __call__(self, *args, **kwargs) -> T: ...
@@ -306,6 +306,24 @@ def _[T: (int | str, int)](_: T):
 def _[T, U: (Intersection[Callable[[], type], type], type)](_: T):
     static_assert(not is_subtype_of(type[T], U))
     static_assert(not is_subtype_of(type[T], U | type[int]))
+
+class Base: ...
+class Other: ...
+class OtherMeta(type): ...
+
+UserId = NewType("UserId", int)
+
+BoundBase = TypeVar("BoundBase", bound=Base)
+BoundList = TypeVar("BoundList", bound=list[int])
+BoundUserId = TypeVar("BoundUserId", bound=UserId)
+
+def lossy_class_object_projections(base: BoundBase, items: BoundList, user_id: BoundUserId) -> None:
+    static_assert(not is_subtype_of(type[BoundBase], TypeOf[Base]))
+    static_assert(not is_subtype_of(type[BoundList], TypeOf[list[int]]))
+    static_assert(not is_subtype_of(type[BoundBase], TypeOf[Base] | type[Other]))
+    static_assert(not is_subtype_of(type[BoundList], TypeOf[list[int]] | type[Other]))
+    static_assert(not is_subtype_of(type[BoundBase], OtherMeta | type[Other]))
+    static_assert(not is_subtype_of(type[BoundUserId], TypeOf[UserId] | type[Other]))
 ```
 
 ## Type aliases in final upper bounds
@@ -319,7 +337,8 @@ python-version = "3.12"
 
 ```py
 from typing import final
-from ty_extensions._internal import TypeOf
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_subtype_of
 
 @final
 class FinalClass: ...
@@ -329,6 +348,7 @@ type Alias = FinalClass
 def accepts_exact(cls: TypeOf[FinalClass]) -> None: ...
 def bounded[T: Alias](cls: type[T]) -> None:
     accepts_exact(cls)
+    static_assert(is_subtype_of(type[T], TypeOf[FinalClass] | type[int]))
 ```
 
 ## Metaclass instances

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1019,6 +1019,47 @@ pub enum Type<'db> {
     NewTypeInstance(NewType<'db>),
 }
 
+/// The result of projecting class-object types into the corresponding instance types.
+///
+/// An exact projection preserves all class-object constraints relevant to a `type[T]` relation;
+/// where `to_meta_type` is a faithful inverse, it round-trips semantically. An over-approximation
+/// may discard class-object constraints and cannot establish a subtype relation in target
+/// position.
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum InstanceProjection<T> {
+    Exact(T),
+    OverApproximation(T),
+}
+
+impl<T> InstanceProjection<T> {
+    pub(crate) const fn is_exact(&self) -> bool {
+        matches!(self, Self::Exact(_))
+    }
+
+    pub(crate) fn into_inner(self) -> T {
+        match self {
+            Self::Exact(value) | Self::OverApproximation(value) => value,
+        }
+    }
+
+    pub(crate) fn map<U>(self, transform: impl FnOnce(T) -> U) -> InstanceProjection<U> {
+        match self {
+            Self::Exact(value) => InstanceProjection::Exact(transform(value)),
+            Self::OverApproximation(value) => {
+                InstanceProjection::OverApproximation(transform(value))
+            }
+        }
+    }
+
+    pub(crate) const fn new(value: T, is_exact: bool) -> Self {
+        if is_exact {
+            Self::Exact(value)
+        } else {
+            Self::OverApproximation(value)
+        }
+    }
+}
+
 /// An ordered pair of types shared by type-relation and set-theoretic queries.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 struct TypePair<'db> {
@@ -2916,7 +2957,7 @@ impl<'db> Type<'db> {
             return class_attr;
         }
 
-        let Some(metaclass_instance) = self.to_meta_type(db).to_instance(db) else {
+        let Some(metaclass_instance) = self.to_meta_type(db).to_instance_approximation(db) else {
             return class_attr;
         };
         let metaclass_attr = metaclass_instance.instance_member(db, name);
@@ -2976,7 +3017,7 @@ impl<'db> Type<'db> {
             .expect("The meta-type of an instance-like type should always have an MRO");
         let Some(metaclass) = class
             .metaclass(db)
-            .to_instance(db)
+            .to_instance_approximation(db)
             .and_then(|metaclass| metaclass.nominal_class(db))
         else {
             return class_attr;
@@ -3290,7 +3331,7 @@ impl<'db> Type<'db> {
                     } else {
                         let self_type = instance.unwrap_or_else(|| {
                             // For classmethod-like callables, bind to the owner class.
-                            owner.to_instance(db).unwrap_or(owner)
+                            owner.to_instance_approximation(db).unwrap_or(owner)
                         });
 
                         Some((
@@ -4365,7 +4406,7 @@ impl<'db> Type<'db> {
 
                     let class_attr_plain = this.class_object_member(db, name_str, policy);
 
-                    let self_instance = receiver.to_instance(db).expect(
+                    let self_instance = receiver.to_instance_approximation(db).expect(
                         "The receiver for a class-object lookup should always be instantiable",
                     );
                     let class_attr_plain =
@@ -5308,7 +5349,9 @@ impl<'db> Type<'db> {
 
         // Keep bespoke constructor behavior for cases that don't map cleanly to `__new__`/`__init__`.
         let fallback_bindings = || {
-            let return_type = self.to_instance(db).unwrap_or(Type::unknown());
+            let return_type = self
+                .to_instance_approximation(db)
+                .unwrap_or(Type::unknown());
             Binding::single(
                 self,
                 Signature::new_generic(
@@ -5386,7 +5429,7 @@ impl<'db> Type<'db> {
                 | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
         );
 
-        let Some(constructor_instance_ty) = self_type.to_instance(db) else {
+        let Some(constructor_instance_ty) = self_type.to_instance_approximation(db) else {
             return fallback_bindings();
         };
 
@@ -5964,21 +6007,41 @@ impl<'db> Type<'db> {
             .and_then(|generator_types| generator_types.send_ty)
     }
 
+    /// Return the instance approximation, discarding whether the projection is exact.
+    ///
+    /// Use this only when an over-approximation is sound, such as constructor inference or a
+    /// source-side relation. Target-side subtype checks must use [`Self::to_instance`].
     #[must_use]
-    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn to_instance_approximation(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        self.to_instance(db).map(InstanceProjection::into_inner)
+    }
+
+    /// Project this class-object type into its instance type while preserving projection quality.
+    #[must_use]
+    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<InstanceProjection<Type<'db>>> {
         match self {
-            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(self),
-            Type::ClassLiteral(class) => Some(Type::instance(db, class.default_specialization(db))),
-            Type::GenericAlias(alias) => Some(Type::instance(db, ClassType::from(alias))),
-            Type::SubclassOf(subclass_of_ty) => Some(subclass_of_ty.to_instance(db)),
-            Type::KnownInstance(KnownInstanceType::NewType(newtype)) => {
-                Some(Type::NewTypeInstance(newtype))
+            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => {
+                Some(InstanceProjection::Exact(self))
             }
+            Type::ClassLiteral(class) => Some(InstanceProjection::OverApproximation(
+                Type::instance(db, class.default_specialization(db)),
+            )),
+            Type::GenericAlias(alias) => Some(InstanceProjection::OverApproximation(
+                Type::instance(db, ClassType::from(alias)),
+            )),
+            Type::SubclassOf(subclass_of_ty) => {
+                Some(InstanceProjection::Exact(subclass_of_ty.to_instance(db)))
+            }
+            Type::KnownInstance(KnownInstanceType::NewType(newtype)) => Some(
+                InstanceProjection::OverApproximation(Type::NewTypeInstance(newtype)),
+            ),
             Type::Union(union) => union.to_instance(db),
             // If there is no bound or constraints on a typevar `T`, `T: object` implicitly, which
             // has no instance type. Otherwise, synthesize a typevar with bound or constraints
             // mapped through `to_instance`.
-            Type::TypeVar(bound_typevar) => Some(Type::TypeVar(bound_typevar.to_instance(db)?)),
+            Type::TypeVar(bound_typevar) => bound_typevar
+                .to_instance(db)
+                .map(|projection| projection.map(Type::TypeVar)),
             Type::TypeAlias(alias) => alias.value_type(db).to_instance(db),
             Type::Intersection(intersection) => intersection.to_instance(db),
             // An instance of class `C` may itself have instances if `C` is a subclass of `type`.
@@ -5990,7 +6053,7 @@ impl<'db> Type<'db> {
                         instance.class(db).is_subclass_of(db, type_class)
                     }) =>
             {
-                Some(Type::object())
+                Some(InstanceProjection::OverApproximation(Type::object()))
             }
             Type::FunctionLiteral(_)
             | Type::Callable(..)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1025,6 +1025,18 @@ pub enum Type<'db> {
 /// where `to_meta_type` is a faithful inverse, it round-trips semantically. An over-approximation
 /// may discard class-object constraints and cannot establish a subtype relation in target
 /// position.
+///
+/// For example, given these Python classes:
+///
+/// ```py
+/// class Base: ...
+/// class Child(Base): ...
+/// ```
+///
+/// `type[Base]` projects to `Base` exactly: both admit `Child`. In contrast,
+/// `TypeOf[Base]` (the type of the expression `Base`) admits only the `Base` class object, but
+/// also projects to `Base`, which admits `Child` instances. That projection is an
+/// over-approximation.
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum InstanceProjection<T> {
     Exact(T),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5980,7 +5980,7 @@ impl<'db> Type<'db> {
             // mapped through `to_instance`.
             Type::TypeVar(bound_typevar) => Some(Type::TypeVar(bound_typevar.to_instance(db)?)),
             Type::TypeAlias(alias) => alias.value_type(db).to_instance(db),
-            Type::Intersection(_) => Some(todo_type!("Type::Intersection.to_instance")),
+            Type::Intersection(intersection) => intersection.to_instance(db),
             // An instance of class `C` may itself have instances if `C` is a subclass of `type`.
             Type::NominalInstance(instance)
                 if KnownClass::Type

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -402,7 +402,7 @@ fn class_attribute_write_requirement<'db>(
     let Some(members) = assignment_attribute_members(db, object_ty, attribute) else {
         return AttributeWriteRequirement::Unconstrained;
     };
-    let Some(class_attr_self_ty) = object_ty.to_instance(db) else {
+    let Some(class_attr_self_ty) = object_ty.to_instance_approximation(db) else {
         return AttributeWriteRequirement::Unconstrained;
     };
     let (type_member, receiver_fallback) = match members {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1807,7 +1807,8 @@ impl<'db> Bindings<'db> {
                         if bound_method.function(db).name(db) == "__iter__"
                             && is_enum_class(db, bound_method.self_instance(db)) =>
                     {
-                        if let Some(enum_instance) = bound_method.self_instance(db).to_instance(db)
+                        if let Some(enum_instance) =
+                            bound_method.self_instance(db).to_instance_approximation(db)
                         {
                             overload.set_return_type(
                                 KnownClass::Iterator.to_specialized_instance(db, &[enum_instance]),

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -693,7 +693,7 @@ impl<'db> ClassLiteral<'db> {
     /// Return a type representing "the set of all instances of the metaclass of this class".
     pub(crate) fn metaclass_instance_type(self, db: &'db dyn Db) -> Type<'db> {
         self.metaclass(db)
-            .to_instance(db)
+            .to_instance_approximation(db)
             .expect("`Type::to_instance()` should always return `Some()` when called on the type of a metaclass")
     }
 
@@ -1592,10 +1592,10 @@ impl<'db> ClassType<'db> {
         if other_metaclass == type_class {
             return true;
         }
-        let Some(self_metaclass_instance) = self_metaclass.to_instance(db) else {
+        let Some(self_metaclass_instance) = self_metaclass.to_instance_approximation(db) else {
             return true;
         };
-        let Some(other_metaclass_instance) = other_metaclass.to_instance(db) else {
+        let Some(other_metaclass_instance) = other_metaclass.to_instance_approximation(db) else {
             return true;
         };
         if types_are_disjoint(self_metaclass_instance, other_metaclass_instance) {
@@ -1609,7 +1609,7 @@ impl<'db> ClassType<'db> {
     pub(super) fn metaclass_instance_type(self, db: &'db dyn Db) -> Type<'db> {
         self
             .metaclass(db)
-            .to_instance(db)
+            .to_instance_approximation(db)
             .expect("`Type::to_instance()` should always return `Some()` when called on the type of a metaclass")
     }
 
@@ -2106,7 +2106,7 @@ impl<'db> ClassType<'db> {
                 !signature.return_ty.is_assignable_to(
                     db,
                     self_ty
-                        .to_instance(db)
+                        .to_instance_approximation(db)
                         .expect("ClassType should be instantiable"),
                 )
             });
@@ -2136,7 +2136,9 @@ impl<'db> ClassType<'db> {
             )
             .place;
 
-        let correct_return_type = self_ty.to_instance(db).unwrap_or_else(Type::unknown);
+        let correct_return_type = self_ty
+            .to_instance_approximation(db)
+            .unwrap_or_else(Type::unknown);
 
         // If the class defines an `__init__` method, then we synthesize a callable type with the
         // same parameters as the `__init__` method after it is bound, and with the return type of

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1133,7 +1133,7 @@ impl KnownClass {
             "Use `Type::heterogeneous_tuple` or `Type::homogeneous_tuple` to create `tuple` instances"
         );
         self.to_specialized_class_type(db, specialization)
-            .and_then(|class_type| Type::from(class_type).to_instance(db))
+            .and_then(|class_type| Type::from(class_type).to_instance_approximation(db))
             .unwrap_or_else(Type::unknown)
     }
 

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -676,7 +676,7 @@ fn synthesize_typed_dict_view_method<'db>(
                     .specialize(db, &[typed_dict.key_type(db), typed_dict.value_type(db)])
             })
         })
-        .and_then(|class| Type::from(class).to_instance(db))
+        .and_then(|class| Type::from(class).to_instance_approximation(db))
         .unwrap_or_else(Type::unknown);
 
     synthesize_typed_dict_no_argument_method(db, typed_dict, return_ty)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2764,7 +2764,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 actual @ (Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_)),
             ) => {
                 let variance = TypeVarVariance::Covariant.compose(polarity);
-                if let Some(actual_instance) = actual.to_instance(self.db) {
+                if let Some(actual_instance) = actual.to_instance_approximation(self.db) {
                     return self.infer_map_impl(
                         formal_typeform.type_argument(self.db),
                         actual_instance,
@@ -3124,7 +3124,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
             (Type::SubclassOf(subclass_of), ty) | (ty, Type::SubclassOf(subclass_of))
                 if let Some(type_var) = subclass_of.into_type_var()
-                    && let Some(actual_instance) = ty.to_instance(self.db) =>
+                    && let Some(actual_instance) = ty.to_instance_approximation(self.db) =>
             {
                 return self.infer_map_impl(
                     Type::TypeVar(type_var),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2236,7 +2236,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for (index, element) in tuple_spec.iter_element_types(self.db()).enumerate() {
                 builder = builder.add(
                     if element.is_assignable_to(self.db(), type_base_exception) {
-                        element.to_instance(self.db()).expect(
+                        element.to_instance_approximation(self.db()).expect(
                             "`Type::to_instance()` should always return `Some()` \
                                 if called on a type assignable to `type[BaseException]`",
                         )
@@ -2317,7 +2317,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.db(),
                 tuple_spec.iter_element_types(self.db()).map(|element| {
                     if element.is_assignable_to(self.db(), type_base_exception) {
-                        Some(element.to_instance(self.db()).expect(
+                        Some(element.to_instance_approximation(self.db()).expect(
                             "`Type::to_instance()` should always return `Some()` \
                                 if called on a type assignable to `type[BaseException]`",
                         ))
@@ -2328,7 +2328,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             )
         } else if ty.is_assignable_to(self.db(), type_base_exception) {
             // `except ValueError as e:`
-            Some(ty.to_instance(self.db()).expect(
+            Some(ty.to_instance_approximation(self.db()).expect(
                 "`Type::to_instance()` should always return `Some()` \
                     if called on a type assignable to `type[BaseException]`",
             ))
@@ -2343,7 +2343,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .and_then(|spec| {
                         let specialization = spec
                             .homogeneous_element_type(self.db())
-                            .to_instance(self.db());
+                            .to_instance_approximation(self.db());
 
                         debug_assert!(specialization.is_some_and(|specialization_type| {
                             specialization_type.is_assignable_to(
@@ -7024,7 +7024,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             .specialize_recursive(self.db(), specialization.into_iter().map(Some))
                     },
                 );
-                return Type::from(class_type).to_instance(self.db());
+                return Type::from(class_type).to_instance_approximation(self.db());
             }
 
             pre_inferred_elt_tys = Some(inferred_elts);
@@ -7263,7 +7263,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
             });
 
-        Type::from(class_type).to_instance(self.db())
+        Type::from(class_type).to_instance_approximation(self.db())
     }
 
     /// Infer the type of the `iter` expression of the first comprehension.

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1032,7 +1032,7 @@ fn check_class_namespace_against_metaclass_members<'db>(
         return;
     }
 
-    let Some(metaclass_instance) = metaclass.to_instance(db) else {
+    let Some(metaclass_instance) = metaclass.to_instance_approximation(db) else {
         return;
     };
 

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -52,7 +52,9 @@ impl<'db> BoundMethodType<'db> {
     pub(crate) fn typing_self_type(self, db: &'db dyn Db) -> Type<'db> {
         let mut self_instance = self.self_instance(db);
         if self.function(db).is_classmethod(db) {
-            self_instance = self_instance.to_instance(db).unwrap_or_else(Type::unknown);
+            self_instance = self_instance
+                .to_instance_approximation(db)
+                .unwrap_or_else(Type::unknown);
         }
         self_instance
     }

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -142,7 +142,7 @@ fn create_bound_method<'db>(
     Type::BoundMethod(BoundMethodType::new(
         db,
         function.expect_function_literal(),
-        builtins_class.to_instance(db).unwrap(),
+        builtins_class.to_instance_approximation(db).unwrap(),
     ))
 }
 
@@ -182,12 +182,12 @@ impl Ty {
             Ty::BuiltinInstance(s) => builtins_symbol(db, s)
                 .place
                 .expect_type()
-                .to_instance(db)
+                .to_instance_approximation(db)
                 .unwrap(),
             Ty::AbcInstance(s) => known_module_symbol(db, KnownModule::Abc, s)
                 .place
                 .expect_type()
-                .to_instance(db)
+                .to_instance_approximation(db)
                 .unwrap(),
             Ty::AbcClassLiteral(s) => known_module_symbol(db, KnownModule::Abc, s)
                 .place
@@ -197,7 +197,7 @@ impl Ty {
                 .expect_type(),
             Ty::UnittestMockInstance => Ty::UnittestMockLiteral
                 .into_type(db)
-                .to_instance(db)
+                .to_instance_approximation(db)
                 .unwrap(),
             Ty::TypingLiteral => Type::SpecialForm(SpecialFormType::Literal),
             Ty::BuiltinClassLiteral(s) => builtins_symbol(db, s).place.expect_type(),

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2119,7 +2119,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // that returns an instance cannot satisfy a protocol that promises the class object.
         let protocol_self_binding_ty = ty.literal_fallback_instance(db).unwrap_or(ty);
         let implementation_self_binding_ty = ty
-            .to_instance(db)
+            .to_instance_approximation(db)
             .or_else(|| ty.literal_fallback_instance(db))
             .unwrap_or(ty);
         let implementation_receiver_binding_ty = if member.is_class_method() {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -15,7 +15,6 @@ use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
 use crate::types::tuple::TupleType;
-use crate::types::visitor::any_over_type;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -966,28 +965,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         })
     }
 
-    /// Can we check `target`s relation to a `type[T]` in either the metaclass-instance domain (it
-    /// must pass `is_metaclass_instance`) or the regular instance domain (it must have Some
-    /// `.to_instance()`)?
-    ///
-    /// Do not use instance subtyping for an exact class object. For `T: (Y, Z)` where `Z` extends
-    /// `Y`, doing so would incorrectly simplify `type[T] & <class 'Y'>` to `type[T]`: both `Y` and
-    /// `Z` instances are subtypes of `Y`, but only the class object `Y` satisfies `klass is Y`.
-    ///
-    /// The exception is a type variable whose upper bound normalizes to this exact class object.
-    /// That can only happen for a final class, so the exact object is the only valid
-    /// specialization of the type variable.
-    fn can_check_typevar_subclass_relation_to_target(
-        db: &'db dyn Db,
-        source_subclass: SubclassOfType<'db>,
-        target: Type<'db>,
-    ) -> bool {
-        let is_exact_upper_bound = source_subclass.exact_typevar_upper_bound(db) == Some(target);
-
-        (!matches!(target, Type::ClassLiteral(_) | Type::GenericAlias(_)) || is_exact_upper_bound)
-            && (Self::is_metaclass_instance(db, target) || target.to_instance(db).is_some())
-    }
-
     /// Check the relation between a `type[T]` and a target type `A` when `A` can either be
     /// projected into the ordinary instance/object domain via `.to_instance()`, or is a plain
     /// metaclass object type.
@@ -1004,28 +981,51 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// the metaclass of the upper bound of `T`, and compare in the metaclass-instance domain
     /// directly.
     ///
-    /// Exact class objects, and types that have no `.to_instance()` projection and are not
-    /// metaclass instances, do not pass the `can_check_typevar_subclass_relation_to_target` guard.
-    /// This helper does not decide their relation; they fall through to other type-pair branches.
+    /// When `.to_instance()` is an over-approximation, compare the original target in the
+    /// class-object domain instead. This preserves constraints that the projection discards, as
+    /// well as source constraints so that `T: (Y, Z)` can still be related to
+    /// `type[Y] | type[Z]`.
+    ///
+    /// Exact class objects also have an over-approximated instance projection. For `T: (Y, Z)`
+    /// where `Z` extends `Y`, instance subtyping would incorrectly simplify
+    /// `type[T] & <class 'Y'>` to `type[T]`: both `Y` and `Z` instances are subtypes of `Y`, but
+    /// only the class object `Y` satisfies `klass is Y`. The exception is a type variable whose
+    /// upper bound normalizes to this exact class object. That can only happen for a final class,
+    /// so the exact object is the only valid specialization of the type variable.
+    ///
+    /// Return `None` for targets without a `.to_instance()` projection, allowing other type-pair
+    /// branches to decide their relation.
     fn check_typevar_subclass_relation_to_target(
         &self,
         db: &'db dyn Db,
         source_subclass: SubclassOfType<'db>,
         target: Type<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        source_subclass
-            .into_type_var()
-            .when_some_and(db, self.constraints, |source_i| {
-                if Self::is_metaclass_instance(db, target) {
-                    self.check_type_pair(db, source_subclass.to_metaclass_instance(db), target)
-                } else {
-                    target
-                        .to_instance(db)
-                        .when_some_and(db, self.constraints, |target_i| {
-                            self.check_type_pair(db, Type::TypeVar(source_i), target_i)
-                        })
-                }
-            })
+    ) -> Option<ConstraintSet<'db, 'c>> {
+        let source_i = source_subclass.into_type_var()?;
+        let is_exact_upper_bound = source_subclass.exact_typevar_upper_bound(db) == Some(target);
+
+        if Self::is_metaclass_instance(db, target) {
+            return Some(self.check_type_pair(
+                db,
+                source_subclass.to_metaclass_instance(db),
+                target,
+            ));
+        }
+
+        let projection = target.to_instance(db)?;
+        if projection.is_exact() || is_exact_upper_bound {
+            return Some(self.check_type_pair(
+                db,
+                Type::TypeVar(source_i),
+                projection.into_inner(),
+            ));
+        }
+
+        let source = source_subclass
+            .subclass_of()
+            .with_transposed_type_var(db)
+            .into_type_var()?;
+        Some(self.check_type_pair(db, Type::TypeVar(source), target))
     }
 
     /// Return a constraint set indicating the conditions under which `self.relation` holds between `source` and `target`.
@@ -1375,43 +1375,23 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.never()
             }
 
-            // `to_instance()` is an over-approximation for intersections, which can be nested in
-            // a union or a type-variable constraint. Compare these targets in the class-object
-            // domain instead, preserving source constraints so that `T: (A, B)` can still be
-            // related to `type[A] | type[B]`.
-            (
-                Type::SubclassOf(subclass_of),
-                Type::Union(_) | Type::Intersection(_) | Type::TypeVar(_),
-            ) if any_over_type(db, target, true, Type::is_intersection)
-                && let Some(type_var) = subclass_of
-                    .subclass_of()
-                    .with_transposed_type_var(db)
-                    .into_type_var() =>
-            {
-                self.check_type_pair(db, Type::TypeVar(type_var), target)
-            }
-
             // `type[T]` is a subtype of the class object `A` if every instance of `T` is a subtype
             // of an instance of `A`. If `A` is a metaclass instance (instance of a specific
             // subclass of `type`), we instead compare in the metaclass-instance domain, since
             // collapsing `A` through `to_instance()` would erase it to `object` (we have no
             // precise representation for "all instances of any classes with a given metaclass").
             (Type::SubclassOf(subclass_of), _)
-                if subclass_of.is_type_var()
-                    && Self::can_check_typevar_subclass_relation_to_target(
-                        db,
-                        subclass_of,
-                        target,
-                    ) =>
+                if let Some(constraint_set) =
+                    self.check_typevar_subclass_relation_to_target(db, subclass_of, target) =>
             {
-                self.check_typevar_subclass_relation_to_target(db, subclass_of, target)
+                constraint_set
             }
 
             // And vice versa. (No special metaclass handling is needed in this direction, since
             // "collapse to 'object'" in this case is a sound over-approximation.)
             (_, Type::SubclassOf(subclass_of))
                 if let Some(type_var) = subclass_of.into_type_var()
-                    && let Some(instance) = source.to_instance(db) =>
+                    && let Some(instance) = source.to_instance_approximation(db) =>
             {
                 self.check_type_pair(db, instance, Type::TypeVar(type_var))
             }
@@ -2658,7 +2638,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // `type[T]` is disjoint from a class object `A` if every instance of `T` is disjoint from an instance of `A`.
             (Type::SubclassOf(subclass_of), other) | (other, Type::SubclassOf(subclass_of))
                 if let Some(type_var) = subclass_of.into_type_var()
-                    && let Some(instance) = other.to_instance(db) =>
+                    && let Some(instance) = other.to_instance_approximation(db) =>
             {
                 self.check_type_pair(db, Type::TypeVar(type_var), instance)
             }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -15,6 +15,7 @@ use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
 use crate::types::tuple::TupleType;
+use crate::types::visitor::any_over_type;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -1372,6 +1373,22 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     && intersection.negative(db).contains(&target) =>
             {
                 self.never()
+            }
+
+            // `to_instance()` is an over-approximation for intersections, which can be nested in
+            // a union or a type-variable constraint. Compare these targets in the class-object
+            // domain instead, preserving source constraints so that `T: (A, B)` can still be
+            // related to `type[A] | type[B]`.
+            (
+                Type::SubclassOf(subclass_of),
+                Type::Union(_) | Type::Intersection(_) | Type::TypeVar(_),
+            ) if any_over_type(db, target, true, Type::is_intersection)
+                && let Some(type_var) = subclass_of
+                    .subclass_of()
+                    .with_transposed_type_var(db)
+                    .into_type_var() =>
+            {
+                self.check_type_pair(db, Type::TypeVar(type_var), target)
             }
 
             // `type[T]` is a subtype of the class object `A` if every instance of `T` is a subtype

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -1103,6 +1103,21 @@ impl<'db> IntersectionType<'db> {
     /// projected positive element, we cannot tell whether the intersection contains class objects
     /// at all. The result is exact only when every positive element projects exactly and there are
     /// no negative elements.
+    ///
+    /// For example, Python narrowing can produce `type[Base] & ~TypeOf[Base]`:
+    ///
+    /// ```py
+    /// class Base: ...
+    /// class Child(Base): ...
+    ///
+    /// def make(cls: type[Base]) -> Base:
+    ///     if cls is not Base:
+    ///         return cls()  # `cls` can be `Child`, so this can return a `Child` instance.
+    ///     return Base()
+    /// ```
+    ///
+    /// Projecting the negative `~TypeOf[Base]` to `~Base` would incorrectly exclude `Child`
+    /// instances too, so only the positive `type[Base]` is projected.
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<InstanceProjection<Type<'db>>> {
         let mut builder = IntersectionBuilder::new(db);
         let mut has_projected_positive = false;

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -7,7 +7,7 @@ use crate::place::{
 };
 use crate::types::class::KnownClass;
 use crate::types::enums::EnumComplement;
-use crate::types::{Type, TypePair, TypeQualifiers};
+use crate::types::{InstanceProjection, Type, TypePair, TypeQualifiers};
 use crate::types::{TypeVarBoundOrConstraints, visitor};
 use crate::{Db, FxOrderSet};
 
@@ -231,8 +231,14 @@ impl<'db> UnionType<'db> {
         Ok(Type::Union(self))
     }
 
-    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        self.try_map(db, |element| element.to_instance(db))
+    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<InstanceProjection<Type<'db>>> {
+        let mut is_exact = true;
+        let instance = self.try_map(db, |element| {
+            let projection = element.to_instance(db)?;
+            is_exact &= projection.is_exact();
+            Some(projection.into_inner())
+        })?;
+        Some(InstanceProjection::new(instance, is_exact))
     }
 
     /// Returns a shared fully static supertype for a union of literal-value types.
@@ -1095,21 +1101,26 @@ impl<'db> IntersectionType<'db> {
     /// elements cannot be projected: a class object excluded by an exact-class negative can still
     /// have subclasses whose instances inhabit the excluded class's instance type. Without a
     /// projected positive element, we cannot tell whether the intersection contains class objects
-    /// at all.
-    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    /// at all. The result is exact only when every positive element projects exactly and there are
+    /// no negative elements.
+    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<InstanceProjection<Type<'db>>> {
         let mut builder = IntersectionBuilder::new(db);
         let mut has_projected_positive = false;
+        let mut is_exact = self.negative(db).is_empty();
         for positive in self.iter_positive(db) {
-            if let Some(instance) = positive.to_instance(db) {
+            if let Some(projection) = positive.to_instance(db) {
                 has_projected_positive = true;
-                builder = builder.add_positive(instance);
+                is_exact &= projection.is_exact();
+                builder = builder.add_positive(projection.into_inner());
+            } else {
+                is_exact = false;
             }
         }
         if !has_projected_positive {
             return None;
         }
 
-        Some(builder.build())
+        Some(InstanceProjection::new(builder.build(), is_exact))
     }
 
     pub(crate) fn has_one_element(self, db: &'db dyn Db) -> bool {

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -1116,8 +1116,9 @@ impl<'db> IntersectionType<'db> {
     ///     return Base()
     /// ```
     ///
-    /// Projecting the negative `~TypeOf[Base]` to `~Base` would incorrectly exclude `Child`
-    /// instances too, so only the positive `type[Base]` is projected.
+    /// Projecting only the positive `type[Base]` is an over-approximation, since we have no
+    /// representation of an exact instance type excluding subclasses, and projecting the negative
+    /// `~TypeOf[Base]` to `~Base` would incorrectly exclude `Child` instances too.
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<InstanceProjection<Type<'db>>> {
         let mut builder = IntersectionBuilder::new(db);
         let mut has_projected_positive = false;

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -1087,6 +1087,31 @@ impl<'db> IntersectionType<'db> {
         self.negative(db).iter().copied()
     }
 
+    /// Project an intersection containing class-object types into the corresponding instance types.
+    ///
+    /// A projected positive element supplies a sound instance-space over-approximation for the
+    /// whole intersection. Other positive elements can constrain class objects in a domain with no
+    /// instance-space projection, so omitting them is also a sound over-approximation. Negative
+    /// elements cannot be projected: a class object excluded by an exact-class negative can still
+    /// have subclasses whose instances inhabit the excluded class's instance type. Without a
+    /// projected positive element, we cannot tell whether the intersection contains class objects
+    /// at all.
+    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        let mut builder = IntersectionBuilder::new(db);
+        let mut has_projected_positive = false;
+        for positive in self.iter_positive(db) {
+            if let Some(instance) = positive.to_instance(db) {
+                has_projected_positive = true;
+                builder = builder.add_positive(instance);
+            }
+        }
+        if !has_projected_positive {
+            return None;
+        }
+
+        Some(builder.build())
+    }
+
     pub(crate) fn has_one_element(self, db: &'db dyn Db) -> bool {
         (self.positive(db).len() + self.negative(db).len()) == 1
     }

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -291,7 +291,7 @@ impl<'db> SubclassOfType<'db> {
         // the upper bound `type[C]`, and transform that to the meta-type `type[M]`, which
         // `to_instance` then resolves to `M`.
         self.to_meta_type(db)
-            .to_instance(db)
+            .to_instance_approximation(db)
             .expect("the meta-type of a SubclassOf type should always be instantiable")
     }
 

--- a/crates/ty_python_semantic/src/types/type_form.rs
+++ b/crates/ty_python_semantic/src/types/type_form.rs
@@ -81,7 +81,7 @@ impl<'db> Type<'db> {
                     instance.type_form_argument(db)
                 }
                 Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => {
-                    ty.to_instance(db)
+                    ty.to_instance_approximation(db)
                 }
                 _ => None,
             }

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -14,9 +14,9 @@ use crate::{
     },
     types::{
         ApplySpecialization, ApplyTypeMappingVisitor, CycleDetector, DynamicType, GenericContext,
-        KnownClass, KnownInstanceType, MaterializationKind, Parameter, Parameters, Type,
-        TypeAliasType, TypeContext, TypeMapping, TypeVarVariance, UnionBuilder, UnionType,
-        any_over_type, binding_type, definition_expression_type,
+        InstanceProjection, KnownClass, KnownInstanceType, MaterializationKind, Parameter,
+        Parameters, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarVariance, UnionBuilder,
+        UnionType, any_over_type, binding_type, definition_expression_type,
         tuple::Tuple,
         variance::VarianceInferable,
         visitor::{self, TypeCollector, TypeVisitor, walk_type_with_recursion_guard},
@@ -333,14 +333,14 @@ impl<'db> TypeVarInstance<'db> {
         )
     }
 
-    fn to_instance(self, db: &'db dyn Db) -> Option<Self> {
+    fn to_instance(self, db: &'db dyn Db) -> Option<InstanceProjection<Self>> {
         let bound_or_constraints = match self.bound_or_constraints(db)? {
-            TypeVarBoundOrConstraints::UpperBound(upper_bound) => {
-                TypeVarBoundOrConstraints::UpperBound(upper_bound.to_instance(db)?)
-            }
-            TypeVarBoundOrConstraints::Constraints(constraints) => {
-                TypeVarBoundOrConstraints::Constraints(constraints.to_instance(db)?)
-            }
+            TypeVarBoundOrConstraints::UpperBound(upper_bound) => upper_bound
+                .to_instance(db)?
+                .map(TypeVarBoundOrConstraints::UpperBound),
+            TypeVarBoundOrConstraints::Constraints(constraints) => constraints
+                .to_instance(db)?
+                .map(TypeVarBoundOrConstraints::Constraints),
         };
         let identity = TypeVarIdentity::new(
             db,
@@ -348,13 +348,15 @@ impl<'db> TypeVarInstance<'db> {
             None, // definition
             self.kind(db),
         );
-        Some(Self::new(
-            db,
-            identity,
-            Some(bound_or_constraints.into()),
-            self.explicit_variance(db),
-            None, // _default
-        ))
+        Some(bound_or_constraints.map(|bound_or_constraints| {
+            Self::new(
+                db,
+                identity,
+                Some(bound_or_constraints.into()),
+                self.explicit_variance(db),
+                None, // _default
+            )
+        }))
     }
 
     fn type_is_self_referential(
@@ -1299,14 +1301,16 @@ impl<'db> BoundTypeVarInstance<'db> {
         )
     }
 
-    pub(super) fn to_instance(self, db: &'db dyn Db) -> Option<Self> {
-        Some(Self::new(
-            db,
-            self.typevar(db).to_instance(db)?,
-            self.binding_context(db),
-            self.paramspec_attr(db),
-            self.freshness(db),
-        ))
+    pub(super) fn to_instance(self, db: &'db dyn Db) -> Option<InstanceProjection<Self>> {
+        Some(self.typevar(db).to_instance(db)?.map(|typevar| {
+            Self::new(
+                db,
+                typevar,
+                self.binding_context(db),
+                self.paramspec_attr(db),
+                self.freshness(db),
+            )
+        }))
     }
 }
 
@@ -1595,14 +1599,17 @@ impl<'db> TypeVarConstraints<'db> {
         UnionType::from_elements(db, self.elements(db))
     }
 
-    fn to_instance(self, db: &'db dyn Db) -> Option<TypeVarConstraints<'db>> {
+    fn to_instance(self, db: &'db dyn Db) -> Option<InstanceProjection<TypeVarConstraints<'db>>> {
         let mut instance_elements = Vec::new();
+        let mut is_exact = true;
         for ty in self.elements(db) {
-            instance_elements.push(ty.to_instance(db)?);
+            let projection = ty.to_instance(db)?;
+            is_exact &= projection.is_exact();
+            instance_elements.push(projection.into_inner());
         }
-        Some(TypeVarConstraints::new(
-            db,
-            instance_elements.into_boxed_slice(),
+        Some(InstanceProjection::new(
+            TypeVarConstraints::new(db, instance_elements.into_boxed_slice()),
+            is_exact,
         ))
     }
 


### PR DESCRIPTION
## Summary

Support `to_instance` on intersection types instead of returning a `Todo` type.

This is split out of #26712 (for [astral-sh/ty#3557](https://github.com/astral-sh/ty/issues/3557)).

We project instantiable positive elements of the intersection into an instance intersection, discarding non-instantiable elements and negative elements. This is a sound over-approximation, which is also the case for several other existing arms of `to_instance`, and is fine for use in type inference.

However, this did expose one case where we used `to_instance` on the "target" side of an assignability relation. In that position an over-approximation is _not_ sound; it can cause us to claim an incorrect relation to be true. This was a pre-existing issue (for all existing arms of `to_instance` that returned an over-approximation), but adding intersections exposed a new case of it in the ecosystem.

To fix that, `to_instance` now returns an enum distinguishing exact projections (safe to use everywhere, including in relation target position) from over-approximating projections (safe to use in inference). In general, an exact projection would be one that round-trips precisely back through `to_meta_type`, whereas an over-approximation would be one that results in a wider type when converted back via `to_meta_type`.

We add a new `to_instance_approximation` method which collapses this distinction (same as the old `to_instance`). This adds noise to the PR diff (converting most existing uses of `to_instance` to `to_instance_approximation`) but seems like better API clarity for future.

This clear distinction between exact and over-approximating `to_instance` allowed simplifying what was previously a confusing set of special cases in the relation code, which were effectively attempting to model the same distinction in an ad-hoc way by matching on specific types.)

## Test plan

- Added an exception-handling mdtest covering multiple positive class constraints, an exact-class negative/proper-subclass case, and the mixed `except A and B` path.
- Added generic narrowing and subtype regressions covering direct and nested intersections and constrained type variables; updated the existing decorator fixtures to expect the newly exposed invalid-return diagnostic.
