### PR TITLE
[ty] Reject frozen-dataclass field deletion through subclasses

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1167,6 +1167,55 @@ child.a = 2  # error: [invalid-assignment]
 child.b = 2  # error: [invalid-assignment]
 ```
 
+Specialized frozen dataclasses still delegate non-field deletions through the unspecialized runtime
+class, for both traditional and PEP 695 generics:
+
+```py
+from dataclasses import dataclass
+from typing import Generic, NoReturn, TypeVar
+
+T = TypeVar("T")
+
+@dataclass(frozen=True)
+class LegacyFrozen(Generic[T]):
+    value: T
+
+@dataclass(frozen=True)
+class Pep695Frozen[T]:
+    value: T
+
+class RejectLater:
+    y: int = 1
+
+    def __delattr__(self, name: str) -> NoReturn:
+        raise AttributeError(name)
+
+class LegacyReadOnly(LegacyFrozen[int]):
+    @property
+    def y(self) -> int:
+        return 1
+
+class Pep695ReadOnly(Pep695Frozen[int]):
+    @property
+    def y(self) -> int:
+        return 1
+
+class LegacyRejectsLater(LegacyFrozen[int], RejectLater): ...
+class Pep695RejectsLater(Pep695Frozen[int], RejectLater): ...
+
+# error: [invalid-assignment] "Cannot delete read-only property `y` on object of type `LegacyReadOnly`"
+del LegacyReadOnly(1).y
+
+# error: [invalid-assignment] "Cannot delete read-only property `y` on object of type `Pep695ReadOnly`"
+del Pep695ReadOnly(1).y
+
+# error: [invalid-assignment] "Cannot delete attribute `y` on type `LegacyRejectsLater` whose `__delattr__` method returns `Never`/`NoReturn`"
+del LegacyRejectsLater(1).y
+
+# error: [invalid-assignment] "Cannot delete attribute `y` on type `Pep695RejectsLater` whose `__delattr__` method returns `Never`/`NoReturn`"
+del Pep695RejectsLater(1).y
+```
+
 ### frozen/non-frozen inheritance
 
 If a non-frozen dataclass inherits from a frozen dataclass, an exception is raised at runtime. We

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1063,7 +1063,7 @@ class MyFrozenClass:
 class MyFrozenChildClass(MyFrozenClass): ...
 
 frozen = MyFrozenChildClass()
-del frozen.x  # TODO this should emit an [invalid-assignment]
+del frozen.x  # error: [invalid-assignment]
 ```
 
 ### frozen/non-frozen inheritance

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1167,6 +1167,39 @@ child.a = 2  # error: [invalid-assignment]
 child.b = 2  # error: [invalid-assignment]
 ```
 
+Init-only fields are not protected by a frozen dataclass, whether that dataclass is the first base
+or a later base:
+
+```py
+from dataclasses import InitVar, dataclass
+
+@dataclass(frozen=True)
+class Frozen:
+    x: int = 1
+
+@dataclass(frozen=True)
+class FrozenWithInitVar:
+    temporary: InitVar[int] = 0
+
+class FirstInitVar(FrozenWithInitVar):
+    temporary: int = 1
+
+class LaterInitVar(Frozen, FrozenWithInitVar):
+    temporary: int = 1
+
+first = FirstInitVar()
+first.temporary = 4
+del first.temporary
+
+later = LaterInitVar()
+# revealed: Overload[(name: Literal["x"], value) -> Never, (name: str, value) -> None]
+reveal_type(later.__setattr__)
+# revealed: Overload[(name: Literal["x"]) -> Never, (name: str) -> None]
+reveal_type(later.__delattr__)
+later.temporary = 4
+del later.temporary
+```
+
 Specialized frozen dataclasses still delegate non-field deletions through the unspecialized runtime
 class, for both traditional and PEP 695 generics:
 

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -659,7 +659,7 @@ reveal_type(WithUnsafeHash.__hash__)  # revealed: (self: WithUnsafeHash) -> int
 
 ### `frozen`
 
-If true (the default is False), assigning to or deleting fields will generate a diagnostic.
+When `frozen=True`, a dataclass does not allow its fields to be assigned or deleted.
 
 ```py
 from dataclasses import dataclass
@@ -670,6 +670,8 @@ class MyFrozenClass:
 
 frozen_instance = MyFrozenClass(1)
 frozen_instance.x = 2  # error: [invalid-assignment]
+
+reveal_type(frozen_instance.__delattr__)  # revealed: (name) -> Never
 
 # error: [invalid-assignment] "Cannot delete attribute `x` on type `MyFrozenClass` whose `__delattr__` method returns `Never`/`NoReturn`"
 del frozen_instance.x
@@ -1022,11 +1024,11 @@ second_init_var_child = ChildWithSecondBaseInitVar()
 second_init_var_child.temporary = 4
 ```
 
-Assignments and deletions of non-field attributes on subclasses of slotted frozen dataclasses are
-still rejected. This correctly models the runtime behavior, but is somewhat surprising and may be a
-CPython bug, as subclasses of slotted classes usually allow arbitrary attributes to be set on them
-unless the subclass also explicitly declares `__slots__`. We should change our behavior here to
-follow CPython, if they "fix" it.
+Non-field attributes on subclasses of slotted frozen dataclasses are still rejected. This correctly
+models the runtime behavior, but is somewhat surprising and may be a CPython bug, as subclasses of
+slotted classes usually allow arbitrary attributes to be set on them unless the subclass also
+explicitly declares `__slots__`. We should change our behavior here to follow CPython, if they "fix"
+it. The same limitation applies when deleting an attribute.
 
 ```py
 from dataclasses import dataclass
@@ -1054,13 +1056,9 @@ grandchild.x = 2  # error: [invalid-assignment]
 grandchild.y = 2  # error: [invalid-assignment]
 grandchild.z = 2  # error: [invalid-assignment]
 grandchild.unknown = 2  # error: [invalid-assignment]
-
-del grandchild.x  # error: [invalid-assignment]
-del grandchild.z  # error: [invalid-assignment]
 ```
 
-The same diagnostic is emitted if a frozen dataclass is inherited, and an attempt is made to delete
-an attribute:
+A frozen dataclass also prevents an ordinary subclass from deleting an inherited field:
 
 ```py
 from dataclasses import dataclass
@@ -1072,28 +1070,37 @@ class MyFrozenClass:
 class MyFrozenChildClass(MyFrozenClass): ...
 
 frozen = MyFrozenChildClass()
