### PR TITLE
[`flake8-bandit`] Document `TYPE_CHECKING` exception (`S101`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/assert_used.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/assert_used.rs
@@ -18,6 +18,23 @@ use crate::checkers::ast::Checker;
 ///
 /// Consider raising a meaningful error instead of using `assert`.
 ///
+/// ## Type narrowing
+/// `assert` is sometimes used to narrow types for static type checkers, e.g.
+/// `assert x is not None`. Since these assertions are only useful to the
+/// type checker and have no runtime effect worth preserving, they are often
+/// better placed under a `TYPE_CHECKING` guard so they are not executed at
+/// runtime:
+///
+/// ```python
+/// from typing import TYPE_CHECKING
+///
+/// if TYPE_CHECKING:
+///     assert isinstance(x, int)
+/// ```
+///
+/// Alternatively, if the assertion is needed at runtime, suppress the rule
+/// at the call site with `# noqa: S101`.
+///
 /// ## Example
 /// ```python
 /// assert x > 0, "Expected positive value."

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/assert_used.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/assert_used.rs
@@ -19,21 +19,10 @@ use crate::checkers::ast::Checker;
 /// Consider raising a meaningful error instead of using `assert`.
 ///
 /// ## Type narrowing
-/// `assert` is sometimes used to narrow types for static type checkers, e.g.
-/// `assert x is not None`. Since these assertions are only useful to the
-/// type checker and have no runtime effect worth preserving, they are often
-/// better placed under a `TYPE_CHECKING` guard so they are not executed at
-/// runtime:
 ///
-/// ```python
-/// from typing import TYPE_CHECKING
-///
-/// if TYPE_CHECKING:
-///     assert isinstance(x, int)
-/// ```
-///
-/// Alternatively, if the assertion is needed at runtime, suppress the rule
-/// at the call site with `# noqa: S101`.
+/// Assertions in `TYPE_CHECKING` blocks are exempt from this rule, assuming
+/// they exist to satisfy a type checker. If the assertion is needed at
+/// runtime, suppress it at the call site with `# noqa: S101`.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/assert_used.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/assert_used.rs
@@ -18,11 +18,8 @@ use crate::checkers::ast::Checker;
 ///
 /// Consider raising a meaningful error instead of using `assert`.
 ///
-/// ## Type narrowing
-///
-/// Assertions in `TYPE_CHECKING` blocks are exempt from this rule, assuming
-/// they exist to satisfy a type checker. If the assertion is needed at
-/// runtime, suppress it at the call site with `# noqa: S101`.
+/// The rule exempts assertions within a `TYPE_CHECKING` block, assuming these are needed to satisfy
+/// a type checker.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
## Summary

Adds documentation for the S101 rule to mention `TYPE_CHECKING` blocks
as a way to avoid the rule when asserts are used for type narrowing.

This was discussed in the issue and aligns with the existing behavior
(introduced in PR #3960) where asserts inside `TYPE_CHECKING` blocks
are already allowed.

## Test Plan

- Existing S101 tests pass (behavior unchanged)
- `cargo fmt --check` clean

Refs #26819