### PR TITLE
[ty] Avoid editing ignore comments with trailing reasons

### DIFF
--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1124,6 +1124,34 @@ class B(A):
     }
 
     #[test]
+    fn add_ignore_does_not_append_to_trailing_reason() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                value = missing  # ty: ignore[] tracked by [123]
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        value = missing  # ty: ignore[] tracked by [123]  # ty:ignore[unresolved-reference]
+        ```
+
+        ## Diagnostics after applying fixes
+
+        warning[unused-ignore-comment]: Unused `ty: ignore` without a code
+         --> test.py:1:18
+          |
+        1 | value = missing  # ty: ignore[] tracked by [123]  # ty:ignore[unresolved-reference]
+          |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          |
+        help: Remove the unused suppression comment
+        "
+        );
+    }
+
+    #[test]
     fn add_ignore_groups_diagnostics_for_same_line_suppression() {
         assert_snapshot!(
             suppress_all_in(r#"

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -282,9 +282,7 @@ fn add_to_existing_suppression(
         })?;
     let comment_text = &source[existing.comment_range];
 
-    // Only add to the existing ignore comment if it has no reason.
-    let before_closing_bracket = comment_text.trim_end().strip_suffix(']')?;
-    let up_to_last_code = before_closing_bracket.trim_end();
+    let up_to_last_code = editable_suppression_prefix(comment_text)?;
     let separator = if up_to_last_code.ends_with('[') {
         ""
     } else if up_to_last_code.ends_with(',') {
@@ -300,6 +298,23 @@ fn add_to_existing_suppression(
         insertion,
         existing.comment_range.end() - relative_offset_from_end,
     )))
+}
+
+/// Returns the portion of an ignore comment before its closing bracket if another code can be
+/// appended to it.
+///
+/// ```python
+/// # ty: ignore[]         # Editable
+/// # ty: ignore[] reason  # Not editable
+/// ```
+fn editable_suppression_prefix(comment_text: &str) -> Option<&str> {
+    // The parser accepts a reason after the code list, but rule codes can't contain `]`, so the
+    // first `]` is the code list's closing bracket. Don't edit comments with trailing reasons.
+    let (before_closing_bracket, after_closing_bracket) = comment_text.split_once(']')?;
+    after_closing_bracket
+        .trim()
+        .is_empty()
+        .then(|| before_closing_bracket.trim_end())
 }
 
 struct Codes<'a>(SuppressionKind, &'a [LintName]);


### PR DESCRIPTION
## Summary

When an add-ignore fix extended an existing suppression, we assumed that a final `]` in the comment closed the rule-code list. Add-ignore already avoids extending comments with trailing reasons, but a reason that itself ended in `]` accidentally passed this check, causing us to insert a rule into the reason instead of adding a valid suppression.

We now identify the code list's actual closing bracket and preserve the existing behavior of treating comments with trailing reasons as uneditable. In that case, the CLI and IDE add a separate end-of-line suppression.

## Example

```python
# Before
value = missing  # ty: ignore[] tracked by [123]

# Previously
value = missing  # ty: ignore[] tracked by [123, unresolved-reference]

# Now
value = missing  # ty: ignore[] tracked by [123]  # ty:ignore[unresolved-reference]
```
