### PR TITLE
[ty] Use the new incremental checker from the `ignore` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1036,7 +1036,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1598,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -3857,7 +3857,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4253,10 +4253,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5462,7 +5462,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ hashbrown = { version = "0.17.0", default-features = false, features = [
 ] }
 heck = "0.5.0"
 icu_properties = { version = "2.1.2" }
-ignore = { version = "0.4.24" }
+ignore = { version = "0.4.30" }
 imara-diff = { version = "0.2.0" }
 imperative = { version = "1.0.4" }
 indexmap = { version = "2.6.0" }

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -13,7 +13,7 @@ use crate::system::{
 };
 
 use super::walk_directory::{
-    DirectoryWalker, IgnoreIncremental, Ignored, WalkDirectoryBuilder, WalkDirectoryConfiguration,
+    DirectoryWalker, IgnoreIncremental, WalkDirectoryBuilder, WalkDirectoryConfiguration,
     WalkDirectoryVisitor, WalkDirectoryVisitorBuilder, WalkState,
 };
 
@@ -569,16 +569,12 @@ struct MemoryIgnoreIncremental {
 }
 
 impl IgnoreIncremental for MemoryIgnoreIncremental {
-    fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored {
+    fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> bool {
         // This matches the semantics of the in-memory recursive
         // directory traversal. That is, the only thing we care
         // about filtering is hidden files. We let everything else
         // through.
-        if self.ignore_hidden && !is_directory && is_hidden(path) {
-            Ignored::Yes
-        } else {
-            Ignored::Uncertain
-        }
+        self.ignore_hidden && !is_directory && is_hidden(path)
     }
 }
 

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -341,11 +341,18 @@ impl DirectoryWalker for OsDirectoryWalker {
         &self,
         configuration: WalkDirectoryConfiguration,
     ) -> Box<dyn IgnoreIncremental> {
-        // N.B. The current work-around `IgnoreFiles` implementation doesn't
-        // support any configuration right now. This will be fixed once we
-        // switch to the `ignore` crate's implementation. --AG
-        let WalkDirectoryConfiguration { paths, .. } = configuration;
-        Box::new(IgnoreFiles::new(paths))
+        let WalkDirectoryConfiguration {
+            paths,
+            ignore_hidden: hidden,
+            standard_filters,
+        } = configuration;
+
+        let mut builder = ::ignore::WalkBuilder::from_iter(paths.iter().map(|p| p.as_std_path()));
+        builder.current_dir(self.cwd.as_std_path());
+        builder.standard_filters(standard_filters);
+        builder.hidden(hidden);
+        let root_matchers = builder.build_matchers();
+        Box::new(IgnoreFiles { root_matchers })
     }
 }
 

--- a/crates/ruff_db/src/system/os/ignore.rs
+++ b/crates/ruff_db/src/system/os/ignore.rs
@@ -1,30 +1,26 @@
 //! Checks whether paths are ignored during incremental project indexing.
 
 use crate::system::SystemPath;
