### PR TITLE
[ty] Check shared receiver domains in overloaded overrides

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1032,13 +1032,10 @@ class SameUnionReceiver(UnionMixin):
     def method(self: HasValue | HasOtherValue, argument: int) -> None: ...
 ```
 
-Overloaded mixin methods need the same treatment for every receiver-specific overload:
+When all overloads on a mixin method share the same explicit receiver annotation, the overload sets
+are compared within that common receiver domain:
 
 ```pyi
-# TODO: We should emit an `invalid-method-override` diagnostic on the second
-# `InvalidOverloadedReceiver.method` overload. Both overload sets need to be
-# compared within the `HasValue` receiver domain instead of being filtered
-# against the concrete mixin subclass.
 class OverloadedMixin:
     @overload
     def method(self: HasValue, argument: int) -> None: ...
@@ -1049,7 +1046,22 @@ class InvalidOverloadedReceiver(OverloadedMixin):
     @overload
     def method(self: HasValue, argument: int) -> None: ...
     @overload
-    def method(self: HasValue, argument: bytes) -> None: ...
+    def method(self: HasValue, argument: bytes) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `method`
+  --> src/mdtest_snippet.pyi:44:9
+   |
+44 |     def method(self: HasValue, argument: bytes) -> None: ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `OverloadedMixin.method`
+   |
+  ::: src/mdtest_snippet.pyi:38:9
+   |
+38 |     def method(self: HasValue, argument: str) -> None: ...
+   |         --------------------------------------------- `OverloadedMixin.method` defined here
+   |
+info: This violates the Liskov Substitution Principle
 ```
 
 The protocol may include the overridden method itself. This must not cause a valid implementation to

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1064,6 +1064,45 @@ error[invalid-method-override]: Invalid override of method `method`
 info: This violates the Liskov Substitution Principle
 ```
 
