### PR TITLE
[ty] Quantify receiver TypeVars over their binding domains

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -212,7 +212,7 @@ static TANJUN: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    110,
+    128,
 );
 
 static STATIC_FRAME: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -297,6 +297,40 @@ def expects_str_return(c: Callable[[int | str], str]) -> None:
 expects_str_return(wide_return_converter)
 ```
 
+## Overloaded callable parameter compatibility
+
+Aggregating overloads must preserve whether the target parameter accepts keywords, and the keyword
+name that callers can use.
+
+```pyi
+from typing import Protocol, overload
+
+class KeywordCallable(Protocol):
+    def __call__(self, value: int | str) -> int | str: ...
+
+class MatchingKeywords:
+    @overload
+    def __call__(self, value: int) -> int: ...
+    @overload
+    def __call__(self, value: str) -> str: ...
+
+class WrongKeywords:
+    @overload
+    def __call__(self, left: int) -> int: ...
+    @overload
+    def __call__(self, right: str) -> str: ...
+
+class PositionalOnly:
+    @overload
+    def __call__(self, value: int, /) -> int: ...
+    @overload
+    def __call__(self, value: str, /) -> str: ...
+
+matching_keywords: KeywordCallable = MatchingKeywords()
+wrong_keywords: KeywordCallable = WrongKeywords()  # error: [invalid-assignment]
+positional_only: KeywordCallable = PositionalOnly()  # error: [invalid-assignment]
+```
+
 ## Union
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -951,11 +951,9 @@ class MyMetaclass(type):
 Using the `self` parameter as a runtime value should not be flagged, even in a metaclass. Only the
 literal `Self` type form should be disallowed.
 
-TODO: Bind receiver TypeVars before checking this override against `type.__or__`.
-
 ```py
 class AnnotableMeta(type):
-    def __or__(self, other):  # error: [invalid-method-override]
+    def __or__(self, other):
         return self  # No `invalid-type-form` error: runtime use of `self`, not the `Self` type form
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -957,6 +957,29 @@ class AnnotableMeta(type):
         return self  # No `invalid-type-form` error: runtime use of `self`, not the `Self` type form
 ```
 
+## Assigning methods to runtime-created classes
+
+The synthesized `Self` type of an assigned method is compatible with the receiver of a
+runtime-created class:
+
+```py
+from collections import namedtuple
+from typing import Generic, TypeVar
+
+value_cls = namedtuple("value_cls", "name value")
+value_cls.__le__ = lambda self, other: True
+# error: [invalid-assignment]
+value_cls.__ge__ = lambda self: True
+
+T = TypeVar("T")
+
+class classproperty(Generic[T]):
+    def __get__(self, instance, owner) -> T:
+        raise NotImplementedError
+
+classproperty.__get__ = lambda self, instance, owner: self
+```
+
 ## Indirect metaclass inheritance
 
 Classes that inherit from `type` indirectly (through another metaclass) are also metaclasses:

--- a/crates/ty_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/string.md
@@ -66,8 +66,6 @@ common runtime error:
 python-version = "3.13"
 ```
 
-TODO: Bind receiver TypeVars before checking this override against `type.__or__`.
-
 ```py
 from typing import Any, TypeVar, Callable, Protocol, TypedDict, TYPE_CHECKING
 
@@ -77,7 +75,7 @@ class P(Protocol):
     x: int
 
 class Meta(type):
-    def __or__(cls, other: str) -> Any:  # error: [invalid-method-override]
+    def __or__(cls, other: str) -> Any:
         return "wow, so fancy, bet type checkers can't handle this"
 
 class UsesMeta(metaclass=Meta): ...

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -41,16 +41,11 @@ from pydantic import BaseModel, Field
 class Product(BaseModel):
     name: str = Field(min_length=1)
     tags: list[str] = Field(default_factory=list)
-    # TODO: Restore this once legacy generic method targets are quantified correctly.
-    # error: [invalid-argument-type]
     internal_price_cent: int = Field(gt=0, alias="price_cent")
 
-# TODO: Restore the `price_cent` alias once legacy generic method targets are quantified correctly.
-# revealed: (self: Product, *, name: LaxStr, tags: Iterable[LaxStr] = ..., internal_price_cent: LaxInt = ..., **extra: Any) -> None
+# revealed: (self: Product, *, name: LaxStr, tags: Iterable[LaxStr] = ..., price_cent: LaxInt, **extra: Any) -> None
 reveal_type(Product.__init__)
 
-# TODO: Remove this once legacy generic method targets are quantified correctly.
-# error: [pydantic-discarded-extra-argument]
 product = Product(name="Laptop", price_cent=999_00)
 ```
 
@@ -67,7 +62,7 @@ Omitting the `name` or the `price_cent` is not allowed:
 ```py
 # error: [missing-argument] "No argument provided for required parameter `name`"
 Product(price_cent=100_00)
-# TODO: Restore the `missing-argument` diagnostic once legacy generic method targets are quantified correctly.
+# error: [missing-argument] "No argument provided for required parameter `price_cent`"
 Product(name="Phone")
 ```
 
@@ -75,7 +70,7 @@ Using the internal field name is not possible (the argument will be accepted, bu
 missing):
 
 ```py
-# TODO: Restore the `missing-argument` diagnostic once legacy generic method targets are quantified correctly.
+# error: [missing-argument]
 Product(name="Laptop", internal_price_cent=999_00)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -178,6 +178,29 @@ reveal_type(generic_context(decorator_factory()))
 reveal_type(decorator_factory()(1))
 ```
 
+The returned callable can also be inferred from a lambda expression:
+
+```py
+from typing import Any
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+def lambda_decorator_factory() -> Callable[[T], T]:
+    return lambda value: value
+
+def bounded_lambda_decorator_factory() -> Callable[[F], F]:
+    return lambda value: value
+
+# revealed: [T'return](T'return, /) -> T'return
+reveal_type(lambda_decorator_factory())
+# revealed: [F'return](F'return, /) -> F'return
+reveal_type(bounded_lambda_decorator_factory())
+
+def invalid_lambda_decorator_factory() -> Callable[[T], T]:
+    # error: [invalid-return-type]
+    return lambda value: 1
+```
+
 If the typevar also appears in a parameter, it is the function that is generic, and the returned
 `Callable` is not:
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -181,7 +181,9 @@ reveal_type(decorator_factory()(1))
 The returned callable can also be inferred from a lambda expression:
 
 ```py
-from typing import Any
+import copy
+import pickle
+from typing import Any, cast
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -199,6 +201,22 @@ reveal_type(bounded_lambda_decorator_factory())
 def invalid_lambda_decorator_factory() -> Callable[[T], T]:
     # error: [invalid-return-type]
     return lambda value: 1
+
+def callable_factory() -> Callable[..., T]:
+    def wrapper(*args: Any) -> Any:
+        return args
+    return cast(Callable[..., T], wrapper)
+
+def invalid_callable_factory() -> Callable[..., T]:
+    def wrapper(*args: Any) -> Any:
+        return args
+    # error: [invalid-return-type]
+    return cast(Callable[..., str], wrapper)
+
+copiers = [copy.copy, copy.deepcopy]
+copiers += [lambda x: pickle.loads(pickle.dumps(x, 1))]
+# error: [unsupported-operator]
+copiers += [lambda x: 1]
 ```
 
 If the typevar also appears in a parameter, it is the function that is generic, and the returned

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -159,6 +159,73 @@ reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecialized))
 reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecializedExtraTypevar))
 ```
 
+## Inheriting from an unresolved generic base
+
+Type variables used to specialize an unresolved base still belong to the class. They must not be
+mistaken for method-local type variables when a concrete subclass overrides a method. The unresolved
+base must also remain gradual when the subclass is used in an annotation.
+
+```toml
+[rules]
+missing-type-argument = "ignore"
+```
+
+```py
+import collections.abc
+from collections.abc import Hashable
+from typing import Any, Generic, TypeVar
+from typing_extensions import dataclass_transform, reveal_type
+from unresolved import Dataset  # error: [unresolved-import]
+
+T_co = TypeVar("T_co", covariant=True)
+
+class VisionDataset(Dataset[T_co]):
+    item: T_co
+
+    def __getitem__(self, index: int) -> T_co:
+        raise NotImplementedError
+
+reveal_type(VisionDataset.__getitem__)  # revealed: def __getitem__(self, index: int) -> Unknown
+
+class ImageDataset(VisionDataset):
+    def __getitem__(self, index: int) -> tuple[Any, Any]:
+        raise NotImplementedError
+
+def read_item(dataset: ImageDataset) -> None:
+    reveal_type(dataset.item)  # revealed: Unknown
+
+T = TypeVar("T")
+
+class MethodGeneric(Dataset[Any]):
+    def method(self, value: T) -> T:
+        return value
+
+class InvalidMethodOverride(MethodGeneric):
+    # error: [invalid-method-override]
+    def method(self, value: int) -> int:
+        return value
+
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
+
+@collections.abc.Mapping.register  # error: [unresolved-attribute]
+class Mapping(Generic[K, V]):
+    def __getitem__(self, key: K, /) -> V:
+        raise NotImplementedError
+
+class FrozenDict(dict, Mapping[K, V]): ...
+class FrozenOrderedDict(FrozenDict[K, V]): ...
+
+@dataclass_transform()
+class Concrete:
+    def __init__(self, **kwargs: object) -> None: ...
+
+class Schema(Concrete):
+    fields: FrozenOrderedDict[str, int]
+
+Schema(fields={"value": 1})
+```
+
 ## Errors for inconsistent type arguments
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -194,6 +194,27 @@ class ImageDataset(VisionDataset):
 def read_item(dataset: ImageDataset) -> None:
     reveal_type(dataset.item)  # revealed: Unknown
 
+KnownT = TypeVar("KnownT")
+MissingT = TypeVar("MissingT")
+
+class Known(Generic[KnownT]): ...
+
+class Mixed(Known[KnownT], Dataset[MissingT]):
+    known: KnownT
+    item: MissingT
+
+    def read(self) -> MissingT:
+        raise NotImplementedError
+
+class MixedChild(Mixed[int]):
+    def read(self) -> str:
+        raise NotImplementedError
+
+reveal_type(Mixed[int].read)  # revealed: def read(self) -> Unknown
+reveal_type(MixedChild.read)  # revealed: def read(self) -> str
+reveal_type(MixedChild().known)  # revealed: int
+reveal_type(MixedChild().item)  # revealed: Unknown
+
 T = TypeVar("T")
 
 class MethodGeneric(Dataset[Any]):

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -159,35 +159,6 @@ reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecialized))
 reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecializedExtraTypevar))
 ```
 
-## Inheriting from an unresolved generic base
-
-Type variables used to specialize an unresolved base still belong to the class. They must not be
-mistaken for method-local type variables when a concrete subclass overrides a method:
-
-```toml
-[rules]
-missing-type-argument = "ignore"
-```
-
-```py
-from typing import Any, TypeVar
-from unresolved import Dataset  # error: [unresolved-import]
-from ty_extensions._internal import generic_context
-
-T_co = TypeVar("T_co", covariant=True)
-
-class VisionDataset(Dataset[T_co]):
-    def __getitem__(self, index: int) -> T_co:
-        raise NotImplementedError
-
-# revealed: ty_extensions._internal.GenericContext[T_co@VisionDataset]
-reveal_type(generic_context(VisionDataset))
-
-class ImageDataset(VisionDataset):
-    def __getitem__(self, index: int) -> tuple[Any, Any]:
-        raise NotImplementedError
-```
-
 ## Errors for inconsistent type arguments
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -159,6 +159,35 @@ reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecialized))
 reveal_type(generic_context(ExplicitInheritedGenericPartiallySpecializedExtraTypevar))
 ```
 
+## Inheriting from an unresolved generic base
+
+Type variables used to specialize an unresolved base still belong to the class. They must not be
+mistaken for method-local type variables when a concrete subclass overrides a method:
+
+```toml
+[rules]
+missing-type-argument = "ignore"
+```
+
+```py
+from typing import Any, TypeVar
+from unresolved import Dataset  # error: [unresolved-import]
+from ty_extensions._internal import generic_context
+
+T_co = TypeVar("T_co", covariant=True)
+
+class VisionDataset(Dataset[T_co]):
+    def __getitem__(self, index: int) -> T_co:
+        raise NotImplementedError
+
+# revealed: ty_extensions._internal.GenericContext[T_co@VisionDataset]
+reveal_type(generic_context(VisionDataset))
+
+class ImageDataset(VisionDataset):
+    def __getitem__(self, index: int) -> tuple[Any, Any]:
+        raise NotImplementedError
+```
+
 ## Errors for inconsistent type arguments
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -687,6 +687,35 @@ def singleton[S](flag: bool = False) -> Callable[[Callable[[int], S]], Callable[
     return wrapper
 ```
 
+The overloads can also refer to type variables captured from the enclosing factory rather than
+declaring their own type parameters:
+
+```py
+type Func[T] = Callable[[int], T]
+type Coro[T] = Coroutine[Any, Any, T]
+
+def captured_singleton[S, T, U]() -> Callable[[Func[S]], Func[S]]:
+    @overload
+    def wrapper(func: Func[Coro[T]]) -> Func[Coro[T]]: ...
+    @overload
+    def wrapper(func: Func[U]) -> Func[U]: ...
+    def wrapper(func: Func[Coro[T] | U]) -> Func[Coro[T] | U]:
+        return func
+
+    return wrapper
+
+def invalid_captured_singleton[S, T, U]() -> Callable[[Func[S]], Func[S]]:
+    @overload
+    def wrapper(func: Func[Coro[T]]) -> Func[Coro[T]]: ...
+    @overload
+    def wrapper(func: Func[U]) -> Func[int]: ...
+    def wrapper(func: Func[Coro[T] | U]) -> Func[Coro[T] | int]:
+        raise NotImplementedError
+
+    # error: [invalid-return-type]
+    return wrapper
+```
+
 ## Multiple occurrences of a higher-order generic callable
 
 If a generic callable is used more than once in a higher-order call, each occurrence should get its

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -104,9 +104,8 @@ valid_constraints: Callable[[], None] = ValidConstrainedReceiver().method
 
 invalid_aliased_bound: Callable[[], None] = InvalidAliasedBoundedReceiver().method  # error: [invalid-assignment]
 
-# TODO: Enforce valid specializations for TypeVars nested inside receiver annotations.
-invalid_nested_bound: Callable[[], None] = InvalidNestedBoundedReceiver().method  # TODO: error: [invalid-assignment]
-invalid_union_constraints: Callable[[], None] = InvalidUnionConstrainedReceiver().method  # TODO: error: [invalid-assignment]
+invalid_nested_bound: Callable[[], None] = InvalidNestedBoundedReceiver().method  # error: [invalid-assignment]
+invalid_union_constraints: Callable[[], None] = InvalidUnionConstrainedReceiver().method  # error: [invalid-assignment]
 ```
 
 When we coerce a generic callable into a `Callable` type, it remembers that it is generic:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1430,10 +1430,10 @@ reveal_type(pair(1, "a"))  # revealed: tuple[Literal[1], Literal["a"]]
 reveal_type(pair("x", 2.5))  # revealed: tuple[Literal["x"], float]
 ```
 
-### Gradual return types
+### Decorators with gradual return types
 
-Gradual return types must not widen a `ParamSpec` captured from a generic function into a union of
-parameter lists. The original generic signature should remain available to the decorated callable.
+A decorator that accepts a callable returning `Any` must preserve the parameter list of a decorated
+generic function. Valid calls should still succeed, and the original arity should still be checked:
 
 ```py
 from collections.abc import Callable, Generator
@@ -1454,7 +1454,12 @@ reveal_type(identity)  # revealed: Wrapped[(value: T@identity)]
 identity.call("value")
 # error: [too-many-positional-arguments]
 identity.call(1, 2)
+```
 
+The return type is ignored only when it is gradual. A decorator that requires an `int` return must
+still reject a function that returns `str`:
+
+```py
 def requires_int[**P](func: Callable[P, int]) -> Wrapped[P]:
     return Wrapped()
 
@@ -1462,7 +1467,11 @@ def requires_int[**P](func: Callable[P, int]) -> Wrapped[P]:
 @requires_int
 def returns_str(value: str) -> str:
     return value
+```
 
+Legacy `ParamSpec` and TypeVar syntax behaves the same way:
+
+```py
 P = ParamSpec("P")
 T = TypeVar("T")
 
@@ -1480,7 +1489,12 @@ reveal_type(legacy_identity)  # revealed: LegacyWrapped[(value: T@legacy_identit
 legacy_identity.call("value")
 # error: [too-many-positional-arguments]
 legacy_identity.call(1, 2)
+```
 
+`types.coroutine` is a standard-library example: a decorated generator must remain generic and
+produce an awaitable callable:
+
+```py
 @types.coroutine
 def stdlib_yield(value: T) -> Generator[T, None, None]:
     yield value

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1430,6 +1430,68 @@ reveal_type(pair(1, "a"))  # revealed: tuple[Literal[1], Literal["a"]]
 reveal_type(pair("x", 2.5))  # revealed: tuple[Literal["x"], float]
 ```
 
+### Gradual return types
+
+Gradual return types must not widen a `ParamSpec` captured from a generic function into a union of
+parameter lists. The original generic signature should remain available to the decorated callable.
+
+```py
+from collections.abc import Callable, Generator
+import types
+from typing import Any, Generic, ParamSpec, TypeVar
+
+class Wrapped[**P]:
+    def call(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+def wrap[**P](func: Callable[P, Any]) -> Wrapped[P]:
+    return Wrapped()
+
+@wrap
+def identity[T](value: T) -> T:
+    return value
+
+reveal_type(identity)  # revealed: Wrapped[(value: T@identity)]
+identity.call("value")
+# error: [too-many-positional-arguments]
+identity.call(1, 2)
+
+def requires_int[**P](func: Callable[P, int]) -> Wrapped[P]:
+    return Wrapped()
+
+# error: [invalid-argument-type]
+@requires_int
+def returns_str(value: str) -> str:
+    return value
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+class LegacyWrapped(Generic[P]):
+    def call(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+def legacy_wrap(func: Callable[P, Any]) -> LegacyWrapped[P]:
+    return LegacyWrapped()
+
+@legacy_wrap
+def legacy_identity(value: T) -> T:
+    return value
+
+reveal_type(legacy_identity)  # revealed: LegacyWrapped[(value: T@legacy_identity)]
+legacy_identity.call("value")
+# error: [too-many-positional-arguments]
+legacy_identity.call(1, 2)
+
+@types.coroutine
+def stdlib_yield(value: T) -> Generator[T, None, None]:
+    yield value
+
+reveal_type(stdlib_yield)  # revealed: [T](value: T) -> Awaitable[None]
+reveal_type(stdlib_yield(1))  # revealed: Awaitable[None]
+
+async def example() -> None:
+    await stdlib_yield(1)
+```
+
 ### Chained decorators with generic functions
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1437,8 +1437,9 @@ generic function. Valid calls should still succeed, and the original arity shoul
 
 ```py
 from collections.abc import Callable, Generator
+import contextvars
 import types
-from typing import Any, Generic, ParamSpec, TypeVar
+from typing import Any, Generic, ParamSpec, TypeVar, overload
 
 class Wrapped[**P]:
     def call(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
@@ -1504,6 +1505,23 @@ reveal_type(stdlib_yield(1))  # revealed: Awaitable[None]
 
 async def example() -> None:
     await stdlib_yield(1)
+
+def step(result: Generator[object, None, None]) -> object:
+    return contextvars.copy_context().run(next, result)
+
+@overload
+def overloaded(value: int) -> int: ...
+@overload
+def overloaded(value: str) -> str: ...
+def overloaded(value: int | str) -> int | str:
+    return value
+
+def requires_int[**P](func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int:
+    return func(*args, **kwargs)
+
+requires_int(overloaded, 1)
+# error: [invalid-argument-type]
+requires_int(overloaded, "value")
 ```
 
 ### Chained decorators with generic functions

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -880,10 +880,9 @@ class C(A):
     def method(self, x: object) -> Never: ...  # fine
 
 class D(A):
-    # TODO: we should emit [invalid-method-override] here:
     # `A.method` accepts an argument of any type,
     # but `D.method` only accepts `int`s
-    def method(self, x: int) -> int: ...
+    def method(self, x: int) -> int: ...  # error: [invalid-method-override]
 
 class A2:
     def method(self, x: int) -> int: ...
@@ -952,11 +951,10 @@ class A4:
     def method[T: int](self, x: T) -> T: ...
 
 class B4(A4):
-    # TODO: we should emit `invalid-method-override` here.
     # `A4.method` promises that if it is passed a `bool`, it will return a `bool`,
     # but this is not necessarily true for `B4.method`: if passed a `bool`,
     # it could return a non-`bool` `int`!
-    def method(self, x: int) -> int: ...
+    def method(self, x: int) -> int: ...  # error: [invalid-method-override]
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -876,6 +876,17 @@ class A:
 class B(A):
     def method[T](self, x: T) -> T: ...  # fine
 
