### PR TITLE
Avoid RUF065 diagnostics after unpacked arguments

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF065_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF065_1.py
@@ -32,3 +32,11 @@ logging.warning("%+s", oct(123))
 
 # %.3s with hex() - precision (should NOT be flagged)
 logging.warning("%.3s", hex(123))
+
+
+# Arguments after an unpack cannot be paired with a specific conversion specifier
+# https://github.com/astral-sh/ruff/issues/26912
+values = [2]
+logging.warning("%s%s%s%s %r", *"1234", str(5))
+logging.warning("%s %r", str(1), *values, str(2))
+logging.log(logging.WARNING, "%s %r", str(1), *values, str(2))

--- a/crates/ruff_linter/src/rules/ruff/rules/logging_eager_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/logging_eager_conversion.rs
@@ -137,7 +137,13 @@ pub(crate) fn logging_eager_conversion(checker: &Checker, call: &ast::ExprCall) 
                 None
             }
         })
-        .zip(call.arguments.args.iter().skip(msg_pos + 1))
+        .zip(
+            call.arguments
+                .args
+                .iter()
+                .skip(msg_pos + 1)
+                .take_while(|arg| !arg.is_starred_expr()),
+        )
     {
         // Check if the argument is a call to eagerly format a value
         if let Expr::Call(ast::ExprCall {

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF065_RUF065_1.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF065_RUF065_1.py.snap
@@ -8,3 +8,22 @@ RUF065 Unnecessary `str()` conversion when formatting with `%s`
 17 | logging.warning("%s", str(object="!"))
    |                       ^^^^^^^^^^^^^^^
    |
+
+RUF065 Unnecessary `str()` conversion when formatting with `%s`
+  --> RUF065_1.py:41:26
+   |
+39 | values = [2]
+40 | logging.warning("%s%s%s%s %r", *"1234", str(5))
+41 | logging.warning("%s %r", str(1), *values, str(2))
+   |                          ^^^^^^
+42 | logging.log(logging.WARNING, "%s %r", str(1), *values, str(2))
+   |
+
+RUF065 Unnecessary `str()` conversion when formatting with `%s`
+  --> RUF065_1.py:42:39
+   |
+40 | logging.warning("%s%s%s%s %r", *"1234", str(5))
+41 | logging.warning("%s %r", str(1), *values, str(2))
+42 | logging.log(logging.WARNING, "%s %r", str(1), *values, str(2))
+   |                                       ^^^^^^
+   |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Fixes #26912.

RUF065 currently pairs logging arguments with format specifiers using `zip`.
This assumes each positional argument consumes exactly one specifier, which is
not valid for a starred argument such as `*values`.

Stop pairing arguments at the first starred argument. This preserves diagnostics
for the deterministic arguments before the unpack while avoiding false positives
for arguments whose matching format specifier cannot be determined statically.

## Test Plan

Added RUF065 fixture and snapshot coverage for:

- The reproduction from #26912.
- Eager conversions before a starred argument, which remain reported.
- Arguments after a starred argument in both level calls and `logging.log`,
  which are not reported.

Validation performed:

- `cargo test -p ruff_linter rules::ruff::tests::rules`
- `cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- Repository `prek` hooks
- End-to-end Ruff CLI reproduction
