### PR TITLE
[`flake8-bugbear`] Stabilize guaranteed-mutable expression detection (`B006`)

### DIFF
--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -231,13 +231,6 @@ pub(crate) const fn is_type_var_default_enabled(settings: &LinterSettings) -> bo
     settings.preview.is_enabled()
 }
 
-// github.com/astral-sh/ruff/issues/20004
-pub(crate) const fn is_b006_check_guaranteed_mutable_expr_enabled(
-    settings: &LinterSettings,
-) -> bool {
-    settings.preview.is_enabled()
-}
-
 pub(crate) const fn is_typing_extensions_str_alias_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -13,7 +13,6 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
-use crate::preview::is_b006_check_guaranteed_mutable_expr_enabled;
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
@@ -111,11 +110,7 @@ pub(crate) fn mutable_argument_default(checker: &Checker, function_def: &ast::St
             .iter()
             .map(|target| QualifiedName::from_dotted_name(target))
             .collect();
-        let is_mut_expr = if is_b006_check_guaranteed_mutable_expr_enabled(checker.settings()) {
-            is_guaranteed_mutable_expr(default, checker.semantic())
-        } else {
-            is_mutable_expr(default, checker.semantic())
-        };
+        let is_mut_expr = is_guaranteed_mutable_expr(default, checker.semantic());
         if is_mut_expr
             && !parameter.annotation().is_some_and(|expr| {
                 is_immutable_annotation(expr, checker.semantic(), extend_immutable_calls.as_slice())

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_9.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_9.py.snap
@@ -2,6 +2,77 @@
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
 ---
 B006 [*] Do not use mutable data structures for argument defaults
+ --> B006_9.py:1:10
+  |
+1 | def f1(x=([],)):
+  |          ^^^^^
+2 |     print(x)
+  |
+help: Replace with `None`; initialize within function
+  |
+  - def f1(x=([],)):
+1 + def f1(x=None):
+2 +     if x is None:
+3 +         x = ([],)
+4 |     print(x)
+  |
+note: This is an unsafe fix and may change runtime behavior
+
+B006 [*] Do not use mutable data structures for argument defaults
+ --> B006_9.py:5:10
+  |
+5 | def f2(x=(x for x in "x")):
+  |          ^^^^^^^^^^^^^^^^
+6 |     print(x)
+  |
+help: Replace with `None`; initialize within function
+  |
+4 |
+  - def f2(x=(x for x in "x")):
+5 + def f2(x=None):
+6 +     if x is None:
+7 +         x = (x for x in "x")
+8 |     print(x)
+  |
+note: This is an unsafe fix and may change runtime behavior
+
+B006 [*] Do not use mutable data structures for argument defaults
+  --> B006_9.py:9:10
+   |
+ 9 | def f3(x=((x for x in "x"),)):
+   |          ^^^^^^^^^^^^^^^^^^^
+10 |     print(x)
+   |
+help: Replace with `None`; initialize within function
+   |
+8  |
+   - def f3(x=((x for x in "x"),)):
+9  + def f3(x=None):
+10 +     if x is None:
+11 +         x = ((x for x in "x"),)
+12 |     print(x)
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+B006 [*] Do not use mutable data structures for argument defaults
+  --> B006_9.py:13:11
+   |
+13 | def f4(x=(z := [1, ])):
+   |           ^^^^^^^^^^
+14 |     print(x)
+   |
+help: Replace with `None`; initialize within function
+   |
+12 |
+   - def f4(x=(z := [1, ])):
+13 + def f4(x=None):
+14 +     if x is None:
+15 +         x = (z := [1, ])
+16 |     print(x)
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+B006 [*] Do not use mutable data structures for argument defaults
   --> B006_9.py:17:11
    |
 17 | def f5(x=([1, ])):


### PR DESCRIPTION
Preview feature: https://github.com/astral-sh/ruff/pull/20024

Rule documentation: https://docs.astral.sh/ruff/rules/mutable-argument-default/

This is currently stacked on #26950. They were technically separate preview features, but to fix some of the expanded mutable expressions requires the source-preserving fix.
