### PR TITLE
[ty] Narrow walrus expression values

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -47,6 +47,7 @@ use crate::predicate::{
     MappingPatternEntryPredicateKind, MappingPatternPredicateKind, PatternPredicate,
     PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral, ScopedPredicateId,
     SequencePatternPredicateKind, StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
+    expr_may_have_nested_bindings,
 };
 use crate::program::Program;
 use crate::re_exports::exported_names;
@@ -1153,7 +1154,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let Some(value) = value else { return };
         let target_name = &target_name_expr.id;
 
-        if !Self::can_register_narrowing_alias(value) {
+        if !Self::can_register_narrowing_alias(value) || expr_may_have_nested_bindings(value) {
             return;
         }
 
@@ -1252,6 +1253,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 Self::walk_narrowing_alias_predicate(&expr_if.test, f);
                 Self::walk_narrowing_alias_predicate(&expr_if.body, f);
                 Self::walk_narrowing_alias_predicate(&expr_if.orelse, f);
+            }
+            ast::Expr::Named(expr_named) => {
+                Self::walk_narrowing_alias_predicate(&expr_named.value, f);
             }
             _ => {}
         }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -47,7 +47,6 @@ use crate::predicate::{
     MappingPatternEntryPredicateKind, MappingPatternPredicateKind, PatternPredicate,
     PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral, ScopedPredicateId,
     SequencePatternPredicateKind, StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
-    expr_may_have_nested_bindings,
 };
 use crate::program::Program;
 use crate::re_exports::exported_names;
@@ -1154,7 +1153,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let Some(value) = value else { return };
         let target_name = &target_name_expr.id;
 
