### PR TITLE
[ty] Respect mixin receiver domains in method overrides

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1003,7 +1003,23 @@ class InvalidReceiver(Mixin):
 
 class InvalidArgument(Mixin):
     value: int
-    def method(self: HasValue, argument: str) -> None: ...  # error: [invalid-method-override]
+    def method(self: HasValue, argument: str) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+  --> src/mdtest_snippet.pyi:28:9
+   |
+28 |     def method(self: HasValue, argument: str) -> None: ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Mixin.method`
+   |
+  ::: src/mdtest_snippet.pyi:7:9
+   |
+ 7 |     def method(self: HasValue, argument: int) -> None: ...
+   |         --------------------------------------------- `Mixin.method` defined here
+   |
+info: parameter `argument` has an incompatible type: `int` is not assignable to `str`
+info: This violates the Liskov Substitution Principle
 ```
 
 The receiver annotation can also accept more than one protocol:

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1514,6 +1514,40 @@ info: `BadChild3B.static_method` is a classmethod but `Parent.static_method` is 
 info: This violates the Liskov Substitution Principle
 ```
 
+## Explicitly annotated classmethod receivers
+
+An explicitly annotated `cls` can specialize the class receiver and return type without changing the
+method's arguments:
+
+```pyi
+from typing_extensions import Self
+
+class Event:
+    @classmethod
+    def deserialize(cls: type[Event], data: dict[str, object]) -> Event: ...
+
+class SwapEvent(Event):
+    @classmethod
+    def deserialize(cls: type[SwapEvent], data: dict[str, object]) -> SwapEvent: ...
+
+class Context:
+    @classmethod
+    def get(cls: type[Self]) -> Self | None: ...
+
+class SettingsContext(Context):
+    @classmethod
+    def get(cls) -> SettingsContext | None: ...
+```
+
+Narrowing an argument accepted by the superclass remains an invalid override:
+
+```pyi
+class InvalidSwapEvent(Event):
+    @classmethod
+    # error: [invalid-method-override]
+    def deserialize(cls: type[InvalidSwapEvent], data: dict[str, int]) -> InvalidSwapEvent: ...
+```
+
 ## Overloaded methods with positional-only parameters with defaults
 
 When a base class has an overloaded method where one overload accepts only keyword arguments

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1567,10 +1567,16 @@ class Item:
 class DynamicItem(Item):
     @classmethod
     def from_component(cls: type[Self], component: object) -> Self: ...
+```
 
+The override can also specialize a gradual parameter or accept additional keyword arguments:
+
+```pyi
 ModelT = TypeVar("ModelT", bound="BaseModel")
 
 class BaseModel:
+    @classmethod
+    def validate(cls: type[ModelT], value: Any) -> Any: ...
     @classmethod
     def strategy(cls: type[ModelT], *, size: int | None = None) -> Any: ...
     @classmethod
@@ -1578,14 +1584,22 @@ class BaseModel:
 
 class FrameModel(BaseModel):
     @classmethod
+    def validate(cls: type[Self], value: int) -> Self: ...
+    @classmethod
     def strategy(cls: type[Self], **kwargs: Any) -> Any: ...
     @classmethod
     def example(cls: type[Self], **kwargs: Any) -> Self: ...
 ```
 
-Narrowing an argument accepted by the superclass remains an invalid override:
+Narrowing a non-gradual argument accepted by the superclass remains an invalid override for both
+generic and concrete class receivers:
 
 ```pyi
+class InvalidDynamicItem(Item):
+    @classmethod
+    # error: [invalid-method-override]
+    def from_component(cls: type[Self], component: int) -> Self: ...
+
 class InvalidSwapEvent(Event):
     @classmethod
     # error: [invalid-method-override]

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -959,6 +959,73 @@ class B4(A4):
     def method(self, x: int) -> int: ...
 ```
 
