### PR TITLE
[ty] Honor metaclass setters in writable protocols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2463,11 +2463,39 @@ class MetaWithGetAttrAndSetAttr(type):
 class ClassWithDynamicX(metaclass=MetaWithGetAttrAndSetAttr): ...
 
 ClassWithDynamicX.x = 1
-# TODO: this should pass once metaclass setters are considered for protocol writes.
-dynamic_x: HasMutableXProperty = ClassWithDynamicX  # error: [invalid-assignment]
+dynamic_x: HasMutableXProperty = ClassWithDynamicX
 ```
 
-Once metaclass setters are considered, one with an incompatible value type must still be rejected:
+Separate setter overloads can cover a union write type, and a variadic setter can accept any of its
+members:
+
+```py
+class MetaWithOverloadedValueSetAttr(type):
+    def __getattr__(cls, attr: str) -> object:
+        return object()
+
+    @overload
+    def __setattr__(cls, attr: str, value: int) -> None: ...
+    @overload
+    def __setattr__(cls, attr: str, value: str) -> None: ...
+    def __setattr__(cls, attr: str, value: int | str) -> None: ...
+
+class ClassWithOverloadedValueSetAttr(metaclass=MetaWithOverloadedValueSetAttr): ...
+
+overloaded_value_x: HasIntOrStrWriteProperty = ClassWithOverloadedValueSetAttr
+
+class MetaWithVariadicSetAttr(type):
+    def __getattr__(cls, attr: str) -> object:
+        return object()
+
+    def __setattr__(cls, *args: object) -> None: ...
+
+class ClassWithVariadicSetAttr(metaclass=MetaWithVariadicSetAttr): ...
+
+variadic_x: HasIntOrStrWriteProperty = ClassWithVariadicSetAttr
+```
+
+A metaclass setter with an incompatible value type is rejected:
 
 ```py
 class MetaWithUnsuitableSetAttr(type):
@@ -2496,8 +2524,7 @@ class ClassWithTerminalSetAttr(metaclass=MetaWithTerminalSetAttr):
 terminal_x: HasMutableXProperty = ClassWithTerminalSetAttr
 ```
 
-Once metaclass setters are considered, an overload for a different attribute must not make the class
-satisfy the protocol:
+An overload for a different attribute must not make the class satisfy the protocol:
 
 ```py
 from typing import Literal
@@ -2520,7 +2547,7 @@ ClassWithOverloadedSetAttr.x = 1
 static_assert(not is_subtype_of(TypeOf[ClassWithOverloadedSetAttr], HasMutableXProperty))
 ```
 
-A generic metaclass setter can satisfy a writable property protocol:
+A generic metaclass setter should satisfy a writable property protocol:
 
 ```py
 from typing import TypeVar
@@ -2536,7 +2563,7 @@ class MetaWithGenericSetAttr(type):
 class ClassWithGenericSetAttr(metaclass=MetaWithGenericSetAttr): ...
 
 ClassWithGenericSetAttr.x = 1
-# TODO: this should pass once metaclass setters are considered for protocol writes.
+# TODO: generic metaclass setters should be considered for protocol writes.
 generic_x: HasMutableXProperty = ClassWithGenericSetAttr  # error: [invalid-assignment]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2484,6 +2484,18 @@ class ClassWithOverloadedValueSetAttr(metaclass=MetaWithOverloadedValueSetAttr):
 
 overloaded_value_x: HasIntOrStrWriteProperty = ClassWithOverloadedValueSetAttr
 
+class InstanceWithOverloadedValueSetAttr:
+    def __getattr__(self, attr: str) -> object:
+        return object()
+
+    @overload
+    def __setattr__(self, attr: str, value: int) -> None: ...
+    @overload
+    def __setattr__(self, attr: str, value: str) -> None: ...
+    def __setattr__(self, attr: str, value: int | str) -> None: ...
+
+static_assert(is_subtype_of(InstanceWithOverloadedValueSetAttr, HasIntOrStrWriteProperty))
+
 class MetaWithVariadicSetAttr(type):
     def __getattr__(cls, attr: str) -> object:
         return object()
@@ -2545,6 +2557,19 @@ class ClassWithOverloadedSetAttr(metaclass=MetaWithOverloadedSetAttr): ...
 
 ClassWithOverloadedSetAttr.x = 1
 static_assert(not is_subtype_of(TypeOf[ClassWithOverloadedSetAttr], HasMutableXProperty))
+
+class InstanceWithOverloadedSetAttr:
+    def __getattr__(self, attr: str) -> int:
+        return 1
+
+    @overload
+    def __setattr__(self, attr: Literal["x"], value: Any) -> None: ...
+    @overload
+    def __setattr__(self, attr: Literal["y"], value: int) -> None: ...
+    # error: [invalid-method-override]
+    def __setattr__(self, attr: str, value: object) -> None: ...
+
+static_assert(not is_subtype_of(InstanceWithOverloadedSetAttr, HasMutableXProperty))
 ```
 
 A generic metaclass setter should satisfy a writable property protocol:
@@ -2563,8 +2588,15 @@ class MetaWithGenericSetAttr(type):
 class ClassWithGenericSetAttr(metaclass=MetaWithGenericSetAttr): ...
 
 ClassWithGenericSetAttr.x = 1
-# TODO: generic metaclass setters should be considered for protocol writes.
-generic_x: HasMutableXProperty = ClassWithGenericSetAttr  # error: [invalid-assignment]
+generic_x: HasMutableXProperty = ClassWithGenericSetAttr
+
+class InstanceWithGenericSetAttr:
+    def __getattr__(self, attr: str) -> int:
+        return 1
+
+    def __setattr__(self, attr: str, value: T) -> None: ...
+
+static_assert(is_subtype_of(InstanceWithGenericSetAttr, HasMutableXProperty))
 ```
 
 For static checking, an explicit attribute declaration takes precedence over `__setattr__`. This

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2818,6 +2818,18 @@ class ClassWithOverloadedValueSetAttr(metaclass=MetaWithOverloadedValueSetAttr):
 
 overloaded_value_x: HasIntOrStrWriteProperty = ClassWithOverloadedValueSetAttr
 
