### PR TITLE
[ty] Introduce shared primitives for parsing backticks in docstrings

### DIFF
--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -1,7 +1,7 @@
 use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_python_trivia::{Cursor, leading_indentation, tab_offset_u32};
 use ruff_source_file::UniversalNewlines;
-use ruff_text_size::{TextRange, TextSize};
+use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 use super::rst::is_field_list_marker;
 
@@ -112,6 +112,288 @@ pub(in crate::docstring) fn is_backtick_run_escaped(text: &str, index: usize) ->
         .take_while(|byte| *byte == b'\\')
         .count()
         .is_multiple_of(2)
+}
+
+/// Losslessly partitions source text around complete, unescaped backtick spans.
+///
+/// For example:
+///
+/// ```text
+/// BacktickFragments::new("before `code` after")
+///     => Text("before "), Span("code"), Text(" after")
+/// ```
+struct BacktickFragments<'a> {
+    /// The scanner used to find complete spans.
+    scanner: BacktickScanner<'a>,
+    /// The end of the last fragment returned to the caller.
+    last_fragment_end: TextSize,
+    /// A span saved while the preceding text is returned first.
+    pending_span: Option<BacktickSpan<'a>>,
+}
+
+impl<'a> BacktickFragments<'a> {
+    /// Creates a lossless iterator over plain text and complete backtick-delimited spans.
+    ///
+    /// Escaped or unmatched backtick runs remain part of a [`BacktickFragment::Text`] fragment.
+    fn new(source: &'a str) -> Self {
+        Self {
+            scanner: BacktickScanner::new(source),
+            last_fragment_end: TextSize::ZERO,
+            pending_span: None,
+        }
+    }
+
+    fn take_remaining_text(&mut self) -> Option<BacktickFragment<'a>> {
+        let source_end = self.scanner.source.text_len();
+        let remaining = TextRange::new(self.last_fragment_end, source_end);
+        self.last_fragment_end = source_end;
+        (!remaining.is_empty()).then(|| BacktickFragment::Text(&self.scanner.source[remaining]))
+    }
+}
+
+impl<'a> Iterator for BacktickFragments<'a> {
+    type Item = BacktickFragment<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.last_fragment_end == TextSize::of(self.scanner.source) {
+            return None;
+        }
+
+        let span = loop {
+            // Emit the span saved while returning its preceding text on the previous call.
+            if let Some(span) = self.pending_span.take() {
+                break span;
+            }
+
+            // Without another backtick run, the remaining source is all plain text.
+            let Some(opening) = self.scanner.next() else {
+                return self.take_remaining_text();
+            };
+
+            // Escaped runs are literal source text, so continue looking for the next possible
+            // opening without emitting a fragment boundary.
+            if opening.is_escaped() {
+                continue;
+            }
+
+            // Without a closing delimiter, callers cannot treat the opening or any later runs as
+            // structured markup. Emit the remainder as one text fragment.
+            let Some(span) = self.scanner.eat_span(opening) else {
+                return self.take_remaining_text();
+            };
+            break span;
+        };
+
+        if self.last_fragment_end < span.start() {
+            let preceding_text = TextRange::new(self.last_fragment_end, span.start());
+            self.last_fragment_end = span.start();
+            self.pending_span = Some(span);
+            return Some(BacktickFragment::Text(&self.scanner.source[preceding_text]));
+        }
+
+        debug_assert_eq!(self.last_fragment_end, span.start());
+        self.last_fragment_end = span.end();
+        Some(BacktickFragment::Span(span))
+    }
+}
+
+/// One lossless fragment produced by [`BacktickFragments`].
+///
+/// For example:
+///
+/// ```text
+/// source      "before `code` after"
+/// fragments   Text("before "), Span("code"), Text(" after")
+/// ```
+///
+/// Escaped and unmatched backticks remain text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BacktickFragment<'a> {
+    /// Source text outside a complete, unescaped backtick span.
+    Text(&'a str),
+    /// A complete span whose delimiters have equal lengths.
+    Span(BacktickSpan<'a>),
+}
+
+/// Source text delimited by ordered backtick runs of equal length.
+///
+/// For example:
+///
+/// ```text
+/// source          "before ``code`` after"
+/// range()         7..15
+/// is_single()     false
+/// content()       "code"
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BacktickSpan<'a> {
+    /// The source between the opening and closing delimiters.
+    content: &'a str,
+    /// The byte range including both delimiters.
+    range: TextRange,
+    /// The byte length of either delimiter.
+    delimiter_len: TextSize,
+}
+
+impl<'a> BacktickSpan<'a> {
+    /// Returns whether both delimiters consist of one backtick.
+    pub(crate) fn is_single(self) -> bool {
+        self.delimiter_len == TextSize::new(1)
+    }
+
+    /// Returns the source between the opening and closing runs.
+    pub(crate) fn content(self) -> &'a str {
+        self.content
+    }
+}
+
+impl Ranged for BacktickSpan<'_> {
+    fn range(&self) -> TextRange {
+        self.range
+    }
+}
+
+/// Scans consecutive backtick runs in source order.
+///
+/// The scanner can consume a complete span after returning its opening run. For example:
+///
+/// ```text
+/// source                  "prefix ``code`` suffix"
+/// opening = next()        Some(BacktickRun("``"))
+/// as_str()                "code`` suffix"
+/// eat_span(opening)       Some(BacktickSpan("``code``"))
+/// as_str()                " suffix"
+/// ```
+#[derive(Clone)]
+pub(crate) struct BacktickScanner<'a> {
+    /// The complete source whose runs are returned.
+    source: &'a str,
+    /// The current scan position within `source`.
+    cursor: Cursor<'a>,
+}
+
+impl<'a> BacktickScanner<'a> {
+    /// Creates a scanner positioned at the start of `source`.
+    pub(crate) fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            cursor: Cursor::new(source),
+        }
+    }
+
+    /// Creates a scanner positioned at `offset` within `source`.
+    fn starts_at(offset: TextSize, source: &'a str) -> Self {
+        let mut scanner = Self::new(source);
+        scanner.cursor.skip_bytes(offset.to_usize());
+        scanner
+    }
+
+    /// Returns the remaining source.
+    pub(crate) fn as_str(&self) -> &'a str {
+        self.cursor.as_str()
+    }
+
+    /// Consumes the closing run that matches the most recently returned `opening`.
+    ///
+    /// Returns `None` without advancing when no matching run exists.
+    pub(crate) fn eat_span(&mut self, opening: BacktickRun) -> Option<BacktickSpan<'a>> {
+        debug_assert_eq!(opening.end(), self.cursor.offset());
+
+        let mut lookahead = self.clone();
+        while let Some(closing) = lookahead.next() {
+            if let Some(span) = self.span(opening, closing) {
+                *self = lookahead;
+                return Some(span);
+            }
+        }
+        None
+    }
+
+    /// Creates a span from two ordered runs of equal length.
+    ///
+    /// Both runs must use ranges in this scanner's source.
+    pub(crate) fn span(
+        &self,
+        opening: BacktickRun,
+        closing: BacktickRun,
+    ) -> Option<BacktickSpan<'a>> {
+        debug_assert!(opening.end() <= closing.start());
+
+        if opening.range.len() != closing.range.len() {
+            return None;
+        }
+
+        Some(BacktickSpan {
+            content: &self.source[TextRange::new(opening.end(), closing.start())],
+            range: opening.range.cover(closing.range),
+            delimiter_len: opening.range.len(),
+        })
+    }
+
+    /// Returns the scanner's cursor at its current position.
+    pub(in crate::docstring) fn into_cursor(self) -> Cursor<'a> {
+        self.cursor
+    }
+}
+
+impl Iterator for BacktickScanner<'_> {
+    type Item = BacktickRun;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.cursor.eat_while(|character| character != '`');
+        if self.cursor.is_eof() {
+            return None;
+        }
+
+        let start = self.cursor.offset();
+        self.cursor.eat_while(|character| character == '`');
+        let range = TextRange::new(start, self.cursor.offset());
+
+        let preceding_backslashes = self.source[..start.to_usize()]
+            .bytes()
+            .rev()
+            .take_while(|byte| *byte == b'\\')
+            .count();
+        let escaped = !preceding_backslashes.is_multiple_of(2);
+
+        Some(BacktickRun { range, escaped })
+    }
+}
+
+/// One consecutive run of backticks found by [`BacktickScanner`].
+///
+/// For example:
+///
+/// ```text
+/// source          "before \\`` after"
+/// range()         8..10
+/// is_single()     false
+/// is_escaped()    true
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BacktickRun {
+    /// The byte range of the consecutive backticks.
+    range: TextRange,
+    /// Whether an odd-length backslash run escapes the first backtick.
+    escaped: bool,
+}
+
+impl BacktickRun {
+    /// Returns whether this run consists of one backtick.
+    pub(crate) fn is_single(self) -> bool {
+        self.range.len() == TextSize::new(1)
+    }
+
+    /// Returns whether a preceding odd-length backslash run escapes this run.
+    pub(crate) fn is_escaped(self) -> bool {
+        self.escaped
+    }
+}
+
+impl Ranged for BacktickRun {
+    fn range(&self) -> TextRange {
+        self.range
+    }
 }
 
 /// Returns the end of an indented Markdown or reStructuredText container block.
