### PR TITLE
[ty] Fix ecosystem metadata collection for split build jobs

### DIFF
--- a/.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md
+++ b/.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md
@@ -25,6 +25,8 @@ scripts/collect_ty_ecosystem_run_metadata.py \
 
 The manifest contains the analyzed Ruff revisions, Actions `EXCLUDE_NEWER`, ecosystem-analyzer and mypy-primer revisions, and each project's CI Python version. Stop if the helper cannot determine a unique value; never substitute a comment timestamp or local default.
 
+The current workflow splits compilation into `Build ty (base)` and `Build ty (pr)`. The helper reads the base job, which records both the merge base and PR merge revision, and still supports historical runs with a single `Build ty` job.
+
 ## Prepare ty
 
 If a primary agent supplied freshly copied base and PR binaries plus the PR ecosystem config, verify the paths exist and reuse them. Do not rebuild, switch Ruff refs, or overwrite the shared artifacts.

--- a/scripts/collect_ty_ecosystem_run_metadata.py
+++ b/scripts/collect_ty_ecosystem_run_metadata.py
@@ -187,10 +187,12 @@ def parse_run_reference(value: str) -> tuple[int, int | None]:
     raise MetadataError(f"invalid Actions run ID or URL: {value}")
 
 
-def job_by_name(jobs: Sequence[dict[str, Any]], name: str) -> dict[str, Any]:
-    matches = [job for job in jobs if job.get("name") == name]
+def build_job(jobs: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    matches = [
+        job for job in jobs if job.get("name") in {"Build ty", "Build ty (base)"}
+    ]
     if len(matches) != 1:
-        raise MetadataError(f"expected exactly one {name!r} job")
+        raise MetadataError("expected exactly one 'Build ty' or 'Build ty (base)' job")
     return matches[0]
 
 
@@ -241,7 +243,7 @@ def collect_metadata(
     jobs = run_data.get("jobs")
     if not isinstance(jobs, list):
         raise MetadataError("the Actions run did not include job metadata")
-    build_job = job_by_name(jobs, "Build ty")
+    selected_build_job = build_job(jobs)
     shard_job = first_shard_job(jobs)
 
     def job_log(job: dict[str, Any]) -> str:
@@ -261,7 +263,7 @@ def collect_metadata(
             ]
         )
 
-    merge_base, pr_revision = parse_build_log(job_log(build_job))
+    merge_base, pr_revision = parse_build_log(job_log(selected_build_job))
     exclude_newer, analyzer_revision, shard_merge_base = parse_shard_log(
         job_log(shard_job)
     )


### PR DESCRIPTION
## Summary

The ty ecosystem workflow now builds its base and PR binaries in separate jobs, but the metadata collector still expects a single `Build ty` job and fails before it can recover the run metadata.

This updates the collector to read `Build ty (base)` while preserving compatibility with historical single-job runs, and documents the split-job behavior in the ecosystem-minimization skill.