### PR TITLE
[ty] Fix nested short-circuit flow snapshots

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -206,6 +206,15 @@ struct ConditionFlowSnapshots {
     falsy: FlowSnapshot,
 }
 
+impl ConditionFlowSnapshots {
+    fn into_short_circuit_and_continuation(self, op: ast::BoolOp) -> (FlowSnapshot, FlowSnapshot) {
+        match op {
+            ast::BoolOp::And => (self.falsy, self.truthy),
+            ast::BoolOp::Or => (self.truthy, self.falsy),
+        }
+    }
+}
+
 enum ConditionFlowSnapshot {
     Fallback,
     Branches(ConditionFlowSnapshots),
@@ -4569,6 +4578,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
             }) => {
                 let mut snapshots = vec![];
                 let mut reachability_constraints = vec![];
+                let mut last_condition_flow_snapshots = None;
 
                 for (index, value) in values.iter().enumerate() {
                     for id in &reachability_constraints {
@@ -4581,9 +4591,10 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                         .record_range_reachability(value.range(), in_type_checking_block);
                     self.visit_expr(value);
 
-                    // For the last value, we don't need to model control flow. There is no short-circuiting
-                    // anymore.
+                    // Only non-final values can short-circuit this boolean operation. The final
+                    // value can still have its own outcome-specific flow if it is nested.
                     if index < values.len() - 1 {
+                        let condition_flow_snapshots = self.take_condition_flow_snapshots(value);
                         let predicate = self.build_predicate(value);
                         let possibly_narrowed = self.compute_possibly_narrowed_places(&predicate);
                         let predicate_id = match op {
@@ -4594,7 +4605,15 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                             .current_reachability_constraints_mut()
                             .add_atom(predicate_id);
 
-                        let after_expr = self.flow_snapshot();
+                        let continuation =
+                            if let Some(condition_flow_snapshots) = condition_flow_snapshots {
+                                let (short_circuit, continuation) = condition_flow_snapshots
+                                    .into_short_circuit_and_continuation(*op);
+                                self.flow_restore(short_circuit);
+                                continuation
+                            } else {
+                                self.flow_snapshot()
+                            };
 
                         // We first model the short-circuiting behavior. We take the short-circuit
                         // path here if all of the previous short-circuit paths were not taken, so
@@ -4607,17 +4626,34 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                         // Then we model the non-short-circuiting behavior. Here, we need to delay
                         // the application of the reachability constraint until after the expression
                         // has been evaluated, so we only push it onto the stack here.
-                        self.flow_restore(after_expr);
+                        self.flow_restore(continuation);
                         self.record_narrowing_constraint_id_for_places(
                             predicate_id,
                             &possibly_narrowed,
                         );
                         reachability_constraints.push(reachability_constraint);
+                    } else {
+                        last_condition_flow_snapshots = self.take_condition_flow_snapshots(value);
                     }
                 }
 
-                let no_short_circuit =
-                    any_over_expr(expr, &ast::Expr::is_named_expr).then(|| self.flow_snapshot());
+                let has_specialized_last = last_condition_flow_snapshots.is_some();
+                let (last_short_circuit, no_short_circuit) =
+                    if let Some(condition_flow_snapshots) = last_condition_flow_snapshots {
+                        let (short_circuit, no_short_circuit) =
+                            condition_flow_snapshots.into_short_circuit_and_continuation(*op);
+                        (Some(short_circuit), Some(no_short_circuit))
+                    } else {
+                        (
+                            None,
+                            any_over_expr(expr, &ast::Expr::is_named_expr)
+                                .then(|| self.flow_snapshot()),
+                        )
+                    };
+
+                if let Some(last_short_circuit) = last_short_circuit {
+                    self.flow_restore(last_short_circuit);
+                }
 
                 for snapshot in snapshots {
                     self.flow_merge(snapshot);
@@ -4626,10 +4662,18 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 if let Some(no_short_circuit) = no_short_circuit {
                     let bool_op_key = ExpressionNodeKey::from(expr);
                     let maybe_short_circuit = self.flow_snapshot();
+
+                    if has_specialized_last {
+                        // Restore the merged post-expression flow after constructing the two
+                        // outcome-specific snapshots.
+                        self.flow_merge(no_short_circuit.clone());
+                    }
+
                     let (truthy, falsy) = match op {
                         ast::BoolOp::And => (no_short_circuit, maybe_short_circuit),
                         ast::BoolOp::Or => (maybe_short_circuit, no_short_circuit),
                     };
+
                     self.condition_flow_snapshots_by_node
                         .insert(bool_op_key, ConditionFlowSnapshots { truthy, falsy });
                 }

--- a/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
+++ b/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
@@ -135,8 +135,8 @@ def _(flag: bool):
     (flag and (x := 1)) or (x := 2)
     reveal_type(x)  # revealed: Literal[1, 2]
 
-def _(flag: bool, first: int, second: str):
-    (flag and (x := first)) or (x := second)
+def _(flag: bool, possibly_falsy_int: int, possibly_falsy_str: str):
+    (flag and (x := possibly_falsy_int)) or (x := possibly_falsy_str)
     reveal_type(x)  # revealed: int | str
 
 def _(flag: bool):
@@ -156,11 +156,7 @@ def _(flag1: bool, flag2: bool):
     (flag1 and (x := 1)) or (flag2 and (x := 2)) or (x := 3)
     reveal_type(x)  # revealed: Literal[1, 2, 3]
 
-def _(flag1: bool, flag2: bool):
-    if (flag1 and (x := 1)) or flag2:
-        # error: [possibly-unresolved-reference]
-        reveal_type(x)  # revealed: Literal[1]
-
+def _(flag1: bool):
     if (flag1 and (y := 1)) or (z := 2):
         # error: [possibly-unresolved-reference]
         reveal_type(y)  # revealed: Literal[1]

--- a/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
+++ b/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
@@ -122,6 +122,52 @@ def _(flag1: bool, flag2: bool):
         reveal_type(z)  # revealed: Literal[1]
 ```
 
+## Nested short-circuit assignments
+
+Assignments in mutually exclusive short-circuit paths can still leave a name definitely bound.
+
+```py
+def _(flag: bool):
+    if (flag and (x := 54)) or (x := 32):
+        reveal_type(x)  # revealed: Literal[54, 32]
+
+def _(flag: bool):
+    (flag and (x := 1)) or (x := 2)
+    reveal_type(x)  # revealed: Literal[1, 2]
+
+def _(flag: bool, first: int, second: str):
+    (flag and (x := first)) or (x := second)
+    reveal_type(x)  # revealed: int | str
+
+def _(flag: bool):
+    (flag or (x := 0)) and (x := 2)
+    reveal_type(x)  # revealed: Literal[0, 2]
+
+def _(flag1: bool, flag2: bool):
+    if (flag1 and (x := 1)) or (flag2 and (x := 2)):
+        reveal_type(x)  # revealed: Literal[1, 2]
+
+    if (flag1 or (y := 0)) and (flag2 or (y := 0)):
+        pass
+    else:
+        reveal_type(y)  # revealed: Literal[0]
+
+def _(flag1: bool, flag2: bool):
+    (flag1 and (x := 1)) or (flag2 and (x := 2)) or (x := 3)
+    reveal_type(x)  # revealed: Literal[1, 2, 3]
+
+def _(flag1: bool, flag2: bool):
+    if (flag1 and (x := 1)) or flag2:
+        # error: [possibly-unresolved-reference]
+        reveal_type(x)  # revealed: Literal[1]
+
+    if (flag1 and (y := 1)) or (z := 2):
+        # error: [possibly-unresolved-reference]
+        reveal_type(y)  # revealed: Literal[1]
+        # error: [possibly-unresolved-reference]
+        reveal_type(z)  # revealed: Literal[2]
+```
+
 ## Negated expressions
 
 ```py


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4025.

Nested boolean expressions were split from their already-merged flow state, so an impossible unbound path from an inner short circuit could reach an outer condition body. Compose the inner truthy/falsy snapshots when evaluating each operand, including the final operand, and restore the merged post-expression state afterward.

This removes false `possibly-unresolved-reference` diagnostics for mutually exclusive walrus assignments while preserving genuine short-circuit warnings.

## Test plan

Added mdtests.
