### PR TITLE
[ty] Preserve unsatisfiable generic-call constraints

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5302,7 +5302,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             Some(promoted)
         };
 
-        let inference = builder.build_inference_with(generic_context, |typevar, bounds| {
+        let mut choose = |typevar: BoundTypeVarInstance<'db>, bounds: Option<&PathBound<'db>>| {
             let bounds = bounds?;
             if let Some(lower) = bounds.lower
                 && let Some(&preferred_ty) = preferred_type_mappings.get(&typevar.identity(self.db))
@@ -5312,7 +5312,30 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             }
 
             maybe_promote(typevar, bounds)
-        });
+        };
+        let inference = match builder.build_inference_with(generic_context, &mut choose) {
+            Ok(inference) => inference,
+            Err(()) => {
+                let parameters = self.signature.parameters();
+                let mut argument_relations = Vec::new();
+                for (argument_index, _, _, argument_types) in self.enumerate_argument_types() {
+                    for matched_parameter in self.argument_matches[argument_index].iter() {
+                        let parameter_index = matched_parameter.index;
+                        if self.is_gradual_variadic_parameter(parameter_index) {
+                            continue;
+                        }
+
+                        let formal = parameters[parameter_index].annotated_type();
+                        let actual = matched_parameter
+                            .argument_type
+                            .unwrap_or_else(|| argument_types.get_for_declared_type(formal));
+                        argument_relations.push((formal, actual));
+                    }
+                }
+
+                builder.build_diagnostic_inference_with(generic_context, argument_relations, choose)
+            }
+        };
         let specialization = inference.specialization(self.db);
 
         self.return_ty = self.return_ty.apply_specialization(self.db, specialization);

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2119,7 +2119,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         generic_context: GenericContext<'db>,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
     ) -> Specialization<'db> {
-        let types = self.solve_pending_with(generic_context, &mut choose);
+        let types = self
+            .solve_pending_with(generic_context, &mut choose)
+            .unwrap_or_else(|()| self.solve_hash_map_with(generic_context, &mut choose));
         let specialization =
             generic_context
                 .variables_inner(self.db)
@@ -2135,12 +2137,42 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     }
 
     /// Build raw type-variable inference, preserving which type variables were left unsolved.
+    ///
+    /// Returns an error if the call-wide pending constraints are unsatisfiable.
     pub(crate) fn build_inference_with(
         &mut self,
         generic_context: GenericContext<'db>,
         mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
+    ) -> Result<TypeVarInference<'db>, ()> {
+        let types = self.solve_pending_with(generic_context, &mut choose)?;
+        Ok(self.typevar_inference(generic_context, &types))
+    }
+
+    /// Build a diagnostic specialization after the call-wide constraints were unsatisfiable.
+    ///
+    /// Each argument relation is solved independently, then its solutions are merged into the
+    /// legacy type map. This preserves enough information to report the conflicting arguments
+    /// even when a migrated inference path only populated `pending`.
+    pub(crate) fn build_diagnostic_inference_with(
+        &mut self,
+        generic_context: GenericContext<'db>,
+        argument_relations: impl IntoIterator<Item = (Type<'db>, Type<'db>)>,
+        mut choose: impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
     ) -> TypeVarInference<'db> {
-        let types = self.solve_pending_with(generic_context, &mut choose);
+        for (formal, actual) in argument_relations {
+            let when = actual.when_constraint_set_assignable_to(self.db, formal, self.constraints);
+            let _ = self.add_type_mappings_from_constraint_set(when);
+        }
+
+        let types = self.solve_hash_map_with(generic_context, &mut choose);
+        self.typevar_inference(generic_context, &types)
+    }
+
+    fn typevar_inference(
+        &self,
+        generic_context: GenericContext<'db>,
+        types: &FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>>,
+    ) -> TypeVarInference<'db> {
         let inferred: Box<[_]> = generic_context
             .variables_inner(self.db)
             .keys()
@@ -2154,14 +2186,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         &mut self,
         generic_context: GenericContext<'db>,
         choose: &mut impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
-    ) -> FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> {
+    ) -> Result<FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>>, ()> {
         // TODO: Move `ParamSpec` and `TypeVarTuple` handling to the new constraint solver.
         if generic_context
             .variables_inner(self.db)
             .values()
             .any(|typevar| typevar.is_paramspec(self.db) || typevar.is_typevartuple(self.db))
         {
-            return self.solve_hash_map_with(generic_context, choose);
+            return Ok(self.solve_hash_map_with(generic_context, choose));
         }
 
         // TODO: This projection / solve can be expensive for large-union collection-literal type
@@ -2181,16 +2213,15 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             self.constraints,
             self.inferable,
             |_variance, path_bound| {
+                // A projection choice must not turn an invalid path into a satisfiable one.
+                let solution = PathBounds::default_solve(self.db, self.constraints, path_bound)?;
                 let typevar = path_bound.bound_typevar;
-                if let Some(ty) = choose(typevar, Some(path_bound)) {
-                    return Ok(Some(ty));
-                }
-
-                PathBounds::default_solve(self.db, self.constraints, path_bound)
+                Ok(choose(typevar, Some(path_bound)).or(solution))
             },
         ) {
-            Solutions::Unsatisfiable | Solutions::Unconstrained => {
-                return self.solve_hash_map_with(generic_context, choose);
+            Solutions::Unsatisfiable => return Err(()),
+            Solutions::Unconstrained => {
+                return Ok(self.solve_hash_map_with(generic_context, choose));
             }
             Solutions::Constrained(solutions) => solutions,
         };
@@ -2231,9 +2262,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         {
             // Recursive specialization cannot reach a fixed point when a cycle grows through an
             // embedded generic type, such as `SupportsAdd[T, S]`.
-            self.solve_hash_map_with(generic_context, choose)
+            Ok(self.solve_hash_map_with(generic_context, choose))
         } else {
-            types
+            Ok(types)
         }
     }
 
