### PR TITLE
[`ruff`] Fix false positive with unpacked arguments (`RUF065`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/ruff/logging-eager-conversion.md
+++ b/crates/ruff_linter/resources/mdtest/ruff/logging-eager-conversion.md
@@ -1,0 +1,43 @@
+# `logging-eager-conversion` (`RUF065`)
+
+```toml
+lint.preview = true
+lint.select = ["RUF065"]
+```
+
+## Unpacked arguments
+
+The presence of a starred expression (`*args`) breaks the positional mapping between format string specifiers and variadic logging arguments. Ensure eager conversions *before* the starred argument are still flagged, but bail out on ambiguous cases *after* it.
+
+```py
+import logging
+
+# 1. Starred before eager conversion (should not trigger for repr("5") because the mapping is broken)
+logging.warning("%s%s%s%s %s", *"1234", repr("5"))
+
+# 2. Eager conversion before starred (should trigger for repr("1") because it maps reliably)
+logging.warning("%s %s", repr("1"), *["1234"])  # snapshot: logging-eager-conversion
+
+# 3. Multiple starred arguments (should not trigger anywhere)
+logging.warning("%s %s %s", *["1"], *["2"], repr("3"))
+
+# 4. Mixed specifiers and eager conversion before starred (should trigger for repr("1"))
+logging.warning("%s %s %s", repr("1"), *["2", "3"])  # snapshot: logging-eager-conversion
+```
+
+```snapshot
+error[RUF065]: Unnecessary `repr()` conversion when formatting with `%s`. Use `%r` instead of `%s`
+ --> src/mdtest_snippet.py:7:26
+  |
+7 | logging.warning("%s %s", repr("1"), *["1234"])  # snapshot: logging-eager-conversion
+  |                          ^^^^^^^^^
+  |
+
+
+error[RUF065]: Unnecessary `repr()` conversion when formatting with `%s`. Use `%r` instead of `%s`
+  --> src/mdtest_snippet.py:13:29
+   |
+13 | logging.warning("%s %s %s", repr("1"), *["2", "3"])  # snapshot: logging-eager-conversion
+   |                             ^^^^^^^^^
+   |
+```

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF065_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF065_0.py
@@ -69,3 +69,4 @@ log(logging.INFO, "Octal: %s", oct(255))
 info("Hex: %s", hex(42))
 log(logging.INFO, "Hex: %s", hex(255))
 
+

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF065_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF065_0.py
@@ -69,4 +69,3 @@ log(logging.INFO, "Octal: %s", oct(255))
 info("Hex: %s", hex(42))
 log(logging.INFO, "Hex: %s", hex(255))
 
-

--- a/crates/ruff_linter/src/rules/ruff/rules/logging_eager_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/logging_eager_conversion.rs
@@ -127,7 +127,6 @@ pub(crate) fn logging_eager_conversion(checker: &Checker, call: &ast::ExprCall) 
         return;
     };
 
-    // Iterate over % placeholders in format string and zip with logging statement arguments
     for (spec, arg) in format_string
         .iter()
         .filter_map(|(_, part)| {
@@ -137,7 +136,13 @@ pub(crate) fn logging_eager_conversion(checker: &Checker, call: &ast::ExprCall) 
                 None
             }
         })
-        .zip(call.arguments.args.iter().skip(msg_pos + 1))
+        .zip(
+            call.arguments
+                .args
+                .iter()
+                .skip(msg_pos + 1)
+                .take_while(|arg| !arg.is_starred_expr()),
+        )
     {
         // Check if the argument is a call to eagerly format a value
         if let Expr::Call(ast::ExprCall {

--- a/crates/ruff_linter/src/rules/ruff/rules/logging_eager_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/logging_eager_conversion.rs
@@ -127,6 +127,7 @@ pub(crate) fn logging_eager_conversion(checker: &Checker, call: &ast::ExprCall) 
         return;
     };
 
+    // Iterate over % placeholders in format string and zip with logging statement arguments
     for (spec, arg) in format_string
         .iter()
         .filter_map(|(_, part)| {


### PR DESCRIPTION
Fixes #26912

RUF065 assumes a strict 1:1 positional mapping between format string specifiers (`%s`) and `logging` arguments. That breaks down entirely when a starred expression (like `*args`) is passed, because it unpacks an unknown number of items at runtime.

When we hit a starred argument, the linter gets misaligned and starts flagging unrelated eager conversions (`str(x)`) that don't actually correspond to a `%s` specifier. (This one's annoying because it means completely valid logging calls get lint errors). 

To fix this, we just bail out of the argument loop as soon as we see `arg.is_starred_expr()`. I think this is right for the common case, but happy to adjust if there's a better way to handle variadics in this context. 

## Test Plan
Added test scenarios to `RUF065_0.py` covering:
- Eager conversion *after* a starred argument (shouldn't trigger)
- Eager conversion *before* a starred argument (still triggers)
- Multiple starred arguments in the same call
- Mixed format specifiers before a starred argument
