### PR TITLE
[ty] Make membership reachability consistent with narrowing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/instances/membership_test.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/instances/membership_test.md
@@ -122,6 +122,133 @@ reveal_type(42 in AlwaysFalse())  # revealed: Literal[False]
 reveal_type(42 not in AlwaysFalse())  # revealed: Literal[True]
 ```
 
+## Built-in containers with fixed contents
+
+Tuple membership compares the tested value against each element. Inline lists and sets cannot be
+changed before the membership check, so their literal elements can also determine the result:
+
+```py
+from typing import Literal
+
+def literal_membership(value: Literal["foo"]):
+    reveal_type(value in ("foo",))  # revealed: Literal[True]
+    reveal_type(value not in ("foo",))  # revealed: Literal[False]
+    reveal_type(value in ("bar",))  # revealed: Literal[False]
+    reveal_type(value not in ("bar",))  # revealed: Literal[True]
+
+    reveal_type(value in ["foo"])  # revealed: Literal[True]
+    reveal_type(value not in ["foo"])  # revealed: Literal[False]
+    reveal_type(value in {"bar"})  # revealed: Literal[False]
+    reveal_type(value not in {"bar"})  # revealed: Literal[True]
+```
+
+An exhaustive membership check proves that a function cannot implicitly return `None`, including
+when the tested value is a literal union:
+
+```py
+def tuple_membership(value: Literal["foo"]) -> int:
+    if value in ("foo",):
+        return 42
+
+def literal_union_membership(value: Literal["foo", "bar"]) -> int:
+    if value in ("foo", "bar"):
+        return 42
+
+def list_membership(value: Literal["foo"]) -> int:
+    if value in ["foo"]:
+        return 42
+
+def set_membership(value: Literal["foo"]) -> int:
+    if value in {"foo"}:
+        return 42
+```
+
+## Wrapped fixed-length tuples
+
+A tuple subclass without a custom `__contains__`, a `NewType` based on a tuple, and type variables
+restricted to tuples all use the containment behavior of the underlying tuple:
+
+```py
+from typing import Literal, NewType, TypeVar
+
+class InheritedTuple(tuple[Literal["foo"]]): ...
+
+WrappedTuple = NewType("WrappedTuple", tuple[Literal["foo"]])
+BoundTuple = TypeVar("BoundTuple", bound=tuple[Literal["foo"]])
+ConstrainedTuple = TypeVar(
+    "ConstrainedTuple",
+    tuple[Literal["foo"], Literal["bar"]],
+    tuple[Literal["foo"], Literal["baz"]],
+)
+
+def inherited_tuple(value: Literal["foo"], values: InheritedTuple) -> int:
+    if value in values:
+        return 42
+
+def wrapped_tuple(value: Literal["foo"], values: WrappedTuple) -> int:
+    if value in values:
+        return 42
+
+def bounded_tuple(value: Literal["foo"], values: BoundTuple) -> int:
+    if value in values:
+        return 42
+
+def constrained_tuple(value: Literal["foo"], values: ConstrainedTuple) -> int:
+    if value in values:
+        return 42
+```
+
+## Finite types
+
+Membership is also exhaustive when a tuple contains every possible value of `bool` or an enum with
+ordinary equality:
+
+```py
+from enum import Enum
+
+class Choice(Enum):
+    A = 1
+    B = 2
+
+def bool_membership(value: bool) -> int:
+    if value in (True, False):
+        return 42
+
+def enum_membership(value: Choice) -> int:
+    if value in (Choice.A, Choice.B):
+        return 42
+
+def finite_union_membership(value: Choice | bool) -> int:
+    if value in (Choice.A, Choice.B, True, False):
+        return 42
+```
+
+## Variable-length and custom containment
+
+A variable-length tuple can be empty, so its element type cannot make membership exhaustive:
+
+```py
+from typing import Literal
+
+def variable_tuple(value: Literal["foo"], values: tuple[Literal["foo"], ...]):
+    reveal_type(value in values)  # revealed: bool
+```
+
+A tuple subclass can override `__contains__`. Its return type determines membership instead of the
+tuple's elements, even when the tested value is itself a tuple:
+
+```py
+from typing import Literal
+
+class NeverContains(tuple[tuple[Literal["foo"]]]):
+    def __contains__(self, value: object) -> Literal[False]:
+        return False
+
+def custom_contains(value: tuple[Literal["foo"]], values: NeverContains):
+    reveal_type(value in values)  # revealed: Literal[False]
+    reveal_type(value not in values)  # revealed: Literal[True]
+```
+
 ## No Fallback for `__contains__`
 
 If `__contains__` is implemented, checking membership of a type it doesn't accept is an error; it

--- a/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
@@ -311,9 +311,8 @@ def _(n: int):
     reveal_type(a not in d)  # revealed: bool
 ```
 
