### PR TITLE
[ty] Make membership and equality narrowing consistent

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -587,6 +587,12 @@ def equality_and_membership(x: Foo | None, y: Foo, values: list[Foo]):
         reveal_type(x)  # revealed: Foo | None
     if x in values:
         reveal_type(x)  # revealed: Foo | None
+
+class C: ...
+
+def broad_union_membership(origin: C | int):
+    if origin in ("x",):
+        reveal_type(origin)  # revealed: C & ~int
 ```
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -331,6 +331,21 @@ def union_literal_haystack(x: Literal["a", "ab", "z"], flag: bool):
     else:
         reveal_type(x)  # revealed: Literal["a", "ab", "z"]
 
+def literal_union_haystack(x: Literal["abc", "def"]):
+    if "a" in x:
+        # `x` could also be validly narrowed to `Literal["abc"]` here:
+        reveal_type(x)  # revealed: Literal["abc", "def"]
+    else:
+        # `x` could also be validly narrowed to `Literal["def"]` here:
+        reveal_type(x)  # revealed: Literal["abc", "def"]
+
+    if "a" not in x:
+        # `x` could also be validly narrowed to `Literal["def"]` here:
+        reveal_type(x)  # revealed: Literal["abc", "def"]
+    else:
+        # `x` could also be validly narrowed to `Literal["abc"]` here:
+        reveal_type(x)  # revealed: Literal["abc", "def"]
+
 def mixed_literal_union_haystack(
     x: Literal["a", "z", "missing"],
     values: Literal["abc"] | tuple[Literal["z"]],
@@ -1094,36 +1109,29 @@ def range_membership(value: Literal["x", 1], values: range) -> None:
 ## `TypedDict` key membership
 
 Membership in a closed `TypedDict` checks its finite set of literal string keys, so the tested value
-can be narrowed to a possible key. An open `TypedDict` can contain arbitrary additional string keys.
-We do not apply key-based narrowing to arbitrary values, because `in` may test substrings or
-elements instead:
+can be narrowed to a possible key. An open `TypedDict` can contain arbitrary additional string keys:
 
 ```py
 from typing import Literal
 from typing_extensions import TypedDict
 
-class Values(TypedDict, closed=True):
+class ClosedValues(TypedDict, closed=True):
     present: int
     other: str
 
-def typed_dict_container(value: Literal["present", "other", "missing", 1], values: Values) -> None:
+class OpenValues(TypedDict):
+    present: int
+    other: str
+
+def closed_typed_dict_container(value: Literal["present", "other", "missing", 1], values: ClosedValues) -> None:
     if value in values:
         reveal_type(value)  # revealed: Literal["other", "present"]
 
-def f(x: Literal["abc", "def"]):
-    if "a" in x:
-        # `x` could also be validly narrowed to `Literal["abc"]` here:
-        reveal_type(x)  # revealed: Literal["abc", "def"]
-    else:
-        # `x` could also be validly narrowed to `Literal["def"]` here:
-        reveal_type(x)  # revealed: Literal["abc", "def"]
-
-    if "a" not in x:
-        # `x` could also be validly narrowed to `Literal["def"]` here:
-        reveal_type(x)  # revealed: Literal["abc", "def"]
-    else:
-        # `x` could also be validly narrowed to `Literal["abc"]` here:
-        reveal_type(x)  # revealed: Literal["abc", "def"]
+def open_typed_dict_container(value: Literal["present", "other", "missing", 1], values: OpenValues) -> None:
+    if value in values:
+        # TODO: It would be safe to narrow `1` away if we could distinguish exact `str` from a
+        # subclass of `str` with custom equality.
+        reveal_type(value)  # revealed: Literal["present", "other", "missing", 1]
 ```
 
 ## bool

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -1093,19 +1093,22 @@ def range_membership(value: Literal["x", 1], values: range) -> None:
 
 ## `TypedDict` key membership
 
-Membership in a `TypedDict` checks its string keys. Equality against a broad `str` key type cannot
-rule out an integer literal. We do not apply key-based narrowing to arbitrary values, because `in`
-may test substrings or elements instead:
+Membership in a closed `TypedDict` checks its finite set of literal string keys, so the tested value
+can be narrowed to a possible key. An open `TypedDict` can contain arbitrary additional string keys.
+We do not apply key-based narrowing to arbitrary values, because `in` may test substrings or
+elements instead:
 
 ```py
-from typing import Literal, TypedDict
+from typing import Literal
+from typing_extensions import TypedDict
 
-class Values(TypedDict):
+class Values(TypedDict, closed=True):
     present: int
+    other: str
 
-def typed_dict_container(value: Literal["present", 1], values: Values) -> None:
+def typed_dict_container(value: Literal["present", "other", "missing", 1], values: Values) -> None:
     if value in values:
-        reveal_type(value)  # revealed: Literal["present", 1]
+        reveal_type(value)  # revealed: Literal["other", "present"]
 
 def f(x: Literal["abc", "def"]):
     if "a" in x:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -441,14 +441,14 @@ def test(x: Literal["a", "b", "c"] | None | int = None):
 
 def broad_element_type(x: str | None, values: dict[str, int]):
     if x in values:
-        reveal_type(x)  # revealed: str
+        reveal_type(x)  # revealed: str | None
     else:
         reveal_type(x)  # revealed: str | None
 
 def broad_element_type_with_unknown(values: dict[str, int]):
     x = [None][0]
     if x in values:
