### PR TITLE
Prefer `let` guards and direct pattern matching

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{self as ast, helpers::is_dunder, name::QualifiedName};
-use ruff_python_semantic::{FromImport, Import, Imported, ResolvedReference, Scope};
+use ruff_python_semantic::{AnyImport, FromImport, Import, Imported, ResolvedReference, Scope};
 use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
 use ruff_text_size::Ranged;
 
@@ -79,9 +79,9 @@ pub(crate) fn import_private_name(checker: &Checker, scope: &Scope) {
         };
 
         let import_info = match import {
-            import if import.is_import() => ImportInfo::from(import.import().unwrap()),
-            import if import.is_from_import() => ImportInfo::from(import.from_import().unwrap()),
-            _ => continue,
+            AnyImport::Import(import) => ImportInfo::from(import),
+            AnyImport::FromImport(import) => ImportInfo::from(import),
+            AnyImport::SubmoduleImport(_) => continue,
         };
 
         let Some(root_module) = import_info.module_name.first() else {

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
@@ -386,15 +386,16 @@ fn affix_matches_slice_bound(data: &RemoveAffixData, semantic: &SemanticModel) -
                 node_index: _,
                 value: string_val,
             }),
-        ) if operand.is_number_literal_expr() => operand.as_number_literal_expr().is_some_and(
-            |ast::ExprNumberLiteral { value, .. }| {
-                // Only support prefix removal for size at most `u32::MAX`
-                value
-                    .as_int()
-                    .and_then(ast::Int::as_usize)
-                    .is_some_and(|x| x == string_val.chars().count())
-            },
-        ),
+        ) if let ast::Expr::NumberLiteral(ast::ExprNumberLiteral {
+            value: ast::Number::Int(value),
+            ..
+        }) = &**operand =>
+        {
+            // Only support prefix removal for size at most `u32::MAX`
+            value
+                .as_usize()
+                .is_some_and(|x| x == string_val.chars().count())
+        }
         (
             AffixKind::EndsWith,
             ast::Expr::UnaryOp(ast::ExprUnaryOp {

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -649,11 +649,14 @@ impl<'src> Lexer<'src> {
                     self.cursor.bump();
                     Some(quote)
                 }
-                second if is_quote(self.cursor.second()) => {
+                second
+                    if let quote = self.cursor.second()
+                        && is_quote(quote) =>
+                {
                     self.try_double_char_prefix([first, second]).then(|| {
                         self.cursor.bump();
-                        // SAFETY: Safe because of the `is_quote` check in this match arm's guard
-                        self.cursor.bump().unwrap()
+                        self.cursor.bump();
+                        quote
                     })
                 }
                 _ => None,

--- a/crates/ty_ide/src/docstring/markdown/general.rs
+++ b/crates/ty_ide/src/docstring/markdown/general.rs
@@ -191,17 +191,18 @@ fn render_with_indentation_mode(
             match directive {
                 // Special directives that should be plaintext
                 Some(
-                    "attention" | "caution" | "danger" | "error" | "hint" | "important" | "note"
-                    | "tip" | "warning" | "admonition" | "versionadded" | "version-added"
-                    | "versionchanged" | "version-changed" | "version-deprecated" | "deprecated"
-                    | "version-removed" | "versionremoved",
+                    directive @ ("attention" | "caution" | "danger" | "error" | "hint"
+                    | "important" | "note" | "tip" | "warning" | "admonition"
+                    | "versionadded" | "version-added" | "versionchanged"
+                    | "version-changed" | "version-deprecated" | "deprecated"
+                    | "version-removed" | "versionremoved"),
                 ) => {
                     // A directive starts a new block and cannot continue a
                     // pending hyperlink from the previous line.
                     renderer.flush_pending_link();
 
                     // Map version directives to human-readable phrases (matching Sphinx output)
-                    let pretty_directive = match directive.unwrap() {
+                    let pretty_directive = match directive {
                         "versionadded" | "version-added" => Cow::Borrowed("Added in version"),
                         "versionchanged" | "version-changed" => Cow::Borrowed("Changed in version"),
                         "deprecated" | "version-deprecated" => {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3328,7 +3328,8 @@ impl<'db> Type<'db> {
                     return Some((ty, AttributeKind::NormalOrNonDataDescriptor));
                 }
                 Type::Callable(callable)
-                    if callable.is_function_like(db) || callable.is_classmethod_like(db) =>
+                    if let is_function_like = callable.is_function_like(db)
+                        && (is_function_like || callable.is_classmethod_like(db)) =>
                 {
                     // For "function-like" or "classmethod-like" callables, model the behavior of
                     // `FunctionType.__get__` or `classmethod.__get__`.
@@ -3338,7 +3339,7 @@ impl<'db> Type<'db> {
                     // method of these synthesized functions. The method-wrapper would then be returned from
                     // `find_name_in_mro` when called on function-like `Callable`s. This would allow us to
                     // correctly model the behavior of *explicit* `SomeDataclass.__init__.__get__` calls.
-                    return if instance.is_none() && callable.is_function_like(db) {
+                    return if instance.is_none() && is_function_like {
                         Some((ty, AttributeKind::NormalOrNonDataDescriptor))
                     } else {
                         let self_type = instance.unwrap_or_else(|| {
@@ -4258,7 +4259,7 @@ impl<'db> Type<'db> {
                     let is_enum_subclass = Type::ClassLiteral(enum_class.class_literal(db))
                         .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db));
 
-                    (match name_str {
+                    let ty = match name_str {
                         "name" if is_enum_subclass => {
                             enum_class.name_type(db, enum_literal.name(db))
                         }
@@ -4268,9 +4269,9 @@ impl<'db> Type<'db> {
                         }
                         "_value_" => enum_class.value_type(db, enum_literal.name(db)),
                         _ => None,
-                    })
-                    .map_or_else(|| Place::Undefined, Place::bound)
-                    .into()
+                    };
+
+                    ty.map(Place::bound).unwrap_or_default().into()
                 }
 
                 Type::TypeVar(typevar) if name_str == "args" && typevar.is_paramspec(db) => {
@@ -4308,27 +4309,22 @@ impl<'db> Type<'db> {
 
                 Type::NominalInstance(instance)
                     if matches!(name_str, "name" | "_name_" | "value" | "_value_")
-                        && enum_metadata(db, instance.class_literal(db)).is_some()
-                        && !enums::class_defines_property(
-                            db,
-                            instance.class_literal(db),
-                            name_str,
-                        ) =>
+                        && let class_literal = instance.class_literal(db)
+                        && let Some(metadata) = enum_metadata(db, class_literal)
+                        && !enums::class_defines_property(db, class_literal, name_str) =>
                 {
-                    let class_literal = instance.class_literal(db);
                     let is_enum_subclass = Type::ClassLiteral(class_literal)
                         .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db));
 
-                    enum_metadata(db, class_literal)
-                        .and_then(|metadata| match name_str {
-                            "name" if is_enum_subclass => metadata.instance_name_type(db),
-                            "_name_" => metadata.instance_name_type(db),
-                            "value" if is_enum_subclass => metadata.instance_value_type(db),
-                            "_value_" => metadata.instance_value_type(db),
-                            _ => None,
-                        })
-                        .map_or_else(Place::default, Place::bound)
-                        .into()
+                    let ty = match name_str {
+                        "name" if is_enum_subclass => metadata.instance_name_type(db),
+                        "_name_" => metadata.instance_name_type(db),
+                        "value" if is_enum_subclass => metadata.instance_value_type(db),
+                        "_value_" => metadata.instance_value_type(db),
+                        _ => None,
+                    };
+
+                    ty.map(Place::bound).unwrap_or_default().into()
                 }
 
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial))

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1748,52 +1748,44 @@ impl<'db> Bindings<'db> {
                     },
 
                     Type::BoundMethod(bound_method)
-                        if bound_method.self_instance(db).is_property_instance() =>
+                        if let Type::PropertyInstance(property) =
+                            bound_method.self_instance(db) =>
                     {
                         match bound_method.function(db).name(db).as_str() {
                             "setter" => {
                                 if let [Some(_), Some(setter)] = overload.parameter_types() {
-                                    let mut ty_property = bound_method.self_instance(db);
-                                    if let Type::PropertyInstance(property) = ty_property {
-                                        ty_property =
-                                            Type::PropertyInstance(property.with_accessors(
-                                                db,
-                                                property.getter(db),
-                                                Some(*setter),
-                                                property.deleter(db),
-                                            ));
-                                    }
-                                    overload.set_return_type(ty_property);
+                                    overload.set_return_type(Type::PropertyInstance(
+                                        property.with_accessors(
+                                            db,
+                                            property.getter(db),
+                                            Some(*setter),
+                                            property.deleter(db),
+                                        ),
+                                    ));
                                 }
                             }
                             "getter" => {
                                 if let [Some(_), Some(getter)] = overload.parameter_types() {
-                                    let mut ty_property = bound_method.self_instance(db);
-                                    if let Type::PropertyInstance(property) = ty_property {
-                                        ty_property =
-                                            Type::PropertyInstance(property.with_accessors(
-                                                db,
-                                                Some(*getter),
-                                                property.setter(db),
-                                                property.deleter(db),
-                                            ));
-                                    }
-                                    overload.set_return_type(ty_property);
+                                    overload.set_return_type(Type::PropertyInstance(
+                                        property.with_accessors(
+                                            db,
+                                            Some(*getter),
+                                            property.setter(db),
+                                            property.deleter(db),
+                                        ),
+                                    ));
                                 }
                             }
                             "deleter" => {
                                 if let [Some(_), Some(deleter)] = overload.parameter_types() {
-                                    let mut ty_property = bound_method.self_instance(db);
-                                    if let Type::PropertyInstance(property) = ty_property {
-                                        ty_property =
-                                            Type::PropertyInstance(property.with_accessors(
-                                                db,
-                                                property.getter(db),
-                                                property.setter(db),
-                                                Some(*deleter),
-                                            ));
-                                    }
-                                    overload.set_return_type(ty_property);
+                                    overload.set_return_type(Type::PropertyInstance(
+                                        property.with_accessors(
+                                            db,
+                                            property.getter(db),
+                                            property.setter(db),
+                                            Some(*deleter),
+                                        ),
+                                    ));
                                 }
                             }
                             _ => {
@@ -5748,7 +5740,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     callable_binding.overload_call_return_type,
                     Some(OverloadCallReturnType::ArgumentTypeExpansion(_))
                 ) {
-                    extend_errors(&callable_binding.overloads().first().unwrap().errors);
+                    extend_errors(&callable_binding.overloads()[0].errors);
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2760,17 +2760,15 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             (Type::TypeForm(formal_typeform), Type::KnownInstance(actual_instance))
-                if actual_instance.is_type_form_value() =>
+                if let Some(actual_argument) = actual_instance.type_form_argument(self.db) =>
             {
                 let variance = TypeVarVariance::Covariant.compose(polarity);
-                if let Some(actual_argument) = actual_instance.type_form_argument(self.db) {
-                    return self.infer_map_impl(
-                        formal_typeform.type_argument(self.db),
-                        actual_argument,
-                        variance,
-                        seen,
-                    );
-                }
+                return self.infer_map_impl(
+                    formal_typeform.type_argument(self.db),
+                    actual_argument,
+                    variance,
+                    seen,
+                );
             }
 
             (Type::TypeForm(formal_typeform), Type::SpecialForm(actual_form)) => {

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -624,9 +624,10 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
                 }
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
                     if kind.is_empty()
-                        && subject_ty.is_subtype_of(db, callable_pattern_type(db)) =>
+                        && let callable_pattern_ty = callable_pattern_type(db)
+                        && subject_ty.is_subtype_of(db, callable_pattern_ty) =>
                 {
-                    return callable_pattern_type(db);
+                    return callable_pattern_ty;
                 }
                 _ => {}
             }

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -505,11 +505,7 @@ fn arbitrary_parameter_list(g: &mut Gen, size: u32, fully_static: bool) -> Vec<P
 }
 
 fn arbitrary_optional_type(g: &mut Gen, size: u32, fully_static: bool) -> Option<Ty> {
-    match u32::arbitrary(g) % 2 {
-        0 => None,
-        1 => Some(arbitrary_type(g, size, fully_static)),
-        _ => unreachable!(),
-    }
+    bool::arbitrary(g).then(|| arbitrary_type(g, size, fully_static))
 }
 
 fn arbitrary_name(g: &mut Gen) -> Name {
@@ -517,11 +513,7 @@ fn arbitrary_name(g: &mut Gen) -> Name {
 }
 
 fn arbitrary_optional_name(g: &mut Gen) -> Option<Name> {
-    match u32::arbitrary(g) % 2 {
-        0 => None,
-        1 => Some(arbitrary_name(g)),
-        _ => unreachable!(),
-    }
+    bool::arbitrary(g).then(|| arbitrary_name(g))
 }
 
 impl Arbitrary for Ty {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1194,15 +1194,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 ),
 
             (Type::KnownInstance(source_instance), Type::TypeForm(target_typeform))
-                if source_instance.is_type_form_value() =>
+                if let Some(source_argument) = source_instance.type_form_argument(db) =>
             {
-                source_instance.type_form_argument(db).when_some_and(
-                    db,
-                    self.constraints,
-                    |source_argument| {
-                        self.check_type_pair(db, source_argument, target_typeform.type_argument(db))
-                    },
-                )
+                self.check_type_pair(db, source_argument, target_typeform.type_argument(db))
             }
 
             (Type::SpecialForm(source_form), Type::TypeForm(target_typeform)) => source_form


### PR DESCRIPTION
## Summary

Use `let` guards and direct pattern matching across Ruff and ty to simplify control flow, avoid repeated queries and redundant variant checks, and remove several unnecessary `unwrap()` and `unreachable!()` calls.

## Test Plan

Existing tests