### PR TITLE
[ty] Preserve constrained TypeVar equality narrowing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1042,7 +1042,8 @@ Equality analysis expands the constraints of a constrained type variable in eith
 The resulting constraint is intersected with the type variable, preserving its identity:
 
 ```py
-from typing import TypeVar, final
+from enum import Enum
+from typing import Literal, TypeVar, final
 
 @final
 class ConstraintA: ...
@@ -1063,6 +1064,18 @@ def constrained_right(value: ConstraintA | None, other: T):
         pass
     else:
         reveal_type(value)  # revealed: ConstraintA
+
+class E(Enum):
+    A = 1
+    B = 2
+
+EnumT = TypeVar("EnumT", Literal[E.A], Literal[E.B])
+
+def correlated_typevar_eq(value: E, other: EnumT) -> EnumT:
+    if value == other:
+        reveal_type(value)  # revealed: EnumT@correlated_typevar_eq
+        return value
+    return other
 ```
 
 ## `LiteralString` and string-valued enums

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -634,7 +634,7 @@ def default_equality(x: Token | Literal[1]):
 
 def overlapping_union_member(x: int | Literal["missing"]):
     if x in ("missing", 1):
-        reveal_type(x)  # revealed: Literal["missing", 1, True]
+        reveal_type(x)  # revealed: Literal[1, True, "missing"]
 
 def custom_equality(x: AlwaysEqual | Literal[1]):
     if x in (1,):
@@ -1125,7 +1125,7 @@ class OpenValues(TypedDict):
 
 def closed_typed_dict_container(value: Literal["present", "other", "missing", 1], values: ClosedValues) -> None:
     if value in values:
-        reveal_type(value)  # revealed: Literal["other", "present"]
+        reveal_type(value)  # revealed: Literal["present", "other"]
 
 def open_typed_dict_container(value: Literal["present", "other", "missing", 1], values: OpenValues) -> None:
     if value in values:

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -130,6 +130,22 @@ pub(super) fn evaluate_type_equality<'db>(
     is_positive: bool,
     soundness_policy: ComparisonSoundnessPolicy,
 ) -> Option<Type<'db>> {
+    let right = right.resolve_type_alias(db);
+
+    // Preserve the shared specialization of a constrained TypeVar. Expanding the TypeVar before
+    // comparing it with `left` would lose the correlation with other occurrences in the function.
+    if is_positive
+        && let Type::TypeVar(typevar) = right
+        && let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =
+            typevar.typevar(db).bound_or_constraints(db)
+        && constraints.elements(db).iter().all(|constraint| {
+            evaluate_type_equality(db, left, *constraint, true, soundness_policy)
+                .is_some_and(|narrowed| narrowed.is_equivalent_to(db, *constraint))
+        })
+    {
+        return Some(right);
+    }
+
     let branch = ComparisonBranch::from(is_positive);
     let condition_expects_equality =
         ComparisonOperator::Equality.condition_expects_equality(branch);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2976,26 +2976,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         {
             return Some(Type::Never);
         }
-        let rhs_values = iterable
-            .homogeneous_element_type(self.db)
-            .resolve_type_alias(self.db);
-        let soundness_policy = self.comparison_soundness_policy();
-
-        if let Type::Union(union) = rhs_values {
-            let mut builder = UnionBuilder::new(self.db);
-            for rhs_value in union.elements(self.db) {
-                builder = builder.add(evaluate_type_equality(
-                    self.db,
-                    lhs_ty,
-                    *rhs_value,
-                    true,
-                    soundness_policy,
-                )?);
-            }
-            Some(builder.build())
-        } else {
-            evaluate_type_equality(self.db, lhs_ty, rhs_values, true, soundness_policy)
-        }
+        evaluate_type_equality(
+            self.db,
+            lhs_ty,
+            iterable.homogeneous_element_type(self.db),
+            true,
+            self.comparison_soundness_policy(),
+        )
     }
 
     fn evaluate_expr_not_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2979,43 +2979,23 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let rhs_values = iterable
             .homogeneous_element_type(self.db)
             .resolve_type_alias(self.db);
+        let soundness_policy = self.comparison_soundness_policy();
 
         if let Type::Union(union) = rhs_values {
             let mut builder = UnionBuilder::new(self.db);
             for rhs_value in union.elements(self.db) {
-                builder = builder.add(self.evaluate_membership_equality(lhs_ty, *rhs_value)?);
+                builder = builder.add(evaluate_type_equality(
+                    self.db,
+                    lhs_ty,
+                    *rhs_value,
+                    true,
+                    soundness_policy,
+                )?);
             }
             Some(builder.build())
         } else {
-            self.evaluate_membership_equality(lhs_ty, rhs_values)
+            evaluate_type_equality(self.db, lhs_ty, rhs_values, true, soundness_policy)
         }
-    }
-
-    /// Apply equality compatibility without losing the container's declared element type.
-    fn evaluate_membership_equality(
-        &self,
-        lhs_ty: Type<'db>,
-        rhs_ty: Type<'db>,
-    ) -> Option<Type<'db>> {
-        let lhs_ty = lhs_ty.resolve_type_alias(self.db);
-        let rhs_ty = rhs_ty.resolve_type_alias(self.db);
-        let soundness_policy = self.comparison_soundness_policy();
-
-        // Preserve the shared specialization of a constrained TypeVar. Expanding the TypeVar
-        // before comparing it with `lhs_ty` would lose the correlation between this occurrence
-        // and other occurrences in the same function.
-        if let Type::TypeVar(typevar) = rhs_ty
-            && let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =
-                typevar.typevar(self.db).bound_or_constraints(self.db)
-            && constraints.elements(self.db).iter().all(|constraint| {
-                evaluate_type_equality(self.db, lhs_ty, *constraint, true, soundness_policy)
-                    .is_some_and(|narrowed| narrowed.is_equivalent_to(self.db, *constraint))
-            })
-        {
-            return Some(rhs_ty);
-        }
-
-        evaluate_type_equality(self.db, lhs_ty, rhs_ty, true, soundness_policy)
     }
 
     fn evaluate_expr_not_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {


### PR DESCRIPTION
## Summary

Prior to this change, membership narrowing (`in`) preserved the shared specialization of a constrained TypeVar, while an equality narrowing (`==`) expanded the TypeVar and lost its correlation with the function's return type:

```python
from enum import Enum
from typing import Literal, TypeVar

class E(Enum):
    A = 1
    B = 2

T = TypeVar("T", Literal[E.A], Literal[E.B])

def correlated(value: E, other: T) -> T:
    if value == other:
        return value  # Previously: invalid-return-type
    return other
```

This PR moves that-TypeVar handling into the shared evaluator.
