### PR TITLE
[ty] Stop existentially reducing target signature typevars

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -185,7 +185,7 @@ static PYDANTIC: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    1600,
+    1601,
 );
 
 static SYMPY: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -951,10 +951,12 @@ class MyMetaclass(type):
 Using the `self` parameter as a runtime value should not be flagged, even in a metaclass. Only the
 literal `Self` type form should be disallowed.
 
+TODO: Bind receiver TypeVars before checking this override against `type.__or__`.
+
 ```py
 class AnnotableMeta(type):
-    def __or__(self, other):
-        return self  # No error: runtime use of `self`, not the `Self` type form
+    def __or__(self, other):  # error: [invalid-method-override]
+        return self  # No `invalid-type-form` error: runtime use of `self`, not the `Self` type form
 ```
 
 ## Indirect metaclass inheritance

--- a/crates/ty_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/string.md
@@ -66,6 +66,8 @@ common runtime error:
 python-version = "3.13"
 ```
 
+TODO: Bind receiver TypeVars before checking this override against `type.__or__`.
+
 ```py
 from typing import Any, TypeVar, Callable, Protocol, TypedDict, TYPE_CHECKING
 
@@ -75,7 +77,7 @@ class P(Protocol):
     x: int
 
 class Meta(type):
-    def __or__(cls, other: str) -> Any:
+    def __or__(cls, other: str) -> Any:  # error: [invalid-method-override]
         return "wow, so fancy, bet type checkers can't handle this"
 
 class UsesMeta(metaclass=Meta): ...

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1138,7 +1138,8 @@ def _(x: list[str]):
     # revealed: ty_extensions._internal.GenericContext[T@GenericClass]
     reveal_type(generic_context(into_regular_callable(GenericClass)))
 
-    # revealed: [T](x: list[T], y: list[T]) -> GenericClass[T]
+    # TODO: Restore the generic binder when target callable typevars can be quantified correctly.
+    # revealed: (x: list[T@GenericClass], y: list[T@GenericClass]) -> GenericClass[T@GenericClass]
     reveal_type(accepts_callable(GenericClass))
     # revealed: ty_extensions._internal.GenericContext[T@GenericClass]
     reveal_type(generic_context(accepts_callable(GenericClass)))

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -335,7 +335,7 @@ respect the metaclass dunder if a class is `|`'d with a non-class, however:
 
 ```py
 class Meta(type):
-    def __or__(self, other) -> str:
+    def __or__(self, other) -> str:  # error: [invalid-method-override]
         return "Meta"
 
 class Foo(metaclass=Meta): ...

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3857,6 +3857,53 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolImplicitSelf))
 static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 ```
 
