### PR TITLE
[ty] Allow recursive type expansion a limited number of times during type relation checking

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -930,6 +930,55 @@ type WrappedRight[T] = tuple[Box[Box[WrappedRight[list[T]]]]]
 static_assert(not is_subtype_of(WrappedLeft[int], WrappedRight[int]))
 ```
 
+### Recursive alias relations that reach an exact cycle
+
+Different specializations of the same recursive aliases are explored until the relation returns to
+an exact pair.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+type Left[T] = tuple[T] | tuple[T, Left[int]]
+type Right[T] = tuple[T] | tuple[T, Right[int]]
+
+static_assert(is_subtype_of(Left[str], Right[str]))
+static_assert(is_subtype_of(Right[str], Left[str]))
+static_assert(not is_subtype_of(Left[int], Right[str]))
+
+def _(left: Left[str], right: Right[str]):
+    right = left
+    left = right
+
+type Left10[A, B, C, D, E, F, G, H, I, J] = tuple[A, Left10[B, C, D, E, F, G, H, I, J, None]]
+type Right10[A, B, C, D, E, F, G, H, I, J] = tuple[A, Right10[B, C, D, E, F, G, H, I, J, None]]
+
+type Left11[A, B, C, D, E, F, G, H, I, J, K] = tuple[A, Left11[B, C, D, E, F, G, H, I, J, K, None]]
+type Right11[A, B, C, D, E, F, G, H, I, J, K] = tuple[A, Right11[B, C, D, E, F, G, H, I, J, K, None]]
+
+# The tenth expansion reaches the all-`None` specialization, whose next expansion is exact.
+static_assert(
+    is_subtype_of(
+        Left10[int, int, int, int, int, int, int, int, int, int],
+        Right10[int, int, int, int, int, int, int, int, int, int],
+    )
+)
+static_assert(
+    not is_subtype_of(
+        Left10[int, int, int, int, int, int, int, int, int, int],
+        Right10[int, int, int, int, str, int, int, int, int, int],
+    )
+)
+
+# Reaching the same specialization requires an eleventh expansion, so the result is conservative.
+static_assert(
+    not is_subtype_of(
+        Left11[int, int, int, int, int, int, int, int, int, int, int],
+        Right11[int, int, int, int, int, int, int, int, int, int, int],
+    )
+)
+```
+
 ### Non-recursive nested generic aliases
 
 A repeated use of the same generic alias can be a finite alias application instead of recursion.

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -1080,9 +1080,9 @@ type StableWrapped[T] = list[StableWrapped[T]]
 def stable_wrapped(x: StableWrapped[int], y: StableWrapped[str]):
     reveal_type(x)  # revealed: list[StableWrapped[int]]
     reveal_type(y)  # revealed: list[StableWrapped[str]]
-    # error: [invalid-assignment] "Object of type `StableWrapped[str]` is not assignable to `StableWrapped[int]`"
+    # We can assume that `StableWrapped[int]` is assignable to `StableWrapped[str]`.
+    # This is because differences in type variables do not make a difference in type structure.
     x = y