+class InstanceWithOverloadedValueSetAttr:
+    def __getattr__(self, attr: str) -> object:
+        return object()
+
+    @overload
+    def __setattr__(self, attr: str, value: int) -> None: ...
+    @overload
+    def __setattr__(self, attr: str, value: str) -> None: ...
+    def __setattr__(self, attr: str, value: int | str) -> None: ...
+
+static_assert(is_subtype_of(InstanceWithOverloadedValueSetAttr, HasIntOrStrWriteProperty))
+
 class MetaWithVariadicSetAttr(type):
     def __getattr__(cls, attr: str) -> object:
         return object()
@@ -2879,6 +2891,19 @@ class ClassWithOverloadedSetAttr(metaclass=MetaWithOverloadedSetAttr): ...
 
 ClassWithOverloadedSetAttr.x = 1
 static_assert(not is_subtype_of(TypeOf[ClassWithOverloadedSetAttr], HasMutableXProperty))
+
+class InstanceWithOverloadedSetAttr:
+    def __getattr__(self, attr: str) -> int:
+        return 1
+
+    @overload
+    def __setattr__(self, attr: Literal["x"], value: Any) -> None: ...
+    @overload
+    def __setattr__(self, attr: Literal["y"], value: int) -> None: ...
+    # error: [invalid-method-override]
+    def __setattr__(self, attr: str, value: object) -> None: ...
+
+static_assert(not is_subtype_of(InstanceWithOverloadedSetAttr, HasMutableXProperty))
 ```
 
 A generic metaclass setter should satisfy a writable property protocol:
@@ -2897,8 +2922,15 @@ class MetaWithGenericSetAttr(type):
 class ClassWithGenericSetAttr(metaclass=MetaWithGenericSetAttr): ...
 
 ClassWithGenericSetAttr.x = 1
-# TODO: generic metaclass setters should be considered for protocol writes.
-generic_x: HasMutableXProperty = ClassWithGenericSetAttr  # error: [invalid-assignment]
+generic_x: HasMutableXProperty = ClassWithGenericSetAttr
+
+class InstanceWithGenericSetAttr:
+    def __getattr__(self, attr: str) -> int:
+        return 1
+
+    def __setattr__(self, attr: str, value: T) -> None: ...
+
+static_assert(is_subtype_of(InstanceWithGenericSetAttr, HasMutableXProperty))
 ```
 
 For static checking, an explicit attribute declaration takes precedence over `__setattr__`. This

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2797,11 +2797,39 @@ class MetaWithGetAttrAndSetAttr(type):
 class ClassWithDynamicX(metaclass=MetaWithGetAttrAndSetAttr): ...
 
 ClassWithDynamicX.x = 1
-# TODO: this should pass once metaclass setters are considered for protocol writes.
-dynamic_x: HasMutableXProperty = ClassWithDynamicX  # error: [invalid-assignment]
+dynamic_x: HasMutableXProperty = ClassWithDynamicX
 ```
 
-Once metaclass setters are considered, one with an incompatible value type must still be rejected:
+Separate setter overloads can cover a union write type, and a variadic setter can accept any of its
+members:
+
+```py
+class MetaWithOverloadedValueSetAttr(type):
+    def __getattr__(cls, attr: str) -> object:
+        return object()
+
+    @overload
+    def __setattr__(cls, attr: str, value: int) -> None: ...
+    @overload
+    def __setattr__(cls, attr: str, value: str) -> None: ...
+    def __setattr__(cls, attr: str, value: int | str) -> None: ...
+
+class ClassWithOverloadedValueSetAttr(metaclass=MetaWithOverloadedValueSetAttr): ...
+
+overloaded_value_x: HasIntOrStrWriteProperty = ClassWithOverloadedValueSetAttr
+
+class MetaWithVariadicSetAttr(type):
+    def __getattr__(cls, attr: str) -> object:
+        return object()
+
+    def __setattr__(cls, *args: object) -> None: ...
+
+class ClassWithVariadicSetAttr(metaclass=MetaWithVariadicSetAttr): ...
+
+variadic_x: HasIntOrStrWriteProperty = ClassWithVariadicSetAttr
+```
+
+A metaclass setter with an incompatible value type is rejected:
 
 ```py
 class MetaWithUnsuitableSetAttr(type):
@@ -2830,8 +2858,7 @@ class ClassWithTerminalSetAttr(metaclass=MetaWithTerminalSetAttr):
 terminal_x: HasMutableXProperty = ClassWithTerminalSetAttr
 ```
 
-Once metaclass setters are considered, an overload for a different attribute must not make the class
-satisfy the protocol:
+An overload for a different attribute must not make the class satisfy the protocol:
 
 ```py
 from typing import Literal
@@ -2854,7 +2881,7 @@ ClassWithOverloadedSetAttr.x = 1
 static_assert(not is_subtype_of(TypeOf[ClassWithOverloadedSetAttr], HasMutableXProperty))
 ```
 
-A generic metaclass setter can satisfy a writable property protocol:
+A generic metaclass setter should satisfy a writable property protocol:
 
 ```py
 from typing import TypeVar
