### PR TITLE
[`ruff`] Fix missing check on unrecognized early bound (`RUF016`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF016.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF016.py
@@ -128,3 +128,7 @@ var = [1, 2, 3][lambda: 0]
 
 # Should emit for invalid access using generator
 var = [1, 2, 3][(x for x in ())]
+
+# Should still emit for a later invalid bound, even if an earlier bound is unrecognized
+x = "x"
+var = [1, 2, 3][x:"y"]

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs
@@ -108,7 +108,7 @@ pub(crate) fn invalid_index_type(checker: &Checker, expr: &ExprSubscript) {
     {
         for is_slice in [lower, upper, step].into_iter().flatten() {
             let Some(is_slice_type) = CheckableExprType::try_from(is_slice) else {
-                return;
+                continue;
             };
             if is_slice_type.is_literal() {
                 // If the index is a slice, require integer or null bounds

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF016_RUF016.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF016_RUF016.py.snap
@@ -445,3 +445,12 @@ RUF016 Indexed access to type `list` uses type `generator` instead of an integer
 131 |
 132 | # Should still emit for a later invalid bound, even if an earlier bound is unrecognized
     |
+
+RUF016 Slice in indexed access to type `list` uses type `str` instead of an integer
+   --> RUF016.py:134:19
+    |
+132 | # Should still emit for a later invalid bound, even if an earlier bound is unrecognized
+133 | x = "x"
+134 | var = [1, 2, 3][x:"y"]
+    |                   ^^^
+    |

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF016_RUF016.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF016_RUF016.py.snap
@@ -442,4 +442,6 @@ RUF016 Indexed access to type `list` uses type `generator` instead of an integer
 129 | # Should emit for invalid access using generator
 130 | var = [1, 2, 3][(x for x in ())]
     |                 ^^^^^^^^^^^^^^^
+131 |
+132 | # Should still emit for a later invalid bound, even if an earlier bound is unrecognized
     |


### PR DESCRIPTION
## Summary

Noticed a bug in `invalid_index_type` - when index expression is a slice and one of the slice elements wasn't recognized, it was running `return` from `invalid_index_type` immediately. 
E.g. `[1, 2, 3][x:"y"]`, where `x` is a variable of unknown type, is a real bug - `"y"` cannot be used as slice upper bound, but since `x` is not recognized, it's a variable and we cannot get its type, code never reached `"y"`.
This PR is just using `continue` for this case instead of `return`, so those issues are recognized too.

## Test Plan

Ran `cargo test`, updated snapshots. 
Separated change in two commits - in first I just added a fixture and updated the snapshot (nothing is emitted - just new fixture appended to previous fixture context), in second I've made the change and updated snapshot.
