### PR TITLE
[ty] Preserve Self in `__new__` calls

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -198,7 +198,7 @@ static SYMPY: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    16617,
+    16700,
 );
 
 static TANJUN: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -277,6 +277,119 @@ class Foo:
 reveal_type(Foo(1))  # revealed: Foo
 ```
 
+## Implicit `__new__` receivers
+
+Adding an implicit `type[Self]` annotation for `cls` must not cause valid constructor calls to be
+rejected when a generic callback determines the class's type argument. These calls already pass on
+`main`; they guard against regressions when the implicit `__new__` receiver is added. The overloaded
+callback, protocol, and `Any` argument exercise the nested specialization that previously caused the
+synthetic `cls` argument to be specialized twice.
+
+```pyi
+from collections.abc import Callable
+from typing import Any, Generic, Protocol, TypeVar, overload
+from typing_extensions import Self
+
+R_co = TypeVar("R_co", covariant=True)
+T = TypeVar("T")
+
+class Box(Protocol[R_co]):
+    def get(self) -> R_co: ...
+
+@overload
+def callback(value: Box[T]) -> T: ...
+@overload
+def callback(value: T) -> T: ...
+
+class Mapper(Generic[R_co]):
+    def __new__(cls, callback: Callable[[T], R_co], values: list[T], /) -> Self: ...
+
+values: Any
+
+# TODO: The doubled `Box` and `Never` are likely over-inferred, but the valid call must not be
+# rejected.
+reveal_type(Mapper(callback, values))  # revealed: Mapper[Box[Box[Never]]]
+```
+
+A signature-preserving decorator can turn `__new__` into a `Callable`:
+
+```pyi
+from typing import ParamSpec
+
+P = ParamSpec("P")
+
+def wrap(function: Callable[P, R_co]) -> Callable[P, R_co]: ...
+
+class Wrapped(Generic[R_co]):
+    @wrap
+    def __new__(cls, callback: Callable[[T], R_co], values: list[T]) -> Self: ...
+
+# TODO: The doubled `Box` and `Never` are likely over-inferred, but the valid call must not be
+# rejected.
+reveal_type(Wrapped(callback, values))  # revealed: Wrapped[Box[Box[Never]]]
+```
+
+A decorator can preserve `cls` explicitly with `Concatenate`. Inferred and explicit specializations
+are both valid:
+
+```pyi
+from typing_extensions import Concatenate
+
+def wrap_cls(function: Callable[Concatenate[type[T], P], R_co]) -> Callable[Concatenate[type[T], P], R_co]: ...
+
+class WrappedCls(Generic[R_co]):
+    @wrap_cls
+    def __new__(cls, callback: Callable[[T], R_co], values: list[T]) -> Self: ...
+
+# TODO: `Concatenate` loses constructor inference, even for a concrete callback and argument.
+reveal_type(WrappedCls(callback, values))  # revealed: WrappedCls[Unknown]
+reveal_type(WrappedCls[str](callback, values))  # revealed: WrappedCls[str]
+
+def concrete_callback(value: int) -> str: ...
+
+int_values: list[int]
+reveal_type(WrappedCls(concrete_callback, int_values))  # revealed: WrappedCls[Unknown]
+```
+
+A decorator can return a callback protocol instead of `Callable`:
+
+```pyi
+class CallableObject(Protocol[P, R_co]):
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R_co: ...
+
+def wrap_object(function: Callable[P, R_co]) -> CallableObject[P, R_co]: ...
+
+class WrappedObject(Generic[R_co]):
+    @wrap_object
+    def __new__(cls, callback: Callable[[T], R_co], values: list[T]) -> Self: ...
+
+# TODO: The doubled `Box` and `Never` are likely over-inferred, but the valid call must not be
+# rejected.
+reveal_type(WrappedObject(callback, values))  # revealed: WrappedObject[Box[Box[Never]]]
+```
+
+The explicit `cls` type in a signature-preserving decorator can also be expressed with a generic
+type alias:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```pyi
+type Receiver[X] = type[X]
+
+def preserve[U, **P, R](
+    function: Callable[Concatenate[Receiver[U], P], R],
+) -> Callable[Concatenate[Receiver[U], P], R]: ...
+
+class Simple:
+    @preserve
+    def __new__(cls) -> Self: ...
+
+reveal_type(Simple())  # revealed: Simple
+```
+
 ## `__new__` defined as a classmethod
 
 Marking it as a classmethod, on the other hand, breaks at runtime.

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -875,7 +875,7 @@ class C[T]:
     x: T
 
     def __new__[S](cls, x: S) -> "C[tuple[S, S]]":
-        return object.__new__(cls)
+        raise NotImplementedError()
 
 reveal_type(C(1))  # revealed: C[tuple[int, int]]
 reveal_type(C("hello"))  # revealed: C[tuple[str, str]]

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -279,79 +279,61 @@ reveal_type(Foo(1))  # revealed: Foo
 
 ## Implicit `__new__` receivers
 
-Adding an implicit `type[Self]` annotation for `cls` must not cause valid constructor calls to be
-rejected when a generic callback determines the class's type argument. These calls already pass on
-`main`; they guard against regressions when the implicit `__new__` receiver is added. The overloaded
-callback, protocol, and `Any` argument exercise the nested specialization that previously caused the
-synthetic `cls` argument to be specialized twice.
+An unannotated `cls` parameter on `__new__` is inferred as `type[Self]`. Constructor calls must be
+accepted when a generic callback determines the class's type argument. Here, the correlated callback
+overloads, covariant `frozenset`, and fully dynamic `values` exercise a path-merged specialization.
+Reapplying that specialization to the synthetic `cls` would introduce an extra `frozenset` layer and
+incorrectly reject both ordinary and signature-preserving `Callable` constructors.
 
 ```pyi
 from collections.abc import Callable
