### PR TITLE
ruff-ecosystem: bump bokeh/bokeh branch to `branch-3.10`

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -38,7 +38,7 @@ DEFAULT_TARGETS = [
     Project(repo=Repository(owner="binary-husky", name="gpt_academic", ref="master")),
     Project(repo=Repository(owner="bloomberg", name="pytest-memray", ref="main")),
     Project(
-        repo=Repository(owner="bokeh", name="bokeh", ref="branch-3.3"),
+        repo=Repository(owner="bokeh", name="bokeh", ref="branch-3.10"),
         check_options=CheckOptions(select="ALL"),
     ),
     # Disabled due to use of explicit `select` with `E999`, which has been removed.

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -126,7 +126,7 @@ REPOSITORIES: list[Repository] = [
     Repository("aws", "aws-sam-cli", "develop"),
     Repository("binary-husky", "gpt_academic", "master"),
     Repository("bloomberg", "pytest-memray", "main"),
-    Repository("bokeh", "bokeh", "branch-3.3", select="ALL"),
+    Repository("bokeh", "bokeh", "branch-3.10", select="ALL"),
     # Disabled due to use of explicit `select` with `E999`, which has been removed.
     # See: https://github.com/astral-sh/ruff/pull/12129
     # Repository("demisto", "content", "master"),


### PR DESCRIPTION
`branch-3.3` got deleted and running `ruff-ecosystem` results in `Failed to clone bokeh/bokeh: fatal: Remote branch branch-3.3 not found in upstream origin` - see error in https://github.com/astral-sh/ruff/pull/26986#issuecomment-5017031308

`branch-3.10` is the current default branch on https://github.com/bokeh/bokeh

Changing deprecated script just for consistency.
