### PR TITLE
[ty] Fix Callable isinstance reachability

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -161,6 +161,25 @@ def _(
     reveal_type(isinstance(x_constrained_sub_a, B))  # revealed: bool
 ```
 
+An `isinstance` check against `Callable` is always true when the checked value is known to be
+callable. This applies to both `typing.Callable` and `collections.abc.Callable`, including after a
+preceding `isinstance` check narrows a union.
+
+```py
+from collections.abc import Callable
+from typing import Callable as TypingCallable
+
+def reveal_callable_result(x: Callable[[int], int], y: Callable[[int], int] | dict[str, int]):
+    reveal_type(isinstance(x, Callable))  # revealed: Literal[True]
+    reveal_type(isinstance(x, TypingCallable))  # revealed: Literal[True]
+
+    if isinstance(y, dict):
+        return
+
+    reveal_type(isinstance(y, Callable))  # revealed: Literal[True]
+    reveal_type(isinstance(y, TypingCallable))  # revealed: Literal[True]
+```
+
 An `isinstance` check against a tuple is always true when each possible type of the checked value is
 accepted by at least one class in the tuple. This avoids a false implicit-return error when the
 check is the only path that returns a value. The same applies when the tuple is assigned to a local

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -818,3 +818,34 @@ def i(x: ComplexN) -> bool:
     elif isinstance(x, complex):
         return False
 ```
+
+## `isinstance` checks with `Callable`
+
+```toml
+[environment]
+python-version = "3.12"
+
+[rules]
+possibly-unresolved-reference = "error"
+```
+
+The final `Callable` check is exhaustive. These examples deliberately omit an `else` branch and any
+terminal-call assertions so that reachability is determined by the `isinstance` checks alone.
+
+```py
+from collections.abc import Callable
+from typing import Callable as TypingCallable
+
+def assigned(x: Callable[[int], int] | dict[str, int]) -> int:
+    if isinstance(x, dict):
+        result = 1
+    elif isinstance(x, Callable):
+        result = 2
+    return result
+
+def returns(x: Callable[[int], int] | dict[str, int]) -> int:
+    if isinstance(x, dict):
+        return 1
+    elif isinstance(x, TypingCallable):
+        return 2
+```

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -848,4 +848,11 @@ def returns(x: Callable[[int], int] | dict[str, int]) -> int:
         return 1
     elif isinstance(x, TypingCallable):
         return 2
+
+def match_exhaustive(x: Callable[[int], int] | dict[str, int]) -> int:
+    match x:
+        case dict():
+            return 1
+        case Callable():
+            return 2
 ```

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5403,17 +5403,19 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         // Some typing special forms are valid class-info arguments at runtime but are not
         // assignable to typeshed's `isinstance`/`issubclass` class-info annotation.
-        let is_valid_isinstance_target = parameter_index == 1
-            && adjusted_argument_index == Some(1)
-            && matches!(
-                self.signature_type
-                    .as_function_literal()
-                    .and_then(|function| function.known(self.db)),
-                Some(KnownFunction::IsInstance | KnownFunction::IsSubclass)
-            )
-            && argument_type
-                .as_special_form()
-                .is_some_and(SpecialFormType::is_valid_isinstance_target);
+        let is_valid_isinstance_target = || {
+            parameter_index == 1
+                && adjusted_argument_index == Some(1)
+                && matches!(
+                    self.signature_type
+                        .as_function_literal()
+                        .and_then(|function| function.known(self.db)),
+                    Some(KnownFunction::IsInstance | KnownFunction::IsSubclass)
+                )
+                && argument_type
+                    .as_special_form()
+                    .is_some_and(SpecialFormType::is_valid_isinstance_target)
+        };
 
         // This is one of the few places where we want to check if there's _any_ specialization
         // where assignability holds; normally we want to check that assignability holds for
@@ -5431,7 +5433,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // TODO: handle starred annotations, e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...]]`
         if !self.constraint_set_errors[argument_index]
             && !parameter.has_starred_annotation()
-            && !is_valid_isinstance_target
+            && !is_valid_isinstance_target()
             && argument_type
                 .when_assignable_to(self.db, expected_ty, constraints, self.inferable_typevars)
                 .is_never_satisfied(self.db)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5400,6 +5400,21 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             argument_type = argument_type.apply_specialization(self.db, specialization);
             expected_ty = expected_ty.apply_specialization(self.db, specialization);
         }