+A receiver TypeVar's bound limits the specializations for which a protocol method must be
+compatible. It is not an additional constraint that must hold for every possible specialization:
+
+TODO: Bind receiver TypeVars before comparing signatures so that these cases pass.
+
+```py
+from typing import Protocol, TypeVar
+from typing_extensions import Self, assert_type
+
+T = TypeVar("T")
+
+class HasParent(Protocol):
+    def get_parent(self: T) -> T: ...
+
+GenericHasParent = TypeVar("GenericHasParent", bound=HasParent)
+
+def generic_get_parent(value: GenericHasParent) -> GenericHasParent:
+    return value.get_parent()
+
+class ConcreteHasParent:
+    def get_parent(self) -> Self:
+        return self
+
+parent = generic_get_parent(ConcreteHasParent())  # error: [invalid-argument-type]
+assert_type(parent, ConcreteHasParent)  # error: [type-assertion-failure]
+
+C = TypeVar("C", bound="Copyable")
+
+class Copyable(Protocol):
+    def copy(self: C) -> C:
+        return self
+
+class One:
+    def copy(self) -> "One":
+        return One()
+
+OtherT = TypeVar("OtherT", bound="Other")
+
+class Other:
+    def copy(self: OtherT) -> OtherT:
+        return self
+
+copyable: Copyable
+copyable = One()  # error: [invalid-assignment]
+copyable = Other()  # error: [invalid-assignment]
+```
+
 ## Module objects with static-method protocol members
 
 Module objects implement protocols through their public interface. A module-level function can

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/string.md_-_String_annotations_-_Partially_deferred_a…_-_Python_less_than_3.1…_(5e6477d05ddea33f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/string.md_-_String_annotations_-_Partially_deferred_a…_-_Python_less_than_3.1…_(5e6477d05ddea33f).snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/string.md
  6 |     x: int
  7 | 
  8 | class Meta(type):
- 9 |     def __or__(cls, other: str) -> Any:
+ 9 |     def __or__(cls, other: str) -> Any:  # error: [invalid-method-override]
 10 |         return "wow, so fancy, bet type checkers can't handle this"
 11 | 
 12 | class UsesMeta(metaclass=Meta): ...
@@ -81,6 +81,22 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/string.md
 ```
 
 # Diagnostics
+
+```
+error[invalid-method-override]: Invalid override of method `__or__`
+   --> src/mdtest_snippet.py:9:9
+    |
+  9 |     def __or__(cls, other: str) -> Any:  # error: [invalid-method-override]
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `type.__or__`
+    |
+   ::: stdlib/builtins.pyi:307:9
+    |
+307 |     def __or__(self: _typeshed.Self, value: Any, /) -> types.UnionType | _typeshed.Self:
+    |         ------------------------------------------------------------------------------- `type.__or__` defined here
+    |
+info: This violates the Liskov Substitution Principle
+
+```
 
 ```
 error[unsupported-operator]: Unsupported `|` operation

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
@@ -572,7 +572,8 @@ def quantifies_callable_typevars_together[V]():
 
     actual = ConstraintSet.always().implies_subtype_of(RegularCallableTypeOf[source], RegularCallableTypeOf[target])
     expected = ConstraintSet.range(int, V, object)
-    static_assert(actual == expected)
+    # TODO: Restore the constraint on `V` when target callable typevars can be quantified correctly.
+    static_assert(actual == expected)  # error: [static-assert-error]
 ```
 
 Invariant generic classes in a generic callable's return type should preserve cross-typevar

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2064,11 +2064,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 })
         });
 
-        // But the caller does not need to consider those extra typevars. Whatever constraint set
-        // we produce, we reduce it back down to the inferable set that the caller asked about.
-        // If we introduced new inferable typevars, those will be existentially quantified away
-        // before returning.
-        when.reduce_inferable(db, self.constraints, signature_inferable)
+        // The caller does not need to consider the source signature's typevars. A relation only
+        // needs one source specialization to succeed, so existentially quantify those away before
+        // returning.
+        //
+        // Target signature typevars require the opposite quantifier: the relation must hold for
+        // every target specialization. Preserve their constraints here instead of existentially
+        // quantifying them away.
+        when.reduce_inferable(db, self.constraints, source_inferable)
     }
 
     fn with_signature_recursion_guard(


### PR DESCRIPTION
## Summary

Prior to this change, callable-local type variables were existentially specialized on both sides of a signature relation. That is valid for source signatures, where one specialization may satisfy the target, but it is the wrong quantifier for target signatures, where the relation must hold for every specialization.

For example, `[T](T) -> T` is a subtype of `(int) -> int`: we can specialize the source's `T` to `int`. The reverse does not hold: `(int) -> int` is not a subtype of `[T](T) -> T`, because the relation must hold for every specialization of the target's `T`, not merely `T = int`. Existentially reducing the target incorrectly accepts the reverse relation by choosing `T = int`.

This PR does exposes some false positives (including in the conformance suite) that are addressed by the stacked follow-ups. For example, this is valid:

```python
from typing import Protocol, TypeVar

C = TypeVar("C", bound="Copyable")

class Copyable(Protocol):
    def copy(self: C) -> C: ...

class One:
    def copy(self) -> "One":
        return One()

copyable: Copyable = One()
```

`main` accepts this, but this PR reports:

```
error[invalid-assignment]: Object of type `One` is not assignable to `Copyable`
```

Here, `C` is a receiver TypeVar: binding the protocol method to `One` specializes `C` to `One`, making both signatures effectively `(self: One) -> One`. The bound on `C` limits the valid receiver specializations; it does not require every possible specialization to match.

Previously, we existentially quantified all target-signature TypeVars. That's too permissive for genuine generic target methods, but IIUC we don't yet distinguish ordinary method TypeVars from receiver TypeVars, which leads to these kinds of issues.