@@ -2870,7 +2897,7 @@ class MetaWithGenericSetAttr(type):
 class ClassWithGenericSetAttr(metaclass=MetaWithGenericSetAttr): ...
 
 ClassWithGenericSetAttr.x = 1
-# TODO: this should pass once metaclass setters are considered for protocol writes.
+# TODO: generic metaclass setters should be considered for protocol writes.
 generic_x: HasMutableXProperty = ClassWithGenericSetAttr  # error: [invalid-assignment]
 ```
 

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -9,7 +9,7 @@
 
 use ty_module_resolver::KnownModule;
 
-use super::call::CallArguments;
+use super::call::{Bindings, CallArguments, CallDunderError};
 use super::callable::CallableTypeKind;
 use super::{
     IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeQualifiers,
@@ -118,6 +118,44 @@ pub(super) enum ClassAttributeWriteMember<'db> {
     /// `has_instance_attribute` distinguishes assigning an instance-only declaration through the
     /// class from assigning a wholly unknown attribute.
     Unresolved { has_instance_attribute: bool },
+}
+
+/// The outcome of binding an attribute write against `__setattr__`.
+pub(super) enum SetAttrWriteRequirement<'a, 'db> {
+    /// At least one setter overload accepts the write.
+    Callable(&'a Bindings<'db>),
+    /// The selected setter never returns, so the write cannot complete.
+    Terminal,
+    /// The setter exists, but the call cannot be bound.
+    Invalid,
+    /// No setter was found.
+    Missing,
+}
+
+/// Interprets a bound `__setattr__` call consistently for assignments and protocol writes.
+///
+/// Terminal setters take precedence over other outcomes; possibly-unbound setters remain callable
+/// so their matching overloads can still govern the write.
+pub(super) fn setattr_write_requirement<'a, 'db>(
+    db: &'db dyn Db,
+    result: &'a Result<Bindings<'db>, CallDunderError<'db>>,
+) -> SetAttrWriteRequirement<'a, 'db> {
+    let returns_never = match result {
+        Ok(bindings) => bindings.return_type(db).is_never(),
+        Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
+    };
+    if returns_never {
+        return SetAttrWriteRequirement::Terminal;
+    }
+
+    match result {
+        Ok(bindings) => SetAttrWriteRequirement::Callable(bindings),
+        Err(CallDunderError::PossiblyUnbound { bindings, .. }) => {
+            SetAttrWriteRequirement::Callable(bindings)
+        }
+        Err(CallDunderError::CallError(..)) => SetAttrWriteRequirement::Invalid,
+        Err(CallDunderError::MethodNotAvailable) => SetAttrWriteRequirement::Missing,
+    }
 }
 
 /// How an explicitly resolved member accepts a write.

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -11,7 +11,7 @@ use crate::Db;
 use ty_module_resolver::KnownModule;
 use ty_python_core::use_def_map;
 
-use super::call::CallArguments;
+use super::call::{Bindings, CallArguments, CallDunderError};
 use super::callable::CallableTypeKind;
 use super::{
     IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeQualifiers,
@@ -124,6 +124,45 @@ pub(super) enum ClassAttributeWriteMember<'db> {
     /// `has_instance_attribute` distinguishes assigning an instance-only declaration through the
     /// class from assigning a wholly unknown attribute.
     Unresolved { has_instance_attribute: bool },
+}
+
+/// The outcome of binding an attribute write against `__setattr__`.
+pub(super) enum SetAttrWriteRequirement<'a, 'db> {
+    /// At least one setter overload accepts the write.
+    Callable(&'a Bindings<'db>),
+    /// The selected setter never returns, so the write cannot complete.
+    Terminal,
+    /// The setter exists, but the call cannot be bound.
+    Invalid,
+    /// No setter was found.
+    Missing,
+}
+
+/// Interprets a bound `__setattr__` call consistently for assignments and protocol writes.
+///
+/// Terminal setters take precedence over other outcomes; possibly-unbound setters remain callable
+/// so their matching overloads can still govern the write.
+pub(super) fn setattr_write_requirement<'a, 'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    result: &'a Result<Bindings<'db>, CallDunderError<'db>>,
+) -> SetAttrWriteRequirement<'a, 'db> {
+    let returns_never = match result {
+        Ok(bindings) => bindings.return_type(db, env).is_never(),
+        Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
+    };
+    if returns_never {
+        return SetAttrWriteRequirement::Terminal;
+    }
+
+    match result {
+        Ok(bindings) => SetAttrWriteRequirement::Callable(bindings),
+        Err(CallDunderError::PossiblyUnbound { bindings, .. }) => {
+            SetAttrWriteRequirement::Callable(bindings)
+        }
+        Err(CallDunderError::CallError(..)) => SetAttrWriteRequirement::Invalid,
+        Err(CallDunderError::MethodNotAvailable) => SetAttrWriteRequirement::Missing,
+    }
 }
 
 /// How an explicitly resolved member accepts a write.

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -6,7 +6,8 @@ use crate::place::{DefinedPlace, Place, PlaceAndQualifiers};
 use crate::types::attribute_write::{
     AttributeWriteRequirement, ClassAttributeWriteMember, ExplicitAttributeWriteRequirement,
     FallbackAttributeWriteRequirement, InstanceAttributeWriteMember,
-    ProtocolMemberWriteRequirement, attribute_write_requirement, property_setter_returns_never,
+    ProtocolMemberWriteRequirement, SetAttrWriteRequirement, attribute_write_requirement,
+    property_setter_returns_never, setattr_write_requirement,
 };
 use crate::types::call::{Bindings, CallArguments, CallError};
 use crate::types::diagnostic::{
@@ -357,11 +358,8 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         };
 
         // A terminal `__setattr__` blocks even explicitly declared attributes.
-        let setattr_returns_never = match &setattr_result {
-            Ok(bindings) => bindings.return_type(db).is_never(),
-            Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
-        };
-        if setattr_returns_never {
+        let setattr_requirement = setattr_write_requirement(db, &setattr_result);
+        if matches!(setattr_requirement, SetAttrWriteRequirement::Terminal) {
             if emit_diagnostics {
                 let is_setattr_synthesized = match object_ty.class_member_with_policy(
                     db,
@@ -408,15 +406,15 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             InstanceAttributeWriteMember::Instance(fallback) => {
                 self.evaluate_instance_fallback(object_ty, fallback, emit_diagnostics)
             }
-            InstanceAttributeWriteMember::SetAttr => match setattr_result {
-                Ok(_) | Err(CallDunderError::PossiblyUnbound { .. }) => true,
-                Err(CallDunderError::CallError(..)) => {
+            InstanceAttributeWriteMember::SetAttr => match setattr_requirement {
+                SetAttrWriteRequirement::Callable(_) => true,
+                SetAttrWriteRequirement::Invalid => {
                     if emit_diagnostics {
                         self.report(AssignmentAttributeWriteDiagnostic::BadSetAttr { value_ty });
                     }
                     false
                 }
-                Err(CallDunderError::MethodNotAvailable) => {
+                SetAttrWriteRequirement::Missing => {
                     if emit_diagnostics {
                         self.report(AssignmentAttributeWriteDiagnostic::Unresolved {
                             with_period: false,
@@ -424,6 +422,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     }
                     false
                 }
+                SetAttrWriteRequirement::Terminal => false,
             },
         }
     }
@@ -468,11 +467,8 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 let db = self.builder.db();
                 let (setattr_result, value_ty) =
                     self.infer_and_try_call_setattr(object_ty, emit_diagnostics);
-                let setattr_returns_never = match &setattr_result {
-                    Ok(bindings) => bindings.return_type(db).is_never(),
-                    Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
-                };
-                if setattr_returns_never {
+                let setattr_requirement = setattr_write_requirement(db, &setattr_result);
+                if matches!(setattr_requirement, SetAttrWriteRequirement::Terminal) {
                     if emit_diagnostics {
                         self.report(AssignmentAttributeWriteDiagnostic::TerminalSetAttr {
                             member_exists: false,
@@ -482,9 +478,9 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     return false;
                 }
 
-                match setattr_result {
-                    Ok(_) | Err(CallDunderError::PossiblyUnbound { .. }) => true,
-                    Err(CallDunderError::CallError(..)) => {
+                match setattr_requirement {
+                    SetAttrWriteRequirement::Callable(_) => true,
+                    SetAttrWriteRequirement::Invalid => {
                         if emit_diagnostics {
                             self.report(AssignmentAttributeWriteDiagnostic::BadSetAttr {
                                 value_ty,
@@ -492,7 +488,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         }
                         false
                     }
-                    Err(CallDunderError::MethodNotAvailable) => {
+                    SetAttrWriteRequirement::Missing => {
                         if emit_diagnostics {
                             self.report(if *has_instance_attribute {
                                 AssignmentAttributeWriteDiagnostic::CannotAssignToInstanceAttribute
@@ -502,6 +498,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         }
                         false
                     }
+                    SetAttrWriteRequirement::Terminal => false,
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -6,7 +6,8 @@ use crate::place::{DefinedPlace, Place, PlaceAndQualifiers};
 use crate::types::attribute_write::{
     AttributeWriteRequirement, ClassAttributeWriteMember, ExplicitAttributeWriteRequirement,
     FallbackAttributeWriteRequirement, InstanceAttributeWriteMember,
-    ProtocolMemberWriteRequirement, attribute_write_requirement, property_setter_returns_never,
+    ProtocolMemberWriteRequirement, SetAttrWriteRequirement, attribute_write_requirement,
+    property_setter_returns_never, setattr_write_requirement,
 };
 use crate::types::call::{Bindings, CallArguments, CallDiagnosticOverride, CallError};
 use crate::types::class::FrozenDataclassDispatch;
@@ -402,13 +403,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         };
 
         // A terminal `__setattr__` blocks even explicitly declared attributes.
-        let setattr_returns_never = matches!(
-            frozen_dataclass_dispatch,
-            Some(FrozenDataclassDispatch::FrozenField)
-        ) || match &setattr_result {
-            Ok(bindings) => bindings.return_type(db, env).is_never(),
-            Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
-        };
+        let setattr_requirement = setattr_write_requirement(db, env, &setattr_result);
+        let setattr_returns_never =
+            matches!(
+                frozen_dataclass_dispatch,
+                Some(FrozenDataclassDispatch::FrozenField)
+            ) || matches!(setattr_requirement, SetAttrWriteRequirement::Terminal);
 
         // We could also model this more precisely by synthesizing a `__setattr__`overload set
         // that only disallows mutation on non-private fields, but for now, we just suppress the
@@ -485,10 +485,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             InstanceAttributeWriteMember::Instance(fallback) => {
                 self.evaluate_instance_fallback(object_ty, fallback, emit_diagnostics)
             }
-            InstanceAttributeWriteMember::SetAttr => match setattr_result {
-                Ok(_) | Err(CallDunderError::PossiblyUnbound { .. }) => true,
-                Err(CallDunderError::CallError(kind, bindings, _)) => {
-                    if emit_diagnostics {
+            InstanceAttributeWriteMember::SetAttr => match setattr_requirement {
+                SetAttrWriteRequirement::Callable(_) => true,
+                SetAttrWriteRequirement::Invalid => {
+                    if emit_diagnostics
+                        && let Err(CallDunderError::CallError(kind, bindings, _)) = setattr_result
+                    {
                         self.report(AssignmentAttributeWriteDiagnostic::BadSetAttr {
                             value_ty,
                             failure: CallError(kind, bindings),
@@ -496,7 +498,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     }
                     false
                 }
-                Err(CallDunderError::MethodNotAvailable)
+                SetAttrWriteRequirement::Missing
                     if matches!(
                         frozen_dataclass_dispatch,
                         Some(FrozenDataclassDispatch::Delegate(_))
@@ -504,7 +506,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 {
                     true
                 }
-                Err(CallDunderError::MethodNotAvailable) => {
+                SetAttrWriteRequirement::Missing => {
                     if emit_diagnostics {
                         self.report(AssignmentAttributeWriteDiagnostic::Unresolved {
                             with_period: false,
@@ -512,6 +514,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     }
                     false
                 }
+                SetAttrWriteRequirement::Terminal => false,
             },
         }
     }
@@ -557,11 +560,8 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             } => {
                 let (setattr_result, value_ty) =
                     self.infer_and_try_call_setattr(object_ty, emit_diagnostics);
-                let setattr_returns_never = match &setattr_result {
-                    Ok(bindings) => bindings.return_type(db, env).is_never(),
-                    Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
-                };
-                if setattr_returns_never {
+                let setattr_requirement = setattr_write_requirement(db, env, &setattr_result);
+                if matches!(setattr_requirement, SetAttrWriteRequirement::Terminal) {
                     if emit_diagnostics {
                         self.report(AssignmentAttributeWriteDiagnostic::TerminalSetAttr {
                             member_exists: false,
@@ -571,10 +571,13 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     return false;
                 }
 
-                match setattr_result {
-                    Ok(_) | Err(CallDunderError::PossiblyUnbound { .. }) => true,
-                    Err(CallDunderError::CallError(kind, bindings, _)) => {
-                        if emit_diagnostics {
+                match setattr_requirement {
+                    SetAttrWriteRequirement::Callable(_) => true,
+                    SetAttrWriteRequirement::Invalid => {
+                        if emit_diagnostics
+                            && let Err(CallDunderError::CallError(kind, bindings, _)) =
+                                setattr_result
+                        {
                             self.report(AssignmentAttributeWriteDiagnostic::BadSetAttr {
                                 value_ty,
                                 failure: CallError(kind, bindings),
@@ -582,7 +585,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         }
                         false
                     }
-                    Err(CallDunderError::MethodNotAvailable) => {
+                    SetAttrWriteRequirement::Missing => {
                         if emit_diagnostics {
                             self.report(if *has_instance_attribute {
                                 AssignmentAttributeWriteDiagnostic::CannotAssignToInstanceAttribute
@@ -592,6 +595,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         }
                         false
                     }
+                    SetAttrWriteRequirement::Terminal => false,
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1964,7 +1964,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 self.check_instance_property_write(db, *object_ty, member, member_name, value_ty)
             }
             AttributeWriteRequirement::Class { object_ty, member } => {
-                self.check_class_property_write(db, *object_ty, member, value_ty)
+                self.check_class_property_write(db, *object_ty, member, member_name, value_ty)
             }
         }
     }
@@ -2024,6 +2024,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         db: &'db dyn Db,
         object_ty: Type<'db>,
         member: &ClassAttributeWriteMember<'db>,
+        member_name: &str,
         value_ty: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
         match member {
@@ -2044,7 +2045,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             ClassAttributeWriteMember::ClassAttribute(fallback) => {
                 self.check_fallback_property_write(db, fallback, value_ty)
             }
-            ClassAttributeWriteMember::Unresolved { .. } => self.never(),
+            ClassAttributeWriteMember::Unresolved { .. } => {
+                self.check_class_setattr_property_write(db, object_ty, member_name, value_ty)
+            }
         }
     }
 
@@ -2123,6 +2126,69 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         };
 
         self.check_callable_write_parameter(db, setattr_ty, 1, object_ty, value_ty)
+    }
+
+    fn check_class_setattr_property_write(
+        &self,
+        db: &'db dyn Db,
+        object_ty: Type<'db>,
+        member_name: &str,
+        value_ty: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        if let Type::Union(union) = value_ty {
+            return union
+                .elements(db)
+                .iter()
+                .when_all(db, self.constraints, |value_ty| {
+                    self.check_class_setattr_property_write(db, object_ty, member_name, *value_ty)
+                });
+        }
+
+        let setattr_result = object_ty.try_call_dunder_with_policy(
+            db,
+            "__setattr__",
+            &mut CallArguments::positional([Type::string_literal(db, member_name), value_ty]),
+            TypeContext::default(),
+            MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+        );
+        if match &setattr_result {
+            Ok(bindings) => bindings.return_type(db).is_never(),
+            Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
+        } {
+            return self.never();
+        }
+
+        let setattr_bindings = match &setattr_result {
+            Ok(bindings) => bindings,
+            Err(CallDunderError::PossiblyUnbound { bindings, .. }) => bindings,
+            Err(CallDunderError::CallError(..) | CallDunderError::MethodNotAvailable) => {
+                return self.never();
+            }
+        };
+        setattr_bindings
+            .iter_flat()
+            .when_all(db, self.constraints, |callable| {
+                callable
+                    .matching_overloads()
+                    .when_any(db, self.constraints, |(_, overload)| {
+                        overload
+                            .argument_matches()
+                            .get(1 + usize::from(callable.bound_type.is_some()))
+                            .when_some_and(db, self.constraints, |argument| {
+                                argument.parameters.iter().when_all(
+                                    db,
+                                    self.constraints,
+                                    |parameter| {
+                                        let write_ty = overload.signature.parameters()
+                                            [parameter.index]
+                                            .annotated_type()
+                                            .bind_self_typevars(db, object_ty);
+                                        self.check_type_pair(db, value_ty, write_ty)
+                                    },
+                                )
+                            })
+                    })
+            })
     }
 
     fn check_callable_write_parameter(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -9,9 +9,10 @@ use rustc_hash::FxHashMap;
 use crate::types::attribute_write::{
     AttributeWriteRequirement, ClassAttributeWriteMember, ExplicitAttributeWriteRequirement,
     FallbackAttributeWriteRequirement, InstanceAttributeWriteMember,
-    ProtocolMemberWriteRequirement, attribute_write_requirement,
+    ProtocolMemberWriteRequirement, SetAttrWriteRequirement, attribute_write_requirement,
+    setattr_write_requirement,
 };
-use crate::types::call::{CallArguments, CallDunderError};
+use crate::types::call::{Bindings, CallArguments};
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
 use crate::types::visitor::any_over_type;
 use crate::types::{TypeContext, UpcastPolicy};
@@ -1984,10 +1985,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             TypeContext::default(),
             MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
-        if match &setattr_result {
-            Ok(bindings) => bindings.return_type(db).is_never(),
-            Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
-        } {
+        let setattr_requirement = setattr_write_requirement(db, &setattr_result);
+        if matches!(setattr_requirement, SetAttrWriteRequirement::Terminal) {
             return self.never();
         }
 
@@ -2008,13 +2007,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 self.check_fallback_property_write(db, fallback, value_ty)
             }
             InstanceAttributeWriteMember::SetAttr => {
-                if !matches!(
-                    setattr_result,
-                    Ok(_) | Err(CallDunderError::PossiblyUnbound { .. })
-                ) {
-                    return self.never();
+                if value_ty.is_union() {
+                    return self.check_setattr_property_write(db, object_ty, member_name, value_ty);
                 }
-                self.check_setattr_property_write(db, object_ty, value_ty)
+                let SetAttrWriteRequirement::Callable(bindings) = setattr_requirement else {
+                    return self.never();
+                };
+                self.check_bound_setattr_property_write(db, object_ty, bindings, value_ty)
             }
         }
     }
@@ -2046,7 +2045,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 self.check_fallback_property_write(db, fallback, value_ty)
             }
             ClassAttributeWriteMember::Unresolved { .. } => {
-                self.check_class_setattr_property_write(db, object_ty, member_name, value_ty)
+                self.check_setattr_property_write(db, object_ty, member_name, value_ty)
             }
         }
     }
@@ -2107,28 +2106,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         self.check_callable_write_parameter(db, setter_ty, 2, descriptor_ty, value_ty)
     }
 
+    /// Checks an unresolved writable-protocol member against `__setattr__`.
+    ///
+    /// Union writes are checked one member at a time so separate setter overloads can cover them:
+    ///
+    /// ```python
+    /// class Meta(type):
+    ///     @overload
+    ///     def __setattr__(cls, attr: str, value: int) -> None: ...
+    ///     @overload
+    ///     def __setattr__(cls, attr: str, value: str) -> None: ...
+    /// ```
     fn check_setattr_property_write(
-        &self,
-        db: &'db dyn Db,
-        object_ty: Type<'db>,
-        value_ty: Type<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        let Place::Defined(DefinedPlace { ty: setattr_ty, .. }) = object_ty
-            .member_lookup_with_policy(
-                db,
-                "__setattr__",
-                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
-                    | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
-            )
-            .place
-        else {
-            return self.never();
-        };
-
-        self.check_callable_write_parameter(db, setattr_ty, 1, object_ty, value_ty)
-    }
-
-    fn check_class_setattr_property_write(
         &self,
         db: &'db dyn Db,
         object_ty: Type<'db>,
@@ -2140,7 +2129,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .elements(db)
                 .iter()
                 .when_all(db, self.constraints, |value_ty| {
-                    self.check_class_setattr_property_write(db, object_ty, member_name, *value_ty)
+                    self.check_setattr_property_write(db, object_ty, member_name, *value_ty)
                 });
         }
 