+
+# revealed: Overload[(name: Literal["x"]) -> Never, (name: str) -> None]
+reveal_type(frozen.__delattr__)
+
 del frozen.x  # error: [invalid-assignment]
 ```
 
-Non-field deletions on a frozen dataclass subclass still use the normal property and inherited
-`__delattr__` checks:
+A frozen dataclass does not make a subclass's read-only property safe to delete:
 
 ```py
 from dataclasses import dataclass
-from typing import NoReturn
 
 @dataclass(frozen=True)
 class Frozen:
     x: int = 1
 
-reveal_type(Frozen().__delattr__)  # revealed: (name) -> Never
-
-class ChildWithReadOnlyProperty(Frozen):
+class ReadOnlyChild(Frozen):
     @property
     def y(self) -> int:
         return 1
 
-class ChildWithRejectingProperty(Frozen):
+# error: [invalid-assignment] "Cannot delete read-only property `y` on object of type `ReadOnlyChild`"
+del ReadOnlyChild().y
+```
+
+Deleting a property is also invalid when its deleter never returns:
+
+```py
+from typing import NoReturn
+
+class RejectingPropertyChild(Frozen):
     @property
     def y(self) -> int:
         return 1
@@ -1102,53 +1109,68 @@ class ChildWithRejectingProperty(Frozen):
     def y(self) -> NoReturn:
         raise AttributeError("y")
 
-class RejectLater:
+# error: [invalid-assignment] "Cannot delete attribute `y` on type `RejectingPropertyChild` whose `__delete__` method returns `Never`/`NoReturn`"
+del RejectingPropertyChild().y
+```
+
+When another base class rejects deletion, the frozen dataclass must not hide its `__delattr__`
+method:
+
+```py
+class RejectsDeletion:
     y: int = 1
 
     def __delattr__(self, name: str) -> NoReturn:
         raise AttributeError(name)
 
-class AllowLater:
+class ChildWithRejectingBase(Frozen, RejectsDeletion): ...
+
+# error: [invalid-assignment] "Cannot delete attribute `y` on type `ChildWithRejectingBase` whose `__delattr__` method returns `Never`/`NoReturn`"
+del ChildWithRejectingBase().y
+```
+
+A second base class can instead allow deletion, even if the attribute is a read-only property:
+
+```py
+class AllowsDeletion:
     @property
     def y(self) -> int:
         return 1
 
     def __delattr__(self, name: str) -> None: ...
 
-class ChildWithLaterRejectingDelAttr(Frozen, RejectLater): ...
-class ChildWithLaterPermissiveDelAttr(Frozen, AllowLater): ...
+class ChildWithAllowingBase(Frozen, AllowsDeletion): ...
 
-class ChildWithDeletableAttribute(Frozen):
+del ChildWithAllowingBase().y
+```
+
+An ordinary attribute defined on a subclass can also be deleted:
+
+```py
+class ChildWithOwnAttribute(Frozen):
     y: int = 1
 
-class ChildWithOverriddenDelAttr(Frozen):
+deletable = ChildWithOwnAttribute()
+deletable.y = 2
+del deletable.y
+```
+
+A subclass can replace the inherited `__delattr__`, but a method that returns `None` is an invalid
+override of the frozen base's method, which returns `Never`. The overriding method still controls
+deletion on both that subclass and its subclasses:
+
+```py
+class ChildWithDeletionOverride(Frozen):
     # error: [invalid-method-override]
     def __delattr__(self, name: str) -> None: ...
 
-class GrandchildWithOverriddenDelAttr(ChildWithOverriddenDelAttr): ...
+class GrandchildWithDeletionOverride(ChildWithDeletionOverride): ...
 
-# error: [invalid-assignment] "Cannot delete read-only property `y` on object of type `ChildWithReadOnlyProperty`"
-del ChildWithReadOnlyProperty().y
-
-# error: [invalid-assignment] "Cannot delete attribute `y` on type `ChildWithRejectingProperty` whose `__delete__` method returns `Never`/`NoReturn`"
-del ChildWithRejectingProperty().y
-
-# revealed: bound method ChildWithLaterRejectingDelAttr.__delattr__(name: str) -> Never
-reveal_type(super(Frozen, ChildWithLaterRejectingDelAttr()).__delattr__)
-
-# error: [invalid-assignment] "Cannot delete attribute `y` on type `ChildWithLaterRejectingDelAttr` whose `__delattr__` method returns `Never`/`NoReturn`"
-del ChildWithLaterRejectingDelAttr().y
-
-del ChildWithLaterPermissiveDelAttr().y
-
-deletable = ChildWithDeletableAttribute()
-deletable.y = 2
-del deletable.y
-del ChildWithOverriddenDelAttr().x
-del GrandchildWithOverriddenDelAttr().x
+del ChildWithDeletionOverride().x
+del GrandchildWithDeletionOverride().x
 ```
 
-Independent frozen dataclasses protect fields from every generated method reachable in the MRO:
+When a subclass inherits from two frozen dataclasses, fields from both bases remain frozen:
 
 ```py
 from dataclasses import dataclass
@@ -1166,18 +1188,13 @@ class Child(A, B): ...
 child = Child()
 # revealed: Overload[(name: Literal["a"]) -> Never, (name: Literal["b"]) -> Never, (name: str) -> None]
 reveal_type(child.__delattr__)
-# revealed: Overload[(name: Literal["a"], value) -> Never, (name: Literal["b"], value) -> Never, (name: str, value) -> None]
-reveal_type(child.__setattr__)
 
-del child.a  # error: [invalid-assignment]
 del child.b  # error: [invalid-assignment]
-
-child.a = 2  # error: [invalid-assignment]
 child.b = 2  # error: [invalid-assignment]
 ```
 
-Init-only fields are not protected by a frozen dataclass, whether that dataclass is the first base
-or a later base:
+An `InitVar` is a constructor argument, not a frozen field. A subclass can assign and delete an
+attribute with the same name:
 
 ```py
 from dataclasses import InitVar, dataclass
@@ -1190,72 +1207,58 @@ class Frozen:
 class FrozenWithInitVar:
     temporary: InitVar[int] = 0
 
-class FirstInitVar(FrozenWithInitVar):
+class FirstInitVarChild(FrozenWithInitVar):
     temporary: int = 1
 
-class LaterInitVar(Frozen, FrozenWithInitVar):
-    temporary: int = 1
-
-first = FirstInitVar()
+first = FirstInitVarChild()
 first.temporary = 4
 del first.temporary