-from typing import Any, Generic, Protocol, TypeVar, overload
+from typing import Any, Generic, ParamSpec, Protocol, TypeVar, overload
 from typing_extensions import Self
 
+P = ParamSpec("P")
+R = TypeVar("R")
 R_co = TypeVar("R_co", covariant=True)
 T = TypeVar("T")
 
-class Box(Protocol[R_co]):
-    def get(self) -> R_co: ...
-
 @overload
-def callback(value: Box[T]) -> T: ...
+def callback(value: frozenset[T]) -> T: ...
 @overload
 def callback(value: T) -> T: ...
 
-class Mapper(Generic[R_co]):
-    def __new__(cls, callback: Callable[[T], R_co], values: list[T], /) -> Self: ...
+class Mapper(Generic[R]):
+    def __new__(cls, callback: Callable[[T], R], values: list[T], /) -> Self: ...
 
 values: Any
 
-# TODO: The doubled `Box` and `Never` are likely over-inferred, but the valid call must not be
-# rejected.
-reveal_type(Mapper(callback, values))  # revealed: Mapper[Box[Box[Never]]]
-```
+Mapper(callback, values)
 
-A signature-preserving decorator can turn `__new__` into a `Callable`:
+def wrap(function: Callable[P, R]) -> Callable[P, R]: ...
 
-```pyi
-from typing import ParamSpec
-
-P = ParamSpec("P")
-
-def wrap(function: Callable[P, R_co]) -> Callable[P, R_co]: ...
-
-class Wrapped(Generic[R_co]):
+class Wrapped(Generic[R]):
     @wrap
-    def __new__(cls, callback: Callable[[T], R_co], values: list[T]) -> Self: ...
+    def __new__(cls, callback: Callable[[T], R], values: list[T]) -> Self: ...
 
-# TODO: The doubled `Box` and `Never` are likely over-inferred, but the valid call must not be
-# rejected.
-reveal_type(Wrapped(callback, values))  # revealed: Wrapped[Box[Box[Never]]]
+Wrapped(callback, values)
 ```
 
-A decorator can preserve `cls` explicitly with `Concatenate`. Inferred and explicit specializations
-are both valid:
+A decorator can preserve `cls` explicitly with `Concatenate`, re-expressing the receiver with its
+own type variable. Constraint inference checks the synthetic receiver; the later assignability pass
+must not reject it merely because that decorator-scoped type variable remains unsolved:
 
 ```pyi
 from typing_extensions import Concatenate
 
