### PR TITLE
[`pydocstyle`] Document fix safety (`D400`)

### DIFF
--- a/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -35,6 +35,11 @@ use crate::rules::pydocstyle::helpers::logical_line;
 ///     """Return the mean of the given values."""
 /// ```
 ///
+/// ## Fix safety
+/// This fix is marked as unsafe, as it may alter the intended formatting of the
+/// docstring, or affect tools that parse docstrings and rely on specific
+/// formatting.
+///
 /// ## Options
 /// - `lint.pydocstyle.convention`
 ///


### PR DESCRIPTION
Addresses #15584 for D400. Adds fix safety documentation to the `D400` rule.