+```
 
-later = LaterInitVar()
-# revealed: Overload[(name: Literal["x"], value) -> Never, (name: str, value) -> None]
-reveal_type(later.__setattr__)
-# revealed: Overload[(name: Literal["x"]) -> Never, (name: str) -> None]
-reveal_type(later.__delattr__)
+The same rule applies when the `InitVar` belongs to the second frozen base:
+
+```py
+class SecondInitVarChild(Frozen, FrozenWithInitVar):
+    temporary: int = 1
+
+later = SecondInitVarChild()
 later.temporary = 4
 del later.temporary
 ```
 
-Specialized frozen dataclasses still delegate non-field deletions through the unspecialized runtime
-class, for both traditional and PEP 695 generics:
+A read-only property remains protected when the frozen base is a specialized `Generic[T]` dataclass:
 
 ```py
 from dataclasses import dataclass
-from typing import Generic, NoReturn, TypeVar
+from typing import Generic, TypeVar
 
 T = TypeVar("T")
 
 @dataclass(frozen=True)
-class LegacyFrozen(Generic[T]):
+class GenericFrozen(Generic[T]):
     value: T
 
+class ReadOnlyGenericChild(GenericFrozen[int]):
+    @property
+    def y(self) -> int:
+        return 1
+
+# error: [invalid-assignment] "Cannot delete read-only property `y` on object of type `ReadOnlyGenericChild`"
+del ReadOnlyGenericChild(1).y
+```
+
+The Python 3.12 type-parameter syntax must also preserve a `__delattr__` method defined by another
+base class:
+
+```py
 @dataclass(frozen=True)
-class Pep695Frozen[T]:
+class TypeParameterFrozen[T]:
     value: T
 
-class RejectLater:
-    y: int = 1
+class RejectingTypeParameterChild(TypeParameterFrozen[int], RejectsDeletion): ...
 
-    def __delattr__(self, name: str) -> NoReturn:
-        raise AttributeError(name)
-
-class LegacyReadOnly(LegacyFrozen[int]):
-    @property
-    def y(self) -> int:
-        return 1
-
-class Pep695ReadOnly(Pep695Frozen[int]):
-    @property
-    def y(self) -> int:
-        return 1
-
-class LegacyRejectsLater(LegacyFrozen[int], RejectLater): ...
-class Pep695RejectsLater(Pep695Frozen[int], RejectLater): ...
-
-# error: [invalid-assignment] "Cannot delete read-only property `y` on object of type `LegacyReadOnly`"
-del LegacyReadOnly(1).y
-
-# error: [invalid-assignment] "Cannot delete read-only property `y` on object of type `Pep695ReadOnly`"
-del Pep695ReadOnly(1).y
-
-# error: [invalid-assignment] "Cannot delete attribute `y` on type `LegacyRejectsLater` whose `__delattr__` method returns `Never`/`NoReturn`"
-del LegacyRejectsLater(1).y
-
-# error: [invalid-assignment] "Cannot delete attribute `y` on type `Pep695RejectsLater` whose `__delattr__` method returns `Never`/`NoReturn`"
-del Pep695RejectsLater(1).y
+# error: [invalid-assignment] "Cannot delete attribute `y` on type `RejectingTypeParameterChild` whose `__delattr__` method returns `Never`/`NoReturn`"
+del RejectingTypeParameterChild(1).y
 ```
 
 ### frozen/non-frozen inheritance

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1133,19 +1133,76 @@ class ChildWithRejectingBase(Frozen, RejectsDeletion): ...
 del ChildWithRejectingBase().y
 ```
 