+An overloaded override cannot replace the shared receiver with an unrelated protocol:
+
+```pyi
+class InvalidOverloadedReceiverAnnotation(OverloadedMixin):
+    @overload
+    def method(self: HasOtherValue, argument: int) -> None: ...
+    @overload
+    def method(self: HasOtherValue, argument: str) -> None: ...  # error: [invalid-method-override]
+```
+
+The superclass method does not impose an override requirement on subclasses outside its receiver
+domain:
+
+```pyi
+class ExcludedOverloadedReceiver(OverloadedMixin):
+    def method(self, argument: bytes) -> bytes: ...
+```
+
+This also applies when a generic specialization excludes the subclass from the receiver domain:
+
+```pyi
+from typing import Generic, Literal, TypeVar, overload
+
+T = TypeVar("T")
+FlagT = TypeVar("FlagT", bound=bool)
+
+class Series: ...
+class DataFrame: ...
+
+class GroupBy(Generic[T]):
+    def size(self: GroupBy[Series]) -> Series: ...
+
+class DataFrameGroupBy(GroupBy[DataFrame], Generic[FlagT]):
+    @overload
+    def size(self: DataFrameGroupBy[Literal[True]]) -> Series: ...
+    @overload
+    def size(self: DataFrameGroupBy[Literal[False]]) -> DataFrame: ...
+```
+
 The protocol may include the overridden method itself. This must not cause a valid implementation to
 be rejected while checking the override:
 

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1074,6 +1074,28 @@ class InvalidOverloadedReceiverAnnotation(OverloadedMixin):
     def method(self: HasOtherValue, argument: str) -> None: ...  # error: [invalid-method-override]
 ```
 
+Explicit receiver annotations can also be disjoint from the superclass receiver domain:
+
+```pyi
+from typing import final
+
+@final
+class InDomain: ...
+
+class FinalReceiverMixin:
+    @overload
+    def method(self: InDomain, argument: int) -> None: ...
+    @overload
+    def method(self: InDomain, argument: str) -> None: ...
+
+@final
+class ExplicitlyExcludedReceiver(FinalReceiverMixin):
+    @overload
+    def method(self: ExplicitlyExcludedReceiver, argument: int) -> None: ...
+    @overload
+    def method(self: ExplicitlyExcludedReceiver, argument: bytes) -> None: ...
+```
+
 The superclass method does not impose an override requirement on subclasses outside its receiver
 domain:
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -718,13 +718,25 @@ fn method_override_types<'db>(
             receiver.map_or((subclass_type, superclass_type), |receiver| {
                 let typing_self_type = subclass_method.typing_self_type(db);
                 let receiver = receiver.bind_self_typevars(db, typing_self_type);
+                // An implicit receiver does not opt into a superclass receiver domain that
+                // excludes the subclass. Preserve normal overload filtering in that case.
+                if superclass_signature.overloads.len() > 1
+                    && !subclass_method
+                        .self_instance(db)
+                        .is_assignable_to(db, receiver)
+                    && subclass_method
+                        .function(db)
+                        .signature(db)
+                        .overloads
+                        .iter()
+                        .all(Signature::has_implicit_positional_receiver_annotation)
+                {
+                    return (subclass_type, superclass_type);
+                }
                 let receiver = IntersectionType::from_elements(
                     db,
                     [subclass_method.self_instance(db), receiver],
                 );
-                if receiver.is_never() {
-                    return (subclass_type, superclass_type);
-                }
                 (
                     Type::Callable(subclass_method.into_callable_type_with_receiver(
                         db,

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -737,6 +737,10 @@ fn method_override_types<'db>(
                     db,
                     [subclass_method.self_instance(db), receiver],
                 );
+                // Normal binding filters out overloads when the shared receiver domain is empty.
+                if superclass_signature.overloads.len() > 1 && receiver.is_never() {
+                    return (subclass_type, superclass_type);
+                }
                 (
                     Type::Callable(subclass_method.into_callable_type_with_receiver(
                         db,

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -699,17 +699,21 @@ fn method_override_types<'db>(
     let (subclass_type, superclass_type) = match (subclass_type, superclass_type) {
         (Type::BoundMethod(subclass_method), Type::BoundMethod(superclass_method)) => {
             let superclass_signature = superclass_method.function(db).signature(db);
-            let receiver = match superclass_signature.overloads.as_slice() {
-                [signature] => signature
+            let explicit_receiver_annotation = |signature: &Signature<'db>| {
+                signature
                     .parameters()
                     .get(0)
                     .filter(|parameter| parameter.is_positional() && !parameter.inferred_annotation)
-                    .map(Parameter::annotated_type),
-                // TODO: Compare overloaded mixin methods within each overload's explicit receiver
-                // domain. Binding them directly to the concrete subclass can filter out applicable
-                // overloads when the subclass does not itself satisfy the receiver protocol.
-                _ => None,
+                    .map(Parameter::annotated_type)
             };
+            let mut overloads = superclass_signature.overloads.iter();
+            let receiver = overloads
+                .next()
+                .and_then(&explicit_receiver_annotation)
+                .filter(|receiver| {
+                    overloads
+                        .all(|signature| explicit_receiver_annotation(signature) == Some(*receiver))
+                });
 
             receiver.map_or((subclass_type, superclass_type), |receiver| {
                 let typing_self_type = subclass_method.typing_self_type(db);
@@ -718,6 +722,9 @@ fn method_override_types<'db>(
                     db,
                     [subclass_method.self_instance(db), receiver],
                 );
+                if receiver.is_never() {
+                    return (subclass_type, superclass_type);
+                }
                 (
                     Type::Callable(subclass_method.into_callable_type_with_receiver(
                         db,
@@ -734,6 +741,7 @@ fn method_override_types<'db>(
         }
         _ => (subclass_type, superclass_type),
     };
+
     let superclass_callable = superclass_type.try_upcast_to_callable(db)?;
 
     Some((subclass_type, superclass_callable.into_type(db)))


### PR DESCRIPTION
## Summary

Follow-up to #26941.

That change compared single-signature mixin overrides within their explicit receiver domain. Overloaded methods still fell back to binding both methods to the concrete subclass, which could filter out every overload when the subclass did not itself satisfy the receiver protocol and hide an incompatible override.

This recognizes an explicit receiver annotation shared by every overload and compares both overload sets within the intersection of that receiver and the subclass instance. Mixed receiver domains and uninhabited intersections retain the existing receiver-filtering behavior.

Adds mdtest coverage for an overloaded protocol-receiver mixin that narrows one accepted argument type.
