### PR TITLE
[`flake8-copyright`] Stabilize `missing-copyright-notice` (`CPY001`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_copyright/rules/missing_copyright_notice.rs
+++ b/crates/ruff_linter/src/rules/flake8_copyright/rules/missing_copyright_notice.rs
@@ -20,7 +20,7 @@ use crate::settings::LinterSettings;
 /// - `lint.flake8-copyright.min-file-size`
 /// - `lint.flake8-copyright.notice-rgx`
 #[derive(ViolationMetadata)]
-#[violation_metadata(preview_since = "v0.0.273")]
+#[violation_metadata(stable_since = "NEXT_RUFF_VERSION")]
 pub(crate) struct MissingCopyrightNotice;
 
 impl Violation for MissingCopyrightNotice {

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -2118,7 +2118,7 @@ mod tests {
     fn select_linter_preview() -> Result<()> {
         let actual = resolve_rules(
             [RuleSelection {
-                select: Some(vec![UnresolvedRuleSelector::cli("CPY")]),
+                select: Some(vec![UnresolvedRuleSelector::cli("RUF91")]),
                 ..RuleSelection::default()
             }],
             Some(PreviewOptions {
@@ -2131,7 +2131,7 @@ mod tests {
 
         let actual = resolve_rules(
             [RuleSelection {
-                select: Some(vec![UnresolvedRuleSelector::cli("CPY")]),
+                select: Some(vec![UnresolvedRuleSelector::cli("RUF91")]),
                 ..RuleSelection::default()
             }],
             Some(PreviewOptions {
@@ -2139,7 +2139,7 @@ mod tests {
                 ..PreviewOptions::default()
             }),
         )?;
-        let expected = RuleSet::from_rule(Rule::MissingCopyrightNotice);
+        let expected = RuleSet::from_rule(Rule::PreviewTestRule);
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -2148,7 +2148,7 @@ mod tests {
     fn select_prefix_preview() -> Result<()> {
         let actual = resolve_rules(
             [RuleSelection {
-                select: Some(vec![UnresolvedRuleSelector::cli("CPY0")]),
+                select: Some(vec![UnresolvedRuleSelector::cli("RUF91")]),
                 ..RuleSelection::default()
             }],
             Some(PreviewOptions {
@@ -2161,7 +2161,7 @@ mod tests {
 
         let actual = resolve_rules(
             [RuleSelection {
-                select: Some(vec![UnresolvedRuleSelector::cli("CPY0")]),
+                select: Some(vec![UnresolvedRuleSelector::cli("RUF91")]),
                 ..RuleSelection::default()
             }],
             Some(PreviewOptions {
@@ -2169,7 +2169,7 @@ mod tests {
                 ..PreviewOptions::default()
             }),
         )?;
-        let expected = RuleSet::from_rule(Rule::MissingCopyrightNotice);
+        let expected = RuleSet::from_rule(Rule::PreviewTestRule);
         assert_eq!(actual, expected);
         Ok(())
     }


### PR DESCRIPTION
This one required a couple of updates to existing tests because the rule was being used as a generic
preview rule. I switched these tests to use `RUF911`, which is our `preview-test-rule`.

I had also previously opened a tracking issue for this rule's stabilization in #19487, but as I
noted in https://github.com/astral-sh/ruff/issues/19487#issuecomment-4454194086, I no longer feel
like these issues really need to block stabilization. This rule is a commonly requested reason to
enable specific preview rules and has been in preview for almost 3 years, so I think these other
issues can be handled separately.

I think we can close #19487 if we land this but keep the individual issues open.
