### PR TITLE
[ty] Improve `match` reachability inference around value-pattern branches

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -130,11 +130,7 @@ This leads us to infer `Literal[1, 3]` as the type of `y` after the `match` stat
 `Literal[1]`:
 
 ```py
-from typing import final
-
-@final
-class C:
-    pass
+class C: ...
 
 def _(subject: C):
     y = 1
@@ -142,6 +138,24 @@ def _(subject: C):
         case 2:
             y = 3
     reveal_type(y)  # revealed: Literal[1, 3]
+```
+
+However, in this variant, we can prove that `D` here does not have a custom `__eq__` implementation,
+since it is `@final`. This means that we know it does not compare equal to `2`, allowing us to infer
+`Literal[1]` after the `match` statement
+
+```py
+from typing import final
+
+@final
+class D: ...
+
+def _(subject: D):
+    y = 1
+    match subject:
+        case 2:
+            y = 3
+    reveal_type(y)  # revealed: Literal[1]
 ```
 
 ## Class match

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1120,11 +1120,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
         PatternPredicateKind::Value(value) => {
             let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
 
-            if subject_ty.is_single_valued(db) {
-                equality_truthiness(db, subject_ty, value_ty)
-            } else {
-                Truthiness::Ambiguous
-            }
+            equality_truthiness(db, subject_ty, value_ty)
         }
         PatternPredicateKind::Singleton(singleton) => {
             let singleton_ty = singleton_pattern_type(db, *singleton);


### PR DESCRIPTION
## Summary

The `.is_single_valued(db)` call (like most `.is_single_valued(db)` calls) was incorrect here, and meant that we had less precise inference in some cases than we needed to have.

## Test Plan

mdtests extended/updated