-def wrap_cls(function: Callable[Concatenate[type[T], P], R_co]) -> Callable[Concatenate[type[T], P], R_co]: ...
+def wrap_cls(function: Callable[Concatenate[type[T], P], R]) -> Callable[Concatenate[type[T], P], R]: ...
 
-class WrappedCls(Generic[R_co]):
+class WrappedCls:
     @wrap_cls
-    def __new__(cls, callback: Callable[[T], R_co], values: list[T]) -> Self: ...
+    def __new__(cls) -> Self: ...
 
-# TODO: `Concatenate` loses constructor inference, even for a concrete callback and argument.
-reveal_type(WrappedCls(callback, values))  # revealed: WrappedCls[Unknown]
-reveal_type(WrappedCls[str](callback, values))  # revealed: WrappedCls[str]
-
-def concrete_callback(value: int) -> str: ...
-
-int_values: list[int]
-reveal_type(WrappedCls(concrete_callback, int_values))  # revealed: WrappedCls[Unknown]
+WrappedCls()
 ```
 
-A decorator can return a callback protocol instead of `Callable`:
+A decorator can also return a callback protocol instead of `Callable`. Its inferred `type[Self]`
+receiver must likewise not be rejected by the later assignability pass:
 
 ```pyi
 class CallableObject(Protocol[P, R_co]):
@@ -359,17 +341,16 @@ class CallableObject(Protocol[P, R_co]):
 
 def wrap_object(function: Callable[P, R_co]) -> CallableObject[P, R_co]: ...
 
-class WrappedObject(Generic[R_co]):
+class WrappedObject:
     @wrap_object
-    def __new__(cls, callback: Callable[[T], R_co], values: list[T]) -> Self: ...
+    def __new__(cls) -> Self: ...
 
-# TODO: The doubled `Box` and `Never` are likely over-inferred, but the valid call must not be
-# rejected.
-reveal_type(WrappedObject(callback, values))  # revealed: WrappedObject[Box[Box[Never]]]
+WrappedObject()
 ```
 
 The explicit `cls` type in a signature-preserving decorator can also be expressed with a generic
-type alias:
+type alias. The alias must be resolved when identifying the constructor receiver, or the later
+assignability pass rejects the synthetic argument against the decorator's unsolved receiver type:
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -305,7 +305,9 @@ class Mapper(Generic[R]):
 
 values: Any
 
-Mapper(callback, values)
+# TODO: Preserve correlated overload solutions so dynamic values do not infer an extra
+# `frozenset` layer or an element type of `Never`.
+reveal_type(Mapper(callback, values))  # revealed: Mapper[frozenset[frozenset[Never]]]
 
 def wrap(function: Callable[P, R]) -> Callable[P, R]: ...
 
@@ -313,7 +315,8 @@ class Wrapped(Generic[R]):
     @wrap
     def __new__(cls, callback: Callable[[T], R], values: list[T]) -> Self: ...
 
-Wrapped(callback, values)
+# TODO: Preserve the callback's correlated overload solutions through the decorator.
+reveal_type(Wrapped(callback, values))  # revealed: Wrapped[frozenset[frozenset[Never]]]
 ```
 
 A decorator can preserve `cls` explicitly with `Concatenate`, re-expressing the receiver with its
@@ -329,7 +332,7 @@ class WrappedCls:
     @wrap_cls
     def __new__(cls) -> Self: ...
 
