### PR TITLE
DOC: Emphasize that implementing `__hash__` for mutable objects is unsound in PLW1641

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -16,26 +16,24 @@ use crate::checkers::ast::Checker;
 ///
 /// ## Example
 /// ```python
-/// def squared(n):
+/// def process_data(data):
 ///     try:
-///         sqr = n**2
-///         return sqr
-///     except Exception:
-///         return "An exception occurred"
+///         return transform(data)
+///     except ValueError:
+///         return None
 ///     finally:
 ///         return -1  # Always returns -1.
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// def squared(n):
+/// def process_data(data):
 ///     try:
-///         return_value = n**2
-///     except Exception:
-///         return_value = "An exception occurred"
+///         return transform(data)
+///     except ValueError:
+///         return None
 ///     finally:
-///         return_value = -1
-///     return return_value
+///         cleanup(data)
 /// ```
 ///
 /// ## References

--- a/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs
@@ -21,6 +21,10 @@ use crate::checkers::ast::Checker;
 /// cause issues when using instances of the class as keys in a dictionary or
 /// members of a set.
 ///
+/// Note that `__hash__` should only be defined for immutable objects. If the
+/// class is intended to be mutable, you should instead explicitly annotate it
+/// with `__hash__ = None`.
+///
 /// ## Example
 ///
 /// ```python


### PR DESCRIPTION
Closes #18821.

Updates the `eq-without-hash` (PLW1641) documentation to explicitly note that `__hash__` should only be defined for immutable objects, and that mutable classes should be annotated with `__hash__ = None` instead of implementing a custom hash method.