+## Mixin methods with protocol receiver annotations
+
+A mixin can restrict a method to receivers that implement a protocol. An override that preserves or
+widens that receiver domain is valid even if the mixin itself does not implement the protocol.
+
+```pyi
+from typing import Protocol
+
+class HasValue(Protocol):
+    value: int
+
+class HasOtherValue(Protocol):
+    other_value: str
+
+class Mixin:
+    def method(self: HasValue, argument: int) -> None: ...
+
+class SameReceiver(Mixin):
+    def method(self: HasValue, argument: int) -> None: ...
+
+class ImplicitReceiver(Mixin):
+    def method(self, argument: int) -> None: ...
+
+class SatisfiesReceiver(Mixin):
+    value: int
+    def method(self: HasValue, argument: int) -> None: ...
+
+class InvalidReceiver(Mixin):
+    def method(self: HasOtherValue, argument: int) -> None: ...  # error: [invalid-method-override]
+
+class InvalidArgument(Mixin):
+    value: int
+    def method(self: HasValue, argument: str) -> None: ...  # error: [invalid-method-override]
+
+receiver: HasValue = SatisfiesReceiver()
+SatisfiesReceiver().method(1)
+
+class UnionMixin:
+    def method(self: HasValue | HasOtherValue, argument: int) -> None: ...
+
+class SameUnionReceiver(UnionMixin):
+    def method(self: HasValue | HasOtherValue, argument: int) -> None: ...
+
+class ImplicitUnionReceiver(UnionMixin):
+    def method(self, argument: int) -> None: ...
+
+class Container(Protocol):
+    def __contains__(self, key: str) -> bool: ...
+    def method(self) -> None: ...
+
+class ContainerMixin:
+    def method(self: Container) -> None: ...
+
+class SameContainerReceiver(ContainerMixin):
+    def method(self: Container) -> None: ...
+
+class ImplicitContainerReceiver(ContainerMixin):
+    def method(self) -> None: ...
+
+class SatisfiesContainerReceiver(ContainerMixin):
+    def __contains__(self, key: str) -> bool: ...
+    def method(self: Container) -> None: ...
+
+container: Container = SatisfiesContainerReceiver()
+SatisfiesContainerReceiver().method()
+```
+
 ## Generic methods on generic classes work as expected
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -965,7 +965,7 @@ A mixin can annotate `self` with a protocol that the mixin itself does not imple
 can keep that annotation or omit it:
 
 ```pyi
-from typing import Protocol
+from typing import Protocol, overload
 
 class HasValue(Protocol):
     value: int
@@ -1030,6 +1030,26 @@ class UnionMixin:
 
 class SameUnionReceiver(UnionMixin):
     def method(self: HasValue | HasOtherValue, argument: int) -> None: ...
+```
+
+Overloaded mixin methods need the same treatment for every receiver-specific overload:
+
+```pyi
+# TODO: We should emit an `invalid-method-override` diagnostic on the second
+# `InvalidOverloadedReceiver.method` overload. Both overload sets need to be
+# compared within the `HasValue` receiver domain instead of being filtered
+# against the concrete mixin subclass.
+class OverloadedMixin:
+    @overload
+    def method(self: HasValue, argument: int) -> None: ...
+    @overload
+    def method(self: HasValue, argument: str) -> None: ...
+
+class InvalidOverloadedReceiver(OverloadedMixin):
+    @overload
+    def method(self: HasValue, argument: int) -> None: ...
+    @overload
+    def method(self: HasValue, argument: bytes) -> None: ...
 ```
 
 The protocol may include the overridden method itself. This must not cause a valid implementation to

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1035,6 +1035,24 @@ container: Container = ImplementsContainer()
 ImplementsContainer().method()
 ```
 
+## Generic instance-method receivers
+
+An instance method can relate its receiver and return type using a bounded type variable. An
+override can express the same relationship with `Self`:
+
+```pyi
+from typing import TypeVar
+from typing_extensions import Self
+
+InstanceT = TypeVar("InstanceT", bound="InstanceBase")
+
+class InstanceBase:
+    def clone(self: InstanceT) -> InstanceT: ...
+
+class InstanceChild(InstanceBase):
+    def clone(self: Self) -> Self: ...
+```
+
 ## Generic methods on generic classes work as expected
 
 ```toml
