### PR TITLE
[`ruff`] Stabilize `ruff:ignore` suppressions

### DIFF
--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -2685,7 +2685,6 @@ fn add_noqa_existing_ignore() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: #ruff:ignore comment found but not active, enable preview mode
         Added 1 noqa directive.
         ",
     );
@@ -2696,7 +2695,7 @@ fn add_noqa_existing_ignore() -> Result<()> {
         test_code,
         @"
 
-        def unused(x):  # ruff:ignore[ANN001, ARG001, D103]  # noqa: ANN001, ANN201, D103
+        def unused(x):  # ruff:ignore[ANN001, ARG001, D103]  # noqa: ANN201
             pass
         ",
     );

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -8,7 +8,6 @@ diagnostic range.
 
 ```toml
 [lint]
-preview = true
 select = ["RUF015"]
 ```
 
@@ -29,7 +28,6 @@ entire class definition.
 
 ```toml
 [lint]
-preview = true
 select = ["B903"]
 ```
 
@@ -46,7 +44,6 @@ Diagnostics with empty ranges should also be suppressible, as with `noqa`.
 
 ```toml
 [lint]
-preview = true
 select = ["W292"]
 ```
 
@@ -61,7 +58,6 @@ after the matching `ruff:enable` comment:
 
 ```toml
 [lint]
-preview = true
 select = ["RUF015"]
 ```
 
