### PR TITLE
Update branch for jrnl

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
@@ -41,7 +41,7 @@ use crate::{Fix, FixAvailability, Violation};
 ///
 ///
 /// def sum_less_than_four(a, b):
-///     logger.debug("Calling  sum_less_than_four")
+///     logger.debug("Calling sum_less_than_four")
 ///     return a + b < 4
 ///
 ///

--- a/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_print/rules/print_call.rs
@@ -41,7 +41,7 @@ use crate::{Fix, FixAvailability, Violation};
 ///
 ///
 /// def sum_less_than_four(a, b):
-///     logger.debug("Calling sum_less_than_four")
+///     logger.debug("Calling  sum_less_than_four")
 ///     return a + b < 4
 ///
 ///

--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -56,7 +56,7 @@ DEFAULT_TARGETS = [
     Project(repo=Repository(owner="fronzbot", name="blinkpy", ref="dev")),
     Project(repo=Repository(owner="ibis-project", name="ibis", ref="main")),
     Project(repo=Repository(owner="ing-bank", name="probatus", ref="main")),
-    Project(repo=Repository(owner="jrnl-org", name="jrnl", ref="develop")),
+    Project(repo=Repository(owner="jrnl-org", name="jrnl", ref="main")),
     Project(repo=Repository(owner="langchain-ai", name="langchain", ref="master")),
     Project(repo=Repository(owner="latchbio", name="latch", ref="main")),
     Project(repo=Repository(owner="lnbits", name="lnbits", ref="main")),

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -136,7 +136,7 @@ REPOSITORIES: list[Repository] = [
     Repository("fronzbot", "blinkpy", "dev"),
     Repository("ibis-project", "ibis", "master"),
     Repository("ing-bank", "probatus", "main"),
-    Repository("jrnl-org", "jrnl", "develop"),
+    Repository("jrnl-org", "jrnl", "main"),
     Repository("langchain-ai", "langchain", "main"),
     Repository("latchbio", "latch", "main"),
     Repository("lnbits", "lnbits", "main"),


### PR DESCRIPTION
Summary
--

Ecosystem checks started failing this morning for a missing branch, for example:

https://github.com/astral-sh/ruff/actions/runs/29745997326/job/88364078381?pr=26770

main now seems to be their default branch: https://github.com/jrnl-org/jrnl

Test Plan
--

Second commit with a small whitespace change to trigger an ecosystem run
