### PR TITLE
[ty] Fix non-converging own-line ignore fixes

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -165,7 +165,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.57">0.0.57</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22blanket-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L64" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L65" target="_blank">View source</a>
 </small>
 
 
@@ -832,7 +832,7 @@ INITIALIZED_CONSTANT: Final[int] = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ignore-comment-unknown-rule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L46" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L47" target="_blank">View source</a>
 </small>
 
 
@@ -1838,7 +1838,7 @@ x: G[int]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L55" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L56" target="_blank">View source</a>
 </small>
 
 
@@ -5069,7 +5069,7 @@ async def main() -> None:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L28" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L29" target="_blank">View source</a>
 </small>
 
 
@@ -5110,7 +5110,7 @@ to `false` to prevent this rule from reporting unused `type: ignore` comments.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-type-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L37" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L38" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty/tests/cli/fixes.rs
+++ b/crates/ty/tests/cli/fixes.rs
@@ -167,6 +167,50 @@ fn add_ignore_unfixable() -> anyhow::Result<()> {
 }
 
 #[test]
+fn add_ignore_with_type_ignore_comments_disabled() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "unknown_rule.py",
+        r#"
+            seen_code = True
+            # ty: ignore[not-a-rule]
+            value = 1
+            "#,
+    )?;
+
+    assert_cmd_snapshot!(
+        case.command()
+            .arg("--add-ignore")
+            .arg("--config")
+            .arg("analysis.respect-type-ignore-comments=false"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning[ignore-comment-unknown-rule]: Unknown rule `not-a-rule`
+     --> unknown_rule.py:3:14
+      |
+    3 | # ty: ignore[not-a-rule]
+      |              ^^^^^^^^^^
+      |
+
+    Found 1 diagnostic
+    Added 0 ignore comment
+
+    ----- stderr -----
+    "
+    );
+
+    assert_snapshot!(fs::read_to_string(case.root().join("unknown_rule.py"))?, @"
+
+    seen_code = True
+    # ty: ignore[not-a-rule]
+    value = 1
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn fix() -> anyhow::Result<()> {
     let case = CliTest::with_file(
         "unused_ignore.py",

--- a/crates/ty/tests/cli/fixes.rs
+++ b/crates/ty/tests/cli/fixes.rs
@@ -197,7 +197,8 @@ fn add_ignore_with_type_ignore_comments_disabled() -> anyhow::Result<()> {
     assert_snapshot!(fs::read_to_string(case.root().join("unknown_rule.py"))?, @"
 
     seen_code = True
-    # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+    # ty:ignore[ignore-comment-unknown-rule]
+    # ty: ignore[not-a-rule]
     value = 1
     value = 1  # ty: ignore[another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
     ");

--- a/crates/ty/tests/cli/fixes.rs
+++ b/crates/ty/tests/cli/fixes.rs
@@ -55,13 +55,14 @@ fn add_ignore_keeps_nested_blanket_suppression_used() -> anyhow::Result<()> {
                 return value
 
             seen_code = True
-            # ty: ignore[]
+            # ty: ignore[unresolved-reference]
             values = [
                 # ty: ignore[blanket-ignore-comment]
                 # ty: ignore
                 f("bad"),
                 # ty: ignore
                 missing,
+                absent,
             ]
             "#,
     )?;
@@ -88,13 +89,14 @@ fn add_ignore_keeps_nested_blanket_suppression_used() -> anyhow::Result<()> {
         return value
 
     seen_code = True
-    # ty: ignore[blanket-ignore-comment]
+    # ty: ignore[unresolved-reference]
     values = [
         # ty: ignore[blanket-ignore-comment]
         # ty: ignore
         f("bad"),
-        # ty: ignore
+        # ty: ignore  # ty:ignore[blanket-ignore-comment]
         missing,
+        absent,
     ]
     "#);
 

--- a/crates/ty/tests/cli/fixes.rs
+++ b/crates/ty/tests/cli/fixes.rs
@@ -174,6 +174,7 @@ fn add_ignore_with_type_ignore_comments_disabled() -> anyhow::Result<()> {
             seen_code = True
             # ty: ignore[not-a-rule]
             value = 1
+            value = 1  # ty: ignore[another-not-a-rule]
             "#,
     )?;
 
@@ -194,7 +195,7 @@ fn add_ignore_with_type_ignore_comments_disabled() -> anyhow::Result<()> {
       |
 
     Found 1 diagnostic
-    Added 0 ignore comment
+    Added 1 ignore comment
 
     ----- stderr -----
     "
@@ -205,6 +206,7 @@ fn add_ignore_with_type_ignore_comments_disabled() -> anyhow::Result<()> {
     seen_code = True
     # ty: ignore[not-a-rule]
     value = 1
+    value = 1  # ty: ignore[another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
     ");
 
     Ok(())

--- a/crates/ty/tests/cli/fixes.rs
+++ b/crates/ty/tests/cli/fixes.rs
@@ -197,10 +197,9 @@ fn add_ignore_with_type_ignore_comments_disabled() -> anyhow::Result<()> {
     assert_snapshot!(fs::read_to_string(case.root().join("unknown_rule.py"))?, @"
 
     seen_code = True
-    # ty:ignore[ignore-comment-unknown-rule]
-    # ty: ignore[not-a-rule]
+    # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
     value = 1
-    value = 1  # ty: ignore[another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+    value = 1  # ty: ignore[another-not-a-rule, ignore-comment-unknown-rule]
     ");
 
     Ok(())

--- a/crates/ty/tests/cli/fixes.rs
+++ b/crates/ty/tests/cli/fixes.rs
@@ -184,18 +184,11 @@ fn add_ignore_with_type_ignore_comments_disabled() -> anyhow::Result<()> {
             .arg("--config")
             .arg("analysis.respect-type-ignore-comments=false"),
         @"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
-    warning[ignore-comment-unknown-rule]: Unknown rule `not-a-rule`
-     --> unknown_rule.py:3:14
-      |
-    3 | # ty: ignore[not-a-rule]
-      |              ^^^^^^^^^^
-      |
-
-    Found 1 diagnostic
-    Added 1 ignore comment
+    All checks passed!
+    Added 2 ignore comments
 
     ----- stderr -----
     "
@@ -204,7 +197,7 @@ fn add_ignore_with_type_ignore_comments_disabled() -> anyhow::Result<()> {
     assert_snapshot!(fs::read_to_string(case.root().join("unknown_rule.py"))?, @"
 
     seen_code = True
-    # ty: ignore[not-a-rule]
+    # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
     value = 1
     value = 1  # ty: ignore[another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
     ");

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -333,6 +333,32 @@ mod tests {
     }
 
     #[test]
+    fn add_code_editable_own_line_unknown_rule_ignore() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            # ty: ignore[<START>not-a-rule<END>]
+            value = 1
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("ignore-comment-unknown-rule"), @"
+        info[code-action]: Ignore 'ignore-comment-unknown-rule' for this line
+         --> main.py:3:14
+          |
+        3 | # ty: ignore[not-a-rule]
+          |              ^^^^^^^^^^
+          |
+          |
+        2 | seen_code = True
+          - # ty: ignore[not-a-rule]
+        3 + # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
+        4 | value = 1
+          |
+        ");
+    }
+
+    #[test]
     fn add_code_mixed_unknown_rule_ignore() {
         let test = CodeActionTest::with_source(
             r#"
@@ -373,7 +399,7 @@ mod tests {
           |
         1 |
           - items = []  # type: list[int]  # ty: ignore[not-a-rule]
-        2 + items = []  # type: list[int]  # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        2 + items = []  # type: list[int]  # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
           |
         ");
     }
@@ -396,7 +422,7 @@ mod tests {
           |
         1 |
           - value = "x"  # type: ignore[assignment]  # ty: ignore[not-a-rule]
-        2 + value = "x"  # type: ignore[assignment]  # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        2 + value = "x"  # type: ignore[assignment]  # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
           |
         "#);
     }
@@ -420,8 +446,9 @@ mod tests {
           |
           |
         2 | seen_code = True
-        3 + # ty:ignore[ignore-comment-unknown-rule]
-        4 | # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+          - # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+        3 + # ty: ignore[not-a-rule, ignore-comment-unknown-rule]  # ty: ignore[unresolved-reference]
+        4 | value = missing
           |
         ");
     }
@@ -520,7 +547,7 @@ mod tests {
           |
         1 |
           - # ty: ignore[not-a-rule]
-        2 + # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        2 + # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
         3 | value = 1
           |
         ");
@@ -557,7 +584,7 @@ mod tests {
           |
           |
           - value = 1  # ty: ignore[not-a-rule]
-        1 + value = 1  # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        1 + value = 1  # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
           |
         ");
     }

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -354,6 +354,52 @@ mod tests {
     }
 
     #[test]
+    fn add_code_unknown_rule_after_type_comment() {
+        let test = CodeActionTest::with_source(
+            r#"
+            items = []  # type: list[int]  # ty: ignore[<START>not-a-rule<END>]
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("ignore-comment-unknown-rule"), @"
+        info[code-action]: Ignore 'ignore-comment-unknown-rule' for this line
+         --> main.py:2:45
+          |
+        2 | items = []  # type: list[int]  # ty: ignore[not-a-rule]
+          |                                             ^^^^^^^^^^
+          |
+          |
+        1 |
+          - items = []  # type: list[int]  # ty: ignore[not-a-rule]
+        2 + items = []  # type: list[int]  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+          |
+        ");
+    }
+
+    #[test]
+    fn add_code_unknown_rule_after_type_ignore() {
+        let test = CodeActionTest::with_source(
+            r#"
+            value = "x"  # type: ignore[assignment]  # ty: ignore[<START>not-a-rule<END>]
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("ignore-comment-unknown-rule"), @r#"
+        info[code-action]: Ignore 'ignore-comment-unknown-rule' for this line
+         --> main.py:2:55
+          |
+        2 | value = "x"  # type: ignore[assignment]  # ty: ignore[not-a-rule]
+          |                                                       ^^^^^^^^^^
+          |
+          |
+        1 |
+          - value = "x"  # type: ignore[assignment]  # ty: ignore[not-a-rule]
+        2 + value = "x"  # type: ignore[assignment]  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+          |
+        "#);
+    }
+
+    #[test]
     fn add_code_nested_unknown_rule_ignore() {
         let test = CodeActionTest::with_source(
             r#"

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -326,9 +326,8 @@ mod tests {
           |
           |
         2 | seen_code = True
-          - # ty: ignore[not-a-rule] tracked by [123]
-        3 + # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule] tracked by [123]
-        4 | value = 1
+        3 + # ty:ignore[ignore-comment-unknown-rule]
+        4 | # ty: ignore[not-a-rule] tracked by [123]
           |
         ");
     }
@@ -421,9 +420,8 @@ mod tests {
           |
           |
         2 | seen_code = True
-          - # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
-        3 + # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
-        4 | value = missing
+        3 + # ty:ignore[ignore-comment-unknown-rule]
+        4 | # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
           |
         ");
     }
@@ -447,9 +445,8 @@ mod tests {
           |
           |
         2 | seen_code = True
-          - # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
-        3 + # ty:ignore[invalid-ignore-comment]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
-        4 | value = missing
+        3 + # ty:ignore[invalid-ignore-comment]
+        4 | # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
           |
         ");
     }
@@ -473,9 +470,8 @@ mod tests {
           |
           |
         2 | seen_code = True
-          - # ty: ignore[#]
-        3 + # ty:ignore[invalid-ignore-comment]  # ty: ignore[#]
-        4 | value = 1
+        3 + # ty:ignore[invalid-ignore-comment]
+        4 | # ty: ignore[#]
           |
         ");
     }
@@ -499,9 +495,8 @@ mod tests {
           |
           |
         2 | seen_code = True
-          - # ty: ignore[unresolved-reference#]
-        3 + # ty:ignore[invalid-ignore-comment]  # ty: ignore[unresolved-reference#]
-        4 | value = 1
+        3 + # ty:ignore[invalid-ignore-comment]
+        4 | # ty: ignore[unresolved-reference#]
           |
         ");
     }

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -455,6 +455,58 @@ mod tests {
     }
 
     #[test]
+    fn add_code_invalid_hash_ignore() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            # ty: ignore[<START>#<END>]
+            value = 1
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("invalid-ignore-comment"), @"
+        info[code-action]: Ignore 'invalid-ignore-comment' for this line
+         --> main.py:3:14
+          |
+        3 | # ty: ignore[#]
+          |              ^
+          |
+          |
+        2 | seen_code = True
+          - # ty: ignore[#]
+        3 + # ty:ignore[invalid-ignore-comment]  # ty: ignore[#]
+        4 | value = 1
+          |
+        ");
+    }
+
+    #[test]
+    fn add_code_invalid_trailing_hash_ignore() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            # ty: ignore[unresolved-reference<START>#<END>]
+            value = 1
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("invalid-ignore-comment"), @"
+        info[code-action]: Ignore 'invalid-ignore-comment' for this line
+         --> main.py:3:34
+          |
+        3 | # ty: ignore[unresolved-reference#]
+          |                                  ^
+          |
+          |
+        2 | seen_code = True
+          - # ty: ignore[unresolved-reference#]
+        3 + # ty:ignore[invalid-ignore-comment]  # ty: ignore[unresolved-reference#]
+        4 | value = 1
+          |
+        ");
+    }
+
+    #[test]
     fn no_ignore_code_action_for_shebang_suppression() {
         let test = CodeActionTest::with_source(
             r#"

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -89,6 +89,9 @@ mod tests {
     use ruff_python_trivia::textwrap::dedent;
     use ruff_text_size::{TextRange, TextSize};
     use ty_project::ProjectMetadata;
+    use ty_project::metadata::Options;
+    use ty_project::metadata::options::AnalysisOptions;
+    use ty_python_core::program::FallibleStrategy;
     use ty_python_semantic::{
         default_lint_registry,
         lint::LintMetadata,
@@ -464,6 +467,27 @@ mod tests {
             test.code_actions_for("ignore-comment-unknown-rule")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn add_code_inline_unknown_rule_ignore_with_type_ignores_disabled() {
+        let test = CodeActionTest::with_source_and_type_ignores(
+            r#"value = 1  # ty: ignore[<START>not-a-rule<END>]"#,
+            false,
+        );
+
+        assert_snapshot!(test.code_actions_for("ignore-comment-unknown-rule"), @"
+        info[code-action]: Ignore 'ignore-comment-unknown-rule' for this line
+         --> main.py:1:25
+          |
+        1 | value = 1  # ty: ignore[not-a-rule]
+          |                         ^^^^^^^^^^
+          |
+          |
+          - value = 1  # ty: ignore[not-a-rule]
+        1 + value = 1  # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+          |
+        ");
     }
 
     #[test]
@@ -1087,8 +1111,24 @@ mod tests {
 
     impl CodeActionTest {
         pub(super) fn with_source(source: &str) -> Self {
-            let mut db =
-                ty_project::TestDb::new(ProjectMetadata::new("test", SystemPathBuf::from("/")));
+            Self::with_source_and_type_ignores(source, true)
+        }
+
+        fn with_source_and_type_ignores(source: &str, respect_type_ignores: bool) -> Self {
+            let project = ProjectMetadata::from_options(
+                Options {
+                    analysis: Some(AnalysisOptions {
+                        respect_type_ignore_comments: Some(respect_type_ignores),
+                        ..AnalysisOptions::default()
+                    }),
+                    ..Options::default()
+                },
+                SystemPathBuf::from("/"),
+                None,
+                &FallibleStrategy,
+            )
+            .unwrap();
+            let mut db = ty_project::TestDb::new(project);
 
             db.init_program().unwrap();
 

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -327,7 +327,7 @@ mod tests {
           |
         2 | seen_code = True
           - # ty: ignore[not-a-rule] tracked by [123]
-        3 + # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule] tracked by [123]
+        3 + # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule] tracked by [123]
         4 | value = 1
           |
         ");
@@ -422,7 +422,7 @@ mod tests {
           |
         2 | seen_code = True
           - # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
-        3 + # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+        3 + # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
         4 | value = missing
           |
         ");
@@ -448,7 +448,7 @@ mod tests {
           |
         2 | seen_code = True
           - # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
-        3 + # type:ignore[ty:invalid-ignore-comment, unused-ignore]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+        3 + # ty:ignore[invalid-ignore-comment]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
         4 | value = missing
           |
         ");

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -507,6 +507,31 @@ mod tests {
     }
 
     #[test]
+    fn add_code_file_level_unknown_rule_ignore() {
+        let test = CodeActionTest::with_source(
+            r#"
+            # ty: ignore[<START>not-a-rule<END>]
+            value = 1
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("ignore-comment-unknown-rule"), @"
+        info[code-action]: Ignore 'ignore-comment-unknown-rule' for this line
+         --> main.py:2:14
+          |
+        2 | # ty: ignore[not-a-rule]
+          |              ^^^^^^^^^^
+          |
+          |
+        1 |
+          - # ty: ignore[not-a-rule]
+        2 + # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        3 | value = 1
+          |
+        ");
+    }
+
+    #[test]
     fn no_ignore_code_action_for_shebang_suppression() {
         let test = CodeActionTest::with_source(
             r#"

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -324,7 +324,7 @@ mod tests {
           |
         2 | seen_code = True
           - # ty: ignore[not-a-rule] tracked by [123]
-        3 + # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule] tracked by [123]
+        3 + # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule] tracked by [123]
         4 | value = 1
           |
         ");
@@ -348,7 +348,7 @@ mod tests {
           |
         1 |
           - value = missing  # ty: ignore[unresolved-reference, not-a-rule] tracked by [123]
-        2 + value = missing  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[unresolved-reference, not-a-rule] tracked by [123]
+        2 + value = missing  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[unresolved-reference, not-a-rule] tracked by [123]
           |
         ");
     }
@@ -371,7 +371,7 @@ mod tests {
           |
         1 |
           - items = []  # type: list[int]  # ty: ignore[not-a-rule]
-        2 + items = []  # type: list[int]  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+        2 + items = []  # type: list[int]  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
           |
         ");
     }
@@ -394,7 +394,7 @@ mod tests {
           |
         1 |
           - value = "x"  # type: ignore[assignment]  # ty: ignore[not-a-rule]
-        2 + value = "x"  # type: ignore[assignment]  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+        2 + value = "x"  # type: ignore[assignment]  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
           |
         "#);
     }
@@ -419,7 +419,7 @@ mod tests {
           |
         2 | seen_code = True
           - # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
-        3 + # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+        3 + # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
         4 | value = missing
           |
         ");
@@ -445,7 +445,7 @@ mod tests {
           |
         2 | seen_code = True
           - # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
-        3 + # type:ignore[ty:invalid-ignore-comment]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+        3 + # type:ignore[ty:invalid-ignore-comment, unused-ignore]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
         4 | value = missing
           |
         ");

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -351,7 +351,7 @@ mod tests {
           |
         1 |
           - value = missing  # ty: ignore[unresolved-reference, not-a-rule] tracked by [123]
-        2 + value = missing  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[unresolved-reference, not-a-rule] tracked by [123]
+        2 + value = missing  # ty: ignore[unresolved-reference, not-a-rule] tracked by [123]  # ty:ignore[ignore-comment-unknown-rule]
           |
         ");
     }
@@ -374,7 +374,7 @@ mod tests {
           |
         1 |
           - items = []  # type: list[int]  # ty: ignore[not-a-rule]
-        2 + items = []  # type: list[int]  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
+        2 + items = []  # type: list[int]  # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
           |
         ");
     }
@@ -397,7 +397,7 @@ mod tests {
           |
         1 |
           - value = "x"  # type: ignore[assignment]  # ty: ignore[not-a-rule]
-        2 + value = "x"  # type: ignore[assignment]  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
+        2 + value = "x"  # type: ignore[assignment]  # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
           |
         "#);
     }

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -239,7 +239,7 @@ mod tests {
           |
         2 | seen_code = True
           - # ty:ignore[] # ty:ignore[not-a-rule] # ty:ignore[division-by-zero]
-        3 + # ty:ignore[ignore-comment-unknown-rule] # ty:ignore[not-a-rule] # ty:ignore[division-by-zero]
+        3 + # ty:ignore[] # ty:ignore[not-a-rule] # ty:ignore[division-by-zero, ignore-comment-unknown-rule]
         4 | value = 1 / 0
           |
         ");
@@ -326,8 +326,9 @@ mod tests {
           |
           |
         2 | seen_code = True
-        3 + # ty:ignore[ignore-comment-unknown-rule]
-        4 | # ty: ignore[not-a-rule] tracked by [123]
+          - # ty: ignore[not-a-rule] tracked by [123]
+        3 + # ty: ignore[not-a-rule] tracked by [123]  # ty:ignore[ignore-comment-unknown-rule]
+        4 | value = 1
           |
         ");
     }
@@ -447,7 +448,7 @@ mod tests {
           |
         2 | seen_code = True
           - # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
-        3 + # ty: ignore[not-a-rule, ignore-comment-unknown-rule]  # ty: ignore[unresolved-reference]
+        3 + # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference, ignore-comment-unknown-rule]
         4 | value = missing
           |
         ");
@@ -472,8 +473,9 @@ mod tests {
           |
           |
         2 | seen_code = True
-        3 + # ty:ignore[invalid-ignore-comment]
-        4 | # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+          - # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+        3 + # ty: ignore[*-*]  # ty: ignore[unresolved-reference, invalid-ignore-comment]
+        4 | value = missing
           |
         ");
     }
@@ -497,8 +499,9 @@ mod tests {
           |
           |
         2 | seen_code = True
-        3 + # ty:ignore[invalid-ignore-comment]
-        4 | # ty: ignore[#]
+          - # ty: ignore[#]
+        3 + # ty: ignore[#]  # ty:ignore[invalid-ignore-comment]
+        4 | value = 1
           |
         ");
     }
@@ -522,8 +525,9 @@ mod tests {
           |
           |
         2 | seen_code = True
-        3 + # ty:ignore[invalid-ignore-comment]
-        4 | # ty: ignore[unresolved-reference#]
+          - # ty: ignore[unresolved-reference#]
+        3 + # ty: ignore[unresolved-reference#]  # ty:ignore[invalid-ignore-comment]
+        4 | value = 1
           |
         ");
     }
@@ -556,16 +560,39 @@ mod tests {
     #[test]
     fn no_ignore_code_action_for_shebang_suppression() {
         let test = CodeActionTest::with_source(
-            r#"
-            #!/usr/bin/env -S python3 -u # ty: ignore[<START>not-a-rule<END>]
-            value = 1
-        "#,
+            "#!/usr/bin/env -S python3 -u # ty: ignore[<START>not-a-rule<END>]\nvalue = 1",
         );
 
         assert!(
             test.code_actions_for("ignore-comment-unknown-rule")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn add_code_mid_file_hash_bang_comment() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            #! notes # ty: ignore[<START>not-a-rule<END>]
+            value = 1
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("ignore-comment-unknown-rule"), @"
+        info[code-action]: Ignore 'ignore-comment-unknown-rule' for this line
+         --> main.py:3:23
+          |
+        3 | #! notes # ty: ignore[not-a-rule]
+          |                       ^^^^^^^^^^
+          |
+          |
+        2 | seen_code = True
+          - #! notes # ty: ignore[not-a-rule]
+        3 + #! notes # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
+        4 | value = 1
+          |
+        ");
     }
 
     #[test]

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -39,12 +39,14 @@ pub fn code_actions(
         actions.extend(import_quick_fix);
     }
 
-    // Suggest just suppressing the lint (always a valid option, but never ideal)
-    actions.push(QuickFix {
-        title: format!("Ignore '{}' for this line", lint_id.name()),
-        edits: suppress_single(db, file, lint_id, diagnostic_range).into_edits(),
-        preferred: false,
-    });
+    // Suggest just suppressing the lint when a safe suppression can be added.
+    if let Some(fix) = suppress_single(db, file, lint_id, diagnostic_range) {
+        actions.push(QuickFix {
+            title: format!("Ignore '{}' for this line", lint_id.name()),
+            edits: fix.into_edits(),
+            preferred: false,
+        });
+    }
 
     actions
 }
@@ -303,6 +305,122 @@ mod tests {
     }
 
     #[test]
+    fn add_code_own_line_unknown_rule_ignore() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            # ty: ignore[<START>not-a-rule<END>] tracked by [123]
+            value = 1
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("ignore-comment-unknown-rule"), @"
+        info[code-action]: Ignore 'ignore-comment-unknown-rule' for this line
+         --> main.py:3:14
+          |
+        3 | # ty: ignore[not-a-rule] tracked by [123]
+          |              ^^^^^^^^^^
+          |
+          |
+        2 | seen_code = True
+          - # ty: ignore[not-a-rule] tracked by [123]
+        3 + # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule] tracked by [123]
+        4 | value = 1
+          |
+        ");
+    }
+
+    #[test]
+    fn add_code_mixed_unknown_rule_ignore() {
+        let test = CodeActionTest::with_source(
+            r#"
+            value = missing  # ty: ignore[unresolved-reference, <START>not-a-rule<END>] tracked by [123]
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("ignore-comment-unknown-rule"), @"
+        info[code-action]: Ignore 'ignore-comment-unknown-rule' for this line
+         --> main.py:2:53
+          |
+        2 | value = missing  # ty: ignore[unresolved-reference, not-a-rule] tracked by [123]
+          |                                                     ^^^^^^^^^^
+          |
+          |
+        1 |
+          - value = missing  # ty: ignore[unresolved-reference, not-a-rule] tracked by [123]
+        2 + value = missing  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[unresolved-reference, not-a-rule] tracked by [123]
+          |
+        ");
+    }
+
+    #[test]
+    fn add_code_nested_unknown_rule_ignore() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            # ty: ignore[<START>not-a-rule<END>]  # ty: ignore[unresolved-reference]
+            value = missing
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("ignore-comment-unknown-rule"), @"
+        info[code-action]: Ignore 'ignore-comment-unknown-rule' for this line
+         --> main.py:3:14
+          |
+        3 | # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+          |              ^^^^^^^^^^
+          |
+          |
+        2 | seen_code = True
+          - # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+        3 + # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+        4 | value = missing
+          |
+        ");
+    }
+
+    #[test]
+    fn add_code_nested_invalid_ignore() {
+        let test = CodeActionTest::with_source(
+            r#"
+            seen_code = True
+            # ty: ignore[<START>*-*<END>]  # ty: ignore[unresolved-reference]
+            value = missing
+        "#,
+        );
+
+        assert_snapshot!(test.code_actions_for("invalid-ignore-comment"), @"
+        info[code-action]: Ignore 'invalid-ignore-comment' for this line
+         --> main.py:3:14
+          |
+        3 | # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+          |              ^^^
+          |
+          |
+        2 | seen_code = True
+          - # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+        3 + # type:ignore[ty:invalid-ignore-comment]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+        4 | value = missing
+          |
+        ");
+    }
+
+    #[test]
+    fn no_ignore_code_action_for_shebang_suppression() {
+        let test = CodeActionTest::with_source(
+            r#"
+            #!/usr/bin/env -S python3 -u # ty: ignore[<START>not-a-rule<END>]
+            value = 1
+        "#,
+        );
+
+        assert!(
+            test.code_actions_for("ignore-comment-unknown-rule")
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn add_code_existing_type_ignore() {
         let test = CodeActionTest::with_source(
             r#"
@@ -423,7 +541,7 @@ mod tests {
     fn add_code_existing_ignore_with_reason() {
         let test = CodeActionTest::with_source(
             r#"
-            b = <START>a<END> / 0  # ty:ignore[division-by-zero] some explanation
+            b = <START>a<END> / 0  # ty:ignore[division-by-zero] some explanation [123]
         "#,
         );
 
@@ -431,13 +549,13 @@ mod tests {
         info[code-action]: Ignore 'unresolved-reference' for this line
          --> main.py:2:5
           |
-        2 | b = a / 0  # ty:ignore[division-by-zero] some explanation
+        2 | b = a / 0  # ty:ignore[division-by-zero] some explanation [123]
           |     ^
           |
           |
         1 |
-          - b = a / 0  # ty:ignore[division-by-zero] some explanation
-        2 + b = a / 0  # ty:ignore[division-by-zero] some explanation  # ty:ignore[unresolved-reference]
+          - b = a / 0  # ty:ignore[division-by-zero] some explanation [123]
+        2 + b = a / 0  # ty:ignore[division-by-zero] some explanation [123]  # ty:ignore[unresolved-reference]
           |
         ");
     }
@@ -959,6 +1077,10 @@ mod tests {
         }
 
         pub(super) fn code_actions(&self, lint: &LintMetadata) -> String {
+            self.code_actions_for(&lint.name)
+        }
+
+        fn code_actions_for(&self, diagnostic_id: &str) -> String {
             use std::fmt::Write;
 
             let mut buf = String::new();
@@ -969,7 +1091,9 @@ mod tests {
                 .context(0)
                 .format(DiagnosticFormat::Full);
 
-            for mut action in code_actions(&self.db, self.file, self.diagnostic_range, &lint.name) {
+            for mut action in
+                code_actions(&self.db, self.file, self.diagnostic_range, diagnostic_id)
+            {
                 let mut diagnostic = Diagnostic::new(
                     DiagnosticId::Lint(LintName::of("code-action")),
                     ruff_db::diagnostic::Severity::Info,

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -38,17 +38,20 @@ e = 1  # ty: ignore
 
 ## Suppression diagnostics
 
-Suppression-related diagnostics are checked before `blanket-ignore-comment`. A blanket ignore that
-suppresses an `ignore-comment-unknown-rule` or `invalid-ignore-comment` diagnostic therefore counts
-as used:
+Suppression-comment diagnostics require an explicit rule code. A blanket ignore cannot suppress an
+unknown or malformed ignore on the same line:
 
 ```py
 # The nested ignore contains an unknown rule.
+# error: [ignore-comment-unknown-rule]
 # error: [blanket-ignore-comment]
+# error: [unused-ignore-comment] "Unused blanket `ty: ignore` directive"
 a = 1  # ty: ignore # ty: ignore[not-a-rule]
 
 # The nested ignore is invalid.
+# error: [invalid-ignore-comment]
 # error: [blanket-ignore-comment]
+# error: [unused-ignore-comment] "Unused blanket `ty: ignore` directive"
 b = 1  # ty: ignore # ty: ignore[*]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/blanket_ignore.md
@@ -70,3 +70,12 @@ A blanket ignore can be suppressed by a code-specific ignore:
 ```py
 a = unresolved  # ty: ignore # ty: ignore[blanket-ignore-comment]
 ```
+
+An own-line `blanket-ignore-comment` suppression also covers a blanket ignore on the following
+logical line.
+
+```py
+def f():
+    # ty: ignore[blanket-ignore-comment]
+    return missing  # ty: ignore
+```

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
@@ -372,17 +372,19 @@ reveal_type(a)  # ty: ignore[revealed-type]
 
 ## Suppressing suppression diagnostics on an own line
 
-Unknown-rule and invalid-comment suppressions on an own line apply only to that physical line, so
-they don't silently suppress a similar diagnostic on the following logical line.
+Unknown-rule and invalid-comment suppressions on an own line apply to following comment-only lines,
+but not to the following logical line.
 
 ```py
 seen_code = True
-# ty: ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+# ty: ignore[ignore-comment-unknown-rule]
+# ty: ignore[not-a-rule]
 value = 1
 # error: [ignore-comment-unknown-rule]
 value = 1  # ty: ignore[another-not-a-rule]
 
-# ty: ignore[invalid-ignore-comment]  # ty: ignore[*-*]
+# ty: ignore[invalid-ignore-comment]
+# ty: ignore[*-*]
 value = 1
 # error: [invalid-ignore-comment]
 value = 1  # ty: ignore[*-*]

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
@@ -372,8 +372,8 @@ reveal_type(a)  # ty: ignore[revealed-type]
 
 ## Suppressing suppression diagnostics on an own line
 
-Unknown-rule and invalid-comment suppressions on an own line apply to following comment-only lines,
-but not to the following logical line.
+An own-line suppression covers its entire physical comment line and the following statement,
+including diagnostics emitted for ignore comments.
 
 ```py
 seen_code = True
@@ -390,8 +390,19 @@ value = 1
 value = 1  # ty: ignore[*-*]
 ```
 
-An `unused-ignore-comment` suppression retains normal own-line coverage so it can suppress an unused
-directive on the following logical line.
+An own-line suppression can also suppress an ignore-comment diagnostic on the following statement.
+
+```py
+seen_code = True
+# ty: ignore[ignore-comment-unknown-rule]
+value = 1  # ty: ignore[not-a-rule]
+
+# ty: ignore[invalid-ignore-comment]
+value = 1  # ty: ignore[*-*]
+```
+
+An `unused-ignore-comment` suppression can likewise suppress an unused directive on the following
+statement.
 
 ```py
 seen_code = True
@@ -408,11 +419,15 @@ def f():
     value = missing
 ```
 
-A nested `type: ignore` retains whole-line coverage and can suppress an earlier sub-comment.
+A rule-specific suppression covers every ignore comment on its physical line, regardless of
+sub-comment order.
 
 ```py
 def f():
     # ty: ignore[not-a-rule] # type: ignore[ty:ignore-comment-unknown-rule]
+    value = 1
+
+    # ty: ignore[first-not-a-rule] # ty: ignore[second-not-a-rule] # ty: ignore[ignore-comment-unknown-rule]
     value = 1
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
@@ -388,6 +388,15 @@ value = 1
 value = 1  # ty: ignore[*-*]
 ```
 
+An indented own-line comment can mix a suppression-comment rule with an ordinary rule without
+changing the source order of its suppression ranges.
+
+```py
+def f():
+    # ty: ignore[unresolved-reference, ignore-comment-unknown-rule, not-a-rule]
+    value = missing
+```
+
 ## Extra whitespace in type ignore comments is allowed
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
@@ -370,6 +370,24 @@ a = 10
 reveal_type(a)  # ty: ignore[revealed-type]
 ```
 
+## Suppressing suppression diagnostics on an own line
+
+Suppression-comment rules on an own line apply only to that physical line, so they don't silently
+suppress a similar diagnostic on the following logical line.
+
+```py
+seen_code = True
+# ty: ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+value = 1
+# error: [ignore-comment-unknown-rule]
+value = 1  # ty: ignore[another-not-a-rule]
+
+# ty: ignore[invalid-ignore-comment]  # ty: ignore[*-*]
+value = 1
+# error: [invalid-ignore-comment]
+value = 1  # ty: ignore[*-*]
+```
+
 ## Extra whitespace in type ignore comments is allowed
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
@@ -414,6 +414,16 @@ def f():
     value = 1
 ```
 
+A later blanket `ty: ignore` does not suppress a malformed earlier sub-comment.
+
+```py
+def f():
+    # error: [ignore-comment-unknown-rule]
+    # error: [unused-ignore-comment] "Unused blanket `ty: ignore` directive"
+    # ty: ignore[not-a-rule] # ty: ignore
+    value = 1
+```
+
 ## Extra whitespace in type ignore comments is allowed
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
@@ -406,6 +406,14 @@ def f():
     value = missing
 ```
 
+A nested `type: ignore` retains whole-line coverage and can suppress an earlier sub-comment.
+
+```py
+def f():
+    # ty: ignore[not-a-rule] # type: ignore[ty:ignore-comment-unknown-rule]
+    value = 1
+```
+
 ## Extra whitespace in type ignore comments is allowed
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/ty_ignore.md
@@ -372,8 +372,8 @@ reveal_type(a)  # ty: ignore[revealed-type]
 
 ## Suppressing suppression diagnostics on an own line
 
-Suppression-comment rules on an own line apply only to that physical line, so they don't silently
-suppress a similar diagnostic on the following logical line.
+Unknown-rule and invalid-comment suppressions on an own line apply only to that physical line, so
+they don't silently suppress a similar diagnostic on the following logical line.
 
 ```py
 seen_code = True
@@ -386,6 +386,15 @@ value = 1  # ty: ignore[another-not-a-rule]
 value = 1
 # error: [invalid-ignore-comment]
 value = 1  # ty: ignore[*-*]
+```
+
+An `unused-ignore-comment` suppression retains normal own-line coverage so it can suppress an unused
+directive on the following logical line.
+
+```py
+seen_code = True
+# ty: ignore[unused-ignore-comment]
+value = 1  # type: ignore[ty:division-by-zero]
 ```
 
 An indented own-line comment can mix a suppression-comment rule with an ordinary rule without

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1,4 +1,4 @@
-use crate::{SuppressFix, is_unused_ignore_comment_lint, suppress_all};
+use crate::{SuppressFix, is_unused_ignore_comment_lint, suppress_all, suppression::can_suppress};
 use ruff_db::cancellation::{Canceled, CancellationToken};
 use ruff_db::diagnostic::{DisplayDiagnosticConfig, DisplayDiagnostics};
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
@@ -93,7 +93,7 @@ where
 
     let has_fixable = diagnostics
         .iter()
-        .any(|diagnostic| fix_mode.is_fixable(diagnostic));
+        .any(|diagnostic| fix_mode.is_fixable(db, diagnostic));
 
     // Early return if there are no diagnostics that can be suppressed to avoid all the heavy work below.
     if !has_fixable {
@@ -204,6 +204,7 @@ where
 
                     if is_last_iteration {
                         let diagnostic = create_too_many_iterations_diagnostics(
+                            &*db,
                             file.file,
                             fix_mode,
                             file.diagnostics(),
@@ -324,13 +325,14 @@ fn create_fix_introduced_syntax_error_diagnostic(
 }
 
 fn create_too_many_iterations_diagnostics(
+    db: &dyn Db,
     file: File,
     fix_mode: FixMode,
     diagnostics: &[Diagnostic],
 ) -> Diagnostic {
     let mut fixable_ids = diagnostics
         .iter()
-        .filter(|diagnostic| fix_mode.is_fixable(diagnostic))
+        .filter(|diagnostic| fix_mode.is_fixable(db, diagnostic))
         .map(|diagnostic| diagnostic.id().as_str())
         .collect::<Vec<_>>();
 
@@ -362,19 +364,18 @@ enum FixMode {
 }
 
 impl FixMode {
-    fn is_fixable(self, diagnostic: &Diagnostic) -> bool {
+    fn is_fixable(self, db: &dyn Db, diagnostic: &Diagnostic) -> bool {
         let Some(primary_span) = diagnostic.primary_span() else {
             return false;
         };
 
         match self {
-            FixMode::Suppress => {
-                primary_span.range().is_some()
-                    && diagnostic
-                        .id()
-                        .as_lint()
-                        .is_some_and(|name| !is_unused_ignore_comment_lint(name))
-            }
+            FixMode::Suppress => primary_span.range().is_some_and(|range| {
+                diagnostic.id().as_lint().is_some_and(|name| {
+                    !is_unused_ignore_comment_lint(name)
+                        && can_suppress(db, primary_span.expect_ty_file(), name, range)
+                })
+            }),
             FixMode::ApplyFixes(applicability) => diagnostic.has_applicable_fix(applicability),
         }
     }
@@ -395,6 +396,10 @@ impl FixMode {
                         // We can't suppress diagnostics without a corresponding file or range.
                         let span = diagnostic.primary_span()?;
                         let range = span.range()?;
+
+                        if !can_suppress(db, file, lint_id, range) {
+                            return None;
+                        }
 
                         Some((lint_id, range))
                     })
@@ -1358,6 +1363,170 @@ class B(A):
     }
 
     #[test]
+    fn add_ignore_updates_own_line_unknown_rule_suppression() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[not-a-rule]
+                value = 1
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+        value = 1
+        ```
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_preserves_bracket_terminated_suppression_reason() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                value = missing  # ty: ignore[unresolved-reference, not-a-rule, another-not-a-rule] tracked by [123]
+                "#),
+            @"
+        Added 2 suppressions
+
+        ## Fixed source
+
+        ```py
+        value = missing  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[unresolved-reference, not-a-rule, another-not-a-rule] tracked by [123]
+        ```
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_handles_nested_suppression_comments() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+                value = missing
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+        value = missing
+        ```
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_does_not_extend_bracket_terminated_suppression_reason() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                value = missing  # ty: ignore[invalid-assignment] tracked by [123]
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        value = missing  # ty: ignore[invalid-assignment] tracked by [123]  # ty:ignore[unresolved-reference]
+        ```
+
+        ## Diagnostics after applying fixes
+
+        warning[unused-ignore-comment]: Unused `ty: ignore` directive
+         --> test.py:1:18
+          |
+        1 | value = missing  # ty: ignore[invalid-assignment] tracked by [123]  # ty:ignore[unresolved-reference]
+          |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          |
+        help: Remove the unused suppression comment
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_handles_invalid_nested_suppression_comments() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+                value = missing
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # type:ignore[ty:invalid-ignore-comment]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+        value = missing
+        ```
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_does_not_suppress_following_logical_line() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[not-a-rule]
+                value = 1  # ty: ignore[another-not-a-rule]
+                "#),
+            @"
+        Added 2 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+        value = 1  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[another-not-a-rule]
+        ```
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_preserves_shebang_suppression() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]
+                value = 1
+                "#),
+            @"
+        Added 0 suppressions
+
+        ## Fixed source
+
+        ```py
+        #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]
+        value = 1
+        ```
+
+        ## Diagnostics after applying fixes
+
+        warning[ignore-comment-unknown-rule]: Unknown rule `not-a-rule`
+         --> test.py:1:43
+          |
+        1 | #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]
+          |                                           ^^^^^^^^^^
+        2 | value = 1
+          |
+        "
+        );
+    }
+
+    #[test]
     fn add_ignore_updates_inner_own_line_suppression() {
         assert_snapshot!(
             suppress_all_in(r#"
@@ -1965,11 +2134,11 @@ class B(A):
         let total_diagnostics = diagnostics.len();
         let suppressible_diagnostics = diagnostics
             .iter()
-            .filter(|diagnostic| FixMode::Suppress.is_fixable(diagnostic))
+            .filter(|diagnostic| FixMode::Suppress.is_fixable(&db, diagnostic))
             .count();
         let unsuppressible_diagnostics: Vec<_> = diagnostics
             .iter()
-            .filter(|diagnostic| !FixMode::Suppress.is_fixable(diagnostic))
+            .filter(|diagnostic| !FixMode::Suppress.is_fixable(&db, diagnostic))
             .cloned()
             .collect();
         let cancellation_token_source = CancellationTokenSource::new();
@@ -1986,7 +2155,7 @@ class B(A):
                 fixes
                     .diagnostics
                     .iter()
-                    .all(|diagnostic| !FixMode::Suppress.is_fixable(diagnostic))
+                    .all(|diagnostic| !FixMode::Suppress.is_fixable(&db, diagnostic))
             );
 
             let unexpected_diagnostics =

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1377,8 +1377,29 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty:ignore[ignore-comment-unknown-rule]
-        # ty: ignore[not-a-rule]
+        # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
+        value = 1
+        ```
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_updates_multiple_own_line_unknown_rules() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[not-a-rule, another-not-a-rule]
+                value = 1
+                "#),
+            @"
+        Added 2 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # ty: ignore[not-a-rule, another-not-a-rule, ignore-comment-unknown-rule]
         value = 1
         ```
         "
@@ -1419,9 +1440,9 @@ class B(A):
 
         ```py
         seen_code = True
-        items = []  # type: list[int]  # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        items = []  # type: list[int]  # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
         invalid = []  # type: list[str]  # ty: ignore[*-*]  # ty:ignore[invalid-ignore-comment]
-        value = "x"  # type: ignore[assignment]  # ty: ignore[another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        value = "x"  # type: ignore[assignment]  # ty: ignore[another-not-a-rule, ignore-comment-unknown-rule]
         ```
         "#
         );
@@ -1442,8 +1463,7 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty:ignore[ignore-comment-unknown-rule]
-        # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+        # ty: ignore[not-a-rule, ignore-comment-unknown-rule]  # ty: ignore[unresolved-reference]
         value = missing
         ```
         "
@@ -1592,14 +1612,13 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty:ignore[ignore-comment-unknown-rule]
-        # ty: ignore[not-a-rule]  # ty: ignore[another-not-a-rule]
+        # ty: ignore[not-a-rule, ignore-comment-unknown-rule]  # ty: ignore[another-not-a-rule, ignore-comment-unknown-rule]
         value = 1
         # ty:ignore[invalid-ignore-comment]
         # ty: ignore[*-*]  # ty: ignore[*-*]
         value = 1
-        # ty:ignore[ignore-comment-unknown-rule, invalid-ignore-comment]
-        # ty: ignore[third-not-a-rule]  # ty: ignore[*-*]
+        # ty:ignore[invalid-ignore-comment]
+        # ty: ignore[third-not-a-rule, ignore-comment-unknown-rule]  # ty: ignore[*-*]
         value = 1
         ```
         "
@@ -1621,9 +1640,8 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty:ignore[ignore-comment-unknown-rule]
-        # ty: ignore[not-a-rule]
-        value = 1  # ty: ignore[another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
+        value = 1  # ty: ignore[another-not-a-rule, ignore-comment-unknown-rule]
         ```
         "
         );
@@ -1643,7 +1661,7 @@ class B(A):
         ## Fixed source
 
         ```py
-        # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
         # ty: ignore[*-*]  # ty:ignore[invalid-ignore-comment]
         value = 1
         ```

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1259,21 +1259,31 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty: ignore[ignore-comment-unknown-rule] # ty: ignore[not-a-rule] # ty: ignore[division-by-zero]
+        # ty: ignore[] # ty: ignore[not-a-rule] # ty: ignore[division-by-zero, ignore-comment-unknown-rule]
         value = 1 / 0
         ```
 
         ## Diagnostics after applying fixes
 
-        warning[unused-ignore-comment]: Unused `ty: ignore` directive
-         --> test.py:2:68
+        warning[unused-ignore-comment]: Unused `ty: ignore` without a code
+         --> test.py:2:1
           |
         1 | seen_code = True
-        2 | # ty: ignore[ignore-comment-unknown-rule] # ty: ignore[not-a-rule] # ty: ignore[division-by-zero]
-          |                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        2 | # ty: ignore[] # ty: ignore[not-a-rule] # ty: ignore[division-by-zero, ignore-comment-unknown-rule]
+          | ^^^^^^^^^^^^^^^
         3 | value = 1 / 0
           |
         help: Remove the unused suppression comment
+
+        warning[unused-ignore-comment]: Unused `ty: ignore` directive: 'division-by-zero'
+         --> test.py:2:54
+          |
+        1 | seen_code = True
+        2 | # ty: ignore[] # ty: ignore[not-a-rule] # ty: ignore[division-by-zero, ignore-comment-unknown-rule]
+          |                                                      ^^^^^^^^^^^^^^^^
+        3 | value = 1 / 0
+          |
+        help: Remove the unused suppression code
         "
         );
     }
@@ -1451,16 +1461,13 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty: ignore[not-a-rule, ignore-comment-unknown-rule]  # ty: ignore[unresolved-reference]
+        # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference, ignore-comment-unknown-rule]
         value = missing
-        # ty:ignore[invalid-ignore-comment]
-        # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+        # ty: ignore[*-*]  # ty: ignore[unresolved-reference, invalid-ignore-comment]
         value = missing
-        # ty:ignore[invalid-ignore-comment]
-        # ty: ignore[#]
+        # ty: ignore[#]  # ty:ignore[invalid-ignore-comment]
         value = 1
-        # ty:ignore[invalid-ignore-comment]
-        # ty: ignore[unresolved-reference#]
+        # ty: ignore[unresolved-reference#]  # ty:ignore[invalid-ignore-comment]
         value = 1
         ```
         "
@@ -1484,36 +1491,33 @@ class B(A):
 
         ```py
         def f():
-            # ty:ignore[ignore-comment-unknown-rule]
-            # type: ignore[ty:division-by-zero, ty:not-a-rule]
+            # type: ignore[ty:division-by-zero, ty:not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
             value = 1
-            # ty:ignore[ignore-comment-unknown-rule]
-            # fmt: off # type: ignore[ty:division-by-zero, ty:another-not-a-rule]
+            # fmt: off # type: ignore[ty:division-by-zero, ty:another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
             value = 1
         ```
 
         ## Diagnostics after applying fixes
 
         warning[unused-type-ignore-comment]: Unused `type: ignore` directive: 'division-by-zero'
-         --> test.py:3:20
+         --> test.py:2:20
           |
         1 | def f():
-        2 |     # ty:ignore[ignore-comment-unknown-rule]
-        3 |     # type: ignore[ty:division-by-zero, ty:not-a-rule]
+        2 |     # type: ignore[ty:division-by-zero, ty:not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
           |                    ^^^^^^^^^^^^^^^^^^^
-        4 |     value = 1
-        5 |     # ty:ignore[ignore-comment-unknown-rule]
+        3 |     value = 1
+        4 |     # fmt: off # type: ignore[ty:division-by-zero, ty:another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
           |
         help: Remove the unused suppression code
 
         warning[unused-type-ignore-comment]: Unused `type: ignore` directive: 'division-by-zero'
-         --> test.py:6:31
+         --> test.py:4:31
           |
-        4 |     value = 1
-        5 |     # ty:ignore[ignore-comment-unknown-rule]
-        6 |     # fmt: off # type: ignore[ty:division-by-zero, ty:another-not-a-rule]
+        2 |     # type: ignore[ty:division-by-zero, ty:not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        3 |     value = 1
+        4 |     # fmt: off # type: ignore[ty:division-by-zero, ty:another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
           |                               ^^^^^^^^^^^^^^^^^^^
-        7 |     value = 1
+        5 |     value = 1
           |
         help: Remove the unused suppression code
         "
@@ -1539,13 +1543,43 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty: ignore[not-a-rule, ignore-comment-unknown-rule]  # ty: ignore[another-not-a-rule, ignore-comment-unknown-rule]
+        # ty: ignore[not-a-rule]  # ty: ignore[another-not-a-rule, ignore-comment-unknown-rule]
         value = 1
-        # ty:ignore[invalid-ignore-comment]
-        # ty: ignore[*-*]  # ty: ignore[*-*]
+        # ty: ignore[*-*]  # ty: ignore[*-*]  # ty:ignore[invalid-ignore-comment]
         value = 1
-        # ty:ignore[invalid-ignore-comment]
-        # ty: ignore[third-not-a-rule, ignore-comment-unknown-rule]  # ty: ignore[*-*]
+        # ty: ignore[third-not-a-rule, ignore-comment-unknown-rule, invalid-ignore-comment]  # ty: ignore[*-*]
+        value = 1
+        ```
+        "
+        );
+    }
+
+    #[test]
+    fn add_ignore_groups_suppression_comments_on_one_physical_line() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                value = 1  # ty: ignore[first-not-a-rule]  # ty: ignore[second-not-a-rule]
+                # ty: ignore[third-not-a-rule]  # type: ignore[ty:fourth-not-a-rule]
+                value = 1
+                #! notes # ty: ignore[fifth-not-a-rule]
+                value = 1
+                # ty: ignore[*-*]  # ty: ignore[sixth-not-a-rule] explanation
+                value = 1
+                "#),
+            @"
+        Added 7 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        value = 1  # ty: ignore[first-not-a-rule]  # ty: ignore[second-not-a-rule, ignore-comment-unknown-rule]
+        # ty: ignore[third-not-a-rule, ignore-comment-unknown-rule]  # type: ignore[ty:fourth-not-a-rule]
+        value = 1
+        #! notes # ty: ignore[fifth-not-a-rule, ignore-comment-unknown-rule]
+        value = 1
+        # ty: ignore[*-*]  # ty: ignore[sixth-not-a-rule] explanation  # ty:ignore[ignore-comment-unknown-rule, invalid-ignore-comment]
         value = 1
         ```
         "
@@ -1604,14 +1638,32 @@ class B(A):
                 value = 1
                 "#),
             @"
-        Added 2 suppressions
+        Added 0 suppressions
 
         ## Fixed source
 
         ```py
-        #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]  # ty: ignore[*-*]  # ty:ignore[ignore-comment-unknown-rule, invalid-ignore-comment]
+        #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]  # ty: ignore[*-*]
         value = 1
         ```
+
+        ## Diagnostics after applying fixes
+
+        warning[ignore-comment-unknown-rule]: Unknown rule `not-a-rule`
+         --> test.py:1:43
+          |
+        1 | #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]  # ty: ignore[*-*]
+          |                                           ^^^^^^^^^^
+        2 | value = 1
+          |
+
+        warning[invalid-ignore-comment]: Invalid `ty: ignore` comment: expected a alphanumeric character or `-` or `_` as code
+         --> test.py:1:69
+          |
+        1 | #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]  # ty: ignore[*-*]
+          |                                                                     ^
+        2 | value = 1
+          |
         "
         );
     }

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1499,6 +1499,32 @@ class B(A):
     }
 
     #[test]
+    fn add_ignore_handles_invalid_hash_in_suppression_comments() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[#]
+                value = 1
+                # ty: ignore[unresolved-reference#]
+                value = 1
+                "#),
+            @"
+        Added 2 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # ty:ignore[invalid-ignore-comment]  # ty: ignore[#]
+        value = 1
+        # ty:ignore[invalid-ignore-comment]  # ty: ignore[unresolved-reference#]
+        value = 1
+        ```
+        "
+        );
+    }
+
+    #[test]
     fn add_ignore_does_not_suppress_following_logical_line() {
         assert_snapshot!(
             suppress_all_in(r#"

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1525,6 +1525,36 @@ class B(A):
     }
 
     #[test]
+    fn add_ignore_deduplicates_nested_suppression_comments() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                # ty: ignore[not-a-rule]  # ty: ignore[another-not-a-rule]
+                value = 1
+                # ty: ignore[*-*]  # ty: ignore[*-*]
+                value = 1
+                # ty: ignore[third-not-a-rule]  # ty: ignore[*-*]
+                value = 1
+                "#),
+            @"
+        Added 6 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]  # ty: ignore[another-not-a-rule]
+        value = 1
+        # ty:ignore[invalid-ignore-comment]  # ty: ignore[*-*]  # ty: ignore[*-*]
+        value = 1
+        # ty:ignore[ignore-comment-unknown-rule, invalid-ignore-comment]  # ty: ignore[third-not-a-rule]  # ty: ignore[*-*]
+        value = 1
+        ```
+        "
+        );
+    }
+
+    #[test]
     fn add_ignore_does_not_suppress_following_logical_line() {
         assert_snapshot!(
             suppress_all_in(r#"

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1525,6 +1525,40 @@ class B(A):
     }
 
     #[test]
+    fn add_ignore_handles_indented_mixed_type_ignore() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                def f():
+                    # type: ignore[ty:division-by-zero, ty:not-a-rule]
+                    value = 1
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        def f():
+            # ty:ignore[ignore-comment-unknown-rule]  # type: ignore[ty:division-by-zero, ty:not-a-rule]
+            value = 1
+        ```
+
+        ## Diagnostics after applying fixes
+
+        warning[unused-type-ignore-comment]: Unused `type: ignore` directive: 'division-by-zero'
+         --> test.py:2:62
+          |
+        1 | def f():
+        2 |     # ty:ignore[ignore-comment-unknown-rule]  # type: ignore[ty:division-by-zero, ty:not-a-rule]
+          |                                                              ^^^^^^^^^^^^^^^^^^^
+        3 |     value = 1
+          |
+        help: Remove the unused suppression code
+        "
+        );
+    }
+
+    #[test]
     fn add_ignore_deduplicates_nested_suppression_comments() {
         assert_snapshot!(
             suppress_all_in(r#"

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1377,7 +1377,7 @@ class B(A):
 
         ```py
         seen_code = True
-        # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+        # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
         value = 1
         ```
         "
@@ -1396,7 +1396,7 @@ class B(A):
         ## Fixed source
 
         ```py
-        value = missing  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[unresolved-reference, not-a-rule, another-not-a-rule] tracked by [123]
+        value = missing  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[unresolved-reference, not-a-rule, another-not-a-rule] tracked by [123]
         ```
         "
         );
@@ -1418,9 +1418,9 @@ class B(A):
 
         ```py
         seen_code = True
-        items = []  # type: list[int]  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
-        invalid = []  # type: list[str]  # type:ignore[ty:invalid-ignore-comment]  # ty: ignore[*-*]
-        value = "x"  # type: ignore[assignment]  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[another-not-a-rule]
+        items = []  # type: list[int]  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
+        invalid = []  # type: list[str]  # type:ignore[ty:invalid-ignore-comment, unused-ignore]  # ty: ignore[*-*]
+        value = "x"  # type: ignore[assignment]  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[another-not-a-rule]
         ```
         "#
         );
@@ -1441,7 +1441,7 @@ class B(A):
 
         ```py
         seen_code = True
-        # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+        # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
         value = missing
         ```
         "
@@ -1491,7 +1491,7 @@ class B(A):
 
         ```py
         seen_code = True
-        # type:ignore[ty:invalid-ignore-comment]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+        # type:ignore[ty:invalid-ignore-comment, unused-ignore]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
         value = missing
         ```
         "
@@ -1513,8 +1513,8 @@ class B(A):
 
         ```py
         seen_code = True
-        # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
-        value = 1  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[another-not-a-rule]
+        # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
+        value = 1  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[another-not-a-rule]
         ```
         "
         );

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1377,7 +1377,7 @@ class B(A):
 
         ```py
         seen_code = True
-        # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
+        # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
         value = 1
         ```
         "
@@ -1441,7 +1441,7 @@ class B(A):
 
         ```py
         seen_code = True
-        # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+        # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
         value = missing
         ```
         "
@@ -1491,7 +1491,7 @@ class B(A):
 
         ```py
         seen_code = True
-        # type:ignore[ty:invalid-ignore-comment, unused-ignore]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+        # ty:ignore[invalid-ignore-comment]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
         value = missing
         ```
         "
@@ -1513,7 +1513,7 @@ class B(A):
 
         ```py
         seen_code = True
-        # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
+        # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
         value = 1  # ty: ignore[another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
         ```
         "

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1377,7 +1377,8 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+        # ty:ignore[ignore-comment-unknown-rule]
+        # ty: ignore[not-a-rule]
         value = 1
         ```
         "
@@ -1441,7 +1442,8 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
+        # ty:ignore[ignore-comment-unknown-rule]
+        # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
         value = missing
         ```
         "
@@ -1463,7 +1465,8 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty:ignore[invalid-ignore-comment]  # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+        # ty:ignore[invalid-ignore-comment]
+        # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
         value = missing
         ```
         "
@@ -1487,9 +1490,11 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty:ignore[invalid-ignore-comment]  # ty: ignore[#]
+        # ty:ignore[invalid-ignore-comment]
+        # ty: ignore[#]
         value = 1
-        # ty:ignore[invalid-ignore-comment]  # ty: ignore[unresolved-reference#]
+        # ty:ignore[invalid-ignore-comment]
+        # ty: ignore[unresolved-reference#]
         value = 1
         ```
         "
@@ -1511,19 +1516,21 @@ class B(A):
 
         ```py
         def f():
-            # ty:ignore[ignore-comment-unknown-rule]  # type: ignore[ty:division-by-zero, ty:not-a-rule]
+            # ty:ignore[ignore-comment-unknown-rule]
+            # type: ignore[ty:division-by-zero, ty:not-a-rule]
             value = 1
         ```
 
         ## Diagnostics after applying fixes
 
         warning[unused-type-ignore-comment]: Unused `type: ignore` directive: 'division-by-zero'
-         --> test.py:2:62
+         --> test.py:3:20
           |
         1 | def f():
-        2 |     # ty:ignore[ignore-comment-unknown-rule]  # type: ignore[ty:division-by-zero, ty:not-a-rule]
-          |                                                              ^^^^^^^^^^^^^^^^^^^
-        3 |     value = 1
+        2 |     # ty:ignore[ignore-comment-unknown-rule]
+        3 |     # type: ignore[ty:division-by-zero, ty:not-a-rule]
+          |                    ^^^^^^^^^^^^^^^^^^^
+        4 |     value = 1
           |
         help: Remove the unused suppression code
         "
@@ -1545,19 +1552,21 @@ class B(A):
 
         ```py
         def f():
-            # fmt: off # ty:ignore[ignore-comment-unknown-rule]  # type: ignore[ty:division-by-zero, ty:not-a-rule]
+            # ty:ignore[ignore-comment-unknown-rule]
+            # fmt: off # type: ignore[ty:division-by-zero, ty:not-a-rule]
             value = 1
         ```
 
         ## Diagnostics after applying fixes
 
         warning[unused-type-ignore-comment]: Unused `type: ignore` directive: 'division-by-zero'
-         --> test.py:2:73
+         --> test.py:3:31
           |
         1 | def f():
-        2 |     # fmt: off # ty:ignore[ignore-comment-unknown-rule]  # type: ignore[ty:division-by-zero, ty:not-a-rule]
-          |                                                                         ^^^^^^^^^^^^^^^^^^^
-        3 |     value = 1
+        2 |     # ty:ignore[ignore-comment-unknown-rule]
+        3 |     # fmt: off # type: ignore[ty:division-by-zero, ty:not-a-rule]
+          |                               ^^^^^^^^^^^^^^^^^^^
+        4 |     value = 1
           |
         help: Remove the unused suppression code
         "
@@ -1583,11 +1592,14 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]  # ty: ignore[another-not-a-rule]
+        # ty:ignore[ignore-comment-unknown-rule]
+        # ty: ignore[not-a-rule]  # ty: ignore[another-not-a-rule]
         value = 1
-        # ty:ignore[invalid-ignore-comment]  # ty: ignore[*-*]  # ty: ignore[*-*]
+        # ty:ignore[invalid-ignore-comment]
+        # ty: ignore[*-*]  # ty: ignore[*-*]
         value = 1
-        # ty:ignore[ignore-comment-unknown-rule, invalid-ignore-comment]  # ty: ignore[third-not-a-rule]  # ty: ignore[*-*]
+        # ty:ignore[ignore-comment-unknown-rule, invalid-ignore-comment]
+        # ty: ignore[third-not-a-rule]  # ty: ignore[*-*]
         value = 1
         ```
         "
@@ -1609,7 +1621,8 @@ class B(A):
 
         ```py
         seen_code = True
-        # ty:ignore[ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+        # ty:ignore[ignore-comment-unknown-rule]
+        # ty: ignore[not-a-rule]
         value = 1  # ty: ignore[another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
         ```
         "

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1403,6 +1403,30 @@ class B(A):
     }
 
     #[test]
+    fn add_ignore_preserves_leading_type_directives() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                seen_code = True
+                items = []  # type: list[int]  # ty: ignore[not-a-rule]
+                invalid = []  # type: list[str]  # ty: ignore[*-*]
+                value = "x"  # type: ignore[assignment]  # ty: ignore[another-not-a-rule]
+                "#),
+            @r#"
+        Added 3 suppressions
+
+        ## Fixed source
+
+        ```py
+        seen_code = True
+        items = []  # type: list[int]  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[not-a-rule]
+        invalid = []  # type: list[str]  # type:ignore[ty:invalid-ignore-comment]  # ty: ignore[*-*]
+        value = "x"  # type: ignore[assignment]  # type:ignore[ty:ignore-comment-unknown-rule]  # ty: ignore[another-not-a-rule]
+        ```
+        "#
+        );
+    }
+
+    #[test]
     fn add_ignore_handles_nested_suppression_comments() {
         assert_snapshot!(
             suppress_all_in(r#"

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1396,7 +1396,7 @@ class B(A):
         ## Fixed source
 
         ```py
-        value = missing  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[unresolved-reference, not-a-rule, another-not-a-rule] tracked by [123]
+        value = missing  # ty: ignore[unresolved-reference, not-a-rule, another-not-a-rule] tracked by [123]  # ty:ignore[ignore-comment-unknown-rule]
         ```
         "
         );
@@ -1418,9 +1418,9 @@ class B(A):
 
         ```py
         seen_code = True
-        items = []  # type: list[int]  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
-        invalid = []  # type: list[str]  # type:ignore[ty:invalid-ignore-comment, unused-ignore]  # ty: ignore[*-*]
-        value = "x"  # type: ignore[assignment]  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[another-not-a-rule]
+        items = []  # type: list[int]  # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        invalid = []  # type: list[str]  # ty: ignore[*-*]  # ty:ignore[invalid-ignore-comment]
+        value = "x"  # type: ignore[assignment]  # ty: ignore[another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
         ```
         "#
         );
@@ -1514,7 +1514,7 @@ class B(A):
         ```py
         seen_code = True
         # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[not-a-rule]
-        value = 1  # type:ignore[ty:ignore-comment-unknown-rule, unused-ignore]  # ty: ignore[another-not-a-rule]
+        value = 1  # ty: ignore[another-not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
         ```
         "
         );

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1645,31 +1645,43 @@ class B(A):
     }
 
     #[test]
-    fn add_ignore_preserves_shebang_suppression() {
+    fn add_ignore_updates_file_level_suppression_comments() {
         assert_snapshot!(
             suppress_all_in(r#"
-                #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]
+                # ty: ignore[not-a-rule]
+                # ty: ignore[*-*]
                 value = 1
                 "#),
             @"
-        Added 0 suppressions
+        Added 2 suppressions
 
         ## Fixed source
 
         ```py
-        #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]
+        # ty: ignore[not-a-rule]  # ty:ignore[ignore-comment-unknown-rule]
+        # ty: ignore[*-*]  # ty:ignore[invalid-ignore-comment]
         value = 1
         ```
+        "
+        );
+    }
 
-        ## Diagnostics after applying fixes
+    #[test]
+    fn add_ignore_preserves_shebang_suppression() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]  # ty: ignore[*-*]
+                value = 1
+                "#),
+            @"
+        Added 2 suppressions
 
-        warning[ignore-comment-unknown-rule]: Unknown rule `not-a-rule`
-         --> test.py:1:43
-          |
-        1 | #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]
-          |                                           ^^^^^^^^^^
-        2 | value = 1
-          |
+        ## Fixed source
+
+        ```py
+        #!/usr/bin/env -S python3 -u # ty: ignore[not-a-rule]  # ty: ignore[*-*]  # ty:ignore[ignore-comment-unknown-rule, invalid-ignore-comment]
+        value = 1
+        ```
         "
         );
     }

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1449,34 +1449,6 @@ class B(A):
     }
 
     #[test]
-    fn add_ignore_does_not_extend_bracket_terminated_suppression_reason() {
-        assert_snapshot!(
-            suppress_all_in(r#"
-                value = missing  # ty: ignore[invalid-assignment] tracked by [123]
-                "#),
-            @"
-        Added 1 suppressions
-
-        ## Fixed source
-
-        ```py
-        value = missing  # ty: ignore[invalid-assignment] tracked by [123]  # ty:ignore[unresolved-reference]
-        ```
-
-        ## Diagnostics after applying fixes
-
-        warning[unused-ignore-comment]: Unused `ty: ignore` directive
-         --> test.py:1:18
-          |
-        1 | value = missing  # ty: ignore[invalid-assignment] tracked by [123]  # ty:ignore[unresolved-reference]
-          |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          |
-        help: Remove the unused suppression comment
-        "
-        );
-    }
-
-    #[test]
     fn add_ignore_handles_invalid_nested_suppression_comments() {
         assert_snapshot!(
             suppress_all_in(r#"

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1369,9 +1369,11 @@ class B(A):
                 seen_code = True
                 # ty: ignore[not-a-rule]
                 value = 1
+                # ty: ignore[another-not-a-rule, third-not-a-rule]
+                value = 1
                 "#),
             @"
-        Added 1 suppressions
+        Added 3 suppressions
 
         ## Fixed source
 
@@ -1379,27 +1381,7 @@ class B(A):
         seen_code = True
         # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
         value = 1
-        ```
-        "
-        );
-    }
-
-    #[test]
-    fn add_ignore_updates_multiple_own_line_unknown_rules() {
-        assert_snapshot!(
-            suppress_all_in(r#"
-                seen_code = True
-                # ty: ignore[not-a-rule, another-not-a-rule]
-                value = 1
-                "#),
-            @"
-        Added 2 suppressions
-
-        ## Fixed source
-
-        ```py
-        seen_code = True
-        # ty: ignore[not-a-rule, another-not-a-rule, ignore-comment-unknown-rule]
+        # ty: ignore[another-not-a-rule, third-not-a-rule, ignore-comment-unknown-rule]
         value = 1
         ```
         "
@@ -1455,9 +1437,15 @@ class B(A):
                 seen_code = True
                 # ty: ignore[not-a-rule]  # ty: ignore[unresolved-reference]
                 value = missing
+                # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
+                value = missing
+                # ty: ignore[#]
+                value = 1
+                # ty: ignore[unresolved-reference#]
+                value = 1
                 "#),
             @"
-        Added 1 suppressions
+        Added 4 suppressions
 
         ## Fixed source
 
@@ -1465,51 +1453,9 @@ class B(A):
         seen_code = True
         # ty: ignore[not-a-rule, ignore-comment-unknown-rule]  # ty: ignore[unresolved-reference]
         value = missing
-        ```
-        "
-        );
-    }
-
-    #[test]
-    fn add_ignore_handles_invalid_nested_suppression_comments() {
-        assert_snapshot!(
-            suppress_all_in(r#"
-                seen_code = True
-                # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
-                value = missing
-                "#),
-            @"
-        Added 1 suppressions
-
-        ## Fixed source
-
-        ```py
-        seen_code = True
         # ty:ignore[invalid-ignore-comment]
         # ty: ignore[*-*]  # ty: ignore[unresolved-reference]
         value = missing
-        ```
-        "
-        );
-    }
-
-    #[test]
-    fn add_ignore_handles_invalid_hash_in_suppression_comments() {
-        assert_snapshot!(
-            suppress_all_in(r#"
-                seen_code = True
-                # ty: ignore[#]
-                value = 1
-                # ty: ignore[unresolved-reference#]
-                value = 1
-                "#),
-            @"
-        Added 2 suppressions
-
-        ## Fixed source
-
-        ```py
-        seen_code = True
         # ty:ignore[invalid-ignore-comment]
         # ty: ignore[#]
         value = 1
@@ -1528,9 +1474,11 @@ class B(A):
                 def f():
                     # type: ignore[ty:division-by-zero, ty:not-a-rule]
                     value = 1
+                    # fmt: off # type: ignore[ty:division-by-zero, ty:another-not-a-rule]
+                    value = 1
                 "#),
             @"
-        Added 1 suppressions
+        Added 2 suppressions
 
         ## Fixed source
 
@@ -1538,6 +1486,9 @@ class B(A):
         def f():
             # ty:ignore[ignore-comment-unknown-rule]
             # type: ignore[ty:division-by-zero, ty:not-a-rule]
+            value = 1
+            # ty:ignore[ignore-comment-unknown-rule]
+            # fmt: off # type: ignore[ty:division-by-zero, ty:another-not-a-rule]
             value = 1
         ```
 
@@ -1551,42 +1502,18 @@ class B(A):
         3 |     # type: ignore[ty:division-by-zero, ty:not-a-rule]
           |                    ^^^^^^^^^^^^^^^^^^^
         4 |     value = 1
+        5 |     # ty:ignore[ignore-comment-unknown-rule]
           |
         help: Remove the unused suppression code
-        "
-        );
-    }
-
-    #[test]
-    fn add_ignore_handles_indented_nested_type_ignore() {
-        assert_snapshot!(
-            suppress_all_in(r#"
-                def f():
-                    # fmt: off # type: ignore[ty:division-by-zero, ty:not-a-rule]
-                    value = 1
-                "#),
-            @"
-        Added 1 suppressions
-
-        ## Fixed source
-
-        ```py
-        def f():
-            # ty:ignore[ignore-comment-unknown-rule]
-            # fmt: off # type: ignore[ty:division-by-zero, ty:not-a-rule]
-            value = 1
-        ```
-
-        ## Diagnostics after applying fixes
 
         warning[unused-type-ignore-comment]: Unused `type: ignore` directive: 'division-by-zero'
-         --> test.py:3:31
+         --> test.py:6:31
           |
-        1 | def f():
-        2 |     # ty:ignore[ignore-comment-unknown-rule]
-        3 |     # fmt: off # type: ignore[ty:division-by-zero, ty:not-a-rule]
-          |                               ^^^^^^^^^^^^^^^^^^^
         4 |     value = 1
+        5 |     # ty:ignore[ignore-comment-unknown-rule]
+        6 |     # fmt: off # type: ignore[ty:division-by-zero, ty:another-not-a-rule]
+          |                               ^^^^^^^^^^^^^^^^^^^
+        7 |     value = 1
           |
         help: Remove the unused suppression code
         "

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1559,6 +1559,40 @@ class B(A):
     }
 
     #[test]
+    fn add_ignore_handles_indented_nested_type_ignore() {
+        assert_snapshot!(
+            suppress_all_in(r#"
+                def f():
+                    # fmt: off # type: ignore[ty:division-by-zero, ty:not-a-rule]
+                    value = 1
+                "#),
+            @"
+        Added 1 suppressions
+
+        ## Fixed source
+
+        ```py
+        def f():
+            # fmt: off # ty:ignore[ignore-comment-unknown-rule]  # type: ignore[ty:division-by-zero, ty:not-a-rule]
+            value = 1
+        ```
+
+        ## Diagnostics after applying fixes
+
+        warning[unused-type-ignore-comment]: Unused `type: ignore` directive: 'division-by-zero'
+         --> test.py:2:73
+          |
+        1 | def f():
+        2 |     # fmt: off # ty:ignore[ignore-comment-unknown-rule]  # type: ignore[ty:division-by-zero, ty:not-a-rule]
+          |                                                                         ^^^^^^^^^^^^^^^^^^^
+        3 |     value = 1
+          |
+        help: Remove the unused suppression code
+        "
+        );
+    }
+
+    #[test]
     fn add_ignore_deduplicates_nested_suppression_comments() {
         assert_snapshot!(
             suppress_all_in(r#"

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -347,7 +347,7 @@ pub(crate) struct Suppressions {
     /// The outer suppression starts before the inner suppression but ends after it.
     inline: IntervalIndex,
 
-    /// Suppressions with lint codes that are unknown.
+    /// Suppressions with lint codes that are unknown, sorted by code range.
     unknown: Vec<UnknownSuppression>,
 
     /// Suppressions that are syntactically invalid.
@@ -734,6 +734,7 @@ impl<'a> SuppressionsBuilder<'a> {
                         Err(error) => self.unknown.push(UnknownSuppression {
                             range: code_range,
                             comment_range: comment.range(),
+                            kind: comment.kind(),
                             reason: error,
                         }),
                     }
@@ -847,6 +848,8 @@ struct UnknownSuppression {
 
     /// The range of the suppression comment
     comment_range: TextRange,
+
+    kind: SuppressionKind,
 
     reason: GetLintError,
 }

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -626,16 +626,14 @@ impl<'a> SuppressionsBuilder<'a> {
         let comment_token_start = tokens.token_range(comment.range().start()).start();
         let is_own_line_comment = indentation_at_offset(comment_token_start, self.source).is_some();
         let is_own_line_suppression = !comment.kind().is_type_ignore() && is_own_line_comment;
-        let line_range = if is_own_line_comment {
-            TextRange::new(comment.range().start(), line_range.end())
-        } else {
-            line_range
-        };
 
         let suppressed_range = if is_file_suppression {
             TextRange::new(0.into(), self.source.text_len())
         } else if is_own_line_suppression {
-            own_line_suppression_range(comment.range(), tokens)
+            TextRange::new(
+                line_range.start(),
+                own_line_suppression_range(comment.range(), tokens).end(),
+            )
         } else {
             line_range
         };
@@ -694,7 +692,7 @@ impl<'a> SuppressionsBuilder<'a> {
                                 && is_suppression_comment_lint(lint.name())
                                 && lint.name() != UNUSED_IGNORE_COMMENT.name()
                             {
-                                TextRange::new(comment.range().start(), line_range.end())
+                                line_range
                             } else {
                                 suppressed_range
                             };

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -688,7 +688,7 @@ impl<'a> SuppressionsBuilder<'a> {
                                 && is_own_line_suppression
                                 && is_suppression_comment_lint(lint.name())
                             {
-                                line_range
+                                TextRange::new(comment.range().start(), line_range.end())
                             } else {
                                 suppressed_range
                             };

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -17,6 +17,7 @@ use rustc_hash::FxHasher;
 
 use crate::diagnostic::DiagnosticGuard;
 use crate::lint::{GetLintError, Level, LintMetadata, LintRegistry, LintStatus};
+pub(crate) use crate::suppression::add_ignore::can_suppress;
 pub use crate::suppression::add_ignore::{SuppressFix, suppress_all, suppress_single};
 use crate::suppression::parser::{
     ParseError, ParseErrorKind, SuppressionComment, SuppressionParser,
@@ -74,6 +75,13 @@ pub fn is_unused_ignore_comment_lint(name: LintName) -> bool {
     name == UNUSED_IGNORE_COMMENT.name() || name == UNUSED_TYPE_IGNORE_COMMENT.name()
 }
 
+fn is_suppression_comment_lint(name: LintName) -> bool {
+    name == IGNORE_COMMENT_UNKNOWN_RULE.name()
+        || name == INVALID_IGNORE_COMMENT.name()
+        || name == BLANKET_IGNORE_COMMENT.name()
+        || is_unused_ignore_comment_lint(name)
+}
+
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
 pub(crate) fn suppressions(db: &dyn Db, file: File) -> Suppressions {
     let parsed = parsed_module(db, file).load(db);
@@ -86,7 +94,7 @@ pub(crate) fn suppressions(db: &dyn Db, file: File) -> Suppressions {
 
     for token in parsed.tokens() {
         if !token.kind().is_trivia() {
-            builder.set_seen_non_trivia_token();
+            builder.set_first_non_trivia_token(token.start());
         }
 
         match token.kind() {
@@ -309,6 +317,9 @@ impl<'ctx, 'db> SuppressionDiagnosticGuardBuilder<'ctx, 'db> {
 /// The suppressions of a single file.
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize)]
 pub(crate) struct Suppressions {
+    /// The start of the first non-trivia token, if any.
+    first_non_trivia_token: Option<TextSize>,
+
     /// Suppressions that apply to the entire file.
     ///
     /// The suppressions are sorted by [`Suppression::comment_range`] and the [`Suppression::suppressed_range`]
@@ -563,8 +574,8 @@ struct SuppressionsBuilder<'a> {
     source: &'a str,
 
     /// Ignore comments at the top of the file before any non-trivia code apply to the entire file.
-    /// This boolean tracks if there has been any non trivia token.
-    seen_non_trivia_token: bool,
+    /// This offset tracks whether there has been any non-trivia token.
+    first_non_trivia_token: Option<TextSize>,
 
     inline: Vec<Suppression>,
     file: SmallVec<[Suppression; 1]>,
@@ -577,7 +588,7 @@ impl<'a> SuppressionsBuilder<'a> {
         Self {
             source,
             lint_registry,
-            seen_non_trivia_token: false,
+            first_non_trivia_token: None,
             inline: Vec::new(),
             file: SmallVec::new_const(),
             unknown: Vec::new(),
@@ -585,8 +596,8 @@ impl<'a> SuppressionsBuilder<'a> {
         }
     }
 
-    fn set_seen_non_trivia_token(&mut self) {
-        self.seen_non_trivia_token = true;
+    fn set_first_non_trivia_token(&mut self, start: TextSize) {
+        self.first_non_trivia_token.get_or_insert(start);
     }
 
     fn finish(mut self) -> Suppressions {
@@ -595,6 +606,7 @@ impl<'a> SuppressionsBuilder<'a> {
         self.invalid.shrink_to_fit();
 
         Suppressions {
+            first_non_trivia_token: self.first_non_trivia_token,
             file: self.file,
             inline: IntervalIndex::from_sorted(self.inline),
             unknown: self.unknown,
@@ -610,7 +622,7 @@ impl<'a> SuppressionsBuilder<'a> {
         // > Blank lines and other comments, such as shebang lines and coding cookies,
         // > may precede the # type: ignore comment.
         // > https://typing.python.org/en/latest/spec/directives.html#type-ignore-comments
-        let is_file_suppression = !self.seen_non_trivia_token;
+        let is_file_suppression = self.first_non_trivia_token.is_none();
         let comment_token_start = tokens.token_range(comment.range().start()).start();
 
         let suppressed_range = if is_file_suppression {

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -624,12 +624,12 @@ impl<'a> SuppressionsBuilder<'a> {
         // > https://typing.python.org/en/latest/spec/directives.html#type-ignore-comments
         let is_file_suppression = self.first_non_trivia_token.is_none();
         let comment_token_start = tokens.token_range(comment.range().start()).start();
+        let is_own_line_suppression = !comment.kind().is_type_ignore()
+            && indentation_at_offset(comment_token_start, self.source).is_some();
 
         let suppressed_range = if is_file_suppression {
             TextRange::new(0.into(), self.source.text_len())
-        } else if !comment.kind().is_type_ignore()
-            && indentation_at_offset(comment_token_start, self.source).is_some()
-        {
+        } else if is_own_line_suppression {
             own_line_suppression_range(comment.range(), tokens)
         } else {
             line_range
@@ -684,6 +684,15 @@ impl<'a> SuppressionsBuilder<'a> {
 
                     match self.lint_registry.get(code) {
                         Ok(lint) => {
+                            let suppressed_range = if !is_file_suppression
+                                && is_own_line_suppression
+                                && is_suppression_comment_lint(lint.name())
+                            {
+                                line_range
+                            } else {
+                                suppressed_range
+                            };
+
                             push_ignore_suppression(Suppression {
                                 target: SuppressionTarget::Lint(lint),
                                 kind: comment.kind(),

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -637,20 +637,18 @@ impl<'a> SuppressionsBuilder<'a> {
         // > https://typing.python.org/en/latest/spec/directives.html#type-ignore-comments
         let is_file_suppression = self.first_non_trivia_token.is_none();
         let comment_token_range = tokens.token_range(comment.range().start());
-        let comment_token_start = comment_token_range.start();
         let is_own_line_suppression = !comment.kind().is_type_ignore()
-            && indentation_at_offset(comment_token_start, self.source).is_some();
+            && indentation_at_offset(comment_token_range.start(), self.source).is_some();
 
         let suppressed_range = if is_file_suppression {
             TextRange::new(0.into(), self.source.text_len())
+        } else if is_own_line_suppression && comment_token_range.end() <= self.comment_only_run_end
+        {
+            TextRange::new(comment.range().start(), self.own_line_suppression_end)
         } else if is_own_line_suppression {
-            if comment_token_range.end() <= self.comment_only_run_end {
-                TextRange::new(comment.range().start(), self.own_line_suppression_end)
-            } else {
-                let range = own_line_suppression_range(comment.range(), tokens);
-                self.own_line_suppression_end = range.end();
-                range
-            }
+            let range = own_line_suppression_range(comment.range(), tokens);
+            self.own_line_suppression_end = range.end();
+            range
         } else {
             line_range
         };

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -624,8 +624,13 @@ impl<'a> SuppressionsBuilder<'a> {
         // > https://typing.python.org/en/latest/spec/directives.html#type-ignore-comments
         let is_file_suppression = self.first_non_trivia_token.is_none();
         let comment_token_start = tokens.token_range(comment.range().start()).start();
-        let is_own_line_suppression = !comment.kind().is_type_ignore()
-            && indentation_at_offset(comment_token_start, self.source).is_some();
+        let is_own_line_comment = indentation_at_offset(comment_token_start, self.source).is_some();
+        let is_own_line_suppression = !comment.kind().is_type_ignore() && is_own_line_comment;
+        let line_range = if is_own_line_comment {
+            TextRange::new(comment_token_start, line_range.end())
+        } else {
+            line_range
+        };
 
         let suppressed_range = if is_file_suppression {
             TextRange::new(0.into(), self.source.text_len())

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -695,7 +695,7 @@ impl<'a> SuppressionsBuilder<'a> {
                                 && lint.name() != UNUSED_IGNORE_COMMENT.name()
                                 && lint.name() != BLANKET_IGNORE_COMMENT.name()
                             {
-                                TextRange::new(comment.range().start(), line_range.end())
+                                own_line_suppression_comment_range(comment.range(), tokens)
                             } else {
                                 suppressed_range
                             };
@@ -722,6 +722,25 @@ impl<'a> SuppressionsBuilder<'a> {
     fn add_invalid_comment(&mut self, kind: SuppressionKind, error: ParseError) {
         self.invalid.push(InvalidSuppression { kind, error });
     }
+}
+
+/// Returns the range covered by an own-line suppression for a suppression-comment diagnostic.
+///
+/// Following comment-only lines are included so an own-line suppression can cover a diagnostic
+/// emitted on the next ignore comment, without also suppressing one on the next logical line.
+fn own_line_suppression_comment_range(range: TextRange, tokens: &Tokens) -> TextRange {
+    let comment_token_range = tokens.token_range(range.start());
+    let mut end = comment_token_range.end();
+
+    for token in tokens.after(comment_token_range.end()) {
+        match token.kind() {
+            TokenKind::Comment => end = token.end(),
+            TokenKind::NonLogicalNewline => {}
+            _ => break,
+        }
+    }
+
+    TextRange::new(range.start(), end)
 }
 
 /// Returns the range covered by an own-line suppression comment.

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -627,7 +627,7 @@ impl<'a> SuppressionsBuilder<'a> {
         let is_own_line_comment = indentation_at_offset(comment_token_start, self.source).is_some();
         let is_own_line_suppression = !comment.kind().is_type_ignore() && is_own_line_comment;
         let line_range = if is_own_line_comment {
-            TextRange::new(comment_token_start, line_range.end())
+            TextRange::new(comment.range().start(), line_range.end())
         } else {
             line_range
         };

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -95,7 +95,7 @@ pub(crate) fn suppressions(db: &dyn Db, file: File) -> Suppressions {
 
     for token in parsed.tokens() {
         if !token.kind().is_trivia() {
-            builder.set_first_non_trivia_token(token.start());
+            builder.set_seen_non_trivia_token();
         }
 
         match token.kind() {
@@ -318,9 +318,6 @@ impl<'ctx, 'db> SuppressionDiagnosticGuardBuilder<'ctx, 'db> {
 /// The suppressions of a single file.
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize)]
 pub(crate) struct Suppressions {
-    /// The start of the first non-trivia token, if any.
-    first_non_trivia_token: Option<TextSize>,
-
     /// Suppressions that apply to the entire file.
     ///
     /// The suppressions are sorted by [`Suppression::comment_range`] and the [`Suppression::suppressed_range`]
@@ -331,9 +328,7 @@ pub(crate) struct Suppressions {
     ///
     /// Comments with multiple codes create multiple [`Suppression`]s that all share the same [`Suppression::comment_range`].
     ///
-    /// The suppressions are indexed by [`Suppression::suppressed_range`] and sorted by interval
-    /// start. A nested `type: ignore` can cover an earlier sub-comment on the same line, so this
-    /// order isn't necessarily source order.
+    /// The suppressions are indexed by [`Suppression::suppressed_range`] and retain source order.
     /// Their range ends aren't necessarily sorted because own-line suppressions can be nested:
     ///
     /// ```py
@@ -487,7 +482,7 @@ impl Suppression {
 
     fn matches(&self, tested_id: LintId) -> bool {
         match self.target {
-            SuppressionTarget::All => true,
+            SuppressionTarget::All => !is_suppression_comment_lint(tested_id.name()),
             SuppressionTarget::Lint(suppressed_id) => tested_id == suppressed_id,
             SuppressionTarget::Empty => false,
         }
@@ -577,14 +572,8 @@ struct SuppressionsBuilder<'a> {
     source: &'a str,
 
     /// Ignore comments at the top of the file before any non-trivia code apply to the entire file.
-    /// This offset tracks whether there has been any non-trivia token.
-    first_non_trivia_token: Option<TextSize>,
-
-    /// The end of the most recently scanned run of comment-only lines.
-    comment_only_run_end: TextSize,
-
-    /// The suppression end shared by own-line comments in the most recent comment-only run.
-    own_line_suppression_end: TextSize,
+    /// This boolean tracks if there has been any non-trivia token.
+    seen_non_trivia_token: bool,
 
     inline: Vec<Suppression>,
     file: SmallVec<[Suppression; 1]>,
@@ -597,9 +586,7 @@ impl<'a> SuppressionsBuilder<'a> {
         Self {
             source,
             lint_registry,
-            first_non_trivia_token: None,
-            comment_only_run_end: TextSize::default(),
-            own_line_suppression_end: TextSize::default(),
+            seen_non_trivia_token: false,
             inline: Vec::new(),
             file: SmallVec::new_const(),
             unknown: Vec::new(),
@@ -607,19 +594,15 @@ impl<'a> SuppressionsBuilder<'a> {
         }
     }
 
-    fn set_first_non_trivia_token(&mut self, start: TextSize) {
-        self.first_non_trivia_token.get_or_insert(start);
+    fn set_seen_non_trivia_token(&mut self) {
+        self.seen_non_trivia_token = true;
     }
 
     fn finish(mut self) -> Suppressions {
         self.file.shrink_to_fit();
         self.unknown.shrink_to_fit();
         self.invalid.shrink_to_fit();
-        self.inline
-            .sort_by_key(|suppression| suppression.suppressed_range.start());
-
         Suppressions {
-            first_non_trivia_token: self.first_non_trivia_token,
             file: self.file,
             inline: IntervalIndex::from_sorted(self.inline),
             unknown: self.unknown,
@@ -635,32 +618,17 @@ impl<'a> SuppressionsBuilder<'a> {
         // > Blank lines and other comments, such as shebang lines and coding cookies,
         // > may precede the # type: ignore comment.
         // > https://typing.python.org/en/latest/spec/directives.html#type-ignore-comments
-        let is_file_suppression = self.first_non_trivia_token.is_none();
-        let comment_token_range = tokens.token_range(comment.range().start());
-        let is_own_line_suppression = !comment.kind().is_type_ignore()
-            && indentation_at_offset(comment_token_range.start(), self.source).is_some();
+        let is_file_suppression = !self.seen_non_trivia_token;
+        let comment_token_start = tokens.token_range(comment.range().start()).start();
 
         let suppressed_range = if is_file_suppression {
             TextRange::new(0.into(), self.source.text_len())
-        } else if is_own_line_suppression && comment_token_range.end() <= self.comment_only_run_end
+        } else if !comment.kind().is_type_ignore()
+            && indentation_at_offset(comment_token_start, self.source).is_some()
         {
-            TextRange::new(comment.range().start(), self.own_line_suppression_end)
-        } else if is_own_line_suppression {
-            let range = own_line_suppression_range(comment.range(), tokens);
-            self.own_line_suppression_end = range.end();
-            range
+            own_line_suppression_range(comment.range(), tokens)
         } else {
             line_range
-        };
-
-        let suppression_comment_range = if !is_file_suppression && is_own_line_suppression {
-            own_line_suppression_comment_range(
-                comment.range(),
-                tokens,
-                &mut self.comment_only_run_end,
-            )
-        } else {
-            suppressed_range
         };
 
         let mut push_ignore_suppression = |suppression: Suppression| {
@@ -712,17 +680,6 @@ impl<'a> SuppressionsBuilder<'a> {
 
                     match self.lint_registry.get(code) {
                         Ok(lint) => {
-                            let suppressed_range = if !is_file_suppression
-                                && is_own_line_suppression
-                                && is_suppression_comment_lint(lint.name())
-                                && lint.name() != UNUSED_IGNORE_COMMENT.name()
-                                && lint.name() != BLANKET_IGNORE_COMMENT.name()
-                            {
-                                suppression_comment_range
-                            } else {
-                                suppressed_range
-                            };
-
                             push_ignore_suppression(Suppression {
                                 target: SuppressionTarget::Lint(lint),
                                 kind: comment.kind(),
@@ -746,34 +703,6 @@ impl<'a> SuppressionsBuilder<'a> {
     fn add_invalid_comment(&mut self, kind: SuppressionKind, error: ParseError) {
         self.invalid.push(InvalidSuppression { kind, error });
     }
-}
-
-/// Returns the range covered by an own-line suppression for a suppression-comment diagnostic.
-///
-/// Following comment-only lines are included so an own-line suppression can cover a diagnostic
-/// emitted on the next ignore comment, without also suppressing one on the next logical line.
-fn own_line_suppression_comment_range(
-    range: TextRange,
-    tokens: &Tokens,
-    comment_only_run_end: &mut TextSize,
-) -> TextRange {
-    let comment_token_range = tokens.token_range(range.start());
-
-    if comment_token_range.end() <= *comment_only_run_end {
-        return TextRange::new(range.start(), *comment_only_run_end);
-    }
-
-    *comment_only_run_end = comment_token_range.end();
-
-    for token in tokens.after(comment_token_range.end()) {
-        match token.kind() {
-            TokenKind::Comment => *comment_only_run_end = token.end(),
-            TokenKind::NonLogicalNewline => {}
-            _ => break,
-        }
-    }
-
-    TextRange::new(range.start(), *comment_only_run_end)
 }
 
 /// Returns the range covered by an own-line suppression comment.
@@ -837,7 +766,7 @@ fn own_line_suppression_range(range: TextRange, tokens: &Tokens) -> TextRange {
         }
     }
 
-    TextRange::new(range.start(), end)
+    TextRange::new(comment_token_start, end)
 }
 
 /// Suppression for an unknown lint rule.

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -692,6 +692,7 @@ impl<'a> SuppressionsBuilder<'a> {
                                 && is_own_line_suppression
                                 && is_suppression_comment_lint(lint.name())
                                 && lint.name() != UNUSED_IGNORE_COMMENT.name()
+                                && lint.name() != BLANKET_IGNORE_COMMENT.name()
                             {
                                 TextRange::new(comment.range().start(), line_range.end())
                             } else {

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -75,6 +75,7 @@ pub fn is_unused_ignore_comment_lint(name: LintName) -> bool {
     name == UNUSED_IGNORE_COMMENT.name() || name == UNUSED_TYPE_IGNORE_COMMENT.name()
 }
 
+/// Returns whether `name` diagnoses an ignore comment rather than the code it suppresses.
 fn is_suppression_comment_lint(name: LintName) -> bool {
     name == IGNORE_COMMENT_UNKNOWN_RULE.name()
         || name == INVALID_IGNORE_COMMENT.name()
@@ -628,8 +629,8 @@ impl<'a> SuppressionsBuilder<'a> {
         // > https://typing.python.org/en/latest/spec/directives.html#type-ignore-comments
         let is_file_suppression = self.first_non_trivia_token.is_none();
         let comment_token_start = tokens.token_range(comment.range().start()).start();
-        let is_own_line_comment = indentation_at_offset(comment_token_start, self.source).is_some();
-        let is_own_line_suppression = !comment.kind().is_type_ignore() && is_own_line_comment;
+        let is_own_line_suppression = !comment.kind().is_type_ignore()
+            && indentation_at_offset(comment_token_start, self.source).is_some();
 
         let suppressed_range = if is_file_suppression {
             TextRange::new(0.into(), self.source.text_len())

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -692,6 +692,7 @@ impl<'a> SuppressionsBuilder<'a> {
                             let suppressed_range = if !is_file_suppression
                                 && is_own_line_suppression
                                 && is_suppression_comment_lint(lint.name())
+                                && lint.name() != UNUSED_IGNORE_COMMENT.name()
                             {
                                 TextRange::new(comment.range().start(), line_range.end())
                             } else {

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -580,6 +580,12 @@ struct SuppressionsBuilder<'a> {
     /// This offset tracks whether there has been any non-trivia token.
     first_non_trivia_token: Option<TextSize>,
 
+    /// The end of the most recently scanned run of comment-only lines.
+    comment_only_run_end: TextSize,
+
+    /// The suppression end shared by own-line comments in the most recent comment-only run.
+    own_line_suppression_end: TextSize,
+
     inline: Vec<Suppression>,
     file: SmallVec<[Suppression; 1]>,
     unknown: Vec<UnknownSuppression>,
@@ -592,6 +598,8 @@ impl<'a> SuppressionsBuilder<'a> {
             source,
             lint_registry,
             first_non_trivia_token: None,
+            comment_only_run_end: TextSize::default(),
+            own_line_suppression_end: TextSize::default(),
             inline: Vec::new(),
             file: SmallVec::new_const(),
             unknown: Vec::new(),
@@ -628,16 +636,33 @@ impl<'a> SuppressionsBuilder<'a> {
         // > may precede the # type: ignore comment.
         // > https://typing.python.org/en/latest/spec/directives.html#type-ignore-comments
         let is_file_suppression = self.first_non_trivia_token.is_none();
-        let comment_token_start = tokens.token_range(comment.range().start()).start();
+        let comment_token_range = tokens.token_range(comment.range().start());
+        let comment_token_start = comment_token_range.start();
         let is_own_line_suppression = !comment.kind().is_type_ignore()
             && indentation_at_offset(comment_token_start, self.source).is_some();
 
         let suppressed_range = if is_file_suppression {
             TextRange::new(0.into(), self.source.text_len())
         } else if is_own_line_suppression {
-            own_line_suppression_range(comment.range(), tokens)
+            if comment_token_range.end() <= self.comment_only_run_end {
+                TextRange::new(comment.range().start(), self.own_line_suppression_end)
+            } else {
+                let range = own_line_suppression_range(comment.range(), tokens);
+                self.own_line_suppression_end = range.end();
+                range
+            }
         } else {
             line_range
+        };
+
+        let suppression_comment_range = if !is_file_suppression && is_own_line_suppression {
+            own_line_suppression_comment_range(
+                comment.range(),
+                tokens,
+                &mut self.comment_only_run_end,
+            )
+        } else {
+            suppressed_range
         };
 
         let mut push_ignore_suppression = |suppression: Suppression| {
@@ -695,7 +720,7 @@ impl<'a> SuppressionsBuilder<'a> {
                                 && lint.name() != UNUSED_IGNORE_COMMENT.name()
                                 && lint.name() != BLANKET_IGNORE_COMMENT.name()
                             {
-                                own_line_suppression_comment_range(comment.range(), tokens)
+                                suppression_comment_range
                             } else {
                                 suppressed_range
                             };
@@ -728,19 +753,28 @@ impl<'a> SuppressionsBuilder<'a> {
 ///
 /// Following comment-only lines are included so an own-line suppression can cover a diagnostic
 /// emitted on the next ignore comment, without also suppressing one on the next logical line.
-fn own_line_suppression_comment_range(range: TextRange, tokens: &Tokens) -> TextRange {
+fn own_line_suppression_comment_range(
+    range: TextRange,
+    tokens: &Tokens,
+    comment_only_run_end: &mut TextSize,
+) -> TextRange {
     let comment_token_range = tokens.token_range(range.start());
-    let mut end = comment_token_range.end();
+
+    if comment_token_range.end() <= *comment_only_run_end {
+        return TextRange::new(range.start(), *comment_only_run_end);
+    }
+
+    *comment_only_run_end = comment_token_range.end();
 
     for token in tokens.after(comment_token_range.end()) {
         match token.kind() {
-            TokenKind::Comment => end = token.end(),
+            TokenKind::Comment => *comment_only_run_end = token.end(),
             TokenKind::NonLogicalNewline => {}
             _ => break,
         }
     }
 
-    TextRange::new(range.start(), end)
+    TextRange::new(range.start(), *comment_only_run_end)
 }
 
 /// Returns the range covered by an own-line suppression comment.

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -330,7 +330,9 @@ pub(crate) struct Suppressions {
     ///
     /// Comments with multiple codes create multiple [`Suppression`]s that all share the same [`Suppression::comment_range`].
     ///
-    /// The suppressions are indexed by [`Suppression::suppressed_range`] and retain source order.
+    /// The suppressions are indexed by [`Suppression::suppressed_range`] and sorted by interval
+    /// start. A nested `type: ignore` can cover an earlier sub-comment on the same line, so this
+    /// order isn't necessarily source order.
     /// Their range ends aren't necessarily sorted because own-line suppressions can be nested:
     ///
     /// ```py
@@ -604,6 +606,8 @@ impl<'a> SuppressionsBuilder<'a> {
         self.file.shrink_to_fit();
         self.unknown.shrink_to_fit();
         self.invalid.shrink_to_fit();
+        self.inline
+            .sort_by_key(|suppression| suppression.suppressed_range.start());
 
         Suppressions {
             first_non_trivia_token: self.first_non_trivia_token,
@@ -630,10 +634,7 @@ impl<'a> SuppressionsBuilder<'a> {
         let suppressed_range = if is_file_suppression {
             TextRange::new(0.into(), self.source.text_len())
         } else if is_own_line_suppression {
-            TextRange::new(
-                line_range.start(),
-                own_line_suppression_range(comment.range(), tokens).end(),
-            )
+            own_line_suppression_range(comment.range(), tokens)
         } else {
             line_range
         };
@@ -692,7 +693,7 @@ impl<'a> SuppressionsBuilder<'a> {
                                 && is_suppression_comment_lint(lint.name())
                                 && lint.name() != UNUSED_IGNORE_COMMENT.name()
                             {
-                                line_range
+                                TextRange::new(comment.range().start(), line_range.end())
                             } else {
                                 suppressed_range
                             };

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -16,8 +16,8 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::token::TokenKind;
-use ruff_python_trivia::indentation_at_offset;
-use ruff_source_file::LineRanges;
+use ruff_python_trivia::{indentation_at_offset, leading_indentation};
+use ruff_source_file::{LineRanges, find_newline};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use smallvec::SmallVec;
 
@@ -106,6 +106,7 @@ pub fn suppress_all(
             .into_values()
             .map(|(start, lints, suppressed_diagnostics)| SuppressFix {
                 fix: add_line_local_suppression(
+                    &source,
                     &lints.into_iter().collect::<SmallVec<[_; 2]>>(),
                     start,
                 ),
@@ -216,7 +217,7 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
     if is_suppression_comment_lint(id.name()) {
         match suppression_comment_fix(db, file, range)? {
             SuppressionCommentFix::LineLocal(start) => {
-                return Some(add_line_local_suppression(&[id.name()], start));
+                return Some(add_line_local_suppression(&source, &[id.name()], start));
             }
             SuppressionCommentFix::SameLine => {}
             SuppressionCommentFix::Shebang => return None,
@@ -291,13 +292,16 @@ fn suppression_comment_fix(
     Some(SuppressionCommentFix::LineLocal(start))
 }
 
-/// Prepends a `ty: ignore` that suppresses only diagnostics on the existing comment line.
-fn add_line_local_suppression(codes: &[LintName], start: TextSize) -> Fix {
+/// Adds an own-line `ty: ignore` before a diagnostic on an existing comment line.
+fn add_line_local_suppression(source: &str, codes: &[LintName], start: TextSize) -> Fix {
+    let line_start = source.line_start(start);
+    let indentation = leading_indentation(&source[line_start.to_usize()..]);
+    let line_ending = find_newline(source).map_or("\n", |(_, ending)| ending.as_str());
     let insertion = format!(
-        "# ty:ignore[{codes}]  ",
+        "{indentation}# ty:ignore[{codes}]{line_ending}",
         codes = Codes(SuppressionKind::Ty, codes)
     );
-    Fix::safe_edit(Edit::insertion(insertion, start))
+    Fix::safe_edit(Edit::insertion(insertion, line_start))
 }
 
 /// Returns the suppression range for the given `range`.

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -232,7 +232,11 @@ fn line_local_suppression_start(db: &dyn Db, file: File, range: TextRange) -> Op
         return None;
     }
 
-    Some(comment.start())
+    let source = source_text(db, file);
+    let before_diagnostic = &source[TextRange::new(comment.start(), range.end())];
+    let hash = before_diagnostic.rfind('#')?;
+
+    Some(comment.start() + before_diagnostic[..hash].text_len())
 }
 
 fn add_line_local_suppression(codes: &[LintName], start: TextSize) -> Fix {

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -44,14 +44,17 @@ pub fn suppress_all(
     let parsed = parsed_module(db, file).load(db);
     let tokens = parsed.tokens();
 
-    let mut line_local = BTreeMap::<TextSize, (BTreeSet<LintName>, usize)>::new();
+    let mut line_local = BTreeMap::<TextSize, (TextSize, BTreeSet<LintName>, usize)>::new();
     let mut ids_with_suppression_range = Vec::with_capacity(ids_with_range.len());
 
     for &(id, diagnostic_range) in ids_with_range {
         if is_suppression_comment_lint(id) {
             match suppression_comment_fix(db, file, diagnostic_range) {
                 Some(SuppressionCommentFix::LineLocal(start)) => {
-                    let (lints, suppressed_diagnostics) = line_local.entry(start).or_default();
+                    let (insertion_start, lints, suppressed_diagnostics) = line_local
+                        .entry(source.line_start(start))
+                        .or_insert_with(|| (start, BTreeSet::new(), 0));
+                    *insertion_start = (*insertion_start).min(start);
                     lints.insert(id);
                     *suppressed_diagnostics += 1;
                 }
@@ -98,8 +101,8 @@ pub fn suppress_all(
 
     fixes.extend(
         line_local
-            .into_iter()
-            .map(|(start, (lints, suppressed_diagnostics))| SuppressFix {
+            .into_values()
+            .map(|(start, lints, suppressed_diagnostics)| SuppressFix {
                 fix: add_line_local_suppression(
                     &lints.into_iter().collect::<SmallVec<[_; 2]>>(),
                     start,

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -16,16 +16,15 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::token::TokenKind;
-use ruff_python_trivia::{indentation_at_offset, leading_indentation};
-use ruff_source_file::{LineRanges, find_newline};
+use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use smallvec::SmallVec;
 
 use crate::Db;
 use crate::lint::LintId;
 use crate::suppression::{
-    IGNORE_COMMENT_UNKNOWN_RULE, SuppressionKind, Suppressions, is_suppression_comment_lint,
-    select_preferred_suppression, suppressions,
+    SuppressionKind, Suppressions, is_suppression_comment_lint, select_preferred_suppression,
+    suppressions,
 };
 
 /// Creates fixes to suppress all violations in `ids_with_range`.
@@ -44,30 +43,11 @@ pub fn suppress_all(
     let parsed = parsed_module(db, file).load(db);
     let tokens = parsed.tokens();
 
-    let mut line_local = BTreeMap::<TextSize, (BTreeSet<LintName>, usize)>::new();
     let mut ids_with_suppression_range = Vec::with_capacity(ids_with_range.len());
 
     for &(id, diagnostic_range) in ids_with_range {
-        if is_suppression_comment_lint(id) {
-            match suppression_comment_fix(db, file, diagnostic_range) {
-                Some(SuppressionCommentFix::LineLocal)
-                    if find_existing_suppression(suppressions, &source, diagnostic_range, id)
-                        .is_none() =>
-                {
-                    let (lints, suppressed_diagnostics) = line_local
-                        .entry(source.line_start(diagnostic_range.start()))
-                        .or_default();
-                    lints.insert(id);
-                    *suppressed_diagnostics += 1;
-                    continue;
-                }
-                Some(
-                    SuppressionCommentFix::LineLocal
-                    | SuppressionCommentFix::SameLine
-                    | SuppressionCommentFix::Shebang,
-                ) => {}
-                None => continue,
-            }
+        if is_suppression_comment_lint(id) && is_executable_shebang(&source, diagnostic_range) {
+            continue;
         }
 
         ids_with_suppression_range.push((
@@ -96,22 +76,9 @@ pub fn suppress_all(
     // but also the diagnostic with the wider range (because the suppression is on its start line).
     ids_with_suppression_range.sort_unstable_by_key(|(_, _, range)| (range.start(), range.end()));
 
-    let mut fixes = Vec::with_capacity(ids_with_suppression_range.len() + line_local.len());
+    let mut fixes = Vec::with_capacity(ids_with_suppression_range.len());
     let mut with_existing = Vec::new();
     let mut without_existing = Vec::new();
-
-    fixes.extend(
-        line_local
-            .into_iter()
-            .map(|(start, (lints, suppressed_diagnostics))| SuppressFix {
-                fix: add_line_local_suppression(
-                    &source,
-                    &lints.into_iter().collect::<SmallVec<[_; 2]>>(),
-                    start,
-                ),
-                suppressed_diagnostics,
-            }),
-    );
 
     // Choose the final existing suppression for every diagnostic before grouping any edits.
     for (id, diagnostic_range, suppression_range) in ids_with_suppression_range {
@@ -203,24 +170,18 @@ pub struct SuppressFix {
     pub suppressed_diagnostics: usize,
 }
 
-/// Creates a fix to suppress a single lint, except for suppression diagnostics in a shebang.
+/// Creates a fix to suppress a single lint, unless doing so would edit an executable shebang.
 pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) -> Option<Fix> {
     let suppressions = suppressions(db, file);
     let source = source_text(db, file);
     let codes = &[id.name()];
 
-    if let Some(existing) = find_existing_suppression(suppressions, &source, range, id.name()) {
-        return Some(add_to_existing_suppression(existing, codes));
+    if is_suppression_comment_lint(id.name()) && is_executable_shebang(&source, range) {
+        return None;
     }
 
-    if is_suppression_comment_lint(id.name()) {
-        match suppression_comment_fix(db, file, range)? {
-            SuppressionCommentFix::LineLocal => {
-                return Some(add_line_local_suppression(&source, codes, range.start()));
-            }
-            SuppressionCommentFix::SameLine => {}
-            SuppressionCommentFix::Shebang => return None,
-        }
+    if let Some(existing) = find_existing_suppression(suppressions, &source, range, id.name()) {
+        return Some(add_to_existing_suppression(existing, codes));
     }
 
     let suppression_range = suppression_range(db, file, range);
@@ -234,68 +195,11 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
 
 /// Returns whether a diagnostic can be included in a bulk suppression fix.
 pub(crate) fn can_suppress(db: &dyn Db, file: File, id: LintName, range: TextRange) -> bool {
-    !is_suppression_comment_lint(id) || suppression_comment_fix(db, file, range).is_some()
+    !is_suppression_comment_lint(id) || !is_executable_shebang(&source_text(db, file), range)
 }
 
-enum SuppressionCommentFix {
-    LineLocal,
-    SameLine,
-    Shebang,
-}
-
-/// Classifies how to suppress a diagnostic emitted for an existing ignore comment.
-///
-/// Own-line diagnostics without an editable suppression get a preceding-line suppression, while
-/// inline and file-level diagnostics use an end-of-line suppression. Shebangs remain eligible for
-/// bulk fixes but not IDE quick fixes.
-///
-/// ```python
-/// seen_code = True
-/// # ty: ignore[*-*]  # receives a preceding-line suppression
-/// ```
-fn suppression_comment_fix(
-    db: &dyn Db,
-    file: File,
-    range: TextRange,
-) -> Option<SuppressionCommentFix> {
-    let parsed = parsed_module(db, file).load(db);
-    let tokens = parsed.tokens();
-    let comment = tokens
-        .at_offset(range.start())
-        .find(|token| token.kind() == TokenKind::Comment)?;
-
-    let source = source_text(db, file);
-    if indentation_at_offset(comment.start(), &source).is_none() {
-        return Some(SuppressionCommentFix::SameLine);
-    }
-
-    // A suppression before the first non-trivia token is file-level, so bulk fixes append a
-    // ty-specific suppression on the same line instead of prepending a line-local one.
-    if suppressions(db, file)
-        .first_non_trivia_token
-        .is_none_or(|start| comment.start() < start)
-    {
-        return Some(if source[comment.range()].starts_with("#!") {
-            SuppressionCommentFix::Shebang
-        } else {
-            SuppressionCommentFix::SameLine
-        });
-    }
-
-    Some(SuppressionCommentFix::LineLocal)
-}
-
-/// Adds an own-line `ty: ignore` before a diagnostic on an existing comment line.
-fn add_line_local_suppression(source: &str, codes: &[LintName], start: TextSize) -> Fix {
-    let line_start = source.line_start(start);
-    let line = &source[line_start.to_usize()..];
-    let indentation = leading_indentation(line);
-    let line_ending = find_newline(line).map_or("\n", |(_, ending)| ending.as_str());
-    let insertion = format!(
-        "{indentation}# ty:ignore[{codes}]{line_ending}",
-        codes = Codes(SuppressionKind::Ty, codes)
-    );
-    Fix::safe_edit(Edit::insertion(insertion, line_start))
+fn is_executable_shebang(source: &str, range: TextRange) -> bool {
+    source.starts_with("#!") && source.line_start(range.start()) == TextSize::ZERO
 }
 
 /// Returns the suppression range for the given `range`.
@@ -376,9 +280,9 @@ fn add_end_of_line_suppression(source: &str, codes: &[LintName], line_end: TextS
 /// Returns insertion metadata for the preferred editable suppression covering `range`.
 ///
 /// When multiple comments apply, a same-line or otherwise nested comment takes precedence over an
-/// outer own-line suppression. Diagnostics about suppression comments never extend a
-/// `type: ignore`, since that would affect other type checkers. A syntactically valid `ty: ignore`
-/// containing only unknown codes remains editable.
+/// outer own-line suppression. Diagnostics about suppression comments only extend a `ty: ignore`
+/// on their own physical line. A syntactically valid `ty: ignore` containing only unknown codes
+/// remains editable even though it has no indexed suppression entries.
 ///
 /// ```python
 /// # ty: ignore[invalid-assignment]
@@ -390,36 +294,44 @@ fn find_existing_suppression(
     range: TextRange,
     id: LintName,
 ) -> Option<ExistingSuppression> {
-    let (comment_range, kind) = select_preferred_suppression(
+    let line_start = source.line_start(range.start());
+    let is_suppression_comment = is_suppression_comment_lint(id);
+
+    let indexed = select_preferred_suppression(
         suppressions
-            .editable_inline_suppressions_rev(range)
+            .file
+            .iter()
+            .rev()
+            .filter(|_| is_suppression_comment)
+            .chain(suppressions.editable_inline_suppressions_rev(range))
             .filter(|suppression| {
-                (!is_suppression_comment_lint(id) || !suppression.kind.is_type_ignore())
+                (!is_suppression_comment
+                    || (!suppression.kind.is_type_ignore()
+                        && source.line_start(suppression.comment_range.start()) == line_start))
                     && editable_suppression_prefix(&source[suppression.comment_range]).is_some()
             }),
         range,
     )
-    .map(|suppression| (suppression.comment_range, suppression.kind))
-    .or_else(|| {
-        // A directive containing only unknown codes produces no editable suppression entry. The
-        // unknown codes are source-ordered, so locate the diagnosed directive without rescanning.
-        if id != IGNORE_COMMENT_UNKNOWN_RULE.name() {
-            return None;
-        }
+    .map(|suppression| (suppression.comment_range, suppression.kind));
 
-        let index = suppressions
-            .unknown
-            .binary_search_by_key(&range.start(), |unknown| unknown.range.start())
-            .ok()?;
-        let unknown = suppressions.unknown.get(index)?;
-        let line_start = source.line_start(unknown.comment_range.start());
+    let line_end = source.line_end(range.start());
+    let first_unknown = suppressions
+        .unknown
+        .partition_point(|unknown| unknown.range.start() < line_start);
+    let unknown = suppressions.unknown[first_unknown..]
+        .iter()
+        .take_while(|unknown| unknown.range.start() < line_end)
+        .filter(|unknown| {
+            unknown.kind == SuppressionKind::Ty
+                && editable_suppression_prefix(&source[unknown.comment_range]).is_some()
+        })
+        .max_by_key(|unknown| unknown.comment_range.start())
+        .map(|unknown| (unknown.comment_range, unknown.kind));
 
-        // Extending either a `type: ignore` or a shebang could change behavior outside ty.
-        (unknown.range == range
-            && unknown.kind == SuppressionKind::Ty
-            && !source[line_start.to_usize()..].starts_with("#!"))
-        .then_some((unknown.comment_range, unknown.kind))
-    })?;
+    let (comment_range, kind) = indexed
+        .into_iter()
+        .chain(unknown)
+        .max_by_key(|(comment_range, _)| comment_range.start())?;
     let prefix = editable_suppression_prefix(&source[comment_range])?;
     let separator = if prefix.ends_with('[') {
         ""

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -401,6 +401,8 @@ fn find_existing_suppression(
     )
     .map(|suppression| (suppression.comment_range, suppression.kind))
     .or_else(|| {
+        // A directive containing only unknown codes produces no editable suppression entry. The
+        // unknown codes are source-ordered, so locate the diagnosed directive without rescanning.
         if id != IGNORE_COMMENT_UNKNOWN_RULE.name() {
             return None;
         }
@@ -412,6 +414,7 @@ fn find_existing_suppression(
         let unknown = suppressions.unknown.get(index)?;
         let line_start = source.line_start(unknown.comment_range.start());
 
+        // Extending either a `type: ignore` or a shebang could change behavior outside ty.
         (unknown.range == range
             && unknown.kind == SuppressionKind::Ty
             && !source[line_start.to_usize()..].starts_with("#!"))

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -44,26 +44,25 @@ pub fn suppress_all(
     let parsed = parsed_module(db, file).load(db);
     let tokens = parsed.tokens();
 
-    let mut line_local = BTreeMap::<TextSize, (TextSize, BTreeSet<LintName>, usize)>::new();
+    let mut line_local = BTreeMap::<TextSize, (BTreeSet<LintName>, usize)>::new();
     let mut ids_with_suppression_range = Vec::with_capacity(ids_with_range.len());
 
     for &(id, diagnostic_range) in ids_with_range {
         if is_suppression_comment_lint(id) {
             match suppression_comment_fix(db, file, diagnostic_range) {
-                Some(SuppressionCommentFix::LineLocal(start))
+                Some(SuppressionCommentFix::LineLocal)
                     if find_existing_suppression(suppressions, &source, diagnostic_range, id)
                         .is_none() =>
                 {
-                    let (insertion_start, lints, suppressed_diagnostics) = line_local
-                        .entry(source.line_start(start))
-                        .or_insert_with(|| (start, BTreeSet::new(), 0));
-                    *insertion_start = (*insertion_start).min(start);
+                    let (lints, suppressed_diagnostics) = line_local
+                        .entry(source.line_start(diagnostic_range.start()))
+                        .or_default();
                     lints.insert(id);
                     *suppressed_diagnostics += 1;
                     continue;
                 }
                 Some(
-                    SuppressionCommentFix::LineLocal(_)
+                    SuppressionCommentFix::LineLocal
                     | SuppressionCommentFix::SameLine
                     | SuppressionCommentFix::Shebang,
                 ) => {}
@@ -103,8 +102,8 @@ pub fn suppress_all(
 
     fixes.extend(
         line_local
-            .into_values()
-            .map(|(start, lints, suppressed_diagnostics)| SuppressFix {
+            .into_iter()
+            .map(|(start, (lints, suppressed_diagnostics))| SuppressFix {
                 fix: add_line_local_suppression(
                     &source,
                     &lints.into_iter().collect::<SmallVec<[_; 2]>>(),
@@ -216,8 +215,12 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
 
     if is_suppression_comment_lint(id.name()) {
         match suppression_comment_fix(db, file, range)? {
-            SuppressionCommentFix::LineLocal(start) => {
-                return Some(add_line_local_suppression(&source, &[id.name()], start));
+            SuppressionCommentFix::LineLocal => {
+                return Some(add_line_local_suppression(
+                    &source,
+                    &[id.name()],
+                    range.start(),
+                ));
             }
             SuppressionCommentFix::SameLine => {}
             SuppressionCommentFix::Shebang => return None,
@@ -239,19 +242,19 @@ pub(crate) fn can_suppress(db: &dyn Db, file: File, id: LintName, range: TextRan
 }
 
 enum SuppressionCommentFix {
-    LineLocal(TextSize),
+    LineLocal,
     SameLine,
     Shebang,
 }
 
 /// Classifies how to suppress a diagnostic emitted for an existing ignore comment.
 ///
-/// Own-line diagnostics get a line-local prefix, while inline and file-level diagnostics use an
+/// Own-line diagnostics get a preceding-line suppression, while inline and file-level diagnostics use an
 /// end-of-line suppression. Shebangs remain eligible for bulk fixes but not IDE quick fixes.
 ///
 /// ```python
 /// seen_code = True
-/// # ty: ignore[not-a-rule]  # receives a line-local prefix
+/// # ty: ignore[not-a-rule]  # receives a preceding-line suppression
 /// ```
 fn suppression_comment_fix(
     db: &dyn Db,
@@ -282,14 +285,7 @@ fn suppression_comment_fix(
         });
     }
 
-    let before_diagnostic = &source[TextRange::new(comment.start(), range.start())];
-    let start = before_diagnostic
-        .rfind('#')
-        .map_or(comment.start(), |hash| {
-            comment.start() + before_diagnostic[..hash].text_len()
-        });
-
-    Some(SuppressionCommentFix::LineLocal(start))
+    Some(SuppressionCommentFix::LineLocal)
 }
 
 /// Adds an own-line `ty: ignore` before a diagnostic on an existing comment line.

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -241,7 +241,7 @@ fn line_local_suppression_start(db: &dyn Db, file: File, range: TextRange) -> Op
 
 fn add_line_local_suppression(codes: &[LintName], start: TextSize) -> Fix {
     let insertion = format!(
-        "# type:ignore[{codes}]  ",
+        "# type:ignore[{codes}, unused-ignore]  ",
         codes = Codes(SuppressionKind::TypeIgnore, codes)
     );
     Fix::safe_edit(Edit::insertion(insertion, start))

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -249,10 +249,6 @@ fn suppression_comment_fix(
         return Some(SuppressionCommentFix::SameLine);
     }
 
-    if !db.analysis_settings(file).respect_type_ignore_comments {
-        return None;
-    }
-
     // A suppression before the first non-trivia token is file-level, so adding one there would
     // affect diagnostics throughout the file.
     if suppressions(db, file)
@@ -272,8 +268,8 @@ fn suppression_comment_fix(
 
 fn add_line_local_suppression(codes: &[LintName], start: TextSize) -> Fix {
     let insertion = format!(
-        "# type:ignore[{codes}, unused-ignore]  ",
-        codes = Codes(SuppressionKind::TypeIgnore, codes)
+        "# ty:ignore[{codes}]  ",
+        codes = Codes(SuppressionKind::Ty, codes)
     );
     Fix::safe_edit(Edit::insertion(insertion, start))
 }

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -59,7 +59,8 @@ pub fn suppress_all(
                     *suppressed_diagnostics += 1;
                 }
                 Some(
-                    SuppressionCommentFix::SameLine | SuppressionCommentFix::FileLevelSameLine,
+                    SuppressionCommentFix::SameLine
+                    | SuppressionCommentFix::FileLevelSameLine { .. },
                 ) => {
                     ids_with_suppression_range.push((
                         id,
@@ -208,8 +209,9 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
             SuppressionCommentFix::LineLocal(start) => {
                 return Some(add_line_local_suppression(&[id.name()], start));
             }
-            SuppressionCommentFix::SameLine => {}
-            SuppressionCommentFix::FileLevelSameLine => return None,
+            SuppressionCommentFix::SameLine
+            | SuppressionCommentFix::FileLevelSameLine { is_shebang: false } => {}
+            SuppressionCommentFix::FileLevelSameLine { is_shebang: true } => return None,
         }
     }
 
@@ -237,7 +239,7 @@ pub(crate) fn can_suppress(db: &dyn Db, file: File, id: LintName, range: TextRan
 enum SuppressionCommentFix {
     LineLocal(TextSize),
     SameLine,
-    FileLevelSameLine,
+    FileLevelSameLine { is_shebang: bool },
 }
 
 fn suppression_comment_fix(
@@ -262,7 +264,9 @@ fn suppression_comment_fix(
         .first_non_trivia_token
         .is_none_or(|start| comment.start() < start)
     {
-        return Some(SuppressionCommentFix::FileLevelSameLine);
+        return Some(SuppressionCommentFix::FileLevelSameLine {
+            is_shebang: source[comment.range()].starts_with("#!"),
+        });
     }
 
     let before_diagnostic = &source[TextRange::new(comment.start(), range.start())];

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -24,8 +24,8 @@ use smallvec::SmallVec;
 use crate::Db;
 use crate::lint::LintId;
 use crate::suppression::{
-    SuppressionKind, Suppressions, is_suppression_comment_lint, select_preferred_suppression,
-    suppressions,
+    IGNORE_COMMENT_UNKNOWN_RULE, SuppressionKind, Suppressions, is_suppression_comment_lint,
+    select_preferred_suppression, suppressions,
 };
 
 /// Creates fixes to suppress all violations in `ids_with_range`.
@@ -249,12 +249,13 @@ enum SuppressionCommentFix {
 
 /// Classifies how to suppress a diagnostic emitted for an existing ignore comment.
 ///
-/// Own-line diagnostics get a preceding-line suppression, while inline and file-level diagnostics use an
-/// end-of-line suppression. Shebangs remain eligible for bulk fixes but not IDE quick fixes.
+/// Own-line diagnostics without an editable suppression get a preceding-line suppression, while
+/// inline and file-level diagnostics use an end-of-line suppression. Shebangs remain eligible for
+/// bulk fixes but not IDE quick fixes.
 ///
 /// ```python
 /// seen_code = True
-/// # ty: ignore[not-a-rule]  # receives a preceding-line suppression
+/// # ty: ignore[*-*]  # receives a preceding-line suppression
 /// ```
 fn suppression_comment_fix(
     db: &dyn Db,
@@ -380,7 +381,8 @@ fn add_end_of_line_suppression(source: &str, codes: &[LintName], line_end: TextS
 ///
 /// When multiple comments apply, a same-line or otherwise nested comment takes precedence over an
 /// outer own-line suppression. Diagnostics about suppression comments never extend a
-/// `type: ignore`, since that would affect other type checkers.
+/// `type: ignore`, since that would affect other type checkers. A syntactically valid `ty: ignore`
+/// containing only unknown codes remains editable.
 ///
 /// ```python
 /// # ty: ignore[invalid-assignment]
@@ -392,7 +394,7 @@ fn find_existing_suppression(
     range: TextRange,
     id: LintName,
 ) -> Option<ExistingSuppression> {
-    let suppression = select_preferred_suppression(
+    let (comment_range, kind) = select_preferred_suppression(
         suppressions
             .editable_inline_suppressions_rev(range)
             .filter(|suppression| {
@@ -400,8 +402,26 @@ fn find_existing_suppression(
                     && editable_suppression_prefix(&source[suppression.comment_range]).is_some()
             }),
         range,
-    )?;
-    let prefix = editable_suppression_prefix(&source[suppression.comment_range])?;
+    )
+    .map(|suppression| (suppression.comment_range, suppression.kind))
+    .or_else(|| {
+        if id != IGNORE_COMMENT_UNKNOWN_RULE.name() {
+            return None;
+        }
+
+        let index = suppressions
+            .unknown
+            .binary_search_by_key(&range.start(), |unknown| unknown.range.start())
+            .ok()?;
+        let unknown = suppressions.unknown.get(index)?;
+        let line_start = source.line_start(unknown.comment_range.start());
+
+        (unknown.range == range
+            && unknown.kind == SuppressionKind::Ty
+            && !source[line_start.to_usize()..].starts_with("#!"))
+        .then_some((unknown.comment_range, unknown.kind))
+    })?;
+    let prefix = editable_suppression_prefix(&source[comment_range])?;
     let separator = if prefix.ends_with('[') {
         ""
     } else if prefix.ends_with(',') {
@@ -411,8 +431,8 @@ fn find_existing_suppression(
     };
 
     Some(ExistingSuppression {
-        insertion_offset: suppression.comment_range.start() + prefix.text_len(),
-        kind: suppression.kind,
+        insertion_offset: comment_range.start() + prefix.text_len(),
+        kind,
         separator,
     })
 }

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -50,30 +50,32 @@ pub fn suppress_all(
     for &(id, diagnostic_range) in ids_with_range {
         if is_suppression_comment_lint(id) {
             match suppression_comment_fix(db, file, diagnostic_range) {
-                Some(SuppressionCommentFix::LineLocal(start)) => {
+                Some(SuppressionCommentFix::LineLocal(start))
+                    if find_existing_suppression(suppressions, &source, diagnostic_range, id)
+                        .is_none() =>
+                {
                     let (insertion_start, lints, suppressed_diagnostics) = line_local
                         .entry(source.line_start(start))
                         .or_insert_with(|| (start, BTreeSet::new(), 0));
                     *insertion_start = (*insertion_start).min(start);
                     lints.insert(id);
                     *suppressed_diagnostics += 1;
+                    continue;
                 }
-                Some(SuppressionCommentFix::SameLine | SuppressionCommentFix::Shebang) => {
-                    ids_with_suppression_range.push((
-                        id,
-                        diagnostic_range,
-                        suppression_range(db, file, diagnostic_range),
-                    ));
-                }
-                None => {}
+                Some(
+                    SuppressionCommentFix::LineLocal(_)
+                    | SuppressionCommentFix::SameLine
+                    | SuppressionCommentFix::Shebang,
+                ) => {}
+                None => continue,
             }
-        } else {
-            ids_with_suppression_range.push((
-                id,
-                diagnostic_range,
-                suppression_range(db, file, diagnostic_range),
-            ));
         }
+
+        ids_with_suppression_range.push((
+            id,
+            diagnostic_range,
+            suppression_range(db, file, diagnostic_range),
+        ));
     }
 
     // Sort the suppression ranges by their start position and length (end position).
@@ -113,7 +115,9 @@ pub fn suppress_all(
 
     // Choose the final existing suppression for every diagnostic before grouping any edits.
     for (id, diagnostic_range, suppression_range) in ids_with_suppression_range {
-        if let Some(existing) = find_existing_suppression(suppressions, &source, diagnostic_range) {
+        if let Some(existing) =
+            find_existing_suppression(suppressions, &source, diagnostic_range, id)
+        {
             with_existing.push((id, suppression_range, existing));
         } else {
             without_existing.push((id, suppression_range));
@@ -201,6 +205,14 @@ pub struct SuppressFix {
 
 /// Creates a fix to suppress a single lint, except for suppression diagnostics in a shebang.
 pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) -> Option<Fix> {
+    let suppressions = suppressions(db, file);
+    let source = source_text(db, file);
+    let codes = &[id.name()];
+
+    if let Some(existing) = find_existing_suppression(suppressions, &source, range, id.name()) {
+        return Some(add_to_existing_suppression(existing, codes));
+    }
+
     if is_suppression_comment_lint(id.name()) {
         match suppression_comment_fix(db, file, range)? {
             SuppressionCommentFix::LineLocal(start) => {
@@ -212,14 +224,6 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
     }
 
     let suppression_range = suppression_range(db, file, range);
-
-    let suppressions = suppressions(db, file);
-    let source = source_text(db, file);
-    let codes = &[id.name()];
-
-    if let Some(existing) = find_existing_suppression(suppressions, &source, range) {
-        return Some(add_to_existing_suppression(existing, codes));
-    }
 
     Some(add_end_of_line_suppression(
         &source,
@@ -374,7 +378,8 @@ fn add_end_of_line_suppression(source: &str, codes: &[LintName], line_end: TextS
 /// Returns insertion metadata for the preferred editable suppression covering `range`.
 ///
 /// When multiple comments apply, a same-line or otherwise nested comment takes precedence over an
-/// outer own-line suppression.
+/// outer own-line suppression. Diagnostics about suppression comments never extend a
+/// `type: ignore`, since that would affect other type checkers.
 ///
 /// ```python
 /// # ty: ignore[invalid-assignment]
@@ -384,12 +389,14 @@ fn find_existing_suppression(
     suppressions: &Suppressions,
     source: &str,
     range: TextRange,
+    id: LintName,
 ) -> Option<ExistingSuppression> {
     let suppression = select_preferred_suppression(
         suppressions
             .editable_inline_suppressions_rev(range)
             .filter(|suppression| {
-                editable_suppression_prefix(&source[suppression.comment_range]).is_some()
+                (!is_suppression_comment_lint(id) || !suppression.kind.is_type_ignore())
+                    && editable_suppression_prefix(&source[suppression.comment_range]).is_some()
             }),
         range,
     )?;

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -16,6 +16,8 @@ use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::token::TokenKind;
+use ruff_python_trivia::indentation_at_offset;
+use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use smallvec::SmallVec;
 
@@ -47,10 +49,20 @@ pub fn suppress_all(
 
     for &(id, diagnostic_range) in ids_with_range {
         if is_suppression_comment_lint(id) {
-            if let Some(start) = line_local_suppression_start(db, file, diagnostic_range) {
-                let (lints, suppressed_diagnostics) = line_local.entry(start).or_default();
-                lints.insert(id);
-                *suppressed_diagnostics += 1;
+            match suppression_comment_fix(db, file, diagnostic_range) {
+                Some(SuppressionCommentFix::LineLocal(start)) => {
+                    let (lints, suppressed_diagnostics) = line_local.entry(start).or_default();
+                    lints.insert(id);
+                    *suppressed_diagnostics += 1;
+                }
+                Some(SuppressionCommentFix::SameLine) => {
+                    ids_with_suppression_range.push((
+                        id,
+                        diagnostic_range,
+                        suppression_range(db, file, diagnostic_range),
+                    ));
+                }
+                None => {}
             }
         } else {
             ids_with_suppression_range.push((
@@ -187,8 +199,12 @@ pub struct SuppressFix {
 /// Creates a fix to suppress a single lint.
 pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) -> Option<Fix> {
     if is_suppression_comment_lint(id.name()) {
-        let start = line_local_suppression_start(db, file, range)?;
-        return Some(add_line_local_suppression(&[id.name()], start));
+        match suppression_comment_fix(db, file, range)? {
+            SuppressionCommentFix::LineLocal(start) => {
+                return Some(add_line_local_suppression(&[id.name()], start));
+            }
+            SuppressionCommentFix::SameLine => {}
+        }
     }
 
     let suppression_range = suppression_range(db, file, range);
@@ -209,19 +225,31 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
 }
 
 pub(crate) fn can_suppress(db: &dyn Db, file: File, id: LintName, range: TextRange) -> bool {
-    !is_suppression_comment_lint(id) || line_local_suppression_start(db, file, range).is_some()
+    !is_suppression_comment_lint(id) || suppression_comment_fix(db, file, range).is_some()
 }
 
-fn line_local_suppression_start(db: &dyn Db, file: File, range: TextRange) -> Option<TextSize> {
-    if !db.analysis_settings(file).respect_type_ignore_comments {
-        return None;
-    }
+enum SuppressionCommentFix {
+    LineLocal(TextSize),
+    SameLine,
+}
 
+fn suppression_comment_fix(
+    db: &dyn Db,
+    file: File,
+    range: TextRange,
+) -> Option<SuppressionCommentFix> {
     let parsed = parsed_module(db, file).load(db);
     let tokens = parsed.tokens();
     let comment = tokens
         .at_offset(range.start())
         .find(|token| token.kind() == TokenKind::Comment)?;
+
+    let source = source_text(db, file);
+    if !db.analysis_settings(file).respect_type_ignore_comments {
+        return indentation_at_offset(comment.start(), &source)
+            .is_none()
+            .then_some(SuppressionCommentFix::SameLine);
+    }
 
     // A suppression before the first non-trivia token is file-level, so adding one there would
     // affect diagnostics throughout the file.
@@ -232,11 +260,12 @@ fn line_local_suppression_start(db: &dyn Db, file: File, range: TextRange) -> Op
         return None;
     }
 
-    let source = source_text(db, file);
     let before_diagnostic = &source[TextRange::new(comment.start(), range.end())];
     let hash = before_diagnostic.rfind('#')?;
 
-    Some(comment.start() + before_diagnostic[..hash].text_len())
+    Some(SuppressionCommentFix::LineLocal(
+        comment.start() + before_diagnostic[..hash].text_len(),
+    ))
 }
 
 fn add_line_local_suppression(codes: &[LintName], start: TextSize) -> Fix {
@@ -281,7 +310,7 @@ fn suppression_range(db: &dyn Db, file: File, range: TextRange) -> TextRange {
             )
         })
         .map(Ranged::start)
-        .unwrap_or(range.end());
+        .unwrap_or_else(|| source_text(db, file).line_end(range.end()));
 
     TextRange::new(line_start, line_end)
 }

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -216,11 +216,7 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
     if is_suppression_comment_lint(id.name()) {
         match suppression_comment_fix(db, file, range)? {
             SuppressionCommentFix::LineLocal => {
-                return Some(add_line_local_suppression(
-                    &source,
-                    &[id.name()],
-                    range.start(),
-                ));
+                return Some(add_line_local_suppression(&source, codes, range.start()));
             }
             SuppressionCommentFix::SameLine => {}
             SuppressionCommentFix::Shebang => return None,

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -245,10 +245,12 @@ fn suppression_comment_fix(
         .find(|token| token.kind() == TokenKind::Comment)?;
 
     let source = source_text(db, file);
+    if indentation_at_offset(comment.start(), &source).is_none() {
+        return Some(SuppressionCommentFix::SameLine);
+    }
+
     if !db.analysis_settings(file).respect_type_ignore_comments {
-        return indentation_at_offset(comment.start(), &source)
-            .is_none()
-            .then_some(SuppressionCommentFix::SameLine);
+        return None;
     }
 
     // A suppression before the first non-trivia token is file-level, so adding one there would

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -58,7 +58,9 @@ pub fn suppress_all(
                     lints.insert(id);
                     *suppressed_diagnostics += 1;
                 }
-                Some(SuppressionCommentFix::SameLine) => {
+                Some(
+                    SuppressionCommentFix::SameLine | SuppressionCommentFix::FileLevelSameLine,
+                ) => {
                     ids_with_suppression_range.push((
                         id,
                         diagnostic_range,
@@ -207,6 +209,7 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
                 return Some(add_line_local_suppression(&[id.name()], start));
             }
             SuppressionCommentFix::SameLine => {}
+            SuppressionCommentFix::FileLevelSameLine => return None,
         }
     }
 
@@ -234,6 +237,7 @@ pub(crate) fn can_suppress(db: &dyn Db, file: File, id: LintName, range: TextRan
 enum SuppressionCommentFix {
     LineLocal(TextSize),
     SameLine,
+    FileLevelSameLine,
 }
 
 fn suppression_comment_fix(
@@ -252,13 +256,13 @@ fn suppression_comment_fix(
         return Some(SuppressionCommentFix::SameLine);
     }
 
-    // A suppression before the first non-trivia token is file-level, so adding one there would
-    // affect diagnostics throughout the file.
+    // A suppression before the first non-trivia token is file-level, so bulk fixes append a
+    // ty-specific suppression on the same line instead of prepending a line-local one.
     if suppressions(db, file)
         .first_non_trivia_token
         .is_none_or(|start| comment.start() < start)
     {
-        return None;
+        return Some(SuppressionCommentFix::FileLevelSameLine);
     }
 
     let before_diagnostic = &source[TextRange::new(comment.start(), range.start())];

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -58,10 +58,7 @@ pub fn suppress_all(
                     lints.insert(id);
                     *suppressed_diagnostics += 1;
                 }
-                Some(
-                    SuppressionCommentFix::SameLine
-                    | SuppressionCommentFix::FileLevelSameLine { .. },
-                ) => {
+                Some(SuppressionCommentFix::SameLine | SuppressionCommentFix::Shebang) => {
                     ids_with_suppression_range.push((
                         id,
                         diagnostic_range,
@@ -202,16 +199,15 @@ pub struct SuppressFix {
     pub suppressed_diagnostics: usize,
 }
 
-/// Creates a fix to suppress a single lint.
+/// Creates a fix to suppress a single lint, except for suppression diagnostics in a shebang.
 pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) -> Option<Fix> {
     if is_suppression_comment_lint(id.name()) {
         match suppression_comment_fix(db, file, range)? {
             SuppressionCommentFix::LineLocal(start) => {
                 return Some(add_line_local_suppression(&[id.name()], start));
             }
-            SuppressionCommentFix::SameLine
-            | SuppressionCommentFix::FileLevelSameLine { is_shebang: false } => {}
-            SuppressionCommentFix::FileLevelSameLine { is_shebang: true } => return None,
+            SuppressionCommentFix::SameLine => {}
+            SuppressionCommentFix::Shebang => return None,
         }
     }
 
@@ -232,6 +228,7 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
     ))
 }
 
+/// Returns whether a diagnostic can be included in a bulk suppression fix.
 pub(crate) fn can_suppress(db: &dyn Db, file: File, id: LintName, range: TextRange) -> bool {
     !is_suppression_comment_lint(id) || suppression_comment_fix(db, file, range).is_some()
 }
@@ -239,9 +236,18 @@ pub(crate) fn can_suppress(db: &dyn Db, file: File, id: LintName, range: TextRan
 enum SuppressionCommentFix {
     LineLocal(TextSize),
     SameLine,
-    FileLevelSameLine { is_shebang: bool },
+    Shebang,
 }
 
+/// Classifies how to suppress a diagnostic emitted for an existing ignore comment.
+///
+/// Own-line diagnostics get a line-local prefix, while inline and file-level diagnostics use an
+/// end-of-line suppression. Shebangs remain eligible for bulk fixes but not IDE quick fixes.
+///
+/// ```python
+/// seen_code = True
+/// # ty: ignore[not-a-rule]  # receives a line-local prefix
+/// ```
 fn suppression_comment_fix(
     db: &dyn Db,
     file: File,
@@ -264,8 +270,10 @@ fn suppression_comment_fix(
         .first_non_trivia_token
         .is_none_or(|start| comment.start() < start)
     {
-        return Some(SuppressionCommentFix::FileLevelSameLine {
-            is_shebang: source[comment.range()].starts_with("#!"),
+        return Some(if source[comment.range()].starts_with("#!") {
+            SuppressionCommentFix::Shebang
+        } else {
+            SuppressionCommentFix::SameLine
         });
     }
 
@@ -279,6 +287,7 @@ fn suppression_comment_fix(
     Some(SuppressionCommentFix::LineLocal(start))
 }
 
+/// Prepends a `ty: ignore` that suppresses only diagnostics on the existing comment line.
 fn add_line_local_suppression(codes: &[LintName], start: TextSize) -> Fix {
     let insertion = format!(
         "# ty:ignore[{codes}]  ",

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -22,7 +22,8 @@ use smallvec::SmallVec;
 use crate::Db;
 use crate::lint::LintId;
 use crate::suppression::{
-    SuppressionKind, Suppressions, select_preferred_suppression, suppressions,
+    SuppressionKind, Suppressions, is_suppression_comment_lint, select_preferred_suppression,
+    suppressions,
 };
 
 /// Creates fixes to suppress all violations in `ids_with_range`.
@@ -41,18 +42,24 @@ pub fn suppress_all(
     let parsed = parsed_module(db, file).load(db);
     let tokens = parsed.tokens();
 
-    // Compute the full suppression ranges for each diagnostic, while retaining the original
-    // diagnostic ranges for matching existing suppressions.
-    let mut ids_with_suppression_range: Vec<_> = ids_with_range
-        .iter()
-        .map(|&(id, diagnostic_range)| {
-            (
+    let mut line_local = BTreeMap::<TextSize, (BTreeSet<LintName>, usize)>::new();
+    let mut ids_with_suppression_range = Vec::with_capacity(ids_with_range.len());
+
+    for &(id, diagnostic_range) in ids_with_range {
+        if is_suppression_comment_lint(id) {
+            if let Some(start) = line_local_suppression_start(db, file, diagnostic_range) {
+                let (lints, suppressed_diagnostics) = line_local.entry(start).or_default();
+                lints.insert(id);
+                *suppressed_diagnostics += 1;
+            }
+        } else {
+            ids_with_suppression_range.push((
                 id,
                 diagnostic_range,
                 suppression_range(db, file, diagnostic_range),
-            )
-        })
-        .collect();
+            ));
+        }
+    }
 
     // Sort the suppression ranges by their start position and length (end position).
     // This ensures that a diagnostic with a shorter range is processed before
@@ -73,9 +80,21 @@ pub fn suppress_all(
     // but also the diagnostic with the wider range (because the suppression is on its start line).
     ids_with_suppression_range.sort_unstable_by_key(|(_, _, range)| (range.start(), range.end()));
 
-    let mut fixes = Vec::with_capacity(ids_with_suppression_range.len());
+    let mut fixes = Vec::with_capacity(ids_with_suppression_range.len() + line_local.len());
     let mut with_existing = Vec::new();
     let mut without_existing = Vec::new();
+
+    fixes.extend(
+        line_local
+            .into_iter()
+            .map(|(start, (lints, suppressed_diagnostics))| SuppressFix {
+                fix: add_line_local_suppression(
+                    &lints.into_iter().collect::<SmallVec<[_; 2]>>(),
+                    start,
+                ),
+                suppressed_diagnostics,
+            }),
+    );
 
     // Choose the final existing suppression for every diagnostic before grouping any edits.
     for (id, diagnostic_range, suppression_range) in ids_with_suppression_range {
@@ -166,7 +185,12 @@ pub struct SuppressFix {
 }
 
 /// Creates a fix to suppress a single lint.
-pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) -> Fix {
+pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) -> Option<Fix> {
+    if is_suppression_comment_lint(id.name()) {
+        let start = line_local_suppression_start(db, file, range)?;
+        return Some(add_line_local_suppression(&[id.name()], start));
+    }
+
     let suppression_range = suppression_range(db, file, range);
 
     let suppressions = suppressions(db, file);
@@ -174,10 +198,49 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
     let codes = &[id.name()];
 
     if let Some(existing) = find_existing_suppression(suppressions, &source, range) {
-        return add_to_existing_suppression(existing, codes);
+        return Some(add_to_existing_suppression(existing, codes));
     }
 
-    add_end_of_line_suppression(&source, codes, suppression_range.end())
+    Some(add_end_of_line_suppression(
+        &source,
+        codes,
+        suppression_range.end(),
+    ))
+}
+
+pub(crate) fn can_suppress(db: &dyn Db, file: File, id: LintName, range: TextRange) -> bool {
+    !is_suppression_comment_lint(id) || line_local_suppression_start(db, file, range).is_some()
+}
+
+fn line_local_suppression_start(db: &dyn Db, file: File, range: TextRange) -> Option<TextSize> {
+    if !db.analysis_settings(file).respect_type_ignore_comments {
+        return None;
+    }
+
+    let parsed = parsed_module(db, file).load(db);
+    let tokens = parsed.tokens();
+    let comment = tokens
+        .at_offset(range.start())
+        .find(|token| token.kind() == TokenKind::Comment)?;
+
+    // A suppression before the first non-trivia token is file-level, so adding one there would
+    // affect diagnostics throughout the file.
+    if suppressions(db, file)
+        .first_non_trivia_token
+        .is_none_or(|start| comment.start() < start)
+    {
+        return None;
+    }
+
+    Some(comment.start())
+}
+
+fn add_line_local_suppression(codes: &[LintName], start: TextSize) -> Fix {
+    let insertion = format!(
+        "# type:ignore[{codes}]  ",
+        codes = Codes(SuppressionKind::TypeIgnore, codes)
+    );
+    Fix::safe_edit(Edit::insertion(insertion, start))
 }
 
 /// Returns the suppression range for the given `range`.

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -258,12 +258,14 @@ fn suppression_comment_fix(
         return None;
     }
 
-    let before_diagnostic = &source[TextRange::new(comment.start(), range.end())];
-    let hash = before_diagnostic.rfind('#')?;
+    let before_diagnostic = &source[TextRange::new(comment.start(), range.start())];
+    let start = before_diagnostic
+        .rfind('#')
+        .map_or(comment.start(), |hash| {
+            comment.start() + before_diagnostic[..hash].text_len()
+        });
 
-    Some(SuppressionCommentFix::LineLocal(
-        comment.start() + before_diagnostic[..hash].text_len(),
-    ))
+    Some(SuppressionCommentFix::LineLocal(start))
 }
 
 fn add_line_local_suppression(codes: &[LintName], start: TextSize) -> Fix {

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -295,8 +295,9 @@ fn suppression_comment_fix(
 /// Adds an own-line `ty: ignore` before a diagnostic on an existing comment line.
 fn add_line_local_suppression(source: &str, codes: &[LintName], start: TextSize) -> Fix {
     let line_start = source.line_start(start);
-    let indentation = leading_indentation(&source[line_start.to_usize()..]);
-    let line_ending = find_newline(source).map_or("\n", |(_, ending)| ending.as_str());
+    let line = &source[line_start.to_usize()..];
+    let indentation = leading_indentation(line);
+    let line_ending = find_newline(line).map_or("\n", |(_, ending)| ending.as_str());
     let insertion = format!(
         "{indentation}# ty:ignore[{codes}]{line_ending}",
         codes = Codes(SuppressionKind::Ty, codes)


### PR DESCRIPTION
## Summary

Prior to this change, applying `--add-ignore` or the IDE quick fix to an unknown rule or invalid syntax in an own-line `ty: ignore` could repeatedly add suppressions without resolving the original diagnostic. Suppression comments also had different coverage rules from ordinary diagnostics, making nested directives difficult to reason about.

We now use one consistent model: a suppression applies to its entire physical comment line, and an own-line suppression also applies to the following statement. Diagnostics about ignore comments require an explicit rule-specific suppression, so blanket ignores cannot hide unknown or malformed directives.

Bulk fixes produce at most one suppression edit per physical line. We extend an editable `ty: ignore[...]` when available, including directives containing only unknown rules; otherwise, we append one ty-specific suppression to that same line. We never introduce or extend `type: ignore` comments when suppressing ignore-comment diagnostics, and neither bulk fixes nor IDE quick fixes edit an actual executable shebang.

## Behavior

### Suppress an unknown rule in an own-line ignore

The original reproduction now converges in one edit:

```python
# Before
seen = True
# ty: ignore[not-a-rule]
value = 1

# After
seen = True
# ty: ignore[not-a-rule, ignore-comment-unknown-rule]
value = 1
```

### Apply one fix per physical line

Multiple unknown directives on the same line share one explicit suppression:

```python
# Before
value = 1  # ty: ignore[first-not-a-rule]  # ty: ignore[second-not-a-rule]

# After
value = 1  # ty: ignore[first-not-a-rule]  # ty: ignore[second-not-a-rule, ignore-comment-unknown-rule]
```

The same rule handles mixed `ty` and `type` directives without editing the latter:

```python
# Before
# ty: ignore[first-not-a-rule]  # type: ignore[ty:second-not-a-rule]

# After
# ty: ignore[first-not-a-rule, ignore-comment-unknown-rule]  # type: ignore[ty:second-not-a-rule]
```

### Handle invalid and non-editable directives

Invalid syntax and trailing explanations make a directive non-editable. When no editable `ty: ignore[...]` exists on the line, we append one combined suppression instead of inserting a preceding comment:

```python
# Before
# ty: ignore[*-*]  # ty: ignore[not-a-rule] explanation

# After
# ty: ignore[*-*]  # ty: ignore[not-a-rule] explanation  # ty:ignore[ignore-comment-unknown-rule, invalid-ignore-comment]
```

### Keep suppression coverage consistent

An own-line suppression covers both its own comment line and the following statement, including ignore-comment diagnostics:

```python
# ty: ignore[ignore-comment-unknown-rule]
value = 1  # ty: ignore[not-a-rule]
```

A blanket ignore does not suppress an unknown or invalid ignore; the corresponding `ignore-comment-unknown-rule` or `invalid-ignore-comment` must be listed explicitly.

Only a `#!` on the first physical line is treated as an executable shebang. A mid-file `#!` remains an ordinary comment and can be fixed in place:

```python
# Before
seen = True
#! notes # ty: ignore[not-a-rule]

# After
seen = True
#! notes # ty: ignore[not-a-rule, ignore-comment-unknown-rule]
```

Inline fixes continue to work when `analysis.respect-type-ignore-comments=false`, and existing `type: ignore` comments retain their meaning for other type checkers.

Closes https://github.com/astral-sh/ty/issues/4032.