@@ -91,7 +87,6 @@ not_suppressed = [
 
 ```toml
 [lint]
-preview = true
 select = ["RUF015"]
 ```
 
@@ -153,7 +148,6 @@ x = (
 
 ```toml
 [lint]
-preview = true
 select = [ "F" ]
 ```
 
@@ -174,7 +168,6 @@ from foo import (  # ruff:ignore[F401]
 
 ```toml
 [lint]
-preview = true
 select = [ "F401", "RUF100" ]
 ```
 
@@ -201,7 +194,6 @@ from sys import ( # ruff:ignore[F401]
 
 ```toml
 [lint]
-preview = true
 select = [ "W291" ]
 ```
 
@@ -303,7 +295,6 @@ def f():
 
 ```toml
 [lint]
-preview = true
 select = ["F401", "RUF100", "RUF104"]
 ```
 
@@ -567,7 +558,6 @@ help: Remove unused suppression
 
 ```toml
 [lint]
-preview = true
 select = ["F401", "RUF103", "RUF104"]
 ```
 
@@ -617,7 +607,6 @@ import foo
 
 ```toml
 [lint]
-preview = true
 select = ["F401", "RUF103", "RUF104"]
 ```
 
@@ -667,7 +656,6 @@ import foo
 
 ```toml
 [lint]
-preview = true
 select = ["F401", "RUF100", "FIX002"]
 ```
 
@@ -699,7 +687,6 @@ a = 10
 
 ```toml
 [lint]
-preview = true
 select = ["E501", "F821", "RUF100", "RUF103"]
 ```
 
@@ -773,7 +760,6 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```toml
 [lint]
-preview = true
 select = ["E501", "RUF100", "FIX002"]
 ```
 
@@ -811,7 +797,6 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```toml
 [lint]
-preview = true
 select = ["E501", "F401", "F821", "RUF100", "RUF103"]
 ```
 
@@ -845,7 +830,6 @@ help: Remove unused suppression
 
 ```toml
 [lint]
-preview = true
 select = ["F821", "RUF102", "RUF103"]
 ```
 
@@ -881,7 +865,6 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```toml
 [lint]
-preview = true
 select = ["F401", "F821", "RUF100", "RUF103"]
 ```
 
@@ -944,7 +927,6 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```toml
 [lint]
-preview = true
 select = ["RUF103"]
 ```
 
@@ -993,7 +975,6 @@ note: This is an unsafe fix and may change runtime behavior
 
 ```toml
 [lint]
-preview = true
 select = ["F401", "RUF103"]
 ```
 
@@ -1008,7 +989,6 @@ import os  # before # ruff:ignore # ruff:ignore[F401] # after
 
 ```toml
 [lint]
-preview = true
 select = ["RUF100"]
 ```
 
@@ -1061,7 +1041,6 @@ at offset zero, as with `noqa`.
 
 ```toml
 [lint]
-preview = true
 select = ["D100"]
 ```
 

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -3070,7 +3070,7 @@ mod tests {
         ## Fixed source
 
         ```py
-        def unused(x):  # ruff:ignore[ANN001, ARG001, D103]  # noqa: ANN001, ANN201, D103
+        def unused(x):  # ruff:ignore[ANN001, ARG001, D103]  # noqa: ANN201
             pass
         ```
         "

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -356,11 +356,6 @@ pub(crate) const fn is_collapsible_if_fix_safe_enabled(settings: &LinterSettings
     settings.preview.is_enabled()
 }
 
-// https://github.com/astral-sh/ruff/pull/23404
-pub(crate) const fn is_ruff_ignore_enabled(settings: &LinterSettings) -> bool {
-    settings.preview.is_enabled()
-}
-
 // https://github.com/astral-sh/ruff/pull/23259
 pub(crate) const fn is_pep604_future_annotations_fix_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -19,7 +19,7 @@ use crate::checkers::ast::{DiagnosticGuard, LintContext};
 use crate::codes::Rule;
 use crate::comments::shebang::leading_shebang_range;
 use crate::fix::edits::delete_comment;
-use crate::preview::{is_human_readable_names_enabled, is_ruff_ignore_enabled};
+use crate::preview::is_human_readable_names_enabled;
 use crate::rule_redirects::get_redirect_target;
 use crate::rules::ruff::rules::{
     InvalidRuleCode, InvalidRuleCodeKind, InvalidSuppressionComment, InvalidSuppressionCommentKind,
@@ -28,7 +28,7 @@ use crate::rules::ruff::rules::{
 };
 use crate::settings::LinterSettings;
 use crate::settings::types::PreviewMode;
-use crate::{Locator, Violation, warn_user_once};
+use crate::{Locator, Violation};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 enum SuppressionAction {
@@ -870,11 +870,9 @@ impl<'a> SuppressionsBuilder<'a> {
     ) -> bool {
         match suppression.action {
             SuppressionAction::Ignore => {
-                if is_ruff_ignore_enabled(self.settings) {
-                    let (before, after) = tokens.split_at(suppression.token_range.start());
-                    let range = if indentation_at_offset(suppression.range.start(), self.source)
-                        .is_some()
-                    {
+                let (before, after) = tokens.split_at(suppression.token_range.start());
+                let range =
+                    if indentation_at_offset(suppression.range.start(), self.source).is_some() {
                         // own-line ignore
                         let mut range =
                             Self::standalone_comment_range(suppression.range, before, after);
@@ -891,55 +889,44 @@ impl<'a> SuppressionsBuilder<'a> {
                         // trailing ignore
                         self.trailing_comment_range(suppression.token_range, before)
                     };
-                    for code in suppression.codes_as_str(self.source) {
-                        self.valid.push(Suppression {
-                            code: code.into(),
-                            range,
-                            used: false.into(),
-                            comments: SuppressionComments::Single(suppression.clone()),
-                        });
-                    }
-                } else {
-                    warn_user_once!(
-                        "#ruff:ignore comment found but not active, enable preview mode"
-                    );
+                for code in suppression.codes_as_str(self.source) {
+                    self.valid.push(Suppression {
+                        code: code.into(),
+                        range,
+                        used: false.into(),
+                        comments: SuppressionComments::Single(suppression.clone()),
+                    });
                 }
                 true
             }
             SuppressionAction::FileIgnore => {
-                if is_ruff_ignore_enabled(self.settings) {
-                    match indentation_at_offset(suppression.range.start(), self.source) {
-                        // Module scope
-                        Some("") => {
-                            let range = TextRange::up_to(self.source.text_len());
-                            for code in suppression.codes_as_str(self.source) {
-                                self.valid.push(Suppression {
-                                    code: code.into(),
-                                    range,
-                                    used: false.into(),
-                                    comments: SuppressionComments::Single(suppression.clone()),
-                                });
-                            }
-                        }
-                        // Indented/inside block
-                        Some(_) => {
-                            self.invalid.push(InvalidSuppression {
-                                kind: InvalidSuppressionKind::NotModuleScope,
-                                comment: suppression.clone(),
-                            });
-                        }
-                        // Trailing
-                        None => {
-                            self.invalid.push(InvalidSuppression {
-                                kind: InvalidSuppressionKind::Trailing,
-                                comment: suppression.clone(),
+                match indentation_at_offset(suppression.range.start(), self.source) {
+                    // Module scope
+                    Some("") => {
+                        let range = TextRange::up_to(self.source.text_len());
+                        for code in suppression.codes_as_str(self.source) {
+                            self.valid.push(Suppression {
+                                code: code.into(),
+                                range,
+                                used: false.into(),
+                                comments: SuppressionComments::Single(suppression.clone()),
                             });
                         }
                     }
-                } else {
-                    warn_user_once!(
-                        "#ruff:file-ignore comment found but not active, enable preview mode"
-                    );
+                    // Indented/inside block
+                    Some(_) => {
+                        self.invalid.push(InvalidSuppression {
+                            kind: InvalidSuppressionKind::NotModuleScope,
+                            comment: suppression.clone(),
+                        });
+                    }
+                    // Trailing
+                    None => {
+                        self.invalid.push(InvalidSuppression {
+                            kind: InvalidSuppressionKind::Trailing,
+                            comment: suppression.clone(),
+                        });
+                    }
                 }
                 true
             }


### PR DESCRIPTION
Codex tried to sneak in bug fixes for https://github.com/astral-sh/ruff/issues/26282, but I don't think these have to block stabilization since they haven't come up in the wild, and I plan to work on this issue after the minor release.