-Membership in a tuple compares each element using equality, so literal needles can also produce a
-definite result. This makes exhaustive membership checks sufficient to prove that a function
-returns.
+A fixed-length tuple tests membership by comparing the value against each element. With a literal
+value, both successful and unsuccessful checks have a definite result:
 
 ```py
 from typing import Literal
@@ -323,7 +322,12 @@ def literal_membership(value: Literal["foo"]):
     reveal_type(value not in ("foo",))  # revealed: Literal[False]
     reveal_type(value in ("bar",))  # revealed: Literal[False]
     reveal_type(value not in ("bar",))  # revealed: Literal[True]
+```
 
+An exhaustive membership check also proves that a function cannot implicitly return `None`,
+including when the value is a literal union:
+
+```py
 def exhaustive_membership(value: Literal["foo"]) -> int:
     if value in ("foo",):
         return 42
@@ -331,14 +335,16 @@ def exhaustive_membership(value: Literal["foo"]) -> int:
 def exhaustive_union_membership(value: Literal["foo", "bar"]) -> int:
     if value in ("foo", "bar"):
         return 42
+```
 
+A tuple subclass can override `__contains__`, so the tuple's elements do not determine membership:
+
+```py
 class NeverContains(tuple[str]):
     def __contains__(self, value: object) -> Literal[False]:
         return False
 
-def overridden_membership(value: Literal["foo"]):
-    reveal_type(value in NeverContains(("foo",)))  # revealed: Literal[False]
-    reveal_type(value not in NeverContains(("foo",)))  # revealed: Literal[True]
+reveal_type("foo" in NeverContains(("foo",)))  # revealed: Literal[False]
 ```
 
 ### Identity Comparisons

--- a/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
@@ -311,42 +311,6 @@ def _(n: int):
     reveal_type(a not in d)  # revealed: bool
 ```
 
-A fixed-length tuple tests membership by comparing the value against each element. With a literal
-value, both successful and unsuccessful checks have a definite result:
-
-```py
-from typing import Literal
-
-def literal_membership(value: Literal["foo"]):
-    reveal_type(value in ("foo",))  # revealed: Literal[True]
-    reveal_type(value not in ("foo",))  # revealed: Literal[False]
-    reveal_type(value in ("bar",))  # revealed: Literal[False]
-    reveal_type(value not in ("bar",))  # revealed: Literal[True]
-```
-
-An exhaustive membership check also proves that a function cannot implicitly return `None`,
-including when the value is a literal union:
-
-```py
-def exhaustive_membership(value: Literal["foo"]) -> int:
-    if value in ("foo",):
-        return 42
-
-def exhaustive_union_membership(value: Literal["foo", "bar"]) -> int:
-    if value in ("foo", "bar"):
-        return 42
-```
-
-A tuple subclass can override `__contains__`, so the tuple's elements do not determine membership:
-
-```py
-class NeverContains(tuple[str]):
-    def __contains__(self, value: object) -> Literal[False]:
-        return False
-
-reveal_type("foo" in NeverContains(("foo",)))  # revealed: Literal[False]
-```
-
 ### Identity Comparisons
 
 "Identity Comparisons" refers to `is` and `is not`.

--- a/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
@@ -311,6 +311,36 @@ def _(n: int):
     reveal_type(a not in d)  # revealed: bool
 ```
 
+Membership in a tuple compares each element using equality, so literal needles can also produce a
+definite result. This makes exhaustive membership checks sufficient to prove that a function
+returns.
+
+```py
+from typing import Literal
+
+def literal_membership(value: Literal["foo"]):
+    reveal_type(value in ("foo",))  # revealed: Literal[True]
+    reveal_type(value not in ("foo",))  # revealed: Literal[False]
+    reveal_type(value in ("bar",))  # revealed: Literal[False]
+    reveal_type(value not in ("bar",))  # revealed: Literal[True]
+
+def exhaustive_membership(value: Literal["foo"]) -> int:
+    if value in ("foo",):
+        return 42
+
+def exhaustive_union_membership(value: Literal["foo", "bar"]) -> int:
+    if value in ("foo", "bar"):
+        return 42
+
+class NeverContains(tuple[str]):
+    def __contains__(self, value: object) -> Literal[False]:
+        return False
+
+def overridden_membership(value: Literal["foo"]):
+    reveal_type(value in NeverContains(("foo",)))  # revealed: Literal[False]
+    reveal_type(value not in NeverContains(("foo",)))  # revealed: Literal[True]
+```
+
 ### Identity Comparisons
 
 "Identity Comparisons" refers to `is` and `is not`.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -124,6 +124,7 @@ mod callable;
 mod class;
 mod class_base;
 mod constraints;
