### PR TITLE
[ty] Accept gradual constrained TypeVar solutions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -379,7 +379,7 @@ A heterogeneous collection can infer a union of tuple types. If every member of 
 compatible with `tuple[Any, ...]`, a constrained type variable can use that constraint.
 
 ```py
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import Any, TypeVar
 
 Row = TypeVar("Row", list[Any], tuple[Any, ...])
@@ -387,9 +387,16 @@ Row = TypeVar("Row", list[Any], tuple[Any, ...])
 class Dense: ...
 class Sparse: ...
 
-def consume(rows: Iterable[Row]) -> None: ...
+def consume(rows: Iterable[Row]) -> Row:
+    raise NotImplementedError
 
-consume([(1.0, Dense()), (0.0, Sparse())])
+reveal_type(consume([(1.0, Dense()), (0.0, Sparse())]))  # revealed: tuple[Any, ...]
+
+def callback(row: tuple[int, ...]) -> None: ...
+def consume_callback(callback: Callable[[Row], None]) -> Row:
+    raise NotImplementedError
+
+reveal_type(consume_callback(callback))  # revealed: tuple[Any, ...]
 ```
 
 ## Typevar inference is a unification problem

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -373,28 +373,23 @@ def unions_are_different(t1: int | str, t2: int | str) -> int | str:
     return t1 + t2
 ```
 
-## Gradual constrained typevars
+## Constraints containing `Any`
 
-A heterogeneous collection can infer a union whose members all promote to the same gradual
-constraint.
+A heterogeneous collection can infer a union of tuple types. If every member of that union is
+compatible with `tuple[Any, ...]`, a constrained type variable can use that constraint.
 
 ```py
 from collections.abc import Iterable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar
 
 Row = TypeVar("Row", list[Any], tuple[Any, ...])
 
 class Dense: ...
 class Sparse: ...
 
-@overload
-def create(data: Iterable[Row], schema: list[str] | tuple[str, ...]) -> None: ...
-@overload
-def create(data: int, schema: None = None) -> None: ...
-def create(data: object, schema: object = None) -> None:
-    raise NotImplementedError
+def consume(rows: Iterable[Row]) -> None: ...
 
-create([(1.0, Dense()), (0.0, Sparse())], ["label", "features"])
+consume([(1.0, Dense()), (0.0, Sparse())])
 ```
 
 ## Typevar inference is a unification problem

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -373,6 +373,30 @@ def unions_are_different(t1: int | str, t2: int | str) -> int | str:
     return t1 + t2
 ```
 
+## Gradual constrained typevars
+
+A heterogeneous collection can infer a union whose members all promote to the same gradual
+constraint.
+
+```py
+from collections.abc import Iterable
+from typing import Any, TypeVar, overload
+
+Row = TypeVar("Row", list[Any], tuple[Any, ...])
+
+class Dense: ...
+class Sparse: ...
+
+@overload
+def create(data: Iterable[Row], schema: list[str] | tuple[str, ...]) -> None: ...
+@overload
+def create(data: int, schema: None = None) -> None: ...
+def create(data: object, schema: object = None) -> None:
+    raise NotImplementedError
+
+create([(1.0, Dense()), (0.0, Sparse())], ["label", "features"])
+```
+
 ## Typevar inference is a unification problem
 
 When inferring typevar assignments in a generic function call, we cannot simply solve constraints

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -399,6 +399,38 @@ def consume_callback(callback: Callable[[Row], None]) -> Row:
 reveal_type(consume_callback(callback))  # revealed: tuple[Any, ...]
 ```
 
+## Gradual constraints can obscure a more specific constraint
+
+A gradual constraint that is compatible with a concrete argument can be selected before a more
+specific constraint. This makes inference depend on the order in which the constraints are declared.
+
+```py
+from typing import Any, TypeVar
+
+class Row(tuple[Any, ...]):
+    def asDict(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+GradualFirst = TypeVar("GradualFirst", list[Any], tuple[Any, ...], Row)
+RowFirst = TypeVar("RowFirst", Row, tuple[Any, ...], list[Any])
+
+def gradual_first(row: GradualFirst) -> GradualFirst:
+    return row
+
+def row_first(row: RowFirst) -> RowFirst:
+    return row
+
+gradual = gradual_first(Row())
+# TODO: revealed: Row
+reveal_type(gradual)  # revealed: tuple[Any, ...]
+# error: [unresolved-attribute] "Object of type `tuple[Any, ...]` has no attribute `asDict`"
+gradual.asDict()
+
+specific = row_first(Row())
+reveal_type(specific)  # revealed: Row
+specific.asDict()
+```
+
 ## Typevar inference is a unification problem
 
 When inferring typevar assignments in a generic function call, we cannot simply solve constraints

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -4067,12 +4067,16 @@ impl<'db> PathBounds<'db> {
                 for constraint in constraints.elements(db).iter().copied() {
                     let constraint_lower = constraint.bottom_materialization(db);
                     let constraint_upper = constraint.top_materialization(db);
+                    // A gradual constraint can choose any materialization that satisfies this
+                    // path. Its top materialization is the most permissive target for lower-bound
+                    // evidence, while its bottom materialization is the most permissive source
+                    // for upper-bound evidence.
                     let when_lower =
-                        lower.when_constraint_set_assignable_to_owned(db, constraint_lower);
+                        lower.when_constraint_set_assignable_to_owned(db, constraint_upper);
                     let when_upper =
                         path_bound
                             .upper
-                            .when_satisfied_by(db, builder, constraint_upper);
+                            .when_satisfied_by(db, builder, constraint_lower);
                     let when = builder
                         .load(db, &when_lower)
                         .and(db, builder, || when_upper);


### PR DESCRIPTION
## Summary

When solving a constrained type variable, we currently compare lower-bound evidence against each constraint's bottom materialization and upper-bound evidence against its top materialization. For a gradual constraint such as `tuple[Any, ...]`, that requires the evidence to fit every possible materialization instead of allowing the solver to choose a compatible one.

This PR instead compares lower-bound evidence with the top materialization and upper-bound evidence with the bottom materialization.