-    # error: [invalid-assignment] "Object of type `StableWrapped[int]` is not assignable to `StableWrapped[str]`"
     y = x
 ```
 

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -20,7 +20,7 @@
 //! avoid this is to prefer always calling `visitor.visit` only in the main recursive method on
 //! `Type`.
 
-use std::cell::RefCell;
+use std::cell::{OnceCell, RefCell};
 use std::cmp::Eq;
 use std::fmt;
 use std::hash::Hash;
@@ -52,6 +52,28 @@ impl<'db> Type<'db> {
     pub(crate) fn to_type_identity(self, db: &'db dyn Db) -> TypeIdentity<'db> {
         self.recursive_identity(db)
             .unwrap_or(TypeIdentity::Other(self))
+    }
+
+    /// Returns `false` if `self` and `other` cannot have the same [`TypeIdentity`].
+    ///
+    /// A `true` result is only a candidate match and must be confirmed with
+    /// [`Type::to_type_identity`].
+    pub(crate) fn may_share_type_identity(self, db: &'db dyn Db, other: Self) -> bool {
+        if self == other {
+            return true;
+        }
+        match (self, other) {
+            (Type::FunctionLiteral(a), Type::FunctionLiteral(b)) => a.literal(db) == b.literal(db),
+            (Type::NewTypeInstance(a), Type::NewTypeInstance(b)) => {
+                a.definition(db) == b.definition(db)
+            }
+            (Type::ProtocolInstance(a), Type::ProtocolInstance(b)) => {
+                a.definition(db) == b.definition(db)
+            }
+            (Type::TypeAlias(a), Type::TypeAlias(b)) => a.definition(db) == b.definition(db),
+            (Type::TypedDict(a), Type::TypedDict(b)) => a.definition(db) == b.definition(db),
+            _ => false,
+        }
     }
 
     #[allow(clippy::inline_always)]
@@ -92,12 +114,24 @@ impl<'db> ProtocolInstanceType<'db> {
 pub trait HasIdentity<'db> {
     type Id: PartialEq;
 
+    /// Returns `false` if `self` and `other` cannot have the same identity.
+    ///
+    /// Implementations can use this to avoid constructing an expensive identity. Returning
+    /// `true` does not imply that the identities match; [`HasIdentity::to_identity`] confirms it.
+    fn may_share_identity(&self, _db: &'db dyn Db, _other: &Self) -> bool {
+        true
+    }
+
     /// Returns an identity that remains stable while this item is active in a [`CycleDetector`].
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id;
 }
 
 impl<'db> HasIdentity<'db> for Type<'db> {
     type Id = TypeIdentity<'db>;
+
+    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
+        self.may_share_type_identity(db, *other)
+    }
 
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         Type::to_type_identity(*self, db)
@@ -109,6 +143,10 @@ pub(crate) type PairVisitor<'db, Tag, C> = CycleDetector<'db, Tag, (Type<'db>, T
 impl<'db> HasIdentity<'db> for (Type<'db>, Type<'db>) {
     type Id = (TypeIdentity<'db>, TypeIdentity<'db>);
 
+    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
+        self.0.may_share_type_identity(db, other.0) && self.1.may_share_type_identity(db, other.1)
+    }
+
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         (self.0.to_type_identity(db), self.1.to_type_identity(db))
     }
@@ -119,6 +157,12 @@ where
     Context: Copy + PartialEq,
 {
     type Id = (TypeIdentity<'db>, Context, TypeIdentity<'db>);
+
+    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
+        self.0.may_share_type_identity(db, other.0)
+            && self.1 == other.1
+            && self.2.may_share_type_identity(db, other.2)
+    }
 
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         (
@@ -228,15 +272,27 @@ where
             return CycleDetectorVisit::Ready(self.fallback.clone());
         }
 
-        let identity = item.to_identity(db);
-        if seen
+        let mut candidates = seen
             .iter()
-            .filter(|active| active.identity == identity)
-            .count()
-            > MAX_RECURSIVE_TYPE_EXPANSIONS
-        {
-            return CycleDetectorVisit::Cycle(item);
-        }
+            .filter(|active| item.may_share_identity(db, &active.item))
+            .peekable();
+        let identity = if candidates.peek().is_none() {
+            OnceCell::new()
+        } else {
+            // Deriving an identity can require a structural definition walk. Defer it until a
+            // cheap candidate match shows that another active item could form a cycle.
+            let identity = item.to_identity(db);
+            if candidates
+                .filter(|active| {
+                    active.identity.get_or_init(|| active.item.to_identity(db)) == &identity
+                })
+                .count()
+                > MAX_RECURSIVE_TYPE_EXPANSIONS
+            {
+                return CycleDetectorVisit::Cycle(item);
+            }
+            OnceCell::from(identity)
+        };
         drop(seen);
 
         self.seen.borrow_mut().push(ActiveCycleDetectorVisit {
@@ -259,7 +315,7 @@ where
 
 struct ActiveCycleDetectorVisit<'db, T: HasIdentity<'db>> {
     item: T,
-    identity: T::Id,
+    identity: OnceCell<T::Id>,
 }
 
 impl<'db, T: fmt::Debug + HasIdentity<'db>> fmt::Debug for ActiveCycleDetectorVisit<'db, T> {
@@ -541,6 +597,10 @@ mod tests {
     impl<'db> HasIdentity<'db> for CountingIdentityItem<'_> {
         type Id = u8;
 
+        fn may_share_identity(&self, _db: &'db dyn Db, other: &Self) -> bool {
+            self.value % 2 == other.value % 2
+        }
+
         fn to_identity(&self, _db: &'db dyn Db) -> Self::Id {
             self.identity_calls.set(self.identity_calls.get() + 1);
             self.value
@@ -599,6 +659,40 @@ mod tests {
             1
         );
         assert_eq!(identity_calls.get(), 2);
+    }
+
+    #[test]
+    fn skips_identity_for_distinct_candidates() {
+        let db = setup_db();
+        let db = &db;
+        let identity_calls = Cell::new(0);
+        let detector = CycleDetector::<TestVisit, CountingIdentityItem<'_>, u8, 1>::new(0);
+
+        assert_eq!(
+            detector.visit(db, CountingIdentityItem::new(1, &identity_calls), || {
+                detector.visit(db, CountingIdentityItem::new(2, &identity_calls), || 1)
+            }),
+            1
+        );
+        assert_eq!(identity_calls.get(), 0);
+    }
+
+    #[test]
+    fn skips_identity_without_a_distinct_active_item() {
+        let db = setup_db();
+        let db = &db;
+        let identity_calls = Cell::new(0);
+        let detector = CycleDetector::<TestVisit, CountingIdentityItem<'_>, u8, 1>::new(0);
+
+        assert_eq!(
+            detector.visit(db, CountingIdentityItem::new(1, &identity_calls), || 1),
+            1
+        );
+        assert_eq!(
+            detector.visit(db, CountingIdentityItem::new(1, &identity_calls), || 2),
+            1
+        );
+        assert_eq!(identity_calls.get(), 0);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -20,7 +20,7 @@
 //! avoid this is to prefer always calling `visitor.visit` only in the main recursive method on
 //! `Type`.
 
-use std::cell::{Cell, OnceCell, RefCell};
+use std::cell::{OnceCell, RefCell};
 use std::cmp::Eq;
 use std::fmt;
 use std::hash::Hash;
@@ -31,11 +31,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use ty_python_core::definition::Definition;
 
+use crate::Db;
 use crate::types::function::FunctionLiteral;
-use crate::types::generics::Specialization;
-use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
-use crate::types::{ClassType, ProtocolInstanceType, Type, TypeAliasType, TypedDictType};
-use crate::{Db, ProgramEnvironment};
+use crate::types::{ProtocolInstanceType, Type};
 
 const MAX_RECURSIVE_TYPE_EXPANSIONS: usize = 10;
 
@@ -44,16 +42,16 @@ const MAX_RECURSIVE_TYPE_EXPANSIONS: usize = 10;
 pub enum TypeIdentity<'db> {
     FunctionLiteral(FunctionLiteral<'db>),
     NewTypeInstance(Definition<'db>),
-    RecursiveProtocol(Definition<'db>),
-    RecursiveTypeAlias(Definition<'db>),
-    RecursiveTypedDict(Definition<'db>),
-    NonRecursive(Type<'db>),
+    Protocol(Definition<'db>),
+    TypeAlias(Definition<'db>),
+    TypedDict(Definition<'db>),
+    Other(Type<'db>),
 }
 
 impl<'db> Type<'db> {
     pub(crate) fn to_type_identity(self, db: &'db dyn Db) -> TypeIdentity<'db> {
         self.recursive_identity(db)
-            .unwrap_or(TypeIdentity::NonRecursive(self))
+            .unwrap_or(TypeIdentity::Other(self))
     }
 
     /// Returns `false` if `self` and `other` cannot have the same [`TypeIdentity`].
@@ -92,148 +90,16 @@ impl<'db> Type<'db> {
                 Some(TypeIdentity::NewTypeInstance(newtype.definition(db)))
             }
             // Type aliases can be self-referential: e.g. `type RecursiveT = int | tuple[RecursiveT, ...]`
-            Type::TypeAlias(alias) if alias.is_recursive(db) => {
-                Some(TypeIdentity::RecursiveTypeAlias(alias.definition(db)))
+            Type::TypeAlias(alias) => Some(TypeIdentity::TypeAlias(alias.definition(db))),
+            Type::ProtocolInstance(protocol) => {
+                Some(TypeIdentity::Protocol(protocol.definition(db)?))
             }
-            Type::ProtocolInstance(protocol) if protocol.is_recursive(db) => {
-                Some(TypeIdentity::RecursiveProtocol(protocol.definition(db)?))
-            }
-            Type::TypedDict(typed_dict) if typed_dict.is_recursive(db) => {
+            Type::TypedDict(typed_dict) => {
                 let definition = typed_dict.definition(db)?;
-                Some(TypeIdentity::RecursiveTypedDict(definition))
+                Some(TypeIdentity::TypedDict(definition))
             }
             _ => None,
         }
-    }
-}
-
-struct DefinitionReferenceVisitor<'db> {
-    env: ProgramEnvironment<'db>,
-    target: Definition<'db>,
-    active_definitions: ActiveRecursionDetector<Definition<'db>>,
-    visited_types: TypeCollector<'db>,
-    found: Cell<bool>,
-}
-
-impl<'db> DefinitionReferenceVisitor<'db> {
-    /// Returns whether the definition represented by `ty` references `target`.
-    fn references(db: &'db dyn Db, ty: Type<'db>, target: Definition<'db>) -> bool {
-        let visitor = Self::new(target);
-        visitor.visit_definition_body(db, ty);
-        visitor.found.get()
-    }
-
-    fn new(target: Definition<'db>) -> Self {
-        Self {
-            env: ProgramEnvironment::from_definition(target),
-            target,
-            active_definitions: ActiveRecursionDetector::default(),
-            visited_types: TypeCollector::default(),
-            found: Cell::new(false),
-        }
-    }
-
-    fn definition_and_specialization(
-        db: &'db dyn Db,
-        ty: Type<'db>,
-    ) -> Option<(Definition<'db>, Option<Specialization<'db>>)> {
-        if let Type::TypeAlias(alias) = ty {
-            return Some((alias.definition(db), alias.specialization(db)));
-        }
-
-        let class = match ty {
-            Type::ProtocolInstance(protocol) => *protocol.class_origin(db)?,
-            Type::TypedDict(typed_dict) => typed_dict.defining_class()?,
-            _ => return None,
-        };
-        let definition = class.definition(db)?;
-        let specialization = class
-            .into_generic_alias()
-            .map(|generic| generic.specialization(db));
-        Some((definition, specialization))
-    }
-
-    fn visit_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) {
-        for ty in specialization.types(db) {
-            self.visit_type(db, *ty);
-        }
-    }
-
-    fn visit_definition_body(&self, db: &'db dyn Db, ty: Type<'db>) {
-        match ty {
-            Type::TypeAlias(alias) => self.visit_type_alias_type(db, alias),
-            Type::ProtocolInstance(protocol) => {
-                self.visit_protocol_instance_type(db, protocol);
-            }
-            Type::TypedDict(typed_dict) => self.visit_typed_dict_type(db, typed_dict),
-            _ => {}
-        }
-    }
-}
-
-impl<'db> TypeVisitor<'db> for DefinitionReferenceVisitor<'db> {
-    fn program_environment(&self) -> &ProgramEnvironment<'db> {
-        &self.env
-    }
-
-    fn should_visit_lazy_type_attributes(&self) -> bool {
-        false
-    }
-
-    fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-        if self.found.get() {
-            return;
-        }
-
-        if let Some((definition, specialization)) = Self::definition_and_specialization(db, ty) {
-            if definition == self.target {
-                self.found.set(true);
-                return;
-            }
-
-            if let Some(specialization) = specialization {
-                self.visit_specialization(db, specialization);
-            }
-
-            if !self.found.get() {
-                self.active_definitions.visit(
-                    &definition,
-                    || {},
-                    || self.visit_definition_body(db, ty),
-                );
-            }
-        } else {
-            walk_type_with_recursion_guard(db, ty, self, &self.visited_types);
-        }
-    }
-
-    fn visit_protocol_instance_type(&self, db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) {
-        if let Some(class) = protocol.class_origin(db) {
-            class.walk_recursive_member_types(db, self);
-        }
-    }
-
-    fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {
-        self.visit_type(db, alias.raw_value_type(db));
-    }
-
-    fn visit_typed_dict_type(&self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
-        for field in typed_dict.items(db).values() {
-            self.visit_type(db, field.declared_ty);
-        }
-        if let Some(extra_items) = typed_dict.explicit_extra_items(db) {
-            self.visit_type(db, extra_items.declared_ty);
-        }
-    }
-}
-
-impl<'db> TypeAliasType<'db> {
-    fn is_recursive(self, db: &'db dyn Db) -> bool {
-        DefinitionReferenceVisitor::references(
-            db,
-            Type::TypeAlias(self.unspecialized(db)),
-            self.definition(db),
-        )
     }
 }
 
@@ -241,37 +107,6 @@ impl<'db> ProtocolInstanceType<'db> {
     fn definition(self, db: &'db dyn Db) -> Option<Definition<'db>> {
         let (origin, _) = self.class_origin(db)?.static_class_literal(db)?;
         Some(origin.definition(db))
-    }
-
-    fn is_recursive(self, db: &'db dyn Db) -> bool {
-        let Some(class) = self.class_origin(db) else {
-            return false;
-        };
-        let Some((origin, _)) = class.static_class_literal(db) else {
-            return false;
-        };
-        let definition = origin.definition(db);
-        let env = ProgramEnvironment::from_definition(definition);
-        // Inspect the definition without its current specialization. Otherwise, a finite
-        // type such as `Protocol[Protocol[int]]` would appear recursive.
-        let unspecialized = Type::instance(db, &env, ClassType::NonGeneric(origin.into()));
-        DefinitionReferenceVisitor::references(db, unspecialized, definition)
-    }
-}
-
-impl<'db> TypedDictType<'db> {
-    fn is_recursive(self, db: &'db dyn Db) -> bool {
-        let Some(class) = self.defining_class() else {
-            return false;
-        };
-        let Some((origin, _)) = class.static_class_literal(db) else {
-            return false;
-        };
-        let definition = origin.definition(db);
-        // Inspect the definition without its current specialization for the same reason as
-        // protocols above.
-        let unspecialized = Type::typed_dict(ClassType::NonGeneric(origin.into()));
-        DefinitionReferenceVisitor::references(db, unspecialized, definition)
     }
 }
 
@@ -396,7 +231,7 @@ where
         item: T,
         compute: impl FnOnce() -> R,
     ) -> Result<R, T> {
-        match self.begin_visit_with_expansion_limit(db, item, MAX_RECURSIVE_TYPE_EXPANSIONS) {
+        match self.begin_visit(db, item) {
             CycleDetectorVisit::Ready(result) => Ok(result),
             CycleDetectorVisit::Cycle(item) => Err(item),
             CycleDetectorVisit::Pending(item) => {
@@ -406,14 +241,9 @@ where
         }
     }
 
-    fn begin_visit(&self, db: &'db dyn Db, item: T) -> CycleDetectorVisit<T, R> {
-        self.begin_visit_with_expansion_limit(db, item, 0)
-    }
-
-    /// Starts a visit while allowing `expansion_limit` different items with the same identity
-    /// after the first active item. A limit of zero therefore stops at the first different item,
-    /// while a limit of `N` permits `N` further expansions. Exact item recurrence is handled
-    /// before this limit and returns the configured fallback at any depth.
+    /// Starts a visit while allowing `MAX_RECURSIVE_TYPE_EXPANSIONS` different items
+    /// with the same identity after the first active item.
+    /// Exact item recurrence is handled before this limit and returns the configured fallback at any depth.
     ///
     /// This is necessary because there are recursive aliases that require several expansions to reach a "stable point", such as:
     ///
@@ -432,12 +262,7 @@ where
     /// A growing specialization chain may never reach such an exact recurrence. The finite limit
     /// guarantees that it eventually produces [`CycleDetectorVisit::Cycle`], allowing the caller
     /// to return a conservative result.
-    fn begin_visit_with_expansion_limit(
-        &self,
-        db: &'db dyn Db,
-        item: T,
-        expansion_limit: usize,
-    ) -> CycleDetectorVisit<T, R> {
+    fn begin_visit(&self, db: &'db dyn Db, item: T) -> CycleDetectorVisit<T, R> {
         if let Some(result) = self.cache.borrow().get(&item) {
             return CycleDetectorVisit::Ready(result.clone());
         }
@@ -462,7 +287,7 @@ where
                     active.identity.get_or_init(|| active.item.to_identity(db)) == &identity
                 })
                 .count()
-                > expansion_limit
+                > MAX_RECURSIVE_TYPE_EXPANSIONS
             {
                 return CycleDetectorVisit::Cycle(item);
             }
@@ -722,16 +547,11 @@ impl<T: Hash + Eq> Drop for ActiveRecursionGuard<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CycleDetector, CycleDetectorVisit, Db, HasIdentity, TypeIdentity};
-    use crate::ProgramEnvironment;
+    use super::MAX_RECURSIVE_TYPE_EXPANSIONS;
+    use super::{CycleDetector, CycleDetectorVisit, Db, HasIdentity};
     use crate::db::tests::setup_db;
-    use crate::place::global_symbol;
-    use crate::types::Type;
-    use ruff_db::files::system_path_to_file;
-    use ruff_db::system::DbWithWritableSystem;
     use std::cell::Cell;
     use std::hash::{Hash, Hasher};
-    use ty_python_core::ProgramFile;
 
     struct TestVisit;
 
@@ -794,63 +614,6 @@ mod tests {
         type Id = ();
 
         fn to_identity(&self, _db: &'db dyn Db) -> Self::Id {}
-    }
-
-    fn global_instance_type<'db>(
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        name: &str,
-    ) -> Type<'db> {
-        let file = system_path_to_file(db, "/src/a.py").unwrap();
-        let file = ProgramFile::new(db, file, env.program(db));
-        global_symbol(db, file, name)
-            .place
-            .expect_type()
-            .to_instance_approximation(db, env)
-            .unwrap()
-    }
-
-    #[test]
-    fn property_receiver_does_not_make_protocol_recursive() {
-        let mut db = setup_db();
-        db.write_dedented(
-            "/src/a.py",
-            r#"
-from __future__ import annotations
-
-from typing import Protocol
-
-class GenericProperty[T](Protocol):
-    @property
-    def value(self) -> T: ...
-
-class RecursiveProperty[T](Protocol):
-    @property
-    def child(self) -> RecursiveProperty[list[T]]: ...
-
-class RecursivePropertySetter[T](Protocol):
-    @property
-    def child(self) -> int: ...
-
-    @child.setter
-    def child(self, value: RecursivePropertySetter[list[T]]) -> None: ...
-"#,
-        )
-        .unwrap();
-
-        let env = db.program_environment();
-        assert_eq!(
-            global_instance_type(&db, &env, "GenericProperty").recursive_identity(&db),
-            None
-        );
-        assert!(matches!(
-            global_instance_type(&db, &env, "RecursiveProperty").recursive_identity(&db),
-            Some(TypeIdentity::RecursiveProtocol(_))
-        ));
-        assert!(matches!(
-            global_instance_type(&db, &env, "RecursivePropertySetter").recursive_identity(&db),
-            Some(TypeIdentity::RecursiveProtocol(_))
-        ));
     }
 
     #[test]
@@ -933,22 +696,32 @@ class RecursivePropertySetter[T](Protocol):
     }
 
     #[test]
-    fn different_items_with_same_identity_form_cycle() {
+    fn different_items_with_same_identity_hit_expansion_limit() {
         let db = setup_db();
         let db = &db;
         let detector = CycleDetector::<TestVisit, ConstantIdentityItem, u8, 1>::new(0);
 
-        let CycleDetectorVisit::Pending(pending) =
-            detector.begin_visit(db, ConstantIdentityItem(1))
+        let mut pending = Vec::new();
+        #[allow(clippy::cast_possible_truncation)]
+        for value in 1..=(MAX_RECURSIVE_TYPE_EXPANSIONS as u8 + 1) {
+            let CycleDetectorVisit::Pending(item) =
+                detector.begin_visit(db, ConstantIdentityItem(value))
+            else {
+                panic!("items within the recursive expansion limit should be pending");
+            };
+            pending.push(item);
+        }
+
+        let CycleDetectorVisit::Cycle(item) = detector.begin_visit(db, ConstantIdentityItem(12))
         else {
-            panic!("the first identity should be pending");
+            panic!("the first item beyond the recursive expansion limit should form a cycle");
         };
-        let CycleDetectorVisit::Cycle(item) = detector.begin_visit(db, ConstantIdentityItem(2))
-        else {
-            panic!("a different item with the same identity should form a cycle");
-        };
-        assert_eq!(item.0, 2);
-        detector.finish_visit(pending, 1);
+        assert_eq!(item.0, 12);
+
+        for item in pending.into_iter().rev() {
+            let result = item.0;
+            detector.finish_visit(item, result);
+        }
 
         let CycleDetectorVisit::Ready(seen) = detector.begin_visit(db, ConstantIdentityItem(1))
         else {
@@ -956,15 +729,15 @@ class RecursivePropertySetter[T](Protocol):
         };
         assert_eq!(seen, 1);
         let CycleDetectorVisit::Pending(pending) =
-            detector.begin_visit(db, ConstantIdentityItem(2))
+            detector.begin_visit(db, ConstantIdentityItem(12))
         else {
-            panic!("the second identity should be pending after the first is finished");
+            panic!("the item beyond the limit should be pending after the active visits finish");
         };
-        detector.finish_visit(pending, 2);
-        let CycleDetectorVisit::Ready(seen) = detector.begin_visit(db, ConstantIdentityItem(2))
+        detector.finish_visit(pending, 12);
+        let CycleDetectorVisit::Ready(seen) = detector.begin_visit(db, ConstantIdentityItem(12))
         else {
-            panic!("the second identity should be ready after the pending visit is finished");
+            panic!("the item should be ready after the pending visit is finished");
         };
-        assert_eq!(seen, 2);
+        assert_eq!(seen, 12);
     }
 }

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -37,6 +37,8 @@ use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion
 use crate::types::{ClassType, ProtocolInstanceType, Type, TypeAliasType, TypedDictType};
 use crate::{Db, ProgramEnvironment};
 
+const MAX_RECURSIVE_TYPE_EXPANSIONS: usize = 10;
+
 /// The type identity used for recursive checks/transformations.
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum TypeIdentity<'db> {
@@ -394,7 +396,7 @@ where
         item: T,
         compute: impl FnOnce() -> R,
     ) -> Result<R, T> {
-        match self.begin_visit(db, item) {
+        match self.begin_visit_with_expansion_limit(db, item, MAX_RECURSIVE_TYPE_EXPANSIONS) {
             CycleDetectorVisit::Ready(result) => Ok(result),
             CycleDetectorVisit::Cycle(item) => Err(item),
             CycleDetectorVisit::Pending(item) => {
@@ -405,6 +407,37 @@ where
     }
 
     fn begin_visit(&self, db: &'db dyn Db, item: T) -> CycleDetectorVisit<T, R> {
+        self.begin_visit_with_expansion_limit(db, item, 0)
+    }
+
+    /// Starts a visit while allowing `expansion_limit` different items with the same identity
+    /// after the first active item. A limit of zero therefore stops at the first different item,
+    /// while a limit of `N` permits `N` further expansions. Exact item recurrence is handled
+    /// before this limit and returns the configured fallback at any depth.
+    ///
+    /// This is necessary because there are recursive aliases that require several expansions to reach a "stable point", such as:
+    ///
+    /// ```python
+    /// type Left[A, B, C] = tuple[A, Left[B, C, None]]
+    /// type Right[A, B, C] = tuple[A, Right[B, C, None]]
+    ///
+    /// # Left[int, int, int]
+    /// # = tuple[int, Left[int, int, None]]
+    /// # = tuple[int, tuple[int, Left[int, None, None]]]
+    /// # = tuple[int, tuple[int, tuple[int, Left[None, None, None]]]]
+    /// # Left[None, None, None] (= tuple[None, Left[None, None, None]]) is stable, so it can be completely determined
+    /// static_assert(is_subtype_of(Left[int, int, int], Right[int, int, int]))
+    /// ```
+    ///
+    /// A growing specialization chain may never reach such an exact recurrence. The finite limit
+    /// guarantees that it eventually produces [`CycleDetectorVisit::Cycle`], allowing the caller
+    /// to return a conservative result.
+    fn begin_visit_with_expansion_limit(
+        &self,
+        db: &'db dyn Db,
+        item: T,
+        expansion_limit: usize,
+    ) -> CycleDetectorVisit<T, R> {
         if let Some(result) = self.cache.borrow().get(&item) {
             return CycleDetectorVisit::Ready(result.clone());
         }
@@ -424,9 +457,13 @@ where
             // Deriving an identity can require a structural definition walk. Defer it until a
             // cheap candidate match shows that another active item could form a cycle.
             let identity = item.to_identity(db);
-            if candidates.any(|active| {
-                active.identity.get_or_init(|| active.item.to_identity(db)) == &identity
-            }) {
+            if candidates
+                .filter(|active| {
+                    active.identity.get_or_init(|| active.item.to_identity(db)) == &identity
+                })
+                .count()
+                > expansion_limit
+            {
                 return CycleDetectorVisit::Cycle(item);
             }
             OnceCell::from(identity)

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -20,7 +20,7 @@
 //! avoid this is to prefer always calling `visitor.visit` only in the main recursive method on
 //! `Type`.
 
-use std::cell::{OnceCell, RefCell};
+use std::cell::RefCell;
 use std::cmp::Eq;
 use std::fmt;
 use std::hash::Hash;
@@ -52,28 +52,6 @@ impl<'db> Type<'db> {
     pub(crate) fn to_type_identity(self, db: &'db dyn Db) -> TypeIdentity<'db> {
         self.recursive_identity(db)
             .unwrap_or(TypeIdentity::Other(self))
-    }
-
-    /// Returns `false` if `self` and `other` cannot have the same [`TypeIdentity`].
-    ///
-    /// A `true` result is only a candidate match and must be confirmed with
-    /// [`Type::to_type_identity`].
-    pub(crate) fn may_share_type_identity(self, db: &'db dyn Db, other: Self) -> bool {
-        if self == other {
-            return true;
-        }
-        match (self, other) {
-            (Type::FunctionLiteral(a), Type::FunctionLiteral(b)) => a.literal(db) == b.literal(db),
-            (Type::NewTypeInstance(a), Type::NewTypeInstance(b)) => {
-                a.definition(db) == b.definition(db)
-            }
-            (Type::ProtocolInstance(a), Type::ProtocolInstance(b)) => {
-                a.definition(db) == b.definition(db)
-            }
-            (Type::TypeAlias(a), Type::TypeAlias(b)) => a.definition(db) == b.definition(db),
-            (Type::TypedDict(a), Type::TypedDict(b)) => a.definition(db) == b.definition(db),
-            _ => false,
-        }
     }
 
     #[allow(clippy::inline_always)]
@@ -114,24 +92,12 @@ impl<'db> ProtocolInstanceType<'db> {
 pub trait HasIdentity<'db> {
     type Id: PartialEq;
 
-    /// Returns `false` if `self` and `other` cannot have the same identity.
-    ///
-    /// Implementations can use this to avoid constructing an expensive identity. Returning
-    /// `true` does not imply that the identities match; [`HasIdentity::to_identity`] confirms it.
-    fn may_share_identity(&self, _db: &'db dyn Db, _other: &Self) -> bool {
-        true
-    }
-
     /// Returns an identity that remains stable while this item is active in a [`CycleDetector`].
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id;
 }
 
 impl<'db> HasIdentity<'db> for Type<'db> {
     type Id = TypeIdentity<'db>;
-
-    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
-        self.may_share_type_identity(db, *other)
-    }
 
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         Type::to_type_identity(*self, db)
@@ -143,10 +109,6 @@ pub(crate) type PairVisitor<'db, Tag, C> = CycleDetector<'db, Tag, (Type<'db>, T
 impl<'db> HasIdentity<'db> for (Type<'db>, Type<'db>) {
     type Id = (TypeIdentity<'db>, TypeIdentity<'db>);
 
-    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
-        self.0.may_share_type_identity(db, other.0) && self.1.may_share_type_identity(db, other.1)
-    }
-
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         (self.0.to_type_identity(db), self.1.to_type_identity(db))
     }
@@ -157,12 +119,6 @@ where
     Context: Copy + PartialEq,
 {
     type Id = (TypeIdentity<'db>, Context, TypeIdentity<'db>);
-
-    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
-        self.0.may_share_type_identity(db, other.0)
-            && self.1 == other.1
-            && self.2.may_share_type_identity(db, other.2)
-    }
 
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         (
@@ -272,27 +228,15 @@ where
             return CycleDetectorVisit::Ready(self.fallback.clone());
         }
 
-        let mut candidates = seen
+        let identity = item.to_identity(db);
+        if seen
             .iter()
-            .filter(|active| item.may_share_identity(db, &active.item))
-            .peekable();
-        let identity = if candidates.peek().is_none() {
-            OnceCell::new()
-        } else {
-            // Deriving an identity can require a structural definition walk. Defer it until a
-            // cheap candidate match shows that another active item could form a cycle.
-            let identity = item.to_identity(db);
-            if candidates
-                .filter(|active| {
-                    active.identity.get_or_init(|| active.item.to_identity(db)) == &identity
-                })
-                .count()
-                > MAX_RECURSIVE_TYPE_EXPANSIONS
-            {
-                return CycleDetectorVisit::Cycle(item);
-            }
-            OnceCell::from(identity)
-        };
+            .filter(|active| active.identity == identity)
+            .count()
+            > MAX_RECURSIVE_TYPE_EXPANSIONS
+        {
+            return CycleDetectorVisit::Cycle(item);
+        }
         drop(seen);
 
         self.seen.borrow_mut().push(ActiveCycleDetectorVisit {
@@ -315,7 +259,7 @@ where
 
 struct ActiveCycleDetectorVisit<'db, T: HasIdentity<'db>> {
     item: T,
-    identity: OnceCell<T::Id>,
+    identity: T::Id,
 }
 
 impl<'db, T: fmt::Debug + HasIdentity<'db>> fmt::Debug for ActiveCycleDetectorVisit<'db, T> {
@@ -597,10 +541,6 @@ mod tests {
     impl<'db> HasIdentity<'db> for CountingIdentityItem<'_> {
         type Id = u8;
 
-        fn may_share_identity(&self, _db: &'db dyn Db, other: &Self) -> bool {
-            self.value % 2 == other.value % 2
-        }
-
         fn to_identity(&self, _db: &'db dyn Db) -> Self::Id {
             self.identity_calls.set(self.identity_calls.get() + 1);
             self.value
@@ -659,40 +599,6 @@ mod tests {
             1
         );
         assert_eq!(identity_calls.get(), 2);
-    }
-
-    #[test]
-    fn skips_identity_for_distinct_candidates() {
-        let db = setup_db();
-        let db = &db;
-        let identity_calls = Cell::new(0);
-        let detector = CycleDetector::<TestVisit, CountingIdentityItem<'_>, u8, 1>::new(0);
-
-        assert_eq!(
-            detector.visit(db, CountingIdentityItem::new(1, &identity_calls), || {
-                detector.visit(db, CountingIdentityItem::new(2, &identity_calls), || 1)
-            }),
-            1
-        );
-        assert_eq!(identity_calls.get(), 0);
-    }
-
-    #[test]
-    fn skips_identity_without_a_distinct_active_item() {
-        let db = setup_db();
-        let db = &db;
-        let identity_calls = Cell::new(0);
-        let detector = CycleDetector::<TestVisit, CountingIdentityItem<'_>, u8, 1>::new(0);
-
-        assert_eq!(
-            detector.visit(db, CountingIdentityItem::new(1, &identity_calls), || 1),
-            1
-        );
-        assert_eq!(
-            detector.visit(db, CountingIdentityItem::new(1, &identity_calls), || 2),
-            1
-        );
-        assert_eq!(identity_calls.get(), 0);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, ops::Deref};
 use itertools::Itertools;
 
 use ruff_python_ast::name::Name;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use crate::types::attribute_write::{
     AttributeWriteRequirement, ClassAttributeWriteMember, ExplicitAttributeWriteRequirement,
@@ -99,31 +99,6 @@ impl<'db> ProtocolClass<'db> {
             specialization.with_materialization_kind(db, None),
         );
         ProtocolClass(ClassType::Generic(alias)).interface(db)
-    }
-
-    /// Walk the effective non-method member types declared by this protocol.
-    ///
-    /// Method relations have their own declaration-based recursion guard. Keeping them out of this
-    /// walk also avoids requesting a method signature while one of its annotations is being
-    /// inferred.
-    pub(super) fn walk_recursive_member_types<V: super::visitor::TypeVisitor<'db> + ?Sized>(
-        self,
-        db: &'db dyn Db,
-        visitor: &V,
-    ) {
-        let mut seen_members = FxHashSet::default();
-
-        self.for_each_member_candidate(
-            db,
-            visitor.program_environment(),
-            |name, candidate, specialization| {
-                if !seen_members.insert(name.clone()) {
-                    return;
-                }
-                let candidate = candidate.apply_specialization(db, specialization);
-                candidate.walk_recursive_member_types(db, visitor);
-            },
-        );
     }
 
     /// Visits protocol member candidates in MRO order after applying declaration precedence.
@@ -3443,42 +3418,6 @@ impl<'db> ProtocolMemberCandidate<'db> {
     ) -> Self {
         self.ty = self.ty.apply_optional_specialization(db, specialization);
         self
-    }
-
-    fn is_bound_method_like(self, db: &'db dyn Db) -> bool {
-        self.bound_on_class.is_yes()
-            && match self.ty {
-                Type::FunctionLiteral(_) => true,
-                Type::Callable(callable) => callable.is_method_like(db),
-                _ => false,
-            }
-    }
-
-    fn walk_recursive_member_types<V: super::visitor::TypeVisitor<'db> + ?Sized>(
-        self,
-        db: &'db dyn Db,
-        visitor: &V,
-    ) {
-        match self.ty {
-            Type::PropertyInstance(property) => {
-                // A property exposes its getter return and setter value types. Walking the
-                // accessor callables themselves would also visit their receiver and make every
-                // generic protocol property appear recursive.
-                for member in [
-                    property.getter(db).map(ProtocolMemberType::property_getter),
-                    property.setter(db).map(ProtocolMemberType::property_setter),
-                ]
-                .into_iter()
-                .flatten()
-                {
-                    if let Some(member) = member.resolve(db, visitor.program_environment()) {
-                        visitor.visit_type(db, member.ty());
-                    }
-                }
-            }
-            _ if self.is_bound_method_like(db) => {}
-            _ => visitor.visit_type(db, self.ty),
-        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -839,13 +839,6 @@ impl<'db> HasIdentity<'db> for (Type<'db>, Type<'db>, TypeRelation, TypeVarEvalu
         TypeVarEvaluation,
     );
 
-    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
-        self.0.may_share_type_identity(db, other.0)
-            && self.1.may_share_type_identity(db, other.1)
-            && self.2 == other.2
-            && self.3 == other.3
-    }
-
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         (
             self.0.to_type_identity(db),

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -839,6 +839,13 @@ impl<'db> HasIdentity<'db> for (Type<'db>, Type<'db>, TypeRelation, TypeVarEvalu
         TypeVarEvaluation,
     );
 
+    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
+        self.0.may_share_type_identity(db, other.0)
+            && self.1.may_share_type_identity(db, other.1)
+            && self.2 == other.2
+            && self.3 == other.3
+    }
+
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         (
             self.0.to_type_identity(db),

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -343,21 +343,6 @@ impl<'db> TypeAliasType<'db> {
         }
     }
 
-    /// Returns the alias without an applied specialization.
-    pub(super) fn unspecialized(self, db: &'db dyn Db) -> Self {
-        match self {
-            TypeAliasType::PEP695(alias) => TypeAliasType::PEP695(PEP695TypeAliasType::new(
-                db,
-                alias.name(db),
-                alias.rhs_scope(db),
-                None,
-            )),
-            TypeAliasType::ManualPEP695(alias) => TypeAliasType::ManualPEP695(
-                ManualPEP695TypeAliasType::new(db, alias.name(db), alias.definition(db), None),
-            ),
-        }
-    }
-
     pub(crate) fn as_pep_695_type_alias(self) -> Option<PEP695TypeAliasType<'db>> {
         match self {
             TypeAliasType::PEP695(type_alias) => Some(type_alias),


### PR DESCRIPTION
## Summary

This PR addresses https://github.com/astral-sh/ruff/pull/26503#discussion_r3607065111

As described in the comment, instead of immediately returning the `Cycle` state when a same identity is found, we expect the recursive expansion to stabilize by `Pending` several times. If it does not stabilize even after expanding 10 times, it will be determined as a cycle.

This makes `DefinitionReferenceVisitor` completely unnecessary. In other words, even if we see signs of a growing pattern, we will try expanding recursive types up to 10 times. At first glance, it might seem better to keep the `DefinitionReferenceVisitor` guard in place, but doing so would actually cause us to miss patterns that look like growing patterns but ultimately converge in a finite number of steps. For example:

```python
type Left[A, B, C, D] = Left[B, C, D, D]
type Right[A, B, C, D] = Right[B, C, D, D]
```

Now consider these type relations:

```python
Left[
    int,
    list[int],
    list[list[int]],
    list[list[list[int]]],
]

Right[
    int,
    list[int],
    list[list[int]],
    list[list[list[int]]],
]
```

`CycleDetector` observes the increase in specialization as follows. However, this will eventually converge after a finite number of steps. In other words, it is not possible to conclude that "this type relation check will not stop" just from the increasing structure of specialization observed by `CycleDetector`.

```python
[int, list[int],  list[list[int]], list[list[list[int]]]]
↓
[list[int], list[list[int]], list[list[list[int]]], list[list[list[int]]]]
↓
[list[list[int]], list[list[list[int]]], list[list[list[int]]], list[list[list[int]]]]
↓
[list[list[list[int]]], list[list[list[int]]], list[list[list[int]]], list[list[list[int]]]]
↓
[list[list[list[int]]], list[list[list[int]]], list[list[list[int]]], list[list[list[int]]]] (converged)
```

## Test Plan

mdtest updated
