### PR TITLE
Pin maturin in the CI wheel build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -863,6 +863,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
+          maturin-version: v1.14.1
           args: --out dist
       - name: "Test wheel"
         run: |


### PR DESCRIPTION
## Summary

The `python package` CI job currently lets `maturin-action` infer a compatible maturin release from Ruff's `pyproject.toml`. That requires a GitHub-hosted version-manifest lookup, which can return a non-list error response and fail the wheel-build step with `candidates is not iterable` (as in [#27001](https://github.com/astral-sh/ruff/actions/runs/29709715582/job/88252152549?pr=27001)).

Pin the CI wheel build to maturin `v1.14.1`, matching the version already used by all release wheel jobs and avoiding that lookup. The pinned wheel build and resulting Ruff CLI/module entry points pass locally.