### PR TITLE
[ty] Fix isinstance tuple coverage for aliases and type variables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -351,6 +351,15 @@ def accepts_alias_bound_typevar(x: T_bound_alias_a_b) -> bool:
     reveal_type(isinstance(x, (A, B)))  # revealed: Literal[True]
     if isinstance(x, (A, B)):
         return True
+
+def accepts_truthy_constrained_typevar(x: T_constrained_a_b) -> bool:
+    if not x:
+        return False
+
+    reveal_type(x)  # revealed: T_constrained_a_b@accepts_truthy_constrained_typevar & ~AlwaysFalsy
+    reveal_type(isinstance(x, (A, B)))  # revealed: Literal[True]
+    if isinstance(x, (A, B)):
+        return True
 ```
 
 ## Generic builtins should not overfit upper-bound-only callback constraints

--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -320,6 +320,7 @@ python-version = "3.12"
 
 ```py
 from typing import TypeVar
+from typing_extensions import TypeAliasType, Union
 
 class A: ...
 class B: ...
@@ -358,6 +359,21 @@ def accepts_truthy_constrained_typevar(x: T_constrained_a_b) -> bool:
 
     reveal_type(x)  # revealed: T_constrained_a_b@accepts_truthy_constrained_typevar & ~AlwaysFalsy
     reveal_type(isinstance(x, (A, B)))  # revealed: Literal[True]
+    if isinstance(x, (A, B)):
+        return True
+
+RecursiveA = TypeAliasType("RecursiveA", Union[A, "RecursiveB"])
+RecursiveB = TypeAliasType("RecursiveB", Union[B, "RecursiveA"])
+RecursivePartialA = TypeAliasType("RecursivePartialA", Union[A, "RecursivePartialB"])
+RecursivePartialB = TypeAliasType("RecursivePartialB", Union[bytes, "RecursivePartialA"])
+
+def accepts_mutually_recursive_alias(x: RecursiveA) -> bool:
+    reveal_type(isinstance(x, (A, B)))  # revealed: Literal[True]
+    if isinstance(x, (A, B)):
+        return True
+
+def partial_mutually_recursive_alias(x: RecursivePartialA) -> bool:  # error: [invalid-return-type]
+    reveal_type(isinstance(x, (A, B)))  # revealed: bool
     if isinstance(x, (A, B)):
         return True
 ```

--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -311,6 +311,48 @@ isinstance("", t.Any)  # error: [invalid-argument-type]
 isinstance("", (int, t.Any))  # error: [invalid-argument-type]
 ```
 