@@ -278,8 +560,55 @@ pub(super) fn indentation(line: &str) -> TextSize {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_markdown_code_span, split_once_at_top_level_colon, split_trailing_parenthetical,
+        BacktickFragment, BacktickFragments, BacktickScanner, TextSize, is_markdown_code_span,
+        split_once_at_top_level_colon, split_trailing_parenthetical,
     };
+
+    #[test]
+    fn scans_backtick_runs_and_spans() {
+        let mut scanner = BacktickScanner::starts_at(TextSize::new(7), "prefix ``code`` suffix");
+        let opening = scanner.next().expect("an opening backtick run");
+
+        assert!(!opening.is_single());
+        assert!(!opening.is_escaped());
+        assert_eq!(scanner.as_str(), "code`` suffix");
+
+        let span = scanner.eat_span(opening).expect("a matching backtick run");
+        assert!(!span.is_single());
+        assert_eq!(span.content(), "code");
+        assert_eq!(scanner.into_cursor().as_str(), " suffix");
+    }
+
+    #[test]
+    fn partitions_text_and_backtick_spans() {
+        let source = "é :class:`~pkg.Widget` or ``literal`tick`` β";
+
+        assert_eq!(
+            fragment_contents(source),
+            vec![
+                ("text", "é :class:"),
+                ("span", "~pkg.Widget"),
+                ("text", " or "),
+                ("span", "literal`tick"),
+                ("text", " β"),
+            ]
+        );
+    }
+
+    #[test]
+    fn partitions_spans_at_source_boundaries() {
+        assert_eq!(
+            fragment_contents("`first` and `last`"),
+            vec![("span", "first"), ("text", " and "), ("span", "last")]
+        );
+    }
+
+    #[test]
+    fn preserves_escaped_and_unmatched_backticks_as_text() {
+        let source = r"\`literal\` and `unfinished";
+
+        assert_eq!(fragment_contents(source), vec![("text", source)]);
+    }
 
     #[test]
     fn recognizes_complete_markdown_code_spans() {
@@ -387,5 +716,14 @@ mod tests {
     #[test]
     fn rejects_parenthesized_group_before_trailing_text() {
         assert_eq!(split_trailing_parenthetical("value (str) or None"), None);
+    }
+
+    fn fragment_contents(source: &str) -> Vec<(&'static str, &str)> {
+        BacktickFragments::new(source)
+            .map(|fragment| match fragment {
+                BacktickFragment::Text(text) => ("text", text),
+                BacktickFragment::Span(span) => ("span", span.content()),
+            })
+            .collect()
     }
 }

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -62,157 +62,115 @@ pub(in crate::docstring) fn starts_with_markdown_list_item(line: &str) -> bool {
 ///
 /// For example, this returns `true` for ``"`value`"`` and `false` for
 /// ``"`value` trailing"``.
-pub(in crate::docstring) fn is_markdown_code_span(text: &str) -> bool {
-    find_backtick_run(text, TextSize::ZERO).and_then(|opening| markdown_code_span(text, opening))
-        == Some(TextRange::up_to(TextSize::of(text)))
+pub(crate) fn is_markdown_code_span(text: &str) -> bool {
+    let mut tokens = InlineMarkupScanner::new(text);
+    let Some(InlineMarkupToken::Code(_)) = tokens.next() else {
+        return false;
+    };
+
+    tokens.next().is_none()
 }
 
-/// Returns the byte range of the first consecutive backtick run at or after `from`.
+/// Emits non-overlapping tokens that completely span the source text.
 ///
-/// For example, searching ``"value `code`"`` from the start returns the range covering the
-/// opening ``"`"``.
-pub(in crate::docstring) fn find_backtick_run(text: &str, from: TextSize) -> Option<TextRange> {
-    let from = from.to_usize();
-    let start = from + text.get(from..)?.find('`')?;
-    let len = text[start..]
-        .bytes()
-        .take_while(|byte| *byte == b'`')
-        .count();
-    Some(TextRange::new(
-        TextSize::of(&text[..start]),
-        TextSize::of(&text[..start + len]),
-    ))
-}
-
-/// Returns the Markdown code span delimited by `opening`, if it has a matching closing run.
-///
-/// For example, the opening run in "``value`with:ticks`` trailing" produces the range covering
-/// "``value`with:ticks``".
-pub(in crate::docstring) fn markdown_code_span(
-    text: &str,
-    opening: TextRange,
-) -> Option<TextRange> {
-    let mut search_from = opening.end();
-    loop {
-        let closing = find_backtick_run(text, search_from)?;
-        if closing.len() == opening.len() {
-            return Some(opening.cover(closing));
-        }
-        search_from = closing.end();
-    }
-}
-
-/// Returns whether the backtick run at `index` is escaped by a preceding backslash.
-///
-/// For example, the backtick in ``"\`"`` is escaped, while the backtick in ``"\\`"`` is not.
-pub(in crate::docstring) fn is_backtick_run_escaped(text: &str, index: usize) -> bool {
-    !text[..index]
-        .bytes()
-        .rev()
-        .take_while(|byte| *byte == b'\\')
-        .count()
-        .is_multiple_of(2)
-}
-
-/// Losslessly partitions source text around complete, unescaped backtick spans.
+/// Currently supports `Code` for complete, unescaped backtick-delimited segments and `Text`
+/// for everything else.
 ///
 /// For example:
 ///
 /// ```text
-/// BacktickFragments::new("before `code` after")
-///     => Text("before "), Span("code"), Text(" after")
+/// InlineMarkupScanner::new("before `code` after")
+///     => Text("before "), Code("code"), Text(" after")
 /// ```
-struct BacktickFragments<'a> {
-    /// The scanner used to find complete spans.
+struct InlineMarkupScanner<'a> {
+    /// The scanner used to find complete code spans.
     scanner: BacktickScanner<'a>,
-    /// The end of the last fragment returned to the caller.
-    last_fragment_end: TextSize,
-    /// A span saved while the preceding text is returned first.
+    /// The end of the last token returned to the caller.
+    last_token_end: TextSize,
+    /// A span saved while its preceding text is returned first.
     pending_span: Option<BacktickSpan<'a>>,
 }
 
-impl<'a> BacktickFragments<'a> {
-    /// Creates a lossless iterator over plain text and complete backtick-delimited spans.
+impl<'a> InlineMarkupScanner<'a> {
+    /// Creates a lossless iterator over plain text and complete backtick-delimited code spans.
     ///
-    /// Escaped or unmatched backtick runs remain part of a [`BacktickFragment::Text`] fragment.
+    /// Escaped or unmatched backticks remain part of an [`InlineMarkupToken::Text`] token.
     fn new(source: &'a str) -> Self {
         Self {
             scanner: BacktickScanner::new(source),
-            last_fragment_end: TextSize::ZERO,
+            last_token_end: TextSize::ZERO,
             pending_span: None,
         }
     }
 
-    fn take_remaining_text(&mut self) -> Option<BacktickFragment<'a>> {
+    fn take_remaining_text(&mut self) -> Option<InlineMarkupToken<'a>> {
         let source_end = self.scanner.source.text_len();
-        let remaining = TextRange::new(self.last_fragment_end, source_end);
-        self.last_fragment_end = source_end;
-        (!remaining.is_empty()).then(|| BacktickFragment::Text(&self.scanner.source[remaining]))
+        let remaining = TextRange::new(self.last_token_end, source_end);
+        self.last_token_end = source_end;
+        (!remaining.is_empty()).then(|| InlineMarkupToken::Text(&self.scanner.source[remaining]))
     }
 }
 
-impl<'a> Iterator for BacktickFragments<'a> {
-    type Item = BacktickFragment<'a>;
+impl<'a> Iterator for InlineMarkupScanner<'a> {
+    type Item = InlineMarkupToken<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.last_fragment_end == TextSize::of(self.scanner.source) {
-            return None;
-        }
-
-        let span = loop {
+        let span = if let Some(span) = self.pending_span.take() {
             // Emit the span saved while returning its preceding text on the previous call.
-            if let Some(span) = self.pending_span.take() {
+            span
+        } else {
+            loop {
+                // Without another backtick run, the remaining source is all plain text.
+                let Some(opening) = self.scanner.next() else {
+                    return self.take_remaining_text();
+                };
+
+                // Escaped runs are literal source text, so continue looking for the next possible
+                // opening without emitting a token boundary.
+                if opening.is_escaped() {
+                    continue;
+                }
+
+                // Without a closing delimiter, callers cannot treat the opening or any later runs as
+                // structured markup. Emit the remainder as one text token.
+                let Some(span) = self.scanner.eat_span(opening) else {
+                    return self.take_remaining_text();
+                };
                 break span;
             }
-
-            // Without another backtick run, the remaining source is all plain text.
-            let Some(opening) = self.scanner.next() else {
-                return self.take_remaining_text();
-            };
-
-            // Escaped runs are literal source text, so continue looking for the next possible
-            // opening without emitting a fragment boundary.
-            if opening.is_escaped() {
-                continue;
-            }
-
-            // Without a closing delimiter, callers cannot treat the opening or any later runs as
-            // structured markup. Emit the remainder as one text fragment.
-            let Some(span) = self.scanner.eat_span(opening) else {
-                return self.take_remaining_text();
-            };
-            break span;
         };
 
-        if self.last_fragment_end < span.start() {
-            let preceding_text = TextRange::new(self.last_fragment_end, span.start());
-            self.last_fragment_end = span.start();
+        if self.last_token_end < span.start() {
+            let preceding_text = TextRange::new(self.last_token_end, span.start());
+            self.last_token_end = span.start();
             self.pending_span = Some(span);
-            return Some(BacktickFragment::Text(&self.scanner.source[preceding_text]));
+            return Some(InlineMarkupToken::Text(
+                &self.scanner.source[preceding_text],
+            ));
         }
 
-        debug_assert_eq!(self.last_fragment_end, span.start());
-        self.last_fragment_end = span.end();
-        Some(BacktickFragment::Span(span))
+        debug_assert_eq!(self.last_token_end, span.start());
+        self.last_token_end = span.end();
+        Some(InlineMarkupToken::Code(span))
     }
 }
 
-/// One lossless fragment produced by [`BacktickFragments`].
+/// One lossless token produced by [`InlineMarkupScanner`].
 ///
 /// For example:
 ///
 /// ```text
 /// source      "before `code` after"
-/// fragments   Text("before "), Span("code"), Text(" after")
+/// tokens      Text("before "), Code("code"), Text(" after")
 /// ```
 ///
 /// Escaped and unmatched backticks remain text.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BacktickFragment<'a> {
+enum InlineMarkupToken<'a> {
     /// Source text outside a complete, unescaped backtick span.
     Text(&'a str),
-    /// A complete span whose delimiters have equal lengths.
-    Span(BacktickSpan<'a>),
+    /// A complete code span whose backtick delimiters have equal lengths.
+    Code(BacktickSpan<'a>),
 }
 
 /// Source text delimited by ordered backtick runs of equal length.
@@ -328,11 +286,6 @@ impl<'a> BacktickScanner<'a> {
             range: opening.range.cover(closing.range),
             delimiter_len: opening.range.len(),
         })
-    }
-
-    /// Returns the scanner's cursor at its current position.
-    pub(in crate::docstring) fn into_cursor(self) -> Cursor<'a> {
-        self.cursor
     }
 }
 
@@ -514,18 +467,31 @@ pub(super) fn split_trailing_parenthetical(value: &str) -> Option<(&str, &str)> 
     let mut outermost_opening = None;
     let mut cursor = Cursor::new(value);
 
-    while let Some(character) = cursor.bump() {
-        let index = cursor.offset().to_usize() - character.len_utf8();
+    loop {
+        let start = cursor.offset();
+        let Some(character) = cursor.bump() else {
+            break;
+        };
+
         match character {
-            '\'' | '"' => consume_quoted_string(&mut cursor, character),
-            '`' if !is_backtick_run_escaped(value, index) => {
-                let opening = find_backtick_run(value, TextSize::of(&value[..index]))?;
-                let span = markdown_code_span(value, opening).unwrap_or(opening);
-                cursor.skip_bytes((span.end() - cursor.offset()).to_usize());
+            quote @ ('\'' | '"') => consume_quoted_string(&mut cursor, quote),
+            '`' => {
+                let mut scanner = BacktickScanner::starts_at(start, value);
+                let opening = scanner.next()?;
+                if opening.is_escaped() {
+                    // The loop has consumed only the first, escaped backtick. Leave the rest of
+                    // the run for the next iteration, where it may open a shorter span.
+                    continue;
+                }
+
+                let end = scanner
+                    .eat_span(opening)
+                    .map_or_else(|| opening.end(), |span| span.end());
+                cursor.skip_bytes((end - cursor.offset()).to_usize());
             }
             '(' => {
                 if depth == 0 {
-                    outermost_opening = Some(index);
+                    outermost_opening = Some(start);
                 }
                 depth += 1;
             }
@@ -533,9 +499,9 @@ pub(super) fn split_trailing_parenthetical(value: &str) -> Option<(&str, &str)> 
                 depth = depth.checked_sub(1)?;
                 if depth == 0 && cursor.is_eof() {
                     let opening = outermost_opening?;
-                    let prefix = value[..opening].trim();
-                    let contents = value[opening + '('.len_utf8()..index].trim();
-                    return Some((prefix, contents));
+                    let (prefix, parenthetical) = value.split_at(opening.to_usize());
+                    let contents = parenthetical.strip_prefix('(')?.strip_suffix(')')?;
+                    return Some((prefix.trim(), contents.trim()));
                 }
             }
             _ => {}
@@ -560,7 +526,7 @@ pub(super) fn indentation(line: &str) -> TextSize {
 #[cfg(test)]
 mod tests {
     use super::{
-        BacktickFragment, BacktickFragments, BacktickScanner, TextSize, is_markdown_code_span,
+        BacktickScanner, InlineMarkupScanner, InlineMarkupToken, TextSize, is_markdown_code_span,
         split_once_at_top_level_colon, split_trailing_parenthetical,
     };
 
@@ -576,30 +542,30 @@ mod tests {
         let span = scanner.eat_span(opening).expect("a matching backtick run");
         assert!(!span.is_single());
         assert_eq!(span.content(), "code");
-        assert_eq!(scanner.into_cursor().as_str(), " suffix");
+        assert_eq!(scanner.as_str(), " suffix");
     }
 
     #[test]
-    fn partitions_text_and_backtick_spans() {
+    fn scans_text_and_code_tokens() {
         let source = "é :class:`~pkg.Widget` or ``literal`tick`` β";
 
         assert_eq!(
-            fragment_contents(source),
+            token_contents(source),
             vec![
                 ("text", "é :class:"),
-                ("span", "~pkg.Widget"),
+                ("code", "~pkg.Widget"),
                 ("text", " or "),
-                ("span", "literal`tick"),
+                ("code", "literal`tick"),
                 ("text", " β"),
             ]
         );
     }
 
     #[test]
-    fn partitions_spans_at_source_boundaries() {
+    fn scans_code_at_source_boundaries() {
         assert_eq!(
-            fragment_contents("`first` and `last`"),
-            vec![("span", "first"), ("text", " and "), ("span", "last")]
+            token_contents("`first` and `last`"),
+            vec![("code", "first"), ("text", " and "), ("code", "last")]
         );
     }
 
@@ -607,7 +573,7 @@ mod tests {
     fn preserves_escaped_and_unmatched_backticks_as_text() {
         let source = r"\`literal\` and `unfinished";
 
-        assert_eq!(fragment_contents(source), vec![("text", source)]);
+        assert_eq!(token_contents(source), vec![("text", source)]);
     }
 
     #[test]
@@ -701,6 +667,22 @@ mod tests {
     }
 
     #[test]
+    fn ignores_parentheses_inside_code_spans_after_escaped_backtick() {
+        assert_eq!(
+            split_trailing_parenthetical(r"value (\``)`)"),
+            Some(("value", r"\``)`"))
+        );
+    }
+
+    #[test]
+    fn treats_unmatched_backticks_as_plain_parenthetical_text() {
+        assert_eq!(
+            split_trailing_parenthetical("value (`unfinished)"),
+            Some(("value", "`unfinished"))
+        );
+    }
+
+    #[test]
     fn ignores_parentheses_after_escaped_quotes() {
         assert_eq!(
             split_trailing_parenthetical(r#"value (Literal["a\"b)c"])"#),
@@ -718,11 +700,11 @@ mod tests {
         assert_eq!(split_trailing_parenthetical("value (str) or None"), None);
     }
 
-    fn fragment_contents(source: &str) -> Vec<(&'static str, &str)> {
-        BacktickFragments::new(source)
-            .map(|fragment| match fragment {
-                BacktickFragment::Text(text) => ("text", text),
-                BacktickFragment::Span(span) => ("span", span.content()),
+    fn token_contents(source: &str) -> Vec<(&'static str, &str)> {
+        InlineMarkupScanner::new(source)
+            .map(|token| match token {
+                InlineMarkupToken::Text(text) => ("text", text),
+                InlineMarkupToken::Code(code) => ("code", code.content()),
             })
             .collect()
     }

--- a/crates/ty_ide/src/docstring/markdown/general/inline.rs
+++ b/crates/ty_ide/src/docstring/markdown/general/inline.rs
@@ -49,11 +49,9 @@
 
 use std::borrow::Cow;
 
-use ruff_text_size::TextSize;
+use ruff_text_size::{Ranged, TextSize};
 
-use crate::docstring::document::syntax::{
-    find_backtick_run, is_backtick_run_escaped, markdown_code_span,
-};
+use crate::docstring::document::syntax::BacktickScanner;
 
 /// Exposes an interface for rendering a line of prose that may contain a hyperlink.
 #[derive(Default)]
@@ -278,28 +276,26 @@ enum Candidate<'a> {
 
 /// Finds the first complete hyperlink or plausible wrapped candidate in `input`.
 fn find_link(input: &str) -> Option<(usize, Candidate<'_>)> {
-    let mut offset = TextSize::ZERO;
+    let mut scanner = BacktickScanner::new(input);
 
     // Visit each backtick run that could delimit inline markup.
-    while let Some(run) = find_backtick_run(input, offset) {
+    while let Some(run) = scanner.next() {
         let index = run.start().to_usize();
 
         // An escaped run is literal text, so continue immediately after it.
-        if is_backtick_run_escaped(input, index) {
-            offset = run.end();
+        if run.is_escaped() {
             continue;
         }
 
-        // Try parsing a link only when a single backtick has valid surrounding characters.
-        if run.len() == TextSize::new(1)
-            && is_link_start(input, index)
+        // Try parsing a link only when the backtick run has valid surrounding characters.
+        if is_link_start(input, index)
             && let Some(candidate) = parse_candidate(&input[index..])
         {
             return Some((index, candidate));
         }
 
         // Skip other backtick-delimited spans rather than searching inside them.
-        offset = markdown_code_span(input, run)?.end();
+        scanner.eat_span(run)?;
     }
 
     None
@@ -310,7 +306,13 @@ fn find_link(input: &str) -> Option<(usize, Candidate<'_>)> {
 /// Plausible wrapped labels without a closing backtick remain pending;
 /// malformed or unsupported forms return `None`.
 fn parse_candidate(input: &str) -> Option<Candidate<'_>> {
-    let after_opening = input.strip_prefix('`')?;
+    let mut scanner = BacktickScanner::new(input);
+    let opening = scanner.next()?;
+    if opening.start() != TextSize::ZERO {
+        return None;
+    }
+
+    let after_opening = scanner.as_str();
     if after_opening
         .chars()
         .next()
@@ -319,7 +321,11 @@ fn parse_candidate(input: &str) -> Option<Candidate<'_>> {
         return None;
     }
 
-    let Some(closing) = find_backtick_run(input, TextSize::new(1)) else {
+    let Some(closing) = scanner.next() else {
+        if !opening.is_single() {
+            return None;
+        }
+
         // Eliminate candidates whose content already contains a disallowed
         // backslash or closing `>`, or whose target cannot become HTTP(S). A
         // partial URI scheme remains valid so it can wrap immediately after
@@ -333,21 +339,22 @@ fn parse_candidate(input: &str) -> Option<Candidate<'_>> {
         }
         return Some(Candidate::Pending);
     };
-    if closing.len() != TextSize::new(1) {
+    let span = scanner.span(opening, closing)?;
+    if !span.is_single() {
         return None;
     }
 
-    let content = &input[1..closing.start().to_usize()];
+    let content = span.content();
     if content.contains('\\') {
         return None;
     }
 
-    let after_closing = &input[closing.end().to_usize()..];
+    let after_closing = scanner.as_str();
     let underscore_count = after_closing
         .bytes()
         .take_while(|byte| *byte == b'_')
         .count();
-    let len = closing.end().to_usize() + underscore_count;
+    let len = span.end().to_usize() + underscore_count;
     if !(1..=2).contains(&underscore_count) || !is_link_suffix(&after_closing[underscore_count..]) {
         return None;
     }


### PR DESCRIPTION
## Summary

This refactors the code span parsing we do in docstrings around a cursor-based scanner and explicit ranged backtick runs and spans. Ultimately, this serves two purposes:

1. To remove duplicated offset arithmetic from inline-link and trailing-parenthetical parsing.
2. To expose an iterator over backtick-delimited fragments of text for [downstream normalization](https://github.com/astral-sh/ruff/pull/26923).

## Test plan

See included tests.