### PR TITLE
[ty] Refactor constraint set path walking

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -6527,12 +6527,12 @@ impl SequentMap {
 pub(crate) struct PathAssignments {
     map: SequentMap,
     /// Each assignment's source order and the first per-path fuel value with which it was derived.
-    assignments: FxIndexMap<ConstraintAssignment, (usize, u16)>,
+    assignments: FxIndexMap<ConstraintAssignment, (usize, AssignmentFuel)>,
     /// Additional per-path fuel values that can derive an assignment, keyed by its index in
     /// `assignments`. These are stored separately so that branch-local additions can be rolled
     /// back by truncating the set. Only the greatest fuel value participates in further
     /// derivation.
-    additional_fuels: FxIndexSet<(usize, u16)>,
+    additional_fuels: Vec<(usize, AssignmentFuel)>,
     /// The amount of global fuel that remains across all assignments and paths.
     remaining_overall_fuel: u16,
     /// Constraints that we have discovered, mapped to whether we have processed them yet. (This
@@ -6541,15 +6541,50 @@ pub(crate) struct PathAssignments {
     discovered: FxIndexMap<ConstraintId, bool>,
     /// Derived assignments that have been queued up to add because of the most recent BDD
     /// assignment
-    assignment_queue: FxIndexMap<ConstraintAssignment, (Option<u16>, u16)>,
+    assignment_queue: FxIndexMap<ConstraintAssignment, AssignmentFuel>,
+}
+
+/// The total amount of fuel that we are willing to spend for this path traversal. This was
+/// chosen empirically, to balance performance with accurate ecosystem diagnostics.
+const OVERALL_FUEL_BUDGET: u16 = 256;
+
+/// The maximum number of "trips through the sequent map" that we are willing to take for a
+/// derived constraint. This records how far removed we are from a constraint that comes
+/// directly from the BDD.
+const PATH_FUEL_BUDGET: u16 = 8;
+
+/// The fuel cost of deriving a particular assignment during BDD path walking.
+#[derive(Clone, Copy, Debug)]
+struct AssignmentFuel {
+    /// The amount of fuel consumed when deriving the assignment, or None if this assignment came
+    /// directly from the BDD
+    consumed: Option<u16>,
+    /// The amount of fuel remaining on the derivation path after deriving this assignment
+    remaining: u16,
+}
+
+impl AssignmentFuel {
+    fn origin() -> AssignmentFuel {
+        AssignmentFuel {
+            consumed: None,
+            remaining: PATH_FUEL_BUDGET,
+        }
+    }
+
+    fn derived(consumed: u16, remaining: u16) -> AssignmentFuel {
+        AssignmentFuel {
+            consumed: Some(consumed),
+            remaining,
+        }
+    }
+
+    fn is_derived(self) -> bool {
+        self.consumed.is_some()
+    }
 }
 
 impl PathAssignments {
     fn new(constraints: impl IntoIterator<Item = ConstraintId>) -> Self {
-        /// The total amount of fuel that we are willing to spend for this path traversal. This was
-        /// chosen empirically, to balance performance with accurate ecosystem diagnostics.
-        const OVERALL_FUEL_BUDGET: u16 = 256;
-
         let discovered = constraints
             .into_iter()
             .map(|constraint| (constraint, false))
@@ -6557,7 +6592,7 @@ impl PathAssignments {
         Self {
             map: SequentMap::default(),
             assignments: FxIndexMap::default(),
-            additional_fuels: FxIndexSet::default(),
+            additional_fuels: Vec::default(),
             discovered,
             remaining_overall_fuel: OVERALL_FUEL_BUDGET,
             assignment_queue: FxIndexMap::default(),
@@ -6594,11 +6629,6 @@ impl PathAssignments {
         source_order: usize,
         f: impl FnOnce(&mut Self, Range<usize>) -> R,
     ) -> Option<R> {
-        /// The maximum number of "trips through the sequent map" that we are willing to take for a
-        /// derived constraint. This records how far removed we are from a constraint that comes
-        /// directly from the BDD.
-        const PATH_FUEL_BUDGET: u16 = 8;
-
         // Record a snapshot of the assignments that we already knew held — both so that we can
         // pass along the range of which assignments are new, and so that we can reset back to this
         // point before returning.
@@ -6619,7 +6649,7 @@ impl PathAssignments {
             "walk edge",
         );
         debug_assert!(self.assignment_queue.is_empty());
-        self.enqueue_assignment(assignment, None, PATH_FUEL_BUDGET);
+        self.enqueue_assignment(assignment, AssignmentFuel::origin());
         let found_conflict = self.drain_assignment_queue(db, builder, source_order);
         let result = if found_conflict.is_err() {
             // If that results in the path now being impossible due to a contradiction, return
@@ -6681,8 +6711,8 @@ impl PathAssignments {
             .additional_fuels
             .iter()
             .filter(|(fuel_index, _)| *fuel_index == index)
-            .map(|(_, fuel)| *fuel)
-            .fold(*first_fuel, u16::max);
+            .map(|(_, fuel)| fuel.remaining)
+            .fold(first_fuel.remaining, u16::max);
         Some(max_fuel)
     }
 
@@ -6720,17 +6750,8 @@ impl PathAssignments {
         builder: &ConstraintSetBuilder<'db>,
         source_order: usize,
     ) -> Result<(), PathAssignmentConflict> {
-        while let Some((assignment, (derived_fuel_cost, path_fuel))) =
-            self.assignment_queue.shift_remove_index(0)
-        {
-            self.add_assignment(
-                db,
-                builder,
-                assignment,
-                source_order,
-                derived_fuel_cost,
-                path_fuel,
-            )?;
+        while let Some((assignment, fuel)) = self.assignment_queue.shift_remove_index(0) {
+            self.add_assignment(db, builder, assignment, source_order, fuel)?;
         }
         Ok(())
     }
@@ -6744,8 +6765,7 @@ impl PathAssignments {
         builder: &ConstraintSetBuilder<'db>,
         assignment: ConstraintAssignment,
         source_order: usize,
-        derived_fuel_cost: Option<u16>,
-        path_fuel: u16,
+        fuel: AssignmentFuel,
     ) -> Result<(), PathAssignmentConflict> {
         if matches!(assignment, ConstraintAssignment::Unconstrained(_)) {
             // An `Unconstrained` assignment means "this constraint can go either way". If there is
@@ -6759,8 +6779,7 @@ impl PathAssignments {
             // derive any additional information from the sequent map. We still want to record the
             // assignment, but as an optimization we can return early without actually querying the
             // sequent map.
-            self.assignments
-                .insert(assignment, (source_order, path_fuel));
+            self.assignments.insert(assignment, (source_order, fuel));
             return Ok(());
         }
 
@@ -6782,14 +6801,14 @@ impl PathAssignments {
 
         match self.assignments.entry(assignment) {
             Entry::Vacant(entry) => {
-                if let Some(fuel_cost) = derived_fuel_cost {
+                if let Some(fuel_cost) = fuel.consumed {
                     self.remaining_overall_fuel =
                         match self.remaining_overall_fuel.checked_sub(fuel_cost) {
                             Some(updated_fuel) => updated_fuel,
                             None => return Ok(()),
                         };
                 }
-                entry.insert((source_order, path_fuel));
+                entry.insert((source_order, fuel));
             }
 
             Entry::Occupied(mut entry) => {
@@ -6800,7 +6819,7 @@ impl PathAssignments {
                 // the BDD structure) and as a "derived" constraint (we infer it from other
                 // constraints), we should prefer the origin source_order, regardless of which
                 // order we encounter the various constraints in the BDD.
-                if derived_fuel_cost.is_none() {
+                if !fuel.is_derived() {
                     *existing_source_order = source_order;
                 }
 
@@ -6815,12 +6834,12 @@ impl PathAssignments {
                 // There is another derivation of this assignment that already provides at least as
                 // much fuel as this constraint. That means replenishing the fuel won't have any
                 // effect.
-                if *existing_fuel >= path_fuel
+                if existing_fuel.remaining >= fuel.remaining
                     || self
                         .additional_fuels
                         .iter()
                         .any(|(fuel_index, existing_fuel)| {
-                            *fuel_index == index && *existing_fuel >= path_fuel
+                            *fuel_index == index && existing_fuel.remaining >= fuel.remaining
                         })
                 {
                     return Ok(());
@@ -6828,7 +6847,7 @@ impl PathAssignments {
 
                 // Record the replenished fuel separately so that `walk_edge` can restore the
                 // parent branch by truncating `additional_fuels`.
-                self.additional_fuels.insert((index, path_fuel));
+                self.additional_fuels.push((index, fuel));
             }
         }
 
@@ -6869,23 +6888,13 @@ impl PathAssignments {
         Ok(())
     }
 
-    fn enqueue_assignment(
-        &mut self,
-        assignment: ConstraintAssignment,
-        derived_fuel_cost: Option<u16>,
-        path_fuel: u16,
-    ) {
-        let new_fuel = (derived_fuel_cost, path_fuel);
+    fn enqueue_assignment(&mut self, assignment: ConstraintAssignment, new_fuel: AssignmentFuel) {
         self.assignment_queue
             .entry(assignment)
             .and_modify(|existing_fuel| {
-                *existing_fuel = std::cmp::max_by_key(
-                    *existing_fuel,
-                    new_fuel,
-                    |&(derived_fuel_cost, path_fuel)| {
-                        (path_fuel, std::cmp::Reverse(derived_fuel_cost))
-                    },
-                );
+                *existing_fuel = std::cmp::max_by_key(*existing_fuel, new_fuel, |fuel| {
+                    (fuel.remaining, std::cmp::Reverse(fuel.consumed))
+                });
             })
             .or_insert(new_fuel);
     }
@@ -6963,7 +6972,10 @@ impl PathAssignments {
         let antecedent_constructor_depth = ante1_constructor_depth.max(ante2_constructor_depth);
         let fuel_cost = builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth);
         if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
-            self.enqueue_assignment(sequent.post.when_true(), Some(fuel_cost), post_fuel);
+            self.enqueue_assignment(
+                sequent.post.when_true(),
+                AssignmentFuel::derived(fuel_cost, post_fuel),
+            );
         }
     }
 
@@ -6986,7 +6998,10 @@ impl PathAssignments {
             builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth)
         };
         if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
-            self.enqueue_assignment(sequent.post.when_true(), Some(fuel_cost), post_fuel);
+            self.enqueue_assignment(
+                sequent.post.when_true(),
+                AssignmentFuel::derived(fuel_cost, post_fuel),
+            );
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -88,6 +88,7 @@
 
 use std::cell::{Cell, Ref, RefCell};
 use std::cmp::Ordering;
+use std::collections::VecDeque;
 use std::fmt::{Debug, Display};
 use std::iter;
 use std::marker::PhantomData;
@@ -6541,7 +6542,7 @@ pub(crate) struct PathAssignments {
     discovered: FxIndexMap<ConstraintId, bool>,
     /// Derived assignments that have been queued up to add because of the most recent BDD
     /// assignment
-    assignment_queue: FxIndexMap<ConstraintAssignment, AssignmentFuel>,
+    assignment_queue: VecDeque<(ConstraintAssignment, AssignmentFuel)>,
 }
 
 /// The total amount of fuel that we are willing to spend for this path traversal. This was
@@ -6595,7 +6596,7 @@ impl PathAssignments {
             additional_fuels: Vec::default(),
             discovered,
             remaining_overall_fuel: OVERALL_FUEL_BUDGET,
-            assignment_queue: FxIndexMap::default(),
+            assignment_queue: VecDeque::default(),
         }
     }
 
@@ -6705,7 +6706,7 @@ impl PathAssignments {
     }
 
     /// Returns the greatest remaining fuel for any derivation of `assignment` on this path.
-    fn fuel_for(&self, assignment: ConstraintAssignment) -> Option<u16> {
+    fn max_remaining_fuel_for(&self, assignment: ConstraintAssignment) -> Option<u16> {
         let (index, _, (_, first_fuel)) = self.assignments.get_full(&assignment)?;
         let max_fuel = self
             .additional_fuels
@@ -6750,7 +6751,7 @@ impl PathAssignments {
         builder: &ConstraintSetBuilder<'db>,
         source_order: usize,
     ) -> Result<(), PathAssignmentConflict> {
-        while let Some((assignment, fuel)) = self.assignment_queue.shift_remove_index(0) {
+        while let Some((assignment, fuel)) = self.assignment_queue.pop_front() {
             self.add_assignment(db, builder, assignment, source_order, fuel)?;
         }
         Ok(())
@@ -6831,18 +6832,38 @@ impl PathAssignments {
                 // there might be some consequents that were skipped previously due to a lack of
                 // fuel, that can be added now because of the replinished fuel budget.
 
-                // There is another derivation of this assignment that already provides at least as
-                // much fuel as this constraint. That means replenishing the fuel won't have any
-                // effect.
-                if existing_fuel.remaining >= fuel.remaining
-                    || self
-                        .additional_fuels
-                        .iter()
-                        .any(|(fuel_index, existing_fuel)| {
-                            *fuel_index == index && existing_fuel.remaining >= fuel.remaining
-                        })
+                // There is no need to replenish the fuel for this derivation if there is already
+                // an existing derivation whose fuel "dominates" (it both consumes as much fuel,
+                // and provides at least as much remaining fuel).
+                let existing_fuels = self
+                    .additional_fuels
+                    .iter()
+                    .filter(|(fuel_index, _)| *fuel_index == index);
+                let max_existing_remaining_fuel = existing_fuels
+                    .clone()
+                    .map(|(_, fuel)| fuel.remaining)
+                    .fold(existing_fuel.remaining, u16::max);
+                let max_existing_consumed_fuel = existing_fuels
+                    .clone()
+                    .filter_map(|(_, fuel)| fuel.consumed)
+                    .fold(existing_fuel.consumed.unwrap_or(0), u16::max);
+                if max_existing_remaining_fuel >= fuel.remaining
+                    && max_existing_consumed_fuel >= fuel.consumed.unwrap_or(0)
                 {
                     return Ok(());
+                }
+
+                // If this derivation of this assignment consumes more fuel than the other
+                // derivations that we've seen, we need to update the overall fuel consumed for
+                // this assignment.
+                if let Some(consumed) = fuel.consumed
+                    && let Some(delta) = consumed.checked_sub(max_existing_consumed_fuel)
+                {
+                    self.remaining_overall_fuel =
+                        match self.remaining_overall_fuel.checked_sub(delta) {
+                            Some(updated_fuel) => updated_fuel,
+                            None => return Ok(()),
+                        };
                 }
 
                 // Record the replenished fuel separately so that `walk_edge` can restore the
@@ -6889,14 +6910,7 @@ impl PathAssignments {
     }
 
     fn enqueue_assignment(&mut self, assignment: ConstraintAssignment, new_fuel: AssignmentFuel) {
-        self.assignment_queue
-            .entry(assignment)
-            .and_modify(|existing_fuel| {
-                *existing_fuel = std::cmp::max_by_key(*existing_fuel, new_fuel, |fuel| {
-                    (fuel.remaining, std::cmp::Reverse(fuel.consumed))
-                });
-            })
-            .or_insert(new_fuel);
+        self.assignment_queue.push_back((assignment, new_fuel));
     }
 
     fn check_single_tautology<'db>(
@@ -6960,10 +6974,10 @@ impl PathAssignments {
         builder: &ConstraintSetBuilder<'db>,
         sequent: PairImplication,
     ) {
-        let Some(ante1_fuel) = self.fuel_for(sequent.ante1.when_true()) else {
+        let Some(ante1_fuel) = self.max_remaining_fuel_for(sequent.ante1.when_true()) else {
             return;
         };
-        let Some(ante2_fuel) = self.fuel_for(sequent.ante2.when_true()) else {
+        let Some(ante2_fuel) = self.max_remaining_fuel_for(sequent.ante2.when_true()) else {
             return;
         };
         let available_fuel = ante1_fuel.min(ante2_fuel);
@@ -6985,7 +6999,7 @@ impl PathAssignments {
         builder: &ConstraintSetBuilder<'db>,
         sequent: SingleImplication,
     ) {
-        let Some(available_fuel) = self.fuel_for(sequent.ante.when_true()) else {
+        let Some(available_fuel) = self.max_remaining_fuel_for(sequent.ante.when_true()) else {
             return;
         };
         let ante_data = builder.constraint_data(sequent.ante);

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -5360,51 +5360,47 @@ impl ConstraintAssignment {
 /// constraint sets.)
 #[derive(Debug, Default)]
 struct SequentMap {
-    single_tautologies: Vec<SingleTautology>,
-    pair_impossibilities: Vec<PairImpossibility>,
-    pair_implications: Vec<PairImplication>,
-    single_implications: Vec<SingleImplication>,
+    sequents: Vec<Sequent>,
 }
 
-/// Sequent of the form `¬C → false`
-///
-/// This indicates that `C` is always true. Any path that assumes it is false is impossible and can
-/// be pruned.
+/// Describes one rule for deriving new implicit constraints from existing constraints in a BDD
+/// path.
 #[derive(Clone, Copy, Debug)]
-struct SingleTautology {
-    ante: ConstraintId,
-}
+enum Sequent {
+    /// Sequent of the form `¬C → false`
+    ///
+    /// This indicates that `C` is always true. Any path that assumes it is false is impossible and
+    /// can be pruned.
+    SingleTautology { ante: ConstraintId },
 
-/// Sequent of the form `C₁ ∧ C₂ → false`
-///
-/// This indicates that `C₁` and `C₂` are disjoint: it is not possible for both to hold. Any path
-/// that assumes both is impossible and can be pruned.
-#[derive(Clone, Copy, Debug)]
-struct PairImpossibility {
-    ante1: ConstraintId,
-    ante2: ConstraintId,
-}
+    /// Sequent of the form `C₁ ∧ C₂ → false`
+    ///
+    /// This indicates that `C₁` and `C₂` are disjoint: it is not possible for both to hold. Any
+    /// path that assumes both is impossible and can be pruned.
+    PairImpossibility {
+        ante1: ConstraintId,
+        ante2: ConstraintId,
+    },
 
-/// Sequent of the form `C₁ ∧ C₂ → D`
-///
-/// This indicates that if `C₁` and `C₂` are both true, then `D` is guaranteed to be true as well.
-/// For any path that assumes both `C₁` and `C₂` hold, we can add `D` to the path even if it
-/// doesn't appear in the BDD.
-#[derive(Clone, Copy, Debug)]
-struct SingleImplication {
-    ante: ConstraintId,
-    post: ConstraintId,
-}
+    /// Sequent of the form `C₁ ∧ C₂ → D`
+    ///
+    /// This indicates that if `C₁` and `C₂` are both true, then `D` is guaranteed to be true as
+    /// well. For any path that assumes both `C₁` and `C₂` hold, we can add `D` to the path even if
+    /// it doesn't appear in the BDD.
+    SingleImplication {
+        ante: ConstraintId,
+        post: ConstraintId,
+    },
 
-/// Sequent of the form `C → D`
-///
-/// This indicates that `C` on its own is enough to imply `D`. For any path that assumes `C` holds,
-/// we can add `D` to the path even if it doesn't appear in the BDD.
-#[derive(Clone, Copy, Debug)]
-struct PairImplication {
-    ante1: ConstraintId,
-    ante2: ConstraintId,
-    post: ConstraintId,
+    /// Sequent of the form `C → D`
+    ///
+    /// This indicates that `C` on its own is enough to imply `D`. For any path that assumes `C`
+    /// holds, we can add `D` to the path even if it doesn't appear in the BDD.
+    PairImplication {
+        ante1: ConstraintId,
+        ante2: ConstraintId,
+        post: ConstraintId,
+    },
 }
 
 impl SequentMap {
@@ -5476,23 +5472,16 @@ impl SequentMap {
 
     /// Merges the sequents from another sequent map into this one.
     fn merge(&mut self, other: &Self) {
-        self.single_tautologies
-            .extend_from_slice(&other.single_tautologies);
-        self.pair_impossibilities
-            .extend_from_slice(&other.pair_impossibilities);
-        self.pair_implications
-            .extend_from_slice(&other.pair_implications);
-        self.single_implications
-            .extend_from_slice(&other.single_implications);
+        self.sequents.extend_from_slice(&other.sequents);
     }
 
     fn add_single_tautology(&mut self, ante: ConstraintId) {
-        self.single_tautologies.push(SingleTautology { ante });
+        self.sequents.push(Sequent::SingleTautology { ante });
     }
 
     fn add_pair_impossibility(&mut self, ante1: ConstraintId, ante2: ConstraintId) {
-        self.pair_impossibilities
-            .push(PairImpossibility { ante1, ante2 });
+        self.sequents
+            .push(Sequent::PairImpossibility { ante1, ante2 });
     }
 
     fn add_pair_implication<'db>(
@@ -5522,8 +5511,8 @@ impl SequentMap {
             return;
         }
 
-        self.pair_implications
-            .push(PairImplication { ante1, ante2, post });
+        self.sequents
+            .push(Sequent::PairImplication { ante1, ante2, post });
     }
 
     fn add_single_implication(&mut self, ante: ConstraintId, post: ConstraintId) {
@@ -5531,8 +5520,8 @@ impl SequentMap {
             return;
         }
 
-        self.single_implications
-            .push(SingleImplication { ante, post });
+        self.sequents
+            .push(Sequent::SingleImplication { ante, post });
     }
 
     fn add_sequents_for_single<'db>(
@@ -6451,35 +6440,41 @@ impl SequentMap {
                     }
                 };
 
-                for sequent in &self.map.pair_impossibilities {
-                    maybe_write_prefix(f)?;
-                    write!(
-                        f,
-                        "{} ∧ {} → false",
-                        sequent.ante1.display(self.db, self.builder),
-                        sequent.ante2.display(self.db, self.builder),
-                    )?;
-                }
+                for sequent in &self.map.sequents {
+                    match sequent {
+                        Sequent::SingleTautology { .. } => {}
 
-                for sequent in &self.map.pair_implications {
-                    maybe_write_prefix(f)?;
-                    write!(
-                        f,
-                        "{} ∧ {} → {}",
-                        sequent.ante1.display(self.db, self.builder),
-                        sequent.ante2.display(self.db, self.builder),
-                        sequent.post.display(self.db, self.builder),
-                    )?;
-                }
+                        Sequent::PairImpossibility { ante1, ante2 } => {
+                            maybe_write_prefix(f)?;
+                            write!(
+                                f,
+                                "{} ∧ {} → false",
+                                ante1.display(self.db, self.builder),
+                                ante2.display(self.db, self.builder),
+                            )?;
+                        }
 
-                for sequent in &self.map.single_implications {
-                    maybe_write_prefix(f)?;
-                    write!(
-                        f,
-                        "{} → {}",
-                        sequent.ante.display(self.db, self.builder),
-                        sequent.post.display(self.db, self.builder)
-                    )?;
+                        Sequent::PairImplication { ante1, ante2, post } => {
+                            maybe_write_prefix(f)?;
+                            write!(
+                                f,
+                                "{} ∧ {} → {}",
+                                ante1.display(self.db, self.builder),
+                                ante2.display(self.db, self.builder),
+                                post.display(self.db, self.builder),
+                            )?;
+                        }
+
+                        Sequent::SingleImplication { ante, post } => {
+                            maybe_write_prefix(f)?;
+                            write!(
+                                f,
+                                "{} → {}",
+                                ante.display(self.db, self.builder),
+                                post.display(self.db, self.builder)
+                            )?;
+                        }
+                    }
                 }
 
                 if first {
@@ -6886,24 +6881,9 @@ impl PathAssignments {
 
         self.discover_constraint(db, builder, assignment.constraint());
 
-        for i in 0..self.map.single_tautologies.len() {
-            let sequent = self.map.single_tautologies[i];
-            self.check_single_tautology(db, builder, sequent)?;
-        }
-
-        for i in 0..self.map.pair_impossibilities.len() {
-            let sequent = self.map.pair_impossibilities[i];
-            self.check_pair_impossibility(db, builder, sequent)?;
-        }
-
-        for i in 0..self.map.pair_implications.len() {
-            let sequent = self.map.pair_implications[i];
-            self.check_pair_implication(db, builder, sequent);
-        }
-
-        for i in 0..self.map.single_implications.len() {
-            let sequent = self.map.single_implications[i];
-            self.check_single_implication(db, builder, sequent);
+        for i in 0..self.map.sequents.len() {
+            let sequent = self.map.sequents[i];
+            self.check_sequent(db, builder, sequent)?;
         }
 
         Ok(())
@@ -6913,18 +6893,40 @@ impl PathAssignments {
         self.assignment_queue.push_back((assignment, new_fuel));
     }
 
+    fn check_sequent<'db>(
+        &mut self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        sequent: Sequent,
+    ) -> Result<(), PathAssignmentConflict> {
+        match sequent {
+            Sequent::SingleTautology { ante } => self.check_single_tautology(db, builder, ante),
+            Sequent::PairImpossibility { ante1, ante2 } => {
+                self.check_pair_impossibility(db, builder, ante1, ante2)
+            }
+            Sequent::PairImplication { ante1, ante2, post } => {
+                self.check_pair_implication(db, builder, ante1, ante2, post);
+                Ok(())
+            }
+            Sequent::SingleImplication { ante, post } => {
+                self.check_single_implication(db, builder, ante, post);
+                Ok(())
+            }
+        }
+    }
+
     fn check_single_tautology<'db>(
         &mut self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
-        sequent: SingleTautology,
+        ante: ConstraintId,
     ) -> Result<(), PathAssignmentConflict> {
-        if self.assignment_holds(sequent.ante.when_false()) {
+        if self.assignment_holds(ante.when_false()) {
             // The sequent map says (ante1) is always true, and the current path asserts that
             // it's false.
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::PathAssignment",
-                ante = %sequent.ante.display(db, builder),
+                ante = %ante.display(db, builder),
                 facts = %format_args!(
                     "[{}]",
                     self.assignments.iter().map(|(assignment, _)| {
@@ -6943,17 +6945,16 @@ impl PathAssignments {
         &mut self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
-        sequent: PairImpossibility,
+        ante1: ConstraintId,
+        ante2: ConstraintId,
     ) -> Result<(), PathAssignmentConflict> {
-        if self.assignment_holds(sequent.ante1.when_true())
-            && self.assignment_holds(sequent.ante2.when_true())
-        {
+        if self.assignment_holds(ante1.when_true()) && self.assignment_holds(ante2.when_true()) {
             // The sequent map says (ante1 ∧ ante2) is an impossible combination, and the
             // current path asserts that both are true.
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::PathAssignment",
-                ante1 = %sequent.ante1.display(db, builder),
-                ante2 = %sequent.ante2.display(db, builder),
+                ante1 = %ante1.display(db, builder),
+                ante2 = %ante2.display(db, builder),
                 facts = %format_args!(
                     "[{}]",
                     self.assignments.iter().map(|(assignment, _)| {
@@ -6972,22 +6973,24 @@ impl PathAssignments {
         &mut self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
-        sequent: PairImplication,
+        ante1: ConstraintId,
+        ante2: ConstraintId,
+        post: ConstraintId,
     ) {
-        let Some(ante1_fuel) = self.max_remaining_fuel_for(sequent.ante1.when_true()) else {
+        let Some(ante1_fuel) = self.max_remaining_fuel_for(ante1.when_true()) else {
             return;
         };
-        let Some(ante2_fuel) = self.max_remaining_fuel_for(sequent.ante2.when_true()) else {
+        let Some(ante2_fuel) = self.max_remaining_fuel_for(ante2.when_true()) else {
             return;
         };
         let available_fuel = ante1_fuel.min(ante2_fuel);
-        let (ante1_constructor_depth, _) = builder.cached_constraint_bound_depth(db, sequent.ante1);
-        let (ante2_constructor_depth, _) = builder.cached_constraint_bound_depth(db, sequent.ante2);
+        let (ante1_constructor_depth, _) = builder.cached_constraint_bound_depth(db, ante1);
+        let (ante2_constructor_depth, _) = builder.cached_constraint_bound_depth(db, ante2);
         let antecedent_constructor_depth = ante1_constructor_depth.max(ante2_constructor_depth);
-        let fuel_cost = builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth);
+        let fuel_cost = builder.sequent_fuel_cost(db, post, antecedent_constructor_depth);
         if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
             self.enqueue_assignment(
-                sequent.post.when_true(),
+                post.when_true(),
                 AssignmentFuel::derived(fuel_cost, post_fuel),
             );
         }
@@ -6997,23 +7000,23 @@ impl PathAssignments {
         &mut self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
-        sequent: SingleImplication,
+        ante: ConstraintId,
+        post: ConstraintId,
     ) {
-        let Some(available_fuel) = self.max_remaining_fuel_for(sequent.ante.when_true()) else {
+        let Some(available_fuel) = self.max_remaining_fuel_for(ante.when_true()) else {
             return;
         };
-        let ante_data = builder.constraint_data(sequent.ante);
-        let (antecedent_constructor_depth, _) =
-            builder.cached_constraint_bound_depth(db, sequent.ante);
-        let post_data = builder.constraint_data(sequent.post);
+        let ante_data = builder.constraint_data(ante);
+        let (antecedent_constructor_depth, _) = builder.cached_constraint_bound_depth(db, ante);
+        let post_data = builder.constraint_data(post);
         let fuel_cost = if post_data.is_bound_projection_of(db, ante_data) {
             1
         } else {
-            builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth)
+            builder.sequent_fuel_cost(db, post, antecedent_constructor_depth)
         };
         if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
             self.enqueue_assignment(
-                sequent.post.when_true(),
+                post.when_true(),
                 AssignmentFuel::derived(fuel_cost, post_fuel),
             );
         }

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -5346,21 +5346,6 @@ impl ConstraintAssignment {
 /// pruned from the search), and new constraints that we can assume to be true even if we haven't
 /// seen them directly.
 ///
-/// We support several kinds of sequent:
-///
-/// - `¬C₁ → false`: This indicates that `C₁` is always true. Any path that assumes it is false is
-///   impossible and can be pruned.
-///
-/// - `C₁ ∧ C₂ → false`: This indicates that `C₁` and `C₂` are disjoint: it is not possible for
-///   both to hold. Any path that assumes both is impossible and can be pruned.
-///
-/// - `C₁ ∧ C₂ → D`: This indicates that the intersection of `C₁` and `C₂` can be simplified to
-///   `D`. Any path that assumes both `C₁` and `C₂` hold, but assumes `D` does _not_, is impossible
-///   and can be pruned.
-///
-/// - `C → D`: This indicates that `C` on its own is enough to imply `D`. Any path that assumes `C`
-///   holds but `D` does _not_ is impossible and can be pruned.
-///
 /// Sequent maps are primarily used when walking a BDD path with a [`PathAssignments`]. The
 /// `PathAssignments` will hold a sequent map containing all of the constraints that are
 /// encountered during the walk. It builds up its sequent map lazily, so that it only has to
@@ -5374,14 +5359,51 @@ impl ConstraintAssignment {
 /// constraint sets.)
 #[derive(Debug, Default)]
 struct SequentMap {
-    /// Sequents of the form `¬C₁ → false`
-    single_tautologies: FxHashSet<ConstraintId>,
-    /// Sequents of the form `C₁ ∧ C₂ → false`
-    pair_impossibilities: FxHashSet<(ConstraintId, ConstraintId)>,
-    /// Sequents of the form `C₁ ∧ C₂ → D`
-    pair_implications: FxIndexMap<(ConstraintId, ConstraintId), FxIndexSet<ConstraintId>>,
-    /// Sequents of the form `C → D`
-    single_implications: FxIndexMap<ConstraintId, FxIndexSet<ConstraintId>>,
+    single_tautologies: Vec<SingleTautology>,
+    pair_impossibilities: Vec<PairImpossibility>,
+    pair_implications: Vec<PairImplication>,
+    single_implications: Vec<SingleImplication>,
+}
+
+/// Sequent of the form `¬C → false`
+///
+/// This indicates that `C` is always true. Any path that assumes it is false is impossible and can
+/// be pruned.
+#[derive(Clone, Copy, Debug)]
+struct SingleTautology {
+    ante: ConstraintId,
+}
+
+/// Sequent of the form `C₁ ∧ C₂ → false`
+///
+/// This indicates that `C₁` and `C₂` are disjoint: it is not possible for both to hold. Any path
+/// that assumes both is impossible and can be pruned.
+#[derive(Clone, Copy, Debug)]
+struct PairImpossibility {
+    ante1: ConstraintId,
+    ante2: ConstraintId,
+}
+
+/// Sequent of the form `C₁ ∧ C₂ → D`
+///
+/// This indicates that if `C₁` and `C₂` are both true, then `D` is guaranteed to be true as well.
+/// For any path that assumes both `C₁` and `C₂` hold, we can add `D` to the path even if it
+/// doesn't appear in the BDD.
+#[derive(Clone, Copy, Debug)]
+struct SingleImplication {
+    ante: ConstraintId,
+    post: ConstraintId,
+}
+
+/// Sequent of the form `C → D`
+///
+/// This indicates that `C` on its own is enough to imply `D`. For any path that assumes `C` holds,
+/// we can add `D` to the path even if it doesn't appear in the BDD.
+#[derive(Clone, Copy, Debug)]
+struct PairImplication {
+    ante1: ConstraintId,
+    ante2: ConstraintId,
+    post: ConstraintId,
 }
 
 impl SequentMap {
@@ -5453,67 +5475,23 @@ impl SequentMap {
 
     /// Merges the sequents from another sequent map into this one.
     fn merge(&mut self, other: &Self) {
-        self.single_tautologies.extend(&other.single_tautologies);
+        self.single_tautologies
+            .extend_from_slice(&other.single_tautologies);
         self.pair_impossibilities
-            .extend(&other.pair_impossibilities);
-        for ((ante1, ante2), post) in &other.pair_implications {
-            self.pair_implications
-                .entry(Self::pair_key(*ante1, *ante2))
-                .or_default()
-                .extend(post);
-        }
-        for (ante, post) in &other.single_implications {
-            self.single_implications
-                .entry(*ante)
-                .or_default()
-                .extend(post);
-        }
+            .extend_from_slice(&other.pair_impossibilities);
+        self.pair_implications
+            .extend_from_slice(&other.pair_implications);
+        self.single_implications
+            .extend_from_slice(&other.single_implications);
     }
 
-    fn pair_key(ante1: ConstraintId, ante2: ConstraintId) -> (ConstraintId, ConstraintId) {
-        if ante1.ordering() < ante2.ordering() {
-            (ante1, ante2)
-        } else {
-            (ante2, ante1)
-        }
+    fn add_single_tautology(&mut self, ante: ConstraintId) {
+        self.single_tautologies.push(SingleTautology { ante });
     }
 
-    fn add_single_tautology<'db>(
-        &mut self,
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
-        ante: ConstraintId,
-    ) {
-        if self.single_tautologies.insert(ante) {
-            tracing::trace!(
-                target: "ty_python_semantic::types::constraints::SequentMap",
-                sequent = %format_args!("¬{} → false", ante.display(db, builder)),
-                "add sequent",
-            );
-        }
-    }
-
-    fn add_pair_impossibility<'db>(
-        &mut self,
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
-        ante1: ConstraintId,
-        ante2: ConstraintId,
-    ) {
-        if self
-            .pair_impossibilities
-            .insert(Self::pair_key(ante1, ante2))
-        {
-            tracing::trace!(
-                target: "ty_python_semantic::types::constraints::SequentMap",
-                sequent = %format_args!(
-                    "{} ∧ {} → false",
-                    ante1.display(db, builder),
-                    ante2.display(db, builder),
-                ),
-                "add sequent",
-            );
-        }
+    fn add_pair_impossibility(&mut self, ante1: ConstraintId, ante2: ConstraintId) {
+        self.pair_impossibilities
+            .push(PairImpossibility { ante1, ante2 });
     }
 
     fn add_pair_implication<'db>(
@@ -5534,7 +5512,7 @@ impl SequentMap {
                 .when_constraint_set_assignable_to_owned(db, post_data.bounds.materialized_upper()),
         );
         if when.is_never_satisfied(db) {
-            self.add_pair_impossibility(db, builder, ante1, ante2);
+            self.add_pair_impossibility(ante1, ante2);
             return;
         }
 
@@ -5542,51 +5520,18 @@ impl SequentMap {
         if ante1.implies(db, builder, post) || ante2.implies(db, builder, post) {
             return;
         }
-        if self
-            .pair_implications
-            .entry(Self::pair_key(ante1, ante2))
-            .or_default()
-            .insert(post)
-        {
-            tracing::trace!(
-                target: "ty_python_semantic::types::constraints::SequentMap",
-                sequent = %format_args!(
-                    "{} ∧ {} → {}",
-                    ante1.display(db, builder),
-                    ante2.display(db, builder),
-                    post.display(db, builder),
-                ),
-                "add sequent",
-            );
-        }
+
+        self.pair_implications
+            .push(PairImplication { ante1, ante2, post });
     }
 
-    fn add_single_implication<'db>(
-        &mut self,
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
-        ante: ConstraintId,
-        post: ConstraintId,
-    ) {
+    fn add_single_implication(&mut self, ante: ConstraintId, post: ConstraintId) {
         if ante == post {
             return;
         }
-        if self
-            .single_implications
-            .entry(ante)
-            .or_default()
-            .insert(post)
-        {
-            tracing::trace!(
-                target: "ty_python_semantic::types::constraints::SequentMap",
-                sequent = %format_args!(
-                    "{} → {}",
-                    ante.display(db, builder),
-                    post.display(db, builder),
-                ),
-                "add sequent",
-            );
-        }
+
+        self.single_implications
+            .push(SingleImplication { ante, post });
     }
 
     fn add_sequents_for_single<'db>(
@@ -5601,7 +5546,7 @@ impl SequentMap {
         let lower = constraint_data.bounds.materialized_lower();
         let upper = constraint_data.bounds.materialized_upper();
         if lower.is_never() && upper.is_object() {
-            self.add_single_tautology(db, builder, constraint);
+            self.add_single_tautology(constraint);
             return;
         }
 
@@ -5710,10 +5655,10 @@ impl SequentMap {
                 Node::Interior(interior) => {
                     let interior = builder.interior_node_data(interior.node());
                     if interior.if_true != ALWAYS_FALSE {
-                        self.add_single_implication(db, builder, constraint, interior.constraint);
+                        self.add_single_implication(constraint, interior.constraint);
                         node = interior.if_true;
                     } else {
-                        self.add_pair_impossibility(db, builder, constraint, interior.constraint);
+                        self.add_pair_impossibility(constraint, interior.constraint);
                         node = interior.if_false;
                     }
                 }
@@ -6428,7 +6373,7 @@ impl SequentMap {
                 right = %right_constraint.display(db, builder),
                 "left implies right",
             );
-            self.add_single_implication(db, builder, left_constraint, right_constraint);
+            self.add_single_implication(left_constraint, right_constraint);
         }
         if builder.cached_constraint_implies(db, right_constraint, left_constraint) {
             tracing::trace!(
@@ -6437,7 +6382,7 @@ impl SequentMap {
                 right = %right_constraint.display(db, builder),
                 "right implies left",
             );
-            self.add_single_implication(db, builder, right_constraint, left_constraint);
+            self.add_single_implication(right_constraint, left_constraint);
         }
 
         match left_constraint.intersect(db, builder, right_constraint) {
@@ -6458,8 +6403,8 @@ impl SequentMap {
                     right_constraint,
                     intersection_constraint,
                 );
-                self.add_single_implication(db, builder, intersection_constraint, left_constraint);
-                self.add_single_implication(db, builder, intersection_constraint, right_constraint);
+                self.add_single_implication(intersection_constraint, left_constraint);
+                self.add_single_implication(intersection_constraint, right_constraint);
             }
 
             // The sequent map only needs to include constraints that might appear in a BDD. If the
@@ -6474,7 +6419,7 @@ impl SequentMap {
                     right = %right_constraint.display(db, builder),
                     "left and right are disjoint",
                 );
-                self.add_pair_impossibility(db, builder, left_constraint, right_constraint);
+                self.add_pair_impossibility(left_constraint, right_constraint);
             }
         }
     }
@@ -6505,43 +6450,35 @@ impl SequentMap {
                     }
                 };
 
-                #[expect(
-                    clippy::iter_over_hash_type,
-                    reason = "this debug-only formatter has no stable ordering contract"
-                )]
-                for (ante1, ante2) in &self.map.pair_impossibilities {
+                for sequent in &self.map.pair_impossibilities {
                     maybe_write_prefix(f)?;
                     write!(
                         f,
                         "{} ∧ {} → false",
-                        ante1.display(self.db, self.builder),
-                        ante2.display(self.db, self.builder),
+                        sequent.ante1.display(self.db, self.builder),
+                        sequent.ante2.display(self.db, self.builder),
                     )?;
                 }
 
-                for ((ante1, ante2), posts) in &self.map.pair_implications {
-                    for post in posts {
-                        maybe_write_prefix(f)?;
-                        write!(
-                            f,
-                            "{} ∧ {} → {}",
-                            ante1.display(self.db, self.builder),
-                            ante2.display(self.db, self.builder),
-                            post.display(self.db, self.builder),
-                        )?;
-                    }
+                for sequent in &self.map.pair_implications {
+                    maybe_write_prefix(f)?;
+                    write!(
+                        f,
+                        "{} ∧ {} → {}",
+                        sequent.ante1.display(self.db, self.builder),
+                        sequent.ante2.display(self.db, self.builder),
+                        sequent.post.display(self.db, self.builder),
+                    )?;
                 }
 
-                for (ante, posts) in &self.map.single_implications {
-                    for post in posts {
-                        maybe_write_prefix(f)?;
-                        write!(
-                            f,
-                            "{} → {}",
-                            ante.display(self.db, self.builder),
-                            post.display(self.db, self.builder)
-                        )?;
-                    }
+                for sequent in &self.map.single_implications {
+                    maybe_write_prefix(f)?;
+                    write!(
+                        f,
+                        "{} → {}",
+                        sequent.ante.display(self.db, self.builder),
+                        sequent.post.display(self.db, self.builder)
+                    )?;
                 }
 
                 if first {
@@ -6887,17 +6824,13 @@ impl PathAssignments {
 
         self.discover_constraint(db, builder, assignment.constraint());
 
-        #[expect(
-            clippy::iter_over_hash_type,
-            reason = "any matching tautology yields the same conflict result"
-        )]
-        for ante in &self.map.single_tautologies {
-            if self.assignment_holds(ante.when_false()) {
+        for sequent in &self.map.single_tautologies {
+            if self.assignment_holds(sequent.ante.when_false()) {
                 // The sequent map says (ante1) is always true, and the current path asserts that
                 // it's false.
                 tracing::trace!(
                     target: "ty_python_semantic::types::constraints::PathAssignment",
-                    ante = %ante.display(db, builder),
+                    ante = %sequent.ante.display(db, builder),
                     facts = %format_args!(
                         "[{}]",
                         self.assignments.iter().map(|(assignment, _)| {
@@ -6910,19 +6843,16 @@ impl PathAssignments {
             }
         }
 
-        #[expect(
-            clippy::iter_over_hash_type,
-            reason = "any matching impossibility yields the same conflict result"
-        )]
-        for (ante1, ante2) in &self.map.pair_impossibilities {
-            if self.assignment_holds(ante1.when_true()) && self.assignment_holds(ante2.when_true())
+        for sequent in &self.map.pair_impossibilities {
+            if self.assignment_holds(sequent.ante1.when_true())
+                && self.assignment_holds(sequent.ante2.when_true())
             {
                 // The sequent map says (ante1 ∧ ante2) is an impossible combination, and the
                 // current path asserts that both are true.
                 tracing::trace!(
                     target: "ty_python_semantic::types::constraints::PathAssignment",
-                    ante1 = %ante1.display(db, builder),
-                    ante2 = %ante2.display(db, builder),
+                    ante1 = %sequent.ante1.display(db, builder),
+                    ante2 = %sequent.ante2.display(db, builder),
                     facts = %format_args!(
                         "[{}]",
                         self.assignments.iter().map(|(assignment, _)| {
@@ -6952,39 +6882,38 @@ impl PathAssignments {
             }
         };
 
-        for ((ante1, ante2), posts) in &self.map.pair_implications {
-            let Some(ante1_fuel) = self.fuel_for(ante1.when_true()) else {
+        for sequent in &self.map.pair_implications {
+            let Some(ante1_fuel) = self.fuel_for(sequent.ante1.when_true()) else {
                 continue;
             };
-            let Some(ante2_fuel) = self.fuel_for(ante2.when_true()) else {
+            let Some(ante2_fuel) = self.fuel_for(sequent.ante2.when_true()) else {
                 continue;
             };
             let available_fuel = ante1_fuel.min(ante2_fuel);
-            let (ante1_constructor_depth, _) = builder.cached_constraint_bound_depth(db, *ante1);
-            let (ante2_constructor_depth, _) = builder.cached_constraint_bound_depth(db, *ante2);
+            let (ante1_constructor_depth, _) =
+                builder.cached_constraint_bound_depth(db, sequent.ante1);
+            let (ante2_constructor_depth, _) =
+                builder.cached_constraint_bound_depth(db, sequent.ante2);
             let antecedent_constructor_depth = ante1_constructor_depth.max(ante2_constructor_depth);
-            for post in posts {
-                let fuel_cost = builder.sequent_fuel_cost(db, *post, antecedent_constructor_depth);
-                add_new_constraint(*post, available_fuel, fuel_cost);
-            }
+            let fuel_cost =
+                builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth);
+            add_new_constraint(sequent.post, available_fuel, fuel_cost);
         }
 
-        for (ante, posts) in &self.map.single_implications {
-            let Some(available_fuel) = self.fuel_for(ante.when_true()) else {
+        for sequent in &self.map.single_implications {
+            let Some(available_fuel) = self.fuel_for(sequent.ante.when_true()) else {
                 continue;
             };
-            let ante_data = builder.constraint_data(*ante);
+            let ante_data = builder.constraint_data(sequent.ante);
             let (antecedent_constructor_depth, _) =
-                builder.cached_constraint_bound_depth(db, *ante);
-            for post in posts {
-                let post_data = builder.constraint_data(*post);
-                let fuel_cost = if post_data.is_bound_projection_of(db, ante_data) {
-                    1
-                } else {
-                    builder.sequent_fuel_cost(db, *post, antecedent_constructor_depth)
-                };
-                add_new_constraint(*post, available_fuel, fuel_cost);
-            }
+                builder.cached_constraint_bound_depth(db, sequent.ante);
+            let post_data = builder.constraint_data(sequent.post);
+            let fuel_cost = if post_data.is_bound_projection_of(db, ante_data) {
+                1
+            } else {
+                builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth)
+            };
+            add_new_constraint(sequent.post, available_fuel, fuel_cost);
         }
 
         for (new_constraint, (available_fuel, fuel_cost)) in new_constraints {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -5382,20 +5382,20 @@ enum Sequent {
         ante2: ConstraintId,
     },
 
-    /// Sequent of the form `C₁ ∧ C₂ → D`
+    /// Sequent of the form `C → D`
     ///
-    /// This indicates that if `C₁` and `C₂` are both true, then `D` is guaranteed to be true as
-    /// well. For any path that assumes both `C₁` and `C₂` hold, we can add `D` to the path even if
-    /// it doesn't appear in the BDD.
+    /// This indicates that `C` on its own is enough to imply `D`. For any path that assumes `C`
+    /// holds, we can add `D` to the path even if it doesn't appear in the BDD.
     SingleImplication {
         ante: ConstraintId,
         post: ConstraintId,
     },
 
-    /// Sequent of the form `C → D`
+    /// Sequent of the form `C₁ ∧ C₂ → D`
     ///
-    /// This indicates that `C` on its own is enough to imply `D`. For any path that assumes `C`
-    /// holds, we can add `D` to the path even if it doesn't appear in the BDD.
+    /// This indicates that if `C₁` and `C₂` are both true, then `D` is guaranteed to be true as
+    /// well. For any path that assumes both `C₁` and `C₂` hold, we can add `D` to the path even if
+    /// it doesn't appear in the BDD.
     PairImplication {
         ante1: ConstraintId,
         ante2: ConstraintId,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -5470,11 +5470,6 @@ impl SequentMap {
         Ref::map(storage, |storage| &storage.pair_sequent_cache[&key])
     }
 
-    /// Merges the sequents from another sequent map into this one.
-    fn merge(&mut self, other: &Self) {
-        self.sequents.extend_from_slice(&other.sequents);
-    }
-
     fn add_single_tautology(&mut self, ante: ConstraintId) {
         self.sequents.push(Sequent::SingleTautology { ante });
     }
@@ -6521,7 +6516,8 @@ impl SequentMap {
 /// constraint that we are currently considering.
 #[derive(Debug)]
 pub(crate) struct PathAssignments {
-    map: SequentMap,
+    /// All of the rules that we know for inferring derived constraints on the current path.
+    sequents: Vec<Sequent>,
     /// Each assignment's source order and the first per-path fuel value with which it was derived.
     assignments: FxIndexMap<ConstraintAssignment, (usize, AssignmentFuel)>,
     /// Additional per-path fuel values that can derive an assignment, keyed by its index in
@@ -6586,7 +6582,7 @@ impl PathAssignments {
             .map(|constraint| (constraint, false))
             .collect();
         Self {
-            map: SequentMap::default(),
+            sequents: Vec::default(),
             assignments: FxIndexMap::default(),
             additional_fuels: Vec::default(),
             discovered,
@@ -6731,12 +6727,12 @@ impl PathAssignments {
         }
 
         let single_map = SequentMap::for_constraint(db, builder, constraint);
-        self.map.merge(&single_map);
+        self.sequents.extend_from_slice(&single_map.sequents);
         drop(single_map);
 
         for existing in self.discovered.keys().dropping_back(1) {
             let pair_map = SequentMap::for_constraint_pair(db, builder, *existing, constraint);
-            self.map.merge(&pair_map);
+            self.sequents.extend_from_slice(&pair_map.sequents);
         }
     }
 
@@ -6881,8 +6877,8 @@ impl PathAssignments {
 
         self.discover_constraint(db, builder, assignment.constraint());
 
-        for i in 0..self.map.sequents.len() {
-            let sequent = self.map.sequents[i];
+        for i in 0..self.sequents.len() {
+            let sequent = self.sequents[i];
             self.check_sequent(db, builder, sequent)?;
         }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -825,7 +825,7 @@ pub(crate) struct ConstraintSetBuilder<'db> {
     storage: RefCell<ConstraintSetStorage<'db>>,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, get_size2::GetSize)]
+#[derive(Debug, Default)]
 struct ConstraintSetStorage<'db> {
     /// Compacted owned storage overlaid onto this builder. This is used by
     /// [`OwnedConstraintSet::query`] to create a [`ConstraintSetBuilder`] that is initially a
@@ -869,7 +869,6 @@ struct ConstraintSetStorage<'db> {
     or_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
     and_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
     exists_cache: FxHashMap<(NodeId, InferableTypeVars<'db>), NodeId>,
-    retain_one_cache: FxHashMap<(NodeId, BoundTypeVarIdentity<'db>), NodeId>,
     restrict_one_cache: FxHashMap<(NodeId, ConstraintAssignment), (NodeId, bool)>,
     simplify_cache: FxHashMap<NodeId, NodeId>,
 
@@ -5373,7 +5372,7 @@ impl ConstraintAssignment {
 /// new constraint, and then merges those cached sequents into its own sequent map. (That means we
 /// also share the work of calculating the sequent map across `PathAssignments` for _different_
 /// constraint sets.)
-#[derive(Clone, Debug, Default, Eq, PartialEq, get_size2::GetSize)]
+#[derive(Debug, Default)]
 struct SequentMap {
     /// Sequents of the form `¬C₁ → false`
     single_tautologies: FxHashSet<ConstraintId>,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -6846,85 +6846,24 @@ impl PathAssignments {
 
         self.discover_constraint(db, builder, assignment.constraint());
 
-        for sequent in &self.map.single_tautologies {
-            if self.assignment_holds(sequent.ante.when_false()) {
-                // The sequent map says (ante1) is always true, and the current path asserts that
-                // it's false.
-                tracing::trace!(
-                    target: "ty_python_semantic::types::constraints::PathAssignment",
-                    ante = %sequent.ante.display(db, builder),
-                    facts = %format_args!(
-                        "[{}]",
-                        self.assignments.iter().map(|(assignment, _)| {
-                            assignment.display(db, builder)
-                        }).format(", "),
-                    ),
-                    "found contradiction",
-                );
-                return Err(PathAssignmentConflict);
-            }
+        for i in 0..self.map.single_tautologies.len() {
+            let sequent = self.map.single_tautologies[i];
+            self.check_single_tautology(db, builder, sequent)?;
         }
 
-        for sequent in &self.map.pair_impossibilities {
-            if self.assignment_holds(sequent.ante1.when_true())
-                && self.assignment_holds(sequent.ante2.when_true())
-            {
-                // The sequent map says (ante1 ∧ ante2) is an impossible combination, and the
-                // current path asserts that both are true.
-                tracing::trace!(
-                    target: "ty_python_semantic::types::constraints::PathAssignment",
-                    ante1 = %sequent.ante1.display(db, builder),
-                    ante2 = %sequent.ante2.display(db, builder),
-                    facts = %format_args!(
-                        "[{}]",
-                        self.assignments.iter().map(|(assignment, _)| {
-                            assignment.display(db, builder)
-                        }).format(", "),
-                    ),
-                    "found contradiction",
-                );
-                return Err(PathAssignmentConflict);
-            }
+        for i in 0..self.map.pair_impossibilities.len() {
+            let sequent = self.map.pair_impossibilities[i];
+            self.check_pair_impossibility(db, builder, sequent)?;
         }
 
         for i in 0..self.map.pair_implications.len() {
             let sequent = self.map.pair_implications[i];
-            let Some(ante1_fuel) = self.fuel_for(sequent.ante1.when_true()) else {
-                continue;
-            };
-            let Some(ante2_fuel) = self.fuel_for(sequent.ante2.when_true()) else {
-                continue;
-            };
-            let available_fuel = ante1_fuel.min(ante2_fuel);
-            let (ante1_constructor_depth, _) =
-                builder.cached_constraint_bound_depth(db, sequent.ante1);
-            let (ante2_constructor_depth, _) =
-                builder.cached_constraint_bound_depth(db, sequent.ante2);
-            let antecedent_constructor_depth = ante1_constructor_depth.max(ante2_constructor_depth);
-            let fuel_cost =
-                builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth);
-            if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
-                self.enqueue_assignment(sequent.post.when_true(), Some(fuel_cost), post_fuel);
-            }
+            self.check_pair_implication(db, builder, sequent);
         }
 
         for i in 0..self.map.single_implications.len() {
             let sequent = self.map.single_implications[i];
-            let Some(available_fuel) = self.fuel_for(sequent.ante.when_true()) else {
-                continue;
-            };
-            let ante_data = builder.constraint_data(sequent.ante);
-            let (antecedent_constructor_depth, _) =
-                builder.cached_constraint_bound_depth(db, sequent.ante);
-            let post_data = builder.constraint_data(sequent.post);
-            let fuel_cost = if post_data.is_bound_projection_of(db, ante_data) {
-                1
-            } else {
-                builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth)
-            };
-            if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
-                self.enqueue_assignment(sequent.post.when_true(), Some(fuel_cost), post_fuel);
-            }
+            self.check_single_implication(db, builder, sequent);
         }
 
         Ok(())
@@ -6949,6 +6888,106 @@ impl PathAssignments {
                 );
             })
             .or_insert(new_fuel);
+    }
+
+    fn check_single_tautology<'db>(
+        &mut self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        sequent: SingleTautology,
+    ) -> Result<(), PathAssignmentConflict> {
+        if self.assignment_holds(sequent.ante.when_false()) {
+            // The sequent map says (ante1) is always true, and the current path asserts that
+            // it's false.
+            tracing::trace!(
+                target: "ty_python_semantic::types::constraints::PathAssignment",
+                ante = %sequent.ante.display(db, builder),
+                facts = %format_args!(
+                    "[{}]",
+                    self.assignments.iter().map(|(assignment, _)| {
+                        assignment.display(db, builder)
+                    }).format(", "),
+                ),
+                "found contradiction",
+            );
+            return Err(PathAssignmentConflict);
+        }
+
+        Ok(())
+    }
+
+    fn check_pair_impossibility<'db>(
+        &mut self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        sequent: PairImpossibility,
+    ) -> Result<(), PathAssignmentConflict> {
+        if self.assignment_holds(sequent.ante1.when_true())
+            && self.assignment_holds(sequent.ante2.when_true())
+        {
+            // The sequent map says (ante1 ∧ ante2) is an impossible combination, and the
+            // current path asserts that both are true.
+            tracing::trace!(
+                target: "ty_python_semantic::types::constraints::PathAssignment",
+                ante1 = %sequent.ante1.display(db, builder),
+                ante2 = %sequent.ante2.display(db, builder),
+                facts = %format_args!(
+                    "[{}]",
+                    self.assignments.iter().map(|(assignment, _)| {
+                        assignment.display(db, builder)
+                    }).format(", "),
+                ),
+                "found contradiction",
+            );
+            return Err(PathAssignmentConflict);
+        }
+
+        Ok(())
+    }
+
+    fn check_pair_implication<'db>(
+        &mut self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        sequent: PairImplication,
+    ) {
+        let Some(ante1_fuel) = self.fuel_for(sequent.ante1.when_true()) else {
+            return;
+        };
+        let Some(ante2_fuel) = self.fuel_for(sequent.ante2.when_true()) else {
+            return;
+        };
+        let available_fuel = ante1_fuel.min(ante2_fuel);
+        let (ante1_constructor_depth, _) = builder.cached_constraint_bound_depth(db, sequent.ante1);
+        let (ante2_constructor_depth, _) = builder.cached_constraint_bound_depth(db, sequent.ante2);
+        let antecedent_constructor_depth = ante1_constructor_depth.max(ante2_constructor_depth);
+        let fuel_cost = builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth);
+        if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
+            self.enqueue_assignment(sequent.post.when_true(), Some(fuel_cost), post_fuel);
+        }
+    }
+
+    fn check_single_implication<'db>(
+        &mut self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        sequent: SingleImplication,
+    ) {
+        let Some(available_fuel) = self.fuel_for(sequent.ante.when_true()) else {
+            return;
+        };
+        let ante_data = builder.constraint_data(sequent.ante);
+        let (antecedent_constructor_depth, _) =
+            builder.cached_constraint_bound_depth(db, sequent.ante);
+        let post_data = builder.constraint_data(sequent.post);
+        let fuel_cost = if post_data.is_bound_projection_of(db, ante_data) {
+            1
+        } else {
+            builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth)
+        };
+        if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
+            self.enqueue_assignment(sequent.post.when_true(), Some(fuel_cost), post_fuel);
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -6539,6 +6539,9 @@ pub(crate) struct PathAssignments {
     /// ensures a stable order for all of the derived constraints that we create, while still
     /// letting us create them lazily.)
     discovered: FxIndexMap<ConstraintId, bool>,
+    /// Derived assignments that have been queued up to add because of the most recent BDD
+    /// assignment
+    assignment_queue: FxIndexMap<ConstraintAssignment, (Option<u16>, u16)>,
 }
 
 impl PathAssignments {
@@ -6557,6 +6560,7 @@ impl PathAssignments {
             additional_fuels: FxIndexSet::default(),
             discovered,
             remaining_overall_fuel: OVERALL_FUEL_BUDGET,
+            assignment_queue: FxIndexMap::default(),
         }
     }
 
@@ -6614,17 +6618,14 @@ impl PathAssignments {
             edge = %assignment.display(db, builder),
             "walk edge",
         );
-        let found_conflict = self.add_assignment(
-            db,
-            builder,
-            assignment,
-            source_order,
-            None,
-            PATH_FUEL_BUDGET,
-        );
+        debug_assert!(self.assignment_queue.is_empty());
+        self.enqueue_assignment(assignment, None, PATH_FUEL_BUDGET);
+        let found_conflict = self.drain_assignment_queue(db, builder, source_order);
         let result = if found_conflict.is_err() {
             // If that results in the path now being impossible due to a contradiction, return
-            // without invoking the callback.
+            // without invoking the callback, and clear any other assignments that were enqueued to
+            // be added to the path.
+            self.assignment_queue.clear();
             None
         } else {
             // Otherwise invoke the callback to keep traversing the BDD. The callback will likely
@@ -6711,6 +6712,27 @@ impl PathAssignments {
             let pair_map = SequentMap::for_constraint_pair(db, builder, *existing, constraint);
             self.map.merge(&pair_map);
         }
+    }
+
+    fn drain_assignment_queue<'db>(
+        &mut self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        source_order: usize,
+    ) -> Result<(), PathAssignmentConflict> {
+        while let Some((assignment, (derived_fuel_cost, path_fuel))) =
+            self.assignment_queue.shift_remove_index(0)
+        {
+            self.add_assignment(
+                db,
+                builder,
+                assignment,
+                source_order,
+                derived_fuel_cost,
+                path_fuel,
+            )?;
+        }
+        Ok(())
     }
 
     /// Adds a new assignment, along with any derived information that we can infer from the new
@@ -6865,24 +6887,8 @@ impl PathAssignments {
             }
         }
 
-        let mut new_constraints: FxIndexMap<ConstraintId, (u16, u16)> = FxIndexMap::default();
-        let mut add_new_constraint = |constraint, available_fuel: u16, fuel_cost: u16| {
-            if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
-                let new_fuel = (post_fuel, fuel_cost);
-                new_constraints
-                    .entry(constraint)
-                    .and_modify(|existing_fuel| {
-                        *existing_fuel = std::cmp::max_by_key(
-                            *existing_fuel,
-                            new_fuel,
-                            |&(post_fuel, fuel_cost)| (post_fuel, std::cmp::Reverse(fuel_cost)),
-                        );
-                    })
-                    .or_insert(new_fuel);
-            }
-        };
-
-        for sequent in &self.map.pair_implications {
+        for i in 0..self.map.pair_implications.len() {
+            let sequent = self.map.pair_implications[i];
             let Some(ante1_fuel) = self.fuel_for(sequent.ante1.when_true()) else {
                 continue;
             };
@@ -6897,10 +6903,13 @@ impl PathAssignments {
             let antecedent_constructor_depth = ante1_constructor_depth.max(ante2_constructor_depth);
             let fuel_cost =
                 builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth);
-            add_new_constraint(sequent.post, available_fuel, fuel_cost);
+            if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
+                self.enqueue_assignment(sequent.post.when_true(), Some(fuel_cost), post_fuel);
+            }
         }
 
-        for sequent in &self.map.single_implications {
+        for i in 0..self.map.single_implications.len() {
+            let sequent = self.map.single_implications[i];
             let Some(available_fuel) = self.fuel_for(sequent.ante.when_true()) else {
                 continue;
             };
@@ -6913,21 +6922,33 @@ impl PathAssignments {
             } else {
                 builder.sequent_fuel_cost(db, sequent.post, antecedent_constructor_depth)
             };
-            add_new_constraint(sequent.post, available_fuel, fuel_cost);
-        }
-
-        for (new_constraint, (available_fuel, fuel_cost)) in new_constraints {
-            self.add_assignment(
-                db,
-                builder,
-                new_constraint.when_true(),
-                source_order,
-                Some(fuel_cost),
-                available_fuel,
-            )?;
+            if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
+                self.enqueue_assignment(sequent.post.when_true(), Some(fuel_cost), post_fuel);
+            }
         }
 
         Ok(())
+    }
+
+    fn enqueue_assignment(
+        &mut self,
+        assignment: ConstraintAssignment,
+        derived_fuel_cost: Option<u16>,
+        path_fuel: u16,
+    ) {
+        let new_fuel = (derived_fuel_cost, path_fuel);
+        self.assignment_queue
+            .entry(assignment)
+            .and_modify(|existing_fuel| {
+                *existing_fuel = std::cmp::max_by_key(
+                    *existing_fuel,
+                    new_fuel,
+                    |&(derived_fuel_cost, path_fuel)| {
+                        (path_fuel, std::cmp::Reverse(derived_fuel_cost))
+                    },
+                );
+            })
+            .or_insert(new_fuel);
     }
 }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -6519,21 +6519,27 @@ pub(crate) struct PathAssignments {
     /// All of the rules that we know for inferring derived constraints on the current path.
     sequents: Vec<Sequent>,
     /// Each assignment's source order and the first per-path fuel value with which it was derived.
-    assignments: FxIndexMap<ConstraintAssignment, (usize, AssignmentFuel)>,
+    assignments: FxIndexMap<ConstraintAssignment, (usize, u16)>,
     /// Additional per-path fuel values that can derive an assignment, keyed by its index in
     /// `assignments`. These are stored separately so that branch-local additions can be rolled
     /// back by truncating the set. Only the greatest fuel value participates in further
     /// derivation.
-    additional_fuels: Vec<(usize, AssignmentFuel)>,
+    additional_fuels: Vec<(usize, u16)>,
     /// The amount of global fuel that remains across all assignments and paths.
     remaining_overall_fuel: u16,
     /// Constraints that we have discovered, mapped to whether we have processed them yet. (This
     /// ensures a stable order for all of the derived constraints that we create, while still
     /// letting us create them lazily.)
     discovered: FxIndexMap<ConstraintId, bool>,
-    /// Derived assignments that have been queued up to add because of the most recent BDD
-    /// assignment
+
+    /// Derived assignments that have been queued up to be added to the current path.
     assignment_queue: VecDeque<(ConstraintAssignment, AssignmentFuel)>,
+
+    /// The next chunk of derived assignments that have been queued up to add to the current path.
+    /// If we derive the same assignment multiple times, we keep the derivation that lets us make
+    /// the most additional progress (more remaining fuel for this derivation chain, less overall
+    /// fuel consumed).
+    new_assignments: FxIndexMap<ConstraintAssignment, AssignmentFuel>,
 }
 
 /// The total amount of fuel that we are willing to spend for this path traversal. This was
@@ -6546,7 +6552,7 @@ const OVERALL_FUEL_BUDGET: u16 = 256;
 const PATH_FUEL_BUDGET: u16 = 8;
 
 /// The fuel cost of deriving a particular assignment during BDD path walking.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct AssignmentFuel {
     /// The amount of fuel consumed when deriving the assignment, or None if this assignment came
     /// directly from the BDD
@@ -6575,6 +6581,20 @@ impl AssignmentFuel {
     }
 }
 
+impl PartialOrd for AssignmentFuel {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AssignmentFuel {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let self_key = (self.remaining, std::cmp::Reverse(self.consumed));
+        let other_key = (other.remaining, std::cmp::Reverse(other.consumed));
+        self_key.cmp(&other_key)
+    }
+}
+
 impl PathAssignments {
     fn new(constraints: impl IntoIterator<Item = ConstraintId>) -> Self {
         let discovered = constraints
@@ -6588,6 +6608,7 @@ impl PathAssignments {
             discovered,
             remaining_overall_fuel: OVERALL_FUEL_BUDGET,
             assignment_queue: VecDeque::default(),
+            new_assignments: FxIndexMap::default(),
         }
     }
 
@@ -6641,7 +6662,8 @@ impl PathAssignments {
             "walk edge",
         );
         debug_assert!(self.assignment_queue.is_empty());
-        self.enqueue_assignment(assignment, AssignmentFuel::origin());
+        self.assignment_queue
+            .push_back((assignment, AssignmentFuel::origin()));
         let found_conflict = self.drain_assignment_queue(db, builder, source_order);
         let result = if found_conflict.is_err() {
             // If that results in the path now being impossible due to a contradiction, return
@@ -6703,8 +6725,8 @@ impl PathAssignments {
             .additional_fuels
             .iter()
             .filter(|(fuel_index, _)| *fuel_index == index)
-            .map(|(_, fuel)| fuel.remaining)
-            .fold(first_fuel.remaining, u16::max);
+            .map(|(_, fuel)| *fuel)
+            .fold(*first_fuel, u16::max);
         Some(max_fuel)
     }
 
@@ -6771,7 +6793,8 @@ impl PathAssignments {
             // derive any additional information from the sequent map. We still want to record the
             // assignment, but as an optimization we can return early without actually querying the
             // sequent map.
-            self.assignments.insert(assignment, (source_order, fuel));
+            self.assignments
+                .insert(assignment, (source_order, fuel.remaining));
             return Ok(());
         }
 
@@ -6800,7 +6823,7 @@ impl PathAssignments {
                             None => return Ok(()),
                         };
                 }
-                entry.insert((source_order, fuel));
+                entry.insert((source_order, fuel.remaining));
             }
 
             Entry::Occupied(mut entry) => {
@@ -6823,43 +6846,23 @@ impl PathAssignments {
                 // there might be some consequents that were skipped previously due to a lack of
                 // fuel, that can be added now because of the replinished fuel budget.
 
-                // There is no need to replenish the fuel for this derivation if there is already
-                // an existing derivation whose fuel "dominates" (it both consumes as much fuel,
-                // and provides at least as much remaining fuel).
-                let existing_fuels = self
-                    .additional_fuels
-                    .iter()
-                    .filter(|(fuel_index, _)| *fuel_index == index);
-                let max_existing_remaining_fuel = existing_fuels
-                    .clone()
-                    .map(|(_, fuel)| fuel.remaining)
-                    .fold(existing_fuel.remaining, u16::max);
-                let max_existing_consumed_fuel = existing_fuels
-                    .clone()
-                    .filter_map(|(_, fuel)| fuel.consumed)
-                    .fold(existing_fuel.consumed.unwrap_or(0), u16::max);
-                if max_existing_remaining_fuel >= fuel.remaining
-                    && max_existing_consumed_fuel >= fuel.consumed.unwrap_or(0)
+                // There is another derivation of this assignment that already provides at least as
+                // much fuel as this constraint. That means replenishing the fuel won't have any
+                // effect.
+                if *existing_fuel >= fuel.remaining
+                    || self
+                        .additional_fuels
+                        .iter()
+                        .any(|(fuel_index, existing_fuel)| {
+                            *fuel_index == index && *existing_fuel >= fuel.remaining
+                        })
                 {
                     return Ok(());
                 }
 
-                // If this derivation of this assignment consumes more fuel than the other
-                // derivations that we've seen, we need to update the overall fuel consumed for
-                // this assignment.
-                if let Some(consumed) = fuel.consumed
-                    && let Some(delta) = consumed.checked_sub(max_existing_consumed_fuel)
-                {
-                    self.remaining_overall_fuel =
-                        match self.remaining_overall_fuel.checked_sub(delta) {
-                            Some(updated_fuel) => updated_fuel,
-                            None => return Ok(()),
-                        };
-                }
-
                 // Record the replenished fuel separately so that `walk_edge` can restore the
                 // parent branch by truncating `additional_fuels`.
-                self.additional_fuels.push((index, fuel));
+                self.additional_fuels.push((index, fuel.remaining));
             }
         }
 
@@ -6875,6 +6878,7 @@ impl PathAssignments {
         // don't anticipate the sequent maps to be very large. We might consider avoiding the
         // brute-force search.
 
+        self.new_assignments.clear();
         self.discover_constraint(db, builder, assignment.constraint());
 
         for i in 0..self.sequents.len() {
@@ -6882,11 +6886,20 @@ impl PathAssignments {
             self.check_sequent(db, builder, sequent)?;
         }
 
+        // If we were able to derive any new assignments from this one, add them to the processing
+        // queue.
+        self.assignment_queue.extend(self.new_assignments.drain(..));
+
         Ok(())
     }
 
     fn enqueue_assignment(&mut self, assignment: ConstraintAssignment, new_fuel: AssignmentFuel) {
-        self.assignment_queue.push_back((assignment, new_fuel));
+        self.new_assignments
+            .entry(assignment)
+            .and_modify(|existing_fuel| {
+                *existing_fuel = std::cmp::max(*existing_fuel, new_fuel);
+            })
+            .or_insert(new_fuel);
     }
 
     fn check_sequent<'db>(


### PR DESCRIPTION
This is a pure refactoring (nervously watches CI) that tightens up our BDD path walking code. There should be no behavioral changes.

- Several hash sets and maps have been replaced with simple Vecs. We're getting all of the deduplication we need by caching the results of `SequentMap::for_constraint` and `for_constraint_pair`. Within each per-constraint and per-pair sequent map shard, we're not seeing any duplicate constraints that require the overhead of a set/map.

- Instead of using the call stack in `add_assignment` to handle chains of multiple derived facts, we switch to an explicit trampoline. The call stacks aren't deep enough for us to be worried about stack overflows, but this will play more nicely with the eventual goal of adding [scoped quantifiers](https://gist.github.com/dcreager/679132607be4c7cfb08ddc8ad1076982#8-visitor-driven-path-traversal) to the constraint set structure.