### PR TITLE
[`flake8-simplify`] Clarify `os.environ` behavior on Windows (`SIM112`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -19,7 +19,7 @@ use crate::{AlwaysFixableViolation, Edit, Fix, FixAvailability, Violation};
 /// Furthermore, `os.environ` behaves differently across platforms. On Windows,
 /// `os.environ` automatically converts environment variable names to uppercase.
 /// This means that if you define a lowercase environment variable (e.g., `foo=1`),
-/// looking it up or iterating over `os.environ` will yield `FOO` on Windows, but
+/// iterating over `os.environ` will yield `FOO` on Windows, but
 /// `foo` on Linux and macOS. This can lead to subtle bugs in cross-platform code
 /// if it assumes environment variables preserve their original case.
 ///

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -16,8 +16,12 @@ use crate::{AlwaysFixableViolation, Edit, Fix, FixAvailability, Violation};
 /// ## Why is this bad?
 /// By convention, environment variables should be capitalized.
 ///
-/// On Windows, environment variables are case-insensitive and are converted to
-/// uppercase, so using lowercase environment variables can lead to subtle bugs.
+/// Furthermore, `os.environ` behaves differently across platforms. On Windows,
+/// `os.environ` automatically converts environment variable names to uppercase.
+/// This means that if you define a lowercase environment variable (e.g., `foo=1`),
+/// looking it up or iterating over `os.environ` will yield `FOO` on Windows, but
+/// `foo` on Linux and macOS. This can lead to subtle bugs in cross-platform code
+/// if it assumes environment variables preserve their original case.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
Closes #14353. Clarifies that `os.environ` converts environment variables to uppercase on Windows, which can lead to cross-platform bugs if code assumes variables preserve their original case.