### PR TITLE
[`flake8-bugbear`] Stabilize source preservation in the fix (`B006`)

### DIFF
--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -238,13 +238,6 @@ pub(crate) const fn is_b006_check_guaranteed_mutable_expr_enabled(
     settings.preview.is_enabled()
 }
 
-// github.com/astral-sh/ruff/issues/20004
-pub(crate) const fn is_b006_unsafe_fix_preserve_assignment_expr_enabled(
-    settings: &LinterSettings,
-) -> bool {
-    settings.preview.is_enabled()
-}
-
 pub(crate) const fn is_typing_extensions_str_alias_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -13,10 +13,7 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
-use crate::preview::{
-    is_b006_check_guaranteed_mutable_expr_enabled,
-    is_b006_unsafe_fix_preserve_assignment_expr_enabled,
-};
+use crate::preview::is_b006_check_guaranteed_mutable_expr_enabled;
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
@@ -183,24 +180,15 @@ fn move_initialization(
     let _ = write!(&mut content, "if {} is None:", parameter.parameter.name());
     content.push_str(stylist.line_ending().as_str());
     content.push_str(stylist.indentation());
-    if is_b006_unsafe_fix_preserve_assignment_expr_enabled(checker.settings()) {
-        let _ = write!(
-            &mut content,
-            "{} = {}",
-            parameter.parameter.name(),
-            locator.slice(
-                parenthesized_range(default.into(), parameter.into(), checker.tokens())
-                    .unwrap_or(default.range())
-            )
-        );
-    } else {
-        let _ = write!(
-            &mut content,
-            "{} = {}",
-            parameter.name(),
-            checker.generator().expr(default)
-        );
-    }
+    let _ = write!(
+        &mut content,
+        "{} = {}",
+        parameter.parameter.name(),
+        locator.slice(
+            parenthesized_range(default.into(), parameter.into(), checker.tokens())
+                .unwrap_or(default.range())
+        )
+    );
 
     content.push_str(stylist.line_ending().as_str());
 

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_9.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_9.py.snap
@@ -14,7 +14,7 @@ help: Replace with `None`; initialize within function
    - def f5(x=([1, ])):
 17 + def f5(x=None):
 18 +     if x is None:
-19 +         x = [1]
+19 +         x = ([1, ])
 20 |     print(x)
    |
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Preview feature: https://github.com/astral-sh/ruff/pull/20024

Rule documentation: https://docs.astral.sh/ruff/rules/mutable-argument-default/