@@ -3399,5 +3430,70 @@ impl<'db> SpecializationError<'db> {
             Self::MismatchedBound { argument, .. } => *argument,
             Self::MismatchedConstraint { argument, .. } => *argument,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::db::tests::setup_db;
+    use crate::types::KnownClass;
+    use ruff_python_ast::name::Name;
+
+    #[test]
+    fn unsatisfiable_pending_constraints_recover_diagnostic_specialization() {
+        let db = setup_db();
+        let typevar =
+            BoundTypeVarInstance::synthetic(&db, Name::new_static("T"), TypeVarVariance::Invariant);
+        let generic_context = GenericContext::from_typevar_instances(&db, [typevar]);
+        let inferable = generic_context.inferable_typevars(&db);
+        let constraints = ConstraintSetBuilder::new();
+
+        let int = KnownClass::Int.to_instance(&db);
+        let str = KnownClass::Str.to_instance(&db);
+        let formal = KnownClass::List.to_specialized_instance(&db, &[Type::TypeVar(typevar)]);
+        let list_int = KnownClass::List.to_specialized_instance(&db, &[int]);
+        let list_str = KnownClass::List.to_specialized_instance(&db, &[str]);
+        let int_relation = list_int.when_constraint_set_assignable_to(&db, formal, &constraints);
+        let str_relation = list_str.when_constraint_set_assignable_to(&db, formal, &constraints);
+
+        assert!(matches!(
+            int_relation.solutions(&db, &constraints, inferable),
+            Solutions::Constrained(_)
+        ));
+        assert!(matches!(
+            str_relation.solutions(&db, &constraints, inferable),
+            Solutions::Constrained(_)
+        ));
+
+        let mut builder = SpecializationBuilder::new(&db, &constraints, inferable);
+        builder.pending.intersect(&db, &constraints, int_relation);
+        builder.pending.intersect(&db, &constraints, str_relation);
+
+        assert_eq!(
+            builder.pending.solutions(&db, &constraints, inferable),
+            Solutions::Unsatisfiable
+        );
+        assert!(
+            builder
+                .build_inference_with(generic_context, |_, _| None)
+                .is_err()
+        );
+        assert!(
+            builder
+                .build_inference_with(generic_context, |_, _| Some(int))
+                .is_err()
+        );
+
+        let inference = builder.build_diagnostic_inference_with(
+            generic_context,
+            [(formal, list_int), (formal, list_str)],
+            |_, _| None,
+        );
+        let specialization = inference.specialization(&db);
+        let expected = KnownClass::List
+            .to_specialized_instance(&db, &[UnionType::from_two_elements(&db, int, str)]);
+        assert_eq!(formal.apply_specialization(&db, specialization), expected);
     }
 }


### PR DESCRIPTION
## Summary

Fix the old-solver/new-solver hybrid generic-call inference gap exposed while reviewing #26712.

Each migrated argument relation can be satisfiable on its own while their conjunction in `SpecializationBuilder.pending` is not. Finalization previously treated `Solutions::Unsatisfiable` like `Unconstrained` and fell back to the legacy type map. A migrated path that only populated `pending` could therefore specialize to `Unknown`, allowing later argument checking to silently accept an invalid call.

This change:

- preserves call-wide unsatisfiability through inference finalization, including when a projection hook is present;
- on the rare unsatisfiable path, has the call binder independently solve the argument relations and merge their solutions into a diagnostic specialization, restoring useful `invalid-argument-type` diagnostics;
- keeps unconstrained, satisfiable, and existing gradual/legacy behavior unchanged.

All existing migrated callable/protocol paths on current `main` also populate the legacy map, so an end-to-end pending-only mdtest reproduction is not currently possible. The focused Rust regression constructs two independently satisfiable invariant relations (`list[int] <= list[T]` and `list[str] <= list[T]`), verifies their conjunction remains `Unsatisfiable`, verifies a projection choice cannot mask it, and verifies diagnostic recovery produces `list[int | str]`. Full end-to-end intersection coverage will be supplied by follow-up #26712 (currently stacked on #26892).

## Validation

- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic --status-level fail` (736 passed)
- focused generic callable/function/protocol mdtests and the new Rust regression (7 passed)
- `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_DEBUG="line-tables-only" cargo clippy -p ty_python_semantic --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- concise-output ad hoc callable/protocol/conflicting-bound reproductions
- `git diff --check`
- file-scoped `prek==0.4.8` hooks passed via `uvx`; the repository-prescribed locked `uv run --only-group dev --locked prek ...` is currently blocked on freshly fetched `main` because the existing `uv.lock` reports that it needs an update

No snapshots were added or updated.

Related: astral-sh/ty#3557.