@@ -1516,10 +1534,12 @@ info: This violates the Liskov Substitution Principle
 
 ## Explicitly annotated classmethod receivers
 
-An explicitly annotated `cls` can specialize the class receiver and return type without changing the
-method's arguments:
+An explicitly annotated `cls` can specialize the class receiver and return type. A subclass can also
+replace a bounded type variable on the class receiver with `Self` while preserving compatible
+arguments:
 
 ```pyi
+from typing import Any, TypeVar
 from typing_extensions import Self
 
 class Event:
@@ -1537,6 +1557,30 @@ class Context:
 class SettingsContext(Context):
     @classmethod
     def get(cls) -> SettingsContext | None: ...
+
+ItemT = TypeVar("ItemT", bound="Item")
+
+class Item:
+    @classmethod
+    def from_component(cls: type[ItemT], component: object) -> ItemT: ...
+
+class DynamicItem(Item):
+    @classmethod
+    def from_component(cls: type[Self], component: object) -> Self: ...
+
+ModelT = TypeVar("ModelT", bound="BaseModel")
+
+class BaseModel:
+    @classmethod
+    def strategy(cls: type[ModelT], *, size: int | None = None) -> Any: ...
+    @classmethod
+    def example(cls: type[ModelT], *, size: int | None = None) -> Any: ...
+
+class FrameModel(BaseModel):
+    @classmethod
+    def strategy(cls: type[Self], **kwargs: Any) -> Any: ...
+    @classmethod
+    def example(cls: type[Self], **kwargs: Any) -> Self: ...
 ```
 
 Narrowing an argument accepted by the superclass remains an invalid override:

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -959,19 +959,16 @@ class B4(A4):
     def method(self, x: int) -> int: ...
 ```
 
-## Mixin methods with protocol receiver annotations
+## Protocol annotations on mixin receivers
 
-A mixin can restrict a method to receivers that implement a protocol. An override that preserves or
-widens that receiver domain is valid even if the mixin itself does not implement the protocol.
+A mixin can annotate `self` with a protocol that the mixin itself does not implement. An override
+can keep that annotation or omit it:
 
 ```pyi
 from typing import Protocol
 
 class HasValue(Protocol):
     value: int
-
-class HasOtherValue(Protocol):
-    other_value: str
 
 class Mixin:
     def method(self: HasValue, argument: int) -> None: ...
@@ -981,10 +978,25 @@ class SameReceiver(Mixin):
 
 class ImplicitReceiver(Mixin):
     def method(self, argument: int) -> None: ...
+```
 
-class SatisfiesReceiver(Mixin):
+A subclass that provides the required protocol member can call the annotated method normally:
+
+```pyi
+class ImplementsProtocol(Mixin):
     value: int
     def method(self: HasValue, argument: int) -> None: ...
+
+receiver: HasValue = ImplementsProtocol()
+ImplementsProtocol().method(1)
+```
+
+An override cannot require an unrelated protocol or change the type of an argument accepted by the
+mixin:
+
+```pyi
+class HasOtherValue(Protocol):
+    other_value: str
 
 class InvalidReceiver(Mixin):
     def method(self: HasOtherValue, argument: int) -> None: ...  # error: [invalid-method-override]
@@ -992,19 +1004,22 @@ class InvalidReceiver(Mixin):
 class InvalidArgument(Mixin):
     value: int
     def method(self: HasValue, argument: str) -> None: ...  # error: [invalid-method-override]