+class BoundedGeneric(A):
+    # `A.method` accepts values of every type, not only subtypes of `int`.
+    def method[T: int](self, x: T) -> T: ...  # error: [invalid-method-override]
+
+class NarrowGeneric(A):
+    # Adding a generic parameter does not make the narrower `list[T]` input valid.
+    def method[T](self, x: list[T]) -> T: ...  # error: [invalid-method-override]
+
+class WrongGenericReturn(A):
+    def method[T](self, x: T) -> int: ...  # error: [invalid-method-override]
+
 class C(A):
     def method(self, x: object) -> Never: ...  # fine
 

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -1007,7 +1007,8 @@ An untyped or explicitly gradual implementation can override a generic method. T
 generic overloads used by methods such as `dict.get` and `dict.pop`:
 
 ```py
-from typing import Any, TypeVar
+from concurrent.futures import Executor, Future
+from typing import Any, Callable, TypeVar
 
 T = TypeVar("T")
 
@@ -1039,4 +1040,15 @@ class AnyDict(dict[object, Any]):
         return super().get(key, default)
     def pop(self, key: object, default: Any = None) -> Any:
         return super().pop(key, default)
+
+class UntypedExecutor(Executor):
+    def submit(self, fn, *args, **kwargs):
+        future = Future()
+        future.set_result(fn(*args, **kwargs))
+        return future
+
+class InvalidExecutor(Executor):
+    # error: [invalid-method-override]
+    def submit(self, fn: Callable[[int], int], value: int) -> Future[int]:
+        return super().submit(fn, value)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -1006,11 +1006,22 @@ class DeferredChild2(DeferredBase):
 An untyped or explicitly gradual implementation can override a generic method. This includes the
 generic overloads used by methods such as `dict.get` and `dict.pop`:
 
+```toml
+[environment]
+python-version = "3.12"
+
+[rules]
+missing-type-argument = "ignore"
+```
+
 ```py
+from collections.abc import Callable, Generator, Iterable, Iterator, Mapping
 from concurrent.futures import Executor, Future
-from typing import Any, Callable, TypeVar
+from typing import Any, Generic, NoReturn, ParamSpec, TypeVar, TypeVarTuple, Unpack, overload
 
 T = TypeVar("T")
+P = ParamSpec("P")
+Ts = TypeVarTuple("Ts")
 
 class Base:
     def method(self, value: T) -> T:
@@ -1051,4 +1062,105 @@ class InvalidExecutor(Executor):
     # error: [invalid-method-override]
     def submit(self, fn: Callable[[int], int], value: int) -> Future[int]:
         return super().submit(fn, value)
+
+class Builder(Generic[T]):
+    def apply(self, fn: Callable[P, Generator[T, None, T]]) -> Callable[P, Iterable[T]]:
+        raise NotImplementedError
+
+class SeqBuilder(Builder[T]):
+    def apply(self, fn: Callable[..., Generator[T, None, T]]) -> Callable[..., Iterable[T]]:
+        raise NotImplementedError
+
+class Frame: ...
+
+FrameT = TypeVar("FrameT", bound=Frame)
+
+class Grouper:
+    def get_iterator(self, data: FrameT) -> Iterator[tuple[int, FrameT]]:
+        raise NotImplementedError
+
+class BinGrouper(Grouper):
+    def get_iterator(self, data: Frame):
+        raise NotImplementedError
+
+class EventLoop:
+    def call_soon(self, callback: Callable[[Unpack[Ts]], object], *args: Unpack[Ts]) -> object:
+        raise NotImplementedError
+
+class WebLoop(EventLoop):
+    def call_soon(self, callback: Callable[..., Any], *args: Any) -> object:
+        raise NotImplementedError
+
+SelectableT = TypeVar("SelectableT", bound="Selectable")
+
+class Selectable: ...
+
+class IOLoop:
+    @overload
+    def add_handler(self, fd: int, callback: Callable[[int, int], None]) -> None: ...
+    @overload
+    def add_handler(self, fd: SelectableT, callback: Callable[[SelectableT, int], None]) -> None: ...
+    def add_handler(self, fd: int | Selectable, callback: Callable[..., None]) -> None:
+        raise NotImplementedError
+
+class AsyncIOLoop(IOLoop):
+    def add_handler(self, fd: int | Selectable, callback: Callable[..., None]) -> None:
+        raise NotImplementedError
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+class FrozenDict(dict[K, V]):
+    @classmethod
+    def fromkeys(cls, *args, **kwargs) -> "FrozenDict":
+        raise NotImplementedError
+    def __or__(self, other: Mapping) -> "FrozenDict":
+        raise NotImplementedError
+    def pop(self, key, default=None) -> NoReturn:
+        raise NotImplementedError
+
+class FrozenList(list):
+    def union(self, other: list | tuple) -> "FrozenList":
+        raise NotImplementedError
+    __add__ = union
+
+class Call(Generic[T]): ...
+
+class Portal:
+    def submit(self, call: Call[T]) -> Call[T]:
+        raise NotImplementedError
+
+class Waiter(Generic[T], Portal):
+    # error: [invalid-method-override]
+    def submit(self, call: Call[T]) -> Call[T]:
+        return call
+
+ConfigT = TypeVar("ConfigT", bound="DiffBase")
+
+class DiffBase:
+    @classmethod
+    def from_hierarchy(cls, configs: list[ConfigT]) -> ConfigT:
+        return configs[0]
+
+class Config(DiffBase):
+    @classmethod
+    # error: [invalid-method-override]
+    def from_hierarchy(cls, configs: list["Config"]) -> "Config":
+        return configs[0]
+
+class Counter(dict[K, int]):
+    @classmethod
+    # error: [invalid-method-override]
+    def fromkeys(cls, iterable: Any, value: int | None = None) -> NoReturn:
+        raise NotImplementedError
+
+class Morsel(dict[str, Any], Generic[V]):
+    # error: [invalid-method-override]
+    def setdefault(self, key: str, value: str | None = None) -> str:
+        raise NotImplementedError
+
+class MultiDict(dict[K, V]):
+    # error: [invalid-method-override]
+    def __or__(self, other: Mapping[K, V | list[V]]) -> "MultiDict[K, V]":
+        raise NotImplementedError
 ```

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -1000,3 +1000,43 @@ class DeferredChild1(DeferredBase):
 class DeferredChild2(DeferredBase):
     def method(self) -> None: ...
 ```
+
+## Gradual overrides of generic methods
+
+An untyped or explicitly gradual implementation can override a generic method. This includes the
+generic overloads used by methods such as `dict.get` and `dict.pop`:
+
+```py
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+class Base:
+    def method(self, value: T) -> T:
+        return value
+
+class AnyChild(Base):
+    def method(self, value: Any) -> Any:
+        return value
+
+class UntypedChild(Base):
+    def method(self, value):
+        return value
+
+class InvalidChild(Base):
+    # error: [invalid-method-override]
+    def method(self, value: int) -> int:
+        return value
+
+class UntypedDict(dict[Any, Any]):
+    def get(self, key, default=None):
+        return super().get(key, default)
+    def pop(self, key, default=None):
+        return super().pop(key, default)
+
+class AnyDict(dict[object, Any]):
+    def get(self, key: object, default: Any = None) -> Any:
+        return super().get(key, default)
+    def pop(self, key: object, default: Any = None) -> Any:
+        return super().pop(key, default)
+```

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4120,6 +4120,27 @@ generic_apply: ReceiverAndMethodLocal = GenericApply()
 int_apply: ReceiverAndMethodLocal = IntApply()  # error: [invalid-assignment]
 ```
 
+A generic implementation must also cover every specialization of an unrelated generic target method.
+Merely making the implementation generic does not make a narrower domain valid:
+
+```py
+class GenericCallback(Protocol):
+    def __call__[T](self, value: T) -> T: ...
+
+def bounded_callback[T: int](value: T) -> T:
+    return value
+
+def narrow_callback[T](value: list[T]) -> T:
+    return value[0]
+
+def generic_callback[T](value: T) -> T:
+    return value
+
+bounded: GenericCallback = bounded_callback  # error: [invalid-assignment]
+narrow: GenericCallback = narrow_callback  # error: [invalid-assignment]
+generic: GenericCallback = generic_callback
+```
+
 The corresponding `cls` annotation on a class method can also use a TypeVar:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2552,8 +2552,10 @@ static_assert(is_subtype_of(PropertyWithSelfSetter, HasConcretePropertySetter))
 static_assert(is_assignable_to(PropertyWithSelfSetter, HasConcretePropertySetter))
 ```
 
-Property accessors can use a callable-local receiver TypeVar instead of `Self`. The receiver must be
-specialized before the getter return or setter value type is compared:
+## Generic receiver annotations on properties
+
+A property getter can use a TypeVar in its `self` annotation. The return type then refers to the
+class that implements the protocol, including when the annotation uses a type alias:
 
 ```py
 from typing import Protocol, TypeAlias, TypeVar
@@ -2580,10 +2582,13 @@ class IntProperty:
         return 1
 
 generic_property: HasGenericSelfProperty = GenericSelfProperty()
-invalid_property: HasGenericSelfProperty = IntProperty()  # error: [invalid-assignment]
 aliased_property: HasAliasedSelfProperty = GenericSelfProperty()
 invalid_aliased_property: HasAliasedSelfProperty = IntProperty()  # error: [invalid-assignment]
+```
 
+The same applies to a setter value whose type refers to `self`:
+
+```py
 class HasMutableSelfProperty(Protocol):
     @property
     def value(self) -> object: ...
@@ -2606,7 +2611,11 @@ class InvalidMutableSelfProperty:
 
 mutable_property: HasMutableSelfProperty = MutableSelfProperty()
 invalid_mutable_property: HasMutableSelfProperty = InvalidMutableSelfProperty()  # error: [invalid-assignment]
+```
 
+A bound on the TypeVar still requires the implementing class to satisfy that bound:
+
+```py
 class PropertyBase: ...
 
 BoundedPropertyT = TypeVar("BoundedPropertyT", bound=PropertyBase)
@@ -2629,8 +2638,10 @@ bounded_property: HasBoundedSelfProperty = BoundedSelfProperty()
 invalid_bounded_property: HasBoundedSelfProperty = InvalidBoundedSelfProperty()  # error: [invalid-assignment]
 ```
 
-Specializing a property's receiver must not allow a non-generic or inconsistently specialized method
-to satisfy an unrelated generic protocol method:
+## Independent generic protocol methods
+
+A TypeVar used by a property receiver does not make another protocol method non-generic. An
+implementation of that method must still work for every allowed type:
 
 ```py
 from typing import Callable, Protocol, TypeVar
@@ -2643,38 +2654,22 @@ class HasPropertyProto(Protocol):
     def f(self: T) -> T: ...
     def m(self, item: T, callback: Callable[[T], str]) -> str: ...
 
-class ConcreteHasProperty1:
+class GenericMethod:
     @property
     def f(self: T) -> T:
         return self
     def m(self, item: T, callback: Callable[[T], str]) -> str:
         return ""
 
-class ConcreteHasProperty2:
+class IntMethod:
     @property
     def f(self) -> Self:
         return self
     def m(self, item: int, callback: Callable[[int], str]) -> str:
         return ""
 
-class ConcreteHasProperty3:
-    @property
-    def f(self) -> int:
-        return 0
-    def m(self, item: int, callback: Callable[[int], str]) -> str:
-        return ""
-
-class ConcreteHasProperty4:
-    @property
-    def f(self) -> Self:
-        return self
-    def m(self, item: str, callback: Callable[[int], str]) -> str:
-        return ""
-
-hp1: HasPropertyProto = ConcreteHasProperty1()
-hp2: HasPropertyProto = ConcreteHasProperty2()  # error: [invalid-assignment]
-hp3: HasPropertyProto = ConcreteHasProperty3()  # error: [invalid-assignment]
-hp4: HasPropertyProto = ConcreteHasProperty4()  # error: [invalid-assignment]
+generic_method: HasPropertyProto = GenericMethod()
+int_method: HasPropertyProto = IntMethod()  # error: [invalid-assignment]
 ```
 
 ## Protocol members defined using descriptor decorators
@@ -3981,8 +3976,10 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolImplicitSelf))
 static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 ```
 
-A receiver TypeVar's bound limits the specializations for which a protocol method must be
-compatible. It is not an additional constraint that must hold for every possible specialization:
+## Generic receiver annotations on protocol methods
+
+A protocol method can use a TypeVar in its `self` annotation and return that same type. A function
+can then preserve the concrete type of an object implementing the protocol:
 
 ```py
 from typing import Any, Protocol, TypeVar
@@ -4014,7 +4011,12 @@ parent = generic_get_parent(ConcreteHasParent())
 assert_type(parent, ConcreteHasParent)
 invalid_parent: HasParent = InvalidHasParent()  # error: [invalid-assignment]
 gradual_parent: HasParent = GradualHasParent()
+```
 
+The TypeVar can be bounded by the protocol itself. Checking the implementation must not reject a
+valid `copy` method because the bound is recursive:
+
+```py
 C = TypeVar("C", bound="Copyable")
 
 class Copyable(Protocol):
@@ -4025,16 +4027,13 @@ class One:
     def copy(self) -> "One":
         return One()
 
-OtherT = TypeVar("OtherT", bound="Other")
+copyable: Copyable = One()
+```
 
-class Other:
-    def copy(self: OtherT) -> OtherT:
-        return self
+The TypeVar in the receiver annotation can also appear in another parameter. In particular,
+comparison protocols used by libraries such as Pydantic must continue to accept integers:
 
-copyable: Copyable
-copyable = One()
-copyable = Other()
-
+```py
 class SupportsGt(Protocol):
     def __gt__(self: T, other: T, /) -> bool: ...
 
@@ -4042,7 +4041,6 @@ class InvalidSupportsGt:
     def __gt__(self, other: str, /) -> bool:
         return False
 
-supports_gt: SupportsGt = 1
 invalid_supports_gt: SupportsGt = InvalidSupportsGt()  # error: [invalid-assignment]
 
 SupportsGtT = TypeVar("SupportsGtT", bound=SupportsGt)
@@ -4052,7 +4050,11 @@ def field(*, gt: SupportsGt | None = None) -> None: ...
 
 accepts_gt(1)
 field(gt=0)
+```
 
+An unrelated bound on the TypeVar still has to be satisfied by the implementing class:
+
+```py
 class HasValue(Protocol):
     value: int
 
@@ -4075,8 +4077,14 @@ valid_bound_receiver: BoundReceiver = ValidBoundReceiver()
 invalid_bound_receiver: BoundReceiver = InvalidBoundReceiver()  # error: [invalid-assignment]
 ```
 
-Receiver TypeVars are distinct from unrelated method TypeVars. Binding the receiver limits the
-former, but the latter must still work for every specialization:
+## Generic receivers and generic methods
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+A type alias around the receiver annotation must not hide its TypeVar:
 
 ```py
 from typing import Protocol
@@ -4092,7 +4100,11 @@ class AliasedCopy:
         return self
 
 aliased_copy: AliasedReceiver = AliasedCopy()
+```
 
+Other method TypeVars are independent of the receiver and must still work for every allowed type:
+
+```py
 class ReceiverAndMethodLocal(Protocol):
     def apply[ReceiverT, T](self: ReceiverT, value: T) -> T: ...
 
@@ -4106,7 +4118,11 @@ class IntApply:
 
 generic_apply: ReceiverAndMethodLocal = GenericApply()
 int_apply: ReceiverAndMethodLocal = IntApply()  # error: [invalid-assignment]
+```
 
+The corresponding `cls` annotation on a class method can also use a TypeVar:
+
+```py
 class GenericClassReceiver(Protocol):
     @classmethod
     def make[T](cls: type[T]) -> T: ...
@@ -4125,9 +4141,15 @@ class_factory: GenericClassReceiver = ClassFactory()
 invalid_class_factory: GenericClassReceiver = InvalidClassFactory()  # error: [invalid-assignment]
 ```
 
-Receiver TypeVars can also occur inside type arguments (including deferred `type[Box[T]]`
-receivers). Discover those variables without traversing the members of a protocol-valued receiver
-annotation or the bounds of a TypeVar:
+## Nested generic receivers
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+A method TypeVar that appears only in a parameter or return type is unrelated to the receiver, even
+when `self` is annotated with a protocol. A non-generic implementation of `apply` is invalid:
 
 ```py
 from typing import Protocol
@@ -4140,7 +4162,11 @@ class BadProtocolReceiver:
         return value
 
 bad_protocol_receiver: ProtocolReceiver = BadProtocolReceiver()  # error: [invalid-assignment]
+```
 
+In contrast, a TypeVar that appears inside a generic receiver annotation is tied to that receiver:
+
+```py
 class Box[T]:
     value: T
 
@@ -4157,7 +4183,11 @@ class BadIntBox(Box[int]):
 
 good_int_box: NestedNominalReceiver = GoodIntBox()
 bad_int_box: NestedNominalReceiver = BadIntBox()  # error: [invalid-assignment]
+```
 
+This also works for a generic `cls` annotation:
+
+```py
 class NestedClassReceiver(Protocol):
     @classmethod
     def make[T](cls: type[Box[T]], value: T) -> T: ...
@@ -4174,7 +4204,12 @@ class BadClassBox(Box[int]):
 
 good_class_box: NestedClassReceiver = GoodClassBox()
 bad_class_box: NestedClassReceiver = BadClassBox()  # error: [invalid-assignment]
+```
 
+When the receiver is itself a generic protocol, its type argument determines which argument type the
+method must accept:
+
+```py
 class NestedReceiver[T](Protocol):
     def apply[U](self: "NestedReceiver[U]", value: U) -> U: ...
 
@@ -4190,8 +4225,15 @@ generic_nested_receiver: NestedReceiver[str] = GenericNestedReceiver()
 bad_nested_receiver: NestedReceiver[str] = BadNestedReceiver()  # error: [invalid-assignment]
 ```
 
-A receiver domain includes the TypeVar's declared bound. This both permits valid bounded overrides
-and prevents a protocol method with an impossible receiver bound from being satisfied vacuously:
+## Bounds and constraints on generic receivers
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+An overriding method can replace a bounded TypeVar in the receiver annotation with the base class.
+This is valid for both modern and legacy TypeVar syntax:
 
 ```py
 from typing import Protocol, TypeVar
@@ -4209,7 +4251,12 @@ class LegacyBase:
 
 class LegacyChild(LegacyBase):
     def method(self, other: LegacyBase) -> None: ...
+```
 
+The same rule applies to class methods. An override can accept the base class, but it cannot narrow
+the other parameter to the subclass:
+
+```py
 class ClassBase:
     @classmethod
     def method[T: "ClassBase"](cls: type[T], other: T) -> T:
@@ -4224,7 +4271,11 @@ class InvalidClassChild(ClassBase):
     @classmethod
     def method(cls, other: "InvalidClassChild") -> ClassBase:  # error: [invalid-method-override]
         return other
+```
 
+A protocol with a bounded receiver can only be implemented by a class that satisfies the bound:
+
+```py
 class BoundedProtocol(Protocol):
     def method[T: int](self: T) -> None: ...
 
@@ -4232,7 +4283,11 @@ class InvalidBoundedProtocolImplementation:
     def method(self) -> None: ...
 
 bounded_protocol: BoundedProtocol = InvalidBoundedProtocolImplementation()  # error: [invalid-assignment]
+```
 
+The bound is checked for class-method receivers as well:
+
+```py
 class BoundedClassProtocol(Protocol):
     @classmethod
     def method[T: int](cls: type[T]) -> None: ...
@@ -4247,7 +4302,11 @@ class InvalidBoundedClassImplementation:
 
 bounded_class_protocol: BoundedClassProtocol = BoundedClassImplementation()
 invalid_bounded_class_protocol: BoundedClassProtocol = InvalidBoundedClassImplementation()  # error: [invalid-assignment]
+```
 
+Bounds and constraints nested inside a receiver annotation also have to be respected:
+
+```py
 class NonRecursiveProtocol(Protocol):
     def method(self) -> None: ...
 
@@ -4261,8 +4320,11 @@ invalid_nested_bounded: NonRecursiveProtocol = InvalidNestedBoundedImplementatio
 invalid_union_constrained: NonRecursiveProtocol = InvalidUnionConstrainedImplementation()  # error: [invalid-assignment]
 ```
 
-A receiver TypeVar can be bounded by the protocol that declares the method. Binding it to the
-concrete receiver must not recursively check the same protocol while constructing its domain:
+## Recursive protocol bounds
+
+A TypeVar in a receiver annotation can be bounded by the protocol that declares the method. The
+bound must accept a compatible implementation and reject an incompatible one without recursing
+indefinitely:
 
 ```py
 from typing import Generic, Protocol, TypeVar

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3987,6 +3987,45 @@ class Other:
 copyable: Copyable
 copyable = One()
 copyable = Other()