-use crate::system::walk_directory::{IgnoreIncremental, Ignored};
+use crate::system::walk_directory::IgnoreIncremental;
 
 pub(super) struct IgnoreFiles {
     pub(super) root_matchers: Vec<ignore::IncrementalIgnore>,
 }
 
 impl IgnoreIncremental for IgnoreFiles {
-    fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored {
+    fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> bool {
         let Some(root) = self
             .root_matchers
             .iter_mut()
             .filter(|root| path.as_std_path().starts_with(root.root()))
             .max_by_key(|root| root.root().as_os_str().len())
         else {
-            return Ignored::Uncertain;
+            return false;
         };
         let Some(norm) = root.normalize(path.as_std_path()) else {
-            return Ignored::Uncertain;
+            return false;
         };
-        if root.matched(norm, is_directory).is_ignore() {
-            Ignored::Yes
-        } else {
-            Ignored::Uncertain
-        }
+        root.matched(norm, is_directory).is_ignore()
     }
 }
 
@@ -32,7 +28,6 @@ impl IgnoreIncremental for IgnoreFiles {
 mod tests {
     use tempfile::TempDir;
 
-    use crate::system::walk_directory::Ignored;
     use crate::system::{OsSystem, System, SystemPath, SystemPathBuf};
 
     struct TestProject {
@@ -75,11 +70,11 @@ mod tests {
             std::fs::create_dir_all(path.as_ref().as_std_path()).unwrap();
         }
 
-        fn is_ignored(&self, path: &SystemPath) -> Ignored {
+        fn is_ignored(&self, path: &SystemPath) -> bool {
             self.is_ignored_from(std::slice::from_ref(&self.root), path)
         }
 
-        fn is_ignored_from(&self, walk_roots: &[SystemPathBuf], path: &SystemPath) -> Ignored {
+        fn is_ignored_from(&self, walk_roots: &[SystemPathBuf], path: &SystemPath) -> bool {
             let (first, additional) = walk_roots.split_first().unwrap();
             let mut builder = self.system.walk_directory(first);
 
@@ -100,7 +95,7 @@ mod tests {
             (project.path("build/.ignore"), "!keep.py\n"),
         ]);
 
-        assert_eq!(project.is_ignored(&path), Ignored::Yes);
+        assert!(project.is_ignored(&path));
     }
 
     #[test]
@@ -110,7 +105,7 @@ mod tests {
         let path = project.path("build/keep.py");
         project.write_files([(project.path(".gitignore"), "build/\n")]);
 
-        assert_eq!(project.is_ignored(&path), Ignored::Uncertain);
+        assert!(!project.is_ignored(&path));
     }
 
     #[test]
@@ -119,7 +114,7 @@ mod tests {
         let path = project.path("build/keep.py");
         project.write_files([(project.path(".ignore"), "\u{feff}build/\n")]);
 
-        assert_eq!(project.is_ignored(&path), Ignored::Yes);
+        assert!(project.is_ignored(&path));
     }
 
     #[test]
@@ -132,7 +127,7 @@ mod tests {
             (project.path(".gitignore"), "build/\n"),
         ]);
 
-        assert_eq!(project.is_ignored(&path), Ignored::Uncertain);
+        assert!(!project.is_ignored(&path));
     }
 
     #[test]
@@ -148,7 +143,7 @@ mod tests {
             ),
         ]);
 
-        assert_eq!(project.is_ignored(&path), Ignored::Uncertain);
+        assert!(!project.is_ignored(&path));
     }
 
     #[test]
@@ -157,7 +152,7 @@ mod tests {
         let path = project.path("pkg/keep.py");
         project.write_files([(project.path(".ignore"), "pkg/keep.py\n")]);
 
-        assert_eq!(project.is_ignored(&path), Ignored::Yes);
+        assert!(project.is_ignored(&path));
     }
 
     #[test]
@@ -170,7 +165,7 @@ mod tests {
             (project.path(".gitignore"), "build/\n"),
         ]);
 
-        assert_eq!(project.is_ignored(&path), Ignored::Yes);
+        assert!(project.is_ignored(&path));
     }
 
     #[test]
@@ -179,10 +174,7 @@ mod tests {
         let path = project.path("build/keep.py");
         project.write_files([(project.path(".ignore"), "build/\n")]);
 
-        assert_eq!(
-            project.is_ignored_from(&[project.root.clone(), path.clone()], &path),
-            Ignored::Uncertain
-        );
+        assert!(!project.is_ignored_from(&[project.root.clone(), path.clone()], &path));
     }
 
     #[test]
@@ -195,9 +187,6 @@ mod tests {
             (project.path("pkg/.ignore"), "build/\n"),
         ]);
 
-        assert_eq!(
-            project.is_ignored_from(&[project.root.clone(), nested_root], &path),
-            Ignored::Yes
-        );
+        assert!(project.is_ignored_from(&[project.root.clone(), nested_root], &path));
     }
 }

--- a/crates/ruff_db/src/system/os/ignore.rs
+++ b/crates/ruff_db/src/system/os/ignore.rs
@@ -1,215 +1,31 @@
-//! Checks whether a root ignore file lets incremental indexing skip a project
-//! walk.
-//!
-//! A full project walk decides which files belong to a project. Incremental
-//! file watcher updates must make the same decision for newly created paths,
-//! including the effect of `.ignore` and `.gitignore` files. Ideally, the
-//! `ignore` crate would expose an API that answers whether a given path is
-//! ignored. It does not, and reimplementing that decision is involved because
-//! it would need to reproduce all of the walker's ignore behavior:
-//!
-//! - parent `.ignore` files;
-//! - parent `.gitignore` files;
-//! - `.git/info/exclude`;
-//! - the global gitignore;
-//! - git and jj repository discovery;
-//! - traversal ordering, such as pruning `build/` before reading a nested
-//!   `build/.ignore`; and
-//! - linked git worktree handling.
-//!
-//! This module is a compromise. It avoids unnecessary traversal in the common
-//! case where a file or directory is already ignored by an ignore file at the
-//! project walk root.
+//! Checks whether paths are ignored during incremental project indexing.
 