@@ -2151,21 +2140,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             TypeContext::default(),
             MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
-        if match &setattr_result {
-            Ok(bindings) => bindings.return_type(db).is_never(),
-            Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
-        } {
+        let SetAttrWriteRequirement::Callable(bindings) =
+            setattr_write_requirement(db, &setattr_result)
+        else {
             return self.never();
-        }
-
-        let setattr_bindings = match &setattr_result {
-            Ok(bindings) => bindings,
-            Err(CallDunderError::PossiblyUnbound { bindings, .. }) => bindings,
-            Err(CallDunderError::CallError(..) | CallDunderError::MethodNotAvailable) => {
-                return self.never();
-            }
         };
-        setattr_bindings
+        self.check_bound_setattr_property_write(db, object_ty, bindings, value_ty)
+    }
+
+    /// Checks the selected setter overloads using their inferred specialization and bound `Self`.
+    fn check_bound_setattr_property_write(
+        &self,
+        db: &'db dyn Db,
+        object_ty: Type<'db>,
+        bindings: &Bindings<'db>,
+        value_ty: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        bindings
             .iter_flat()
             .when_all(db, self.constraints, |callable| {
                 callable
@@ -2174,18 +2165,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         overload
                             .argument_matches()
                             .get(1 + usize::from(callable.bound_type.is_some()))
-                            .when_some_and(db, self.constraints, |argument| {
-                                argument.parameters.iter().when_all(
-                                    db,
-                                    self.constraints,
-                                    |parameter| {
-                                        let write_ty = overload.signature.parameters()
-                                            [parameter.index]
-                                            .annotated_type()
-                                            .bind_self_typevars(db, object_ty);
-                                        self.check_type_pair(db, value_ty, write_ty)
+                            .into_iter()
+                            .flat_map(|argument| &argument.parameters)
+                            .when_all(db, self.constraints, |parameter| {
+                                let write_ty = overload.signature.parameters()[parameter.index]
+                                    .annotated_type()
+                                    .bind_self_typevars(db, object_ty);
+                                let write_ty = overload.specialization(db).map_or(
+                                    write_ty,
+                                    |specialization| {
+                                        write_ty.apply_specialization(db, specialization)
                                     },
-                                )
+                                );
+                                self.check_type_pair(db, value_ty, write_ty)
                             })
                     })
             })

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -10,9 +10,10 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::types::attribute_write::{
     AttributeWriteRequirement, ClassAttributeWriteMember, ExplicitAttributeWriteRequirement,
     FallbackAttributeWriteRequirement, InstanceAttributeWriteMember,
-    ProtocolMemberWriteRequirement, attribute_write_requirement,
+    ProtocolMemberWriteRequirement, SetAttrWriteRequirement, attribute_write_requirement,
+    setattr_write_requirement,
 };
-use crate::types::call::{CallArguments, CallDunderError};
+use crate::types::call::{Bindings, CallArguments};
 use crate::types::overrides::{VariableKind, effective_superclass_variable_kind};
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
 use crate::types::visitor::any_over_type_expanding_aliases;
@@ -2601,10 +2602,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             TypeContext::default(),
             MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
-        if match &setattr_result {
-            Ok(bindings) => bindings.return_type(db, env).is_never(),
-            Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
-        } {
+        let setattr_requirement = setattr_write_requirement(db, env, &setattr_result);
+        if matches!(setattr_requirement, SetAttrWriteRequirement::Terminal) {
             return self.never();
         }
 
@@ -2625,13 +2624,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 self.check_fallback_property_write(db, fallback, value_ty)
             }
             InstanceAttributeWriteMember::SetAttr => {
-                if !matches!(
-                    setattr_result,
-                    Ok(_) | Err(CallDunderError::PossiblyUnbound { .. })
-                ) {
-                    return self.never();
+                if value_ty.is_union() {
+                    return self.check_setattr_property_write(db, object_ty, member_name, value_ty);
                 }
-                self.check_setattr_property_write(db, object_ty, value_ty)
+                let SetAttrWriteRequirement::Callable(bindings) = setattr_requirement else {
+                    return self.never();
+                };
+                self.check_bound_setattr_property_write(db, object_ty, bindings, value_ty)
             }
         }
     }
@@ -2663,7 +2662,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 self.check_fallback_property_write(db, fallback, value_ty)
             }
             ClassAttributeWriteMember::Unresolved { .. } => {
-                self.check_class_setattr_property_write(db, object_ty, member_name, value_ty)
+                self.check_setattr_property_write(db, object_ty, member_name, value_ty)
             }
         }
     }
