### PR TITLE
[ty] Add membership narrowing ecosystem regression

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -44,6 +44,22 @@ def from_dict(value: str, valid_values: dict[MyType, int]) -> int | None:
     return None
 ```
 
+Explicitly annotated literals remain unpromotable through membership narrowing and inferred instance
+attributes:
+
+```py
+from typing import Literal
+
+class Backend:
+    def connect(self, mode: Literal["streaming", "batch"]) -> None:
+        if mode not in ("batch", "streaming"):
+            return
+        self._mode = mode
+
+    def mode(self) -> Literal["streaming", "batch"]:
+        return self._mode
+```
+
 ```py
 from typing import Literal
 


### PR DESCRIPTION
## Summary

Adds a regression test for the [ibis ecosystem hit surfaced by #26988](https://github.com/astral-sh/ruff/pull/26988#issuecomment-5017218003). Membership narrowing previously replaced an explicitly annotated literal union with promotable literals from the tuple, causing an inferred instance attribute to widen to `str` when read from another method.

The test ensures that the literal union is preserved across the assignment and subsequent return.