-use ::ignore::gitignore;
-use rustc_hash::FxHashMap;
-
+use crate::system::SystemPath;
 use crate::system::walk_directory::{IgnoreIncremental, Ignored};
-use crate::system::{SystemPath, SystemPathBuf};
 
 pub(super) struct IgnoreFiles {
-    walk_roots: Box<[SystemPathBuf]>,
-    roots: FxHashMap<SystemPathBuf, RootIgnoreFiles>,
-}
-
-impl IgnoreFiles {
-    pub(super) fn new(walk_roots: Vec<SystemPathBuf>) -> Self {
-        Self {
-            walk_roots: walk_roots.into_boxed_slice(),
-            roots: FxHashMap::default(),
-        }
-    }
-
-    /// Answers the question whether the ignore file in the `root` directory
-    /// ignores `path`.
-    fn root_ignore_prunes_path(
-        roots: &mut FxHashMap<SystemPathBuf, RootIgnoreFiles>,
-        root: &SystemPath,
-        path: &SystemPath,
-        is_directory: bool,
-    ) -> bool {
-        let Ok(relative_path) = path.strip_prefix(root) else {
-            return false;
-        };
-        let mut components = relative_path.components();
-        let Some(first_component) = components.next() else {
-            return false;
-        };
-
-        let first_child = root.join(first_component);
-        let first_child_is_target = components.next().is_none();
-
-        let first_child_is_directory = !first_child_is_target || is_directory;
-
-        Self::root_ignore_files(roots, root).is_ignored(&first_child, first_child_is_directory)
-    }
-
-    fn root_ignore_files<'a>(
-        roots: &'a mut FxHashMap<SystemPathBuf, RootIgnoreFiles>,
-        root: &SystemPath,
-    ) -> &'a RootIgnoreFiles {
-        roots
-            .entry(root.to_path_buf())
-            .or_insert_with(|| RootIgnoreFiles::read(root))
-    }
+    pub(super) root_matchers: Vec<ignore::IncrementalIgnore>,
 }
 
 impl IgnoreIncremental for IgnoreFiles {
-    /// Returns `Yes` only when the matching walk root can prune `path`
-    /// from its own ignore files. In all other cases, return uncertain.
     fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored {
-        let Self { walk_roots, roots } = self;
-
-        // A nested explicit walk root gets its own depth-0 walk, so an ancestor
-        // root cannot prove that the nested root's descendants are ignored.
-        let Some(root) = walk_roots
-            .iter()
-            .filter(|root| path.starts_with(root))
-            .max_by_key(|root| root.as_str().len())
+        let Some(root) = self
+            .root_matchers
+            .iter_mut()
+            .filter(|root| path.as_std_path().starts_with(root.root()))
+            .max_by_key(|root| root.root().as_os_str().len())
         else {
             return Ignored::Uncertain;
         };
-
-        if Self::root_ignore_prunes_path(roots, root, path, is_directory) {
+        let Some(norm) = root.normalize(path.as_std_path()) else {
+            return Ignored::Uncertain;
+        };
+        if root.matched(norm, is_directory).is_ignore() {
             Ignored::Yes
         } else {
             Ignored::Uncertain
         }
     }
-}
-
-/// The cached ignore files for a specific root-folder.
-struct RootIgnoreFiles {
-    ignore: Option<IgnoreFile>,
-    gitignore: Option<IgnoreFile>,
-}
-
-impl RootIgnoreFiles {
-    fn read(root: &SystemPath) -> Self {
-        let canonical_root = root.as_utf8_path().canonicalize_utf8().ok().map(|path| {
-            SystemPathBuf::from_utf8_path_buf(path)
-                .simplified()
-                .to_path_buf()
-        });
-
-        let gitignore = if let Some(canonical_root) = canonical_root.as_deref()
-            && in_git_repository(canonical_root)
-            // A parent `.ignore` allowlist takes precedence over a matching
-            // `.gitignore` at the walk root. Let the walker resolve that case.
-            && !has_parent_ignore_file(canonical_root)
-        {
-            IgnoreFile::read(root, ".gitignore")
-        } else {
-            None
-        };
-
-        Self {
-            ignore: IgnoreFile::read(root, ".ignore"),
-            gitignore,
-        }
-    }
-
-    fn is_ignored(&self, path: &SystemPath, is_directory: bool) -> bool {
-        for ignore_file in [&self.ignore, &self.gitignore].into_iter().flatten() {
-            match ignore_file.match_path(path, is_directory) {
-                Ok(Some(is_ignored)) => return is_ignored,
-                Ok(_) => {}
-                Err(()) => return false,
-            }
-        }
-
-        false
-    }
-}
-
-enum IgnoreFile {
-    Matcher(gitignore::Gitignore),
-    /// Building the matcher failed.
-    Error,
-}
-
-impl IgnoreFile {
-    fn read(root: &SystemPath, file_name: &str) -> Option<Self> {
-        let ignore_path = root.join(file_name);
-        let contents = match std::fs::read_to_string(ignore_path.as_std_path()) {
-            Ok(contents) => contents,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
-            Err(_) => return Some(Self::Error),
-        };
-
-        match build_matcher(root, &ignore_path, &contents) {
-            Some(matcher) => Some(Self::Matcher(matcher)),
-            None => Some(Self::Error),
-        }
-    }
-
-    fn match_path(&self, path: &SystemPath, is_directory: bool) -> Result<Option<bool>, ()> {
-        let matcher = match self {
-            Self::Matcher(matcher) => matcher,
-            Self::Error => return Err(()),
-        };
-
-        Ok(match matcher.matched(path.as_std_path(), is_directory) {
-            ::ignore::Match::None => None,
-            ::ignore::Match::Ignore(_) => Some(true),
-            ::ignore::Match::Whitelist(_) => Some(false),
-        })
-    }
-}
-
-fn build_matcher(
-    root: &SystemPath,
-    ignore_path: &SystemPath,
-    contents: &str,
-) -> Option<gitignore::Gitignore> {
-    const UTF8_BOM: &str = "\u{feff}";
-
-    let mut builder = gitignore::GitignoreBuilder::new(root.as_std_path());
-
-    let contents = contents.trim_start_matches(UTF8_BOM);
-
-    for line in contents.lines() {
-        builder
-            .add_line(Some(ignore_path.as_std_path().to_path_buf()), line)
-            .ok()?;
-    }
-
-    builder.build().ok()
-}
-
-fn in_git_repository(canonical_root: &SystemPath) -> bool {
-    canonical_root.ancestors().any(|directory| {
-        directory.join(".git").as_std_path().exists()
-            || directory.join(".jj").as_std_path().exists()
-    })
-}
-
-fn has_parent_ignore_file(canonical_root: &SystemPath) -> bool {
-    canonical_root
-        .parent()
-        .into_iter()
-        .flat_map(SystemPath::ancestors)
-        .any(|directory| directory.join(".ignore").as_std_path().exists())
 }
 
 #[cfg(test)]
@@ -341,7 +157,7 @@ mod tests {
         let path = project.path("pkg/keep.py");
         project.write_files([(project.path(".ignore"), "pkg/keep.py\n")]);
 
-        assert_eq!(project.is_ignored(&path), Ignored::Uncertain);
+        assert_eq!(project.is_ignored(&path), Ignored::Yes);
     }
 
     #[test]
@@ -354,7 +170,7 @@ mod tests {
             (project.path(".gitignore"), "build/\n"),
         ]);
 