+mod containment;
 mod context;
 mod context_manager;
 mod cyclic;

--- a/crates/ty_python_semantic/src/types/containment.rs
+++ b/crates/ty_python_semantic/src/types/containment.rs
@@ -1,7 +1,12 @@
 use crate::{
     Db,
-    types::{ClassBase, IntersectionBuilder, KnownClass, Type, UnionBuilder},
+    types::{
+        ClassBase, IntersectionBuilder, KnownClass, Type, UnionBuilder,
+        equality::{equality_exclusion_constraint, equality_truthiness},
+    },
 };
+use ruff_python_ast as ast;
+use ty_python_core::Truthiness;
 
 enum ContainmentBehavior<'db> {
     /// Membership compares against the elements yielded by the wrapped type. Callers use
@@ -138,6 +143,89 @@ pub(super) fn elements_of<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'d
         ContainmentBehavior::ElementsOf(elements_of) => Some(elements_of),
         ContainmentBehavior::Custom | ContainmentBehavior::Unknown => None,
     }
+}
+
+/// Preserve the precise element types of an immediately consumed list or set literal.
+///
+/// These expressions cannot be mutated before membership is evaluated. Representing them as
+/// fixed-length tuples lets comparison inference and negative narrowing use the same elements.
+pub(super) fn inline_membership_rhs_type<'db>(
+    db: &'db dyn Db,
+    rhs: &ast::Expr,
+    mut expression_type: impl FnMut(&ast::Expr) -> Type<'db>,
+) -> Option<Type<'db>> {
+    let elements = match rhs.expression_value() {
+        ast::Expr::List(list) => &list.elts,
+        ast::Expr::Set(set) => &set.elts,
+        _ => return None,
+    };
+
+    if elements.iter().any(ast::Expr::is_starred_expr) {
+        return None;
+    }
+
+    Some(Type::heterogeneous_tuple(
+        db,
+        elements.iter().map(&mut expression_type),
+    ))
+}
+
+/// Return a constraint excluding every value known to compare equal to a fixed container element.
+///
+/// `not in` negates equality with every element; it does not use `__ne__`. Only add an exclusion
+/// when every value represented by a slot is known to compare equal.
+pub(super) fn membership_exclusion_constraint<'db>(
+    db: &'db dyn Db,
+    elements: &[Type<'db>],
+) -> Option<Type<'db>> {
+    let mut builder = IntersectionBuilder::new(db);
+    let mut constrained = false;
+
+    for element_ty in elements.iter().copied() {
+        if let Some(constraint) = equality_exclusion_constraint(db, element_ty) {
+            builder = builder.add_positive(constraint);
+            constrained = true;
+        }
+    }
+
+    constrained.then(|| builder.build())
+}
+
+/// Return the truthiness of an element-based membership check when its result is known.
+///
+/// A check is always false if no element can compare equal, and always true if applying the same
+/// exclusions used for negative narrowing leaves no possible value.
+pub(super) fn membership_truthiness<'db>(
+    db: &'db dyn Db,
+    lhs_ty: Type<'db>,
+    rhs_ty: Type<'db>,
+) -> Truthiness {
+    let Some(iterable) = elements_of(db, rhs_ty).and_then(|ty| ty.try_iterate(db).ok()) else {
+        return Truthiness::Ambiguous;
+    };
+    let Some(fixed_length) = iterable.as_fixed_length() else {
+        return Truthiness::Ambiguous;
+    };
+    let elements = fixed_length.all_elements();
+
+    if elements
+        .iter()
+        .all(|element| equality_truthiness(db, lhs_ty, *element).is_always_false())
+    {
+        return Truthiness::AlwaysFalse;
+    }
+
+    if let Some(exclusion) = membership_exclusion_constraint(db, elements)
+        && IntersectionBuilder::new(db)
+            .add_positive(lhs_ty)
+            .add_positive(exclusion)
+            .build()
+            .is_never()
+    {
+        return Truthiness::AlwaysTrue;
+    }
+
+    Truthiness::Ambiguous
 }
 
 /// Maximum haystack length for which we synthesize a negative type per character.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -50,6 +50,7 @@ use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorK
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
 use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