+## Calls to `isinstance` with tuple-covered aliases and type variables
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypeVar
+
+class A: ...
+class B: ...
+
+type AliasA = A
+type AliasB = B
+type AliasAB = AliasA | AliasB
+
+T_constrained_a_b = TypeVar("T_constrained_a_b", A, B)
+T_bound_a_b = TypeVar("T_bound_a_b", bound=A | B)
+T_bound_alias_a_b = TypeVar("T_bound_alias_a_b", bound=AliasAB)
+
+def accepts_alias(x: AliasAB) -> bool:
+    reveal_type(isinstance(x, (A, B)))  # revealed: Literal[True]
+    if isinstance(x, (A, B)):
+        return True
+
+def accepts_constrained_typevar(x: T_constrained_a_b) -> bool:
+    reveal_type(isinstance(x, (A, B)))  # revealed: Literal[True]
+    if isinstance(x, (A, B)):
+        return True
+
+def accepts_union_bound_typevar(x: T_bound_a_b) -> bool:
+    reveal_type(isinstance(x, (A, B)))  # revealed: Literal[True]
+    if isinstance(x, (A, B)):
+        return True
+
+def accepts_alias_bound_typevar(x: T_bound_alias_a_b) -> bool:
+    reveal_type(isinstance(x, (A, B)))  # revealed: Literal[True]
+    if isinstance(x, (A, B)):
+        return True
+```
+
 ## Generic builtins should not overfit upper-bound-only callback constraints
 
 These examples are minimized from ecosystem regressions seen while preserving explicit `Never` and

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1911,28 +1911,39 @@ fn is_instance_tuple_exhaustive<'db>(db: &'db dyn Db, ty: Type<'db>, classinfo: 
         return false;
     }
 
-    is_instance_tuple_covers(db, &tuple, ty)
+    is_instance_tuple_covers(db, &tuple, ty, &ActiveRecursionDetector::default())
 }
 
-fn is_instance_tuple_covers<'db>(db: &'db dyn Db, tuple: &TupleSpec<'db>, ty: Type<'db>) -> bool {
-    match ty.resolve_type_alias(db) {
+fn is_instance_tuple_covers<'db>(
+    db: &'db dyn Db,
+    tuple: &TupleSpec<'db>,
+    ty: Type<'db>,
+    recursion_guard: &ActiveRecursionDetector<Type<'db>>,
+) -> bool {
+    match ty {
+        Type::TypeAlias(alias) => recursion_guard.visit(
+            &ty,
+            || true,
+            || is_instance_tuple_covers(db, tuple, alias.value_type(db), recursion_guard),
+        ),
         Type::Union(union) => union
             .elements(db)
             .iter()
-            .all(|element| is_instance_tuple_covers(db, tuple, *element)),
+            .all(|element| is_instance_tuple_covers(db, tuple, *element, recursion_guard)),
         Type::Intersection(intersection) => intersection
             .positive(db)
             .iter()
-            .any(|element| is_instance_tuple_covers(db, tuple, *element)),
+            .any(|element| is_instance_tuple_covers(db, tuple, *element, recursion_guard)),
         Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db) {
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                is_instance_tuple_covers(db, tuple, bound)
+                is_instance_tuple_covers(db, tuple, bound, recursion_guard)
             }
-            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
-                .elements(db)
-                .iter()
-                .all(|constraint| is_instance_tuple_covers(db, tuple, *constraint)),
-            None => is_instance_tuple_covers(db, tuple, Type::object()),
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                constraints.elements(db).iter().all(|constraint| {
+                    is_instance_tuple_covers(db, tuple, *constraint, recursion_guard)
+                })
+            }
+            None => is_instance_tuple_covers(db, tuple, Type::object(), recursion_guard),
         },
         ty => tuple.fixed_elements().any(|element| {
             let Type::ClassLiteral(class) = element else {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -85,6 +85,7 @@ use crate::types::list_members::all_members;
 use crate::types::narrow::ClassInfoConstraintFunction;
 use crate::types::relation::TypeRelationChecker;
 use crate::types::signatures::{CallableSignature, ReturnCallableTypeVarScope, Signature};
+use crate::types::tuple::TupleSpec;
 use crate::types::variance::{TypeVarVariance, VarianceInferable};
 use crate::types::visitor::non_any_dynamic_content;
 use crate::types::{
@@ -1890,7 +1891,7 @@ fn is_instance_truthiness<'db>(
     }
 }
 
-/// Return whether a fixed `isinstance` tuple covers every member of an input union.
+/// Return whether a fixed `isinstance` tuple covers every possible type of an input.
 ///
 /// Each class in the tuple uses the same truthiness inference as a single-class `isinstance` check.
 ///
@@ -1910,18 +1911,31 @@ fn is_instance_tuple_exhaustive<'db>(db: &'db dyn Db, ty: Type<'db>, classinfo: 
         return false;
     }
 
-    let is_covered = |ty: Type<'db>| {
-        tuple.fixed_elements().any(|element| {
+    is_instance_tuple_covers(db, &tuple, ty)
+}
+
+fn is_instance_tuple_covers<'db>(db: &'db dyn Db, tuple: &TupleSpec<'db>, ty: Type<'db>) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| is_instance_tuple_covers(db, tuple, *element)),
+        Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db) {
+            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                is_instance_tuple_covers(db, tuple, bound)
+            }
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
+                .elements(db)
+                .iter()
+                .all(|constraint| is_instance_tuple_covers(db, tuple, *constraint)),
+            None => is_instance_tuple_covers(db, tuple, Type::object()),
+        },
+        ty => tuple.fixed_elements().any(|element| {
             let Type::ClassLiteral(class) = element else {
                 return false;
             };
             is_instance_truthiness(db, ty, *class).is_always_true()
-        })
-    };
-
-    match ty {
-        Type::Union(union) => union.elements(db).iter().copied().all(is_covered),
-        ty => is_covered(ty),
+        }),
     }
 }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1920,6 +1920,10 @@ fn is_instance_tuple_covers<'db>(db: &'db dyn Db, tuple: &TupleSpec<'db>, ty: Ty
             .elements(db)
             .iter()
             .all(|element| is_instance_tuple_covers(db, tuple, *element)),
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .any(|element| is_instance_tuple_covers(db, tuple, *element)),
         Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db) {
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                 is_instance_tuple_covers(db, tuple, bound)


### PR DESCRIPTION
Follow-up to #26935.

Fixed `isinstance` tuple coverage only expanded a direct union. PEP 695 union aliases, constrained `TypeVar`s, and union-bounded `TypeVar`s therefore continued to infer `bool` and could incorrectly report an implicit `None` return even when every possible value was covered.

This recursively resolves aliases and expands union members plus TypeVar bounds/constraints before checking fixed tuple coverage. The added mdtest covers nested PEP 695 aliases, constrained TypeVars, union bounds, and alias bounds.