### PR TITLE
[`flake8-implicit-str-concat`] Stabilize `implicit-string-concatenation-in-collection-literal` (`ISC004`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/collection_literal.rs
+++ b/crates/ruff_linter/src/rules/flake8_implicit_str_concat/rules/collection_literal.rs
@@ -49,9 +49,9 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// ## Fix safety
 /// The fix is safe in that it does not change the semantics of your code.
 /// However, the issue is that you may often want to change semantics
-/// by adding a missing comma.
+/// by adding a missing comma. Thus, the fix is always marked as unsafe.
 #[derive(ViolationMetadata)]
-#[violation_metadata(preview_since = "0.14.10")]
+#[violation_metadata(stable_since = "NEXT_RUFF_VERSION")]
 pub(crate) struct ImplicitStringConcatenationInCollectionLiteral;
 
 impl Violation for ImplicitStringConcatenationInCollectionLiteral {


### PR DESCRIPTION
Small tweak to the docs but otherwise looked good