+```
 
-receiver: HasValue = SatisfiesReceiver()
-SatisfiesReceiver().method(1)
+The receiver annotation can also accept more than one protocol:
 
+```pyi
 class UnionMixin:
     def method(self: HasValue | HasOtherValue, argument: int) -> None: ...
 
 class SameUnionReceiver(UnionMixin):
     def method(self: HasValue | HasOtherValue, argument: int) -> None: ...
+```
 
-class ImplicitUnionReceiver(UnionMixin):
-    def method(self, argument: int) -> None: ...
+The protocol may include the overridden method itself. This must not cause a valid implementation to
+be rejected while checking the override:
 
+```pyi
 class Container(Protocol):
     def __contains__(self, key: str) -> bool: ...
     def method(self) -> None: ...
@@ -1012,18 +1027,12 @@ class Container(Protocol):
 class ContainerMixin:
     def method(self: Container) -> None: ...
 
-class SameContainerReceiver(ContainerMixin):
-    def method(self: Container) -> None: ...
-
-class ImplicitContainerReceiver(ContainerMixin):
-    def method(self) -> None: ...
-
-class SatisfiesContainerReceiver(ContainerMixin):
+class ImplementsContainer(ContainerMixin):
     def __contains__(self, key: str) -> bool: ...
     def method(self: Container) -> None: ...
 
