### PR TITLE
[ty] Guard recursive Protocol and TypedDict relations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -641,6 +641,14 @@ type Right[T] = tuple[Right[list[T]]]
 
 # TODO: Left[int] should be equivalent to (subtype of) Right[int]
 static_assert(not is_subtype_of(Left[int], Right[int]))
+
+type Box[T] = list[T]
+type WrappedLeft[T] = tuple[Box[Box[WrappedLeft[list[T]]]]]
+type WrappedRight[T] = tuple[Box[Box[WrappedRight[list[T]]]]]
+
+# A repeated non-recursive alias must not hide the recursive reference in its type arguments.
+# TODO: WrappedLeft[int] should be equivalent to (subtype of) WrappedRight[int]
+static_assert(not is_subtype_of(WrappedLeft[int], WrappedRight[int]))
 ```
 
 ### Non-recursive nested generic aliases

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -706,6 +706,58 @@ def finite_alias_union(x: NonRecursiveId[NestedNoneAlias], condition: bool):
     reveal_type(x if condition else 1)  # revealed: None | Literal[1]
 ```
 
+### Generic self-recursive aliases with deeper specializations
+
+Regression test for <https://github.com/astral-sh/ty/issues/3452>.
+
+A recursive alias may refer to itself with a more deeply nested specialization. This should still
+terminate and preserve the alias at the recursive position.
+
+```py
+from typing import Callable, Concatenate
+
+type Recursive[T] = int | Recursive[list[T]]
+
+def _(value: Recursive[int]):
+    reveal_type(value + 1)  # revealed: int
+    reveal_type(1 + value)  # revealed: int
+
+type RecursiveParamspec[**P] = Callable[[], RecursiveParamspec[Concatenate[int, P]]]
+
+def paramspec_alias(func: RecursiveParamspec):
+    reveal_type(func)  # revealed: () -> RecursiveParamspec[(int, /, *args: Unknown, **kwargs: Unknown)]
+
+type RecursiveCallable[T] = Callable[[RecursiveCallable[T]], RecursiveCallable[T | RecursiveCallable[T]]]
+
+def callable_alias(x: RecursiveCallable[int]):
+    reveal_type(x)  # revealed: (RecursiveCallable[int], /) -> RecursiveCallable[int | RecursiveCallable[int]]
+
+type GrowingList[T] = list[GrowingList[T | GrowingList[T]]]
+
+def growing_list(x: GrowingList[int]):
+    reveal_type(x)  # revealed: list[GrowingList[int | GrowingList[int]]]
+
+type GrowingCallable[T] = Callable[[], GrowingCallable[T | GrowingCallable[T]] | None]
+
+def growing_callable(x: GrowingCallable[int]):
+    # revealed: (() -> GrowingCallable[int | GrowingCallable[int] | GrowingCallable[int | GrowingCallable[int]]] | None) | None
+    reveal_type(x())
+```
+
+Non-growing recursive aliases should continue to preserve distinct specializations.
+
+```py
+type StableWrapped[T] = list[StableWrapped[T]]
+
+def stable_wrapped(x: StableWrapped[int], y: StableWrapped[str]):
+    reveal_type(x)  # revealed: list[StableWrapped[int]]
+    reveal_type(y)  # revealed: list[StableWrapped[str]]
+    # error: [invalid-assignment] "Object of type `StableWrapped[str]` is not assignable to `StableWrapped[int]`"
+    x = y
+    # error: [invalid-assignment] "Object of type `StableWrapped[int]` is not assignable to `StableWrapped[str]`"
+    y = x
+```
+
 ### Subtyping of materializations of cyclic aliases
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5294,6 +5294,61 @@ class Bar(Protocol):
 static_assert(is_equivalent_to(Foo, Bar))
 ```
 
+### Recursively-specialized generic protocols
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class LeftProtocol[T](Protocol):
+    child: LeftAlias[list[T]]
+
+class RightProtocol[T](Protocol):
+    child: RightAlias[list[T]]
+
+class DifferentProtocol[T](Protocol):
+    child: DifferentProtocol[set[T]]
+
+type LeftAlias[T] = LeftProtocol[T]
+type RightAlias[T] = RightProtocol[T]
+
+# TODO: These structurally equivalent protocols should be recognized as subtypes.
+static_assert(not is_subtype_of(LeftProtocol[int], RightProtocol[int]))
+static_assert(not is_subtype_of(LeftAlias[int], RightAlias[int]))
+# A conservative cycle fallback must not accept structurally different recursive protocols.
+static_assert(not is_subtype_of(LeftProtocol[int], DifferentProtocol[int]))
+
+class FiniteLeft[T](Protocol):
+    value: T
+
+class FiniteRight[T](Protocol):
+    value: T
+
+# Reusing a non-recursive protocol at a finite nesting depth is not a recursive definition.
+static_assert(is_subtype_of(FiniteLeft[FiniteLeft[int]], FiniteRight[FiniteRight[int]]))
+static_assert(not is_subtype_of(FiniteLeft[FiniteLeft[int]], FiniteRight[FiniteRight[str]]))
+
+class ProtocolBox[T](Protocol):
+    value: T
+
+class NestedLeftProtocol[T](Protocol):
+    child: ProtocolBox[ProtocolBox[NestedLeftProtocol[list[T]]]]
+
+class NestedRightProtocol[T](Protocol):
+    child: ProtocolBox[ProtocolBox[NestedRightProtocol[list[T]]]]
+
+# TODO: These structurally equivalent protocols should be recognized as subtypes.
+static_assert(not is_subtype_of(NestedLeftProtocol[int], NestedRightProtocol[int]))
+```
+
 ### Disjointness of recursive protocol and recursive final type
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -5707,6 +5707,35 @@ def f(c: C[int]) -> None:
     # The cycle detection assumes compatibility when it detects potential
     # infinite recursion between protocol specializations.
     takes_c(c)
+
+class Left[T](Protocol):
+    @property
+    def value(self) -> T: ...
+    @property
+    def child(self) -> "Left[list[T]]": ...
+
+class Right1[T](Protocol):
+    @property
+    def value(self) -> T: ...
+    @property
+    def child(self) -> "RightAlias1[list[T]]": ...
+
+class Right2[T](Protocol):
+    @property
+    def value(self) -> T: ...
+    @property
+    def child(self) -> "RightAlias2[set[T]]": ...
+
+type RightAlias1[T] = Right1[T]
+type RightAlias2[T] = Right2[T]
+
+def expect_right1(value: RightAlias1[int]) -> None: ...
+def expect_right2(value: RightAlias2[int]) -> None: ...
+def check(value: Left[int]) -> None:
+    # TODO: no error
+    expect_right1(value)  # error: [invalid-argument-type]
+    # This should be an error
+    expect_right2(value)  # error: [invalid-argument-type]
 ```
 
 ### Recursive legacy generic protocol

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2091,6 +2091,67 @@ static_assert(is_assignable_to(Person1, Person2))
 static_assert(is_equivalent_to(Person1, Person2))
 ```
 