-A second base class can instead allow deletion, even if the attribute is a read-only property:
+A second base class can customize deletion of an ordinary attribute:
 
 ```py
 class AllowsDeletion:
-    @property
-    def y(self) -> int:
-        return 1
+    y: int = 1
 
     def __delattr__(self, name: str) -> None: ...
 
 class ChildWithAllowingBase(Frozen, AllowsDeletion): ...
 
 del ChildWithAllowingBase().y
+```
+
+A later `__delattr__` can forward to `object.__delattr__`, which still invokes data descriptors:
+
+```py
+class ForwardsDeletion:
+    def __delattr__(self, name: str) -> None:
+        super().__delattr__(name)
+```
+
+A read-only property therefore remains read-only:
+
+```py
+class ReadOnlyDeletionBase(ForwardsDeletion):
+    @property
+    def y(self) -> int:
+        return 1
+
+class ChildWithReadOnlyDeletion(Frozen, ReadOnlyDeletionBase): ...
+
+# error: [invalid-assignment] "Cannot delete read-only property `y` on object of type `ChildWithReadOnlyDeletion`"
+del ChildWithReadOnlyDeletion().y
+```
+
+A property deleter that never returns also prevents deletion:
+
+```py
+class TerminalDeletionBase(ForwardsDeletion):
+    @property
+    def y(self) -> int:
+        return 1
+
+    @y.deleter
+    def y(self) -> NoReturn:
+        raise AttributeError
+
+class ChildWithTerminalDeletion(Frozen, TerminalDeletionBase): ...
+
+# error: [invalid-assignment] "Cannot delete attribute `y` on type `ChildWithTerminalDeletion` whose `__delete__` method returns `Never`/`NoReturn`"
+del ChildWithTerminalDeletion().y
+```
+
+The same rule applies to a custom descriptor whose deleter never returns:
+
+```py
+class TerminalDeleteDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __delete__(self, instance: object) -> NoReturn:
+        raise AttributeError
+
+class TerminalDescriptorDeletionBase(ForwardsDeletion):
+    y: TerminalDeleteDescriptor = TerminalDeleteDescriptor()
+
+class ChildWithTerminalDescriptorDeletion(Frozen, TerminalDescriptorDeletionBase): ...
+
+# error: [invalid-assignment] "Cannot delete attribute `y` on type `ChildWithTerminalDescriptorDeletion` whose `__delete__` method returns `Never`/`NoReturn`"
+del ChildWithTerminalDescriptorDeletion().y
 ```
 
 An ordinary attribute defined on a subclass can also be deleted:

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1066,6 +1066,107 @@ frozen = MyFrozenChildClass()
 del frozen.x  # error: [invalid-assignment]
 ```
 
+Non-field deletions on a frozen dataclass subclass still use the normal property and inherited
+`__delattr__` checks:
+
+```py
+from dataclasses import dataclass
+from typing import NoReturn
+
+@dataclass(frozen=True)
+class Frozen:
+    x: int = 1
+
+reveal_type(Frozen().__delattr__)  # revealed: (name) -> Never
+
+class ChildWithReadOnlyProperty(Frozen):
+    @property
+    def y(self) -> int:
+        return 1
+
+class ChildWithRejectingProperty(Frozen):
+    @property
+    def y(self) -> int:
+        return 1
+
+    @y.deleter
+    def y(self) -> NoReturn:
+        raise AttributeError("y")
+
+class RejectLater:
+    y: int = 1
+
+    def __delattr__(self, name: str) -> NoReturn:
+        raise AttributeError(name)
+
+class AllowLater:
+    @property
+    def y(self) -> int:
+        return 1
+
+    def __delattr__(self, name: str) -> None: ...
+
+class ChildWithLaterRejectingDelAttr(Frozen, RejectLater): ...
+class ChildWithLaterPermissiveDelAttr(Frozen, AllowLater): ...
+
+class ChildWithDeletableAttribute(Frozen):
+    y: int = 1
+
+class ChildWithOverriddenDelAttr(Frozen):
+    # error: [invalid-method-override]
+    def __delattr__(self, name: str) -> None: ...
+
+class GrandchildWithOverriddenDelAttr(ChildWithOverriddenDelAttr): ...
+
+# error: [invalid-assignment] "Cannot delete read-only property `y` on object of type `ChildWithReadOnlyProperty`"
+del ChildWithReadOnlyProperty().y
+
+# error: [invalid-assignment] "Cannot delete attribute `y` on type `ChildWithRejectingProperty` whose `__delete__` method returns `Never`/`NoReturn`"
+del ChildWithRejectingProperty().y
+
+# revealed: bound method ChildWithLaterRejectingDelAttr.__delattr__(name: str) -> Never
+reveal_type(super(Frozen, ChildWithLaterRejectingDelAttr()).__delattr__)
+
+# error: [invalid-assignment] "Cannot delete attribute `y` on type `ChildWithLaterRejectingDelAttr` whose `__delattr__` method returns `Never`/`NoReturn`"
+del ChildWithLaterRejectingDelAttr().y
+
+del ChildWithLaterPermissiveDelAttr().y
+
+deletable = ChildWithDeletableAttribute()
+deletable.y = 2
+del deletable.y
+del ChildWithOverriddenDelAttr().x
+del GrandchildWithOverriddenDelAttr().x
+```
+
+Independent frozen dataclasses protect fields from every generated method reachable in the MRO:
+
+```py
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class A:
+    a: int = 1
+
+@dataclass(frozen=True)
+class B:
+    b: int = 1
+
+class Child(A, B): ...
+
+child = Child()
+# revealed: Overload[(name: Literal["a"]) -> Never, (name: Literal["b"]) -> Never, (name: str) -> None]
+reveal_type(child.__delattr__)
+# revealed: Overload[(name: Literal["a"], value) -> Never, (name: Literal["b"], value) -> Never, (name: str, value) -> None]
+reveal_type(child.__setattr__)
+
+del child.a  # error: [invalid-assignment]
+del child.b  # error: [invalid-assignment]
+
+child.a = 2  # error: [invalid-assignment]
+child.b = 2  # error: [invalid-assignment]
+```
+
 ### frozen/non-frozen inheritance
 
 If a non-frozen dataclass inherits from a frozen dataclass, an exception is raised at runtime. We

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -659,7 +659,7 @@ reveal_type(WithUnsafeHash.__hash__)  # revealed: (self: WithUnsafeHash) -> int
 
 ### `frozen`
 
-If true (the default is False), assigning to fields will generate a diagnostic.
+If true (the default is False), assigning to or deleting fields will generate a diagnostic.
 
 ```py
 from dataclasses import dataclass
@@ -670,6 +670,9 @@ class MyFrozenClass:
 
 frozen_instance = MyFrozenClass(1)
 frozen_instance.x = 2  # error: [invalid-assignment]
+
+# error: [invalid-assignment] "Cannot delete attribute `x` on type `MyFrozenClass` whose `__delattr__` method returns `Never`/`NoReturn`"
+del frozen_instance.x
 ```
 
 If `__setattr__()` or `__delattr__()` is defined in the class, a diagnostic is emitted.
@@ -1019,11 +1022,11 @@ second_init_var_child = ChildWithSecondBaseInitVar()
 second_init_var_child.temporary = 4
 ```
 
