### PR TITLE
[ty] Preserve constrained TypeVar inequality narrowing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1076,6 +1076,12 @@ def correlated_typevar_eq(value: E, other: EnumT) -> EnumT:
         reveal_type(value)  # revealed: EnumT@correlated_typevar_eq
         return value
     return other
+
+def correlated_typevar_ne(value: E, other: EnumT) -> EnumT:
+    if value != other:
+        return other
+    reveal_type(value)  # revealed: EnumT@correlated_typevar_ne
+    return value
 ```
 
 ## `LiteralString` and string-valued enums

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -228,6 +228,21 @@ pub(super) fn evaluate_type_inequality<'db>(
     is_positive: bool,
     soundness_policy: ComparisonSoundnessPolicy,
 ) -> Option<Type<'db>> {
+    let right = right.resolve_type_alias(db);
+
+    // Preserve the shared specialization of a constrained TypeVar when `left != right` is false.
+    if !is_positive
+        && let Type::TypeVar(typevar) = right
+        && let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =
+            typevar.typevar(db).bound_or_constraints(db)
+        && constraints.elements(db).iter().all(|constraint| {
+            evaluate_type_inequality(db, left, *constraint, false, soundness_policy)
+                .is_some_and(|narrowed| narrowed.is_equivalent_to(db, *constraint))
+        })
+    {
+        return Some(right);
+    }
+
     let branch = ComparisonBranch::from(is_positive);
     let condition_expects_equality =
         ComparisonOperator::Inequality.condition_expects_equality(branch);


### PR DESCRIPTION
## Summary

Follow-up to [#26988](https://github.com/astral-sh/ruff/pull/26988#issuecomment-5017439215). Positive equality narrowing preserves the shared specialization of a constrained TypeVar, but the equivalent false branch of `!=` still expanded it and lost its correlation with the return type:

```py
def correlated(value: E, other: T) -> T:
    if value != other:
        return other
    return value  # Previously: invalid-return-type
```
