### PR TITLE
[`pylint`] Avoid imported-name collisions in custom-exception checking (`PLW0133`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pylint/useless-exception-statement.md
+++ b/crates/ruff_linter/resources/mdtest/pylint/useless-exception-statement.md
@@ -1,0 +1,27 @@
+# `useless-exception-statement` (`PLW0133`)
+
+```toml
+[lint]
+preview = true
+select = ["PLW0133"]
+```
+
+## Imported names do not collide with local exceptions
+
+The custom-exception check resolves the binding referenced by the call. A
+qualified or imported name must not be mistaken for an unrelated local
+exception with the same final segment.
+
+```py
+import http
+from http import HTTPStatus as ImportedHTTPStatus
+
+
+class HTTPStatus(Exception):
+    pass
+
+
+HTTPStatus()  # error: [useless-exception-statement]
+http.HTTPStatus(200)
+ImportedHTTPStatus(200)
+```

--- a/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/useless_exception_statement.rs
@@ -94,13 +94,10 @@ fn is_custom_exception(
     semantic: &SemanticModel,
     target_version: PythonVersion,
 ) -> bool {
-    let Some(qualified_name) = semantic.resolve_qualified_name(expr) else {
+    let Expr::Name(name) = expr else {
         return false;
     };
-    let Some(symbol) = qualified_name.segments().last() else {
-        return false;
-    };
-    let Some(binding_id) = semantic.lookup_symbol(symbol).binding_id() else {
+    let Some(binding_id) = semantic.resolve_name(name) else {
         return false;
     };
     let binding = semantic.binding(binding_id);


### PR DESCRIPTION
Summary
--

While trying to stabilize this preview feature, Codex found a bug in name resolution. We were
previously checking only the last segment of a qualified name, which meant that a local name like
`HTTPStatus` was considered the same as an imported name. We now require the expression to be a
locally-defined `Name` and use `resolve_name` instead.

https://play.ruff.rs/79fbc32d-c179-4160-9692-57cbc2956544

This is a relatively new preview feature anyway, so I think this can block stabilization.

Test Plan
--

New mdtest