+## Recursively-specialized generic `TypedDict`s
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class LeftRecursiveDict[T](TypedDict):
+    child: LeftRecursiveDict[list[T]]
+
+class RightRecursiveDict[T](TypedDict):
+    child: RightRecursiveDict[list[T]]
+
+class DifferentRecursiveDict[T](TypedDict):
+    child: DifferentRecursiveDict[set[T]]
+
+# TODO: These structurally equivalent TypedDicts should be recognized as subtypes.
+static_assert(not is_subtype_of(LeftRecursiveDict[int], RightRecursiveDict[int]))
+# A conservative cycle fallback must not accept structurally different recursive TypedDicts.
+static_assert(not is_subtype_of(LeftRecursiveDict[int], DifferentRecursiveDict[int]))
+
+class FiniteLeftDict[T](TypedDict):
+    value: T
+
+class FiniteRightDict[T](TypedDict):
+    value: T
+
+# Reusing a non-recursive TypedDict at a finite nesting depth is not a recursive definition.
+static_assert(
+    is_subtype_of(
+        FiniteLeftDict[FiniteLeftDict[int]],
+        FiniteRightDict[FiniteRightDict[int]],
+    )
+)
+static_assert(
+    not is_subtype_of(
+        FiniteLeftDict[FiniteLeftDict[int]],
+        FiniteRightDict[FiniteRightDict[str]],
+    )
+)
+
+class DictBox[T](TypedDict):
+    value: T
+
+class NestedLeftDict[T](TypedDict):
+    child: DictBox[DictBox[NestedLeftDict[list[T]]]]
+
+class NestedRightDict[T](TypedDict):
+    child: DictBox[DictBox[NestedRightDict[list[T]]]]
+
+# TODO: These structurally equivalent TypedDicts should be recognized as subtypes.
+static_assert(not is_subtype_of(NestedLeftDict[int], NestedRightDict[int]))
+```
+
 ## Redundant cast warnings
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -526,6 +526,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     ///
     /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
     /// nodes.
+    #[inline]
     pub(crate) fn and(
         mut self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -20,7 +20,7 @@
 //! avoid this is to prefer always calling `visitor.visit` only in the main recursive method on
 //! `Type`.
 
-use std::cell::{Cell, OnceCell, RefCell};
+use std::cell::{Cell, RefCell};
 use std::cmp::Eq;
 use std::fmt;
 use std::hash::Hash;
@@ -404,21 +404,11 @@ where
 
         let mut candidates = seen
             .iter()
-            .filter(|active| item.may_share_identity(db, &active.item))
-            .peekable();
-        let identity = if candidates.peek().is_none() {
-            OnceCell::new()
-        } else {
-            // Deriving an identity can require a structural definition walk. Defer it until a
-            // cheap candidate match shows that another active item could form a cycle.
-            let identity = item.to_identity(db);
-            if candidates.any(|active| {
-                active.identity.get_or_init(|| active.item.to_identity(db)) == &identity
-            }) {
-                return CycleDetectorVisit::Cycle(item);
-            }
-            OnceCell::from(identity)
-        };
+            .filter(|active| item.may_share_identity(db, &active.item));
+        let identity = item.to_identity(db);
+        if candidates.any(|active| active.identity == identity) {
+            return CycleDetectorVisit::Cycle(item);
+        }
         drop(seen);
 
         self.seen.borrow_mut().push(ActiveCycleDetectorVisit {
@@ -441,7 +431,7 @@ where
 
 struct ActiveCycleDetectorVisit<'db, T: HasIdentity<'db>> {
     item: T,
-    identity: OnceCell<T::Id>,
+    identity: T::Id,
 }
 
 impl<'db, T: fmt::Debug + HasIdentity<'db>> fmt::Debug for ActiveCycleDetectorVisit<'db, T> {

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -685,7 +685,8 @@ mod tests {
     use crate::types::Type;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::DbWithWritableSystem;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::cell::Cell;
+    use std::hash::{Hash, Hasher};
 
     struct TestVisit;
 
@@ -699,21 +700,45 @@ mod tests {
         }
     }
 
-    static IDENTITY_CALLS: AtomicUsize = AtomicUsize::new(0);
+    #[derive(Clone)]
+    struct CountingIdentityItem<'a> {
+        value: u8,
+        identity_calls: &'a Cell<usize>,
+    }
 
-    #[derive(Clone, Eq, Hash, PartialEq)]
-    struct CountingIdentityItem(u8);
+    impl<'a> CountingIdentityItem<'a> {
+        const fn new(value: u8, identity_calls: &'a Cell<usize>) -> Self {
+            Self {
+                value,
+                identity_calls,
+            }
+        }
+    }
 
-    impl<'db> HasIdentity<'db> for CountingIdentityItem {
+    impl PartialEq for CountingIdentityItem<'_> {
+        fn eq(&self, other: &Self) -> bool {
+            self.value == other.value
+        }
+    }
+
+    impl Eq for CountingIdentityItem<'_> {}
+
+    impl Hash for CountingIdentityItem<'_> {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.value.hash(state);
+        }
+    }
+
+    impl<'db> HasIdentity<'db> for CountingIdentityItem<'_> {
         type Id = u8;
 
         fn may_share_identity(&self, _db: &'db dyn Db, other: &Self) -> bool {
-            self.0 % 2 == other.0 % 2
+            self.value % 2 == other.value % 2
         }
 
         fn to_identity(&self, _db: &'db dyn Db) -> Self::Id {
-            IDENTITY_CALLS.fetch_add(1, Ordering::Relaxed);
-            self.0
+            self.identity_calls.set(self.identity_calls.get() + 1);
+            self.value
         }
     }
 
@@ -807,42 +832,48 @@ class RecursivePropertySetter[T](Protocol):
     #[test]
     fn computes_each_active_identity_once() {
         let db = setup_db();
-        IDENTITY_CALLS.store(0, Ordering::Relaxed);
-        let detector = CycleDetector::<TestVisit, CountingIdentityItem, u8, 1>::new(0);
+        let identity_calls = Cell::new(0);
+        let detector = CycleDetector::<TestVisit, CountingIdentityItem<'_>, u8, 1>::new(0);
 
         assert_eq!(
-            detector.visit(&db, CountingIdentityItem(1), || {
-                detector.visit(&db, CountingIdentityItem(3), || 1)
+            detector.visit(&db, CountingIdentityItem::new(1, &identity_calls), || {
+                detector.visit(&db, CountingIdentityItem::new(3, &identity_calls), || 1)
             }),
             1
         );
-        assert_eq!(IDENTITY_CALLS.load(Ordering::Relaxed), 2);
+        assert_eq!(identity_calls.get(), 2);
     }
 
     #[test]
     fn skips_identity_for_distinct_candidates() {
         let db = setup_db();
-        IDENTITY_CALLS.store(0, Ordering::Relaxed);
-        let detector = CycleDetector::<TestVisit, CountingIdentityItem, u8, 1>::new(0);
+        let identity_calls = Cell::new(0);
+        let detector = CycleDetector::<TestVisit, CountingIdentityItem<'_>, u8, 1>::new(0);
 
         assert_eq!(
-            detector.visit(&db, CountingIdentityItem(1), || {
-                detector.visit(&db, CountingIdentityItem(2), || 1)
+            detector.visit(&db, CountingIdentityItem::new(1, &identity_calls), || {
+                detector.visit(&db, CountingIdentityItem::new(2, &identity_calls), || 1)
             }),
             1
         );
-        assert_eq!(IDENTITY_CALLS.load(Ordering::Relaxed), 0);
+        assert_eq!(identity_calls.get(), 0);
     }
 
     #[test]
     fn skips_identity_without_a_distinct_active_item() {
         let db = setup_db();
-        IDENTITY_CALLS.store(0, Ordering::Relaxed);
-        let detector = CycleDetector::<TestVisit, CountingIdentityItem, u8, 1>::new(0);
+        let identity_calls = Cell::new(0);
+        let detector = CycleDetector::<TestVisit, CountingIdentityItem<'_>, u8, 1>::new(0);
 
-        assert_eq!(detector.visit(&db, CountingIdentityItem(1), || 1), 1);
-        assert_eq!(detector.visit(&db, CountingIdentityItem(1), || 2), 1);
-        assert_eq!(IDENTITY_CALLS.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            detector.visit(&db, CountingIdentityItem::new(1, &identity_calls), || 1),
+            1
+        );
+        assert_eq!(
+            detector.visit(&db, CountingIdentityItem::new(1, &identity_calls), || 2),
+            1
+        );
+        assert_eq!(identity_calls.get(), 0);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -109,14 +109,8 @@ struct DefinitionReferenceVisitor<'db> {
     found: Cell<bool>,
 }
 
-#[salsa::tracked]
 impl<'db> DefinitionReferenceVisitor<'db> {
     /// Returns whether the definition represented by `ty` references `target`.
-    #[salsa::tracked(
-        returns(copy),
-        cycle_initial=|_, _, _, _| false,
-        heap_size=ruff_memory_usage::heap_size,
-    )]
     fn references(db: &'db dyn Db, ty: Type<'db>, target: Definition<'db>) -> bool {
         let visitor = Self::new(target);
         visitor.visit_definition_body(db, ty);

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -20,7 +20,7 @@
 //! avoid this is to prefer always calling `visitor.visit` only in the main recursive method on
 //! `Type`.
 
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::cmp::Eq;
 use std::fmt;
 use std::hash::Hash;
@@ -93,8 +93,14 @@ struct DefinitionReferenceVisitor<'db> {
     found: Cell<bool>,
 }
 
+#[salsa::tracked]
 impl<'db> DefinitionReferenceVisitor<'db> {
     /// Returns whether the definition represented by `ty` references `target`.
+    #[salsa::tracked(
+        returns(copy),
+        cycle_initial=|_, _, _, _| false,
+        heap_size=ruff_memory_usage::heap_size,
+    )]
     fn references(db: &'db dyn Db, ty: Type<'db>, target: Definition<'db>) -> bool {
         let visitor = Self::new(target);
         visitor.visit_definition_body(db, ty);
@@ -200,7 +206,11 @@ impl<'db> TypeVisitor<'db> for DefinitionReferenceVisitor<'db> {
 
 impl<'db> TypeAliasType<'db> {
     fn is_recursive(self, db: &'db dyn Db) -> bool {
-        DefinitionReferenceVisitor::references(db, Type::TypeAlias(self), self.definition(db))
+        DefinitionReferenceVisitor::references(
+            db,
+            Type::TypeAlias(self.unspecialized(db)),
+            self.definition(db),
+        )
     }
 }
 
@@ -281,7 +291,7 @@ where
 /// paths inline even when that makes `seen` slightly larger than an `FxIndexSet<T>`.
 #[derive(Debug)]
 pub struct CycleDetector<'db, Tag, T: HasIdentity<'db>, R, const INLINE_CAPACITY: usize> {
-    /// The active recursion stack and the identity of each item.
+    /// The active recursion stack and the lazily-computed identity of each item.
     /// Completed visits are removed from the end of the stack.
     seen: RefCell<SmallVec<[ActiveCycleDetectorVisit<'db, T>; INLINE_CAPACITY]>>,
 
@@ -355,10 +365,19 @@ where
             return CycleDetectorVisit::Ready(self.fallback.clone());
         }
 
-        let identity = item.to_identity(db);
-        if seen.iter().any(|active| active.identity == identity) {
-            return CycleDetectorVisit::Cycle(item);
-        }
+        let identity = if seen.is_empty() {
+            OnceCell::new()
+        } else {
+            // Deriving an identity can require a structural definition walk. Defer it until
+            // another active item could actually form a cycle.
+            let identity = item.to_identity(db);
+            if seen.iter().any(|active| {
+                active.identity.get_or_init(|| active.item.to_identity(db)) == &identity
+            }) {
+                return CycleDetectorVisit::Cycle(item);
+            }
+            OnceCell::from(identity)
+        };
         drop(seen);
 
         self.seen.borrow_mut().push(ActiveCycleDetectorVisit {
@@ -381,7 +400,7 @@ where
 
 struct ActiveCycleDetectorVisit<'db, T: HasIdentity<'db>> {
     item: T,
-    identity: T::Id,
+    identity: OnceCell<T::Id>,
 }
 
 impl<'db, T: fmt::Debug + HasIdentity<'db>> fmt::Debug for ActiveCycleDetectorVisit<'db, T> {
@@ -692,6 +711,17 @@ mod tests {
             1
         );
         assert_eq!(IDENTITY_CALLS.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn skips_identity_without_a_distinct_active_item() {
+        let db = setup_db();
+        IDENTITY_CALLS.store(0, Ordering::Relaxed);
+        let detector = CycleDetector::<TestVisit, CountingIdentityItem, u8, 1>::new(0);
+
+        assert_eq!(detector.visit(&db, CountingIdentityItem(1), || 1), 1);
+        assert_eq!(detector.visit(&db, CountingIdentityItem(1), || 2), 1);
+        assert_eq!(IDENTITY_CALLS.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -679,8 +679,12 @@ impl<T: Hash + Eq> Drop for ActiveRecursionGuard<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CycleDetector, CycleDetectorVisit, Db, HasIdentity};
-    use crate::db::tests::setup_db;
+    use super::{CycleDetector, CycleDetectorVisit, Db, HasIdentity, TypeIdentity};
+    use crate::db::tests::{TestDb, setup_db};
+    use crate::place::global_symbol;
+    use crate::types::Type;
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::DbWithWritableSystem;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     struct TestVisit;
@@ -720,6 +724,57 @@ mod tests {
         type Id = ();
 
         fn to_identity(&self, _db: &'db dyn Db) -> Self::Id {}
+    }
+
+    fn global_instance_type<'db>(db: &'db TestDb, name: &str) -> Type<'db> {
+        let file = system_path_to_file(db, "/src/a.py").unwrap();
+        global_symbol(db, file, name)
+            .place
+            .expect_type()
+            .to_instance_approximation(db)
+            .unwrap()
+    }
+
+    #[test]
+    fn property_receiver_does_not_make_protocol_recursive() {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            r#"
+from __future__ import annotations
+
+from typing import Protocol
+
+class GenericProperty[T](Protocol):
+    @property
+    def value(self) -> T: ...
+
+class RecursiveProperty[T](Protocol):
+    @property
+    def child(self) -> RecursiveProperty[list[T]]: ...
+
+class RecursivePropertySetter[T](Protocol):
+    @property
+    def child(self) -> int: ...
+
+    @child.setter
+    def child(self, value: RecursivePropertySetter[list[T]]) -> None: ...
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            global_instance_type(&db, "GenericProperty").recursive_identity(&db),
+            None
+        );
+        assert!(matches!(
+            global_instance_type(&db, "RecursiveProperty").recursive_identity(&db),
+            Some(TypeIdentity::RecursiveProtocol(_))
+        ));
+        assert!(matches!(
+            global_instance_type(&db, "RecursivePropertySetter").recursive_identity(&db),
+            Some(TypeIdentity::RecursiveProtocol(_))
+        ));
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -59,6 +59,9 @@ impl<'db> Type<'db> {
     /// A `true` result is only a candidate match and must be confirmed with
     /// [`Type::to_type_identity`].
     pub(crate) fn may_share_type_identity(self, db: &'db dyn Db, other: Self) -> bool {
+        if self == other {
+            return true;
+        }
         match (self, other) {
             (Type::FunctionLiteral(a), Type::FunctionLiteral(b)) => a.literal(db) == b.literal(db),
             (Type::NewTypeInstance(a), Type::NewTypeInstance(b)) => {

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -20,7 +20,7 @@
 //! avoid this is to prefer always calling `visitor.visit` only in the main recursive method on
 //! `Type`.
 
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::cmp::Eq;
 use std::fmt;
 use std::hash::Hash;
@@ -404,11 +404,21 @@ where
 
         let mut candidates = seen
             .iter()
-            .filter(|active| item.may_share_identity(db, &active.item));
-        let identity = item.to_identity(db);
-        if candidates.any(|active| active.identity == identity) {
-            return CycleDetectorVisit::Cycle(item);
-        }
+            .filter(|active| item.may_share_identity(db, &active.item))
+            .peekable();
+        let identity = if candidates.peek().is_none() {
+            OnceCell::new()
+        } else {
+            // Deriving an identity can require a structural definition walk. Defer it until a
+            // cheap candidate match shows that another active item could form a cycle.
+            let identity = item.to_identity(db);
+            if candidates.any(|active| {
+                active.identity.get_or_init(|| active.item.to_identity(db)) == &identity
+            }) {
+                return CycleDetectorVisit::Cycle(item);
+            }
+            OnceCell::from(identity)
+        };
         drop(seen);
 
         self.seen.borrow_mut().push(ActiveCycleDetectorVisit {
@@ -431,7 +441,7 @@ where
 
 struct ActiveCycleDetectorVisit<'db, T: HasIdentity<'db>> {
     item: T,
-    identity: T::Id,
+    identity: OnceCell<T::Id>,
 }
 
 impl<'db, T: fmt::Debug + HasIdentity<'db>> fmt::Debug for ActiveCycleDetectorVisit<'db, T> {

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -54,6 +54,25 @@ impl<'db> Type<'db> {
             .unwrap_or(TypeIdentity::NonRecursive(self))
     }
 
+    /// Returns `false` if `self` and `other` cannot have the same [`TypeIdentity`].
+    ///
+    /// A `true` result is only a candidate match and must be confirmed with
+    /// [`Type::to_type_identity`].
+    pub(crate) fn may_share_type_identity(self, db: &'db dyn Db, other: Self) -> bool {
+        match (self, other) {
+            (Type::FunctionLiteral(a), Type::FunctionLiteral(b)) => a.literal(db) == b.literal(db),
+            (Type::NewTypeInstance(a), Type::NewTypeInstance(b)) => {
+                a.definition(db) == b.definition(db)
+            }
+            (Type::ProtocolInstance(a), Type::ProtocolInstance(b)) => {
+                a.definition(db) == b.definition(db)
+            }
+            (Type::TypeAlias(a), Type::TypeAlias(b)) => a.definition(db) == b.definition(db),
+            (Type::TypedDict(a), Type::TypedDict(b)) => a.definition(db) == b.definition(db),
+            _ => false,
+        }
+    }
+
     #[allow(clippy::inline_always)]
     #[inline(always)]
     pub(crate) fn recursive_identity(self, db: &'db dyn Db) -> Option<TypeIdentity<'db>> {
@@ -72,10 +91,7 @@ impl<'db> Type<'db> {
                 Some(TypeIdentity::RecursiveTypeAlias(alias.definition(db)))
             }
             Type::ProtocolInstance(protocol) if protocol.is_recursive(db) => {
-                let class = protocol.class_origin()?;
-                let (origin, _) = class.static_class_literal(db)?;
-                let definition = origin.definition(db);
-                Some(TypeIdentity::RecursiveProtocol(definition))
+                Some(TypeIdentity::RecursiveProtocol(protocol.definition(db)?))
             }
             Type::TypedDict(typed_dict) if typed_dict.is_recursive(db) => {
                 let definition = typed_dict.definition(db)?;
@@ -215,6 +231,11 @@ impl<'db> TypeAliasType<'db> {
 }
 
 impl<'db> ProtocolInstanceType<'db> {
+    fn definition(self, db: &'db dyn Db) -> Option<Definition<'db>> {
+        let (origin, _) = self.class_origin()?.static_class_literal(db)?;
+        Some(origin.definition(db))
+    }
+
     fn is_recursive(self, db: &'db dyn Db) -> bool {
         let Some(class) = self.class_origin() else {
             return false;
@@ -250,12 +271,24 @@ impl<'db> TypedDictType<'db> {
 pub trait HasIdentity<'db> {
     type Id: PartialEq;
 
+    /// Returns `false` if `self` and `other` cannot have the same identity.
+    ///
+    /// Implementations can use this to avoid constructing an expensive identity. Returning
+    /// `true` does not imply that the identities match; [`HasIdentity::to_identity`] confirms it.
+    fn may_share_identity(&self, _db: &'db dyn Db, _other: &Self) -> bool {
+        true
+    }
+
     /// Returns an identity that remains stable while this item is active in a [`CycleDetector`].
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id;
 }
 
 impl<'db> HasIdentity<'db> for Type<'db> {
     type Id = TypeIdentity<'db>;
+
+    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
+        self.may_share_type_identity(db, *other)
+    }
 
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         Type::to_type_identity(*self, db)
@@ -267,6 +300,10 @@ pub(crate) type PairVisitor<'db, Tag, C> = CycleDetector<'db, Tag, (Type<'db>, T
 impl<'db> HasIdentity<'db> for (Type<'db>, Type<'db>) {
     type Id = (TypeIdentity<'db>, TypeIdentity<'db>);
 
+    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
+        self.0.may_share_type_identity(db, other.0) && self.1.may_share_type_identity(db, other.1)
+    }
+
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         (self.0.to_type_identity(db), self.1.to_type_identity(db))
     }
@@ -277,6 +314,12 @@ where
     Context: Copy + PartialEq,
 {
     type Id = (TypeIdentity<'db>, Context, TypeIdentity<'db>);
+
+    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
+        self.0.may_share_type_identity(db, other.0)
+            && self.1 == other.1
+            && self.2.may_share_type_identity(db, other.2)
+    }
 
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         (
@@ -365,13 +408,17 @@ where
             return CycleDetectorVisit::Ready(self.fallback.clone());
         }
 
-        let identity = if seen.is_empty() {
+        let mut candidates = seen
+            .iter()
+            .filter(|active| item.may_share_identity(db, &active.item))
+            .peekable();
+        let identity = if candidates.peek().is_none() {
             OnceCell::new()
         } else {
-            // Deriving an identity can require a structural definition walk. Defer it until
-            // another active item could actually form a cycle.
+            // Deriving an identity can require a structural definition walk. Defer it until a
+            // cheap candidate match shows that another active item could form a cycle.
             let identity = item.to_identity(db);
-            if seen.iter().any(|active| {
+            if candidates.any(|active| {
                 active.identity.get_or_init(|| active.item.to_identity(db)) == &identity
             }) {
                 return CycleDetectorVisit::Cycle(item);
@@ -656,6 +703,10 @@ mod tests {
     impl<'db> HasIdentity<'db> for CountingIdentityItem {
         type Id = u8;
 
+        fn may_share_identity(&self, _db: &'db dyn Db, other: &Self) -> bool {
+            self.0 % 2 == other.0 % 2
+        }
+
         fn to_identity(&self, _db: &'db dyn Db) -> Self::Id {
             IDENTITY_CALLS.fetch_add(1, Ordering::Relaxed);
             self.0
@@ -706,11 +757,26 @@ mod tests {
 
         assert_eq!(
             detector.visit(&db, CountingIdentityItem(1), || {
-                detector.visit(&db, CountingIdentityItem(2), || 1)
+                detector.visit(&db, CountingIdentityItem(3), || 1)
             }),
             1
         );
         assert_eq!(IDENTITY_CALLS.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn skips_identity_for_distinct_candidates() {
+        let db = setup_db();
+        IDENTITY_CALLS.store(0, Ordering::Relaxed);
+        let detector = CycleDetector::<TestVisit, CountingIdentityItem, u8, 1>::new(0);
+
+        assert_eq!(
+            detector.visit(&db, CountingIdentityItem(1), || {
+                detector.visit(&db, CountingIdentityItem(2), || 1)
+            }),
+            1
+        );
+        assert_eq!(IDENTITY_CALLS.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -20,7 +20,7 @@
 //! avoid this is to prefer always calling `visitor.visit` only in the main recursive method on
 //! `Type`.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::cmp::Eq;
 use std::fmt;
 use std::hash::Hash;
@@ -32,15 +32,19 @@ use smallvec::SmallVec;
 use ty_python_core::definition::Definition;
 
 use crate::Db;
-use crate::types::Type;
 use crate::types::function::FunctionLiteral;
+use crate::types::generics::Specialization;
+use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
+use crate::types::{ClassType, ProtocolInstanceType, Type, TypeAliasType, TypedDictType};
 
 /// The type identity used for recursive checks/transformations.
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum TypeIdentity<'db> {
     FunctionLiteral(FunctionLiteral<'db>),
     NewTypeInstance(Definition<'db>),
+    RecursiveProtocol(Definition<'db>),
     RecursiveTypeAlias(Definition<'db>),
+    RecursiveTypedDict(Definition<'db>),
     NonRecursive(Type<'db>),
 }
 
@@ -67,8 +71,168 @@ impl<'db> Type<'db> {
             Type::TypeAlias(alias) if alias.is_recursive(db) => {
                 Some(TypeIdentity::RecursiveTypeAlias(alias.definition(db)))
             }
+            Type::ProtocolInstance(protocol) if protocol.is_recursive(db) => {
+                let class = protocol.class_origin()?;
+                let (origin, _) = class.static_class_literal(db)?;
+                let definition = origin.definition(db);
+                Some(TypeIdentity::RecursiveProtocol(definition))
+            }
+            Type::TypedDict(typed_dict) if typed_dict.is_recursive(db) => {
+                let definition = typed_dict.definition(db)?;
+                Some(TypeIdentity::RecursiveTypedDict(definition))
+            }
             _ => None,
         }
+    }
+}
+
+struct DefinitionReferenceVisitor<'db> {
+    target: Definition<'db>,
+    active_definitions: ActiveRecursionDetector<Definition<'db>>,
+    visited_types: TypeCollector<'db>,
+    found: Cell<bool>,
+}
+
+impl<'db> DefinitionReferenceVisitor<'db> {
+    /// Returns whether the definition represented by `ty` references `target`.
+    fn references(db: &'db dyn Db, ty: Type<'db>, target: Definition<'db>) -> bool {
+        let visitor = Self::new(target);
+        visitor.visit_definition_body(db, ty);
+        visitor.found.get()
+    }
+
+    fn new(target: Definition<'db>) -> Self {
+        Self {
+            target,
+            active_definitions: ActiveRecursionDetector::default(),
+            visited_types: TypeCollector::default(),
+            found: Cell::new(false),
+        }
+    }
+
+    fn definition_and_specialization(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+    ) -> Option<(Definition<'db>, Option<Specialization<'db>>)> {
+        if let Type::TypeAlias(alias) = ty {
+            return Some((alias.definition(db), alias.specialization(db)));
+        }
+
+        let class = match ty {
+            Type::ProtocolInstance(protocol) => *protocol.class_origin()?,
+            Type::TypedDict(typed_dict) => typed_dict.defining_class()?,
+            _ => return None,
+        };
+        let definition = class.definition(db)?;
+        let specialization = class
+            .into_generic_alias()
+            .map(|generic| generic.specialization(db));
+        Some((definition, specialization))
+    }
+
+    fn visit_specialization(&self, db: &'db dyn Db, specialization: Specialization<'db>) {
+        for ty in specialization.types(db) {
+            self.visit_type(db, *ty);
+        }
+    }
+
+    fn visit_definition_body(&self, db: &'db dyn Db, ty: Type<'db>) {
+        match ty {
+            Type::TypeAlias(alias) => self.visit_type_alias_type(db, alias),
+            Type::ProtocolInstance(protocol) => self.visit_protocol_instance_type(db, protocol),
+            Type::TypedDict(typed_dict) => self.visit_typed_dict_type(db, typed_dict),
+            _ => {}
+        }
+    }
+}
+
+impl<'db> TypeVisitor<'db> for DefinitionReferenceVisitor<'db> {
+    fn should_visit_lazy_type_attributes(&self) -> bool {
+        false
+    }
+
+    fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+        if self.found.get() {
+            return;
+        }
+
+        if let Some((definition, specialization)) = Self::definition_and_specialization(db, ty) {
+            if definition == self.target {
+                self.found.set(true);
+                return;
+            }
+
+            if let Some(specialization) = specialization {
+                self.visit_specialization(db, specialization);
+            }
+
+            if !self.found.get() {
+                self.active_definitions.visit(
+                    &definition,
+                    || {},
+                    || self.visit_definition_body(db, ty),
+                );
+            }
+        } else {
+            walk_type_with_recursion_guard(db, ty, self, &self.visited_types);
+        }
+    }
+
+    fn visit_protocol_instance_type(&self, db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) {
+        if let Some(class) = protocol.class_origin() {
+            class.walk_recursive_member_types(db, self);
+        }
+    }
+
+    fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {
+        self.visit_type(db, alias.raw_value_type(db));
+    }
+
+    fn visit_typed_dict_type(&self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
+        for field in typed_dict.items(db).values() {
+            self.visit_type(db, field.declared_ty);
+        }
+        if let Some(extra_items) = typed_dict.explicit_extra_items(db) {
+            self.visit_type(db, extra_items.declared_ty);
+        }
+    }
+}
+
+impl<'db> TypeAliasType<'db> {
+    fn is_recursive(self, db: &'db dyn Db) -> bool {
+        DefinitionReferenceVisitor::references(db, Type::TypeAlias(self), self.definition(db))
+    }
+}
+
+impl<'db> ProtocolInstanceType<'db> {
+    fn is_recursive(self, db: &'db dyn Db) -> bool {
+        let Some(class) = self.class_origin() else {
+            return false;
+        };
+        let Some((origin, _)) = class.static_class_literal(db) else {
+            return false;
+        };
+        let definition = origin.definition(db);
+        // Inspect the definition without its current specialization. Otherwise, a finite
+        // type such as `Protocol[Protocol[int]]` would appear recursive.
+        let unspecialized = Type::instance(db, ClassType::NonGeneric(origin.into()));
+        DefinitionReferenceVisitor::references(db, unspecialized, definition)
+    }
+}
+
+impl<'db> TypedDictType<'db> {
+    fn is_recursive(self, db: &'db dyn Db) -> bool {
+        let Some(class) = self.defining_class() else {
+            return false;
+        };
+        let Some((origin, _)) = class.static_class_literal(db) else {
+            return false;
+        };
+        let definition = origin.definition(db);
+        // Inspect the definition without its current specialization for the same reason as
+        // protocols above.
+        let unspecialized = Type::typed_dict(ClassType::NonGeneric(origin.into()));
+        DefinitionReferenceVisitor::references(db, unspecialized, definition)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -93,10 +93,7 @@ impl<'db> ProtocolClass<'db> {
                 return;
             }
             let candidate = candidate.apply_specialization(db, specialization);
-            if candidate.is_bound_method_like(db) {
-                return;
-            }
-            visitor.visit_type(db, candidate.ty);
+            candidate.walk_recursive_member_types(db, visitor);
         });
     }
 
@@ -2962,6 +2959,33 @@ impl<'db> ProtocolMemberCandidate<'db> {
                 Type::Callable(callable) => callable.is_method_like(db),
                 _ => false,
             }
+    }
+
+    fn walk_recursive_member_types<V: super::visitor::TypeVisitor<'db> + ?Sized>(
+        self,
+        db: &'db dyn Db,
+        visitor: &V,
+    ) {
+        match self.ty {
+            Type::PropertyInstance(property) => {
+                // A property exposes its getter return and setter value types. Walking the
+                // accessor callables themselves would also visit their receiver and make every
+                // generic protocol property appear recursive.
+                for member in [
+                    property.getter(db).map(ProtocolMemberType::property_getter),
+                    property.setter(db).map(ProtocolMemberType::property_setter),
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    if let Some(member) = member.resolve(db) {
+                        visitor.visit_type(db, member.ty());
+                    }
+                }
+            }
+            _ if self.is_bound_method_like(db) => {}
+            _ => visitor.visit_type(db, self.ty),
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, ops::Deref};
 use itertools::Itertools;
 
 use ruff_python_ast::name::Name;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::types::attribute_write::{
     AttributeWriteRequirement, ClassAttributeWriteMember, ExplicitAttributeWriteRequirement,
@@ -31,6 +31,7 @@ use crate::{
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
         diagnostic::report_undeclared_protocol_member,
+        generics::Specialization,
         signatures::walk_signature,
     },
 };
@@ -73,6 +74,107 @@ impl<'db> ProtocolClass<'db> {
     pub(super) fn interface(self, db: &'db dyn Db) -> ProtocolInterface<'db> {
         let _span = tracing::trace_span!("protocol_members", "class='{}'", self.name(db)).entered();
         cached_protocol_interface(db, *self)
+    }
+
+    /// Walk the effective non-method member types declared by this protocol.
+    ///
+    /// Method relations have their own declaration-based recursion guard. Keeping them out of this
+    /// walk also avoids requesting a method signature while one of its annotations is being
+    /// inferred.
+    pub(super) fn walk_recursive_member_types<V: super::visitor::TypeVisitor<'db> + ?Sized>(
+        self,
+        db: &'db dyn Db,
+        visitor: &V,
+    ) {
+        let mut seen_members = FxHashSet::default();
+
+        self.for_each_member_candidate(db, |name, candidate, specialization| {
+            if !seen_members.insert(name.clone()) {
+                return;
+            }
+            let candidate = candidate.apply_specialization(db, specialization);
+            if candidate.is_bound_method_like(db) {
+                return;
+            }
+            visitor.visit_type(db, candidate.ty);
+        });
+    }
+
+    /// Visits protocol member candidates in MRO order after applying declaration precedence.
+    ///
+    /// Consumers discard shadowed names before applying the accompanying specialization.
+    fn for_each_member_candidate(
+        self,
+        db: &'db dyn Db,
+        mut visit: impl FnMut(&Name, ProtocolMemberCandidate<'db>, Option<Specialization<'db>>),
+    ) {
+        for (parent_scope, specialization) in self
+            .iter_mro(db)
+            .filter_map(ClassBase::into_class)
+            .filter_map(|class| {
+                let (class_literal, specialization) = class.static_class_literal(db)?;
+                let protocol_class = class_literal.into_protocol_class(db)?;
+                Some((
+                    protocol_class.static_class_literal(db)?.0.body_scope(db),
+                    specialization,
+                ))
+            })
+        {
+            let use_def_map = use_def_map(db, parent_scope);
+            let place_table = place_table(db, parent_scope);
+            let mut direct_members = FxHashMap::default();
+
+            // Bindings that are not declared in the class body are invalid protocol members, but
+            // runtime-checkable protocols still consider them members for `isinstance()` and
+            // `issubclass()`.
+            for (symbol_id, bindings) in use_def_map.all_end_of_scope_symbol_bindings() {
+                let place_and_definition = place_from_bindings(db, bindings);
+                if let Some(ty) = place_and_definition.place.ignore_possibly_undefined() {
+                    direct_members.insert(
+                        symbol_id,
+                        ProtocolMemberCandidate {
+                            ty,
+                            qualifiers: TypeQualifiers::default(),
+                            definition: place_and_definition.first_definition,
+                            bound_on_class: BoundOnClass::Yes,
+                        },
+                    );
+                }
+            }
+
+            for (symbol_id, declarations) in use_def_map.all_end_of_scope_symbol_declarations() {
+                let place_result = place_from_declarations(db, declarations);
+                let first_declaration = place_result.first_declaration;
+                let place = place_result.ignore_conflicting_declarations();
+                if let Some(ty) = place.place.ignore_possibly_undefined() {
+                    direct_members
+                        .entry(symbol_id)
+                        .and_modify(|candidate| {
+                            candidate.ty = ty;
+                            candidate.qualifiers = place.qualifiers;
+                        })
+                        .or_insert(ProtocolMemberCandidate {
+                            ty,
+                            qualifiers: place.qualifiers,
+                            definition: first_declaration,
+                            bound_on_class: BoundOnClass::No,
+                        });
+                }
+            }
+
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "member names are unique within each class and both consumers are order-independent"
+            )]
+            for (symbol_id, candidate) in direct_members {
+                let name = place_table.symbol(symbol_id).name();
+                if excluded_from_proto_members(name) {
+                    continue;
+                }
+
+                visit(name, candidate, specialization);
+            }
+        }
     }
 
     pub(super) fn is_runtime_checkable(self, db: &'db dyn Db) -> bool {
@@ -2835,6 +2937,34 @@ impl BoundOnClass {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+struct ProtocolMemberCandidate<'db> {
+    ty: Type<'db>,
+    qualifiers: TypeQualifiers,
+    definition: Option<Definition<'db>>,
+    bound_on_class: BoundOnClass,
+}
+
+impl<'db> ProtocolMemberCandidate<'db> {
+    fn apply_specialization(
+        mut self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+    ) -> Self {
+        self.ty = self.ty.apply_optional_specialization(db, specialization);
+        self
+    }
+
+    fn is_bound_method_like(self, db: &'db dyn Db) -> bool {
+        self.bound_on_class.is_yes()
+            && match self.ty {
+                Type::FunctionLiteral(_) => true,
+                Type::Callable(callable) => callable.is_method_like(db),
+                _ => false,
+            }
+    }
+}
+
 /// Inner Salsa query for [`ProtocolClass::interface`].
 #[salsa::tracked(
     returns(copy),
@@ -2848,118 +2978,54 @@ fn cached_protocol_interface<'db>(
 ) -> ProtocolInterface<'db> {
     let mut members = BTreeMap::default();
 
-    for (parent_scope, specialization) in class
-        .iter_mro(db)
-        .filter_map(ClassBase::into_class)
-        .filter_map(|class| {
-            let (class_literal, specialization) = class.static_class_literal(db)?;
-            let protocol_class = class_literal.into_protocol_class(db)?;
-            let parent_scope = protocol_class.static_class_literal(db)?.0.body_scope(db);
-            Some((parent_scope, specialization))
-        })
-    {
-        let use_def_map = use_def_map(db, parent_scope);
-        let place_table = place_table(db, parent_scope);
-        let mut direct_members = FxHashMap::default();
-
-        // Bindings in the class body that are not declared in the class body
-        // are not valid protocol members, and we plan to emit diagnostics for them
-        // elsewhere. Invalid or not, however, it's important that we still consider
-        // them to be protocol members. The implementation of `issubclass()` and
-        // `isinstance()` for runtime-checkable protocols considers them to be protocol
-        // members at runtime, and it's important that we accurately understand
-        // type narrowing that uses `isinstance()` or `issubclass()` with
-        // runtime-checkable protocols.
-        for (symbol_id, bindings) in use_def_map.all_end_of_scope_symbol_bindings() {
-            let place_and_definition = place_from_bindings(db, bindings);
-            let Some(ty) = place_and_definition.place.ignore_possibly_undefined() else {
-                continue;
-            };
-            direct_members.insert(
-                symbol_id,
-                (
-                    ty,
-                    TypeQualifiers::default(),
-                    place_and_definition.first_definition,
-                    BoundOnClass::Yes,
-                ),
-            );
+    ProtocolClass(class).for_each_member_candidate(db, |name, candidate, specialization| {
+        if members.contains_key(name) {
+            return;
         }
 
-        for (symbol_id, declarations) in use_def_map.all_end_of_scope_symbol_declarations() {
-            let place_result = place_from_declarations(db, declarations);
-            let first_declaration = place_result.first_declaration;
-            let place = place_result.ignore_conflicting_declarations();
-            if let Some(new_type) = place.place.ignore_possibly_undefined() {
-                direct_members
-                    .entry(symbol_id)
-                    .and_modify(|(ty, quals, _, _)| {
-                        *ty = new_type;
-                        *quals = place.qualifiers;
-                    })
-                    .or_insert((
-                        new_type,
-                        place.qualifiers,
-                        first_declaration,
-                        BoundOnClass::No,
-                    ));
+        let candidate = candidate.apply_specialization(db, specialization);
+        let ProtocolMemberCandidate {
+            ty,
+            qualifiers,
+            definition,
+            bound_on_class,
+        } = candidate;
+
+        let member = match ty {
+            Type::PropertyInstance(property) => ProtocolMemberData::property(
+                property.getter(db).map(ProtocolMemberType::property_getter),
+                property
+                    .setter(db)
+                    .map(ProtocolMemberType::property_setter)
+                    .map(ProtocolMemberWrite::from_type),
+                definition,
+            ),
+            Type::Callable(callable) if bound_on_class.is_yes() && callable.is_method_like(db) => {
+                ProtocolMemberData::method(db, callable, definition)
             }
-        }
-
-        #[expect(
-            clippy::iter_over_hash_type,
-            reason = "direct members have unique names and the final map is ordered"
-        )]
-        for (symbol_id, (ty, qualifiers, definition, bound_on_class)) in direct_members {
-            let name = place_table.symbol(symbol_id).name();
-            if excluded_from_proto_members(name) {
-                continue;
+            Type::FunctionLiteral(function)
+                if bound_on_class.is_yes()
+                    || function.is_staticmethod(db)
+                    || function.is_classmethod(db) =>
+            {
+                ProtocolMemberData::method(db, function.into_callable_type(db), definition)
             }
-            if members.contains_key(name) {
-                continue;
+            _ if bound_on_class.is_yes()
+                && definition.is_some_and(|definition| definition.kind(db).is_function_def()) =>
+            {
+                if let Some(descriptor) =
+                    descriptor_decorated_protocol_member(db, ty, class, definition)
+                {
+                    descriptor
+                } else {
+                    ProtocolMemberData::attribute(ty, qualifiers, definition)
+                }
             }
+            _ => ProtocolMemberData::attribute(ty, qualifiers, definition),
+        };
 
-            let ty = ty.apply_optional_specialization(db, specialization);
-
-            let member = match ty {
-                Type::PropertyInstance(property) => ProtocolMemberData::property(
-                    property.getter(db).map(ProtocolMemberType::property_getter),
-                    property
-                        .setter(db)
-                        .map(ProtocolMemberType::property_setter)
-                        .map(ProtocolMemberWrite::from_type),
-                    definition,
-                ),
-                Type::Callable(callable)
-                    if bound_on_class.is_yes() && callable.is_method_like(db) =>
-                {
-                    ProtocolMemberData::method(db, callable, definition)
-                }
-                Type::FunctionLiteral(function)
-                    if bound_on_class.is_yes()
-                        || function.is_staticmethod(db)
-                        || function.is_classmethod(db) =>
-                {
-                    ProtocolMemberData::method(db, function.into_callable_type(db), definition)
-                }
-                _ if bound_on_class.is_yes()
-                    && definition
-                        .is_some_and(|definition| definition.kind(db).is_function_def()) =>
-                {
-                    if let Some(descriptor) =
-                        descriptor_decorated_protocol_member(db, ty, class, definition)
-                    {
-                        descriptor
-                    } else {
-                        ProtocolMemberData::attribute(ty, qualifiers, definition)
-                    }
-                }
-                _ => ProtocolMemberData::attribute(ty, qualifiers, definition),
-            };
-
-            members.insert(name.clone(), member);
-        }
-    }
+        members.insert(name.clone(), member);
+    });
 
     ProtocolInterface::new(db, members)
 }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -874,6 +874,25 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         }
     }
 
+    /// Checks class subtyping without discarding the active recursive relation state.
+    pub(super) fn is_class_subtype(
+        &self,
+        db: &'db dyn Db,
+        source: ClassType<'db>,
+        target: ClassType<'db>,
+    ) -> bool {
+        Self::subtyping(
+            self.constraints,
+            InferableTypeVars::None,
+            self.relation_visitor,
+            self.disjointness_visitor,
+            self.signature_relation_visitor,
+            self.materialization_visitor,
+        )
+        .check_class_pair(db, source, target)
+        .is_always_satisfied(db)
+    }
+
     pub(super) const fn is_eager_assignability(&self) -> bool {
         self.relation.is_assignability()
             && matches!(self.typevar_evaluation, TypeVarEvaluation::Eager)
@@ -970,15 +989,20 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         source: Type<'db>,
         target: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        if matches!((source, target), (Type::TypeAlias(_), Type::TypeAlias(_))) {
-            // TODO: Recursive aliases can encode context-free languages, whose inclusion and
-            // equivalence are undecidable. No complete fallback exists, but more decidable cases
-            // can be recognized here before conservatively rejecting the pair.
+        if matches!(
+            (source, target),
+            (Type::TypeAlias(_), Type::TypeAlias(_))
+                | (Type::ProtocolInstance(_), Type::ProtocolInstance(_))
+                | (Type::TypedDict(_), Type::TypedDict(_))
+        ) {
+            // TODO: Recursively-specialized structural types can encode context-free languages,
+            // whose inclusion and equivalence are undecidable. No complete fallback exists, but
+            // more decidable cases can be recognized here before conservatively rejecting the pair.
             return self.never();
         }
 
-        // Mixed recursive cycles (for example, alias vs. protocol) keep the existing coinductive
-        // fallback. Alias pairs are rejected above instead of generating another recursive
+        // Mixed recursive cycles keep the existing coinductive fallback. Pairs of the same
+        // recursively structural kind are rejected above instead of generating another recursive
         // obligation.
         self.always()
     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -993,25 +993,17 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
     fn recursive_type_pair_fallback(
         &self,
-        source: Type<'db>,
-        target: Type<'db>,
+        _source: Type<'db>,
+        _target: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        if matches!(
-            (source, target),
-            (Type::TypeAlias(_), Type::TypeAlias(_))
-                | (Type::ProtocolInstance(_), Type::ProtocolInstance(_))
-                | (Type::TypedDict(_), Type::TypedDict(_))
-        ) {
-            // TODO: Recursively-specialized structural types can encode context-free languages,
-            // whose inclusion and equivalence are undecidable. No complete fallback exists, but
-            // more decidable cases can be recognized here before conservatively rejecting the pair.
-            return self.never();
-        }
-
-        // Mixed recursive cycles keep the existing coinductive fallback. Pairs of the same
-        // recursively structural kind are rejected above instead of generating another recursive
-        // obligation.
-        self.always()
+        // TODO: Recursively-specialized structural types can encode context-free languages,
+        // whose inclusion and equivalence are undecidable. No complete fallback exists, but
+        // more decidable cases can be recognized here before conservatively rejecting the pair.
+        //
+        // Strictly speaking, it is incorrect to use either `never` or `always` as a conservative result.
+        // The correct choice here is a logical value that is "neither true nor false", and expressing this requires the introduction of 3-valued logic.
+        // Discussion: https://github.com/astral-sh/ty/issues/4050
+        self.never()
     }
 
     /// Is `target` a metaclass instance (a nominal instance of a subclass of `builtins.type`)?

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -732,6 +732,13 @@ impl<'db> HasIdentity<'db> for (Type<'db>, Type<'db>, TypeRelation, TypeVarEvalu
         TypeVarEvaluation,
     );
 
+    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
+        self.0.may_share_type_identity(db, other.0)
+            && self.1.may_share_type_identity(db, other.1)
+            && self.2 == other.2
+            && self.3 == other.3
+    }
+
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
         (
             self.0.to_type_identity(db),

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -262,6 +262,19 @@ impl<'db> TypeAliasType<'db> {
         }
     }
 
+    /// Returns the alias without an applied specialization.
+    pub(super) fn unspecialized(self, db: &'db dyn Db) -> Self {
+        match self {
+            TypeAliasType::PEP695(alias) => TypeAliasType::PEP695(PEP695TypeAliasType::new(
+                db,
+                alias.name(db),
+                alias.rhs_scope(db),
+                None,
+            )),
+            TypeAliasType::ManualPEP695(_) => self,
+        }
+    }
+
     pub(crate) fn as_pep_695_type_alias(self) -> Option<PEP695TypeAliasType<'db>> {
         match self {
             TypeAliasType::PEP695(type_alias) => Some(type_alias),

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, fmt::Write};
+use std::fmt::Write;
 
 use crate::{
     Db,
@@ -8,7 +8,7 @@ use crate::{
         display::qualified_name_components_from_scope,
         generics::{ApplySpecialization, Specialization},
         variance::VarianceInferable,
-        visitor::{self, TypeKind, TypeVisitor, walk_non_atomic_type},
+        visitor,
     },
 };
 use ty_python_core::{
@@ -262,41 +262,6 @@ impl<'db> TypeAliasType<'db> {
         }
     }
 
-    /// Returns whether this alias participates in a recursive alias definition.
-    pub(crate) fn is_recursive(self, db: &'db dyn Db) -> bool {
-        self.unspecialized(db)
-            .references_alias(db, self.definition(db))
-    }
-
-    fn unspecialized(self, db: &'db dyn Db) -> Self {
-        match self {
-            TypeAliasType::PEP695(alias) => TypeAliasType::PEP695(PEP695TypeAliasType::new(
-                db,
-                alias.name(db),
-                alias.rhs_scope(db),
-                None,
-            )),
-            TypeAliasType::ManualPEP695(_) => self,
-        }
-    }
-
-    /// Returns whether this alias's value references `target` through named aliases.
-    ///
-    /// `false` seeds the least fixed point of alias reachability.
-    #[salsa::tracked(
-        returns(copy),
-        cycle_initial=|_, _, _, _| false,
-        heap_size=ruff_memory_usage::heap_size,
-    )]
-    fn references_alias(self, db: &'db dyn Db, target: Definition<'db>) -> bool {
-        let visitor = AliasReferenceVisitor {
-            target,
-            found: Cell::new(false),
-        };
-        visitor.visit_type(db, self.raw_value_type(db));
-        visitor.found.get()
-    }
-
     pub(crate) fn as_pep_695_type_alias(self) -> Option<PEP695TypeAliasType<'db>> {
         match self {
             TypeAliasType::PEP695(type_alias) => Some(type_alias),
@@ -335,45 +300,6 @@ impl<'db> TypeAliasType<'db> {
     /// Returns a struct that can display the fully qualified name of this type alias.
     pub(crate) fn qualified_name(self, db: &'db dyn Db) -> QualifiedTypeAliasName<'db> {
         QualifiedTypeAliasName::from_type_alias(db, self)
-    }
-}
-
-struct AliasReferenceVisitor<'db> {
-    target: Definition<'db>,
-    found: Cell<bool>,
-}
-
-impl<'db> TypeVisitor<'db> for AliasReferenceVisitor<'db> {
-    fn should_visit_lazy_type_attributes(&self) -> bool {
-        false
-    }
-
-    fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-        if self.found.get() {
-            return;
-        }
-
-        if let Type::TypeAlias(alias) = ty {
-            if alias.definition(db) == self.target {
-                self.found.set(true);
-                return;
-            }
-
-            if let Some(specialization) = alias.specialization(db) {
-                for ty in specialization.types(db) {
-                    self.visit_type(db, *ty);
-                }
-            }
-
-            if !self.found.get() && alias.unspecialized(db).references_alias(db, self.target) {
-                self.found.set(true);
-            }
-            return;
-        }
-
-        if let TypeKind::NonAtomic(non_atomic) = TypeKind::from(ty) {
-            walk_non_atomic_type(db, non_atomic, self);
-        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -715,7 +715,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // This should be cheaper in many cases, and also helps us avoid some cycles.
         if let Some(defining_class) = source.defining_class()
             && let Some(target_defining_class) = target.defining_class()
-            && defining_class.is_subclass_of(db, target_defining_class)
+            && self.is_class_subtype(db, defining_class, target_defining_class)
         {
             return self.always();
         }


### PR DESCRIPTION
## Summary

This PR addresses https://github.com/astral-sh/ruff/pull/26503#discussion_r3607102256

The basic approach is to just add `TypeIdentity::{RecursiveProtocol, RecursiveTypedDict}`, but it was found that calculating `to_identity` for these types was more costly than expected, so I implemented some measures to delay the `to_identity` calculation.

## Test Plan

mdtest updated
