### PR TITLE
Propagate invalid format type characters from `FormatSpec::parse()` in `ruff_python_literal`

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_character.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/bad_string_format_character.rs
@@ -50,16 +50,8 @@ pub(crate) fn call(checker: &Checker, string: &str, range: TextRange) {
             };
 
             match FormatSpec::parse(format_spec) {
-                Err(FormatSpecError::InvalidFormatType) => {
-                    checker.report_diagnostic(
-                        BadStringFormatCharacter {
-                            // The format type character is always the last one.
-                            // More info in the official spec:
-                            // https://docs.python.org/3/library/string.html#format-specification-mini-language
-                            format_char: format_spec.chars().last().unwrap(),
-                        },
-                        range,
-                    );
+                Err(FormatSpecError::InvalidFormatType(format_char)) => {
+                    checker.report_diagnostic(BadStringFormatCharacter { format_char }, range);
                 }
                 Err(_) => {}
                 Ok(FormatSpec::Static(_)) => {}
@@ -68,18 +60,11 @@ pub(crate) fn call(checker: &Checker, string: &str, range: TextRange) {
                         let FormatPart::Field { format_spec, .. } = placeholder else {
                             continue;
                         };
-                        if let Err(FormatSpecError::InvalidFormatType) =
+                        if let Err(FormatSpecError::InvalidFormatType(format_char)) =
                             FormatSpec::parse(&format_spec)
                         {
-                            checker.report_diagnostic(
-                                BadStringFormatCharacter {
-                                    // The format type character is always the last one.
-                                    // More info in the official spec:
-                                    // https://docs.python.org/3/library/string.html#format-specification-mini-language
-                                    format_char: format_spec.chars().last().unwrap(),
-                                },
-                                range,
-                            );
+                            checker
+                                .report_diagnostic(BadStringFormatCharacter { format_char }, range);
                         }
                     }
                 }

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -5,12 +5,6 @@ use std::str::FromStr;
 
 use crate::Case;
 
-trait FormatParse {
-    fn parse(text: &str) -> (Option<Self>, &str)
-    where
-        Self: Sized;
-}
-
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FormatConversion {
     Str,
@@ -19,7 +13,7 @@ pub enum FormatConversion {
     Bytes,
 }
 
-impl FormatParse for FormatConversion {
+impl FormatConversion {
     fn parse(text: &str) -> (Option<Self>, &str) {
         let Some(conversion) = Self::from_string(text) else {
             return (None, text);
@@ -72,7 +66,7 @@ impl FormatAlign {
     }
 }
 
-impl FormatParse for FormatAlign {
+impl FormatAlign {
     fn parse(text: &str) -> (Option<Self>, &str) {
         let mut chars = text.chars();
         if let Some(maybe_align) = chars.next().and_then(Self::from_char) {
@@ -90,15 +84,16 @@ pub enum FormatSign {
     MinusOrSpace,
 }
 
-impl FormatParse for FormatSign {
+impl FormatSign {
     fn parse(text: &str) -> (Option<Self>, &str) {
         let mut chars = text.chars();
-        match chars.next() {
-            Some('-') => (Some(Self::Minus), chars.as_str()),
-            Some('+') => (Some(Self::Plus), chars.as_str()),
-            Some(' ') => (Some(Self::MinusOrSpace), chars.as_str()),
-            _ => (None, text),
-        }
+        let kind = match chars.next() {
+            Some('-') => Self::Minus,
+            Some('+') => Self::Plus,
+            Some(' ') => Self::MinusOrSpace,
+            Some(_) | None => return (None, text),
+        };
+        (Some(kind), chars.as_str())
     }
 }
 
@@ -108,13 +103,13 @@ pub enum FormatGrouping {
     Underscore,
 }
 
-impl FormatParse for FormatGrouping {
+impl FormatGrouping {
     fn parse(text: &str) -> (Option<Self>, &str) {
         let mut chars = text.chars();
         match chars.next() {
             Some('_') => (Some(Self::Underscore), chars.as_str()),
             Some(',') => (Some(Self::Comma), chars.as_str()),
-            _ => (None, text),
+            Some(_) | None => (None, text),
         }
     }
 }
@@ -157,29 +152,30 @@ impl From<&FormatType> for char {
     }
 }
 
-impl FormatParse for FormatType {
-    fn parse(text: &str) -> (Option<Self>, &str) {
+impl FormatType {
+    fn parse(text: &str) -> (Result<Self, Option<char>>, &str) {
         let mut chars = text.chars();
-        match chars.next() {
-            Some('s') => (Some(Self::String), chars.as_str()),
-            Some('b') => (Some(Self::Binary), chars.as_str()),
-            Some('c') => (Some(Self::Character), chars.as_str()),
-            Some('d') => (Some(Self::Decimal), chars.as_str()),
-            Some('o') => (Some(Self::Octal), chars.as_str()),
-            Some('n') => (Some(Self::Number(Case::Lower)), chars.as_str()),
-            Some('N') => (Some(Self::Number(Case::Upper)), chars.as_str()),
-            Some('x') => (Some(Self::Hex(Case::Lower)), chars.as_str()),
-            Some('X') => (Some(Self::Hex(Case::Upper)), chars.as_str()),
-            Some('e') => (Some(Self::Exponent(Case::Lower)), chars.as_str()),
-            Some('E') => (Some(Self::Exponent(Case::Upper)), chars.as_str()),
-            Some('f') => (Some(Self::FixedPoint(Case::Lower)), chars.as_str()),
-            Some('F') => (Some(Self::FixedPoint(Case::Upper)), chars.as_str()),
-            Some('g') => (Some(Self::GeneralFormat(Case::Lower)), chars.as_str()),
-            Some('G') => (Some(Self::GeneralFormat(Case::Upper)), chars.as_str()),
-            Some('%') => (Some(Self::Percentage), chars.as_str()),
-            Some(_) => (None, chars.as_str()),
-            _ => (None, text),
-        }
+        let kind = match chars.next() {
+            Some('s') => Self::String,
+            Some('b') => Self::Binary,
+            Some('c') => Self::Character,
+            Some('d') => Self::Decimal,
+            Some('o') => Self::Octal,
+            Some('n') => Self::Number(Case::Lower),
+            Some('N') => Self::Number(Case::Upper),
+            Some('x') => Self::Hex(Case::Lower),
+            Some('X') => Self::Hex(Case::Upper),
+            Some('e') => Self::Exponent(Case::Lower),
+            Some('E') => Self::Exponent(Case::Upper),
+            Some('f') => Self::FixedPoint(Case::Lower),
+            Some('F') => Self::FixedPoint(Case::Upper),
+            Some('g') => Self::GeneralFormat(Case::Lower),
+            Some('G') => Self::GeneralFormat(Case::Upper),
+            Some('%') => Self::Percentage,
+            Some(invalid) => return (Err(Some(invalid)), chars.as_str()),
+            None => return (Err(None), text),
+        };
+        (Ok(kind), chars.as_str())
     }
 }
 
@@ -297,7 +293,7 @@ fn parse_alternate_form(text: &str) -> (bool, &str) {
     let mut chars = text.chars();
     match chars.next() {
         Some('#') => (true, chars.as_str()),
-        _ => (false, text),
+        Some(_) | None => (false, text),
     }
 }
 
@@ -323,7 +319,7 @@ fn parse_precision(text: &str) -> Result<(Option<usize>, &str), FormatSpecError>
                 (None, text)
             }
         }
-        _ => (None, text),
+        Some(_) | None => (None, text),
     })
 }
 
@@ -368,20 +364,17 @@ impl FormatSpec {
         let (grouping_option, text) = FormatGrouping::parse(text);
         let (precision, text) = parse_precision(text)?;
 
-        let (format_type, _text) = if text.is_empty() {
-            (None, text)
-        } else {
-            // If there's any remaining text, we should yield a valid format type and consume it
-            // all.
-            let (format_type, text) = FormatType::parse(text);
-            if format_type.is_none() {
-                return Err(FormatSpecError::InvalidFormatType);
-            }
-            if !text.is_empty() {
-                return Err(FormatSpecError::InvalidFormatSpecifier);
-            }
-            (format_type, text)
+        // If there's any remaining text, we should yield a valid format type and consume it
+        // all.
+        let (format_type, text) = FormatType::parse(text);
+        let format_type = match format_type {
+            Ok(format) => Some(format),
+            Err(Some(invalid)) => return Err(FormatSpecError::InvalidFormatType(invalid)),
+            Err(None) => None,
         };
+        if !text.is_empty() {
+            return Err(FormatSpecError::InvalidFormatSpecifier);
+        }
 
         if zero && fill.is_none() {
             fill.replace('0');
@@ -407,7 +400,7 @@ pub enum FormatSpecError {
     DecimalDigitsTooMany,
     PrecisionTooBig,
     InvalidFormatSpecifier,
-    InvalidFormatType,
+    InvalidFormatType(char),
     InvalidPlaceholder(FormatParseError),
     PlaceholderRecursionExceeded,
     UnspecifiedFormat(char, char),
@@ -969,7 +962,7 @@ mod tests {
         );
         assert_eq!(
             FormatSpec::parse("}"),
-            Err(FormatSpecError::InvalidFormatType)
+            Err(FormatSpecError::InvalidFormatType('}'))
         );
         assert_eq!(
             FormatSpec::parse("{}}"),
@@ -995,7 +988,7 @@ mod tests {
         );
         assert_eq!(
             FormatSpec::parse("z"),
-            Err(FormatSpecError::InvalidFormatType)
+            Err(FormatSpecError::InvalidFormatType('z'))
         );
     }
 

--- a/crates/ruff_python_literal/src/format.rs
+++ b/crates/ruff_python_literal/src/format.rs
@@ -153,7 +153,17 @@ impl From<&FormatType> for char {
 }
 
 impl FormatType {
-    fn parse(text: &str) -> (Result<Self, Option<char>>, &str) {
+    /// Attempt to parse the [conversion type] of the f-string.
+    ///
+    /// A conversion type is optional in an f-string.
+    /// If it is present, it is always the last character of the format specifier.
+    ///
+    /// If a valid conversion type was encountered, this function returns `Ok((Some(FormatType), remaining_text))`.
+    /// If an invalid conversion type was encountered, this function returns `Err(invalid_char)`.
+    /// If no conversion type was encountered, this function returns `Ok((None, remaining_text))`.
+    ///
+    /// [conversion type]: https://docs.python.org/3/library/string.html#format-specification-mini-language
+    fn parse(text: &str) -> Result<(Option<Self>, &str), char> {
         let mut chars = text.chars();
         let kind = match chars.next() {
             Some('s') => Self::String,
@@ -172,10 +182,10 @@ impl FormatType {
             Some('g') => Self::GeneralFormat(Case::Lower),
             Some('G') => Self::GeneralFormat(Case::Upper),
             Some('%') => Self::Percentage,
-            Some(invalid) => return (Err(Some(invalid)), chars.as_str()),
-            None => return (Err(None), text),
+            Some(invalid) => return Err(invalid),
+            None => return Ok((None, text)),
         };
-        (Ok(kind), chars.as_str())
+        Ok((Some(kind), chars.as_str()))
     }
 }
 
@@ -366,12 +376,8 @@ impl FormatSpec {
 
         // If there's any remaining text, we should yield a valid format type and consume it
         // all.
-        let (format_type, text) = FormatType::parse(text);
-        let format_type = match format_type {
-            Ok(format) => Some(format),
-            Err(Some(invalid)) => return Err(FormatSpecError::InvalidFormatType(invalid)),
-            Err(None) => None,
-        };
+        let (format_type, text) =
+            FormatType::parse(text).map_err(FormatSpecError::InvalidFormatType)?;
         if !text.is_empty() {
             return Err(FormatSpecError::InvalidFormatSpecifier);
         }


### PR DESCRIPTION
## Summary

`FormatSpec::parse` previously discarded the character that made a format type invalid, so `PLE1300` had to recover it from the original format specifier with `chars().last().unwrap()`. Carry the unsupported character in `FormatSpecError::InvalidFormatType` instead, allowing both static and nested format-specifier diagnostics to use the parser result directly.

This removes the two panic-prone calls, makes the parser's error information explicit, and simplifies the small format-parsing helpers by removing the unnecessary `FormatParse` trait and handling each parse result directly.

## Test plan

Existing tests