### PR TITLE
[ty] Preserve generic ParamSpec captures with gradual returns

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1430,6 +1430,68 @@ reveal_type(pair(1, "a"))  # revealed: tuple[Literal[1], Literal["a"]]
 reveal_type(pair("x", 2.5))  # revealed: tuple[Literal["x"], float]
 ```
 
+### Gradual return types
+
+Gradual return types must not widen a `ParamSpec` captured from a generic function into a union of
+parameter lists. The original generic signature should remain available to the decorated callable.
+
+```py
+from collections.abc import Callable, Generator
+import types
+from typing import Any, Generic, ParamSpec, TypeVar
+
+class Wrapped[**P]:
+    def call(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+def wrap[**P](func: Callable[P, Any]) -> Wrapped[P]:
+    return Wrapped()
+
+@wrap
+def identity[T](value: T) -> T:
+    return value
+
+reveal_type(identity)  # revealed: Wrapped[(value: T@identity)]
+identity.call("value")
+# error: [too-many-positional-arguments]
+identity.call(1, 2)
+
+def requires_int[**P](func: Callable[P, int]) -> Wrapped[P]:
+    return Wrapped()
+
+# error: [invalid-argument-type]
+@requires_int
+def returns_str(value: str) -> str:
+    return value
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+class LegacyWrapped(Generic[P]):
+    def call(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+def legacy_wrap(func: Callable[P, Any]) -> LegacyWrapped[P]:
+    return LegacyWrapped()
+
+@legacy_wrap
+def legacy_identity(value: T) -> T:
+    return value
+
+reveal_type(legacy_identity)  # revealed: LegacyWrapped[(value: T@legacy_identity)]
+legacy_identity.call("value")
+# error: [too-many-positional-arguments]
+legacy_identity.call(1, 2)
+
+@types.coroutine
+def stdlib_yield(value: T) -> Generator[T, None, None]:
+    yield value
+
+reveal_type(stdlib_yield)  # revealed: [T](value: T) -> Awaitable[None]
+reveal_type(stdlib_yield(1))  # revealed: Awaitable[None]
+
+async def example() -> None:
+    await stdlib_yield(1)
+```
+
 ### Chained decorators with generic functions
 
 ```py

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -7,7 +7,7 @@ use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::types::callable::walk_callable_type;
+use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind, walk_callable_type};
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
@@ -19,7 +19,9 @@ use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation,
     TypeRelationChecker, TypeVarEvaluation,
 };
-use crate::types::signatures::{CallableSignature, Parameters, SignatureRelationVisitor};
+use crate::types::signatures::{
+    CallableSignature, Parameters, Signature, SignatureRelationVisitor,
+};
 use crate::types::tuple::{
     TupleSpec, TupleSpecBuilder, TupleType, VariableSegment, walk_tuple_type,
 };
@@ -2656,14 +2658,43 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         formal_signature: &CallableSignature<'db>,
         actual_callables: &CallableTypes<'db>,
     ) -> Result<(), ()> {
-        let formal_is_single_paramspec = formal_signature.is_single_paramspec().is_some();
+        let formal_paramspec = formal_signature.is_single_paramspec();
 
         for actual_callable in actual_callables.as_slice() {
-            if formal_is_single_paramspec {
-                let when = actual_callable
-                    .signatures(self.db)
-                    .when_constraint_set_assignable_to(self.db, formal_signature, self.constraints);
+            if let Some((paramspec, _)) = formal_paramspec {
+                // Capture the actual parameter signature independently of return constraints. A
+                // gradual return can introduce relationships such as `T <= Any`, which must not
+                // widen the captured `ParamSpec` through transitivity. Overloaded callables still
+                // rely on the relation below to filter signatures by their return type.
+                let paramspec_identity = paramspec.identity(self.db);
+                let paramspec_was_inferred = self.types.contains_key(&paramspec_identity);
+                let actual_signatures = actual_callable.signatures(self.db);
+                let paramspec_value = match actual_signatures.overloads.as_slice() {
+                    [signature] if signature.generic_context.is_some() => {
+                        Some(Type::Callable(CallableType::new(
+                            self.db,
+                            CallableSignature::single(Signature::new_generic(
+                                signature.generic_context,
+                                signature.parameters().clone(),
+                                Type::unknown(),
+                            )),
+                            CallableTypeKind::ParamSpecValue,
+                            CallableFunctionProvenance::None,
+                        )))
+                    }
+                    _ => None,
+                };
+
+                let when = actual_signatures.when_constraint_set_assignable_to(
+                    self.db,
+                    formal_signature,
+                    self.constraints,
+                );
                 self.add_type_mappings_from_constraint_set(when)?;
+                if !paramspec_was_inferred && let Some(paramspec_value) = paramspec_value {
+                    self.types
+                        .insert(paramspec_identity, UnionAccumulator::new(paramspec_value));
+                }
                 self.pending.intersect(self.db, self.constraints, when);
             } else {
                 // An overloaded actual callable is compatible with the formal signature if at


### PR DESCRIPTION
## Summary

Stacked on #26916.

When a generic function is passed to a `ParamSpec` decorator with a gradual return type, return-type constraints can widen the captured parameter list. For example:

```python
from typing import Any, Callable, Generic, ParamSpec, TypeVar

P = ParamSpec("P")
T = TypeVar("T")

class Wrapped(Generic[P]):
    def call(self, *args: P.args, **kwargs: P.kwargs) -> None: ...

def wrap(function: Callable[P, Any]) -> Wrapped[P]: ...

@wrap
def identity(value: T) -> T:
    return value

identity.call("value")
```

The base branch infers `Wrapped[((value: Any)) | ((value: T@identity))]` and rejects both the decorator application and the valid call. The callable relation produces `(value: T@identity) <= P` together with `T@identity <= Any`; constraint transitivity incorrectly turns those into two possible parameter lists. The same issue causes the first `types.coroutine` overload to be rejected, leaving generic generators non-awaitable.

This PR preserves the original `ParamSpec` value when the source is a single generic signature, independently of gradual return constraints. The source generic context remains attached to the captured parameters, valid calls and arity errors are restored, and `types.coroutine` now produces the expected generic awaitable callable. Overloaded sources continue through the existing return-type filtering path.
