### PR TITLE
[ty] Remove unnecessary call to `is_single_valued` in `match_pattern.rs`

### DIFF
--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -1047,10 +1047,9 @@ pub(crate) fn definite_match_pattern_type<'db>(
         PatternPredicateKind::Singleton(singleton) => singleton_pattern_type(db, *singleton),
         PatternPredicateKind::Value(value) => {
             let ty = infer_same_file_expression_type(db, *value, TypeContext::default());
-            // Only return the type if it's single-valued and guaranteed to match itself.
+            // Only return the type if it's guaranteed to match itself.
             // Otherwise, we can't definitively exclude it from subsequent patterns.
-            if ty.is_single_valued(db) && equality_truthiness(db, ty, ty) == Truthiness::AlwaysTrue
-            {
+            if equality_truthiness(db, ty, ty) == Truthiness::AlwaysTrue {
                 ty
             } else {
                 Type::Never


### PR DESCRIPTION
## Summary

This doesn't seem necessary, and removes another use of `Type::is_single_valued()` from the codebase, getting us one step closer to removing it altogether

## Test Plan

existing tests