-        reveal_type(x)  # revealed: Unknown
+        reveal_type(x)  # revealed: None | Unknown
     else:
         reveal_type(x)  # revealed: None | Unknown
 ```
@@ -517,7 +517,7 @@ def broad_dict_element(x: str | None, values: dict[str, int]) -> None:
     if x not in values:
         reveal_type(x)  # revealed: str | None
     else:
-        reveal_type(x)  # revealed: str
+        reveal_type(x)  # revealed: str | None
 
 def union_tuple_slot(x: Literal[1, 2], values: tuple[Literal[1, 2]]) -> None:
     if x not in values:
@@ -575,6 +575,19 @@ When containment is known to compare items using equality, we can remove a union
 compare equal to any item in the container. A `TypedDict` cannot compare equal to a string, and a
 final class with the default identity-based equality cannot compare equal to an integer. We retain
 types such as `int` and classes with custom equality when they might still match an item.
+
+A non-final element type can have a subclass that compares equal to `None`, so membership must
+preserve `None` just as an equality check does:
+
+```py
+class Foo: ...
+
+def equality_and_membership(x: Foo | None, y: Foo, values: list[Foo]):
+    if x == y:
+        reveal_type(x)  # revealed: Foo | None
+    if x in values:
+        reveal_type(x)  # revealed: Foo | None
+```
 
 ```py
 from typing import Literal, TypedDict, final
@@ -1061,21 +1074,22 @@ def custom_containment_component_prevents_narrowing(
 
 ## Range membership
 
-A `range` contains integers, so a string literal can be removed from the type of the tested value:
+A `range` contains integers, but equality against a broad `int` element type cannot rule out a
+string literal:
 
 ```py
 from typing import Literal
 
 def range_membership(value: Literal["x", 1], values: range) -> None:
     if value in values:
-        reveal_type(value)  # revealed: Literal[1]
+        reveal_type(value)  # revealed: Literal["x", 1]
 ```
 
 ## `TypedDict` key membership
 
-Membership in a `TypedDict` checks its string keys, so the tested value can be narrowed to a
-possible key. We do not apply key-based narrowing to arbitrary values, because `in` may test
-substrings or elements instead:
+Membership in a `TypedDict` checks its string keys. Equality against a broad `str` key type cannot
+rule out an integer literal. We do not apply key-based narrowing to arbitrary values, because `in`
+may test substrings or elements instead:
 
 ```py
 from typing import Literal, TypedDict
@@ -1085,7 +1099,7 @@ class Values(TypedDict):
 
 def typed_dict_container(value: Literal["present", 1], values: Values) -> None:
     if value in values:
-        reveal_type(value)  # revealed: Literal["present"]
+        reveal_type(value)  # revealed: Literal["present", 1]
 
 def f(x: Literal["abc", "def"]):
     if "a" in x:

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2992,11 +2992,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     }
 
     /// Apply equality compatibility without losing the container's declared element type.
-    ///
-    /// Generic equality retains disjoint single-valued arms when an element subclass could define
-    /// custom equality. Membership narrowing instead removes those arms unless the equality
-    /// evaluator can establish a more specific compatibility, while retaining broader arms whose
-    /// runtime values may still match an element.
     fn evaluate_membership_equality(
         &self,
         lhs_ty: Type<'db>,
@@ -3020,39 +3015,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             return Some(rhs_ty);
         }
 
-        let has_single_valued_component = match lhs_ty {
-            Type::Union(union) => union
-                .elements(self.db)
-                .iter()
-                .any(|element| element.is_single_valued(self.db)),
-            _ => lhs_ty.is_single_valued(self.db),
-        };
-        if !has_single_valued_component {
-            return evaluate_type_equality(self.db, lhs_ty, rhs_ty, true, soundness_policy);
-        }
-
-        let mut builder = UnionBuilder::new(self.db);
-        let add_lhs_element = |builder: UnionBuilder<'db>, element: Type<'db>| {
-            let element = element.resolve_type_alias(self.db);
-            match evaluate_type_equality(self.db, element, rhs_ty, true, soundness_policy) {
-                Some(Type::Never) => builder,
-                Some(constraint) => builder.add(constraint),
-                None if !element.is_single_valued(self.db) => builder.add(element),
-                None => builder,
-            }
-        };
-
-        if let Type::Union(union) = lhs_ty {
-            for element in union.elements(self.db).iter().copied() {
-                builder = add_lhs_element(builder, element);
-            }
-        } else {
-            builder = add_lhs_element(builder, lhs_ty);
-        }
-
-        builder = builder.add(rhs_ty);
-        let narrowed = builder.build();
-        (narrowed != lhs_ty).then_some(narrowed)
+        evaluate_type_equality(self.db, lhs_ty, rhs_ty, true, soundness_policy)
     }
 
     fn evaluate_expr_not_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {


### PR DESCRIPTION
## Summary

Prior to this change, membership narrowing removed single-valued union members when the container's element type was broad, even though an element subclass could define custom equality. That made `in` and `==` inconsistent and could unsoundly remove `None`:

```py
class Foo: ...

def f(x: Foo | None, y: Foo, values: list[Foo]):
    if x == y:
        reveal_type(x)  # Foo | None
    if x in values:
        reveal_type(x)  # Previously: Foo
```

This removes the membership-only single-valued fallback and reuses the shared equality evaluator.

Closes https://github.com/astral-sh/ty/issues/4039.