### PR TITLE
DOC: fix misleading SIM107 example (#22325)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -16,26 +16,24 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
-/// def squared(n):
+/// def process_data(data):
 ///     try:
-///         sqr = n**2
-///         return sqr
-///     except Exception:
-///         return "An exception occurred"
+///         return transform(data)
+///     except ValueError:
+///         return None
 ///     finally:
 ///         return -1  # Always returns -1.
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// def squared(n):
+/// def process_data(data):
 ///     try:
-///         return_value = n**2
-///     except Exception:
-///         return_value = "An exception occurred"
+///         return transform(data)
+///     except ValueError:
+///         return None
 ///     finally:
-///         return_value = -1
-///     return return_value
+///         cleanup(data)
 /// ```
 ///
 /// ## References


### PR DESCRIPTION
Closes #22325. Replaces the broken `SIM107` documentation example that overwrites a return variable with one that correctly demonstrates a cleanup action in the `finally` block.