### PR TITLE
[ty] Remove unused own-line ignore comments

### DIFF
--- a/crates/ty/tests/cli/fixes.rs
+++ b/crates/ty/tests/cli/fixes.rs
@@ -172,16 +172,20 @@ fn fix() -> anyhow::Result<()> {
         "unused_ignore.py",
         r#"
             x = 1  # ty: ignore[unresolved-reference]
+            values = [
+                # ty: ignore[]
+                1,
+            ]
             "#,
     )?;
 
     assert_cmd_snapshot!(
         case.command().arg("--fix").arg("--warn").arg("unused-ignore-comment"),
-        @r"
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
-    Found 1 diagnostic (1 fixed, 0 remaining).
+    Found 2 diagnostics (2 fixed, 0 remaining).
 
     ----- stderr -----
     "
@@ -189,8 +193,12 @@ fn fix() -> anyhow::Result<()> {
 
     assert_snapshot!(
         fs::read_to_string(case.root().join("unused_ignore.py"))?,
-        @r"
+        @"
+
     x = 1
+    values = [
+        1,
+    ]
     "
     );
 

--- a/crates/ty_python_semantic/src/suppression/unused.rs
+++ b/crates/ty_python_semantic/src/suppression/unused.rs
@@ -1,6 +1,7 @@
 use ruff_db::source::source_text;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_trivia::indentation_at_offset;
+use ruff_source_file::LineRanges;
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use std::fmt::Write as _;
 
@@ -209,6 +210,12 @@ fn remove_comment_fix(suppression: &Suppression, source: &str) -> Fix {
     let comment_end = suppression.comment_range.end();
     let comment_start = suppression.comment_range.start();
     let after_comment = &source[comment_end.to_usize()..];
+
+    if indentation_at_offset(comment_start, source).is_some()
+        && (after_comment.starts_with(['\n', '\r']) || after_comment.is_empty())
+    {
+        return Fix::safe_edit(Edit::range_deletion(source.full_line_range(comment_start)));
+    }
 
     if !after_comment.starts_with(['\n', '\r']) && !after_comment.is_empty() {
         // For example: `# ty: ignore # fmt: off`

--- a/crates/ty_python_semantic/src/suppression/unused.rs
+++ b/crates/ty_python_semantic/src/suppression/unused.rs
@@ -211,12 +211,6 @@ fn remove_comment_fix(suppression: &Suppression, source: &str) -> Fix {
     let comment_start = suppression.comment_range.start();
     let after_comment = &source[comment_end.to_usize()..];
 
-    if indentation_at_offset(comment_start, source).is_some()
-        && (after_comment.starts_with(['\n', '\r']) || after_comment.is_empty())
-    {
-        return Fix::safe_edit(Edit::range_deletion(source.full_line_range(comment_start)));
-    }
-
     if !after_comment.starts_with(['\n', '\r']) && !after_comment.is_empty() {
         // For example: `# ty: ignore # fmt: off`
         // Don't remove the trailing whitespace up to the `ty: ignore` comment
@@ -229,6 +223,10 @@ fn remove_comment_fix(suppression: &Suppression, source: &str) -> Fix {
         }
 
         return Fix::safe_edit(edit);
+    }
+
+    if indentation_at_offset(comment_start, source).is_some() {
+        return Fix::safe_edit(Edit::range_deletion(source.full_line_range(comment_start)));
     }
 
     // Remove any leading whitespace before the comment


### PR DESCRIPTION
## Summary

Follow-up to [the review discussion in #27006](https://github.com/astral-sh/ruff/pull/27006#discussion_r3615478685).

Prior to this change, removing an unused `ty: ignore` on its own line deleted the directive and its indentation but preserved the newline, leaving an empty line behind. We now delete the full line, matching Ruff's behavior while preserving the existing handling for inline ignores and directives followed by another pragma.

```python
# Before
values = [
    # ty: ignore[]
    1,
]

# After
values = [
    1,
]
```

The CLI-fix regression and the relevant suppression tests pass.