### PR TITLE
[ty] Normalize type labels in structured docstrings

### DIFF
--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -848,14 +848,14 @@ fn split_once_at_field_delimiter(line: &str) -> Option<(&str, &str)> {
 /// :exc:`ValueError`
 /// ```
 fn consume_rest_prefix_role(cursor: &mut Cursor<'_>) -> bool {
-    let Some(InlineMarkupToken::RestPrefixRole { span, .. }) =
+    let Some(InlineMarkupToken::RestPrefixRole(role)) =
         InlineMarkupScanner::new(cursor.as_str()).next()
     else {
         return false;
     };
 
     // Resume delimiter scanning after the closing backtick in e.g., `` :exc:`ValueError` ``.
-    cursor.skip_bytes(span.end().to_usize());
+    cursor.skip_bytes(role.span().end().to_usize());
     true
 }
 

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -145,7 +145,7 @@ impl<'a> Iterator for InlineMarkupScanner<'a> {
         {
             (
                 preceding_text,
-                InlineMarkupToken::RestPrefixRole { name, span },
+                InlineMarkupToken::RestPrefixRole(Role { name, span }),
             )
         } else {
             (preceding_text, InlineMarkupToken::Code(span))
@@ -178,12 +178,24 @@ pub(crate) enum InlineMarkupToken<'a> {
     /// A complete code span whose backtick delimiters have equal lengths.
     Code(BacktickSpan<'a>),
     /// A reStructuredText prefix-role pattern and its single-backtick span.
-    RestPrefixRole {
-        /// The role name between the colons, for example `py:class`.
-        name: &'a str,
-        /// The complete single-backtick span following the role name.
-        span: BacktickSpan<'a>,
-    },
+    RestPrefixRole(Role<'a>),
+}
+
+/// A reStructuredText prefix role recognized by [`InlineMarkupScanner`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Role<'a> {
+    name: &'a str,
+    span: BacktickSpan<'a>,
+}
+
+impl<'a> Role<'a> {
+    /// Returns the complete single-backtick span following the role name.
+    ///
+    /// For `` :class:`Model <pkg.Model>` ``, this returns the span
+    /// `` `Model <pkg.Model>` ``.
+    pub(crate) fn span(self) -> BacktickSpan<'a> {
+        self.span
+    }
 }
 
 /// Splits a trailing reStructuredText prefix-role pattern from its preceding text.
@@ -688,8 +700,8 @@ mod tests {
             (":foo..bar:`Value`", None),
         ] {
             let actual = InlineMarkupScanner::new(source).next().and_then(|token| {
-                if let InlineMarkupToken::RestPrefixRole { name, span } = token {
-                    Some((name, span.content()))
+                if let InlineMarkupToken::RestPrefixRole(role) = token {
+                    Some((role.name, role.span().content()))
                 } else {
                     None
                 }
@@ -811,7 +823,7 @@ mod tests {
             .map(|token| match token {
                 InlineMarkupToken::Text(text) => ("text", text),
                 InlineMarkupToken::Code(code) => ("code", code.content()),
-                InlineMarkupToken::RestPrefixRole { span, .. } => ("rest role", span.content()),
+                InlineMarkupToken::RestPrefixRole(role) => ("rest role", role.span().content()),
             })
             .collect()
     }

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -196,6 +196,50 @@ impl<'a> Role<'a> {
     pub(crate) fn span(self) -> BacktickSpan<'a> {
         self.span
     }
+
+    /// Returns the source between the role's backtick delimiters.
+    ///
+    /// For `` :class:`Model <pkg.Model>` ``, this returns `Model <pkg.Model>`.
+    pub(crate) fn content(self) -> &'a str {
+        self.span.content()
+    }
+
+    /// Returns the explicit display title, if present.
+    ///
+    /// For `` :class:`Model <pkg.Model>` ``, this returns `Some("Model")`.
+    pub(crate) fn explicit_title(self) -> Option<&'a str> {
+        self.content()
+            .strip_suffix('>')
+            .and_then(|content| content.split_once('<'))
+            .map(|(title, _)| title.trim_end())
+    }
+
+    /// Returns whether this is a Sphinx Python-domain cross-reference role.
+    ///
+    /// For example, this returns `true` for `class`, `py:func`, and
+    /// `external+python:py:obj`.
+    pub(crate) fn is_python_domain_cross_reference(self) -> bool {
+        let mut components = self.name.rsplit(':');
+        let Some(role) = components.next() else {
+            return false;
+        };
+
+        matches!(components.next(), None | Some("py"))
+            && matches!(
+                role,
+                "attr"
+                    | "class"
+                    | "const"
+                    | "data"
+                    | "deco"
+                    | "exc"
+                    | "func"
+                    | "meth"
+                    | "mod"
+                    | "obj"
+                    | "type"
+            )
+    }
 }
 
 /// Splits a trailing reStructuredText prefix-role pattern from its preceding text.
@@ -701,7 +745,7 @@ mod tests {
         ] {
             let actual = InlineMarkupScanner::new(source).next().and_then(|token| {
                 if let InlineMarkupToken::RestPrefixRole(role) = token {
-                    Some((role.name, role.span().content()))
+                    Some((role.name, role.content()))
                 } else {
                     None
                 }
@@ -823,7 +867,7 @@ mod tests {
             .map(|token| match token {
                 InlineMarkupToken::Text(text) => ("text", text),
                 InlineMarkupToken::Code(code) => ("code", code.content()),
-                InlineMarkupToken::RestPrefixRole(role) => ("rest role", role.span().content()),
+                InlineMarkupToken::RestPrefixRole(role) => ("rest role", role.content()),
             })
             .collect()
     }

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -7,7 +7,8 @@ use super::general;
 use crate::docstring::document::SectionKind;
 use crate::docstring::document::preformatted::MarkdownFence;
 use crate::docstring::document::syntax::{
-    is_wrapped_in_markdown_code_span, starts_with_markdown_list_item,
+    InlineMarkupScanner, InlineMarkupToken, is_wrapped_in_markdown_code_span,
+    starts_with_markdown_list_item,
 };
 
 mod google;
@@ -374,12 +375,96 @@ fn description_block_start(description: &str) -> Option<usize> {
 fn render_type_code_span_into(output: &mut String, ty: &str) {
     let normalized = normalize_type_for_code_span(ty);
 
-    if is_wrapped_in_markdown_code_span(&normalized) {
+    // Preserve existing code spans, except for abbreviated Sphinx references
+    // such as "`~pkg.Model`" (whose display should be normalized to "Model").
+    if is_wrapped_in_markdown_code_span(&normalized) && !normalized.starts_with("`~") {
         output.push_str(&normalized);
         return;
     }
 
+    let normalized = normalize_embedded_type_markup(&normalized);
     render_code_span_into(output, normalized.as_ref());
+}
+
+/// Removes embedded markup before wrapping the normalize type label in a code span.
+///
+/// For example:
+///     - ``"str or :class:`pkg.Type` or `pkg.Other`"`` becomes `"str or pkg.Type or pkg.Other"`
+///     - `"-\\|>"` becomes `"-|>"`.
+fn normalize_embedded_type_markup(ty: &str) -> Cow<'_, str> {
+    if !ty.contains('`') && !ty.contains('\\') {
+        return Cow::Borrowed(ty);
+    }
+
+    let mut normalized = String::with_capacity(ty.len());
+    for token in InlineMarkupScanner::new(ty) {
+        match token {
+            InlineMarkupToken::Text(text) => push_unescaped(&mut normalized, text),
+            InlineMarkupToken::Code(span) => {
+                let markup = span.content();
+
+                // "`~pkg.Widget`" becomes "Widget"
+                // "``literal`tick``" becomes "literal`tick".
+                let display_text = if span.is_single() {
+                    interpreted_text_label(markup, false)
+                } else {
+                    markup
+                };
+
+                push_unescaped(&mut normalized, display_text);
+            }
+            InlineMarkupToken::RestPrefixRole(role) => {
+                let markup = role.content();
+
+                // ":class:`Model <pkg.Model>`" becomes "Model"
+                // ":obj:`.lines.line`" becomes "lines.line".
+                let display_text = role.explicit_title().unwrap_or_else(|| {
+                    interpreted_text_label(markup, role.is_python_domain_cross_reference())
+                });
+
+                push_unescaped(&mut normalized, display_text);
+            }
+        }
+    }
+
+    Cow::Owned(normalized)
+}
+
+/// Returns the display label for reStructuredText interpreted text.
+///
+/// For example, "~pkg.Widget" becomes "Widget"; a Python role target like
+/// ".lines.line" becomes "lines.line".
+fn interpreted_text_label(text: &str, is_python_role_target: bool) -> &str {
+    let (is_abbreviated, target) = text
+        .strip_prefix('~')
+        .map_or((false, text), |target| (true, target));
+    let target = if is_python_role_target {
+        target.strip_prefix('.').unwrap_or(target)
+    } else {
+        target
+    };
+    if target.is_empty() {
+        return text;
+    }
+
+    if is_abbreviated {
+        target.rsplit_once('.').map_or(target, |(_, label)| label)
+    } else {
+        target
+    }
+}
+
+fn push_unescaped(output: &mut String, text: &str) {
+    let mut characters = text.chars().peekable();
+    while let Some(character) = characters.next() {
+        if character == '\\'
+            && let Some(escaped) = characters.next_if(char::is_ascii_punctuation)
+        {
+            output.push(escaped);
+        } else {
+            output.push(character);
+        }
+    }
 }
 
 /// Normalizes type text so it fits in a single Markdown code span.
@@ -602,6 +687,109 @@ mod tests {
 
         **&lt;value&gt; &amp; \[docs\](target) \| \~deleted\~**<HB>
         Escaped name.
+        ");
+    }
+
+    #[test]
+    fn section_items_normalize_source_markup_in_types() {
+        let _snap = bind_markdown_snapshot_filters();
+        let section = section_block(vec![
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("rng"),
+                Some("{None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional"),
+                "Random number generator.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("arrowstyle"),
+                Some(r"str (default='-\|>')"),
+                "Arrow style.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("model"),
+                Some("str or :class:`pkg.Model`"),
+                "Model type.",
+            ),
+        ]);
+
+        assert_snapshot!(render_markdown(&section), @"
+        ## Parameters
+        **rng**: `{None, int, numpy.random.Generator, numpy.random.RandomState}, optional`<HB>
+        Random number generator.
+
+        **arrowstyle**: `str (default='-|>')`<HB>
+        Arrow style.
+
+        **model**: `str or pkg.Model`<HB>
+        Model type.
+        ");
+    }
+
+    #[test]
+    fn section_items_remove_rest_roles_from_types() {
+        let _snap = bind_markdown_snapshot_filters();
+        let section = section_block(vec![
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("colormap"),
+                Some(
+                    "str or :class:`~matplotlib.colors.Colormap` or :mod:`matplotlib.colors` or `~.pandas.Index`",
+                ),
+                "Color mapping.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("model"),
+                Some("`~astropy.modeling.core.Model`"),
+                "Model.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("extension"),
+                Some("`.py`"),
+                "File extension.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("config"),
+                Some("str or `.env` or `.Figure` or `.lines.Line2D`"),
+                "Configuration source.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("line"),
+                Some(":py:obj:`.lines.line`"),
+                "Line helper.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("model"),
+                Some(":class:`Model <pkg.Model>`"),
+                "Named model.",
+            ),
+        ]);
+
+        assert_snapshot!(render_markdown(&section), @"
+        ## Parameters
+        **colormap**: `str or Colormap or matplotlib.colors or Index`<HB>
+        Color mapping.
+
+        **model**: `Model`<HB>
+        Model.
+
+        **extension**: `.py`<HB>
+        File extension.
+
+        **config**: `str or .env or .Figure or .lines.Line2D`<HB>
+        Configuration source.
+
+        **line**: `lines.line`<HB>
+        Line helper.
+
+        **model**: `Model`<HB>
+        Named model.
         ");
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This normalizes the source markup used to describe a type in a docstring before we wrap that type in backticks in order to render it as a code span. The outcome is that our rendering of types improves across all docstring formats.

The normalization performs the following operations:

1. Removes embedded backtick delimiters from the type expression.
2. Removes valid reStructuredText role prefixes.
3. Uses the abbreviated display label requested by a leading `~` in a single-backtick span, including spans without an explicit role.
4. Removes Sphinx's leading-dot resolver marker from explicit Python-domain references, such as `` :py:obj:`.lines.line` ``, while preserving literal spans such as `.py`, `.env`, and `.Figure`.
5. Removes reStructuredText escapes from punctuation.

Existing Markdown code spans otherwise continue to pass through unchanged.

The table below gives examples of parameter docstrings with their emitted Markdown before and after this change (note that the changes are subtle!):

| Category / real-world example | Before | After |
| :--- | :--- | :--- |
| [Embedded type markup](https://github.com/scipy/scipy/blob/75aedcaae44102a9abaeba389cf3a0f87ff4f61f/scipy/stats/_kde.py#L471) | `` **rng**: `{None, `Generator`}` `` | `` **rng**: `{None, Generator}` `` |
| [Escaped punctuation](https://github.com/networkx/networkx/blob/3b4c227fda1c5462e6c04ac1ed7e7b0d8f2eacd4/networkx/drawing/nx_pylab.py#L1211) | `` **style**: `str ('-\\|>')` `` | `` **style**: `str ('-\|>')` `` |
| [reST role and abbreviated label](https://github.com/astropy/astropy/blob/0c2b1f70ebd1203f8343fde9c7a59dd9d53c1a3e/astropy/units/quantity.py#L388) | `` **unit**: `:class:`~pkg.Unit` or str` `` | `` **unit**: `Unit or str` `` |

This should improve even further with https://github.com/astral-sh/ruff/pull/27116, but I think this is already a considerable improvement given that it fixes some plainly broken Markdown.

## Test Plan

See included tests.
<!-- How was it tested? -->