-WrappedCls()
+reveal_type(WrappedCls())  # revealed: WrappedCls
 ```
 
 A decorator can also return a callback protocol instead of `Callable`. Its inferred `type[Self]`
@@ -345,7 +348,7 @@ class WrappedObject:
     @wrap_object
     def __new__(cls) -> Self: ...
 
-WrappedObject()
+reveal_type(WrappedObject())  # revealed: WrappedObject
 ```
 
 The explicit `cls` type in a signature-preserving decorator can also be expressed with a generic

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -1019,6 +1019,48 @@ class X:
         return self.__new__(type(self))
 ```
 
+Calling `object.__new__` from an overriding `__new__` method preserves `Self`, so an invalid
+attribute access on the result is reported:
+
+```py
+class Item:
+    def __new__(cls) -> Self:
+        result = object.__new__(cls)
+        reveal_type(result)  # revealed: Self@__new__
+        # error: [unresolved-attribute]
+        result.nonexistent()
+        return result
+```
+
+Explicitly marking `__new__` as a static method does not change the inferred result:
+
+```py
+class StaticItem:
+    @staticmethod
+    def __new__(cls) -> Self:
+        result = object.__new__(cls)
+        reveal_type(result)  # revealed: Self@__new__
+        return result
+```
+
+`Self` is also preserved through a chain of inherited `__new__` calls:
+
+```py
+class Foo: ...
+
+class Bar(Foo):
+    def __new__(cls) -> Self:
+        return Foo.__new__(cls)
+
+class Baz(Bar):
+    def __new__(cls) -> Self:
+        result = Bar.__new__(cls)
+        reveal_type(result)  # revealed: Self@__new__
+        # error: [unresolved-attribute]
+        result.nonexistent()
+        return result
+```
+
 ## Bound-method attribute fallback
 
 Bound-method attributes are resolved first on `types.MethodType`, then, if absent, on the underlying

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -527,6 +527,8 @@ to `Any`:
 from enum import Enum
 
 class Connector(Enum):
+    connector_id: int
+
     def __new__(cls, value: str, connector_id: int) -> "Connector":
         obj = object.__new__(cls)
         obj._value_ = value
@@ -546,6 +548,7 @@ from enum import Enum
 
 class AnnotatedConnector(Enum):
     _value_: str
+    connector_id: int
 
     def __new__(cls, value: str, connector_id: int = 0) -> "AnnotatedConnector":
         obj = object.__new__(cls)
@@ -661,6 +664,8 @@ annotation, subclass member values remain dynamic:
 from enum import Enum
 
 class Base(Enum):
+    connector_id: int
+
     def __new__(cls, value: str, connector_id: int) -> "Base":
         obj = object.__new__(cls)
         obj._value_ = value
@@ -680,6 +685,8 @@ An explicit `_value_` annotation on the subclass still takes precedence:
 from enum import Enum
 
 class Base(Enum):
+    connector_id: int
+
     def __new__(cls, value: str, connector_id: int = 0) -> "Base":
         obj = object.__new__(cls)
         obj._value_ = value
@@ -702,6 +709,8 @@ explicitly annotated:
 from enum import Enum
 
 class Base(Enum):
+    connector_id: int
+
     def __new__(cls, value: int, connector_id: int = 0) -> "Base":
         obj = object.__new__(cls)
         obj._value_ = value

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1873,7 +1873,7 @@ class MetaWithIntReturn(type):
 
 class F(metaclass=MetaWithIntReturn):
     def __new__(cls) -> str:
-        return super().__new__(cls)
+        return ""
 
 class Returns[T](Protocol):
     def __call__(self) -> T: ...
@@ -1952,7 +1952,7 @@ static_assert(not is_subtype_of(TypeOf[A], Returns[A]))
 
 class B:
     def __new__(cls, a: int) -> int:
-        return super().__new__(cls)
+        return 0
 
     def __init__(self, a: str) -> None: ...
 
@@ -2023,7 +2023,7 @@ class MetaWithIntReturn(type):
 
 class F(metaclass=MetaWithIntReturn):
     def __new__(cls) -> str:
-        return super().__new__(cls)
+        return ""
 
     def __init__(self, x: int) -> None: ...
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5539,20 +5539,39 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             return;
         }
 
-        // The synthetic `cls` already carries the constructor's identity specialization.
-        // For example, typeshed's `map` constructor is roughly:
+        // Constraint inference has already checked the synthetic `cls`. For example:
         //
         // ```py
-        // class map[S]:
-        //     def __new__[T](cls, callback: Callable[[T], S], values: Iterable[T], /) -> Self: ...
+        // from collections.abc import Callable
+        // from typing import Any, Self, overload
         //