+
+class SupportsGt(Protocol):
+    def __gt__(self: T, other: T, /) -> bool: ...
+
+class InvalidSupportsGt:
+    def __gt__(self, other: str, /) -> bool:
+        return False
+
+supports_gt: SupportsGt = 1
+invalid_supports_gt: SupportsGt = InvalidSupportsGt()  # error: [invalid-assignment]
+
+SupportsGtT = TypeVar("SupportsGtT", bound=SupportsGt)
+
+def accepts_gt(value: SupportsGtT) -> None: ...
+def field(*, gt: SupportsGt | None = None) -> None: ...
+
+accepts_gt(1)
+field(gt=0)
+
+class HasValue(Protocol):
+    value: int
+
+BoundT = TypeVar("BoundT", bound=HasValue)
+
+class BoundReceiver(Protocol):
+    def same(self: BoundT) -> BoundT: ...
+
+class ValidBoundReceiver:
+    value = 1
+
+    def same(self) -> Self:
+        return self
+
+class InvalidBoundReceiver:
+    def same(self) -> Self:
+        return self
+
+valid_bound_receiver: BoundReceiver = ValidBoundReceiver()
+invalid_bound_receiver: BoundReceiver = InvalidBoundReceiver()  # error: [invalid-assignment]
 ```
 
 Receiver TypeVars are distinct from unrelated method TypeVars. Binding the receiver limits the

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -24,7 +24,7 @@ A protocol is defined by inheriting from the `Protocol` class, which is annotate
 `_SpecialForm` in typeshed's stubs.
 
 ```py
-from typing import Protocol
+from typing import Any, Protocol
 from ty_extensions._internal import reveal_mro
 
 class MyProtocol(Protocol): ...
@@ -2611,7 +2611,7 @@ type instead of reducing it to a bare `Unknown`, which would allow an incompatib
 
 ```py
 from functools import cached_property
-from typing import Protocol, TypeVar
+from typing import Any, Protocol, TypeVar
 from ty_extensions import static_assert
 from ty_extensions._internal import is_assignable_to, reveal_protocol_interface
 
@@ -3860,8 +3860,6 @@ static_assert(not is_assignable_to(BadReturnType, ShapeProtocolExplicitSelf))
 A receiver TypeVar's bound limits the specializations for which a protocol method must be
 compatible. It is not an additional constraint that must hold for every possible specialization:
 
-TODO: Bind receiver TypeVars before comparing signatures so that these cases pass.
-
 ```py
 from typing import Protocol, TypeVar
 from typing_extensions import Self, assert_type
@@ -3880,8 +3878,18 @@ class ConcreteHasParent:
     def get_parent(self) -> Self:
         return self
 
-parent = generic_get_parent(ConcreteHasParent())  # error: [invalid-argument-type]
-assert_type(parent, ConcreteHasParent)  # error: [type-assertion-failure]
+class InvalidHasParent:
+    def get_parent(self) -> object:
+        return self
+
+class GradualHasParent:
+    def get_parent(self) -> Any:
+        return self
+
+parent = generic_get_parent(ConcreteHasParent())
+assert_type(parent, ConcreteHasParent)
+invalid_parent: HasParent = InvalidHasParent()  # error: [invalid-assignment]
+gradual_parent: HasParent = GradualHasParent()
 
 C = TypeVar("C", bound="Copyable")
 
@@ -3900,8 +3908,58 @@ class Other:
         return self
 
 copyable: Copyable
-copyable = One()  # error: [invalid-assignment]
-copyable = Other()  # error: [invalid-assignment]
+copyable = One()
+copyable = Other()
+```
+
+Receiver TypeVars are distinct from unrelated method TypeVars. Binding the receiver limits the
+former, but the latter must still work for every specialization:
+
+```py
+from typing import Protocol
+from typing_extensions import Self
+
+type ReceiverAlias[T] = T
+
+class AliasedReceiver(Protocol):
+    def copy[T](self: ReceiverAlias[T]) -> T: ...
+
+class AliasedCopy:
+    def copy(self) -> Self:
+        return self
+
+aliased_copy: AliasedReceiver = AliasedCopy()
+
+class ReceiverAndMethodLocal(Protocol):
+    def apply[ReceiverT, T](self: ReceiverT, value: T) -> T: ...
+
+class GenericApply:
+    def apply[T](self, value: T) -> T:
+        return value
+
+class IntApply:
+    def apply(self, value: int) -> int:
+        return value
+
+generic_apply: ReceiverAndMethodLocal = GenericApply()
+int_apply: ReceiverAndMethodLocal = IntApply()  # error: [invalid-assignment]
+
+class GenericClassReceiver(Protocol):
+    @classmethod
+    def make[T](cls: type[T]) -> T: ...
+
+class ClassFactory:
+    @classmethod
+    def make(cls) -> Self:
+        return cls()
+
+class InvalidClassFactory:
+    @classmethod
+    def make(cls) -> object:
+        return object()
+
+class_factory: GenericClassReceiver = ClassFactory()
+invalid_class_factory: GenericClassReceiver = InvalidClassFactory()  # error: [invalid-assignment]
 ```
 
 ## Module objects with static-method protocol members

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -24,7 +24,7 @@ A protocol is defined by inheriting from the `Protocol` class, which is annotate
 `_SpecialForm` in typeshed's stubs.
 
 ```py
-from typing import Any, Protocol
+from typing import Protocol
 from ty_extensions._internal import reveal_mro
 
 class MyProtocol(Protocol): ...
@@ -2552,6 +2552,83 @@ static_assert(is_subtype_of(PropertyWithSelfSetter, HasConcretePropertySetter))
 static_assert(is_assignable_to(PropertyWithSelfSetter, HasConcretePropertySetter))
 ```
 
+Property accessors can use a callable-local receiver TypeVar instead of `Self`. The receiver must be
+specialized before the getter return or setter value type is compared:
+
+```py
+from typing import Protocol, TypeAlias, TypeVar
+
+PropertySelfT = TypeVar("PropertySelfT")
+PropertyReceiver: TypeAlias = PropertySelfT
+
+class HasGenericSelfProperty(Protocol):
+    @property
+    def value(self: PropertySelfT) -> PropertySelfT: ...
+
+class HasAliasedSelfProperty(Protocol):
+    @property
+    def value(self: PropertyReceiver) -> PropertyReceiver: ...
+
+class GenericSelfProperty:
+    @property
+    def value(self) -> "GenericSelfProperty":
+        return self
+
+class IntProperty:
+    @property
+    def value(self) -> int:
+        return 1
+
+generic_property: HasGenericSelfProperty = GenericSelfProperty()
+invalid_property: HasGenericSelfProperty = IntProperty()  # error: [invalid-assignment]
+aliased_property: HasAliasedSelfProperty = GenericSelfProperty()
+invalid_aliased_property: HasAliasedSelfProperty = IntProperty()  # error: [invalid-assignment]
+
+class HasMutableSelfProperty(Protocol):
+    @property
+    def value(self) -> object: ...
+    @value.setter
+    def value(self: PropertySelfT, value: PropertySelfT) -> None: ...
+
+class MutableSelfProperty:
+    @property
+    def value(self) -> object:
+        return self
+    @value.setter
+    def value(self, value: "MutableSelfProperty") -> None: ...
+
+class InvalidMutableSelfProperty:
+    @property
+    def value(self) -> object:
+        return self
+    @value.setter
+    def value(self, value: int) -> None: ...
+
+mutable_property: HasMutableSelfProperty = MutableSelfProperty()
+invalid_mutable_property: HasMutableSelfProperty = InvalidMutableSelfProperty()  # error: [invalid-assignment]
+
+class PropertyBase: ...
+
+BoundedPropertyT = TypeVar("BoundedPropertyT", bound=PropertyBase)
+
+class HasBoundedSelfProperty(Protocol):
+    @property
+    def value(self: BoundedPropertyT) -> BoundedPropertyT: ...
+
+class BoundedSelfProperty(PropertyBase):
+    @property
+    def value(self) -> "BoundedSelfProperty":
+        return self
+
+class InvalidBoundedSelfProperty:
+    @property
+    def value(self) -> "InvalidBoundedSelfProperty":
+        return self
+
+bounded_property: HasBoundedSelfProperty = BoundedSelfProperty()
+invalid_bounded_property: HasBoundedSelfProperty = InvalidBoundedSelfProperty()  # error: [invalid-assignment]
+```
+
 ## Protocol members defined using descriptor decorators
 
 ### Descriptor reads and writes
@@ -2611,7 +2688,7 @@ type instead of reducing it to a bare `Unknown`, which would allow an incompatib
 
 ```py
 from functools import cached_property
-from typing import Any, Protocol, TypeVar
+from typing import Protocol, TypeVar
 from ty_extensions import static_assert
 from ty_extensions._internal import is_assignable_to, reveal_protocol_interface
 
@@ -3861,7 +3938,7 @@ A receiver TypeVar's bound limits the specializations for which a protocol metho
 compatible. It is not an additional constraint that must hold for every possible specialization:
 
 ```py
-from typing import Protocol, TypeVar
+from typing import Any, Protocol, TypeVar
 from typing_extensions import Self, assert_type
 
 T = TypeVar("T")
@@ -3960,6 +4037,130 @@ class InvalidClassFactory:
 
 class_factory: GenericClassReceiver = ClassFactory()
 invalid_class_factory: GenericClassReceiver = InvalidClassFactory()  # error: [invalid-assignment]
+```
+
+Receiver TypeVars can also occur inside type arguments (including deferred `type[Box[T]]`
+receivers). Discover those variables without traversing the members of a protocol-valued receiver
+annotation or the bounds of a TypeVar:
+
+```py
+from typing import Protocol
+
+class ProtocolReceiver(Protocol):
+    def apply[T](self: "ProtocolReceiver", value: T) -> T: ...
+
+class BadProtocolReceiver:
+    def apply(self, value: int) -> int:
+        return value
+
+bad_protocol_receiver: ProtocolReceiver = BadProtocolReceiver()  # error: [invalid-assignment]
+
+class Box[T]:
+    value: T
+
+class NestedNominalReceiver(Protocol):
+    def apply[T](self: Box[T], value: T) -> T: ...
+
+class GoodIntBox(Box[int]):
+    def apply(self, value: int) -> int:
+        return value
+
+class BadIntBox(Box[int]):
+    def apply(self, value: str) -> str:
+        return value
+
+good_int_box: NestedNominalReceiver = GoodIntBox()
+bad_int_box: NestedNominalReceiver = BadIntBox()  # error: [invalid-assignment]
+
+class NestedClassReceiver(Protocol):
+    @classmethod
+    def make[T](cls: type[Box[T]], value: T) -> T: ...
+
+class GoodClassBox(Box[int]):
+    @classmethod
+    def make(cls, value: int) -> int:
+        return value
+
+class BadClassBox(Box[int]):
+    @classmethod
+    def make(cls, value: str) -> str:
+        return value
+
+good_class_box: NestedClassReceiver = GoodClassBox()
+bad_class_box: NestedClassReceiver = BadClassBox()  # error: [invalid-assignment]
+
+class NestedReceiver[T](Protocol):
+    def apply[U](self: "NestedReceiver[U]", value: U) -> U: ...
+
+class GenericNestedReceiver:
+    def apply[T](self, value: T) -> T:
+        return value
+
+class BadNestedReceiver:
+    def apply(self, value: int) -> int:
+        return value
+
+generic_nested_receiver: NestedReceiver[str] = GenericNestedReceiver()
+bad_nested_receiver: NestedReceiver[str] = BadNestedReceiver()  # error: [invalid-assignment]
+```
+
+A receiver domain includes the TypeVar's declared bound. This both permits valid bounded overrides
+and prevents a protocol method with an impossible receiver bound from being satisfied vacuously:
+
+```py
+from typing import Protocol, TypeVar
+
+class Base:
+    def method[T: "Base"](self: T, other: T) -> None: ...
+
+class Child(Base):
+    def method(self, other: Base) -> None: ...
+
+LegacyT = TypeVar("LegacyT", bound="LegacyBase")
+
+class LegacyBase:
+    def method(self: LegacyT, other: LegacyT) -> None: ...
+
+class LegacyChild(LegacyBase):
+    def method(self, other: LegacyBase) -> None: ...
+
+class ClassBase:
+    @classmethod
+    def method[T: "ClassBase"](cls: type[T], other: T) -> T:
+        return other
+
+class ClassChild(ClassBase):
+    @classmethod
+    def method(cls, other: ClassBase) -> "ClassChild":
+        return cls()
+
+class InvalidClassChild(ClassBase):
+    @classmethod
+    def method(cls, other: "InvalidClassChild") -> ClassBase:  # error: [invalid-method-override]
+        return other
+
+class BoundedProtocol(Protocol):
+    def method[T: int](self: T) -> None: ...
+
+class InvalidBoundedProtocolImplementation:
+    def method(self) -> None: ...
+
+bounded_protocol: BoundedProtocol = InvalidBoundedProtocolImplementation()  # error: [invalid-assignment]
+
+class BoundedClassProtocol(Protocol):
+    @classmethod
+    def method[T: int](cls: type[T]) -> None: ...
+
+class BoundedClassImplementation(int):
+    @classmethod
+    def method(cls) -> None: ...
+
+class InvalidBoundedClassImplementation:
+    @classmethod
+    def method(cls) -> None: ...
+
+bounded_class_protocol: BoundedClassProtocol = BoundedClassImplementation()
+invalid_bounded_class_protocol: BoundedClassProtocol = InvalidBoundedClassImplementation()  # error: [invalid-assignment]
 ```
 
 ## Module objects with static-method protocol members

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2629,6 +2629,54 @@ bounded_property: HasBoundedSelfProperty = BoundedSelfProperty()
 invalid_bounded_property: HasBoundedSelfProperty = InvalidBoundedSelfProperty()  # error: [invalid-assignment]
 ```
 
+Specializing a property's receiver must not allow a non-generic or inconsistently specialized method
+to satisfy an unrelated generic protocol method:
+
+```py
+from typing import Callable, Protocol, TypeVar
+from typing_extensions import Self
+
+T = TypeVar("T")
+
+class HasPropertyProto(Protocol):
+    @property
+    def f(self: T) -> T: ...
+    def m(self, item: T, callback: Callable[[T], str]) -> str: ...
+
+class ConcreteHasProperty1:
+    @property
+    def f(self: T) -> T:
+        return self
+    def m(self, item: T, callback: Callable[[T], str]) -> str:
+        return ""
+
+class ConcreteHasProperty2:
+    @property
+    def f(self) -> Self:
+        return self
+    def m(self, item: int, callback: Callable[[int], str]) -> str:
+        return ""
+
+class ConcreteHasProperty3:
+    @property
+    def f(self) -> int:
+        return 0
+    def m(self, item: int, callback: Callable[[int], str]) -> str:
+        return ""
+
+class ConcreteHasProperty4:
+    @property
+    def f(self) -> Self:
+        return self
+    def m(self, item: str, callback: Callable[[int], str]) -> str:
+        return ""
+
+hp1: HasPropertyProto = ConcreteHasProperty1()
+hp2: HasPropertyProto = ConcreteHasProperty2()  # error: [invalid-assignment]
+hp3: HasPropertyProto = ConcreteHasProperty3()  # error: [invalid-assignment]
+hp4: HasPropertyProto = ConcreteHasProperty4()  # error: [invalid-assignment]
+```
+
 ## Protocol members defined using descriptor decorators
 
 ### Descriptor reads and writes
@@ -3872,9 +3920,8 @@ static_assert(not is_assignable_to(NominalWithSelf, LegacyFunctionScoped))
 static_assert(is_assignable_to(NominalWithSelf, UsesSelf))
 static_assert(is_subtype_of(NominalWithSelf, UsesSelf))
 
-# TODO: these should pass
-static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))  # error: [static-assert-error]
-static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))  # error: [static-assert-error]
+static_assert(not is_assignable_to(NominalNotGeneric, NewStyleFunctionScoped))
+static_assert(not is_assignable_to(NominalNotGeneric, LegacyFunctionScoped))
 static_assert(not is_assignable_to(NominalNotGeneric, UsesSelf))
 
 static_assert(not is_assignable_to(NominalReturningSelfNotGeneric, NewStyleFunctionScoped))

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2638,6 +2638,57 @@ bounded_property: HasBoundedSelfProperty = BoundedSelfProperty()
 invalid_bounded_property: HasBoundedSelfProperty = InvalidBoundedSelfProperty()  # error: [invalid-assignment]
 ```
 
+Receiver TypeVars can also be nested in a generic receiver annotation. The accessor type must use
+the concrete receiver's corresponding type argument:
+
+```py
+from typing import Generic, Protocol, TypeVar
+
+BoxT = TypeVar("BoxT")
+
+class PropertyBox(Generic[BoxT]): ...
+
+class HasBoxProperty(Protocol):
+    @property
+    def value(self: PropertyBox[BoxT]) -> BoxT: ...
+
+class IntBoxProperty(PropertyBox[int]):
+    @property
+    def value(self) -> int:
+        return 1
+
+class StringBoxProperty(PropertyBox[int]):
+    @property
+    def value(self) -> str:
+        return ""
+
+box_property: HasBoxProperty = IntBoxProperty()
+invalid_box_property: HasBoxProperty = StringBoxProperty()  # error: [invalid-assignment]
+
+class HasMutableBoxProperty(Protocol):
+    @property
+    def value(self) -> object: ...
+    @value.setter
+    def value(self: PropertyBox[BoxT], value: BoxT) -> None: ...
+
+class MutableIntBoxProperty(PropertyBox[int]):
+    @property
+    def value(self) -> object:
+        return 1
+    @value.setter
+    def value(self, value: int) -> None: ...
+
+class MutableStringBoxProperty(PropertyBox[int]):
+    @property
+    def value(self) -> object:
+        return ""
+    @value.setter
+    def value(self, value: str) -> None: ...
+
+mutable_box_property: HasMutableBoxProperty = MutableIntBoxProperty()
+invalid_mutable_box_property: HasMutableBoxProperty = MutableStringBoxProperty()  # error: [invalid-assignment]
+```
+
 ## Independent generic protocol methods
 
 A TypeVar used by a property receiver does not make another protocol method non-generic. An

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4161,6 +4161,48 @@ class InvalidBoundedClassImplementation:
 
 bounded_class_protocol: BoundedClassProtocol = BoundedClassImplementation()
 invalid_bounded_class_protocol: BoundedClassProtocol = InvalidBoundedClassImplementation()  # error: [invalid-assignment]
+
+class NonRecursiveProtocol(Protocol):
+    def method(self) -> None: ...
+
+class InvalidNestedBoundedImplementation(list[str]):
+    def method[T: int](self: list[T]) -> None: ...
+
+class InvalidUnionConstrainedImplementation:
+    def method[T: (int, str)](self: T | None) -> None: ...
+
+invalid_nested_bounded: NonRecursiveProtocol = InvalidNestedBoundedImplementation()  # error: [invalid-assignment]
+invalid_union_constrained: NonRecursiveProtocol = InvalidUnionConstrainedImplementation()  # error: [invalid-assignment]
+```
+
+A receiver TypeVar can be bounded by the protocol that declares the method. Binding it to the
+concrete receiver must not recursively check the same protocol while constructing its domain:
+
+```py
+from typing import Generic, Protocol, TypeVar
+
+RecursiveT = TypeVar("RecursiveT", bound="RecursiveReceiver")
+
+class RecursiveReceiver(Protocol):
+    def copy(self: RecursiveT, other: RecursiveT) -> RecursiveT: ...
+
+class RecursiveImplementation:
+    def copy(self, other: "RecursiveImplementation") -> "RecursiveImplementation":
+        return self
+
+class InvalidRecursiveImplementation:
+    def copy(self, other: int) -> int:
+        return other
+
+recursive_receiver: RecursiveReceiver = RecursiveImplementation()
+invalid_recursive_receiver: RecursiveReceiver = InvalidRecursiveImplementation()  # error: [invalid-assignment]
+
+U = TypeVar("U", bound=RecursiveReceiver)
+
+class RecursiveBox(Generic[U]): ...
+
+recursive_box: RecursiveBox[RecursiveImplementation]
+invalid_recursive_box: RecursiveBox[InvalidRecursiveImplementation]  # error: [invalid-type-arguments]
 ```
 
 ## Module objects with static-method protocol members

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/string.md_-_String_annotations_-_Partially_deferred_a…_-_Python_less_than_3.1…_(5e6477d05ddea33f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/string.md_-_String_annotations_-_Partially_deferred_a…_-_Python_less_than_3.1…_(5e6477d05ddea33f).snap
@@ -21,7 +21,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/string.md
  6 |     x: int
  7 | 
  8 | class Meta(type):
- 9 |     def __or__(cls, other: str) -> Any:  # error: [invalid-method-override]
+ 9 |     def __or__(cls, other: str) -> Any:
 10 |         return "wow, so fancy, bet type checkers can't handle this"
 11 | 
 12 | class UsesMeta(metaclass=Meta): ...
@@ -81,22 +81,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/annotations/string.md
 ```
 
 # Diagnostics