-Non-field attributes on subclasses of slotted frozen dataclasses are still rejected. This correctly
-models the runtime behavior, but is somewhat surprising and may be a CPython bug, as subclasses of
-slotted classes usually allow arbitrary attributes to be set on them unless the subclass also
-explicitly declares `__slots__`. We should change our behavior here to follow CPython, if they "fix"
-it.
+Assignments and deletions of non-field attributes on subclasses of slotted frozen dataclasses are
+still rejected. This correctly models the runtime behavior, but is somewhat surprising and may be a
+CPython bug, as subclasses of slotted classes usually allow arbitrary attributes to be set on them
+unless the subclass also explicitly declares `__slots__`. We should change our behavior here to
+follow CPython, if they "fix" it.
 
 ```py
 from dataclasses import dataclass
@@ -1043,11 +1046,17 @@ frozen.x = 2  # error: [invalid-assignment]
 frozen.y = 2  # error: [invalid-assignment]
 frozen.z = 2  # error: [invalid-assignment]
 
+del frozen.x  # error: [invalid-assignment]
+del frozen.y  # error: [invalid-assignment]
+
 grandchild = MySlottedFrozenGrandchildClass()
 grandchild.x = 2  # error: [invalid-assignment]
 grandchild.y = 2  # error: [invalid-assignment]
 grandchild.z = 2  # error: [invalid-assignment]
 grandchild.unknown = 2  # error: [invalid-assignment]
+
+del grandchild.x  # error: [invalid-assignment]
+del grandchild.z  # error: [invalid-assignment]
 ```
 
 The same diagnostic is emitted if a frozen dataclass is inherited, and an attempt is made to delete

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -976,8 +976,7 @@ class RejectingTypeParameterAssignmentChild(TypeParameterFrozen[int], RejectsAss
 RejectingTypeParameterAssignmentChild(1).y = 2
 ```
 
-When a subclass inherits from two frozen dataclasses, assignments to fields from both bases remain
-frozen:
+When a subclass inherits from two frozen dataclasses, fields from both bases remain frozen:
 
 ```py
 @dataclass(frozen=True)
@@ -993,12 +992,15 @@ class ChildWithTwoFrozenBases(FirstFrozen, SecondFrozen): ...
 multiple = ChildWithTwoFrozenBases()
 # revealed: Overload[(name: Literal["first"], value) -> Never, (name: Literal["second"], value) -> Never, (name: str, value) -> None]
 reveal_type(multiple.__setattr__)
+# revealed: Overload[(name: Literal["first"]) -> Never, (name: Literal["second"]) -> Never, (name: str) -> None]
+reveal_type(multiple.__delattr__)
 
 multiple.second = 2  # error: [invalid-assignment]
+del multiple.second  # error: [invalid-assignment]
 ```
 
-An `InitVar` is a constructor argument, not a frozen field. A subclass can assign to an attribute
-with the same name:
+An `InitVar` is a constructor argument, not a frozen field. A subclass can assign and delete an
+attribute with the same name:
 
 ```py
 from dataclasses import InitVar
@@ -1012,6 +1014,7 @@ class ChildWithInitVar(FrozenWithInitVar):
 
 init_var_child = ChildWithInitVar()
 init_var_child.temporary = 4
+del init_var_child.temporary
 ```
 
 The same rule applies when the `InitVar` belongs to a second frozen base:
@@ -1022,6 +1025,7 @@ class ChildWithSecondBaseInitVar(Frozen, FrozenWithInitVar):
 
 second_init_var_child = ChildWithSecondBaseInitVar()
 second_init_var_child.temporary = 4
+del second_init_var_child.temporary
 ```
 
 Non-field attributes on subclasses of slotted frozen dataclasses are still rejected. This correctly
@@ -1170,74 +1174,9 @@ del ChildWithDeletionOverride().x
 del GrandchildWithDeletionOverride().x
 ```
 
-When a subclass inherits from two frozen dataclasses, fields from both bases remain frozen:
-
-```py
-from dataclasses import dataclass
-
-@dataclass(frozen=True)
-class A:
-    a: int = 1
-
-@dataclass(frozen=True)
-class B:
-    b: int = 1
-
-class Child(A, B): ...
-
-child = Child()
-# revealed: Overload[(name: Literal["a"]) -> Never, (name: Literal["b"]) -> Never, (name: str) -> None]
-reveal_type(child.__delattr__)
-
-del child.b  # error: [invalid-assignment]
-child.b = 2  # error: [invalid-assignment]
-```
-
-An `InitVar` is a constructor argument, not a frozen field. A subclass can assign and delete an
-attribute with the same name:
-
-```py
-from dataclasses import InitVar, dataclass
-
-@dataclass(frozen=True)
-class Frozen:
-    x: int = 1
-
-@dataclass(frozen=True)
-class FrozenWithInitVar:
-    temporary: InitVar[int] = 0
-
-class FirstInitVarChild(FrozenWithInitVar):
-    temporary: int = 1
-
-first = FirstInitVarChild()
-first.temporary = 4
-del first.temporary
-```
-
-The same rule applies when the `InitVar` belongs to the second frozen base:
-
-```py
-class SecondInitVarChild(Frozen, FrozenWithInitVar):
-    temporary: int = 1
-
-later = SecondInitVarChild()
-later.temporary = 4
-del later.temporary
-```
-
 A read-only property remains protected when the frozen base is a specialized `Generic[T]` dataclass:
 
 ```py
-from dataclasses import dataclass
-from typing import Generic, TypeVar
-
-T = TypeVar("T")
-
-@dataclass(frozen=True)
-class GenericFrozen(Generic[T]):
-    value: T
-
 class ReadOnlyGenericChild(GenericFrozen[int]):
     @property
     def y(self) -> int:
@@ -1251,10 +1190,6 @@ The Python 3.12 type-parameter syntax must also preserve a `__delattr__` method 
 base class:
 
 ```py
-@dataclass(frozen=True)
-class TypeParameterFrozen[T]:
-    value: T
-
 class RejectingTypeParameterChild(TypeParameterFrozen[int], RejectsDeletion): ...
 
 # error: [invalid-assignment] "Cannot delete attribute `y` on type `RejectingTypeParameterChild` whose `__delattr__` method returns `Never`/`NoReturn`"

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1883,6 +1883,20 @@ impl<'db> StaticClassLiteral<'db> {
                 }
                 None
             }
+            (CodeGeneratorKind::DataclassLike(_), "__delattr__")
+                if self.is_frozen_dataclass(db) == Some(true) =>
+            {
+                let signature = Signature::new(
+                    Parameters::standard([
+                        Parameter::positional_or_keyword(Name::new_static("self"))
+                            .with_annotated_type(instance_ty),
+                        Parameter::positional_or_keyword(Name::new_static("name")),
+                    ]),
+                    Type::Never,
+                );
+
+                Some(Type::function_like_callable(db, signature))
+            }
             (field_policy @ CodeGeneratorKind::DataclassLike(_), "__slots__")
                 if Program::get(db).python_version(db) >= PythonVersion::PY310 =>
             {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1942,16 +1942,21 @@ impl<'db> StaticClassLiteral<'db> {
         let instance_ty =
             Type::instance(db, self.apply_optional_specialization(db, specialization));
         let method_signature = |name_ty, return_ty| {
-            let mut parameters = vec![
-                Parameter::positional_or_keyword(Name::new_static("self"))
-                    .with_annotated_type(instance_ty),
-                Parameter::positional_or_keyword(Name::new_static("name"))
-                    .with_annotated_type(name_ty),
-            ];
-            if matches!(method, FrozenDataclassMethod::SetAttr) {
-                parameters.push(Parameter::positional_or_keyword(Name::new_static("value")));
-            }
-            Signature::new(Parameters::standard(parameters), return_ty)
+            let self_parameter = Parameter::positional_or_keyword(Name::new_static("self"))
+                .with_annotated_type(instance_ty);
+            let name_parameter = Parameter::positional_or_keyword(Name::new_static("name"))
+                .with_annotated_type(name_ty);
+            let parameters = match method {
+                FrozenDataclassMethod::SetAttr => Parameters::standard([
+                    self_parameter,
+                    name_parameter,
+                    Parameter::positional_or_keyword(Name::new_static("value")),
+                ]),
+                FrozenDataclassMethod::DelAttr => {
+                    Parameters::standard([self_parameter, name_parameter])
+                }
+            };
+            Signature::new(parameters, return_ty)
         };
 
         let overloads = frozen_base_fields

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2024,7 +2024,7 @@ impl<'db> StaticClassLiteral<'db> {
         }
     }
 
-    /// Returns the inherited fields protected by a generated frozen-dataclass method.
+    /// Returns the inherited fields whose generated `__setattr__` or `__delattr__` still applies.
     fn inherited_non_slotted_frozen_dataclass_fields(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -153,6 +153,7 @@ impl<'db> FrozenDataclassDispatch<'db> {
     }
 }
 
+/// An attribute-mutator method generated for a frozen dataclass.
 #[derive(Clone, Copy)]
 enum FrozenDataclassMutator {
     Set,
@@ -160,6 +161,7 @@ enum FrozenDataclassMutator {
 }
 
 impl FrozenDataclassMutator {
+    /// Returns the frozen-dataclass mutator for `name`, if it is an attribute-mutator method.
     fn from_name(name: &str) -> Option<Self> {
         match name {
             "__setattr__" => Some(Self::Set),
@@ -168,6 +170,7 @@ impl FrozenDataclassMutator {
         }
     }
 
+    /// Returns the corresponding Python special-method name.
     const fn name(self) -> &'static str {
         match self {
             Self::Set => "__setattr__",

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -153,19 +153,19 @@ impl<'db> FrozenDataclassDispatch<'db> {
     }
 }
 
-/// An attribute-mutator method generated for a frozen dataclass.
+/// A method synthesized for a frozen dataclass.
 #[derive(Clone, Copy)]
-enum FrozenDataclassMutator {
-    Set,
-    Delete,
+enum FrozenDataclassMethod {
+    SetAttr,
+    DelAttr,
 }
 
-impl FrozenDataclassMutator {
-    /// Returns the frozen-dataclass mutator for `name`, if it is an attribute-mutator method.
+impl FrozenDataclassMethod {
+    /// Returns the frozen-dataclass method for `name`, if it is `__setattr__` or `__delattr__`.
     fn from_name(name: &str) -> Option<Self> {
         match name {
-            "__setattr__" => Some(Self::Set),
-            "__delattr__" => Some(Self::Delete),
+            "__setattr__" => Some(Self::SetAttr),
+            "__delattr__" => Some(Self::DelAttr),
             _ => None,
         }
     }
@@ -173,8 +173,8 @@ impl FrozenDataclassMutator {
     /// Returns the corresponding Python special-method name.
     const fn name(self) -> &'static str {
         match self {
-            Self::Set => "__setattr__",
-            Self::Delete => "__delattr__",
+            Self::SetAttr => "__setattr__",
+            Self::DelAttr => "__delattr__",
         }
     }
 }
@@ -1447,10 +1447,11 @@ impl<'db> StaticClassLiteral<'db> {
         // An ordinary subclass of a frozen dataclass is not itself dataclass-like, so the
         // `CodeGeneratorKind::from_class` check below would return `None` before dataclass-like
         // synthesis runs. Still, an instance of such a subclass inherits the frozen dataclass's
-        // generated `__setattr__` and `__delattr__`, which reject mutations of frozen base fields.
-        if let Some(mutator) = FrozenDataclassMutator::from_name(name)
+        // generated `__setattr__` and `__delattr__`, which reject assignments and deletions of
+        // frozen base fields.
+        if let Some(method) = FrozenDataclassMethod::from_name(name)
             && let Some(synthesized_method) =
-                self.own_frozen_dataclass_subclass_mutator(db, specialization, mutator)
+                self.own_frozen_dataclass_subclass_method(db, specialization, method)
         {
             return Some(synthesized_method);
         }
@@ -1904,11 +1905,13 @@ impl<'db> StaticClassLiteral<'db> {
         }
     }
 
-    /// Synthesize an attribute-mutator view for an ordinary subclass of a frozen dataclass.
+    /// Synthesize a `__setattr__` or `__delattr__` view for an ordinary subclass of a frozen
+    /// dataclass.
     ///
-    /// CPython's generated frozen-dataclass `__setattr__` and `__delattr__` reject all mutations on
-    /// exact instances of the frozen dataclass, but on subclass instances they only reject
-    /// mutations of that dataclass's fields before delegating to the next method in the MRO.
+    /// CPython's generated frozen-dataclass `__setattr__` and `__delattr__` reject all assignments
+    /// and deletions on exact instances of the frozen dataclass, but on subclass instances they
+    /// only reject assignments and deletions of that dataclass's fields before delegating to the
+    /// next method in the MRO.
     ///
     /// ```python
     /// @dataclass(frozen=True)
@@ -1918,32 +1921,29 @@ impl<'db> StaticClassLiteral<'db> {
     /// Child().x = 1  # raises FrozenInstanceError
     /// del Child().x  # raises FrozenInstanceError
     /// ```
-    fn own_frozen_dataclass_subclass_mutator(
+    fn own_frozen_dataclass_subclass_method(
         self,
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
-        mutator: FrozenDataclassMutator,
+        method: FrozenDataclassMethod,
     ) -> Option<Type<'db>> {
         if CodeGeneratorKind::from_static_class(db, self).is_some() {
             return None;
         }
 
-        let frozen_base_fields = self.inherited_non_slotted_frozen_dataclass_fields(
-            db,
-            specialization,
-            mutator.name(),
-        )?;
+        let frozen_base_fields =
+            self.inherited_non_slotted_frozen_dataclass_fields(db, specialization, method.name())?;
 
         let instance_ty =
             Type::instance(db, self.apply_optional_specialization(db, specialization));
-        let mutator_signature = |name_ty, return_ty| {
+        let method_signature = |name_ty, return_ty| {
             let mut parameters = vec![
                 Parameter::positional_or_keyword(Name::new_static("self"))
                     .with_annotated_type(instance_ty),
                 Parameter::positional_or_keyword(Name::new_static("name"))
                     .with_annotated_type(name_ty),
             ];
-            if matches!(mutator, FrozenDataclassMutator::Set) {
+            if matches!(method, FrozenDataclassMethod::SetAttr) {
                 parameters.push(Parameter::positional_or_keyword(Name::new_static("value")));
             }
             Signature::new(Parameters::standard(parameters), return_ty)
@@ -1952,8 +1952,8 @@ impl<'db> StaticClassLiteral<'db> {
         let overloads = frozen_base_fields
             .names
             .iter()
-            .map(|field| mutator_signature(Type::string_literal(db, field), Type::Never))
-            .chain([mutator_signature(
+            .map(|field| method_signature(Type::string_literal(db, field), Type::Never))
+            .chain([method_signature(
                 KnownClass::Str.to_instance(db),
                 Type::none(db),
             )]);
@@ -2043,7 +2043,7 @@ impl<'db> StaticClassLiteral<'db> {
                 break;
             };
 
-            // Stop if another class in the MRO replaces the relevant generated frozen mutator:
+            // Stop if another class in the MRO replaces the relevant generated frozen method:
             //
             //   @dataclass(frozen=True)
             //   class Frozen: x: int

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2043,18 +2043,19 @@ impl<'db> StaticClassLiteral<'db> {
                 break;
             };
 
-            // Stop if another class in the MRO replaces the generated frozen setter:
+            // Stop if another class in the MRO replaces the relevant generated frozen mutator:
             //
             //   @dataclass(frozen=True)
             //   class Frozen: x: int
             //
             //   class Mutable(Frozen):
             //       def __setattr__(self, name: str, value: object) -> None: ...
+            //       def __delattr__(self, name: str) -> None: ...
             //
             //   class Child(Mutable): ...
             //
-            // Writes to `Child().x` dispatch to `Mutable.__setattr__`, not to the synthesized
-            // `Frozen.__setattr__`.
+            // Writes and deletions of `Child().x` dispatch to the corresponding `Mutable` method,
+            // not to the synthesized `Frozen` method.
             if class_member(db, base_class.body_scope(db), method)
                 .ignore_possibly_undefined()
                 .is_some()

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -153,6 +153,29 @@ impl<'db> FrozenDataclassDispatch<'db> {
     }
 }
 
+#[derive(Clone, Copy)]
+enum FrozenDataclassMutator {
+    Set,
+    Delete,
+}
+
+impl FrozenDataclassMutator {
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "__setattr__" => Some(Self::Set),
+            "__delattr__" => Some(Self::Delete),
+            _ => None,
+        }
+    }
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Set => "__setattr__",
+            Self::Delete => "__delattr__",
+        }
+    }
+}
+
 /// Fields protected by reachable frozen-dataclass methods.
 struct InheritedFrozenDataclassFields<'db> {
     names: Box<[Name]>,
@@ -1421,12 +1444,12 @@ impl<'db> StaticClassLiteral<'db> {
         // An ordinary subclass of a frozen dataclass is not itself dataclass-like, so the
         // `CodeGeneratorKind::from_class` check below would return `None` before dataclass-like
         // synthesis runs. Still, an instance of such a subclass inherits the frozen dataclass's
-        // generated `__setattr__`, which rejects writes to frozen base fields.
-        if name == "__setattr__"
-            && let Some(synthesized_setattr) =
-                self.own_frozen_dataclass_subclass_setattr(db, specialization)
+        // generated `__setattr__` and `__delattr__`, which reject mutations of frozen base fields.
+        if let Some(mutator) = FrozenDataclassMutator::from_name(name)
+            && let Some(synthesized_method) =
+                self.own_frozen_dataclass_subclass_mutator(db, specialization, mutator)
         {
-            return Some(synthesized_setattr);
+            return Some(synthesized_method);
         }
 
         let field_policy = CodeGeneratorKind::from_class(db, self.into())?;
@@ -1878,43 +1901,56 @@ impl<'db> StaticClassLiteral<'db> {
         }
     }
 
-    /// Synthesize a `__setattr__` view for an ordinary subclass of a frozen dataclass.
+    /// Synthesize an attribute-mutator view for an ordinary subclass of a frozen dataclass.
     ///
-    /// CPython's generated frozen-dataclass `__setattr__` rejects all writes on exact instances of
-    /// the frozen dataclass, but on subclass instances it only rejects writes to that dataclass's
-    /// fields before delegating to the next `__setattr__` in the MRO.
-    fn own_frozen_dataclass_subclass_setattr(
+    /// CPython's generated frozen-dataclass `__setattr__` and `__delattr__` reject all mutations on
+    /// exact instances of the frozen dataclass, but on subclass instances they only reject
+    /// mutations of that dataclass's fields before delegating to the next method in the MRO.
+    ///
+    /// ```python
+    /// @dataclass(frozen=True)
+    /// class Frozen: x: int
+    /// class Child(Frozen): ...
+    ///
+    /// Child().x = 1  # raises FrozenInstanceError
+    /// del Child().x  # raises FrozenInstanceError
+    /// ```
+    fn own_frozen_dataclass_subclass_mutator(
         self,
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
+        mutator: FrozenDataclassMutator,
     ) -> Option<Type<'db>> {
         if CodeGeneratorKind::from_static_class(db, self).is_some() {
             return None;
         }
 
-        let frozen_base_fields =
-            self.inherited_non_slotted_frozen_dataclass_fields(db, specialization, "__setattr__")?;
+        let frozen_base_fields = self.inherited_non_slotted_frozen_dataclass_fields(
+            db,
+            specialization,
+            mutator.name(),
+        )?;
 
         let instance_ty =
             Type::instance(db, self.apply_optional_specialization(db, specialization));
-        let setattr_signature = |name_ty, return_ty| {
-            Signature::new(
-                Parameters::standard([
-                    Parameter::positional_or_keyword(Name::new_static("self"))
-                        .with_annotated_type(instance_ty),
-                    Parameter::positional_or_keyword(Name::new_static("name"))
-                        .with_annotated_type(name_ty),
-                    Parameter::positional_or_keyword(Name::new_static("value")),
-                ]),
-                return_ty,
-            )
+        let mutator_signature = |name_ty, return_ty| {
+            let mut parameters = vec![
+                Parameter::positional_or_keyword(Name::new_static("self"))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_or_keyword(Name::new_static("name"))
+                    .with_annotated_type(name_ty),
+            ];
+            if matches!(mutator, FrozenDataclassMutator::Set) {
+                parameters.push(Parameter::positional_or_keyword(Name::new_static("value")));
+            }
+            Signature::new(Parameters::standard(parameters), return_ty)
         };
 
         let overloads = frozen_base_fields
             .names
             .iter()
-            .map(|field| setattr_signature(Type::string_literal(db, field), Type::Never))
-            .chain([setattr_signature(
+            .map(|field| mutator_signature(Type::string_literal(db, field), Type::Never))
+            .chain([mutator_signature(
                 KnownClass::Str.to_instance(db),
                 Type::none(db),
             )]);

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1912,15 +1912,6 @@ impl<'db> StaticClassLiteral<'db> {
     /// and deletions on exact instances of the frozen dataclass, but on subclass instances they
     /// only reject assignments and deletions of that dataclass's fields before delegating to the
     /// next method in the MRO.
-    ///
-    /// ```python
-    /// @dataclass(frozen=True)
-    /// class Frozen: x: int
-    /// class Child(Frozen): ...
-    ///
-    /// Child().x = 1  # raises FrozenInstanceError
-    /// del Child().x  # raises FrozenInstanceError
-    /// ```
     fn own_frozen_dataclass_subclass_method(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -126,7 +126,7 @@ impl get_size2::GetSize for StaticClassLiteral<'_> {}
 /// non-fields on subclass instances.
 #[derive(Clone, Copy)]
 pub(crate) enum FrozenDataclassDispatch<'db> {
-    /// A reachable frozen dataclass rejects modification of one of its fields.
+    /// A reachable frozen dataclass rejects assignment to or deletion of one of its fields.
     FrozenField,
     /// Every reachable frozen method delegates, with lookup resuming after this base.
     Delegate(StaticClassLiteral<'db>),
@@ -1998,6 +1998,7 @@ impl<'db> StaticClassLiteral<'db> {
     /// Assigning to `Child().x` is rejected because `x` is a field of `Frozen`. Assigning to
     /// `Child().y` instead delegates to `super(Frozen, child).__setattr__`, where a later
     /// `__setattr__` or the descriptor for `y` can still reject the assignment.
+    /// Deletion follows the same lookup through `__delattr__` and `__delete__`.
     ///
     /// If multiple frozen dataclasses are reachable before an explicit implementation of
     /// `method`, a non-field delegates past each generated method. [`FrozenDataclassDispatch::Delegate`]

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3018,7 +3018,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
 
                 match delattr_dunder_call_result {
-                    Ok(_) | Err(CallDunderError::PossiblyUnbound { .. }) => {
+                    Ok(_) | Err(CallDunderError::PossiblyUnbound { .. })
+                        if !matches!(
+                            frozen_dataclass_dispatch,
+                            Some(FrozenDataclassDispatch::Delegate(_))
+                        ) =>
+                    {
                         if self.validate_final_attribute_deletion(
                             target,
                             object_ty,
@@ -3029,6 +3034,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
                         return true;
                     }
+                    Ok(_) | Err(CallDunderError::PossiblyUnbound { .. }) => {}
                     Err(CallDunderError::CallError(kind, _bindings, _)) => {
                         if emit_diagnostics {
                             report_bad_dunder_delattr_call(
@@ -3072,7 +3078,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         TypeContext::default(),
                     );
 
-                    if self.property_deleter_returns_never(attr_ty, object_ty) {
+                    // `Never` supports arbitrary operations only because there can be no runtime
+                    // value to mutate; it is not a concrete descriptor with a terminal deleter.
+                    let deleter_returns_never = !attr_ty.is_never()
+                        && match &delete_dunder_call_result {
+                            Ok(bindings) => bindings.return_type(db).is_never(),
+                            Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
+                        };
+                    if deleter_returns_never
+                        || self.property_deleter_returns_never(attr_ty, object_ty)
+                    {
                         if emit_diagnostics
                             && let Some(builder) =
                                 self.context.report_lint(&INVALID_ASSIGNMENT, target)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -48,7 +48,9 @@ use crate::types::call::bind::{
 };
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
-use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
+use crate::types::class::{
+    ClassLiteral, CodeGeneratorKind, FrozenDataclassDispatch, MethodDecorator,
+};
 use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
 use crate::types::context::InferContext;
 use crate::types::dedicated::pydantic;
@@ -2939,15 +2941,66 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             | Type::TypeForm(_)
             | Type::TypedDict(_)
             | Type::NewTypeInstance(_) => {
-                let delattr_dunder_call_result = object_ty.try_call_dunder_with_policy(
-                    db,
-                    "__delattr__",
-                    &mut CallArguments::positional([Type::string_literal(db, attribute)]),
-                    TypeContext::default(),
-                    MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-                );
+                let frozen_dataclass_dispatch = object_ty
+                    .nominal_class(db)
+                    .and_then(|class| class.static_class_literal(db))
+                    .and_then(|(class, specialization)| {
+                        class.inherited_frozen_dataclass_dispatch(
+                            db,
+                            specialization,
+                            "__delattr__",
+                            attribute,
+                        )
+                    });
 
-                let returns_never = match &delattr_dunder_call_result {
+                let delattr_receiver = frozen_dataclass_dispatch
+                    .map_or(object_ty, |dispatch| dispatch.receiver(db, object_ty));
+
+                let mut delattr_arguments =
+                    CallArguments::positional([Type::string_literal(db, attribute)]);
+                let delattr_dunder_call_result = if matches!(delattr_receiver, Type::BoundSuper(_))
+                {
+                    match delattr_receiver
+                        .member_lookup_with_policy(
+                            db,
+                            "__delattr__",
+                            MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+                        )
+                        .place
+                    {
+                        Place::Defined(DefinedPlace {
+                            ty: delattr,
+                            definedness,
+                            provenance,
+                            ..
+                        }) => match delattr.try_call(db, &delattr_arguments) {
+                            Ok(bindings) if definedness == Definedness::PossiblyUndefined => {
+                                Err(CallDunderError::PossiblyUnbound {
+                                    bindings: Box::new(bindings),
+                                    unbound_on: None,
+                                })
+                            }
+                            Ok(bindings) => Ok(bindings),
+                            Err(CallError(kind, bindings)) => {
+                                Err(CallDunderError::CallError(kind, bindings, provenance))
+                            }
+                        },
+                        Place::Undefined => Err(CallDunderError::MethodNotAvailable),
+                    }
+                } else {
+                    delattr_receiver.try_call_dunder_with_policy(
+                        db,
+                        "__delattr__",
+                        &mut delattr_arguments,
+                        TypeContext::default(),
+                        MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+                    )
+                };
+
+                let returns_never = matches!(
+                    frozen_dataclass_dispatch,
+                    Some(FrozenDataclassDispatch::FrozenField)
+                ) || match &delattr_dunder_call_result {
                     Ok(result) => result.return_type(db).is_never(),
                     Err(err) => err.return_type(db).is_some_and(|ty| ty.is_never()),
                 };


### PR DESCRIPTION
## Summary

Stacked on #27217.

Prior to this change, we rejected assignments to fields inherited from a frozen dataclass but allowed the equivalent deletion through an ordinary subclass, even though it raises `FrozenInstanceError` at runtime:

```python
from dataclasses import dataclass


@dataclass(frozen=True)
class Frozen:
    x: int = 1


class Child(Frozen): ...


del Child().x
```

We now synthesize frozen `__delattr__` for both frozen dataclasses and their ordinary subclasses, reuse the frozen-method dispatch from #27217, and continue through `super()` for non-field deletions. This preserves descriptor and later-MRO checks, supports multiple frozen bases and generic specializations, excludes `InitVar`, and retains the existing Python 3.12 behavior for slotted frozen dataclasses.

The generated signatures also make direct and intermediate method overrides consistent with frozen `__setattr__`.