+use crate::types::containment::inline_membership_rhs_type;
 use crate::types::context::InferContext;
 use crate::types::dedicated::pydantic;
 use crate::types::diagnostic::{
@@ -10565,6 +10566,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             |builder, ((left, right), op), _peer_ty| {
                 let left_ty = builder.expression_type(left);
                 let right_ty = builder.infer_expression(right, TypeContext::default());
+                let comparison_right_ty = if matches!(op, ast::CmpOp::In | ast::CmpOp::NotIn) {
+                    inline_membership_rhs_type(builder.db(), right, |element| {
+                        builder.expression_type(element)
+                    })
+                    .unwrap_or(right_ty)
+                } else {
+                    right_ty
+                };
 
                 let range = TextRange::new(left.start(), right.end());
 
@@ -10572,7 +10581,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     &builder.context,
                     left_ty,
                     *op,
-                    right_ty,
+                    comparison_right_ty,
                     range,
                     &BinaryComparisonVisitor::new(Ok(Type::bool_literal(true))),
                 )

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -5,6 +5,7 @@ use smallvec::SmallVec;
 use crate::Db;
 use crate::types::call::{CallArguments, CallDunderError};
 use crate::types::constraints::ConstraintSetBuilder;
+use crate::types::containment::{elements_of, membership_truthiness};
 use crate::types::context::InferContext;
 use crate::types::cyclic::CycleDetector;
 use crate::types::equality::{equality_truthiness, inequality_truthiness};
@@ -172,25 +173,14 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
     };
 
-    let comparison_truthiness =
-        match op {
-            ast::CmpOp::Eq => equality_truthiness(db, left, right),
-            ast::CmpOp::NotEq => inequality_truthiness(db, left, right),
-            ast::CmpOp::In | ast::CmpOp::NotIn => right
-                .exact_tuple_instance_spec(db)
-                .and_then(|tuple| {
-                    let tuple = tuple.as_fixed_length()?;
-                    Some(tuple.all_elements().iter().fold(
-                        Truthiness::AlwaysFalse,
-                        |truthiness, element| {
-                            truthiness.or(equality_truthiness(db, left, *element))
-                        },
-                    ))
-                })
-                .unwrap_or(Truthiness::Ambiguous)
-                .negate_if(op.is_not_in()),
-            _ => Truthiness::Ambiguous,
-        };
+    let comparison_truthiness = match op {
+        ast::CmpOp::Eq => equality_truthiness(db, left, right),
+        ast::CmpOp::NotEq => inequality_truthiness(db, left, right),
+        ast::CmpOp::In | ast::CmpOp::NotIn => {
+            membership_truthiness(db, left, right).negate_if(op.is_not_in())
+        }
+        _ => Truthiness::Ambiguous,
+    };
     if comparison_truthiness != Truthiness::Ambiguous {
         return Ok(Type::from_truthiness(db, comparison_truthiness));
     }
@@ -638,6 +628,10 @@ pub(super) fn infer_binary_type_comparison<'db>(
                     ast::CmpOp::Gt => tuple_rich_comparison(RichCompareOperator::Gt),
                     ast::CmpOp::GtE => tuple_rich_comparison(RichCompareOperator::Ge),
                     ast::CmpOp::In | ast::CmpOp::NotIn => {
+                        if elements_of(db, right).is_none() {
+                            return try_dunder(MemberLookupPolicy::default());
+                        }
+
                         let mut any_eq = false;
                         let mut any_ambiguous = false;
 

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -172,11 +172,25 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
     };
 
-    let comparison_truthiness = match op {
-        ast::CmpOp::Eq => equality_truthiness(db, left, right),
-        ast::CmpOp::NotEq => inequality_truthiness(db, left, right),
-        _ => Truthiness::Ambiguous,
-    };
+    let comparison_truthiness =
+        match op {
+            ast::CmpOp::Eq => equality_truthiness(db, left, right),
+            ast::CmpOp::NotEq => inequality_truthiness(db, left, right),
+            ast::CmpOp::In | ast::CmpOp::NotIn => right
+                .exact_tuple_instance_spec(db)
+                .and_then(|tuple| {
+                    let tuple = tuple.as_fixed_length()?;
+                    Some(tuple.all_elements().iter().fold(
+                        Truthiness::AlwaysFalse,
+                        |truthiness, element| {
+                            truthiness.or(equality_truthiness(db, left, *element))
+                        },
+                    ))
+                })
+                .unwrap_or(Truthiness::Ambiguous)
+                .negate_if(op.is_not_in()),
+            _ => Truthiness::Ambiguous,
+        };
     if comparison_truthiness != Truthiness::Ambiguous {
         return Ok(Type::from_truthiness(db, comparison_truthiness));
     }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -39,9 +39,13 @@ use ruff_python_stdlib::identifiers::is_identifier;
 use super::UnionType;
 use super::call::CallArguments;
 use super::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