-
-```
-error[invalid-method-override]: Invalid override of method `__or__`
-   --> src/mdtest_snippet.py:9:9
-    |
-  9 |     def __or__(cls, other: str) -> Any:  # error: [invalid-method-override]
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `type.__or__`
-    |
-   ::: stdlib/builtins.pyi:307:9
-    |
-307 |     def __or__(self: _typeshed.Self, value: Any, /) -> types.UnionType | _typeshed.Self:
-    |         ------------------------------------------------------------------------------- `type.__or__` defined here
-    |
-info: This violates the Liskov Substitution Principle
-
-```
 
 ```
 error[unsupported-operator]: Unsupported `|` operation

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
@@ -572,7 +572,7 @@ def quantifies_callable_typevars_together[V]():
 
     actual = ConstraintSet.always().implies_subtype_of(RegularCallableTypeOf[source], RegularCallableTypeOf[target])
     expected = ConstraintSet.range(int, V, object)
-    # TODO: Preserve the constraint on `V` when the target callable typevar is quantified universally.
+    # TODO: This should preserve `int ≤ V` when the target callable is generic.
     static_assert(actual == expected)  # error: [static-assert-error]
 ```
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1690,9 +1690,19 @@ impl<'db> ClassType<'db> {
         let fallback_member_lookup = || {
             let specialization = specialization
                 .map(|specialization| specialization.tuple_runtime_element_specialization(db));
+            let unresolved_specialization = match self {
+                Self::Generic(generic) => generic
+                    .origin(db)
+                    .unresolved_legacy_generic_context(db)
+                    .map(|generic_context| generic_context.unknown_specialization(db)),
+                Self::NonGeneric(_) => None,
+            };
             class_literal
                 .own_class_member(db, inherited_generic_context, specialization, name)
-                .map_type(|ty| ty.apply_optional_specialization(db, specialization))
+                .map_type(|ty| {
+                    ty.apply_optional_specialization(db, specialization)
+                        .apply_optional_specialization(db, unresolved_specialization)
+                })
         };
 
         match name {
@@ -2047,10 +2057,17 @@ impl<'db> ClassType<'db> {
             }
             Self::Generic(generic) => {
                 let specialization = generic.specialization(db);
+                let unresolved_specialization = generic
+                    .origin(db)
+                    .unresolved_legacy_generic_context(db)
+                    .map(|generic_context| generic_context.unknown_specialization(db));
                 generic
                     .origin(db)
                     .own_instance_member(db, name)
-                    .map_type(|ty| ty.apply_optional_specialization(db, Some(specialization)))
+                    .map_type(|ty| {
+                        ty.apply_optional_specialization(db, Some(specialization))
+                            .apply_optional_specialization(db, unresolved_specialization)
+                    })
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1676,7 +1676,14 @@ impl<'db> ClassType<'db> {
             Self::NonGeneric(ClassLiteral::DynamicEnum(enum_lit)) => {
                 return enum_lit.own_class_member(db, name);
             }
-            Self::NonGeneric(ClassLiteral::Static(class)) => (class, None),
+            // Type variables owned by an unresolved base remain gradual when the non-generic
+            // class is used from outside its body.
+            Self::NonGeneric(ClassLiteral::Static(class)) => (
+                class,
+                class
+                    .unresolved_legacy_generic_context(db)
+                    .map(|generic_context| generic_context.unknown_specialization(db)),
+            ),
             Self::Generic(generic) => (generic.origin(db), Some(generic.specialization(db))),
         };
 
@@ -2028,8 +2035,15 @@ impl<'db> ClassType<'db> {
             Self::NonGeneric(ClassLiteral::DynamicEnum(enum_lit)) => {
                 enum_lit.own_instance_member(db, name)
             }
+            // Type variables owned by an unresolved base remain gradual when the non-generic
+            // class is used from outside its body.
             Self::NonGeneric(ClassLiteral::Static(class_literal)) => {
-                class_literal.own_instance_member(db, name)
+                let specialization = class_literal
+                    .unresolved_legacy_generic_context(db)
+                    .map(|generic_context| generic_context.unknown_specialization(db));
+                class_literal
+                    .own_instance_member(db, name)
+                    .map_type(|ty| ty.apply_optional_specialization(db, specialization))
             }
             Self::Generic(generic) => {
                 let specialization = generic.specialization(db);

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -20,7 +20,7 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance, CallArguments,
         CallableType, ClassBase, ClassLiteral, ClassType, DATACLASS_FLAGS, DataclassFlags,
-        DataclassParams, GenericAlias, GenericContext, KnownClass, KnownInstanceType,
+        DataclassParams, DynamicType, GenericAlias, GenericContext, KnownClass, KnownInstanceType,
         MaterializationKind, MemberLookupPolicy, MetaclassCandidate, MetaclassTransformInfo,
         Parameter, Parameters, PropertyInstanceType, Signature, SpecialFormType, StaticMroError,
         SubclassOfType, Truthiness, Type, TypeContext, TypeMapping, TypeVarVariance,
@@ -344,11 +344,12 @@ impl<'db> StaticClassLiteral<'db> {
             GenericContext::from_base_classes(
                 db,
                 class.definition(db),
-                class
-                    .explicit_bases(db)
-                    .iter()
-                    .copied()
-                    .filter(|ty| matches!(ty, Type::GenericAlias(_))),
+                class.explicit_bases(db).iter().copied().filter(|ty| {
+                    matches!(
+                        ty,
+                        Type::GenericAlias(_) | Type::Dynamic(DynamicType::UnknownGeneric(_))
+                    )
+                }),
             )
         }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -20,7 +20,7 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance, CallArguments,
         CallableType, ClassBase, ClassLiteral, ClassType, DATACLASS_FLAGS, DataclassFlags,
-        DataclassParams, DynamicType, GenericAlias, GenericContext, KnownClass, KnownInstanceType,
+        DataclassParams, GenericAlias, GenericContext, KnownClass, KnownInstanceType,
         MaterializationKind, MemberLookupPolicy, MetaclassCandidate, MetaclassTransformInfo,
         Parameter, Parameters, PropertyInstanceType, Signature, SpecialFormType, StaticMroError,
         SubclassOfType, Truthiness, Type, TypeContext, TypeMapping, TypeVarVariance,
@@ -344,12 +344,11 @@ impl<'db> StaticClassLiteral<'db> {
             GenericContext::from_base_classes(
                 db,
                 class.definition(db),
-                class.explicit_bases(db).iter().copied().filter(|ty| {
-                    matches!(
-                        ty,
-                        Type::GenericAlias(_) | Type::Dynamic(DynamicType::UnknownGeneric(_))
-                    )
-                }),
+                class
+                    .explicit_bases(db)
+                    .iter()
+                    .copied()
+                    .filter(|ty| matches!(ty, Type::GenericAlias(_))),
             )
         }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -20,7 +20,7 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance, CallArguments,
         CallableType, ClassBase, ClassLiteral, ClassType, DATACLASS_FLAGS, DataclassFlags,
-        DataclassParams, GenericAlias, GenericContext, KnownClass, KnownInstanceType,
+        DataclassParams, DynamicType, GenericAlias, GenericContext, KnownClass, KnownInstanceType,
         MaterializationKind, MemberLookupPolicy, MetaclassCandidate, MetaclassTransformInfo,
         Parameter, Parameters, PropertyInstanceType, Signature, SpecialFormType, StaticMroError,
         SubclassOfType, Truthiness, Type, TypeContext, TypeMapping, TypeVarVariance,
@@ -356,6 +356,37 @@ impl<'db> StaticClassLiteral<'db> {
             return None;
         }
         inherited_legacy_generic_context_inner(db, self)
+    }
+
+    /// Returns the legacy type variables owned by unresolved generic bases.
+    pub(crate) fn unresolved_legacy_generic_context(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<GenericContext<'db>> {
+        #[salsa::tracked(
+            returns(copy),
+            cycle_initial=|_, _, _| None,
+            heap_size=ruff_memory_usage::heap_size,
+        )]
+        fn unresolved_legacy_generic_context_inner<'db>(
+            db: &'db dyn Db,
+            class: StaticClassLiteral<'db>,
+        ) -> Option<GenericContext<'db>> {
+            GenericContext::from_base_classes(
+                db,
+                class.definition(db),
+                class
+                    .explicit_bases(db)
+                    .iter()
+                    .copied()
+                    .filter(|ty| matches!(ty, Type::Dynamic(DynamicType::UnknownGeneric(_)))),
+            )
+        }
+
+        if !self.has_explicit_bases(db) {
+            return None;
+        }
+        unresolved_legacy_generic_context_inner(db, self)
     }
 
     /// Returns all of the typevars that are referenced in this class's base class list.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2661,29 +2661,44 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let formal_paramspec = formal_signature.is_single_paramspec();
 
         for actual_callable in actual_callables.as_slice() {
-            if let Some((paramspec, _)) = formal_paramspec {
+            if let Some((paramspec, formal_return)) = formal_paramspec {
                 // Capture the actual parameter signature independently of return constraints. A
                 // gradual return can introduce relationships such as `T <= Any`, which must not
-                // widen the captured `ParamSpec` through transitivity. Overloaded callables still
-                // rely on the relation below to filter signatures by their return type.
+                // widen the captured `ParamSpec` through transitivity. Generic overloads can be
+                // captured together only when the formal return does not filter any overload arm.
                 let paramspec_identity = paramspec.identity(self.db);
                 let paramspec_was_inferred = self.types.contains_key(&paramspec_identity);
                 let actual_signatures = actual_callable.signatures(self.db);
-                let paramspec_value = match actual_signatures.overloads.as_slice() {
-                    [signature] if signature.generic_context.is_some() => {
-                        Some(Type::Callable(CallableType::new(
-                            self.db,
-                            CallableSignature::single(Signature::new_generic(
-                                signature.generic_context,
-                                signature.parameters().clone(),
-                                Type::unknown(),
-                            )),
-                            CallableTypeKind::ParamSpecValue,
-                            CallableFunctionProvenance::None,
+                let paramspec_value = (actual_signatures
+                    .overloads
+                    .iter()
+                    .all(|signature| signature.generic_context.is_some())
+                    && (actual_signatures.overloads.len() == 1
+                        || formal_return.is_dynamic()
+                        || matches!(
+                            formal_return,
+                            Type::TypeVar(typevar)
+                                if typevar
+                                    .typevar(self.db)
+                                    .bound_or_constraints(self.db)
+                                    .is_none()
                         )))
-                    }
-                    _ => None,
-                };
+                .then(|| {
+                    Type::Callable(CallableType::new(
+                        self.db,
+                        CallableSignature::from_overloads(actual_signatures.overloads.iter().map(
+                            |signature| {
+                                Signature::new_generic(
+                                    signature.generic_context,
+                                    signature.parameters().clone(),
+                                    Type::unknown(),
+                                )
+                            },
+                        )),
+                        CallableTypeKind::ParamSpecValue,
+                        CallableFunctionProvenance::None,
+                    ))
+                });
 
                 let when = actual_signatures.when_constraint_set_assignable_to(
                     self.db,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1701,6 +1701,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     && !ty.is_union()
                 {
                     let ty = ty.materialized_divergent_fallback().unwrap_or(ty);
+                    // A gradual invariant argument is consistent with every specialization of a
+                    // universally quantified type variable.
+                    if self.relation.is_assignability()
+                        && ty.is_dynamic()
+                        && typevar.is_inferable(db, self.universally_quantified)
+                    {
+                        return self.always();
+                    }
                     let (lower, upper) = if self.relation.is_subtyping() {
                         (ty.top_materialization(db), ty.bottom_materialization(db))
                     } else {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -377,7 +377,12 @@ impl<'db> GenericContext<'db> {
         match node {
             NodeWithScopeKind::Class(class) => {
                 let definition = index.expect_single_definition(class);
-                original_class_type(db, definition)?.generic_context(db)
+                let class = original_class_type(db, definition)?;
+                // An unresolved generic base can still own legacy type variables referenced by
+                // methods, even though the class itself cannot be reliably specialized.
+                class
+                    .generic_context(db)
+                    .or_else(|| class.as_static()?.unresolved_legacy_generic_context(db))
             }
             NodeWithScopeKind::Function(function) => {
                 let definition = index.expect_single_definition(function);

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -380,9 +380,13 @@ impl<'db> GenericContext<'db> {
                 let class = original_class_type(db, definition)?;
                 // An unresolved generic base can still own legacy type variables referenced by
                 // methods, even though the class itself cannot be reliably specialized.
-                class
-                    .generic_context(db)
-                    .or_else(|| class.as_static()?.unresolved_legacy_generic_context(db))
+                Self::merge_optional(
+                    db,
+                    class.generic_context(db),
+                    class
+                        .as_static()
+                        .and_then(|class| class.unresolved_legacy_generic_context(db)),
+                )
             }
             NodeWithScopeKind::Function(function) => {
                 let definition = index.expect_single_definition(function);

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -7,7 +7,7 @@ use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::types::callable::walk_callable_type;
+use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind, walk_callable_type};
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
@@ -19,7 +19,9 @@ use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation,
     TypeRelationChecker, TypeVarEvaluation,
 };
-use crate::types::signatures::{CallableSignature, Parameters, SignatureRelationVisitor};
+use crate::types::signatures::{
+    CallableSignature, Parameters, Signature, SignatureRelationVisitor,
+};
 use crate::types::tuple::{
     TupleSpec, TupleSpecBuilder, TupleType, VariableSegment, walk_tuple_type,
 };
@@ -2656,14 +2658,43 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         formal_signature: &CallableSignature<'db>,
         actual_callables: &CallableTypes<'db>,
     ) -> Result<(), ()> {
-        let formal_is_single_paramspec = formal_signature.is_single_paramspec().is_some();
+        let formal_paramspec = formal_signature.is_single_paramspec();
 
         for actual_callable in actual_callables.as_slice() {
-            if formal_is_single_paramspec {
-                let when = actual_callable
-                    .signatures(self.db)
-                    .when_constraint_set_assignable_to(self.db, formal_signature, self.constraints);
+            if let Some((paramspec, _)) = formal_paramspec {
+                // Capture the actual parameter signature independently of return constraints. A
+                // gradual return can introduce relationships such as `T <= Any`, which must not
+                // widen the captured `ParamSpec` through transitivity. Overloaded callables still
+                // rely on the relation below to filter signatures by their return type.
+                let paramspec_identity = paramspec.identity(self.db);
+                let paramspec_was_inferred = self.types.contains_key(&paramspec_identity);
+                let actual_signatures = actual_callable.signatures(self.db);
+                let paramspec_value = match actual_signatures.overloads.as_slice() {
+                    [signature] if signature.generic_context.is_some() => {
+                        Some(Type::Callable(CallableType::new(
+                            self.db,
+                            CallableSignature::single(Signature::new_generic(
+                                signature.generic_context,
+                                signature.parameters().clone(),
+                                Type::unknown(),
+                            )),
+                            CallableTypeKind::ParamSpecValue,
+                            CallableFunctionProvenance::None,
+                        )))
+                    }
+                    _ => None,
+                };
+
+                let when = actual_signatures.when_constraint_set_assignable_to(
+                    self.db,
+                    formal_signature,
+                    self.constraints,
+                );
                 self.add_type_mappings_from_constraint_set(when)?;
+                if !paramspec_was_inferred && let Some(paramspec_value) = paramspec_value {
+                    self.types
+                        .insert(paramspec_identity, UnionAccumulator::new(paramspec_value));
+                }
                 self.pending.intersect(self.db, self.constraints, when);
             } else {
                 // An overloaded actual callable is compatible with the formal signature if at

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4738,7 +4738,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } else {
             TypeContext::default()
         };
-        if let Some(ty) = self.infer_optional_expression(ret.value.as_deref(), tcx) {
+        // A legacy type variable that only occurs in a returned `Callable` is not part of the
+        // function's public generic context, but type forms in the return expression still need
+        // to bind it to this function's lexical context.
+        let previous_typevar_binding_context = self.typevar_binding_context;
+        self.typevar_binding_context = previous_typevar_binding_context.or_else(|| {
+            nearest_enclosing_function(self.db(), self.index, self.scope())
+                .map(|function| function.definition(self.db()))
+        });
+        let inferred_ty = self.infer_optional_expression(ret.value.as_deref(), tcx);
+        self.typevar_binding_context = previous_typevar_binding_context;
+
+        if let Some(ty) = inferred_ty {
             let range = ret
                 .value
                 .as_ref()
@@ -7955,9 +7966,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.extend_scope(inference);
 
         let return_ty = inference.expression_type(lambda_expression.body.as_ref());
+        let generic_context = callable_tcx.and_then(|signature| {
+            let generic_context = signature.generic_context?;
+            (return_ty.is_dynamic()
+                || return_ty.has_typevar(self.db())
+                || generic_context
+                    .variables(self.db())
+                    .all(|typevar| typevar.typevar(self.db()).is_self(self.db())))
+            .then_some(generic_context)
+        });
         Type::Callable(CallableType::new(
             self.db(),
-            CallableSignature::single(Signature::new(parameters, return_ty)),
+            // Contextual parameter types can refer to callable-local type variables (including an
+            // implicit `Self`). Keep their binder when the lambda return remains compatible.
+            CallableSignature::single(Signature::new_generic(
+                generic_context,
+                parameters,
+                return_ty,
+            )),
             CallableTypeKind::FunctionLike,
             CallableFunctionProvenance::ImplicitReturn,
         ))

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -60,17 +60,13 @@ fn parameters_have_annotations(parameters: &ast::Parameters) -> bool {
 struct ExpectedReturnType<'db> {
     /// The externally-visible return type.
     public: Type<'db>,
-    /// The lexical return type, if it differs for a generic PEP 695 function.
+    /// The lexical return type, if the public return type contains a type variable.
     lexical: Option<Type<'db>>,
 }
 
 impl<'db> ExpectedReturnType<'db> {
-    /// Creates the expected return type policy for `function_node`.
-    fn from_function(
-        db: &'db dyn Db,
-        function: FunctionType<'db>,
-        function_node: &ast::StmtFunctionDef,
-    ) -> Self {
+    /// Creates the expected return type policy for `function`.
+    fn from_function(db: &'db dyn Db, function: FunctionType<'db>) -> Self {
         /// Normalizes special return annotations to the type actually returned by expressions.
         fn normalize<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
             match ty {
@@ -84,7 +80,7 @@ impl<'db> ExpectedReturnType<'db> {
             same_module_uncached_raw_signature(db, function, ReturnCallableTypeVarScope::Public)
                 .return_ty,
         );
-        let lexical = function_node.type_params.is_some().then(|| {
+        let lexical = public.has_typevar(db).then(|| {
             normalize(
                 db,
                 same_module_uncached_raw_signature(
@@ -176,8 +172,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ReturnCallableTypeVarScope::Public,
             )
             .return_ty;
-            let expected_return =
-                ExpectedReturnType::from_function(db, enclosing_function, function);
+            let expected_return = ExpectedReturnType::from_function(db, enclosing_function);
             let expected_ty = expected_return.public();
 
             let scope_id = self.index.node_scope(NodeWithScopeRef::Function(function));

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -16,7 +16,7 @@ use crate::{
             OverloadLiteral, function_body_kind, is_implicit_classmethod,
             same_module_uncached_raw_signature,
         },
-        generics::{enclosing_generic_contexts, typing_self},
+        generics::{GenericContext, enclosing_generic_contexts, typing_self},
         infer::{
             InferenceFlags, TypeExpressionFlags, TypeInferenceBuilder,
             builder::{
@@ -62,6 +62,8 @@ struct ExpectedReturnType<'db> {
     public: Type<'db>,
     /// The lexical return type, if the public return type contains a type variable.
     lexical: Option<Type<'db>>,
+    /// The enclosing generic context available to a nested callable returned from this function.
+    lexical_generic_context: Option<GenericContext<'db>>,
 }
 
 impl<'db> ExpectedReturnType<'db> {
@@ -80,19 +82,20 @@ impl<'db> ExpectedReturnType<'db> {
             same_module_uncached_raw_signature(db, function, ReturnCallableTypeVarScope::Public)
                 .return_ty,
         );
-        let lexical = public.has_typevar(db).then(|| {
-            normalize(
-                db,
-                same_module_uncached_raw_signature(
-                    db,
-                    function,
-                    ReturnCallableTypeVarScope::Lexical,
-                )
-                .return_ty,
-            )
+        let lexical_signature = public.has_typevar(db).then(|| {
+            same_module_uncached_raw_signature(db, function, ReturnCallableTypeVarScope::Lexical)
         });
+        let lexical = lexical_signature
+            .as_ref()
+            .map(|signature| normalize(db, signature.return_ty));
+        let lexical_generic_context =
+            lexical_signature.and_then(|signature| signature.generic_context);
 
-        Self { public, lexical }
+        Self {
+            public,
+            lexical,
+            lexical_generic_context,
+        }
     }
 
     /// Returns the externally-visible return type.
@@ -107,6 +110,12 @@ impl<'db> ExpectedReturnType<'db> {
             || self
                 .lexical
                 .is_some_and(|lexical| ty.is_assignable_to(db, lexical))
+            || matches!(
+                (ty, self.lexical_generic_context),
+                (Type::FunctionLiteral(function), Some(generic_context))
+                    if Type::FunctionLiteral(function.with_inherited_generic_context(db, generic_context))
+                        .is_assignable_to(db, self.public)
+            )
     }
 }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -786,17 +786,22 @@ impl<'db> ProtocolMemberType<'db> {
     fn resolve(self, db: &'db dyn Db) -> Option<Self> {
         match self {
             Self::Value { .. } => Some(self),
-            Self::PropertyGetter(getter) => property_get_member_type(db, getter),
-            Self::PropertySetter(setter) => property_set_member_type(db, setter),
+            Self::PropertyGetter(getter) => property_get_member_type(db, getter, None),
+            Self::PropertySetter(setter) => property_set_member_type(db, setter, None),
         }
     }
 
     /// Resolves this member type and binds member-local `Self` occurrences to `self_type`.
     fn bind_self(self, db: &'db dyn Db, self_type: Type<'db>) -> Option<Type<'db>> {
+        let resolved = match self {
+            Self::Value { .. } => Some(self),
+            Self::PropertyGetter(getter) => property_get_member_type(db, getter, Some(self_type)),
+            Self::PropertySetter(setter) => property_set_member_type(db, setter, Some(self_type)),
+        }?;
         let Self::Value {
             ty,
             self_binding_context,
-        } = self.resolve(db)?
+        } = resolved
         else {
             return None;
         };
@@ -1473,12 +1478,27 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
 fn property_get_member_type<'db>(
     db: &'db dyn Db,
     getter: Type<'db>,
+    receiver_ty: Option<Type<'db>>,
 ) -> Option<ProtocolMemberType<'db>> {
     let mut get_types = Vec::new();
     let mut definition = None;
     for callable in &getter.try_upcast_to_callable(db)? {
         for signature in callable.signatures(db) {
-            get_types.push(signature.return_ty);
+            let receiver_typevar = property_accessor_receiver_typevar(db, signature);
+            let return_ty = match receiver_typevar.zip(receiver_ty) {
+                Some((typevar, receiver_ty))
+                    if Signature::receiver_violates_typevar_domain(db, receiver_ty, typevar) =>
+                {
+                    return None;
+                }
+                Some((typevar, receiver_ty)) => {
+                    signature
+                        .return_ty
+                        .substitute_one_typevar(db, typevar, receiver_ty)
+                }
+                None => signature.return_ty,
+            };
+            get_types.push(return_ty);
             definition = definition.or(signature.definition());
         }
     }
@@ -1491,12 +1511,26 @@ fn property_get_member_type<'db>(
 fn property_set_member_type<'db>(
     db: &'db dyn Db,
     setter: Type<'db>,
+    receiver_ty: Option<Type<'db>>,
 ) -> Option<ProtocolMemberType<'db>> {
     let mut set_types = Vec::new();
     let mut definition = None;
     for callable in &setter.try_upcast_to_callable(db)? {
         for signature in callable.signatures(db) {
-            set_types.push(signature.parameters().get_positional(1)?.annotated_type());
+            let parameter_ty = signature.parameters().get_positional(1)?.annotated_type();
+            let receiver_typevar = property_accessor_receiver_typevar(db, signature);
+            let parameter_ty = match receiver_typevar.zip(receiver_ty) {
+                Some((typevar, receiver_ty))
+                    if Signature::receiver_violates_typevar_domain(db, receiver_ty, typevar) =>
+                {
+                    return None;
+                }
+                Some((typevar, receiver_ty)) => {
+                    parameter_ty.substitute_one_typevar(db, typevar, receiver_ty)
+                }
+                None => parameter_ty,
+            };
+            set_types.push(parameter_ty);
             definition = definition.or(signature.definition());
         }
     }
@@ -1504,6 +1538,23 @@ fn property_set_member_type<'db>(
         UnionType::from_elements(db, set_types),
         definition,
     ))
+}
+
+/// Returns the direct, callable-local receiver `TypeVar` of a property accessor.
+fn property_accessor_receiver_typevar<'db>(
+    db: &'db dyn Db,
+    signature: &Signature<'db>,
+) -> Option<BoundTypeVarInstance<'db>> {
+    if !signature.has_explicit_positional_receiver_annotation() {
+        return None;
+    }
+    let typevar = signature
+        .parameters()
+        .get_positional(0)?
+        .annotated_type()
+        .resolve_type_alias(db)
+        .as_typevar()?;
+    (typevar.binding_context(db).definition() == signature.definition()).then_some(typevar)
 }
 
 /// Derive the observable instance capabilities of a descriptor-decorated protocol member.
@@ -1729,7 +1780,8 @@ fn property_set_type<'db>(
     property: PropertyInstanceType<'db>,
     receiver_ty: Type<'db>,
 ) -> Option<Type<'db>> {
-    property_set_member_type(db, property.setter(db)?)?.bind_self(db, receiver_ty)
+    property_set_member_type(db, property.setter(db)?, Some(receiver_ty))?
+        .bind_self(db, receiver_ty)
 }
 
 fn is_class_object_type(ty: Type<'_>) -> bool {
@@ -2474,9 +2526,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             (Some(source), Some(target)) => {
                 let bind_read = |member_type: ProtocolMemberType<'db>,
                                  member: &ProtocolMember<'_, 'db>| {
-                    let member_type = member_type.resolve(db)?;
                     if member.is_method()
-                        && let Type::Callable(callable) = member_type.ty()
+                        && let Type::Callable(callable) = member_type.resolve(db)?.ty()
                     {
                         Some(Type::Callable(callable.apply_self(db, source_type)))
                     } else {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1484,8 +1484,9 @@ fn property_get_member_type<'db>(
     let mut definition = None;
     for callable in &getter.try_upcast_to_callable(db)? {
         for signature in callable.signatures(db) {
-            let return_ty =
-                bind_property_accessor_type(db, signature, signature.return_ty, receiver_ty)?;
+            let return_ty = receiver_ty.map_or(Some(signature.return_ty), |receiver_ty| {
+                signature.specialize_type_for_receiver(db, signature.return_ty, receiver_ty)
+            })?;
             get_types.push(return_ty);
             definition = definition.or(signature.definition());
         }
@@ -1506,8 +1507,9 @@ fn property_set_member_type<'db>(
     for callable in &setter.try_upcast_to_callable(db)? {
         for signature in callable.signatures(db) {
             let parameter_ty = signature.parameters().get_positional(1)?.annotated_type();
-            let parameter_ty =
-                bind_property_accessor_type(db, signature, parameter_ty, receiver_ty)?;
+            let parameter_ty = receiver_ty.map_or(Some(parameter_ty), |receiver_ty| {
+                signature.specialize_type_for_receiver(db, parameter_ty, receiver_ty)
+            })?;
             set_types.push(parameter_ty);
             definition = definition.or(signature.definition());
         }
@@ -1516,45 +1518,6 @@ fn property_set_member_type<'db>(
         UnionType::from_elements(db, set_types),
         definition,
     ))
-}
-
-/// Specializes a property getter or setter type for its callable-local receiver `TypeVar`.
-///
-/// ```python
-/// @property
-/// def value[T](self: T) -> T: ...
-/// ```
-///
-/// Returns `None` when the concrete receiver violates the accessor's declared `TypeVar` domain.
-fn bind_property_accessor_type<'db>(
-    db: &'db dyn Db,
-    signature: &Signature<'db>,
-    ty: Type<'db>,
-    receiver_ty: Option<Type<'db>>,
-) -> Option<Type<'db>> {
-    let Some(receiver_ty) = receiver_ty else {
-        return Some(ty);
-    };
-    if !signature.has_explicit_positional_receiver_annotation() {
-        return Some(ty);
-    }
-    let Some(typevar) = signature
-        .parameters()
-        .get_positional(0)
-        .and_then(|parameter| {
-            parameter
-                .annotated_type()
-                .resolve_type_alias(db)
-                .as_typevar()
-        })
-    else {
-        return Some(ty);
-    };
-    if typevar.binding_context(db).definition() != signature.definition() {
-        return Some(ty);
-    }
-    (!Signature::receiver_violates_typevar_domain(db, receiver_ty, typevar))
-        .then(|| ty.substitute_one_typevar(db, typevar, receiver_ty))
 }
 
 /// Derive the observable instance capabilities of a descriptor-decorated protocol member.

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1484,20 +1484,8 @@ fn property_get_member_type<'db>(
     let mut definition = None;
     for callable in &getter.try_upcast_to_callable(db)? {
         for signature in callable.signatures(db) {
-            let receiver_typevar = property_accessor_receiver_typevar(db, signature);
-            let return_ty = match receiver_typevar.zip(receiver_ty) {
-                Some((typevar, receiver_ty))
-                    if Signature::receiver_violates_typevar_domain(db, receiver_ty, typevar) =>
-                {
-                    return None;
-                }
-                Some((typevar, receiver_ty)) => {
-                    signature
-                        .return_ty
-                        .substitute_one_typevar(db, typevar, receiver_ty)
-                }
-                None => signature.return_ty,
-            };
+            let return_ty =
+                bind_property_accessor_type(db, signature, signature.return_ty, receiver_ty)?;
             get_types.push(return_ty);
             definition = definition.or(signature.definition());
         }
@@ -1518,18 +1506,8 @@ fn property_set_member_type<'db>(
     for callable in &setter.try_upcast_to_callable(db)? {
         for signature in callable.signatures(db) {
             let parameter_ty = signature.parameters().get_positional(1)?.annotated_type();
-            let receiver_typevar = property_accessor_receiver_typevar(db, signature);
-            let parameter_ty = match receiver_typevar.zip(receiver_ty) {
-                Some((typevar, receiver_ty))
-                    if Signature::receiver_violates_typevar_domain(db, receiver_ty, typevar) =>
-                {
-                    return None;
-                }
-                Some((typevar, receiver_ty)) => {
-                    parameter_ty.substitute_one_typevar(db, typevar, receiver_ty)
-                }
-                None => parameter_ty,
-            };
+            let parameter_ty =
+                bind_property_accessor_type(db, signature, parameter_ty, receiver_ty)?;
             set_types.push(parameter_ty);
             definition = definition.or(signature.definition());
         }
@@ -1540,21 +1518,43 @@ fn property_set_member_type<'db>(
     ))
 }
 
-/// Returns the direct, callable-local receiver `TypeVar` of a property accessor.
-fn property_accessor_receiver_typevar<'db>(
+/// Specializes a property getter or setter type for its callable-local receiver `TypeVar`.
+///
+/// ```python
+/// @property
+/// def value[T](self: T) -> T: ...
+/// ```
+///
+/// Returns `None` when the concrete receiver violates the accessor's declared `TypeVar` domain.
+fn bind_property_accessor_type<'db>(
     db: &'db dyn Db,
     signature: &Signature<'db>,
-) -> Option<BoundTypeVarInstance<'db>> {
+    ty: Type<'db>,
+    receiver_ty: Option<Type<'db>>,
+) -> Option<Type<'db>> {
+    let Some(receiver_ty) = receiver_ty else {
+        return Some(ty);
+    };
     if !signature.has_explicit_positional_receiver_annotation() {
-        return None;
+        return Some(ty);
     }
-    let typevar = signature
+    let Some(typevar) = signature
         .parameters()
-        .get_positional(0)?
-        .annotated_type()
-        .resolve_type_alias(db)
-        .as_typevar()?;
-    (typevar.binding_context(db).definition() == signature.definition()).then_some(typevar)
+        .get_positional(0)
+        .and_then(|parameter| {
+            parameter
+                .annotated_type()
+                .resolve_type_alias(db)
+                .as_typevar()
+        })
+    else {
+        return Some(ty);
+    };
+    if typevar.binding_context(db).definition() != signature.definition() {
+        return Some(ty);
+    }
+    (!Signature::receiver_violates_typevar_domain(db, receiver_ty, typevar))
+        .then(|| ty.substitute_one_typevar(db, typevar, receiver_ty))
 }
 
 /// Derive the observable instance capabilities of a descriptor-decorated protocol member.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -14,7 +14,7 @@ use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
-use crate::types::tuple::TupleType;
+use crate::types::tuple::{Tuple, TupleType, VariableSegment};
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -1073,16 +1073,28 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         // With lazy evaluation, comparisons with a type variable are translated directly into a
         // constraint set.
         if self.typevar_evaluation == TypeVarEvaluation::Lazy {
-            // `Any` and `Unknown` are assignable to every specialization of a universally
+            // Gradual types are assignable to every specialization of a rigid or universally
             // quantified target type variable. Ordinary inference still needs to record gradual
             // evidence as a constraint so that it can infer `Any` or `Unknown`.
             if self.relation.is_assignability()
-                && matches!(
-                    (source, target),
-                    (Type::TypeVar(typevar), Type::Dynamic(_))
-                        | (Type::Dynamic(_), Type::TypeVar(typevar))
-                        if typevar.is_inferable(db, self.universally_quantified)
-                )
+                && let (Type::TypeVar(typevar), gradual) | (gradual, Type::TypeVar(typevar)) =
+                    (source, target)
+                && (typevar.is_inferable(db, self.universally_quantified)
+                    || (self.universally_quantified != InferableTypeVars::None
+                        && !typevar.is_inferable(db, self.inferable)))
+                && (gradual.is_dynamic()
+                    || (typevar.is_typevartuple(db)
+                        && matches!(
+                            gradual.exact_tuple_instance_spec(db).as_deref(),
+                            Some(Tuple::Variable(tuple))
+                                if tuple.prefix_elements().is_empty()
+                                    && tuple.suffix_elements().is_empty()
+                                    && matches!(
+                                        tuple.variable(),
+                                        VariableSegment::Homogeneous(element)
+                                            if element.is_dynamic()
+                                    )
+                        )))
             {
                 return self.always();
             }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -344,6 +344,7 @@ impl<'db> Type<'db> {
         let checker = TypeRelationChecker {
             constraints,
             inferable,
+            universally_quantified: InferableTypeVars::None,
             relation: TypeRelation::SubtypingAssuming,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: None,
@@ -381,6 +382,7 @@ impl<'db> Type<'db> {
         let checker = TypeRelationChecker {
             constraints: &builder,
             inferable: InferableTypeVars::None,
+            universally_quantified: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: Some(ErrorContextTree::new()),
@@ -588,6 +590,7 @@ impl<'db> Type<'db> {
         let checker = TypeRelationChecker {
             constraints,
             inferable,
+            universally_quantified: InferableTypeVars::None,
             relation,
             typevar_evaluation,
             context_tree: None,
@@ -743,6 +746,8 @@ impl<'db, 'c> IsDisjointVisitor<'db, 'c> {
 pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     pub(super) inferable: InferableTypeVars<'db>,
+    /// Target-signature type variables that will be universally quantified after comparison.
+    pub(super) universally_quantified: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
     pub(super) typevar_evaluation: TypeVarEvaluation,
     context_tree: Option<ErrorContextTree<'db>>,
@@ -772,6 +777,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable,
+            universally_quantified: InferableTypeVars::None,
             relation: TypeRelation::Subtyping,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: None,
@@ -793,6 +799,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
+            universally_quantified: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
             context_tree: None,
@@ -814,6 +821,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
+            universally_quantified: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
             context_tree: Some(ErrorContextTree::new()),
@@ -835,6 +843,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
+            universally_quantified: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: Some(ErrorContextTree::new()),
@@ -1064,6 +1073,20 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         // With lazy evaluation, comparisons with a type variable are translated directly into a
         // constraint set.
         if self.typevar_evaluation == TypeVarEvaluation::Lazy {
+            // `Any` and `Unknown` are assignable to every specialization of a universally
+            // quantified target type variable. Ordinary inference still needs to record gradual
+            // evidence as a constraint so that it can infer `Any` or `Unknown`.
+            if self.relation.is_assignability()
+                && matches!(
+                    (source, target),
+                    (Type::TypeVar(typevar), Type::Dynamic(_))
+                        | (Type::Dynamic(_), Type::TypeVar(typevar))
+                        if typevar.is_inferable(db, self.universally_quantified)
+                )
+            {
+                return self.always();
+            }
+
             // A typevar satisfies a relation when...it satisfies the relation. Yes that's a
             // tautology! We're moving the caller's subtyping/assignability requirement into a
             // constraint set. If the typevar has an upper bound or constraints, then the relation
@@ -2403,6 +2426,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             context_tree: None,
             given: self.given,
             inferable: InferableTypeVars::None,
+            universally_quantified: InferableTypeVars::None,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,
             signature_relation_visitor: self.signature_relation_visitor,
@@ -2486,6 +2510,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             typevar_evaluation: TypeVarEvaluation::Eager,
             constraints: self.constraints,
             inferable: self.inferable,
+            universally_quantified: InferableTypeVars::None,
             context_tree: None,
             given: self.given,
             relation_visitor: self.relation_visitor,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3010,6 +3010,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // self: callable without ParamSpec
                 // other: `P`
                 (None, Some(([], target_bound_typevar))) => {
+                    // A gradual source accepts every target parameter list. Constraining a
+                    // universally quantified ParamSpec to `...` would incorrectly reject it.
+                    if self.relation.is_assignability()
+                        && source.parameters.is_gradual()
+                        && target_bound_typevar.is_inferable(db, self.universally_quantified)
+                    {
+                        return result;
+                    }
                     let lower = Type::Callable(CallableType::new(
                         db,
                         CallableSignature::single(Signature::new_generic(
@@ -3156,6 +3164,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     let source_params = source
                         .parameters
                         .with_transformed_parameters(source_params.cloned());
+                    // The fixed prefix has been checked above; a gradual remainder accepts every
+                    // specialization of the target ParamSpec.
+                    if self.relation.is_assignability()
+                        && source_params.is_gradual()
+                        && target_bound_typevar.is_inferable(db, self.universally_quantified)
+                    {
+                        return result;
+                    }
                     let lower = Type::Callable(CallableType::new(
                         db,
                         CallableSignature::single(Signature::new_generic(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1573,12 +1573,26 @@ impl<'db> Signature<'db> {
         checker: &TypeRelationChecker<'_, 'c, 'db>,
         db: &'db dyn Db,
     ) -> ConstraintSet<'db, 'c> {
-        self.receiver_binding
-            .as_ref()
-            .and_then(|binding| binding.generic_context)
-            .into_iter()
-            .flat_map(|generic_context| generic_context.variables(db))
-            .filter(|typevar| !self.receiver_typevar_has_enclosing_protocol_bound(db, *typevar))
+        Self::declared_domain_when_satisfied(
+            checker,
+            db,
+            self.receiver_binding
+                .as_ref()
+                .and_then(|binding| binding.generic_context)
+                .into_iter()
+                .flat_map(|generic_context| generic_context.variables(db))
+                .filter(|typevar| {
+                    !self.receiver_typevar_has_enclosing_protocol_bound(db, *typevar)
+                }),
+        )
+    }
+
+    fn declared_domain_when_satisfied<'c>(
+        checker: &TypeRelationChecker<'_, 'c, 'db>,
+        db: &'db dyn Db,
+        typevars: impl Iterator<Item = BoundTypeVarInstance<'db>>,
+    ) -> ConstraintSet<'db, 'c> {
+        typevars
             .filter_map(|typevar| {
                 typevar
                     .typevar(db)
@@ -2540,8 +2554,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         //
         // Target signature typevars require the opposite quantifier: the relation must hold for
         // every target specialization. Receiver typevars are quantified over the domain imposed
-        // by binding the receiver; the remaining target variables are unconditional.
-        when.reduce_inferable(db, self.constraints, source_inferable)
+        // by binding the receiver; the remaining target variables use their declared domains.
+        let target_declared_domain = Signature::declared_domain_when_satisfied(
+            &checker,
+            db,
+            target
+                .generic_context
+                .into_iter()
+                .flat_map(|generic_context| generic_context.variables(db))
+                .filter(|typevar| typevar.is_inferable(db, target_non_receiver_inferable)),
+        );
+        target_declared_domain
+            .implies(db, self.constraints, || {
+                when.reduce_inferable(db, self.constraints, source_inferable)
+            })
             .for_all(db, self.constraints, target_receiver_inferable)
             .for_all(db, self.constraints, target_non_receiver_inferable)
     }
@@ -3196,6 +3222,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // self: `P`
                 // other: callable without ParamSpec
                 (Some(([], source_bound_typevar)), None) => {
+                    // A gradual target is consistent with every specialization of a universally
+                    // quantified source ParamSpec in this contravariant comparison.
+                    if self.relation.is_assignability()
+                        && target.parameters.is_gradual()
+                        && source_bound_typevar.is_inferable(db, self.universally_quantified)
+                    {
+                        return result;
+                    }
                     let upper = Type::Callable(CallableType::new(
                         db,
                         CallableSignature::single(Signature::new_generic(
@@ -3310,6 +3344,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     let target_params = target
                         .parameters
                         .with_transformed_parameters(target_params.cloned());
+                    // The fixed prefix has been checked above; a gradual remainder is consistent
+                    // with every specialization of the universally quantified ParamSpec.
+                    if self.relation.is_assignability()
+                        && target_params.is_gradual()
+                        && source_bound_typevar.is_inferable(db, self.universally_quantified)
+                    {
+                        return result;
+                    }
                     let upper = Type::Callable(CallableType::new(
                         db,
                         CallableSignature::single(Signature::new_generic(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -134,20 +134,39 @@ fn merge_receiver_constraints<'db>(
     }
 }
 
-/// The constraint domain introduced by binding an explicitly annotated receiver.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+enum ReceiverBindingKind {
+    Constrained,
+    Specialized,
+}
+
+/// The constraint domain or specialization introduced by binding an explicitly annotated receiver.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 struct ReceiverBinding<'db> {
     constraints: OwnedConstraintSet<'db>,
     generic_context: Option<GenericContext<'db>>,
+    kind: ReceiverBindingKind,
 }
 
 impl<'db> ReceiverBinding<'db> {
     fn merge(db: &'db dyn Db, first: Option<&Self>, second: Option<&Self>) -> Option<Self> {
+        let kind = if first
+            .into_iter()
+            .chain(second)
+            .any(|binding| binding.kind == ReceiverBindingKind::Specialized)
+        {
+            ReceiverBindingKind::Specialized
+        } else {
+            ReceiverBindingKind::Constrained
+        };
         let constraints = merge_receiver_constraints(
             db,
             first.map(|binding| &binding.constraints),
             second.map(|binding| &binding.constraints),
-        )?;
+        );
+        let constraints = constraints.or_else(|| {
+            (kind == ReceiverBindingKind::Specialized).then(OwnedConstraintSet::always)
+        })?;
         let generic_context = GenericContext::merge_optional(
             db,
             first.and_then(|binding| binding.generic_context),
@@ -156,6 +175,7 @@ impl<'db> ReceiverBinding<'db> {
         Some(Self {
             constraints,
             generic_context,
+            kind,
         })
     }
 }
@@ -578,7 +598,7 @@ pub struct Signature<'db> {
     /// This is useful for locating and extracting docstring information for the signature.
     pub(crate) definition: Option<Definition<'db>>,
 
-    /// The constraint domain introduced by binding an explicitly annotated receiver, if any.
+    /// The constraint domain or specialization introduced by binding an explicitly annotated receiver.
     receiver_binding: Option<ReceiverBinding<'db>>,
 
     /// Parameters, in source order.
@@ -1071,6 +1091,74 @@ impl<'db> Signature<'db> {
             .parameters
             .get(0)
             .filter(|parameter| parameter.is_positional() && !parameter.inferred_annotation);
+        let binding_context = self.definition.map(BindingContext::Definition);
+
+        // Protocol interfaces bind their receiver before the concrete implementation is known.
+        // A direct receiver `TypeVar` in that deferred path is the eventual receiver exactly, so
+        // substitute it through the visible parameters and return before removing the receiver.
+        // Ordinary descriptor binding retains its lower-bound inference semantics.
+        if receiver_type.is_none()
+            && let Some(parameter) = explicit_receiver
+        {
+            let receiver = Type::TypeVar(BoundTypeVarInstance::synthetic_self(
+                db,
+                Type::object(),
+                BindingContext::Synthetic,
+            ));
+            let annotation = if let Some(typing_self_type) = typing_self_type {
+                parameter.annotated_type().apply_type_mapping(
+                    db,
+                    &TypeMapping::BindSelf(SelfBinding::new(db, typing_self_type, binding_context)),
+                    TypeContext::default(),
+                )
+            } else {
+                parameter.annotated_type()
+            }
+            .resolve_type_alias(db);
+            let specialization = match annotation {
+                Type::TypeVar(typevar) if !typevar.typevar(db).is_self(db) => {
+                    Some((typevar, receiver))
+                }
+                Type::SubclassOf(subclass_of) => subclass_of
+                    .into_type_var()
+                    .filter(|typevar| !typevar.typevar(db).is_self(db))
+                    .map(|typevar| {
+                        let specialization = Type::TypeVar(BoundTypeVarInstance::synthetic_self(
+                            db,
+                            Type::object(),
+                            binding_context.unwrap_or(BindingContext::Synthetic),
+                        ));
+                        (typevar, specialization)
+                    }),
+                _ => None,
+            };
+            if let Some((typevar, specialization)) = specialization
+                && !matches!(
+                    specialization,
+                    Type::TypeVar(receiver_typevar)
+                        if receiver_typevar.is_same_typevar_as(db, typevar)
+                )
+            {
+                let receiver_domain =
+                    Self::specialized_receiver_domain(db, specialization, typevar);
+                let mapping = TypeMapping::ApplySpecialization(ApplySpecialization::Single(
+                    typevar,
+                    specialization,
+                ));
+                let mut specialized = self.apply_type_mapping_impl(
+                    db,
+                    &mapping,
+                    TypeContext::default(),
+                    &ApplyTypeMappingVisitor::default(),
+                );
+                specialized.receiver_binding = ReceiverBinding::merge(
+                    db,
+                    specialized.receiver_binding.as_ref(),
+                    Some(&receiver_domain),
+                );
+                return specialized.bind_self_with_receiver(db, receiver_type, typing_self_type);
+            }
+        }
 
         // TODO: Theoretically, for a signature like `f(*args: *tuple[MyClass, int, *tuple[str, ...]])` with
         // a variadic first parameter, we should also "skip the first parameter" by modifying the tuple type.
@@ -1080,7 +1168,6 @@ impl<'db> Signature<'db> {
             self.parameters.clone()
         };
         let mut return_ty = self.return_ty;
-        let binding_context = self.definition.map(BindingContext::Definition);
         let receiver_binding = explicit_receiver.and_then(|parameter| {
             let receiver = receiver_type.unwrap_or_else(|| {
                 Type::TypeVar(BoundTypeVarInstance::synthetic_self(
@@ -1137,6 +1224,7 @@ impl<'db> Signature<'db> {
                 return Some(ReceiverBinding {
                     constraints,
                     generic_context: receiver_generic_context,
+                    kind: ReceiverBindingKind::Constrained,
                 });
             }
             if receiver_typevar.is_some_and(|typevar| {
@@ -1145,6 +1233,7 @@ impl<'db> Signature<'db> {
                 return Some(ReceiverBinding {
                     constraints: OwnedConstraintSet::default(),
                     generic_context: None,
+                    kind: ReceiverBindingKind::Constrained,
                 });
             }
             let receiver_constraint =
@@ -1154,6 +1243,7 @@ impl<'db> Signature<'db> {
             Some(ReceiverBinding {
                 constraints,
                 generic_context: receiver_generic_context,
+                kind: ReceiverBindingKind::Constrained,
             })
         });
         let receiver_binding = ReceiverBinding::merge(
@@ -1182,6 +1272,45 @@ impl<'db> Signature<'db> {
             receiver_binding,
             parameters,
             return_ty,
+        }
+    }
+
+    /// Returns the declared-domain obligation that remains after specializing a receiver `TypeVar`.
+    fn specialized_receiver_domain(
+        db: &'db dyn Db,
+        receiver: Type<'db>,
+        typevar: BoundTypeVarInstance<'db>,
+    ) -> ReceiverBinding<'db> {
+        let constraints = typevar.typevar(db).bound_or_constraints(db).map_or_else(
+            OwnedConstraintSet::always,
+            |domain| {
+                ConstraintSetBuilder::new().into_owned(|builder| match domain {
+                    TypeVarBoundOrConstraints::UpperBound(bound) => receiver
+                        .when_constraint_set_assignable_to(
+                            db,
+                            bound.top_materialization(db),
+                            builder,
+                        ),
+                    TypeVarBoundOrConstraints::Constraints(typevar_constraints) => {
+                        typevar_constraints.elements(db).iter().when_any(
+                            db,
+                            builder,
+                            |constraint| {
+                                receiver.when_constraint_set_assignable_to(
+                                    db,
+                                    constraint.top_materialization(db),
+                                    builder,
+                                )
+                            },
+                        )
+                    }
+                })
+            },
+        );
+        ReceiverBinding {
+            constraints,
+            generic_context: None,
+            kind: ReceiverBindingKind::Specialized,
         }
     }
 
@@ -1372,26 +1501,43 @@ impl<'db> Signature<'db> {
                     TypeContext::default(),
                     &self_visitor,
                 );
-                (!constraints.query(|_builder, constraints| constraints.is_always_satisfied(db)))
-                    .then_some(ReceiverBinding {
-                        constraints,
-                        generic_context: binding.generic_context,
-                    })
+                (binding.kind == ReceiverBindingKind::Specialized
+                    || !constraints
+                        .query(|_builder, constraints| constraints.is_always_satisfied(db)))
+                .then_some(ReceiverBinding {
+                    constraints,
+                    generic_context: binding.generic_context,
+                    kind: binding.kind,
+                })
             });
+        let parameters = self.parameters.apply_type_mapping_impl(
+            db,
+            &receiver_mapping,
+            TypeContext::default(),
+            &receiver_visitor,
+        );
+        let return_ty = self.return_ty.apply_type_mapping_impl(
+            db,
+            &receiver_mapping,
+            TypeContext::default(),
+            &receiver_visitor,
+        );
         if !self.needs_self_mapping(db, false) {
             return Self {
                 receiver_binding,
+                parameters,
+                return_ty,
                 ..self.clone()
             };
         }
 
-        let parameters = self.parameters.apply_type_mapping_impl(
+        let parameters = parameters.apply_type_mapping_impl(
             db,
             &self_mapping,
             TypeContext::default(),
             &self_visitor,
         );
-        let return_ty = self.return_ty.apply_type_mapping_impl(
+        let return_ty = return_ty.apply_type_mapping_impl(
             db,
             &self_mapping,
             TypeContext::default(),
@@ -1474,7 +1620,9 @@ impl<'db> Signature<'db> {
         let binding = self.receiver_binding.as_ref()?;
         let constraints =
             Self::map_constraints(db, &binding.constraints, type_mapping, tcx, visitor);
-        if constraints.query(|_builder, constraints| constraints.is_always_satisfied(db)) {
+        if binding.kind != ReceiverBindingKind::Specialized
+            && constraints.query(|_builder, constraints| constraints.is_always_satisfied(db))
+        {
             return None;
         }
         let generic_context = binding.generic_context.and_then(|generic_context| {
@@ -1485,6 +1633,7 @@ impl<'db> Signature<'db> {
         Some(ReceiverBinding {
             constraints,
             generic_context,
+            kind: binding.kind,
         })
     }
 
@@ -1939,13 +2088,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source_signatures: &[Signature<'db>],
         target_signature: &Signature<'db>,
     ) -> Option<ConstraintSet<'db, 'c>> {
-        // Aggregation summarizes visible parameters and return types, but receiver bindings are
-        // additional per-signature obligations. Leave those signatures to the ordinary relation,
-        // which checks each receiver binding before comparing the visible signature.
-        if target_signature.receiver_binding.is_some()
+        // Aggregation summarizes visible parameters and return types, but receiver constraints
+        // are additional per-signature obligations. Leave those signatures to the ordinary
+        // relation, which checks each receiver binding before comparing the visible signature.
+        if target_signature
+            .receiver_binding
+            .as_ref()
+            .is_some_and(|binding| !binding.constraints.is_trivially_always_satisfied())
             || source_signatures
                 .iter()
-                .any(|signature| signature.receiver_binding.is_some())
+                .filter_map(|signature| signature.receiver_binding.as_ref())
+                .any(|binding| !binding.constraints.is_trivially_always_satisfied())
         {
             return None;
         }
@@ -2308,10 +2461,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
-        // Every nonterminal receiver constraint constrains at least one typevar. Terminal `always`
-        // sets are discarded when receiver constraints are merged, so presence alone is enough to
-        // require lazy typevar evaluation here.
-        if source.receiver_binding.is_some() || target.receiver_binding.is_some() {
+        // Receiver constraints and deferred receiver specialization both require lazy typevar
+        // evaluation: specializing the receiver can still leave unrelated method TypeVars that
+        // must be checked universally.
+        if source
+            .receiver_binding
+            .iter()
+            .chain(target.receiver_binding.iter())
+            .any(|binding| {
+                !binding.constraints.is_trivially_always_satisfied()
+                    || signature_inferable != InferableTypeVars::None
+            })
+        {
             checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         }
         let when = checker.with_signature_recursion_guard(source, target, || {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -22,6 +22,7 @@ use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
+    Solutions,
 };
 use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::generics::{
@@ -2483,10 +2484,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             checker.universally_quantified =
                 checker.universally_quantified.merge(db, target_inferable);
         }
-        // A non-generic source cannot choose a specialization that satisfies a generic target;
-        // use lazy typevar evaluation so the target's obligations can be universally quantified.
+        // Keep this higher-rank source check to unary declared callables for now. More complex
+        // overload and multi-parameter constraints still require the ordinary inference path.
+        let check_generic_source = source.definition.is_some()
+            && target.definition.is_some()
+            && source_inferable != InferableTypeVars::None
+            && target_inferable != InferableTypeVars::None
+            && source.parameters.len() == 1
+            && target.parameters.len() == 1;
+        // A generic target must be compared lazily so its obligations survive until universal
+        // quantification, including when the source signature is generic too.
         // Keep recursive protocol members on the existing eager path to avoid expanding cycles.
-        if (source_inferable == InferableTypeVars::None
+        if ((source_inferable == InferableTypeVars::None || check_generic_source)
             && target_inferable != InferableTypeVars::None
             && !source.is_recursive_protocol_member(db)
             && !target.is_recursive_protocol_member(db))
@@ -2504,6 +2513,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let when = checker.with_signature_recursion_guard(source, target, || {
             source
                 .receiver_constraints_when_satisfied(&checker, db)
+                .and(db, self.constraints, || {
+                    if check_generic_source {
+                        Signature::declared_domain_when_satisfied(
+                            &checker,
+                            db,
+                            source
+                                .generic_context
+                                .into_iter()
+                                .flat_map(|generic_context| generic_context.variables(db))
+                                .filter(|typevar| typevar.is_inferable(db, source_inferable)),
+                        )
+                    } else {
+                        checker.always()
+                    }
+                })
                 .and(db, self.constraints, || {
                     // Recursive protocol members can revisit this same source signature while
                     // checking a declared bound. Concrete receiver compatibility was already
@@ -2564,6 +2588,42 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .flat_map(|generic_context| generic_context.variables(db))
                 .filter(|typevar| typevar.is_inferable(db, target_non_receiver_inferable)),
         );
+        let when = if check_generic_source
+            && source_inferable != InferableTypeVars::None
+            && target_inferable != InferableTypeVars::None
+            && let Some(source_generic_context) = source.generic_context
+        {
+            // Existential abstraction can discard a constraint that relates a target variable to
+            // a source variable nested in another type (for example, `T <= list[S]`). Recheck each
+            // inferred source specialization before abstraction so that such obligations remain
+            // attached to the universally quantified target variables.
+            let source_specialization_holds =
+                match when.solutions(db, self.constraints, source_inferable) {
+                    Solutions::Unsatisfiable => checker.never(),
+                    Solutions::Unconstrained => checker.always(),
+                    Solutions::Constrained(solutions) => {
+                        solutions.iter().when_any(db, self.constraints, |solution| {
+                            let specialization = source_generic_context.specialize_recursive(
+                                db,
+                                source_generic_context.variables(db).map(|typevar| {
+                                    solution
+                                        .iter()
+                                        .find(|binding| {
+                                            binding.bound_typevar.is_same_typevar_as(db, typevar)
+                                        })
+                                        .map(|binding| binding.solution)
+                                }),
+                            );
+                            let specialized_source =
+                                source.apply_specialization(db, specialization);
+                            checker.check_signature_pair_inner(db, &specialized_source, target)
+                        })
+                    }
+                };
+            when.and(db, self.constraints, || source_specialization_holds)
+        } else {
+            when
+        };
         target_declared_domain
             .implies(db, self.constraints, || {
                 when.reduce_inferable(db, self.constraints, source_inferable)

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -134,9 +134,12 @@ fn merge_receiver_constraints<'db>(
     }
 }
 
+/// Distinguishes an inferred receiver constraint from an already-specialized receiver variable.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 enum ReceiverBindingKind {
+    /// The receiver `TypeVar` still participates in constraint solving.
     Constrained,
+    /// The receiver `TypeVar` was substituted, but its declared domain may still need checking.
     Specialized,
 }
 
@@ -149,6 +152,7 @@ struct ReceiverBinding<'db> {
 }
 
 impl<'db> ReceiverBinding<'db> {
+    /// Combines receiver domains while retaining a specialization whose constraints are trivial.
     fn merge(db: &'db dyn Db, first: Option<&Self>, second: Option<&Self>) -> Option<Self> {
         let kind = if first
             .into_iter()

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1114,6 +1114,31 @@ impl<'db> Signature<'db> {
                 };
                 (Some(typevar), receiver)
             });
+            let receiver_generic_context = self.generic_context_for_receiver_annotation(
+                db,
+                parameter.annotated_type(),
+                bind_class_receiver,
+            );
+            if let Some(typevar) = receiver_typevar
+                && matches!(resolved_annotation, Type::TypeVar(_))
+                && self.receiver_typevar_has_enclosing_protocol_bound(db, typevar)
+            {
+                // Checking the declared bound here would recursively check the protocol that is
+                // already being compared. The concrete receiver is the valid specialization.
+                let constraints = ConstraintSetBuilder::new().into_owned(|builder| {
+                    ConstraintSet::constrain_typevar(
+                        db,
+                        builder,
+                        typevar,
+                        receiver_for_domain,
+                        receiver_for_domain,
+                    )
+                });
+                return Some(ReceiverBinding {
+                    constraints,
+                    generic_context: receiver_generic_context,
+                });
+            }
             if receiver_typevar.is_some_and(|typevar| {
                 Self::receiver_violates_typevar_domain(db, receiver_for_domain, typevar)
             }) {
@@ -1122,25 +1147,10 @@ impl<'db> Signature<'db> {
                     generic_context: None,
                 });
             }
-            let receiver_generic_context = self.generic_context_for_receiver_annotation(
-                db,
-                parameter.annotated_type(),
-                bind_class_receiver,
-            );
             let receiver_constraint =
                 receiver.when_constraint_set_assignable_to_owned(db, annotation);
-            let declared_domain = receiver_generic_context
-                .into_iter()
-                .flat_map(|generic_context| generic_context.variables(db))
-                .filter_map(|typevar| Self::receiver_typevar_domain(db, typevar))
-                .fold(None, |constraints, domain| {
-                    merge_receiver_constraints(db, constraints.as_ref(), Some(&domain))
-                });
-            let constraints = merge_receiver_constraints(
-                db,
-                Some(receiver_constraint.as_ref()),
-                declared_domain.as_ref(),
-            )?;
+            let constraints = (!receiver_constraint.is_trivially_always_satisfied())
+                .then(|| receiver_constraint.into_owned())?;
             Some(ReceiverBinding {
                 constraints,
                 generic_context: receiver_generic_context,
@@ -1209,37 +1219,48 @@ impl<'db> Signature<'db> {
         }
     }
 
-    /// Returns the declared domain of a callable-local receiver `TypeVar` as a constraint set.
-    fn receiver_typevar_domain(
+    /// Returns whether a receiver `TypeVar` is bounded by the protocol that declares this method.
+    fn receiver_typevar_has_enclosing_protocol_bound(
+        &self,
         db: &'db dyn Db,
         typevar: BoundTypeVarInstance<'db>,
-    ) -> Option<OwnedConstraintSet<'db>> {
-        let domain = typevar.typevar(db).bound_or_constraints(db)?;
-        let constraints = ConstraintSetBuilder::new();
-        Some(constraints.into_owned(|builder| {
-            match domain {
-                TypeVarBoundOrConstraints::UpperBound(bound) => {
-                    ConstraintSet::constrain_typevar_upper_bound(
-                        db,
-                        builder,
-                        typevar,
-                        bound.top_materialization(db),
-                    )
-                }
-                TypeVarBoundOrConstraints::Constraints(typevar_constraints) => typevar_constraints
-                    .elements(db)
-                    .iter()
-                    .when_any(db, builder, |constraint| {
-                        ConstraintSet::constrain_typevar(
-                            db,
-                            builder,
-                            typevar,
-                            constraint.bottom_materialization(db),
-                            constraint.top_materialization(db),
-                        )
-                    }),
-            }
-        }))
+    ) -> bool {
+        let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
+            typevar.typevar(db).bound_or_constraints(db)
+        else {
+            return false;
+        };
+        self.references_enclosing_protocol(db, bound)
+    }
+
+    /// Returns whether `ty` references the protocol that declares this method.
+    fn references_enclosing_protocol(&self, db: &'db dyn Db, ty: Type<'db>) -> bool {
+        let Some(definition) = self.definition else {
+            return false;
+        };
+        super::visitor::any_over_type(db, ty, false, |ty| {
+            let class = match ty {
+                Type::NominalInstance(instance) => Some(instance.class(db)),
+                Type::ProtocolInstance(protocol) => protocol
+                    .to_nominal_instance()
+                    .map(|instance| instance.class(db)),
+                _ => None,
+            };
+            class
+                .and_then(|class| class.static_class_literal(db))
+                .is_some_and(|(class, _)| {
+                    class.is_protocol(db) && class.body_scope(db) == definition.scope(db)
+                })
+        })
+    }
+
+    /// Returns whether this signature participates in a recursive protocol member relation.
+    fn is_recursive_protocol_member(&self, db: &'db dyn Db) -> bool {
+        self.parameters
+            .iter()
+            .map(Parameter::annotated_type)
+            .chain(std::iter::once(self.return_ty))
+            .any(|ty| self.references_enclosing_protocol(db, ty))
     }
 
     /// Returns `true` if this signature's first parameter can accept the bound `self` type.
@@ -1394,6 +1415,53 @@ impl<'db> Signature<'db> {
             return checker.always();
         };
         checker.constraints.load(db, &binding.constraints)
+    }
+
+    /// Returns the declared domain of the callable-local receiver `TypeVar`s.
+    fn receiver_declared_domain_when_satisfied<'c>(
+        &self,
+        checker: &TypeRelationChecker<'_, 'c, 'db>,
+        db: &'db dyn Db,
+    ) -> ConstraintSet<'db, 'c> {
+        self.receiver_binding
+            .as_ref()
+            .and_then(|binding| binding.generic_context)
+            .into_iter()
+            .flat_map(|generic_context| generic_context.variables(db))
+            .filter(|typevar| !self.receiver_typevar_has_enclosing_protocol_bound(db, *typevar))
+            .filter_map(|typevar| {
+                typevar
+                    .typevar(db)
+                    .bound_or_constraints(db)
+                    .map(|domain| (typevar, domain))
+            })
+            .fold(checker.always(), |constraints, (typevar, domain)| {
+                constraints.and(db, checker.constraints, || match domain {
+                    TypeVarBoundOrConstraints::UpperBound(bound) => {
+                        ConstraintSet::constrain_typevar_upper_bound(
+                            db,
+                            checker.constraints,
+                            typevar,
+                            bound.top_materialization(db),
+                        )
+                    }
+                    TypeVarBoundOrConstraints::Constraints(typevar_constraints) => {
+                        typevar_constraints.elements(db).iter().when_any(
+                            db,
+                            checker.constraints,
+                            |constraint| {
+                                ConstraintSet::constrain_typevar(
+                                    db,
+                                    checker.constraints,
+                                    typevar,
+                                    constraint.bottom_materialization(db),
+                                    constraint.top_materialization(db),
+                                )
+                            },
+                        )
+                    }
+                })
+            })
     }
 
     fn map_receiver_binding(
@@ -2250,6 +2318,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             source
                 .receiver_constraints_when_satisfied(&checker, db)
                 .and(db, self.constraints, || {
+                    // Recursive protocol members can revisit this same source signature while
+                    // checking a declared bound. Concrete receiver compatibility was already
+                    // checked when the signature was bound; keep the obligation for all other
+                    // comparisons, including coercion to `Callable`.
+                    if source
+                        .receiver_binding
+                        .as_ref()
+                        .and_then(|binding| binding.generic_context)
+                        .is_some()
+                        && !target.is_recursive_protocol_member(db)
+                    {
+                        source.receiver_declared_domain_when_satisfied(&checker, db)
+                    } else {
+                        checker.always()
+                    }
+                })
+                .and(db, self.constraints, || {
                     if matches!(target_receiver_inferable, InferableTypeVars::None) {
                         target
                             .receiver_constraints_when_satisfied(&checker, db)
@@ -2257,8 +2342,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 checker.check_signature_pair_inner(db, source, target)
                             })
                     } else {
-                        let target_domain =
-                            target.receiver_constraints_when_satisfied(&checker, db);
+                        let target_domain = target
+                            .receiver_constraints_when_satisfied(&checker, db)
+                            .and(db, self.constraints, || {
+                                target.receiver_declared_domain_when_satisfied(&checker, db)
+                            });
                         // A target receiver must admit at least one valid specialization. Without
                         // this check, an impossible declared bound makes the implication vacuous
                         // and an invalid implementation can satisfy the protocol.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2465,6 +2465,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
+        if target_inferable != InferableTypeVars::None {
+            checker.universally_quantified =
+                checker.universally_quantified.merge(db, target_inferable);
+        }
         // A non-generic source cannot choose a specialization that satisfies a generic target;
         // use lazy typevar evaluation so the target's obligations can be universally quantified.
         // Keep recursive protocol members on the existing eager path to avoid expanding cycles.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -329,6 +329,8 @@ impl<'db> CallableSignature<'db> {
                             tcx,
                             visitor,
                         ),
+                        receiver_generic_context: self_signature
+                            .map_receiver_generic_context(db, type_mapping),
                         parameters,
                         return_ty: self_signature.return_ty.apply_type_mapping_impl(
                             db,
@@ -364,6 +366,11 @@ impl<'db> CallableSignature<'db> {
                                     mapped.as_ref(),
                                 )
                             },
+                            receiver_generic_context: GenericContext::merge_optional(
+                                db,
+                                signature.receiver_generic_context,
+                                self_signature.map_receiver_generic_context(db, type_mapping),
+                            ),
                             parameters: signature.parameters().with_prefix(
                                 prefix_parameters.iter().map(|param| {
                                     param.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
@@ -555,6 +562,12 @@ pub struct Signature<'db> {
     /// The constraint introduced by binding an explicitly annotated receiver, if any.
     receiver_constraints: Option<OwnedConstraintSet<'db>>,
 
+    /// The callable-local type variables that occur in an explicitly annotated receiver.
+    ///
+    /// These variables are quantified over the receiver constraint's domain, rather than over
+    /// every specialization of the callable's generic context.
+    receiver_generic_context: Option<GenericContext<'db>>,
+
     /// Parameters, in source order.
     ///
     /// The ordering of parameters in a valid signature must be: first positional-only parameters,
@@ -693,6 +706,7 @@ impl<'db> Signature<'db> {
             generic_context: None,
             definition: None,
             receiver_constraints: None,
+            receiver_generic_context: None,
             parameters,
             return_ty,
         }
@@ -707,6 +721,7 @@ impl<'db> Signature<'db> {
             generic_context,
             definition: None,
             receiver_constraints: None,
+            receiver_generic_context: None,
             parameters,
             return_ty,
         }
@@ -718,6 +733,7 @@ impl<'db> Signature<'db> {
             generic_context: None,
             definition: None,
             receiver_constraints: None,
+            receiver_generic_context: None,
             parameters: Parameters::gradual_form(),
             return_ty: signature_type,
         }
@@ -771,6 +787,7 @@ impl<'db> Signature<'db> {
             generic_context,
             definition: Some(definition),
             receiver_constraints: None,
+            receiver_generic_context: None,
             parameters,
             return_ty,
         }
@@ -844,6 +861,7 @@ impl<'db> Signature<'db> {
             generic_context: self.generic_context,
             definition: self.definition,
             receiver_constraints: self.receiver_constraints.clone(),
+            receiver_generic_context: self.receiver_generic_context,
             parameters,
             return_ty,
         }
@@ -874,6 +892,7 @@ impl<'db> Signature<'db> {
             generic_context: self.generic_context,
             definition: self.definition,
             receiver_constraints: self.receiver_constraints.clone(),
+            receiver_generic_context: self.receiver_generic_context,
             parameters,
             return_ty,
         })
@@ -892,6 +911,7 @@ impl<'db> Signature<'db> {
                 .map(|context| type_mapping.update_signature_generic_context(db, context)),
             definition: self.definition,
             receiver_constraints: self.map_receiver_constraints(db, type_mapping, tcx, visitor),
+            receiver_generic_context: self.map_receiver_generic_context(db, type_mapping),
             parameters: self
                 .parameters
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
@@ -1092,6 +1112,13 @@ impl<'db> Signature<'db> {
             self.receiver_constraints.as_ref(),
             receiver_constraint.as_deref(),
         );
+        let receiver_generic_context = GenericContext::merge_optional(
+            db,
+            self.receiver_generic_context,
+            explicit_receiver.and_then(|parameter| {
+                self.generic_context_for_receiver_annotation(db, parameter.annotated_type())
+            }),
+        );
         if let Some(self_type) = typing_self_type
             && self.needs_self_mapping(db, removed_receiver)
         {
@@ -1111,6 +1138,7 @@ impl<'db> Signature<'db> {
                 .map(|generic_context| generic_context.remove_self(db, binding_context)),
             definition: self.definition,
             receiver_constraints,
+            receiver_generic_context,
             parameters,
             return_ty,
         }
@@ -1286,6 +1314,7 @@ impl<'db> Signature<'db> {
             generic_context: self.generic_context,
             definition: self.definition,
             receiver_constraints,
+            receiver_generic_context: self.receiver_generic_context,
             parameters,
             return_ty,
         }
@@ -1318,6 +1347,55 @@ impl<'db> Signature<'db> {
         );
         (!constraints.query(|_builder, constraints| constraints.is_always_satisfied(db)))
             .then_some(constraints)
+    }
+
+    fn map_receiver_generic_context(
+        &self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'_, 'db>,
+    ) -> Option<GenericContext<'db>> {
+        let generic_context =
+            type_mapping.update_signature_generic_context(db, self.receiver_generic_context?);
+        (generic_context.variables(db).len() > 0).then_some(generic_context)
+    }
+
+    /// Extracts the callable-local variables whose quantifier domain is set by the receiver.
+    ///
+    /// ```python
+    /// def apply[ReceiverT, T](self: ReceiverT, value: T) -> T: ...
+    /// ```
+    ///
+    /// This returns a context containing `ReceiverT`, but not `T`. `typing.Self` is excluded
+    /// because descriptor binding substitutes it directly.
+    fn generic_context_for_receiver_annotation(
+        &self,
+        db: &'db dyn Db,
+        annotation: Type<'db>,
+    ) -> Option<GenericContext<'db>> {
+        let generic_context = self.generic_context?;
+        let typevars = generic_context.variables(db).filter(|typevar| {
+            !typevar.typevar(db).is_self(db)
+                && super::visitor::any_over_type(db, annotation, true, |ty| {
+                    matches!(
+                        ty,
+                        Type::TypeVar(annotation_typevar)
+                            if annotation_typevar.is_same_typevar_as(db, *typevar)
+                    )
+                })
+        });
+        let receiver_generic_context = GenericContext::from_typevar_instances(db, typevars);
+        (receiver_generic_context.variables(db).len() > 0).then_some(receiver_generic_context)
+    }
+
+    fn receiver_inferable_typevars(&self, db: &'db dyn Db) -> InferableTypeVars<'db> {
+        InferableTypeVars::from_typevars(
+            db,
+            self.receiver_generic_context
+                .into_iter()
+                .flat_map(|generic_context| generic_context.variables(db))
+                .map(|typevar| typevar.identity(db))
+                .collect(),
+        )
     }
 
     fn map_constraints(
@@ -2011,9 +2089,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
         // If either signature is generic, freshen that signature's typevars before considering
-        // them inferable for this relation. The relation only needs to find one specialization of
-        // each generic callable that causes the check to succeed, but those callable-local
-        // specializations must not collide with any same-source typevars in the other signature.
+        // them inferable for this relation. The source and target variables are quantified below,
+        // but their callable-local occurrences must not collide with same-source typevars in the
+        // other signature.
         let freshened_source;
         let source = if source.generic_context != target.generic_context
             && let Some(generic_context) = source.generic_context
@@ -2039,8 +2117,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target
         };
 
-        let source_inferable = source.inferable_typevars(db);
-        let target_inferable = target.inferable_typevars(db);
+        let source_inferable = source
+            .inferable_typevars(db)
+            .merge(db, source.receiver_inferable_typevars(db));
+        let target_receiver_inferable = target.receiver_inferable_typevars(db);
+        let target_inferable = target
+            .inferable_typevars(db)
+            .merge(db, target_receiver_inferable);
+        let target_non_receiver_inferable = InferableTypeVars::from_typevars(
+            db,
+            target_inferable
+                .iter(db)
+                .filter(|typevar| !typevar.is_inferable(db, target_receiver_inferable))
+                .collect(),
+        );
         let signature_inferable = source_inferable.merge(db, target_inferable);
         let inferable = self.inferable.merge(db, signature_inferable);
 
@@ -2056,11 +2146,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             source
                 .receiver_constraints_when_satisfied(&checker, db)
                 .and(db, self.constraints, || {
-                    target
-                        .receiver_constraints_when_satisfied(&checker, db)
-                        .and(db, self.constraints, || {
-                            checker.check_signature_pair_inner(db, source, target)
-                        })
+                    if matches!(target_receiver_inferable, InferableTypeVars::None) {
+                        target
+                            .receiver_constraints_when_satisfied(&checker, db)
+                            .and(db, self.constraints, || {
+                                checker.check_signature_pair_inner(db, source, target)
+                            })
+                    } else {
+                        target
+                            .receiver_constraints_when_satisfied(&checker, db)
+                            .implies(db, self.constraints, || {
+                                checker.check_signature_pair_inner(db, source, target)
+                            })
+                    }
                 })
         });
 
@@ -2069,9 +2167,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // returning.
         //
         // Target signature typevars require the opposite quantifier: the relation must hold for
-        // every target specialization, so universally quantify those away before returning.
+        // every target specialization. Receiver typevars are quantified over the domain imposed
+        // by binding the receiver; the remaining target variables are unconditional.
         when.reduce_inferable(db, self.constraints, source_inferable)
-            .for_all(db, self.constraints, target_inferable)
+            .for_all(db, self.constraints, target_receiver_inferable)
+            .for_all(db, self.constraints, target_non_receiver_inferable)
     }
 
     fn with_signature_recursion_guard(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2487,11 +2487,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Keep this higher-rank source check to unary declared callables for now. More complex
         // overload and multi-parameter constraints still require the ordinary inference path.
         let check_generic_source = source.definition.is_some()
-            && target.definition.is_some()
+            && self.inferable == InferableTypeVars::None
             && source_inferable != InferableTypeVars::None
             && target_inferable != InferableTypeVars::None
             && source.parameters.len() == 1
-            && target.parameters.len() == 1;
+            && target.parameters.len() == 1
+            && !target.return_ty.has_dynamic(db)
+            && target
+                .parameters
+                .iter()
+                .all(|parameter| !parameter.annotated_type().has_dynamic(db));
         // A generic target must be compared lazily so its obligations survive until universal
         // quantification, including when the source signature is generic too.
         // Keep recursive protocol members on the existing eager path to avoid expanding cycles.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2237,6 +2237,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 continue;
             }
 
+            let source_parameter = self_signature.parameters().get(0)?;
+            let target_parameter = target_signature.parameters().get(0)?;
+            if target_parameter
+                .keyword_name()
+                .is_some_and(|target_name| source_parameter.keyword_name() != Some(target_name))
+            {
+                continue;
+            }
+
             has_overlapping_domain = true;
             parameter_type_union = parameter_type_union.add(self_parameter_type);
             return_type_union = return_type_union.add(self_signature.return_ty);

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2461,17 +2461,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let mut checker = self.with_inferable_typevars(inferable);
-        // Receiver constraints and deferred receiver specialization both require lazy typevar
-        // evaluation: specializing the receiver can still leave unrelated method TypeVars that
-        // must be checked universally.
-        if source
-            .receiver_binding
-            .iter()
-            .chain(target.receiver_binding.iter())
-            .any(|binding| {
-                !binding.constraints.is_trivially_always_satisfied()
-                    || signature_inferable != InferableTypeVars::None
-            })
+        // A non-generic source cannot choose a specialization that satisfies a generic target;
+        // use lazy typevar evaluation so the target's obligations can be universally quantified.
+        // Keep recursive protocol members on the existing eager path to avoid expanding cycles.
+        if (source_inferable == InferableTypeVars::None
+            && target_inferable != InferableTypeVars::None
+            && !source.is_recursive_protocol_member(db)
+            && !target.is_recursive_protocol_member(db))
+            || source
+                .receiver_binding
+                .iter()
+                .chain(target.receiver_binding.iter())
+                .any(|binding| {
+                    !binding.constraints.is_trivially_always_satisfied()
+                        || signature_inferable != InferableTypeVars::None
+                })
         {
             checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -134,6 +134,32 @@ fn merge_receiver_constraints<'db>(
     }
 }
 
+/// The constraint domain introduced by binding an explicitly annotated receiver.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+struct ReceiverBinding<'db> {
+    constraints: OwnedConstraintSet<'db>,
+    generic_context: Option<GenericContext<'db>>,
+}
+
+impl<'db> ReceiverBinding<'db> {
+    fn merge(db: &'db dyn Db, first: Option<&Self>, second: Option<&Self>) -> Option<Self> {
+        let constraints = merge_receiver_constraints(
+            db,
+            first.map(|binding| &binding.constraints),
+            second.map(|binding| &binding.constraints),
+        )?;
+        let generic_context = GenericContext::merge_optional(
+            db,
+            first.and_then(|binding| binding.generic_context),
+            second.and_then(|binding| binding.generic_context),
+        );
+        Some(Self {
+            constraints,
+            generic_context,
+        })
+    }
+}
+
 /// The per-overload information needed to synthesize one reduced signature for
 /// `functools.partial(...)`.
 #[derive(Clone, Debug)]
@@ -323,14 +349,12 @@ impl<'db> CallableSignature<'db> {
                             type_mapping.update_signature_generic_context(db, context)
                         }),
                         definition: self_signature.definition,
-                        receiver_constraints: self_signature.map_receiver_constraints(
+                        receiver_binding: self_signature.map_receiver_binding(
                             db,
                             type_mapping,
                             tcx,
                             visitor,
                         ),
-                        receiver_generic_context: self_signature
-                            .map_receiver_generic_context(db, type_mapping),
                         parameters,
                         return_ty: self_signature.return_ty.apply_type_mapping_impl(
                             db,
@@ -353,24 +377,19 @@ impl<'db> CallableSignature<'db> {
                                 }),
                             ),
                             definition: signature.definition,
-                            receiver_constraints: {
-                                let mapped = self_signature.map_receiver_constraints(
+                            receiver_binding: {
+                                let mapped = self_signature.map_receiver_binding(
                                     db,
                                     type_mapping,
                                     tcx,
                                     visitor,
                                 );
-                                merge_receiver_constraints(
+                                ReceiverBinding::merge(
                                     db,
-                                    signature.receiver_constraints.as_ref(),
+                                    signature.receiver_binding.as_ref(),
                                     mapped.as_ref(),
                                 )
                             },
-                            receiver_generic_context: GenericContext::merge_optional(
-                                db,
-                                signature.receiver_generic_context,
-                                self_signature.map_receiver_generic_context(db, type_mapping),
-                            ),
                             parameters: signature.parameters().with_prefix(
                                 prefix_parameters.iter().map(|param| {
                                     param.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
@@ -559,14 +578,8 @@ pub struct Signature<'db> {
     /// This is useful for locating and extracting docstring information for the signature.
     pub(crate) definition: Option<Definition<'db>>,
 
-    /// The constraint introduced by binding an explicitly annotated receiver, if any.
-    receiver_constraints: Option<OwnedConstraintSet<'db>>,
-
-    /// The callable-local type variables that occur in an explicitly annotated receiver.
-    ///
-    /// These variables are quantified over the receiver constraint's domain, rather than over
-    /// every specialization of the callable's generic context.
-    receiver_generic_context: Option<GenericContext<'db>>,
+    /// The constraint domain introduced by binding an explicitly annotated receiver, if any.
+    receiver_binding: Option<ReceiverBinding<'db>>,
 
     /// Parameters, in source order.
     ///
@@ -705,8 +718,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: None,
             definition: None,
-            receiver_constraints: None,
-            receiver_generic_context: None,
+            receiver_binding: None,
             parameters,
             return_ty,
         }
@@ -720,8 +732,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context,
             definition: None,
-            receiver_constraints: None,
-            receiver_generic_context: None,
+            receiver_binding: None,
             parameters,
             return_ty,
         }
@@ -732,8 +743,7 @@ impl<'db> Signature<'db> {
         Signature {
             generic_context: None,
             definition: None,
-            receiver_constraints: None,
-            receiver_generic_context: None,
+            receiver_binding: None,
             parameters: Parameters::gradual_form(),
             return_ty: signature_type,
         }
@@ -786,8 +796,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context,
             definition: Some(definition),
-            receiver_constraints: None,
-            receiver_generic_context: None,
+            receiver_binding: None,
             parameters,
             return_ty,
         }
@@ -860,8 +869,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: self.generic_context,
             definition: self.definition,
-            receiver_constraints: self.receiver_constraints.clone(),
-            receiver_generic_context: self.receiver_generic_context,
+            receiver_binding: self.receiver_binding.clone(),
             parameters,
             return_ty,
         }
@@ -891,8 +899,7 @@ impl<'db> Signature<'db> {
         Some(Self {
             generic_context: self.generic_context,
             definition: self.definition,
-            receiver_constraints: self.receiver_constraints.clone(),
-            receiver_generic_context: self.receiver_generic_context,
+            receiver_binding: self.receiver_binding.clone(),
             parameters,
             return_ty,
         })
@@ -910,8 +917,7 @@ impl<'db> Signature<'db> {
                 .generic_context
                 .map(|context| type_mapping.update_signature_generic_context(db, context)),
             definition: self.definition,
-            receiver_constraints: self.map_receiver_constraints(db, type_mapping, tcx, visitor),
-            receiver_generic_context: self.map_receiver_generic_context(db, type_mapping),
+            receiver_binding: self.map_receiver_binding(db, type_mapping, tcx, visitor),
             parameters: self
                 .parameters
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
@@ -1075,7 +1081,7 @@ impl<'db> Signature<'db> {
         };
         let mut return_ty = self.return_ty;
         let binding_context = self.definition.map(BindingContext::Definition);
-        let receiver_constraint = explicit_receiver.map(|parameter| {
+        let receiver_binding = explicit_receiver.and_then(|parameter| {
             let receiver = receiver_type.unwrap_or_else(|| {
                 Type::TypeVar(BoundTypeVarInstance::synthetic_self(
                     db,
@@ -1092,32 +1098,58 @@ impl<'db> Signature<'db> {
             } else {
                 parameter.annotated_type()
             };
-            // TODO: Also intersect nested receiver type variables, such as the `T` in
-            // `self: list[T]`, with their valid specializations when constructing or solving the
-            // receiver constraint set.
-            let receiver_typevar = match annotation {
+            let receiver_is_class_method = receiver_type != typing_self_type;
+            let bind_class_receiver = receiver_type.is_none() || receiver_is_class_method;
+            let resolved_annotation = annotation.resolve_type_alias(db);
+            let (receiver_typevar, receiver_for_domain) = match resolved_annotation {
                 Type::TypeVar(typevar) => Some(typevar),
-                Type::TypeAlias(_) => annotation.resolve_type_alias(db).as_typevar(),
+                Type::SubclassOf(subclass_of) if bind_class_receiver => subclass_of.into_type_var(),
                 _ => None,
-            };
-            if receiver_typevar.is_some_and(|typevar| {
-                Self::receiver_violates_typevar_domain(db, receiver, typevar)
-            }) {
-                return std::borrow::Cow::Owned(OwnedConstraintSet::default());
             }
-            receiver.when_constraint_set_assignable_to_owned(db, annotation)
+            .map_or((None, receiver), |typevar| {
+                let receiver = if resolved_annotation.is_subclass_of() {
+                    receiver.to_instance(db).unwrap_or(receiver)
+                } else {
+                    receiver
+                };
+                (Some(typevar), receiver)
+            });
+            if receiver_typevar.is_some_and(|typevar| {
+                Self::receiver_violates_typevar_domain(db, receiver_for_domain, typevar)
+            }) {
+                return Some(ReceiverBinding {
+                    constraints: OwnedConstraintSet::default(),
+                    generic_context: None,
+                });
+            }
+            let receiver_generic_context = self.generic_context_for_receiver_annotation(
+                db,
+                parameter.annotated_type(),
+                bind_class_receiver,
+            );
+            let receiver_constraint =
+                receiver.when_constraint_set_assignable_to_owned(db, annotation);
+            let declared_domain = receiver_generic_context
+                .into_iter()
+                .flat_map(|generic_context| generic_context.variables(db))
+                .filter_map(|typevar| Self::receiver_typevar_domain(db, typevar))
+                .fold(None, |constraints, domain| {
+                    merge_receiver_constraints(db, constraints.as_ref(), Some(&domain))
+                });
+            let constraints = merge_receiver_constraints(
+                db,
+                Some(receiver_constraint.as_ref()),
+                declared_domain.as_ref(),
+            )?;
+            Some(ReceiverBinding {
+                constraints,
+                generic_context: receiver_generic_context,
+            })
         });
-        let receiver_constraints = merge_receiver_constraints(
+        let receiver_binding = ReceiverBinding::merge(
             db,
-            self.receiver_constraints.as_ref(),
-            receiver_constraint.as_deref(),
-        );
-        let receiver_generic_context = GenericContext::merge_optional(
-            db,
-            self.receiver_generic_context,
-            explicit_receiver.and_then(|parameter| {
-                self.generic_context_for_receiver_annotation(db, parameter.annotated_type())
-            }),
+            self.receiver_binding.as_ref(),
+            receiver_binding.as_ref(),
         );
         if let Some(self_type) = typing_self_type
             && self.needs_self_mapping(db, removed_receiver)
@@ -1137,8 +1169,7 @@ impl<'db> Signature<'db> {
                 .generic_context
                 .map(|generic_context| generic_context.remove_self(db, binding_context)),
             definition: self.definition,
-            receiver_constraints,
-            receiver_generic_context,
+            receiver_binding,
             parameters,
             return_ty,
         }
@@ -1154,7 +1185,7 @@ impl<'db> Signature<'db> {
     /// class C:
     ///     def method[T: int](self: T) -> None: ...
     /// ```
-    fn receiver_violates_typevar_domain(
+    pub(super) fn receiver_violates_typevar_domain(
         db: &'db dyn Db,
         receiver: Type<'db>,
         typevar: BoundTypeVarInstance<'db>,
@@ -1176,6 +1207,39 @@ impl<'db> Signature<'db> {
                 })
             }
         }
+    }
+
+    /// Returns the declared domain of a callable-local receiver `TypeVar` as a constraint set.
+    fn receiver_typevar_domain(
+        db: &'db dyn Db,
+        typevar: BoundTypeVarInstance<'db>,
+    ) -> Option<OwnedConstraintSet<'db>> {
+        let domain = typevar.typevar(db).bound_or_constraints(db)?;
+        let constraints = ConstraintSetBuilder::new();
+        Some(constraints.into_owned(|builder| {
+            match domain {
+                TypeVarBoundOrConstraints::UpperBound(bound) => {
+                    ConstraintSet::constrain_typevar_upper_bound(
+                        db,
+                        builder,
+                        typevar,
+                        bound.top_materialization(db),
+                    )
+                }
+                TypeVarBoundOrConstraints::Constraints(typevar_constraints) => typevar_constraints
+                    .elements(db)
+                    .iter()
+                    .when_any(db, builder, |constraint| {
+                        ConstraintSet::constrain_typevar(
+                            db,
+                            builder,
+                            typevar,
+                            constraint.bottom_materialization(db),
+                            constraint.top_materialization(db),
+                        )
+                    }),
+            }
+        }))
     }
 
     /// Returns `true` if this signature's first parameter can accept the bound `self` type.
@@ -1272,28 +1336,30 @@ impl<'db> Signature<'db> {
         let self_mapping = TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
         let receiver_visitor = ApplyTypeMappingVisitor::default();
         let self_visitor = ApplyTypeMappingVisitor::default();
-        let receiver_constraints = self
-            .map_receiver_constraints(
+        let receiver_binding = self
+            .map_receiver_binding(
                 db,
                 &receiver_mapping,
                 TypeContext::default(),
                 &receiver_visitor,
             )
-            .map(|constraints| {
-                Self::map_constraints(
+            .and_then(|binding| {
+                let constraints = Self::map_constraints(
                     db,
-                    &constraints,
+                    &binding.constraints,
                     &self_mapping,
                     TypeContext::default(),
                     &self_visitor,
-                )
-            })
-            .filter(|constraints| {
-                !constraints.query(|_builder, constraints| constraints.is_always_satisfied(db))
+                );
+                (!constraints.query(|_builder, constraints| constraints.is_always_satisfied(db)))
+                    .then_some(ReceiverBinding {
+                        constraints,
+                        generic_context: binding.generic_context,
+                    })
             });
         if !self.needs_self_mapping(db, false) {
             return Self {
-                receiver_constraints,
+                receiver_binding,
                 ..self.clone()
             };
         }
@@ -1313,8 +1379,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: self.generic_context,
             definition: self.definition,
-            receiver_constraints,
-            receiver_generic_context: self.receiver_generic_context,
+            receiver_binding,
             parameters,
             return_ty,
         }
@@ -1325,57 +1390,62 @@ impl<'db> Signature<'db> {
         checker: &TypeRelationChecker<'_, 'c, 'db>,
         db: &'db dyn Db,
     ) -> ConstraintSet<'db, 'c> {
-        let Some(constraints) = self.receiver_constraints.as_ref() else {
+        let Some(binding) = self.receiver_binding.as_ref() else {
             return checker.always();
         };
-        checker.constraints.load(db, constraints)
+        checker.constraints.load(db, &binding.constraints)
     }
 
-    fn map_receiver_constraints(
+    fn map_receiver_binding(
         &self,
         db: &'db dyn Db,
         type_mapping: &TypeMapping<'_, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
-    ) -> Option<OwnedConstraintSet<'db>> {
-        let constraints = Self::map_constraints(
-            db,
-            self.receiver_constraints.as_ref()?,
-            type_mapping,
-            tcx,
-            visitor,
-        );
-        (!constraints.query(|_builder, constraints| constraints.is_always_satisfied(db)))
-            .then_some(constraints)
+    ) -> Option<ReceiverBinding<'db>> {
+        let binding = self.receiver_binding.as_ref()?;
+        let constraints =
+            Self::map_constraints(db, &binding.constraints, type_mapping, tcx, visitor);
+        if constraints.query(|_builder, constraints| constraints.is_always_satisfied(db)) {
+            return None;
+        }
+        let generic_context = binding.generic_context.and_then(|generic_context| {
+            let generic_context =
+                type_mapping.update_signature_generic_context(db, generic_context);
+            (generic_context.variables(db).len() > 0).then_some(generic_context)
+        });
+        Some(ReceiverBinding {
+            constraints,
+            generic_context,
+        })
     }
 
-    fn map_receiver_generic_context(
-        &self,
-        db: &'db dyn Db,
-        type_mapping: &TypeMapping<'_, 'db>,
-    ) -> Option<GenericContext<'db>> {
-        let generic_context =
-            type_mapping.update_signature_generic_context(db, self.receiver_generic_context?);
-        (generic_context.variables(db).len() > 0).then_some(generic_context)
-    }
-
-    /// Extracts the callable-local variables whose quantifier domain is set by the receiver.
+    /// Returns the callable-local `TypeVar`s referenced by a receiver annotation.
     ///
     /// ```python
     /// def apply[ReceiverT, T](self: ReceiverT, value: T) -> T: ...
     /// ```
     ///
     /// This returns a context containing `ReceiverT`, but not `T`. `typing.Self` is excluded
-    /// because descriptor binding substitutes it directly.
+    /// because descriptor binding substitutes it directly. Type arguments are traversed, but
+    /// protocol members and `TypeVar` bounds are not. `type[T]` is only treated as a receiver
+    /// variable during deferred or classmethod binding, so ordinary metaclass methods retain their
+    /// existing semantics.
     fn generic_context_for_receiver_annotation(
         &self,
         db: &'db dyn Db,
         annotation: Type<'db>,
+        bind_class_receiver: bool,
     ) -> Option<GenericContext<'db>> {
         let generic_context = self.generic_context?;
+        let annotation = annotation.resolve_type_alias(db);
+        if annotation.is_subclass_of() && !bind_class_receiver {
+            return None;
+        }
+
         let typevars = generic_context.variables(db).filter(|typevar| {
             !typevar.typevar(db).is_self(db)
-                && super::visitor::any_over_type(db, annotation, true, |ty| {
+                && super::visitor::any_over_type(db, annotation, false, |ty| {
                     matches!(
                         ty,
                         Type::TypeVar(annotation_typevar)
@@ -1390,7 +1460,9 @@ impl<'db> Signature<'db> {
     fn receiver_inferable_typevars(&self, db: &'db dyn Db) -> InferableTypeVars<'db> {
         InferableTypeVars::from_typevars(
             db,
-            self.receiver_generic_context
+            self.receiver_binding
+                .as_ref()
+                .and_then(|binding| binding.generic_context)
                 .into_iter()
                 .flat_map(|generic_context| generic_context.variables(db))
                 .map(|typevar| typevar.identity(db))
@@ -1420,9 +1492,9 @@ impl<'db> Signature<'db> {
     }
 
     fn receiver_constraint_types(&self) -> impl Iterator<Item = Type<'db>> + '_ {
-        self.receiver_constraints
+        self.receiver_binding
             .iter()
-            .flat_map(OwnedConstraintSet::types)
+            .flat_map(|binding| binding.constraints.types())
     }
 
     /// Returns this signature with the given specialization applied to parameters and return type.
@@ -1802,10 +1874,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Aggregation summarizes visible parameters and return types, but receiver bindings are
         // additional per-signature obligations. Leave those signatures to the ordinary relation,
         // which checks each receiver binding before comparing the visible signature.
-        if target_signature.receiver_constraints.is_some()
+        if target_signature.receiver_binding.is_some()
             || source_signatures
                 .iter()
-                .any(|signature| signature.receiver_constraints.is_some())
+                .any(|signature| signature.receiver_binding.is_some())
         {
             return None;
         }
@@ -2117,20 +2189,52 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target
         };
 
-        let source_inferable = source
-            .inferable_typevars(db)
-            .merge(db, source.receiver_inferable_typevars(db));
-        let target_receiver_inferable = target.receiver_inferable_typevars(db);
-        let target_inferable = target
-            .inferable_typevars(db)
-            .merge(db, target_receiver_inferable);
-        let target_non_receiver_inferable = InferableTypeVars::from_typevars(
-            db,
-            target_inferable
-                .iter(db)
-                .filter(|typevar| !typevar.is_inferable(db, target_receiver_inferable))
-                .collect(),
-        );
+        let source_inferable = source.inferable_typevars(db);
+        let target_inferable = target.inferable_typevars(db);
+        // Most signature comparisons do not have receiver-local variables. Keep their existing
+        // inferable sets intact so this path does not introduce tracked merges or new interned
+        // sets into ordinary callable relations.
+        let (
+            source_inferable,
+            target_inferable,
+            target_receiver_inferable,
+            target_non_receiver_inferable,
+        ) = if source
+            .receiver_binding
+            .as_ref()
+            .and_then(|binding| binding.generic_context)
+            .is_none()
+            && target
+                .receiver_binding
+                .as_ref()
+                .and_then(|binding| binding.generic_context)
+                .is_none()
+        {
+            (
+                source_inferable,
+                target_inferable,
+                InferableTypeVars::None,
+                target_inferable,
+            )
+        } else {
+            let source_inferable =
+                source_inferable.merge(db, source.receiver_inferable_typevars(db));
+            let target_receiver_inferable = target.receiver_inferable_typevars(db);
+            let target_inferable = target_inferable.merge(db, target_receiver_inferable);
+            let target_non_receiver_inferable = InferableTypeVars::from_typevars(
+                db,
+                target_inferable
+                    .iter(db)
+                    .filter(|typevar| !typevar.is_inferable(db, target_receiver_inferable))
+                    .collect(),
+            );
+            (
+                source_inferable,
+                target_inferable,
+                target_receiver_inferable,
+                target_non_receiver_inferable,
+            )
+        };
         let signature_inferable = source_inferable.merge(db, target_inferable);
         let inferable = self.inferable.merge(db, signature_inferable);
 
@@ -2139,7 +2243,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Every nonterminal receiver constraint constrains at least one typevar. Terminal `always`
         // sets are discarded when receiver constraints are merged, so presence alone is enough to
         // require lazy typevar evaluation here.
-        if source.receiver_constraints.is_some() || target.receiver_constraints.is_some() {
+        if source.receiver_binding.is_some() || target.receiver_binding.is_some() {
             checker.typevar_evaluation = TypeVarEvaluation::Lazy;
         }
         let when = checker.with_signature_recursion_guard(source, target, || {
@@ -2153,10 +2257,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 checker.check_signature_pair_inner(db, source, target)
                             })
                     } else {
-                        target
-                            .receiver_constraints_when_satisfied(&checker, db)
-                            .implies(db, self.constraints, || {
-                                checker.check_signature_pair_inner(db, source, target)
+                        let target_domain =
+                            target.receiver_constraints_when_satisfied(&checker, db);
+                        // A target receiver must admit at least one valid specialization. Without
+                        // this check, an impossible declared bound makes the implication vacuous
+                        // and an invalid implementation can satisfy the protocol.
+                        target_domain
+                            .reduce_inferable(db, self.constraints, target_receiver_inferable)
+                            .and(db, self.constraints, || {
+                                target_domain.implies(db, self.constraints, || {
+                                    checker.check_signature_pair_inner(db, source, target)
+                                })
                             })
                     }
                 })

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1280,6 +1280,65 @@ impl<'db> Signature<'db> {
         }
     }
 
+    /// Specializes a type that refers to callable-local variables in this signature's receiver.
+    ///
+    /// This uses the same receiver constraints as ordinary descriptor binding, including nested
+    /// receiver annotations such as `Box[T]`. Returns `None` if the receiver cannot satisfy the
+    /// annotation or a declared `TypeVar` domain.
+    pub(super) fn specialize_type_for_receiver(
+        &self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        receiver: Type<'db>,
+    ) -> Option<Type<'db>> {
+        if !self.has_explicit_positional_receiver_annotation() {
+            return Some(ty);
+        }
+
+        let bound = self.bind_self_with_receiver(db, Some(receiver), Some(receiver));
+        let Some(binding) = bound.receiver_binding.as_ref() else {
+            return Some(ty);
+        };
+        let inferable = InferableTypeVars::from_typevars(
+            db,
+            binding
+                .generic_context
+                .into_iter()
+                .flat_map(|generic_context| generic_context.variables(db))
+                .map(|typevar| typevar.identity(db))
+                .collect(),
+        );
+
+        binding.constraints.query(|builder, constraints| {
+            match constraints.solutions(db, builder, inferable) {
+                Solutions::Unsatisfiable => None,
+                Solutions::Unconstrained => Some(ty),
+                Solutions::Constrained(solutions) => {
+                    let Some(generic_context) = binding.generic_context else {
+                        return Some(ty);
+                    };
+                    Some(UnionType::from_elements(
+                        db,
+                        solutions.into_iter().map(|solution| {
+                            let specialization = generic_context.specialize_recursive(
+                                db,
+                                generic_context.variables(db).map(|typevar| {
+                                    solution
+                                        .iter()
+                                        .find(|binding| {
+                                            binding.bound_typevar.is_same_typevar_as(db, typevar)
+                                        })
+                                        .map(|binding| binding.solution)
+                                }),
+                            );
+                            ty.apply_specialization(db, specialization)
+                        }),
+                    ))
+                }
+            }
+        })
+    }
+
     /// Returns the declared-domain obligation that remains after specializing a receiver `TypeVar`.
     fn specialized_receiver_domain(
         db: &'db dyn Db,


### PR DESCRIPTION
## Summary

Binding an explicitly annotated receiver currently retains its receiver constraint, but not which callable-local TypeVars introduced that constraint. Once target signature TypeVars are quantified universally, we cannot distinguish receiver variables from unrelated method variables that must range over every specialization.

For example, this is valid:

```python
from typing import Protocol, TypeVar

C = TypeVar("C", bound="Copyable")

class Copyable(Protocol):
    def copy(self: C) -> C: ...

class One:
    def copy(self) -> "One": ...

copyable: Copyable = One()
```

Here, `C` is a receiver TypeVar: binding the protocol method to `One` restricts `C` to the specializations permitted by that receiver constraint. The method only needs to be compatible over that domain, rather than over every unconditional specialization of `C`. This also applies when the receiver variable appears in another parameter, such as `__gt__(self: T, other: T)`.

This PR preserves the exact subset of a callable's generic context referenced by its explicit receiver annotation. That provenance survives binding, freshening, specialization, and type mapping. During target signature comparison, receiver variables are universally quantified with the receiver constraint as their domain, while unrelated target variables continue through unconditional universal quantification. Direct and nested receiver annotations, class methods, declared bounds, properties, and deferred protocol binding retain the appropriate receiver information without broadly expanding recursive protocols.

The same comparison needs to reject a non-generic implementation of an unrelated generic target method. In eager mode, relations involving the target TypeVar can be discarded before universal quantification, which incorrectly accepts examples like:

```python
from typing import Callable, Protocol, Self, TypeVar

T = TypeVar("T")

class HasProperty(Protocol):
    @property
    def value(self: T) -> T: ...
    def apply(self, value: T, callback: Callable[[T], str]) -> str: ...

class Invalid:
    @property
    def value(self) -> Self: ...
    def apply(self, value: int, callback: Callable[[int], str]) -> str: ...

value: HasProperty = Invalid()  # error
```

We now generate those constraints lazily for non-generic sources and generic targets, while retaining the existing path for recursive protocol members. This restores the two lost typing-conformance diagnostics and the corresponding generic-method override checks.

Finally, passing a generic function to a `ParamSpec` decorator with a gradual return type can allow return constraints to widen the captured parameter list:

```python
from typing import Any, Callable, Generic, ParamSpec, TypeVar

P = ParamSpec("P")
T = TypeVar("T")

class Wrapped(Generic[P]):
    def call(self, *args: P.args, **kwargs: P.kwargs) -> None: ...

def wrap(function: Callable[P, Any]) -> Wrapped[P]: ...

@wrap
def identity(value: T) -> T: ...

identity.call("value")
```

The base infers a union of `(value: Any)` and `(value: T@identity)` and rejects the decorator application and valid call. We preserve the original `ParamSpec` value when the source is a single generic signature, independently of gradual return constraints; overloaded sources continue through the existing return-type filtering path. This also restores the generic awaitable callable produced by `types.coroutine`.
