### PR TITLE
invalid_index_type: remove redundant `is_slice_type` re-check

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs
@@ -127,7 +127,7 @@ pub(crate) fn invalid_index_type(checker: &Checker, expr: &ExprSubscript) {
                         is_slice.range(),
                     );
                 }
-            } else if let Some(is_slice_type) = CheckableExprType::try_from(is_slice.as_ref()) {
+            } else {
                 checker.report_diagnostic(
                     InvalidIndexType {
                         value_type: value_type.to_string(),


### PR DESCRIPTION
## Summary

A small change. Noticed in `invalid_index_type` rule code that  `else if` branch was rechecking that  `is_slice_type` is not `None`

https://github.com/astral-sh/ruff/blob/8bbdb8e392e13481db33abc731546eec5a827d36/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs#L130

while there's a guard at the beginning of the loop body checking exactly this:

https://github.com/astral-sh/ruff/blob/8bbdb8e392e13481db33abc731546eec5a827d36/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs#L110-L112

So `else if` is safe to replace with just `else`.

## Test Plan

Reran the tests with `cargo test`, no snapshot changes and all tests passed.