-        assert_eq!(project.is_ignored(&path), Ignored::Uncertain);
+        assert_eq!(project.is_ignored(&path), Ignored::Yes);
     }
 
     #[test]

--- a/crates/ruff_db/src/system/os/ignore.rs
+++ b/crates/ruff_db/src/system/os/ignore.rs
@@ -9,18 +9,18 @@ pub(super) struct IgnoreFiles {
 
 impl IgnoreIncremental for IgnoreFiles {
     fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> bool {
-        let Some(root) = self
+        let Some((root, relative)) = self
             .root_matchers
             .iter_mut()
-            .filter(|root| path.as_std_path().starts_with(root.root()))
-            .max_by_key(|root| root.root().as_os_str().len())
+            .filter_map(|root| {
+                let relative = path.as_std_path().strip_prefix(root.root()).ok()?;
+                Some((root, relative))
+            })
+            .max_by_key(|(root, _)| root.root().as_os_str().len())
         else {
             return false;
         };
-        let Some(norm) = root.normalize(path.as_std_path()) else {
-            return false;
-        };
-        root.matched(norm, is_directory).is_ignore()
+        root.matched(relative, is_directory).is_ignore()
     }
 }
 

--- a/crates/ruff_db/src/system/walk_directory.rs
+++ b/crates/ruff_db/src/system/walk_directory.rs
@@ -4,27 +4,10 @@ use std::path::PathBuf;
 
 use super::{FileType, SystemPath};
 
-/// Whether a path is known to be ignored by a directory walker.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum Ignored {
-    /// An ignore file proves that the directory walker would skip this path.
-    Yes,
-
-    /// The path might be ignored, but a directory walk is required to know for sure.
-    Uncertain,
-}
-
-impl Ignored {
-    /// Returns `true` if a directory walk is required to determine whether the path is ignored.
-    pub const fn is_uncertain(self) -> bool {
-        matches!(self, Self::Uncertain)
-    }
-}
-
 /// A matcher for determining whether paths are ignored during incremental directory walking.
 pub trait IgnoreIncremental {
-    /// Returns whether the directory walker is known to ignore `path`.
-    fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored;
+    /// Returns whether the directory walker ignores `path`.
+    fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> bool;
 }
 
 /// A builder for constructing a directory recursive traversal.

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -91,7 +91,7 @@ impl ProjectDatabase {
                             reload_project_files = true;
                         } else if project.is_directory_included(self, directory)
                             && ignore_files.as_mut().is_none_or(|ignore_files| {
-                                ignore_files.is_ignored(directory, true).is_uncertain()
+                                !ignore_files.is_ignored(directory, true)
                             })
                         {
                             tracing::debug!(
@@ -142,8 +142,8 @@ impl ProjectDatabase {
                     }
 
                     // A created file can be indexed directly unless project indexing needs the
-                    // walker to apply ignore-file semantics. The ignore fast path below skips
-                    // that walk when it can prove a root ignore file already prunes the path.
+                    // walker to apply ignore-file semantics. The ignore check below skips that
+                    // walk when the path is ignored.
                     if !project.file_set(self).is_lazy() {
                         if self.system().is_file(path) {
                             if !project
@@ -153,17 +153,17 @@ impl ProjectDatabase {
                                 continue;
                             }
 
-                            if let Some(ignore_files) = ignore_files.as_mut() {
-                                if ignore_files.is_ignored(path, false).is_uncertain() {
-                                    added_paths.insert(path.to_path_buf());
-                                }
-                            } else if let Ok(file) = system_path_to_file(self, path) {
+                            if ignore_files
+                                .as_mut()
+                                .is_none_or(|ignore_files| !ignore_files.is_ignored(path, false))
+                                && let Ok(file) = system_path_to_file(self, path)
+                            {
                                 project.add_file(self, file);
                             }
                         } else if project.is_directory_included(self, path)
-                            && ignore_files.as_mut().is_none_or(|ignore_files| {
-                                ignore_files.is_ignored(path, true).is_uncertain()
-                            })
+                            && ignore_files
+                                .as_mut()
+                                .is_none_or(|ignore_files| !ignore_files.is_ignored(path, true))
                         {
                             // Unlike a new file, a new directory needs walking to discover
                             // project files that exist below it.


### PR DESCRIPTION
This PR updates the `ignore` crate to `0.4.30` to make use of the
new [incremental path checker] merged [added in this PR][pr].

Because of #26771, the changes here are pretty small. Indeed, the
overall API gets simpler since we no longer need the notion of
uncertainty. We just "trust" the `ignore` crate to get it right.

[incremental path checker]: https://docs.rs/ignore/latest/ignore/struct.IncrementalIgnore.html
[pr]: https://github.com/BurntSushi/ripgrep/pull/3472