@@ -2726,30 +2725,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         self.check_callable_write_parameter(db, setter_ty, 2, descriptor_ty, value_ty)
     }
 
+    /// Checks an unresolved writable-protocol member against `__setattr__`.
+    ///
+    /// Union writes are checked one member at a time so separate setter overloads can cover them:
+    ///
+    /// ```python
+    /// class Meta(type):
+    ///     @overload
+    ///     def __setattr__(cls, attr: str, value: int) -> None: ...
+    ///     @overload
+    ///     def __setattr__(cls, attr: str, value: str) -> None: ...
+    /// ```
     fn check_setattr_property_write(
-        &self,
-        db: &'db dyn Db,
-        object_ty: Type<'db>,
-        value_ty: Type<'db>,
-    ) -> ConstraintSet<'db, 'c> {
-        let env = self.env;
-        let Place::Defined(DefinedPlace { ty: setattr_ty, .. }) = object_ty
-            .member_lookup_with_policy(
-                db,
-                env,
-                "__setattr__",
-                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
-                    | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
-            )
-            .place
-        else {
-            return self.never();
-        };
-
-        self.check_callable_write_parameter(db, setattr_ty, 1, object_ty, value_ty)
-    }
-
-    fn check_class_setattr_property_write(
         &self,
         db: &'db dyn Db,
         object_ty: Type<'db>,
@@ -2761,32 +2748,36 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .elements(db)
                 .iter()
                 .when_all(db, self.constraints, |value_ty| {
-                    self.check_class_setattr_property_write(db, object_ty, member_name, *value_ty)
+                    self.check_setattr_property_write(db, object_ty, member_name, *value_ty)
                 });
         }
 
