### PR TITLE
[ty] Reuse applicable own-line suppressions in `--add-ignore`

### DIFF
--- a/crates/ty/tests/cli/fixes.rs
+++ b/crates/ty/tests/cli/fixes.rs
@@ -47,6 +47,61 @@ fn add_ignore() -> anyhow::Result<()> {
 }
 
 #[test]
+fn add_ignore_keeps_nested_blanket_suppression_used() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "nested.py",
+        r#"
+            def f(value: int) -> int:
+                return value
+
+            seen_code = True
+            # ty: ignore[]
+            values = [
+                # ty: ignore[blanket-ignore-comment]
+                # ty: ignore
+                f("bad"),
+                # ty: ignore
+                missing,
+            ]
+            "#,
+    )?;
+
+    assert_cmd_snapshot!(
+        case.command()
+            .arg("--add-ignore")
+            .arg("--warn")
+            .arg("blanket-ignore-comment"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+    Added 1 ignore comment
+
+    ----- stderr -----
+    "
+    );
+
+    assert_snapshot!(fs::read_to_string(case.root().join("nested.py"))?, @r#"
+
+    def f(value: int) -> int:
+        return value
+
+    seen_code = True
+    # ty: ignore[blanket-ignore-comment]
+    values = [
+        # ty: ignore[blanket-ignore-comment]
+        # ty: ignore
+        f("bad"),
+        # ty: ignore
+        missing,
+    ]
+    "#);
+
+    Ok(())
+}
+
+#[test]
 fn add_ignore_unfixable() -> anyhow::Result<()> {
     let case = CliTest::with_files([
         ("has_syntax_error.py", r"print(x  # [unresolved-reference]"),

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -210,35 +210,9 @@ mod tests {
     }
 
     #[test]
-    fn add_ignore_does_not_append_to_reason_ending_in_bracket() {
-        let test = CodeActionTest::with_source(
-            r#"
-            seen_code = True
-            # ty:ignore[] tracked by [123]
-            values = [
-                <START>missing<END>,
-            ]
-        "#,
-        );
-
-        assert_snapshot!(test.code_actions(&UNRESOLVED_REFERENCE), @"
-        info[code-action]: Ignore 'unresolved-reference' for this line
-         --> main.py:5:5
-          |
-        5 |     missing,
-          |     ^^^^^^^
-          |
-          |
-        4 | values = [
-          -     missing,
-        5 +     missing,  # ty:ignore[unresolved-reference]
-        6 | ]
-          |
-        ");
-    }
-
-    #[test]
     fn add_ignore_matches_existing_suppression_against_diagnostic_range() {
+        // The first suppression is intentional: `not-a-rule` has no indexed suppression, and
+        // repeatedly extending the final suppression can't suppress a diagnostic before it.
         let test = CodeActionTest::with_source(
             r#"
             seen_code = True

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -88,6 +88,7 @@ mod tests {
     use ruff_text_size::{TextRange, TextSize};
     use ty_project::ProjectMetadata;
     use ty_python_semantic::{
+        default_lint_registry,
         lint::LintMetadata,
         types::{UNDEFINED_REVEAL, UNRESOLVED_REFERENCE},
     };
@@ -183,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn add_ignore_does_not_update_preceding_own_line_suppression() {
+    fn add_ignore_updates_preceding_own_line_suppression() {
         let test = CodeActionTest::with_source(
             r#"
             seen_code = True
@@ -200,9 +201,129 @@ mod tests {
           |     ^
           |
           |
-        3 | # ty:ignore[]
-          - b = a / 10
-        4 + b = a / 10  # ty:ignore[unresolved-reference]
+        2 | seen_code = True
+          - # ty:ignore[]
+        3 + # ty:ignore[unresolved-reference]
+        4 | b = a / 10
+          |
+        ");
+    }
+
+    #[test]
+    fn add_ignore_does_not_append_to_reason_ending_in_bracket() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            # ty:ignore[] tracked by [123]
+            values = [
+                <START>missing<END>,
+            ]
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions(&UNRESOLVED_REFERENCE), @"
+        info[code-action]: Ignore 'unresolved-reference' for this line
+         --> main.py:5:5
+          |
+        5 |     missing,
+          |     ^^^^^^^
+          |
+          |
+        4 | values = [
+          -     missing,
+        5 +     missing,  # ty:ignore[unresolved-reference]
+        6 | ]
+          |
+        ");
+    }
+
+    #[test]
+    fn add_ignore_matches_existing_suppression_against_diagnostic_range() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            # ty:ignore[] # ty:ignore[<START>not-a-rule<END>] # ty:ignore[division-by-zero]
+            value = 1 / 0
+        "#,
+        );
+
+        let lint = default_lint_registry()
+            .get("ignore-comment-unknown-rule")
+            .unwrap();
+        assert_snapshot!(test.code_actions(&lint), @"
+        info[code-action]: Ignore 'ignore-comment-unknown-rule' for this line
+         --> main.py:3:27
+          |
+        3 | # ty:ignore[] # ty:ignore[not-a-rule] # ty:ignore[division-by-zero]
+          |                           ^^^^^^^^^^
+          |
+          |
+        2 | seen_code = True
+          - # ty:ignore[] # ty:ignore[not-a-rule] # ty:ignore[division-by-zero]
+        3 + # ty:ignore[ignore-comment-unknown-rule] # ty:ignore[not-a-rule] # ty:ignore[division-by-zero]
+        4 | value = 1 / 0
+          |
+        ");
+    }
+
+    #[test]
+    fn add_ignore_does_not_make_nested_suppression_unused() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            # ty:ignore[]
+            values = [
+                # ty:ignore[unresolved-reference]
+                missing,
+                <START>absent<END>,
+            ]
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions(&UNRESOLVED_REFERENCE), @"
+        info[code-action]: Ignore 'unresolved-reference' for this line
+         --> main.py:7:5
+          |
+        7 |     absent,
+          |     ^^^^^^
+          |
+          |
+        2 | seen_code = True
+          - # ty:ignore[]
+        3 + # ty:ignore[unresolved-reference]
+        4 | values = [
+          |
+        ");
+    }
+
+    #[test]
+    fn add_ignore_reuses_outer_suppression_with_nested_blanket() {
+        let test = CodeActionTest::with_source(
+            r#"
+            def f(value: int) -> int: return value
+
+            seen_code = True
+            # ty:ignore[invalid-assignment]
+            values: tuple[int] = [
+                # ty:ignore
+                f("bad"),
+                <START>absent<END>,
+            ]
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions(&UNRESOLVED_REFERENCE), @"
+        info[code-action]: Ignore 'unresolved-reference' for this line
+         --> main.py:9:5
+          |
+        9 |     absent,
+          |     ^^^^^^
+          |
+          |
+        4 | seen_code = True
+          - # ty:ignore[invalid-assignment]
+        5 + # ty:ignore[invalid-assignment, unresolved-reference]
+        6 | values: tuple[int] = [
           |
         ");
     }
@@ -863,7 +984,7 @@ mod tests {
             }
         }
 
-        pub(super) fn code_actions(&self, lint: &'static LintMetadata) -> String {
+        pub(super) fn code_actions(&self, lint: &LintMetadata) -> String {
             use std::fmt::Write;
 
             let mut buf = String::new();

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1021,6 +1021,50 @@ mod tests {
     }
 
     #[test]
+    fn add_ignore_deduplicates_existing_edit_against_planned_start_line() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                from typing import TypeAlias
+
+                JsonValue: TypeAlias = dict[str, "JsonValue"] | list["JsonValue"] | int
+
+
+                def get_data() -> dict[str, JsonValue]:
+                    return {"home_assistant": {"entities": [{"entity_id": "sensor.test"}]}}
+
+
+                def f() -> None:
+                    diag = get_data()
+                    diag["home_assistant"]["entities"] = sorted(
+                        diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]
+                    ); missing  # ty: ignore[unresolved-reference]
+                "#),
+            @r#"
+        Added 4 suppressions
+
+        ## Fixed source
+
+        ```py
+        from typing import TypeAlias
+
+        JsonValue: TypeAlias = dict[str, "JsonValue"] | list["JsonValue"] | int
+
+
+        def get_data() -> dict[str, JsonValue]:
+            return {"home_assistant": {"entities": [{"entity_id": "sensor.test"}]}}
+
+
+        def f() -> None:
+            diag = get_data()
+            diag["home_assistant"]["entities"] = sorted(  # ty:ignore[invalid-assignment]
+                diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]  # ty:ignore[invalid-argument-type, not-subscriptable]
+            ); missing  # ty: ignore[unresolved-reference]
+        ```
+        "#
+        );
+    }
+
+    #[test]
     fn return_type() {
         assert_snapshot!(
             suppress_all_in(r#"class A:
@@ -1152,6 +1196,99 @@ class B(A):
     }
 
     #[test]
+    fn add_ignore_does_not_append_to_reason_ending_in_bracket() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[] tracked by [123]
+                values = [
+                    missing,
+                ]
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # ty: ignore[] tracked by [123]
+        values = [
+            missing,  # ty:ignore[unresolved-reference]
+        ]
+        ```
+
+        ## Diagnostics after applying fixes
+
+        warning[unused-ignore-comment]: Unused `ty: ignore` without a code
+         --> test.py:2:1
+          |
+        1 | seen_code = True
+        2 | # ty: ignore[] tracked by [123]
+          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        3 | values = [
+        4 |     missing,  # ty:ignore[unresolved-reference]
+          |
+        help: Remove the unused suppression comment
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_matches_existing_suppression_against_diagnostic_range() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[] # ty: ignore[not-a-rule] # ty: ignore[division-by-zero]
+                value = 1 / 0
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # ty: ignore[ignore-comment-unknown-rule] # ty: ignore[not-a-rule] # ty: ignore[division-by-zero]
+        value = 1 / 0
+        ```
+
+        ## Diagnostics after applying fixes
+
+        warning[unused-ignore-comment]: Unused `ty: ignore` directive
+         --> test.py:2:68
+          |
+        1 | seen_code = True
+        2 | # ty: ignore[ignore-comment-unknown-rule] # ty: ignore[not-a-rule] # ty: ignore[division-by-zero]
+          |                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        3 | value = 1 / 0
+          |
+        help: Remove the unused suppression comment
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_prefers_same_line_suppression_over_outer_own_line() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                # ty: ignore[invalid-assignment]
+                values: tuple[int] = [missing]  # ty: ignore[]
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        # ty: ignore[invalid-assignment]
+        values: tuple[int] = [missing]  # ty: ignore[unresolved-reference]
+        ```
+        "
+        );
+    }
+
+    #[test]
     fn add_ignore_groups_diagnostics_for_same_line_suppression() {
         assert_snapshot!(
             suppress_all_in(r#"
@@ -1186,7 +1323,37 @@ class B(A):
     }
 
     #[test]
-    fn add_ignore_does_not_update_inner_own_line_suppression() {
+    fn add_ignore_groups_suppression_matched_at_start_and_end() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                def f(a: int, b: int, c: int) -> None: ...
+
+                f(
+                    "a" +
+                    # ty: ignore[]
+                    "b", "c", missing
+                )
+                "#),
+            @r#"
+        Added 3 suppressions
+
+        ## Fixed source
+
+        ```py
+        def f(a: int, b: int, c: int) -> None: ...
+
+        f(
+            "a" +
+            # ty: ignore[invalid-argument-type, unresolved-reference]
+            "b", "c", missing
+        )
+        ```
+        "#
+        );
+    }
+
+    #[test]
+    fn add_ignore_updates_inner_own_line_suppression() {
         assert_snapshot!(
             suppress_all_in(r#"
                 seen_code = True
@@ -1203,30 +1370,16 @@ class B(A):
         ```py
         seen_code = True
         values = [
-            # ty: ignore[]
-            missing,  # ty:ignore[unresolved-reference]
+            # ty: ignore[unresolved-reference]
+            missing,
         ]
         ```
-
-        ## Diagnostics after applying fixes
-
-        warning[unused-ignore-comment]: Unused `ty: ignore` without a code
-         --> test.py:3:5
-          |
-        1 | seen_code = True
-        2 | values = [
-        3 |     # ty: ignore[]
-          |     ^^^^^^^^^^^^^^
-        4 |     missing,  # ty:ignore[unresolved-reference]
-        5 | ]
-          |
-        help: Remove the unused suppression comment
         "
         );
     }
 
     #[test]
-    fn add_ignore_does_not_update_preceding_own_line_suppressions() {
+    fn add_ignore_updates_preceding_own_line_suppressions() {
         assert_snapshot!(
             suppress_all_in(r#"
                 seen_code = True
@@ -1248,30 +1401,225 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty: ignore[]
-        value = missing  # ty:ignore[unresolved-reference]
+        # ty: ignore[unresolved-reference]
+        value = missing
 
         def f(a: int, b: int) -> list[int]: return []
 
-        # ty: ignore[invalid-assignment]
+        # ty: ignore[invalid-assignment, invalid-argument-type, unresolved-reference]
         values: tuple[int] = f(
-            missing,  # ty:ignore[unresolved-reference]
-            "bad",  # ty:ignore[invalid-argument-type]
+            missing,
+            "bad",
         )
+        ```
+        "#
+        );
+    }
+
+    #[test]
+    fn add_ignore_does_not_make_nested_suppression_unused() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[]
+                values = [
+                    # ty: ignore[unresolved-reference]
+                    missing,
+                    absent,
+                ]
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # ty: ignore[unresolved-reference]
+        values = [
+            # ty: ignore[unresolved-reference]
+            missing,
+            absent,
+        ]
+        ```
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_keeps_disjoint_start_suppression_used() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                def f(a: int, b: int) -> None: pass
+                def g(a: int, b: int) -> int: return 0
+
+                f(  # ty: ignore[missing-argument]
+                    g(missing))  # ty: ignore[unresolved-reference]
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        def f(a: int, b: int) -> None: pass
+        def g(a: int, b: int) -> int: return 0
+
+        f(  # ty: ignore[missing-argument]
+            g(missing))  # ty: ignore[unresolved-reference, missing-argument]
+        ```
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_reconciles_nested_same_code_edits() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                def f(a: int, b: int, c: int) -> None: pass
+                def g(a: int, b: int) -> int: return 0
+
+                seen_code = True
+                # ty: ignore[unresolved-reference]
+                f(
+                    missing,
+                    g("bad"))  # ty: ignore[invalid-argument-type]
+                "#),
+            @r#"
+        Added 2 suppressions
+
+        ## Fixed source
+
+        ```py
+        def f(a: int, b: int, c: int) -> None: pass
+        def g(a: int, b: int) -> int: return 0
+
+        seen_code = True
+        # ty: ignore[unresolved-reference]
+        f(
+            missing,
+            g("bad"))  # ty: ignore[invalid-argument-type, missing-argument]
+        ```
+        "#
+        );
+    }
+
+    #[test]
+    fn add_ignore_updates_nested_and_outer_suppressions() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[too-many-positional-arguments]
+                values = [
+                    # ty: ignore[invalid-argument-type]
+                    missing,
+                    absent,
+                ]
+                "#),
+            @"
+        Added 2 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # ty: ignore[too-many-positional-arguments, unresolved-reference]
+        values = [
+            # ty: ignore[invalid-argument-type, unresolved-reference]
+            missing,
+            absent,
+        ]
         ```
 
         ## Diagnostics after applying fixes
 
-        warning[unused-ignore-comment]: Unused `ty: ignore` without a code
-         --> test.py:2:1
+        warning[unused-ignore-comment]: Unused `ty: ignore` directive: 'too-many-positional-arguments'
+         --> test.py:2:14
           |
         1 | seen_code = True
-        2 | # ty: ignore[]
-          | ^^^^^^^^^^^^^^
-        3 | value = missing  # ty:ignore[unresolved-reference]
+        2 | # ty: ignore[too-many-positional-arguments, unresolved-reference]
+          |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        3 | values = [
+        4 |     # ty: ignore[invalid-argument-type, unresolved-reference]
           |
-        help: Remove the unused suppression comment
+        help: Remove the unused suppression code
+
+        warning[unused-ignore-comment]: Unused `ty: ignore` directive: 'invalid-argument-type'
+         --> test.py:4:18
+          |
+        2 | # ty: ignore[too-many-positional-arguments, unresolved-reference]
+        3 | values = [
+        4 |     # ty: ignore[invalid-argument-type, unresolved-reference]
+          |                  ^^^^^^^^^^^^^^^^^^^^^
+        5 |     missing,
+        6 |     absent,
+          |
+        help: Remove the unused suppression code
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_reuses_outer_suppression_with_nested_blanket() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                def f(value: int) -> int: return value
+
+                seen_code = True
+                # ty: ignore[invalid-assignment]
+                values: tuple[int] = [
+                    # ty: ignore
+                    f("bad"),
+                    absent,
+                ]
+                "#),
+            @r#"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        def f(value: int) -> int: return value
+
+        seen_code = True
+        # ty: ignore[invalid-assignment, unresolved-reference]
+        values: tuple[int] = [
+            # ty: ignore
+            f("bad"),
+            absent,
+        ]
+        ```
         "#
+        );
+    }
+
+    #[test]
+    fn add_ignore_keeps_nested_blanket_used_for_same_code() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[]
+                values = [
+                    # ty: ignore
+                    missing,
+                    absent,
+                ]
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # ty: ignore[unresolved-reference]
+        values = [
+            # ty: ignore
+            missing,
+            absent,
+        ]
+        ```
+        "
         );
     }
 

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1196,12 +1196,13 @@ class B(A):
     }
 
     #[test]
-    fn add_ignore_does_not_append_to_reason_ending_in_bracket() {
+    fn add_ignore_prefers_editable_outer_suppression_over_inner_with_reason() {
         assert_snapshot!(
             suppress_all_in(r#"
                 seen_code = True
-                # ty: ignore[] tracked by [123]
+                # ty: ignore[]
                 values = [
+                    # ty: ignore[] tracked by [123]
                     missing,
                 ]
                 "#),
@@ -1212,22 +1213,24 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty: ignore[] tracked by [123]
+        # ty: ignore[unresolved-reference]
         values = [
-            missing,  # ty:ignore[unresolved-reference]
+            # ty: ignore[] tracked by [123]
+            missing,
         ]
         ```
 
         ## Diagnostics after applying fixes
 
         warning[unused-ignore-comment]: Unused `ty: ignore` without a code
-         --> test.py:2:1
+         --> test.py:4:5
           |
-        1 | seen_code = True
-        2 | # ty: ignore[] tracked by [123]
-          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        2 | # ty: ignore[unresolved-reference]
         3 | values = [
-        4 |     missing,  # ty:ignore[unresolved-reference]
+        4 |     # ty: ignore[] tracked by [123]
+          |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        5 |     missing,
+        6 | ]
           |
         help: Remove the unused suppression comment
         "
@@ -1236,6 +1239,8 @@ class B(A):
 
     #[test]
     fn add_ignore_matches_existing_suppression_against_diagnostic_range() {
+        // The first suppression is intentional: `not-a-rule` has no indexed suppression, and
+        // repeatedly extending the final suppression can't suppress a diagnostic before it.
         assert_snapshot!(
             suppress_all_in(r#"
                 seen_code = True

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -358,25 +358,24 @@ impl Suppressions {
     ) -> impl Iterator<Item = &Suppression> + '_ {
         self.file
             .iter()
-            .chain(self.inline.intersecting_rev(range, id))
+            .chain(self.inline.intersecting_rev(
+                range,
+                SuppressionTarget::All.target_mask() | SuppressionTarget::Lint(id).target_mask(),
+            ))
             .filter(move |suppression| suppression.matches(id) && suppression.applies_to(range))
     }
 
-    /// Returns the inline suppressions whose comments are on `line_range`.
-    fn inline_suppressions_on_line(
+    /// Returns applicable comments that `--add-ignore` can extend, in reverse source order.
+    ///
+    /// The interval index marks one editable entry per comment, excluding comments with trailing
+    /// reasons and duplicate entries for a multi-code suppression.
+    fn editable_inline_suppressions_rev(
         &self,
-        line_range: TextRange,
+        range: TextRange,
     ) -> impl Iterator<Item = &Suppression> + '_ {
-        // The interval index retains source order, so comment ranges are also ordered by start.
-        let start = self
-            .inline
-            .entries
-            .partition_point(|entry| entry.suppression.comment_range.start() < line_range.start());
-
-        self.inline.entries[start..]
-            .iter()
-            .map(|entry| &entry.suppression)
-            .take_while(move |suppression| suppression.comment_range.start() < line_range.end())
+        self.inline
+            .intersecting_rev(range, IntervalIndex::EDITABLE_MASK)
+            .filter(move |suppression| suppression.editable && suppression.applies_to(range))
     }
 
     fn iter(&self) -> impl Iterator<Item = &Suppression> {
@@ -427,6 +426,7 @@ fn select_preferred_suppression<'a>(
 pub(crate) struct Suppression {
     target: SuppressionTarget,
     kind: SuppressionKind,
+    editable: bool,
 
     /// The range of the code in this suppression.
     ///
@@ -507,6 +507,23 @@ impl fmt::Display for SuppressionKind {
     }
 }
 
+/// Returns the portion of an ignore comment before its closing bracket if another code can be
+/// appended to it.
+///
+/// ```python
+/// # ty: ignore[]         # Editable
+/// # ty: ignore[] reason  # Not editable
+/// ```
+fn editable_suppression_prefix(comment_text: &str) -> Option<&str> {
+    // The parser accepts a reason after the code list, but rule codes can't contain `]`, so the
+    // first `]` is the code list's closing bracket. Don't edit comments with trailing reasons.
+    let (before_closing_bracket, after_closing_bracket) = comment_text.split_once(']')?;
+    after_closing_bracket
+        .trim()
+        .is_empty()
+        .then(|| before_closing_bracket.trim_end())
+}
+
 /// Unique ID for a suppression in a file.
 ///
 /// ## Implementation
@@ -545,7 +562,8 @@ impl SuppressionTarget {
             SuppressionTarget::Lint(id) => {
                 let mut hasher = FxHasher::default();
                 id.hash(&mut hasher);
-                1 << (1 + hasher.finish() % 63)
+                // The top bit is reserved for editable suppressions.
+                1 << (1 + hasher.finish() % 62)
             }
         }
     }
@@ -616,10 +634,24 @@ impl<'a> SuppressionsBuilder<'a> {
             line_range
         };
 
-        let mut push_ignore_suppression = |suppression: Suppression| {
+        let is_editable = comment.codes().is_some()
+            && editable_suppression_prefix(&self.source[comment.range()]).is_some();
+        let mut indexed_editable_comment = false;
+
+        let mut push_ignore_suppression = |mut suppression: Suppression| {
             if is_file_suppression {
                 self.file.push(suppression);
             } else {
+                if is_editable
+                    && !indexed_editable_comment
+                    && matches!(
+                        suppression.target,
+                        SuppressionTarget::Lint(_) | SuppressionTarget::Empty
+                    )
+                {
+                    suppression.editable = true;
+                    indexed_editable_comment = true;
+                }
                 self.inline.push(suppression);
             }
         };
@@ -630,6 +662,7 @@ impl<'a> SuppressionsBuilder<'a> {
                 push_ignore_suppression(Suppression {
                     target: SuppressionTarget::All,
                     kind: comment.kind(),
+                    editable: false,
                     comment_range: comment.range(),
                     range: comment.range(),
                     suppressed_range,
@@ -641,6 +674,7 @@ impl<'a> SuppressionsBuilder<'a> {
                 push_ignore_suppression(Suppression {
                     target: SuppressionTarget::Empty,
                     kind: comment.kind(),
+                    editable: false,
                     range: comment.range(),
                     comment_range: comment.range(),
                     suppressed_range,
@@ -668,6 +702,7 @@ impl<'a> SuppressionsBuilder<'a> {
                             push_ignore_suppression(Suppression {
                                 target: SuppressionTarget::Lint(lint),
                                 kind: comment.kind(),
+                                editable: false,
                                 range: code_range,
                                 comment_range: comment.range(),
                                 suppressed_range,
@@ -790,6 +825,9 @@ struct IntervalEntry {
 }
 
 impl IntervalIndex {
+    /// Marks the single editable entry for an inline suppression comment.
+    const EDITABLE_MASK: u64 = 1 << 63;
+
     /// Builds an index from values sorted by interval start, retaining their input order.
     fn from_sorted(suppressions: Vec<Suppression>) -> Self {
         debug_assert!(
@@ -800,7 +838,12 @@ impl IntervalIndex {
             .into_iter()
             .map(|suppression| IntervalEntry {
                 subtree_max_end: suppression.suppressed_range.end(),
-                subtree_target_mask: suppression.target.target_mask(),
+                subtree_target_mask: suppression.target.target_mask()
+                    | if suppression.editable {
+                        Self::EDITABLE_MASK
+                    } else {
+                        0
+                    },
                 suppression,
             })
             .collect::<Box<[_]>>();
@@ -835,10 +878,12 @@ impl IntervalIndex {
     /// Interval endpoints are treated as inclusive so that an empty diagnostic range at an
     /// interval boundary remains a candidate. Callers can apply stricter containment rules to the
     /// returned values.
-    fn intersecting_rev(&self, query: TextRange, id: LintId) -> impl Iterator<Item = &Suppression> {
+    fn intersecting_rev(
+        &self,
+        query: TextRange,
+        wanted: u64,
+    ) -> impl Iterator<Item = &Suppression> {
         let mut pending: SmallVec<[&[IntervalEntry]; 16]> = smallvec![self.entries.as_ref()];
-        let wanted =
-            SuppressionTarget::All.target_mask() | SuppressionTarget::Lint(id).target_mask();
 
         std::iter::from_fn(move || {
             while let Some(entries) = pending.pop() {
@@ -924,6 +969,33 @@ value = missing
         assert_eq!(
             suppressions
                 .lint_suppressions(missing_range, unresolved_reference)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn editable_index_skips_nested_suppressions_with_reasons() {
+        let source = r#"seen_code = True
+# ty: ignore[] reason
+# ty: ignore[] reason
+# ty: ignore[] reason
+# ty: ignore[]
+value = missing
+"#;
+        let db = TestDbBuilder::new()
+            .with_file("test.py", source)
+            .build()
+            .unwrap();
+        let file = system_path_to_file(&db, "test.py").unwrap();
+        let missing_start = source.find("missing").unwrap().try_into().unwrap();
+        let missing_range = TextRange::at(missing_start, "missing".text_len());
+
+        let suppressions = suppressions(&db, file);
+        assert_eq!(suppressions.inline.len(), 4);
+        assert_eq!(
+            suppressions
+                .editable_inline_suppressions_rev(missing_range)
                 .count(),
             1
         );

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -365,17 +365,23 @@ impl Suppressions {
             .filter(move |suppression| suppression.matches(id) && suppression.applies_to(range))
     }
 
-    /// Returns applicable comments that `--add-ignore` can extend, in reverse source order.
+    /// Returns applicable comments whose targets allow `--add-ignore` to append a code, in
+    /// reverse source order.
     ///
-    /// The interval index marks one editable entry per comment, excluding comments with trailing
-    /// reasons and duplicate entries for a multi-code suppression.
+    /// The interval index filters out blanket suppressions. Comments with multiple codes can
+    /// appear more than once, and callers must still exclude comments with trailing reasons.
     fn editable_inline_suppressions_rev(
         &self,
         range: TextRange,
     ) -> impl Iterator<Item = &Suppression> + '_ {
         self.inline
             .intersecting_rev(range, IntervalIndex::EDITABLE_MASK)
-            .filter(move |suppression| suppression.editable && suppression.applies_to(range))
+            .filter(move |suppression| {
+                matches!(
+                    suppression.target,
+                    SuppressionTarget::Lint(_) | SuppressionTarget::Empty
+                ) && suppression.applies_to(range)
+            })
     }
 
     fn iter(&self) -> impl Iterator<Item = &Suppression> {
@@ -426,7 +432,6 @@ fn select_preferred_suppression<'a>(
 pub(crate) struct Suppression {
     target: SuppressionTarget,
     kind: SuppressionKind,
-    editable: bool,
 
     /// The range of the code in this suppression.
     ///
@@ -507,23 +512,6 @@ impl fmt::Display for SuppressionKind {
     }
 }
 
-/// Returns the portion of an ignore comment before its closing bracket if another code can be
-/// appended to it.
-///
-/// ```python
-/// # ty: ignore[]         # Editable
-/// # ty: ignore[] reason  # Not editable
-/// ```
-fn editable_suppression_prefix(comment_text: &str) -> Option<&str> {
-    // The parser accepts a reason after the code list, but rule codes can't contain `]`, so the
-    // first `]` is the code list's closing bracket. Don't edit comments with trailing reasons.
-    let (before_closing_bracket, after_closing_bracket) = comment_text.split_once(']')?;
-    after_closing_bracket
-        .trim()
-        .is_empty()
-        .then(|| before_closing_bracket.trim_end())
-}
-
 /// Unique ID for a suppression in a file.
 ///
 /// ## Implementation
@@ -552,8 +540,9 @@ impl SuppressionTarget {
 
     /// Returns the conservative bit used to skip subtrees without this target.
     ///
-    /// Lints are hashed into 63 buckets, with one bucket reserved for blanket suppressions. The
-    /// interval index only traverses subtrees whose buckets overlap the queried lint.
+    /// Lints are hashed into 62 buckets, with one bucket reserved for blanket suppressions and
+    /// one for editable suppressions. The interval index only traverses subtrees whose buckets
+    /// overlap the queried lint.
     fn target_mask(self) -> u64 {
         match self {
             // Keep blanket suppressions separate so they are always considered.
@@ -634,24 +623,10 @@ impl<'a> SuppressionsBuilder<'a> {
             line_range
         };
 
-        let is_editable = comment.codes().is_some()
-            && editable_suppression_prefix(&self.source[comment.range()]).is_some();
-        let mut indexed_editable_comment = false;
-
-        let mut push_ignore_suppression = |mut suppression: Suppression| {
+        let mut push_ignore_suppression = |suppression: Suppression| {
             if is_file_suppression {
                 self.file.push(suppression);
             } else {
-                if is_editable
-                    && !indexed_editable_comment
-                    && matches!(
-                        suppression.target,
-                        SuppressionTarget::Lint(_) | SuppressionTarget::Empty
-                    )
-                {
-                    suppression.editable = true;
-                    indexed_editable_comment = true;
-                }
                 self.inline.push(suppression);
             }
         };
@@ -662,7 +637,6 @@ impl<'a> SuppressionsBuilder<'a> {
                 push_ignore_suppression(Suppression {
                     target: SuppressionTarget::All,
                     kind: comment.kind(),
-                    editable: false,
                     comment_range: comment.range(),
                     range: comment.range(),
                     suppressed_range,
@@ -674,7 +648,6 @@ impl<'a> SuppressionsBuilder<'a> {
                 push_ignore_suppression(Suppression {
                     target: SuppressionTarget::Empty,
                     kind: comment.kind(),
-                    editable: false,
                     range: comment.range(),
                     comment_range: comment.range(),
                     suppressed_range,
@@ -702,7 +675,6 @@ impl<'a> SuppressionsBuilder<'a> {
                             push_ignore_suppression(Suppression {
                                 target: SuppressionTarget::Lint(lint),
                                 kind: comment.kind(),
-                                editable: false,
                                 range: code_range,
                                 comment_range: comment.range(),
                                 suppressed_range,
@@ -825,7 +797,7 @@ struct IntervalEntry {
 }
 
 impl IntervalIndex {
-    /// Marks the single editable entry for an inline suppression comment.
+    /// Marks lint-specific and empty suppressions that `--add-ignore` can consider extending.
     const EDITABLE_MASK: u64 = 1 << 63;
 
     /// Builds an index from values sorted by interval start, retaining their input order.
@@ -839,7 +811,10 @@ impl IntervalIndex {
             .map(|suppression| IntervalEntry {
                 subtree_max_end: suppression.suppressed_range.end(),
                 subtree_target_mask: suppression.target.target_mask()
-                    | if suppression.editable {
+                    | if matches!(
+                        suppression.target,
+                        SuppressionTarget::Lint(_) | SuppressionTarget::Empty
+                    ) {
                         Self::EDITABLE_MASK
                     } else {
                         0
@@ -975,11 +950,11 @@ value = missing
     }
 
     #[test]
-    fn editable_index_skips_nested_suppressions_with_reasons() {
+    fn editable_index_skips_nested_blanket_suppressions() {
         let source = r#"seen_code = True
-# ty: ignore[] reason
-# ty: ignore[] reason
-# ty: ignore[] reason
+# ty: ignore
+# ty: ignore
+# ty: ignore
 # ty: ignore[]
 value = missing
 "#;

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -1,3 +1,11 @@
+//! Helpers for adding suppression comments without changing which existing suppression is used.
+//!
+//! An applicable same-line or nested own-line suppression is extended first because it has the
+//! narrowest scope. For diagnostics spanning multiple lines, an opening-line suppression takes
+//! precedence over a separate closing-line suppression, matching normal suppression resolution.
+//! Comments with trailing reasons are never extended: preserving the reason requires adding a
+//! separate suppression instead.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Formatter;
 
@@ -14,8 +22,7 @@ use smallvec::SmallVec;
 use crate::Db;
 use crate::lint::LintId;
 use crate::suppression::{
-    SuppressionKind, Suppressions, editable_suppression_prefix, select_preferred_suppression,
-    suppressions,
+    SuppressionKind, Suppressions, select_preferred_suppression, suppressions,
 };
 
 /// Creates fixes to suppress all violations in `ids_with_range`.
@@ -262,8 +269,14 @@ fn find_existing_suppression(
     source: &str,
     range: TextRange,
 ) -> Option<ExistingSuppression> {
-    let suppression =
-        select_preferred_suppression(suppressions.editable_inline_suppressions_rev(range), range)?;
+    let suppression = select_preferred_suppression(
+        suppressions
+            .editable_inline_suppressions_rev(range)
+            .filter(|suppression| {
+                editable_suppression_prefix(&source[suppression.comment_range]).is_some()
+            }),
+        range,
+    )?;
     let prefix = editable_suppression_prefix(&source[suppression.comment_range])?;
     let separator = if prefix.ends_with('[') {
         ""
@@ -285,6 +298,23 @@ fn add_to_existing_suppression(existing: ExistingSuppression, codes: &[LintName]
     let insertion = format!("{separator}{codes}", codes = Codes(existing.kind, codes));
 
     Fix::safe_edit(Edit::insertion(insertion, existing.insertion_offset))
+}
+
+/// Returns the portion of an ignore comment before its closing bracket if another code can be
+/// appended to it.
+///
+/// ```python
+/// # ty: ignore[]         # Editable
+/// # ty: ignore[] reason  # Not editable
+/// ```
+fn editable_suppression_prefix(comment_text: &str) -> Option<&str> {
+    // The parser accepts a reason after the code list, but rule codes can't contain `]`, so the
+    // first `]` is the code list's closing bracket. Don't edit comments with trailing reasons.
+    let (before_closing_bracket, after_closing_bracket) = comment_text.split_once(']')?;
+    after_closing_bracket
+        .trim()
+        .is_empty()
+        .then(|| before_closing_bracket.trim_end())
 }
 
 #[derive(Copy, Clone)]

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -8,19 +8,22 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::token::TokenKind;
-use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use smallvec::SmallVec;
 
 use crate::Db;
 use crate::lint::LintId;
-use crate::suppression::{SuppressionKind, SuppressionTarget, Suppressions, suppressions};
+use crate::suppression::{
+    SuppressionKind, Suppressions, editable_suppression_prefix, select_preferred_suppression,
+    suppressions,
+};
 
 /// Creates fixes to suppress all violations in `ids_with_range`.
 ///
-/// This is different from calling `suppress_single` for every item in `ids_with_range`
-/// in that errors on the same line are grouped together and ty will only insert a single
-/// suppression with possibly multiple codes instead of adding multiple suppression comments.
+/// Unlike calling [`suppress_single`] for each diagnostic, this groups diagnostics that can share
+/// an edit. It appends codes once to each applicable existing suppression and otherwise inserts at
+/// most one end-of-line suppression at each destination. Every returned [`SuppressFix`] records
+/// how many diagnostics its edit accounts for.
 pub fn suppress_all(
     db: &dyn Db,
     file: File,
@@ -31,10 +34,17 @@ pub fn suppress_all(
     let parsed = parsed_module(db, file).load(db);
     let tokens = parsed.tokens();
 
-    // Compute the full suppression ranges for each diagnostic.
-    let mut ids_full_range: Vec<_> = ids_with_range
+    // Compute the full suppression ranges for each diagnostic, while retaining the original
+    // diagnostic ranges for matching existing suppressions.
+    let mut ids_with_suppression_range: Vec<_> = ids_with_range
         .iter()
-        .map(|&(id, range)| (id, suppression_range(db, file, range)))
+        .map(|&(id, diagnostic_range)| {
+            (
+                id,
+                diagnostic_range,
+                suppression_range(db, file, diagnostic_range),
+            )
+        })
         .collect();
 
     // Sort the suppression ranges by their start position and length (end position).
@@ -54,103 +64,91 @@ pub fn suppress_all(
     // can result in a start-line suppression for a wider range. In the example above,
     // inserting a `ty:ignore` after `sorted(` suppresses the diagnostic with the narrower range
     // but also the diagnostic with the wider range (because the suppression is on its start line).
-    ids_full_range.sort_unstable_by_key(|(_, range)| (range.start(), range.end()));
+    ids_with_suppression_range.sort_unstable_by_key(|(_, _, range)| (range.start(), range.end()));
 
-    // 1. Group the diagnostics by their line-start position and try to add
-    //    the suppression to an existing `ty: ignore` comment on that line.
-    let mut by_start: BTreeMap<_, (BTreeSet<LintName>, usize)> = BTreeMap::new();
+    let mut fixes = Vec::with_capacity(ids_with_suppression_range.len());
+    let mut with_existing = Vec::new();
+    let mut without_existing = Vec::new();
 
-    for &(id, range) in &ids_full_range {
-        let (lints, suppressed_diagnostics) = by_start.entry(range.start()).or_default();
-        lints.insert(id);
-        *suppressed_diagnostics += 1;
-    }
-
-    let mut fixes = Vec::with_capacity(ids_full_range.len());
-
-    // Tracks which lints get inserted by line. The offset is the line's start offset.
-    // This is necessary to avoid inserting an end of line suppression if the diagnostic
-    // was suppressed by inserting a suppression on its start line.
-    // This also allows deduplicating suppressions for diagnostics with different ranges
-    // where an end-suppression of one diagnostic becomes a start-suppression for another
-    // (see the example with the wider range above).
-    let mut by_line = BTreeMap::<TextSize, BTreeMap<LintName, SuppressionPosition>>::new();
-
-    for (start_offset, (lints, suppressed_diagnostics)) in by_start {
-        let codes: SmallVec<[LintName; 2]> = lints.into_iter().collect();
-        if let Some(add_to_start) =
-            add_to_existing_suppression(suppressions, &source, &codes, start_offset)
-        {
-            by_line.entry(start_offset).or_default().extend(
-                codes
-                    .iter()
-                    .copied()
-                    .map(|code| (code, SuppressionPosition::StartLine)),
-            );
-            fixes.push(SuppressFix {
-                fix: add_to_start,
-                suppressed_diagnostics,
-            });
+    // Choose the final existing suppression for every diagnostic before grouping any edits.
+    for (id, diagnostic_range, suppression_range) in ids_with_suppression_range {
+        if let Some(existing) = find_existing_suppression(suppressions, &source, diagnostic_range) {
+            with_existing.push((id, suppression_range, existing));
+        } else {
+            without_existing.push((id, suppression_range));
         }
     }
 
-    // 2. Group the diagnostics by their end position and try to add the code to an
-    //    existing `ty: ignore` comment or insert a new `ty: ignore` comment.
+    // Tracks newly inserted end-of-line suppressions by the physical line where they become start
+    // suppressions. This avoids inserting another suppression for a wider same-code diagnostic
+    // that starts on that line (see the example above).
+    let mut by_line = BTreeMap::<TextSize, BTreeMap<LintName, TextSize>>::new();
     let mut by_end: BTreeMap<TextSize, (BTreeSet<LintName>, usize)> = BTreeMap::new();
 
-    for (id, range) in ids_full_range {
-        let suppression_position = by_line
+    for (id, range) in without_existing {
+        let existing_end = by_line
             .get(&range.start())
             .and_then(|planned| planned.get(&id))
             .copied();
 
-        match suppression_position {
-            // Start-line suppressions already include all diagnostics that start on the same line.
-            Some(SuppressionPosition::StartLine) => {}
-
-            // If coverage comes from an other end-line suppression, count this diagnostic on that fix.
-            Some(SuppressionPosition::EndLine(end_offset)) => {
-                let (_, suppressed_diagnostics) = by_end.entry(end_offset).or_default();
-                *suppressed_diagnostics += 1;
-            }
-
-            None => {
-                let (lints, suppressed_diagnostics) = by_end.entry(range.end()).or_default();
-                lints.insert(id);
-                *suppressed_diagnostics += 1;
-
-                // Record the physical line where this end-line suppression will be inserted so wider
-                // same-code ranges starting there can be recognized as already covered.
-                by_line
-                    .entry(line_start(tokens, range.end()))
-                    .or_default()
-                    .entry(id)
-                    .or_insert(SuppressionPosition::EndLine(range.end()));
-            }
+        if let Some(end_offset) = existing_end {
+            let (_, suppressed_diagnostics) = by_end.entry(end_offset).or_default();
+            *suppressed_diagnostics += 1;
+            continue;
         }
+
+        let (lints, suppressed_diagnostics) = by_end.entry(range.end()).or_default();
+        lints.insert(id);
+        *suppressed_diagnostics += 1;
+
+        by_line
+            .entry(line_start(tokens, range.end()))
+            .or_default()
+            .entry(id)
+            .or_insert(range.end());
+    }
+
+    let mut by_suppression =
+        BTreeMap::<TextSize, (ExistingSuppression, BTreeSet<LintName>, usize)>::new();
+
+    // Reconcile existing-comment edits after planning new suppressions. A new suppression inserted
+    // at the end of a narrower range can cover the start of a wider diagnostic and make an edit to
+    // the wider diagnostic's existing end-line suppression immediately unused.
+    for (id, range, existing) in with_existing {
+        if let Some(end_offset) = by_line
+            .get(&range.start())
+            .and_then(|planned| planned.get(&id))
+        {
+            let (_, suppressed_diagnostics) = by_end.entry(*end_offset).or_default();
+            *suppressed_diagnostics += 1;
+            continue;
+        }
+
+        let insertion_offset = existing.insertion_offset;
+        let (_, grouped_codes, grouped_diagnostics) = by_suppression
+            .entry(insertion_offset)
+            .or_insert_with(|| (existing, BTreeSet::new(), 0));
+        grouped_codes.insert(id);
+        *grouped_diagnostics += 1;
     }
 
     for (end_offset, (lints, suppressed_diagnostics)) in by_end {
         let codes: SmallVec<[LintName; 2]> = lints.into_iter().collect();
-
         fixes.push(SuppressFix {
-            fix: append_to_existing_or_add_end_of_line_suppression(
-                suppressions,
-                &source,
-                &codes,
-                end_offset,
-            ),
+            fix: add_end_of_line_suppression(&source, &codes, end_offset),
+            suppressed_diagnostics,
+        });
+    }
+
+    for (existing, codes, suppressed_diagnostics) in by_suppression.into_values() {
+        let codes: SmallVec<[LintName; 2]> = codes.into_iter().collect();
+        fixes.push(SuppressFix {
+            fix: add_to_existing_suppression(existing, &codes),
             suppressed_diagnostics,
         });
     }
 
     fixes
-}
-
-#[derive(Copy, Clone)]
-enum SuppressionPosition {
-    StartLine,
-    EndLine(TextSize),
 }
 
 /// Fix to suppress one or more diagnostics.
@@ -168,18 +166,11 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
     let source = source_text(db, file);
     let codes = &[id.name()];
 
-    if let Some(add_fix) =
-        add_to_existing_suppression(suppressions, &source, codes, suppression_range.start())
-    {
-        return add_fix;
+    if let Some(existing) = find_existing_suppression(suppressions, &source, range) {
+        return add_to_existing_suppression(existing, codes);
     }
 
-    append_to_existing_or_add_end_of_line_suppression(
-        suppressions,
-        &source,
-        codes,
-        suppression_range.end(),
-    )
+    add_end_of_line_suppression(&source, codes, suppression_range.end())
 }
 
 /// Returns the suppression range for the given `range`.
@@ -235,16 +226,7 @@ fn line_start(tokens: &ruff_python_ast::token::Tokens, offset: TextSize) -> Text
         .unwrap_or_default()
 }
 
-fn append_to_existing_or_add_end_of_line_suppression(
-    suppressions: &Suppressions,
-    source: &str,
-    codes: &[LintName],
-    line_end: TextSize,
-) -> Fix {
-    if let Some(add_fix) = add_to_existing_suppression(suppressions, source, codes, line_end) {
-        return add_fix;
-    }
-
+fn add_end_of_line_suppression(source: &str, codes: &[LintName], line_end: TextSize) -> Fix {
     let up_to_line_end = &source[..line_end.to_usize()];
     // Don't use `trim_end` in case the previous line ends with a `\` followed by a newline. We don't want to eat
     // into that newline!
@@ -266,55 +248,50 @@ fn append_to_existing_or_add_end_of_line_suppression(
     })
 }
 
-fn add_to_existing_suppression(
+/// Returns insertion metadata for the preferred editable suppression covering `range`.
+///
+/// When multiple comments apply, a same-line or otherwise nested comment takes precedence over an
+/// outer own-line suppression.
+///
+/// ```python
+/// # ty: ignore[invalid-assignment]
+/// values: tuple[int] = [missing]  # ty: ignore[]
+/// ```
+fn find_existing_suppression(
     suppressions: &Suppressions,
     source: &str,
-    codes: &[LintName],
-    offset: TextSize,
-) -> Option<Fix> {
-    let existing = suppressions
-        .inline_suppressions_on_line(source.line_range(offset))
-        .find(|suppression| {
-            matches!(
-                suppression.target,
-                SuppressionTarget::Lint(_) | SuppressionTarget::Empty,
-            )
-        })?;
-    let comment_text = &source[existing.comment_range];
-
-    let up_to_last_code = editable_suppression_prefix(comment_text)?;
-    let separator = if up_to_last_code.ends_with('[') {
+    range: TextRange,
+) -> Option<ExistingSuppression> {
+    let suppression =
+        select_preferred_suppression(suppressions.editable_inline_suppressions_rev(range), range)?;
+    let prefix = editable_suppression_prefix(&source[suppression.comment_range])?;
+    let separator = if prefix.ends_with('[') {
         ""
-    } else if up_to_last_code.ends_with(',') {
+    } else if prefix.ends_with(',') {
         " "
     } else {
         ", "
     };
-    let relative_offset_from_end = comment_text.text_len() - up_to_last_code.text_len();
 
-    let insertion = format!("{separator}{codes}", codes = Codes(existing.kind, codes));
-
-    Some(Fix::safe_edit(Edit::insertion(
-        insertion,
-        existing.comment_range.end() - relative_offset_from_end,
-    )))
+    Some(ExistingSuppression {
+        insertion_offset: suppression.comment_range.start() + prefix.text_len(),
+        kind: suppression.kind,
+        separator,
+    })
 }
 
-/// Returns the portion of an ignore comment before its closing bracket if another code can be
-/// appended to it.
-///
-/// ```python
-/// # ty: ignore[]         # Editable
-/// # ty: ignore[] reason  # Not editable
-/// ```
-fn editable_suppression_prefix(comment_text: &str) -> Option<&str> {
-    // The parser accepts a reason after the code list, but rule codes can't contain `]`, so the
-    // first `]` is the code list's closing bracket. Don't edit comments with trailing reasons.
-    let (before_closing_bracket, after_closing_bracket) = comment_text.split_once(']')?;
-    after_closing_bracket
-        .trim()
-        .is_empty()
-        .then(|| before_closing_bracket.trim_end())
+fn add_to_existing_suppression(existing: ExistingSuppression, codes: &[LintName]) -> Fix {
+    let separator = existing.separator;
+    let insertion = format!("{separator}{codes}", codes = Codes(existing.kind, codes));
+
+    Fix::safe_edit(Edit::insertion(insertion, existing.insertion_offset))
+}
+
+#[derive(Copy, Clone)]
+struct ExistingSuppression {
+    insertion_offset: TextSize,
+    kind: SuppressionKind,
+    separator: &'static str,
 }
 
 struct Codes<'a>(SuppressionKind, &'a [LintName]);


### PR DESCRIPTION
## Summary

In #26808, we deliberately restricted `--add-ignore` to comments on the diagnostic's physical line, which meant that we ignored an existing own-line suppression even when it already applied to the diagnostic and added a second end-of-line suppression instead. So, in effect, we never added to own-line ignores.

We now extend an editable suppression that already applies to the diagnostic. A same-line suppression wins when both same-line and own-line comments apply; otherwise, we prefer the innermost applicable own-line suppression. When diagnostics from multiple physical lines resolve to the same comment, we group their codes into one edit while retaining the number of diagnostics accounted for by that edit.

## Behavior

### 1. Reuse a same-line suppression

```python
# Before
value = missing  # ty: ignore[division-by-zero]

# After
value = missing  # ty: ignore[division-by-zero, unresolved-reference]
```

### 2. Reuse an own-line suppression for the following physical line

This applies to a comment inside an already-continued statement:

```python
# Before
values = [
    # ty: ignore[]
    missing,
]

# After
values = [
    # ty: ignore[unresolved-reference]
    missing,
]
```

### 3. Reuse an own-line suppression for an entire logical statement

A Python statement can span several physical lines. Because the preceding suppression applies throughout this statement, we add all three diagnostic codes to that one comment:

```python
# Before
# ty: ignore[invalid-assignment]
values: tuple[int] = f(
    missing,
    "bad",
)

# After
# ty: ignore[invalid-assignment, invalid-argument-type, unresolved-reference]
values: tuple[int] = f(
    missing,
    "bad",
)
```

### 4. Add an end-of-line suppression when no editable suppression applies

```python
# Before
value = missing

# After
value = missing  # ty:ignore[unresolved-reference]
```

## Test plan

Beyond our standard CI suite, reran the following against rebased head `788148ead4f8e85a29a480c92a1d4ca98e586dac`:

- Ran `ty check --error all --add-ignore homeassistant` followed by `ty check --error all homeassistant` on [Home Assistant `1ce5ae3`](https://github.com/home-assistant/core/tree/1ce5ae3c0bea37dd3825ad57c8ba3e55266bed9b): 16,677 diagnostics suppressed and zero remaining. A second `--add-ignore` added zero comments and left the source unchanged.
- Ran the same round trip with `--python-version 3.14` on [Airflow `d413861`](https://github.com/apache/airflow/tree/d413861ef7f080217ff70830461143cdce477e12): 31,513 diagnostics suppressed. The 152 pre-existing unused `type: ignore` comments were removed with `--fix`, leaving zero diagnostics; a second `--add-ignore` made no changes.
- Cross-checked the open `ruff:ignore` issues with nested `# fmt: off`, trailing `# noqa`/`# pragma`, adjacent `# type: ignore`, trailing reasons, and multiline statements.
- Ran the 49 focused add-ignore and suppression tests; all passed.
- Confirmed the prior [ty ecosystem-analyzer run](https://github.com/astral-sh/ruff/actions/runs/29643524390) reports no diagnostic changes; the [rebased-head run](https://github.com/astral-sh/ruff/actions/runs/29701998795) is in progress.
