### PR TITLE
Remove `DisplayDiagnosticConfig::show_fix_diff`

### DIFF
--- a/crates/mdtest/src/lib.rs
+++ b/crates/mdtest/src/lib.rs
@@ -317,7 +317,6 @@ impl TestFile<'_> {
 pub(crate) fn diagnostic_display_config(tool_name: &'static str) -> DisplayDiagnosticConfig {
     DisplayDiagnosticConfig::new(tool_name)
         .color(false)
-        .show_fix_diff(true)
         .with_fix_applicability(Applicability::DisplayOnly)
         // Surrounding context in source annotations can be confusing in mdtests,
         // since you may get to see context from the *subsequent* code block (all

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -601,7 +601,6 @@ impl<'a> FormatResults<'a> {
         let context = EmitterContext::new(&notebook_index);
         let config = DisplayDiagnosticConfig::new("ruff")
             .hide_severity(true)
-            .show_fix_diff(true)
             .color(!cfg!(test) && colored::control::SHOULD_COLORIZE.should_colorize());
 
         render_diagnostics(f, output_format, config, &context, &diagnostics)

--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -240,8 +240,7 @@ impl Printer {
             .hide_severity(true)
             .color(!cfg!(test) && colored::control::SHOULD_COLORIZE.should_colorize())
             .with_show_fix_status(show_fix_status(self.fix_mode, fixables.as_ref()))
-            .with_fix_applicability(self.unsafe_fixes.required_applicability())
-            .show_fix_diff(true);
+            .with_fix_applicability(self.unsafe_fixes.required_applicability());
 
         render_diagnostics(writer, self.format, config, &context, &diagnostics.inner)?;
 
@@ -414,8 +413,7 @@ impl Printer {
                 .hide_severity(true)
                 .color(!cfg!(test) && colored::control::SHOULD_COLORIZE.should_colorize())
                 .with_show_fix_status(show_fix_status(self.fix_mode, fixables.as_ref()))
-                .with_fix_applicability(self.unsafe_fixes.required_applicability())
-                .show_fix_diff(true);
+                .with_fix_applicability(self.unsafe_fixes.required_applicability());
             render_diagnostics(writer, self.format, config, &context, &diagnostics.inner)?;
         }
         writer.flush()?;

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1438,10 +1438,6 @@ pub struct DisplayDiagnosticConfig {
     hide_severity: bool,
     /// Whether to show the availability of a fix in a diagnostic.
     show_fix_status: bool,
-    /// Whether to show the diff for an available fix after the main diagnostic.
-    ///
-    /// This currently only applies to `DiagnosticFormat::Full`.
-    show_fix_diff: bool,
     /// The lowest applicability that should be shown when reporting diagnostics.
     fix_applicability: Applicability,
 
@@ -1461,7 +1457,6 @@ impl DisplayDiagnosticConfig {
             preview: false,
             hide_severity: false,
             show_fix_status: false,
-            show_fix_diff: false,
             fix_applicability: Applicability::Safe,
             cancellation_token: None,
         }
@@ -1536,14 +1531,6 @@ impl DisplayDiagnosticConfig {
     pub fn with_show_fix_status(self, yes: bool) -> DisplayDiagnosticConfig {
         DisplayDiagnosticConfig {
             show_fix_status: yes,
-            ..self
-        }
-    }
-
-    /// Whether to show a diff for an available fix after the main diagnostic.
-    pub fn show_fix_diff(self, yes: bool) -> DisplayDiagnosticConfig {
-        DisplayDiagnosticConfig {
-            show_fix_diff: yes,
             ..self
         }
     }

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -2637,12 +2637,6 @@ watermelon
             self.config = config.with_show_fix_status(yes);
         }
 
-        /// Show a diff for the fix when rendering.
-        pub(super) fn show_fix_diff(&mut self, yes: bool) {
-            let config = self.config.clone();
-            self.config = config.show_fix_diff(yes);
-        }
-
         /// The lowest fix applicability to show when rendering.
         pub(super) fn fix_applicability(&mut self, applicability: Applicability) {
             let config = self.config.clone();

--- a/crates/ruff_db/src/diagnostic/render/full.rs
+++ b/crates/ruff_db/src/diagnostic/render/full.rs
@@ -64,8 +64,7 @@ impl<'a> FullRenderer<'a> {
                 writeln!(f, "{}", renderer.render(diag.to_annotate()))?;
             }
 
-            if self.config.show_fix_diff
-                && diag.has_applicable_fix(self.config.fix_applicability())
+            if diag.has_applicable_fix(self.config.fix_applicability())
                 && let Some(diff) =
                     Diff::from_diagnostic(diag, &stylesheet, self.resolver, self.config)
             {
@@ -480,6 +479,11 @@ mod tests {
           |        ^^
           |
         help: Remove unused import: `os`
+          |
+          - import os
+        1 |
+          |
+        note: This is an unsafe fix and may change runtime behavior
 
         F841 [*] Local variable `x` is assigned to but never used
          --> fib.py:6:5
@@ -492,6 +496,13 @@ mod tests {
         8 |         return 0
           |
         help: Remove assignment to unused variable `x`
+          |
+        5 |     """Compute the nth number in the Fibonacci sequence."""
+          -     x = 1
+        6 +     
+        7 |     if n == 0:
+          |
+        note: This is an unsafe fix and may change runtime behavior
 
         F821 Undefined name `a`
          --> undef.py:1:4
@@ -709,7 +720,7 @@ print()
     fn notebook_output() {
         let (mut env, diagnostics) = create_notebook_diagnostics(DiagnosticFormat::Full);
         env.show_fix_status(true);
-        insta::assert_snapshot!(env.render_diagnostics(&diagnostics), @r###"
+        insta::assert_snapshot!(env.render_diagnostics(&diagnostics), @"
         error[F401][*]: `os` imported but unused
          --> notebook.ipynb:cell 1:2:8
           |
@@ -718,6 +729,11 @@ print()
           |        ^^
           |
         help: Remove unused import: `os`
+         ::: cell 1
+          |
+        1 | # cell 1
+          - import os
+          |
 
         error[F401][*]: `math` imported but unused
          --> notebook.ipynb:cell 2:2:8
@@ -729,6 +745,12 @@ print()
         4 | print('hello world')
           |
         help: Remove unused import: `math`
+         ::: cell 2
+          |
+        1 | # cell 2
+          - import math
+        2 |
+          |
 
         error[F841]: Local variable `x` is assigned to but never used
          --> notebook.ipynb:cell 3:4:5
@@ -739,7 +761,7 @@ print()
           |     ^
           |
         help: Remove assignment to unused variable `x`
-        "###);
+        ");
     }
 
     /// Check notebook handling for multiple annotations in a single diagnostic that span cells.
@@ -821,7 +843,6 @@ print()
     #[test]
     fn notebook_output_with_diff() {
         let (mut env, diagnostics) = create_notebook_diagnostics(DiagnosticFormat::Full);
-        env.show_fix_diff(true);
         env.show_fix_status(true);
         env.fix_applicability(Applicability::DisplayOnly);
 
@@ -831,7 +852,6 @@ print()
     #[test]
     fn notebook_output_with_diff_spanning_cells() {
         let (mut env, mut diagnostics) = create_notebook_diagnostics(DiagnosticFormat::Full);
-        env.show_fix_diff(true);
         env.show_fix_status(true);
         env.fix_applicability(Applicability::DisplayOnly);
 
@@ -984,7 +1004,6 @@ line 10
         ";
         env.add("example.py", contents);
         env.format(DiagnosticFormat::Full);
-        env.show_fix_diff(true);
         env.show_fix_status(true);
         env.fix_applicability(Applicability::DisplayOnly);
 
@@ -1042,7 +1061,6 @@ line 13
         env.format(DiagnosticFormat::Full);
         env.context(0);
         env.merge_window(2);
-        env.show_fix_diff(true);
 
         let replacement = |target: &str| {
             let start = contents.find(target).unwrap();

--- a/crates/ruff_linter/src/test.rs
+++ b/crates/ruff_linter/src/test.rs
@@ -486,7 +486,6 @@ pub(crate) fn print_jupyter_messages(
         .format(DiagnosticFormat::Full)
         .hide_severity(true)
         .with_show_fix_status(true)
-        .show_fix_diff(true)
         .with_fix_applicability(Applicability::DisplayOnly);
 
     DisplayDiagnostics::new(
@@ -505,7 +504,6 @@ pub(crate) fn print_messages(diagnostics: &[Diagnostic]) -> String {
         .format(DiagnosticFormat::Full)
         .hide_severity(true)
         .with_show_fix_status(true)
-        .show_fix_diff(true)
         .with_fix_applicability(Applicability::DisplayOnly);
 
     DisplayDiagnostics::new(

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -519,7 +519,6 @@ impl MainLoop {
                         .format(terminal_settings.output_format.into())
                         .color(colored::control::SHOULD_COLORIZE.should_colorize())
                         .with_cancellation_token(Some(self.cancellation_token.clone()))
-                        .show_fix_diff(true)
                         .context(0);
 
                     write!(

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -870,7 +870,6 @@ mod tests {
 
             let config = DisplayDiagnosticConfig::new("ty")
                 .color(false)
-                .show_fix_diff(true)
                 .context(0)
                 .format(DiagnosticFormat::Full);
 

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -977,7 +977,6 @@ Source with applied edits:
 
             let config = DisplayDiagnosticConfig::new("ty")
                 .color(false)
-                .show_fix_diff(true)
                 .context(0)
                 .format(DiagnosticFormat::Full);
 

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1158,6 +1158,10 @@ class B(A):
           |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           |
         help: Remove the unused suppression comment
+          |
+          - value = missing  # ty: ignore[] tracked by [123]  # ty:ignore[unresolved-reference]
+        1 + value = missing  # ty:ignore[unresolved-reference]
+          |
         "
         );
     }

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -900,6 +900,11 @@ mod tests {
           |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           |
         help: Remove the unused suppression comment
+          |
+        1 | import sys
+          - a = 5 + 10  # ty: ignore[unresolved-reference]
+        2 + a = 5 + 10
+          |
         ");
     }
 
@@ -1102,6 +1107,12 @@ class B(A):
         9 |         b: str
           |
         help: Remove the unused suppression code
+          |
+        6 | class B(A):
+          -     def test(  # ty:ignore[unresolved-reference, invalid-method-override]
+        7 +     def test(  # ty:ignore[invalid-method-override]
+        8 |         self,
+          |
         "#);
     }
 
@@ -1181,6 +1192,11 @@ class B(A):
           |                                        ^^^^^^^^^^^^^^^^
           |
         help: Remove the unused suppression code
+          |
+        2 |
+          - result: int = f(missing)  # ty: ignore[division-by-zero, invalid-assignment, too-many-positional-arguments, unresolved-reference]
+        3 + result: int = f(missing)  # ty: ignore[invalid-assignment, too-many-positional-arguments, unresolved-reference]
+          |
         "#
         );
     }
@@ -1221,6 +1237,12 @@ class B(A):
         5 | ]
           |
         help: Remove the unused suppression comment
+          |
+        2 | values = [
+          -     # ty: ignore[]
+        3 +
+        4 |     missing,  # ty:ignore[unresolved-reference]
+          |
         "
         );
     }
@@ -1271,6 +1293,12 @@ class B(A):
         3 | value = missing  # ty:ignore[unresolved-reference]
           |
         help: Remove the unused suppression comment
+          |
+        1 | seen_code = True
+          - # ty: ignore[]
+        2 +
+        3 | value = missing  # ty:ignore[unresolved-reference]
+          |
         "#
         );
     }


### PR DESCRIPTION
Summary
--

Follow up to https://github.com/astral-sh/ruff/pull/26958#discussion_r3607966160. This setting was now always* set to true and only read in the `full` output format, so we can just remove it.

The few cases where it wasn't already set to true were in tests, but it seems fine or even
preferable to show the fixes there too.

Test Plan
--

Updated existing snapshots