+        let env = self.env;
         let setattr_result = object_ty.try_call_dunder_with_policy(
             db,
+            env,
             "__setattr__",
             &mut CallArguments::positional([Type::string_literal(db, member_name), value_ty]),
             TypeContext::default(),
             MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
-        if match &setattr_result {
-            Ok(bindings) => bindings.return_type(db).is_never(),
-            Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
-        } {
+        let SetAttrWriteRequirement::Callable(bindings) =
+            setattr_write_requirement(db, env, &setattr_result)
+        else {
             return self.never();
-        }
-
-        let setattr_bindings = match &setattr_result {
-            Ok(bindings) => bindings,
-            Err(CallDunderError::PossiblyUnbound { bindings, .. }) => bindings,
-            Err(CallDunderError::CallError(..) | CallDunderError::MethodNotAvailable) => {
-                return self.never();
-            }
         };
-        setattr_bindings
+        self.check_bound_setattr_property_write(db, object_ty, bindings, value_ty)
+    }
+
+    /// Checks the selected setter overloads using their inferred specialization and bound `Self`.
+    fn check_bound_setattr_property_write(
+        &self,
+        db: &'db dyn Db,
+        object_ty: Type<'db>,
+        bindings: &Bindings<'db>,
+        value_ty: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        bindings
             .iter_flat()
             .when_all(db, self.constraints, |callable| {
                 callable
@@ -2795,18 +2786,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         overload
                             .argument_matches()
                             .get(1 + usize::from(callable.bound_type.is_some()))
-                            .when_some_and(db, self.constraints, |argument| {
-                                argument.parameters.iter().when_all(
-                                    db,
-                                    self.constraints,
-                                    |parameter| {
-                                        let write_ty = overload.signature.parameters()
-                                            [parameter.index]
-                                            .annotated_type()
-                                            .bind_self_typevars(db, object_ty);
-                                        self.check_type_pair(db, value_ty, write_ty)
+                            .into_iter()
+                            .flat_map(|argument| &argument.parameters)
+                            .when_all(db, self.constraints, |parameter| {
+                                let write_ty = overload.signature.parameters()[parameter.index]
+                                    .annotated_type()
+                                    .bind_self_typevars(db, self.env, object_ty);
+                                let write_ty = overload.specialization(db).map_or(
+                                    write_ty,
+                                    |specialization| {
+                                        write_ty.apply_specialization(db, specialization)
                                     },
-                                )
+                                );
+                                self.check_type_pair(db, value_ty, write_ty)
                             })
                     })
             })

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2579,7 +2579,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 self.check_instance_property_write(db, *object_ty, member, member_name, value_ty)
             }
             AttributeWriteRequirement::Class { object_ty, member } => {
-                self.check_class_property_write(db, *object_ty, member, value_ty)
+                self.check_class_property_write(db, *object_ty, member, member_name, value_ty)
             }
         }
     }
