### PR TITLE
[ty] Narrow inline list and set membership checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -68,6 +68,84 @@ def _(x: Literal["a", "b", "c", 1]):
         reveal_type(x)  # revealed: Literal[1]
 ```
 
+## `in` for inline list and set literals
+
+Inline list and set literals are consumed immediately, so membership can use their precise element
+types without promoting them as mutable containers.
+
+```py
+from typing import Literal
+from typing_extensions import assert_never
+
+Choice = Literal["a", "b", "c"]
+
+def inline_list(value: Choice):
+    if value in ["a", "b"]:
+        reveal_type(value)  # revealed: Literal["a", "b"]
+    else:
+        reveal_type(value)  # revealed: Literal["c"]
+
+    if value not in ["a", "b"]:
+        reveal_type(value)  # revealed: Literal["c"]
+    else:
+        reveal_type(value)  # revealed: Literal["a", "b"]
+
+def inline_set(value: Choice):
+    if value in {"a", "b"}:
+        reveal_type(value)  # revealed: Literal["a", "b"]
+    else:
+        reveal_type(value)  # revealed: Literal["c"]
+
+    if value not in {"a", "b"}:
+        reveal_type(value)  # revealed: Literal["c"]
+    else:
+        reveal_type(value)  # revealed: Literal["a", "b"]
+
+def literal_locals(value: Choice):
+    a = "a"
+    b = "b"
+    if value in [a, b]:
+        reveal_type(value)  # revealed: Literal["a", "b"]
+    else:
+        reveal_type(value)  # revealed: Literal["c"]
+
+    if value in {a, b}:
+        reveal_type(value)  # revealed: Literal["a", "b"]
+    else:
+        reveal_type(value)  # revealed: Literal["c"]
+
+def mixed_literals(value: Literal["a", "b", 1, 2, b"x"] | None):
+    if value in ["a", 1, b"x", None]:
+        reveal_type(value)  # revealed: Literal["a", 1, b"x"] | None
+    else:
+        reveal_type(value)  # revealed: Literal["b", 2]
+
+    if value in {"a", 1, b"x", None}:
+        reveal_type(value)  # revealed: Literal["a", 1, b"x"] | None
+    else:
+        reveal_type(value)  # revealed: Literal["b", 2]
+
+def union_valued_slots(value: Choice, a: Literal["a", "b"], b: Literal["a", "b"]):
+    if value not in [a, b]:
+        reveal_type(value)  # revealed: Literal["a", "b", "c"]
+    if value not in {a, b}:
+        reveal_type(value)  # revealed: Literal["a", "b", "c"]
+
+def exhaustive_list(value: Choice):
+    if value in ["a", "b"]:
+        return
+    if value == "c":
+        return
+    assert_never(value)
+
+def exhaustive_set(value: Choice):
+    if value in {"a", "b"}:
+        return
+    if value == "c":
+        return
+    assert_never(value)
+```
+
 ## `in` for PEP 695 aliases
 
 ```toml
@@ -144,6 +222,18 @@ type Foo = Literal["a", "b", "c"] | int
 def _(x: Foo):
     if x in ("a", "b"):
         reveal_type(x)  # revealed: Literal["a", "b"] | int
+
+def inline_list(x: str):
+    if x in ["a", "b"]:
+        reveal_type(x)  # revealed: str
+    else:
+        reveal_type(x)  # revealed: str & ~Literal["a"] & ~Literal["b"]
+
+def inline_set(x: str):
+    if x in {"a", "b"}:
+        reveal_type(x)  # revealed: str
+    else:
+        reveal_type(x)  # revealed: str & ~Literal["a"] & ~Literal["b"]
 ```
 
 ## `in` for `str` and literal strings

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3057,6 +3057,33 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         constrained.then(|| builder.build())
     }
 
+    /// Preserve the precise element types of an immediately consumed list or set literal.
+    ///
+    /// These expressions cannot be mutated before membership is evaluated. Representing them as
+    /// fixed-length tuples also lets negative narrowing exclude values that are guaranteed present.
+    fn inline_membership_rhs_type(
+        &self,
+        rhs: &ast::Expr,
+        inference: &ExpressionInference<'db>,
+    ) -> Option<Type<'db>> {
+        let elements = match rhs.expression_value() {
+            ast::Expr::List(list) => &list.elts,
+            ast::Expr::Set(set) => &set.elts,
+            _ => return None,
+        };
+
+        if elements.iter().any(ast::Expr::is_starred_expr) {
+            return None;
+        }
+
+        Some(Type::heterogeneous_tuple(
+            self.db,
+            elements
+                .iter()
+                .map(|element| inference.expression_type(element)),
+        ))
+    }
+
     fn evaluate_expr_compare_op(
         &mut self,
         lhs_ty: Type<'db>,
@@ -3478,6 +3505,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         for (op, (left, right)) in std::iter::zip(&**ops, comparator_tuples) {
             let lhs_ty = last_rhs_ty.unwrap_or_else(|| inference.expression_type(left));
             let rhs_ty = inference.expression_type(right);
+            let lhs_narrowing_rhs_ty = if matches!(op, ast::CmpOp::In | ast::CmpOp::NotIn) {
+                self.inline_membership_rhs_type(right, inference)
+                    .unwrap_or(rhs_ty)
+            } else {
+                rhs_ty
+            };
 
             // Narrowing for:
             // - `if type(x) is Y`
@@ -3540,7 +3573,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             // - `if x not in y`
             if narrowable_ast(left)
                 && let Some(narrowable) = PlaceExpr::try_from_expr(left)
-                && let Some(ty) = self.evaluate_expr_compare_op(lhs_ty, rhs_ty, *op, is_positive)
+                && let Some(ty) =
+                    self.evaluate_expr_compare_op(lhs_ty, lhs_narrowing_rhs_ty, *op, is_positive)
             {
                 let place = self.expect_place(&narrowable);
                 let constraint = NarrowingConstraint::intersection(ty);


### PR DESCRIPTION
## Summary

Preserve the precise element types of immediately consumed list and set literals during membership narrowing. Collection inference normally promotes their members because the containers are mutable, which prevented both positive narrowing and the negative exclusions needed for exhaustive checks.

This represents direct, non-starred list/set membership operands as temporary fixed-length tuples only while evaluating the narrowing constraint. The actual inferred container type is unchanged (including for hover and chained comparisons), starred expressions retain the conservative fallback, and existing equality/strict-literal-narrowing behavior is reused.

Closes astral-sh/ty#4026.

## Test plan

Adds mdtest coverage for:

- positive and negative list/set membership branches;
- literal-valued locals and mixed literals;
- union-valued slots that cannot be safely excluded;
- `assert_never` exhaustiveness;
- strict literal narrowing.