-        if !Self::can_register_narrowing_alias(value) || expr_may_have_nested_bindings(value) {
+        if !Self::can_register_narrowing_alias(value) {
             return;
         }
 

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -9,7 +9,7 @@
 
 use ruff_db::files::File;
 use ruff_index::{FrozenIndexVec, Idx, IndexVec};
-use ruff_python_ast::{Expr, Singleton, helpers::any_over_expr, name::Name};
+use ruff_python_ast::{Singleton, name::Name};
 
 use crate::ast_ids::ExpressionNodeKey;
 use crate::db::Db;
@@ -17,21 +17,6 @@ use crate::expression::Expression;
 use crate::global_scope;
 use crate::scope::{FileScopeId, ScopeId};
 use crate::symbol::ScopedSymbolId;
-
-/// Returns `true` if `expr` contains a nested assignment or scope that may introduce bindings.
-pub fn expr_may_have_nested_bindings(expr: &Expr) -> bool {
-    any_over_expr(expr, |expression| {
-        matches!(
-            expression,
-            Expr::Named(_)
-                | Expr::Lambda(_)
-                | Expr::ListComp(_)
-                | Expr::SetComp(_)
-                | Expr::DictComp(_)
-                | Expr::Generator(_)
-        )
-    })
-}
 
 // A scoped identifier for each `Predicate` in a scope.
 #[derive(Clone, Debug, Copy, PartialOrd, Ord, PartialEq, Eq, Hash, get_size2::GetSize)]

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -9,7 +9,7 @@
 
 use ruff_db::files::File;
 use ruff_index::{FrozenIndexVec, Idx, IndexVec};
-use ruff_python_ast::{Singleton, name::Name};
+use ruff_python_ast::{Expr, Singleton, helpers::any_over_expr, name::Name};
 
 use crate::ast_ids::ExpressionNodeKey;
 use crate::db::Db;
@@ -17,6 +17,21 @@ use crate::expression::Expression;
 use crate::global_scope;
 use crate::scope::{FileScopeId, ScopeId};
 use crate::symbol::ScopedSymbolId;
+
+/// Returns `true` if `expr` contains a nested assignment or scope that may introduce bindings.
+pub fn expr_may_have_nested_bindings(expr: &Expr) -> bool {
+    any_over_expr(expr, |expression| {
+        matches!(
+            expression,
+            Expr::Named(_)
+                | Expr::Lambda(_)
+                | Expr::ListComp(_)
+                | Expr::SetComp(_)
+                | Expr::DictComp(_)
+                | Expr::Generator(_)
+        )
+    })
+}
 
 // A scoped identifier for each `Predicate` in a scope.
 #[derive(Clone, Debug, Copy, PartialOrd, Ord, PartialEq, Eq, Hash, get_size2::GetSize)]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -162,65 +162,6 @@ def _(x: int | None):
         reveal_type(x)  # revealed: int | None
 ```
 
-## Aliases containing named expressions or nested scopes
-
-A named expression or nested scope can invalidate a narrowed place before an aliased predicate is
-used, so the expression must not be registered as a narrowing alias. Rejecting all nested scopes is
-overly conservative, but we can remain conservative until motivated by real use cases.
-
-```py
-from typing_extensions import TypeGuard
-
-def get_string() -> str:
-    return "s"
-
-def guard_list(value: object) -> TypeGuard[list[int]]:
-    return isinstance(value, list)
-
-def _(value: int | str):
-    predicate = isinstance(value, int) and (value := get_string())
-    if result := predicate:
-        reveal_type(value)  # revealed: int | str
-        reveal_type(result)  # revealed: str & ~AlwaysFalsy
-    else:
-        reveal_type(value)  # revealed: int | str
-        reveal_type(result)  # revealed: Literal[False] | (str & ~AlwaysTruthy)
-
-    if result := bool(predicate):
-        reveal_type(value)  # revealed: int | str
-        reveal_type(result)  # revealed: Literal[True]
-
-def _(value: object):
-    predicate = guard_list(value) and (value := get_string())
-    if result := predicate:
-        reveal_type(value)  # revealed: object
-
-def _(value: int | str, items: list[int]):
-    lambda_predicate = isinstance(value, int) and (lambda: True)
-    if result := lambda_predicate:
-        reveal_type(value)  # revealed: int | str
-
-    lambda_default_predicate = isinstance(value, int) and (lambda item=(value := get_string()): item)
-    if result := lambda_default_predicate:
-        reveal_type(value)  # revealed: int | str
-
-    list_predicate = isinstance(value, int) and [item for item in items]
-    if result := list_predicate:
-        reveal_type(value)  # revealed: int | str
-
-    set_predicate = isinstance(value, int) and {item for item in items}
-    if result := set_predicate:
-        reveal_type(value)  # revealed: int | str
-
-    dict_predicate = isinstance(value, int) and {item: item for item in items}
-    if result := dict_predicate:
-        reveal_type(value)  # revealed: int | str
-
-    generator_predicate = isinstance(value, int) and (item for item in items)
-    if result := generator_predicate:
-        reveal_type(value)  # revealed: int | str
-```
-
 ## Attribute access alias
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -152,11 +152,73 @@ def _(x: int | None):
         # TODO: same as above
         reveal_type(x)  # revealed: int | None
     if y := is_none:
-        # TODO: same as above
-        reveal_type(x)  # revealed: int | None
+        reveal_type(x)  # revealed: None
+        reveal_type(y)  # revealed: Literal[True]
+    else:
+        reveal_type(x)  # revealed: int
+        reveal_type(y)  # revealed: Literal[False]
     if (lambda: is_none)():
         # TODO: same as above
         reveal_type(x)  # revealed: int | None
+```
+
+## Aliases containing named expressions or nested scopes
+
+A named expression or nested scope can invalidate a narrowed place before an aliased predicate is
+used, so the expression must not be registered as a narrowing alias. Rejecting all nested scopes is
+overly conservative, but we can remain conservative until motivated by real use cases.
+
+```py
+from typing_extensions import TypeGuard
+
+def get_string() -> str:
+    return "s"
+
+def guard_list(value: object) -> TypeGuard[list[int]]:
+    return isinstance(value, list)
+
+def _(value: int | str):
+    predicate = isinstance(value, int) and (value := get_string())
+    if result := predicate:
+        reveal_type(value)  # revealed: int | str
+        reveal_type(result)  # revealed: str & ~AlwaysFalsy
+    else:
+        reveal_type(value)  # revealed: int | str
+        reveal_type(result)  # revealed: Literal[False] | (str & ~AlwaysTruthy)
+
+    if result := bool(predicate):
+        reveal_type(value)  # revealed: int | str
+        reveal_type(result)  # revealed: Literal[True]
+
+def _(value: object):
+    predicate = guard_list(value) and (value := get_string())
+    if result := predicate:
+        reveal_type(value)  # revealed: object
+
+def _(value: int | str, items: list[int]):
+    lambda_predicate = isinstance(value, int) and (lambda: True)
+    if result := lambda_predicate:
+        reveal_type(value)  # revealed: int | str
+
+    lambda_default_predicate = isinstance(value, int) and (lambda item=(value := get_string()): item)
+    if result := lambda_default_predicate:
+        reveal_type(value)  # revealed: int | str
+
+    list_predicate = isinstance(value, int) and [item for item in items]
+    if result := list_predicate:
+        reveal_type(value)  # revealed: int | str
+
+    set_predicate = isinstance(value, int) and {item for item in items}
+    if result := set_predicate:
+        reveal_type(value)  # revealed: int | str
+
+    dict_predicate = isinstance(value, int) and {item: item for item in items}
+    if result := dict_predicate:
+        reveal_type(value)  # revealed: int | str
+
+    generator_predicate = isinstance(value, int) and (item for item in items)
+    if result := generator_predicate:
+        reveal_type(value)  # revealed: int | str
 ```
 
 ## Attribute access alias

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1299,6 +1299,27 @@ if (x := f()) != 1:
     reveal_type(x)  # revealed: Literal[2, 3]
 else:
     reveal_type(x)  # revealed: Literal[1]
+
+value = f()
+if result := (value == 1):
+    reveal_type(value)  # revealed: Literal[1]
+    reveal_type(result)  # revealed: Literal[True]
+else:
+    reveal_type(value)  # revealed: Literal[2, 3]
+    reveal_type(result)  # revealed: Literal[False]
+
+class A:
+    tag: Literal["a"]
+
+class B:
+    tag: Literal["b"]
+
+def overwritten_tagged_union(value: A | B | bool):
+    if isinstance(value, (A, B)):
+        if value := (value.tag == "a"):
+            reveal_type(value)  # revealed: Literal[True]
+        else:
+            reveal_type(value)  # revealed: Literal[False]
 ```
 
 ## Union with `Any`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -110,6 +110,20 @@ if (x := f()) is None:
     reveal_type(x)  # revealed: None
 else:
     reveal_type(x)  # revealed: Literal[1, 2]
+
+value = f()
+if result := (value is None):
+    reveal_type(value)  # revealed: None
+    reveal_type(result)  # revealed: Literal[True]
+else:
+    reveal_type(value)  # revealed: Literal[1, 2]
+    reveal_type(result)  # revealed: Literal[False]
+
+value = f()
+if value := (value is None):
+    reveal_type(value)  # revealed: Literal[True]
+else:
+    reveal_type(value)  # revealed: Literal[False]
 ```
 
 ## `is` with two narrowable operands

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -837,7 +837,8 @@ def test(a: Any, items: list[T]) -> None:
 ## Narrowing with named expressions (walrus operator)
 
 When `isinstance()` is used with a named expression, the target of the named expression should be
-narrowed.
+narrowed. When the `isinstance()` check is the value of a named expression, its argument should also
+be narrowed.
 
 ```py
 def get_value() -> int | str:
@@ -848,4 +849,48 @@ def f():
         reveal_type(x)  # revealed: int
     else:
         reveal_type(x)  # revealed: str
+
+    value = get_value()
+    if result := isinstance(value, int):
+        reveal_type(value)  # revealed: int
+        reveal_type(result)  # revealed: Literal[True]
+    else:
+        reveal_type(value)  # revealed: str
+        reveal_type(result)  # revealed: Literal[False]
+
+def get_string() -> str:
+    return "s"
+
+def later_rebinding(value: int | str):
+    if result := (isinstance(value, int) and (value := get_string())):
+        reveal_type(value)  # revealed: int | str
+        reveal_type(result)  # revealed: str & ~AlwaysFalsy
+    else:
+        reveal_type(value)  # revealed: int | str
+        reveal_type(result)  # revealed: Literal[False] | (str & ~AlwaysTruthy)
+
+class Box:
+    value: int | str
+
+def later_base_rebinding(first: Box, second: Box):
+    if result := (isinstance(first.value, int) and (first := second)):
+        reveal_type(first.value)  # revealed: int | str
+        reveal_type(result)  # revealed: Box & ~AlwaysFalsy
+    else:
+        reveal_type(first.value)  # revealed: int | str
+        reveal_type(result)  # revealed: Literal[False] | (Box & ~AlwaysTruthy)
+
+def nested_scopes(value: int | str, items: list[int]):
+    if result := (isinstance(value, int) and (lambda: True)):
+        reveal_type(value)  # revealed: int | str
+    if result := (isinstance(value, int) and (lambda item=(value := get_string()): item)):
+        reveal_type(value)  # revealed: int | str
+    if result := (isinstance(value, int) and [item for item in items]):
+        reveal_type(value)  # revealed: int | str
+    if result := (isinstance(value, int) and {item for item in items}):
+        reveal_type(value)  # revealed: int | str
+    if result := (isinstance(value, int) and {item: item for item in items}):
+        reveal_type(value)  # revealed: int | str
+    if result := (isinstance(value, int) and (item for item in items)):
+        reveal_type(value)  # revealed: int | str
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -857,40 +857,4 @@ def f():
     else:
         reveal_type(value)  # revealed: str
         reveal_type(result)  # revealed: Literal[False]
-
-def get_string() -> str:
-    return "s"
-
-def later_rebinding(value: int | str):
-    if result := (isinstance(value, int) and (value := get_string())):
-        reveal_type(value)  # revealed: int | str
-        reveal_type(result)  # revealed: str & ~AlwaysFalsy
-    else:
-        reveal_type(value)  # revealed: int | str
-        reveal_type(result)  # revealed: Literal[False] | (str & ~AlwaysTruthy)
-
-class Box:
-    value: int | str
-
-def later_base_rebinding(first: Box, second: Box):
-    if result := (isinstance(first.value, int) and (first := second)):
-        reveal_type(first.value)  # revealed: int | str
-        reveal_type(result)  # revealed: Box & ~AlwaysFalsy
-    else:
-        reveal_type(first.value)  # revealed: int | str
-        reveal_type(result)  # revealed: Literal[False] | (Box & ~AlwaysTruthy)
-
-def nested_scopes(value: int | str, items: list[int]):
-    if result := (isinstance(value, int) and (lambda: True)):
-        reveal_type(value)  # revealed: int | str
-    if result := (isinstance(value, int) and (lambda item=(value := get_string()): item)):
-        reveal_type(value)  # revealed: int | str
-    if result := (isinstance(value, int) and [item for item in items]):
-        reveal_type(value)  # revealed: int | str
-    if result := (isinstance(value, int) and {item for item in items}):
-        reveal_type(value)  # revealed: int | str
-    if result := (isinstance(value, int) and {item: item for item in items}):
-        reveal_type(value)  # revealed: int | str
-    if result := (isinstance(value, int) and (item for item in items)):
-        reveal_type(value)  # revealed: int | str
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -586,6 +586,7 @@ def _(x: object):
 ## Narrowing with named expressions (walrus operator)
 
 When a type guard is used with a named expression, the target of the named expression should be
+narrowed. When a type guard is the value of a named expression, its argument should also be
 narrowed.
 
 ```py
@@ -610,4 +611,29 @@ def f():
         reveal_type(y)  # revealed: str
     else:
         reveal_type(y)  # revealed: int | str
+
+    value = get_value()
+    if result := is_str(value):
+        reveal_type(value)  # revealed: str
+        reveal_type(result)  # revealed: TypeIs[str @ value] & ~AlwaysFalsy
+    else:
+        reveal_type(value)  # revealed: int
+        reveal_type(result)  # revealed: TypeIs[str @ value] & ~AlwaysTruthy
+
+    other = get_value()
+    if result := guard_str(other):
+        reveal_type(other)  # revealed: str
+        reveal_type(result)  # revealed: TypeGuard[str @ other] & ~AlwaysFalsy
+    else:
+        reveal_type(other)  # revealed: int | str
+        reveal_type(result)  # revealed: TypeGuard[str @ other] & ~AlwaysTruthy
+
+def guard_list(value: object) -> TypeGuard[list[int]]:
+    return isinstance(value, list)
+
+def overwritten_target(value: object):
+    if value := guard_list(value):
+        reveal_type(value)  # revealed: TypeGuard[list[int] @ value] & ~AlwaysFalsy
+    else:
+        reveal_type(value)  # revealed: TypeGuard[list[int] @ value] & ~AlwaysTruthy
 ```

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -27,7 +27,7 @@ use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
     CallableAndCallExpr, ClassPatternPredicateKind, MappingPatternPredicateKind, PatternPredicate,
     PatternPredicateKind, Predicate, PredicateNode, SequencePatternPredicateKind,
-    SubjectElementPatternPredicate,
+    SubjectElementPatternPredicate, expr_may_have_nested_bindings,
 };
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
@@ -1158,7 +1158,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             }
             ast::Expr::BoolOp(bool_op) => self.evaluate_bool_op(bool_op, expression, is_positive),
             ast::Expr::If(expr_if) => self.evaluate_expr_if(expr_if, expression, is_positive),
-            ast::Expr::Named(expr_named) => self.evaluate_expr_named(expr_named, is_positive),
+            ast::Expr::Named(expr_named) => {
+                self.evaluate_expr_named(expr_named, expression, is_positive)
+            }
             _ => None,
         }
     }
@@ -2909,10 +2911,33 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     fn evaluate_expr_named(
         &mut self,
         expr_named: &ast::ExprNamed,
+        expression: Expression<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
         let target_constraints = self.evaluate_simple_expr(&expr_named.target, is_positive);
-        let value_constraints = self.evaluate_simple_expr(&expr_named.value, is_positive);
+        let mut value_constraints = if expr_may_have_nested_bindings(&expr_named.value) {
+            // Nested assignments and scopes can invalidate constraints before this predicate is
+            // applied to the final binding.
+            self.evaluate_simple_expr(&expr_named.value, is_positive)
+        } else {
+            self.evaluate_expression_node_predicate(&expr_named.value, expression, is_positive)
+        };
+
+        if let Some(value_constraints) = value_constraints.as_mut()
+            && let Some(target) = PlaceExpr::try_from_expr(&expr_named.target)
+            && let Some(target_place) = self.places().place_id(&target)
+        {
+            let places = self.places();
+            // The target is rebound after the value is evaluated, invalidating constraints on the
+            // target and any member places rooted at it.
+            value_constraints.retain(|place, _| {
+                *place != target_place
+                    && !places
+                        .parents(places.place(*place))
+                        .any(|parent| parent == target_place)
+            });
+        }
+
         match (target_constraints, value_constraints) {
             (Some(mut target), Some(value)) => {
                 merge_constraints_and(&mut target, value);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -27,7 +27,7 @@ use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
     CallableAndCallExpr, ClassPatternPredicateKind, MappingPatternPredicateKind, PatternPredicate,
     PatternPredicateKind, Predicate, PredicateNode, SequencePatternPredicateKind,
-    SubjectElementPatternPredicate, expr_may_have_nested_bindings,
+    SubjectElementPatternPredicate,
 };
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
@@ -2915,13 +2915,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
         let target_constraints = self.evaluate_simple_expr(&expr_named.target, is_positive);
-        let mut value_constraints = if expr_may_have_nested_bindings(&expr_named.value) {
-            // Nested assignments and scopes can invalidate constraints before this predicate is
-            // applied to the final binding.
-            self.evaluate_simple_expr(&expr_named.value, is_positive)
-        } else {
-            self.evaluate_expression_node_predicate(&expr_named.value, expression, is_positive)
-        };
+        let mut value_constraints =
+            self.evaluate_expression_node_predicate(&expr_named.value, expression, is_positive);
 
         if let Some(value_constraints) = value_constraints.as_mut()
             && let Some(target) = PlaceExpr::try_from_expr(&expr_named.target)


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4020.

Narrowing predicates on the right-hand side of a walrus expression were evaluated only as simple expressions, so checks such as `if result := isinstance(value, int):`, `TypeGuard`/`TypeIs` predicates, comparisons, and aliased conditions failed to narrow `value`.

This recursively evaluates the walrus value as a predicate, preserves the target's truthiness constraint, and discards constraints on the rebound target and its member places.

## Test plan

Added focused mdtests for `isinstance`, `TypeGuard`/`TypeIs`, equality/identity comparisons, and aliased predicates.