@@ -2641,6 +2641,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         db: &'db dyn Db,
         object_ty: Type<'db>,
         member: &ClassAttributeWriteMember<'db>,
+        member_name: &str,
         value_ty: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
         match member {
@@ -2661,7 +2662,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             ClassAttributeWriteMember::ClassAttribute(fallback) => {
                 self.check_fallback_property_write(db, fallback, value_ty)
             }
-            ClassAttributeWriteMember::Unresolved { .. } => self.never(),
+            ClassAttributeWriteMember::Unresolved { .. } => {
+                self.check_class_setattr_property_write(db, object_ty, member_name, value_ty)
+            }
         }
     }
 
@@ -2744,6 +2747,69 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         };
 
         self.check_callable_write_parameter(db, setattr_ty, 1, object_ty, value_ty)
+    }
+
+    fn check_class_setattr_property_write(
+        &self,
+        db: &'db dyn Db,
+        object_ty: Type<'db>,
+        member_name: &str,
+        value_ty: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        if let Type::Union(union) = value_ty {
+            return union
+                .elements(db)
+                .iter()
+                .when_all(db, self.constraints, |value_ty| {
+                    self.check_class_setattr_property_write(db, object_ty, member_name, *value_ty)
+                });
+        }
+
+        let setattr_result = object_ty.try_call_dunder_with_policy(
+            db,
+            "__setattr__",
+            &mut CallArguments::positional([Type::string_literal(db, member_name), value_ty]),
+            TypeContext::default(),
+            MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+        );
+        if match &setattr_result {
+            Ok(bindings) => bindings.return_type(db).is_never(),
+            Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
+        } {
+            return self.never();
+        }
+
+        let setattr_bindings = match &setattr_result {
+            Ok(bindings) => bindings,
+            Err(CallDunderError::PossiblyUnbound { bindings, .. }) => bindings,
+            Err(CallDunderError::CallError(..) | CallDunderError::MethodNotAvailable) => {
+                return self.never();
+            }
+        };
+        setattr_bindings
+            .iter_flat()
+            .when_all(db, self.constraints, |callable| {
+                callable
+                    .matching_overloads()
+                    .when_any(db, self.constraints, |(_, overload)| {
+                        overload
+                            .argument_matches()
+                            .get(1 + usize::from(callable.bound_type.is_some()))
+                            .when_some_and(db, self.constraints, |argument| {
+                                argument.parameters.iter().when_all(
+                                    db,
+                                    self.constraints,
+                                    |parameter| {
+                                        let write_ty = overload.signature.parameters()
+                                            [parameter.index]
+                                            .annotated_type()
+                                            .bind_self_typevars(db, object_ty);
+                                        self.check_type_pair(db, value_ty, write_ty)
+                                    },
+                                )
+                            })
+                    })
+            })
     }
 
     fn check_callable_write_parameter(


### PR DESCRIPTION
## Summary

Prior to this change, assignments to an undefined class attribute could be accepted through a metaclass `__setattr__`, while the same class object was rejected when assigned to a protocol with a writable property:

```py
class WritableX(Protocol):
    @property
    def x(self) -> int: ...
    @x.setter
    def x(self, value: int) -> None: ...

class Meta(type):
    def __getattr__(cls, name: str) -> int: ...
    def __setattr__(cls, name: str, value: int) -> None: ...

class C(metaclass=Meta): ...

C.x = 1
value: WritableX = C  # Previously: invalid-assignment
```

This PR adds the missing class-object fallback for unresolved writable protocol members.