-container: Container = SatisfiesContainerReceiver()
-SatisfiesContainerReceiver().method()
+container: Container = ImplementsContainer()
+ImplementsContainer().method()
 ```
 
 ## Generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -85,11 +85,40 @@ impl<'db> BoundMethodType<'db> {
         )
     }
 
+    /// Converts this bound method into a callable using separate runtime-receiver and `Self` types.
+    pub(crate) fn into_callable_type_with_receiver(
+        self,
+        db: &'db dyn Db,
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) -> CallableType<'db> {
+        let function = self.function(db);
+
+        CallableType::new(
+            db,
+            self.bound_signatures_with_receiver(db, receiver_type, typing_self_type),
+            CallableTypeKind::FunctionLike,
+            CallableFunctionProvenance::from_function_return_annotation(
+                function.has_explicit_return_annotation(db),
+            ),
+        )
+    }
+
     #[salsa::tracked(returns(ref), cycle_initial=|_, _, _| CallableSignature::bottom(), heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn bound_signatures(self, db: &'db dyn Db) -> CallableSignature<'db> {
-        let function_signature = self.function(db).signature(db);
         let typing_self_type = self.typing_self_type(db);
         let receiver_type = self.self_instance(db);
+
+        self.bound_signatures_with_receiver(db, receiver_type, typing_self_type)
+    }
+
+    fn bound_signatures_with_receiver(
+        self,
+        db: &'db dyn Db,
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) -> CallableSignature<'db> {
+        let function_signature = self.function(db).signature(db);
 
         let [signature] = function_signature.overloads.as_slice() else {
             if !function_signature

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -19,8 +19,8 @@ use crate::{
     place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin},
     reachability::ReachabilityConstraintsExtension,
     types::{
-        CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, Parameter, Parameters,
-        Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
+        CallableType, ClassBase, ClassLiteral, ClassType, IntersectionType, KnownClass, Parameter,
+        Parameters, Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
         call::CallArguments,
         class::{CodeGeneratorKind, FieldKind},
         constraints::ConstraintSetBuilder,
@@ -566,7 +566,8 @@ fn check_class_declaration<'db>(
 
             let superclass_type_as_type = superclass_type_as_callable.into_type(db);
 
-            if type_on_subclass_instance.is_assignable_to(db, superclass_type_as_type) {
+            if is_assignable_method_override(db, class, type_on_subclass_instance, superclass_type)
+            {
                 continue;
             }
 
@@ -580,7 +581,12 @@ fn check_class_declaration<'db>(
                     // The immediate parent already defines this method and is different from the
                     // current ancestor we're checking. Check if the immediate parent's method
                     // is also incompatible with this ancestor.
-                    if !immediate_parent_type.is_assignable_to(db, superclass_type_as_type) {
+                    if !is_assignable_method_override(
+                        db,
+                        immediate_parent,
+                        immediate_parent_type,
+                        superclass_type,
+                    ) {
                         // The immediate parent already has an LSP violation with this ancestor.
                         // Don't report the same violation for the child.
                         continue;
@@ -666,6 +672,46 @@ fn check_class_declaration<'db>(
             superclass_definition,
         );
     }
+}
+
+/// Checks whether a method override preserves its superclass method's callable domain.
+///
+/// An explicitly annotated superclass receiver can restrict a method to a subset of subclass
+/// instances. Bind both methods to that common receiver domain before comparing their signatures.
+fn is_assignable_method_override<'db>(
+    db: &'db dyn Db,
+    class: ClassType<'db>,
+    subclass_type: Type<'db>,
+    superclass_type: Type<'db>,
+) -> bool {
+    let (subclass_type, superclass_type) = match (subclass_type, superclass_type) {
+        (Type::BoundMethod(subclass_method), Type::BoundMethod(superclass_method)) => {
+            let superclass_signature = superclass_method.function(db).signature(db);
+            let receiver = match superclass_signature.overloads.as_slice() {
+                [signature] => signature
+                    .parameters()
+                    .get(0)
+                    .filter(|parameter| parameter.is_positional() && !parameter.inferred_annotation)
+                    .map(Parameter::annotated_type),
+                _ => None,
+            };
+
+            receiver.map_or((subclass_type, superclass_type), |receiver| {
+                let receiver =
+                    IntersectionType::from_elements(db, [Type::instance(db, class), receiver]);
+                (
+                    Type::BoundMethod(subclass_method.map_self_type(db, |_| receiver)),
+                    Type::BoundMethod(superclass_method.map_self_type(db, |_| receiver)),
+                )
+            })
+        }
+        _ => (subclass_type, superclass_type),
+    };
+    let Some(superclass_callable) = superclass_type.try_upcast_to_callable(db) else {
+        return false;
+    };
+
+    subclass_type.is_assignable_to(db, superclass_callable.into_type(db))
 }
 
 /// Whether an attribute declaration is a class variable or an instance variable.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -702,15 +702,23 @@ fn is_assignable_method_override<'db>(
             };
 
             receiver.map_or((subclass_type, superclass_type), |receiver| {
-                let receiver =
-                    receiver.bind_self_typevars(db, subclass_method.typing_self_type(db));
+                let typing_self_type = subclass_method.typing_self_type(db);
+                let receiver = receiver.bind_self_typevars(db, typing_self_type);
                 let receiver = IntersectionType::from_elements(
                     db,
                     [subclass_method.self_instance(db), receiver],
                 );
                 (
-                    Type::BoundMethod(subclass_method.map_self_type(db, |_| receiver)),
-                    Type::BoundMethod(superclass_method.map_self_type(db, |_| receiver)),
+                    Type::Callable(subclass_method.into_callable_type_with_receiver(
+                        db,
+                        receiver,
+                        typing_self_type,
+                    )),
+                    Type::Callable(superclass_method.into_callable_type_with_receiver(
+                        db,
+                        receiver,
+                        typing_self_type,
+                    )),
                 )
             })
         }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -705,6 +705,9 @@ fn method_override_types<'db>(
                     .get(0)
                     .filter(|parameter| parameter.is_positional() && !parameter.inferred_annotation)
                     .map(Parameter::annotated_type),
+                // TODO: Compare overloaded mixin methods within each overload's explicit receiver
+                // domain. Binding them directly to the concrete subclass can filter out applicable
+                // overloads when the subclass does not itself satisfy the receiver protocol.
                 _ => None,
             };
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -559,7 +559,13 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            if is_assignable_method_override(db, type_on_subclass_instance, superclass_type) {
+            let Some((subclass_override_type, superclass_override_type)) =
+                method_override_types(db, type_on_subclass_instance, superclass_type)
+            else {
+                continue;
+            };
+
+            if subclass_override_type.is_assignable_to(db, superclass_override_type) {
                 continue;
             }
 
@@ -581,12 +587,6 @@ fn check_class_declaration<'db>(
                 }
             }
 
-            let Some(superclass_type_as_callable) = superclass_type.try_upcast_to_callable(db)
-            else {
-                continue;
-            };
-            let superclass_type_as_type = superclass_type_as_callable.into_type(db);
-
             report_invalid_method_override(
                 context,
                 &member.name,
@@ -596,10 +596,7 @@ fn check_class_declaration<'db>(
                 superclass,
                 superclass_type,
                 method_kind,
-                || {
-                    type_on_subclass_instance
-                        .assignability_error_context(db, superclass_type_as_type)
-                },
+                || subclass_override_type.assignability_error_context(db, superclass_override_type),
             );
 
             liskov_diagnostic_emitted = true;
@@ -689,6 +686,16 @@ fn is_assignable_method_override<'db>(
     subclass_type: Type<'db>,
     superclass_type: Type<'db>,
 ) -> bool {
+    method_override_types(db, subclass_type, superclass_type).is_some_and(
+        |(subclass_type, superclass_type)| subclass_type.is_assignable_to(db, superclass_type),
+    )
+}
+
+fn method_override_types<'db>(
+    db: &'db dyn Db,
+    subclass_type: Type<'db>,
+    superclass_type: Type<'db>,
+) -> Option<(Type<'db>, Type<'db>)> {
     let (subclass_type, superclass_type) = match (subclass_type, superclass_type) {
         (Type::BoundMethod(subclass_method), Type::BoundMethod(superclass_method)) => {
             let superclass_signature = superclass_method.function(db).signature(db);
@@ -724,11 +731,9 @@ fn is_assignable_method_override<'db>(
         }
         _ => (subclass_type, superclass_type),
     };
-    let Some(superclass_callable) = superclass_type.try_upcast_to_callable(db) else {
-        return false;
-    };
+    let superclass_callable = superclass_type.try_upcast_to_callable(db)?;
 
-    subclass_type.is_assignable_to(db, superclass_callable.into_type(db))
+    Some((subclass_type, superclass_callable.into_type(db)))
 }
 
 /// Whether an attribute declaration is a class variable or an instance variable.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -559,13 +559,6 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            let Some(superclass_type_as_callable) = superclass_type.try_upcast_to_callable(db)
-            else {
-                continue;
-            };
-
-            let superclass_type_as_type = superclass_type_as_callable.into_type(db);
-
             if is_assignable_method_override(db, class, type_on_subclass_instance, superclass_type)
             {
                 continue;
@@ -593,6 +586,12 @@ fn check_class_declaration<'db>(
                     }
                 }
             }
+
+            let Some(superclass_type_as_callable) = superclass_type.try_upcast_to_callable(db)
+            else {
+                continue;
+            };
+            let superclass_type_as_type = superclass_type_as_callable.into_type(db);
 
             report_invalid_method_override(
                 context,
@@ -678,6 +677,19 @@ fn check_class_declaration<'db>(
 ///
 /// An explicitly annotated superclass receiver can restrict a method to a subset of subclass
 /// instances. Bind both methods to that common receiver domain before comparing their signatures.
+///
+/// ```python
+/// from typing import Protocol
+///
+/// class HasValue(Protocol):
+///     value: int
+///
+/// class Mixin:
+///     def method(self: HasValue) -> None: ...
+///
+/// class Sub(Mixin):
+///     def method(self: HasValue) -> None: ...
+/// ```
 fn is_assignable_method_override<'db>(
     db: &'db dyn Db,
     class: ClassType<'db>,

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -559,8 +559,7 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            if is_assignable_method_override(db, class, type_on_subclass_instance, superclass_type)
-            {
+            if is_assignable_method_override(db, type_on_subclass_instance, superclass_type) {
                 continue;
             }
 
@@ -574,12 +573,7 @@ fn check_class_declaration<'db>(
                     // The immediate parent already defines this method and is different from the
                     // current ancestor we're checking. Check if the immediate parent's method
                     // is also incompatible with this ancestor.
-                    if !is_assignable_method_override(
-                        db,
-                        immediate_parent,
-                        immediate_parent_type,
-                        superclass_type,
-                    ) {
+                    if !is_assignable_method_override(db, immediate_parent_type, superclass_type) {
                         // The immediate parent already has an LSP violation with this ancestor.
                         // Don't report the same violation for the child.
                         continue;
@@ -676,7 +670,7 @@ fn check_class_declaration<'db>(
 /// Checks whether a method override preserves its superclass method's callable domain.
 ///
 /// An explicitly annotated superclass receiver can restrict a method to a subset of subclass
-/// instances. Bind both methods to that common receiver domain before comparing their signatures.
+/// receivers. Bind both methods to that common receiver domain before comparing their signatures.
 ///
 /// ```python
 /// from typing import Protocol
@@ -692,7 +686,6 @@ fn check_class_declaration<'db>(
 /// ```
 fn is_assignable_method_override<'db>(
     db: &'db dyn Db,
-    class: ClassType<'db>,
     subclass_type: Type<'db>,
     superclass_type: Type<'db>,
 ) -> bool {
@@ -710,7 +703,11 @@ fn is_assignable_method_override<'db>(
 
             receiver.map_or((subclass_type, superclass_type), |receiver| {
                 let receiver =
-                    IntersectionType::from_elements(db, [Type::instance(db, class), receiver]);
+                    receiver.bind_self_typevars(db, subclass_method.typing_self_type(db));
+                let receiver = IntersectionType::from_elements(
+                    db,
+                    [subclass_method.self_instance(db), receiver],
+                );
                 (
                     Type::BoundMethod(subclass_method.map_self_type(db, |_| receiver)),
                     Type::BoundMethod(superclass_method.map_self_type(db, |_| receiver)),

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2029,6 +2029,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         let freshened_target;
         let target = if let Some(generic_context) = target.generic_context
+            // A target-local type variable can occur in the source receiver constraint after both
+            // methods are bound to a common receiver. That occurrence represents the same receiver
+            // domain, rather than a collision between independent signatures, so keep it shared.
+            && max_typevar_freshness_matching_generic_context(
+                db,
+                source.receiver_constraint_types(),
+                generic_context,
+            )
+            .is_none()
             && let Some(delta) = source
                 .max_typevar_freshness_matching_generic_context(db, generic_context)
                 .map(|freshness| freshness.increment().value())

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2029,15 +2029,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         let freshened_target;
         let target = if let Some(generic_context) = target.generic_context
-            // A target-local type variable can occur in the source receiver constraint after both
-            // methods are bound to a common receiver. That occurrence represents the same receiver
-            // domain, rather than a collision between independent signatures, so keep it shared.
-            && max_typevar_freshness_matching_generic_context(
-                db,
-                source.receiver_constraint_types(),
-                generic_context,
-            )
-            .is_none()
             && let Some(delta) = source
                 .max_typevar_freshness_matching_generic_context(db, generic_context)
                 .map(|freshness| freshness.increment().value())


### PR DESCRIPTION
## Summary

Prior to this change, we compared method overrides after binding each method to its declaring class. For a mixin whose method explicitly restricts `self`, that turns the inherited receiver constraint into a concrete failed relation and can reject an identical override:

```python
from typing import Protocol

class HasValue(Protocol):
    value: int

class Mixin:
    def method(self: HasValue) -> None: ...

class Sub(Mixin):
    def method(self: HasValue) -> None: ...  # Previously: invalid-method-override
```

This compares an explicitly restricted base method on its actual callable domain, intersecting the subclass receiver with the base receiver annotation before binding both signatures.

Closes https://github.com/astral-sh/ty/issues/4018.