-        // map(os.path.abspath, list_fonts("fonts"))
+        // @overload
+        // def callback[T](value: frozenset[T]) -> T: ...
+        // @overload
+        // def callback[T](value: T) -> T: ...
+        //
+        // class Mapper[R]:
+        //     def __new__[T](cls, callback: Callable[[T], R], values: list[T]) -> Self: ...
+        //
+        // values: Any
+        // Mapper(callback, values)
         // ```
         //
-        // Once the call specializes `S` to `PathLike[Never]`, applying that specialization to
-        // `cls` again produces `map[PathLike[PathLike[Never]]]` instead of
-        // `map[PathLike[Never]]`, causing a spurious argument error. Decorators can also
-        // re-express the `cls` annotation using their own TypeVar, possibly through a type alias.
+        // The overloads provide alternative, correlated solutions for `T` and `R`. The current
+        // solver merges each TypeVar's solutions separately, losing that correlation. Applying
+        // the merged specialization to `cls` a second time then changes the receiver from
+        // `type[Mapper[frozenset[Never]]]` to
+        // `type[Mapper[frozenset[frozenset[Never]]]]`, incorrectly rejecting the valid call.
+        //
+        // A decorator using `Concatenate[type[U], P]` can also replace the inferred `type[Self]`
+        // receiver with its own `type[U]`, possibly through a type alias. Constraint inference has
+        // already checked the actual class against `type[U]`. If the other arguments cannot solve
+        // `U`, independently checking the class against `type[U]` again would reject the call
+        // solely because `U` remains unsolved.
+        //
+        // TODO: Remove this special case once solution extraction preserves correlations between
+        // TypeVars across alternative inference paths and constructor calls are solved in a single
+        // constraint set, so decorator-scoped receiver variables are not rechecked independently.
         let constructor_receiver = matches!(argument, Argument::Synthetic)
             && self.constructor_kind == Some(ConstructorCallableKind::New)
             && matches!(

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5047,6 +5047,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
 struct ArgumentTypeChecker<'a, 'db> {
     db: &'db dyn Db,
     signature_type: Type<'db>,
+    constructor_kind: Option<ConstructorCallableKind>,
     signature: &'a Signature<'db>,
     arguments: &'a CallArguments<'a, 'db>,
     argument_matches: &'a [MatchedArgument<'db>],
@@ -5115,6 +5116,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     fn new(
         db: &'db dyn Db,
         signature_type: Type<'db>,
+        constructor_kind: Option<ConstructorCallableKind>,
         signature: &'a Signature<'db>,
         arguments: &'a CallArguments<'a, 'db>,
         argument_matches: &'a [MatchedArgument<'db>],
@@ -5126,6 +5128,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         Self {
             db,
             signature_type,
+            constructor_kind,
             signature,
             arguments,
             argument_matches,
@@ -5536,9 +5539,32 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             return;
         }
 
+        // The synthetic `cls` already carries the constructor's identity specialization.
+        // For example, typeshed's `map` constructor is roughly:
+        //
+        // ```py
+        // class map[S]:
+        //     def __new__[T](cls, callback: Callable[[T], S], values: Iterable[T], /) -> Self: ...
+        //
+        // map(os.path.abspath, list_fonts("fonts"))
+        // ```
+        //
+        // Once the call specializes `S` to `PathLike[Never]`, applying that specialization to
+        // `cls` again produces `map[PathLike[PathLike[Never]]]` instead of
+        // `map[PathLike[Never]]`, causing a spurious argument error. Decorators can also
+        // re-express the `cls` annotation using their own TypeVar, possibly through a type alias.
+        let constructor_receiver = matches!(argument, Argument::Synthetic)
+            && self.constructor_kind == Some(ConstructorCallableKind::New)
+            && matches!(
+                parameter.annotated_type().resolve_type_alias(self.db),
+                Type::SubclassOf(subclass_of) if subclass_of.into_type_var().is_some()
+            );
+
         let mut expected_ty = parameter.annotated_type();
         if let Some(specialization) = self.specialization() {
-            argument_type = argument_type.apply_specialization(self.db, specialization);
+            if !constructor_receiver {
+                argument_type = argument_type.apply_specialization(self.db, specialization);
+            }
             expected_ty = expected_ty.apply_specialization(self.db, specialization);
         }
 
@@ -5573,6 +5599,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         //
         // TODO: handle starred annotations, e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...]]`
         if !self.constraint_set_errors[argument_index]
+            && !constructor_receiver
             && !parameter.has_starred_annotation()
             && !is_valid_isinstance_target()
             && argument_type
@@ -6772,6 +6799,7 @@ impl<'db> Binding<'db> {
         let mut checker = ArgumentTypeChecker::new(
             db,
             self.signature_type,
+            self.constructor_context.map(ConstructorContext::kind),
             &self.signature,
             arguments,
             &self.argument_matches,

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -553,7 +553,7 @@ impl<'db> ConstructorContext<'db> {
         self.instance_type
     }
 
-    fn kind(self) -> ConstructorCallableKind {
+    pub(super) fn kind(self) -> ConstructorCallableKind {
         self.kind
     }
 }
@@ -635,7 +635,7 @@ impl<'db> Binding<'db> {
             return false;
         };
 
-        let Type::SubclassOf(subclass_of) = cls_parameter_ty else {
+        let Type::SubclassOf(subclass_of) = cls_parameter_ty.resolve_type_alias(db) else {
             return false;
         };
         let Some(cls_typevar) = subclass_of.into_type_var() else {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -630,7 +630,9 @@ impl<'db> OverloadLiteral<'db> {
 
         let generic_context = raw_signature.generic_context;
         raw_signature.add_implicit_self_annotation(db, || {
-            if self.is_staticmethod(db) {
+            let is_staticmethod = self.is_staticmethod(db);
+            let is_dunder_new = self.name(db) == "__new__";
+            if is_staticmethod && !is_dunder_new {
                 return None;
             }
 
@@ -678,7 +680,7 @@ impl<'db> OverloadLiteral<'db> {
                      for an implicit self: Self annotation",
                     );
 
-                if self.is_classmethod(db) {
+                if self.is_classmethod(db) || is_dunder_new {
                     Some(SubclassOfType::from(
                         db,
                         SubclassOfInner::TypeVar(typing_self),
@@ -689,7 +691,7 @@ impl<'db> OverloadLiteral<'db> {
             } else {
                 // If skip creating the typevar, we use "instance of class" or "subclass of
                 // class" as the implicit annotation instead.
-                if self.is_classmethod(db) {
+                if self.is_classmethod(db) || is_dunder_new {
                     Some(SubclassOfType::from(
                         db,
                         SubclassOfInner::Class(ClassType::NonGeneric(class_literal)),

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -1057,7 +1057,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .as_class_literal()
                 .and_then(|class| class.known(db))
             {
-                if known_class == KnownClass::Staticmethod {
+                if known_class == KnownClass::Staticmethod && function_name != "__new__" {
                     return None;
                 }
 


### PR DESCRIPTION
## Summary

Prior to this change, calling an inherited `__new__` implementation could lose `Self` and return `Unknown`. This caused us to miss invalid attribute access and broke chains of custom `__new__` implementations:

```py
from typing import Self

class Foo: ...

class Bar(Foo):
    def __new__(cls) -> Self:
        return Foo.__new__(cls)

class Baz(Bar):
    def __new__(cls) -> Self:
        result = Bar.__new__(cls)  # Previously: Unknown
        result.nonexistent()  # Previously: no diagnostic
        return result
```

This gives every unannotated `__new__` receiver an implicit `type[Self]`, matching the constructor typing specification and preserving `Self` through inherited calls.

It also preserves existing generic constructor calls where the synthetic `cls` receiver would otherwise be specialized and checked twice. The regression coverage includes overloaded callbacks, signature-preserving and callable-protocol decorators, `Concatenate`, and aliased receiver types; the intentionally odd nested and `Concatenate` inference results remain documented as pre-existing limitations.

Closes https://github.com/astral-sh/ty/issues/3965.
