### PR TITLE
[ty] Walk protocol interfaces in member order

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1896,6 +1896,25 @@ class ImplicitProtocolSubtype(Protocol):
 static_assert(is_subtype_of(ImplicitProtocolSubtype, HasX))
 static_assert(is_assignable_to(ImplicitProtocolSubtype, HasX))
 
+class ImplicitProtocolSubtypeWithExtraMembers(Protocol):
+    z: int
+    a: int
+    x: int
+
+static_assert(is_subtype_of(ImplicitProtocolSubtypeWithExtraMembers, HasX))
+static_assert(is_assignable_to(ImplicitProtocolSubtypeWithExtraMembers, HasX))
+
+class HasAY(Protocol):
+    a: int
+    y: int
+
+class HasAZ(Protocol):
+    a: int
+    z: int
+
+static_assert(not is_subtype_of(HasAZ, HasAY))
+static_assert(not is_assignable_to(HasAZ, HasAY))
+
 class Meta(type):
     x: int
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2637,12 +2637,25 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return self.never();
         }
 
+        // Both interfaces store their members in name order. Pair them before sorting target
+        // members by structural priority to avoid a separate tree lookup for every target member.
+        let mut source_members = source.members(db).peekable();
+
         target
             .members(db)
-            .sorted_by_cached_key(|member| member.structural_member_priority(db))
-            .when_all(db, self.constraints, |target_member| {
-                let source_member = source.member_by_name(db, target_member.name);
-
+            .map(|target_member| {
+                while source_members
+                    .peek()
+                    .is_some_and(|source_member| source_member.name < target_member.name)
+                {
+                    source_members.next();
+                }
+                let source_member = source_members
+                    .next_if(|source_member| source_member.name == target_member.name);
+                (target_member, source_member)
+            })
+            .sorted_by_cached_key(|(member, _)| member.structural_member_priority(db))
+            .when_all(db, self.constraints, |(target_member, source_member)| {
                 if let Some(context) = self.report_context()
                     && source_member.is_none()
                 {


### PR DESCRIPTION
## Summary

Prior to this change, protocol-to-protocol compatibility performed a separate `BTreeMap` lookup for every required member. Large interfaces therefore spent a substantial amount of time repeatedly walking the same tree, especially while constructing diagnostic context for a missing member.

We now walk the two name-ordered interfaces together, advancing the source iterator past unrelated members and matching each required member once. This changes the comparison from O(n log n) to O(n) while preserving member compatibility and diagnostic behavior.
