### PR TITLE
[`refurb`] Stabilize `unnecessary-from-float` (`FURB164`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB164.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB164.py
@@ -75,3 +75,8 @@ _ = (
     # text
     .from_float(4.2)
 )
+
+_ = Decimal.from_float(
+    # keep this comment
+    float("inf")
+)

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_from_float.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_from_float.rs
@@ -61,7 +61,7 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 /// - [Python documentation: `decimal`](https://docs.python.org/3/library/decimal.html)
 /// - [Python documentation: `fractions`](https://docs.python.org/3/library/fractions.html)
 #[derive(ViolationMetadata)]
-#[violation_metadata(preview_since = "v0.3.5")]
+#[violation_metadata(stable_since = "NEXT_RUFF_VERSION")]
 pub(crate) struct UnnecessaryFromFloat {
     method_name: MethodName,
     constructor: Constructor,
@@ -134,6 +134,7 @@ pub(crate) fn unnecessary_from_float(checker: &Checker, call: &ExprCall) {
     };
 
     let constructor_name = checker.locator().slice(&**value).to_string();
+    let has_comments = checker.comment_ranges().intersects(call.range());
 
     // Special case for non-finite float literals: Decimal.from_float(float("inf")) -> Decimal("inf")
     if let Some(replacement) = handle_non_finite_float_special_case(
@@ -144,7 +145,14 @@ pub(crate) fn unnecessary_from_float(checker: &Checker, call: &ExprCall) {
         &constructor_name,
         checker,
     ) {
-        diagnostic.set_fix(Fix::safe_edit(replacement));
+        diagnostic.set_fix(Fix::applicable_edit(
+            replacement,
+            if has_comments {
+                Applicability::Unsafe
+            } else {
+                Applicability::Safe
+            },
+        ));
         return;
     }
 
@@ -152,7 +160,7 @@ pub(crate) fn unnecessary_from_float(checker: &Checker, call: &ExprCall) {
     let is_type_safe = is_valid_argument_type(arg_value, method_name, constructor, checker);
 
     // Determine fix safety
-    let applicability = if is_type_safe && !checker.comment_ranges().intersects(call.range()) {
+    let applicability = if is_type_safe && !has_comments {
         Applicability::Safe
     } else {
         Applicability::Unsafe

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB164_FURB164.py.snap
@@ -687,3 +687,26 @@ help: Replace with `Fraction` constructor
 75 | )
    |
 note: This is an unsafe fix and may change runtime behavior
+
+FURB164 [*] Verbose method `from_float` in `Decimal` construction
+  --> FURB164.py:79:5
+   |
+77 |   )
+78 |
+79 |   _ = Decimal.from_float(
+   |  _____^
+80 | |     # keep this comment
+81 | |     float("inf")
+82 | | )
+   | |_^
+   |
+help: Replace with `Decimal` constructor
+   |
+78 |
+   - _ = Decimal.from_float(
+   -     # keep this comment
+   -     float("inf")
+   - )
+79 + _ = Decimal("inf")
+   |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Codex noticed a fix safety bug where comments could be deleted in a safe fix branch, so I fixed that
too. Docs and tests looked good

```py
from decimal import Decimal

_ = Decimal.from_float(
    # keep this comment
    float("inf")
)
```

[Playground](https://play.ruff.rs/1016fd80-d170-4765-9856-c5b5f6b7fdeb)