+use super::containment::{
+    elements_of, inline_membership_rhs_type, membership_exclusion_constraint,
+    narrow_string_membership,
+};
 use super::equality::{
-    ComparisonSoundnessPolicy, equality_exclusion_constraint, equality_truthiness,
-    evaluate_type_equality, evaluate_type_inequality,
+    ComparisonSoundnessPolicy, equality_truthiness, evaluate_type_equality,
+    evaluate_type_inequality,
 };
 use super::variance::TypeVarVariance;
 use itertools::Itertools;
@@ -49,10 +53,6 @@ use ruff_python_ast as ast;
 use ruff_python_ast::{BoolOp, ExprBoolOp};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec, smallvec_inline};
-
-mod containment;
-
-use self::containment::{elements_of, narrow_string_membership};
 
 /// Return the type constraints that `test` would place on `symbol` if true and false.
 ///
@@ -2992,46 +2992,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let membership_type = elements_of(self.db, rhs_ty)?;
         let iterable = membership_type.try_iterate(self.db).ok()?;
         let fixed_length = iterable.as_fixed_length()?;
-        let mut builder = IntersectionBuilder::new(self.db);
-        let mut constrained = false;
-
-        // `not in` negates equality with every element; it does not use `__ne__`. Only add an
-        // exclusion when every value represented by a slot is known to compare equal.
-        for element_ty in fixed_length.all_elements().iter().copied() {
-            if let Some(constraint) = equality_exclusion_constraint(self.db, element_ty) {
-                builder = builder.add_positive(constraint);
-                constrained = true;
-            }
-        }
-
-        constrained.then(|| builder.build())
-    }
-
-    /// Preserve the precise element types of an immediately consumed list or set literal.
-    ///
-    /// These expressions cannot be mutated before membership is evaluated. Representing them as
-    /// fixed-length tuples also lets negative narrowing exclude values that are guaranteed present.
-    fn inline_membership_rhs_type(
-        &self,
-        rhs: &ast::Expr,
-        inference: &ExpressionInference<'db>,
-    ) -> Option<Type<'db>> {
-        let elements = match rhs.expression_value() {
-            ast::Expr::List(list) => &list.elts,
-            ast::Expr::Set(set) => &set.elts,
-            _ => return None,
-        };
-
-        if elements.iter().any(ast::Expr::is_starred_expr) {
-            return None;
-        }
-
-        Some(Type::heterogeneous_tuple(
-            self.db,
-            elements
-                .iter()
-                .map(|element| inference.expression_type(element)),
-        ))
+        membership_exclusion_constraint(self.db, fixed_length.all_elements())
     }
 
     fn evaluate_expr_compare_op(
@@ -3456,8 +3417,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             let lhs_ty = last_rhs_ty.unwrap_or_else(|| inference.expression_type(left));
             let rhs_ty = inference.expression_type(right);
             let lhs_narrowing_rhs_ty = if matches!(op, ast::CmpOp::In | ast::CmpOp::NotIn) {
-                self.inline_membership_rhs_type(right, inference)
-                    .unwrap_or(rhs_ty)
+                inline_membership_rhs_type(self.db, right, |element| {
+                    inference.expression_type(element)
+                })
+                .unwrap_or(rhs_ty)
             } else {
                 rhs_ty
             };


### PR DESCRIPTION
## Summary

Prior to this change, narrowing could prove that a fixed-content membership check was exhaustive while comparison inference still returned `bool`. This left valid functions with an `invalid-return-type` error:

```py
from typing import Literal

def f(value: Literal["foo"]) -> int:
    if value in ["foo"]:
        return 42  # Previously: invalid-return-type
```

This shares containment behavior, inline list/set element handling, and negative equality exclusions between narrowing and comparison inference. It covers fixed tuples (including inherited, `NewType`, and type-variable-wrapped tuples), literal unions, `bool`, and enums; preserves conservative behavior for variable-length containers; and ensures a tuple subclass's custom `__contains__` remains authoritative even when the needle is a tuple.

Closes https://github.com/astral-sh/ty/issues/4040.