+
+        // Some typing special forms are valid class-info arguments at runtime but are not
+        // assignable to typeshed's `isinstance`/`issubclass` class-info annotation.
+        let is_valid_isinstance_target = parameter_index == 1
+            && adjusted_argument_index == Some(1)
+            && matches!(
+                self.signature_type
+                    .as_function_literal()
+                    .and_then(|function| function.known(self.db)),
+                Some(KnownFunction::IsInstance | KnownFunction::IsSubclass)
+            )
+            && argument_type
+                .as_special_form()
+                .is_some_and(SpecialFormType::is_valid_isinstance_target);
+
         // This is one of the few places where we want to check if there's _any_ specialization
         // where assignability holds; normally we want to check that assignability holds for
         // _all_ specializations.
@@ -5416,6 +5431,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // TODO: handle starred annotations, e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...]]`
         if !self.constraint_set_errors[argument_index]
             && !parameter.has_starred_annotation()
+            && !is_valid_isinstance_target
             && argument_type
                 .when_assignable_to(self.db, expected_ty, constraints, self.inferable_typevars)
                 .is_never_satisfied(self.db)
@@ -7453,31 +7469,6 @@ impl<'db> BindingError<'db> {
                 provided_ty,
                 provenance,
             } => {
-                // Certain special forms in the typing module are aliases for classes
-                // elsewhere in the standard library. These special forms are not instances of `type`,
-                // and you cannot use them in place of their aliased classes in *all* situations:
-                // for example, `dict()` succeeds at runtime, but `typing.Dict()` fails. However,
-                // they *can* all be used as the second argument to `isinstance` and `issubclass`.
-                // We model that specific aspect of their behaviour here.
-                //
-                // This is implemented as a special case in call-binding machinery because overriding
-                // typeshed's signatures for `isinstance()` and `issubclass()` would be complex and
-                // error-prone, due to the fact that they are annotated with recursive type aliases.
-                if parameter.index == 1
-                    && *argument_index == Some(1)
-                    && matches!(
-                        callable_ty
-                            .as_function_literal()
-                            .and_then(|function| function.known(context.db())),
-                        Some(KnownFunction::IsInstance | KnownFunction::IsSubclass)
-                    )
-                    && provided_ty
-                        .as_special_form()
-                        .is_some_and(SpecialFormType::is_valid_isinstance_target)
-                {
-                    return;
-                }
-
                 // TODO: Ideally we would not emit diagnostics for `TypedDict` literal arguments
                 // here (see `diagnostic::is_invalid_typed_dict_literal`). However, we may have
                 // silenced diagnostics during overload evaluation, and rely on the assignability

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2629,6 +2629,18 @@ impl KnownFunction {
                 if self == KnownFunction::IsInstance {
                     let truthiness = match second_argument {
                         Type::ClassLiteral(class) => is_instance_truthiness(db, *first_arg, *class),
+                        Type::SpecialForm(
+                            SpecialFormType::TypingCallable
+                            | SpecialFormType::CollectionsAbcCallable,
+                        ) => {
+                            let callable_top =
+                                Type::Callable(CallableType::unknown(db)).top_materialization(db);
+                            if first_arg.is_subtype_of(db, callable_top) {
+                                Truthiness::AlwaysTrue
+                            } else {
+                                Truthiness::Ambiguous
+                            }
+                        }
                         _ if is_instance_tuple_exhaustive(db, *first_arg, *second_argument) => {
                             Truthiness::AlwaysTrue
                         }


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ty/issues/4030.

`isinstance(x, Callable)` correctly narrows a remaining callable value, but the call was still represented as an internally failed binding because typing special forms were only exempted while reporting `invalid-argument-type`. As a result, the known-function truthiness hook never ran and exhaustive branches could incorrectly produce `possibly-unresolved-reference` or `invalid-return-type`.

This moves the existing runtime-valid `isinstance`/`issubclass` special-form exception into argument binding, removes the redundant diagnostic-layer suppression, and infers `Literal[True]` for both `typing.Callable` and `collections.abc.Callable` when the checked value is known to be callable.

## Test Plan

Added direct truthiness and exhaustive-control-flow mdtests covering both Callable spellings and a previously narrowed union.