### PR TITLE
[ty] Fix memory report detail outcome icons

### DIFF
--- a/scripts/memory_report.py
+++ b/scripts/memory_report.py
@@ -224,9 +224,7 @@ def render_summary(projects: list[ProjectComparison]) -> str:
             )
 
             for name, old_bytes, new_bytes in item_diffs[:MAX_CHANGED_ITEMS]:
-                outcome = format_outcome(
-                    old_bytes=proj.old.total_bytes, new_bytes=proj.new.total_bytes
-                )
+                outcome = format_outcome(old_bytes=old_bytes, new_bytes=new_bytes)
 
                 lines.append(
                     f"| `{name}` | {format_bytes(old_bytes)} | "


### PR DESCRIPTION
## Summary

Use each detailed memory-report row's own delta to select its outcome icon. This fixes decreasing queries showing an increase icon when the project-wide total increased, and vice versa.

## Test Plan

Testing: Verified both mixed-direction cases and ran the changed-file checks.
