### PR TITLE
[`ruff`] Remove redundant `is_literal` check (`RUF016`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs
@@ -88,21 +88,7 @@ pub(crate) fn invalid_index_type(checker: &Checker, expr: &ExprSubscript) {
         return;
     };
 
-    if index_type.is_literal() {
-        // If the index is a literal, require an integer
-        if index_type != CheckableExprType::IntLiteral
-            && index_type != CheckableExprType::BooleanLiteral
-        {
-            checker.report_diagnostic(
-                InvalidIndexType {
-                    value_type: value_type.to_string(),
-                    index_type: index_type.to_string(),
-                    is_slice: false,
-                },
-                index.range(),
-            );
-        }
-    } else if let Expr::Slice(ExprSlice {
+    if let Expr::Slice(ExprSlice {
         lower, upper, step, ..
     }) = index.as_ref()
     {
@@ -110,24 +96,13 @@ pub(crate) fn invalid_index_type(checker: &Checker, expr: &ExprSubscript) {
             let Some(is_slice_type) = CheckableExprType::try_from(is_slice) else {
                 continue;
             };
-            if is_slice_type.is_literal() {
-                // If the index is a slice, require integer or null bounds
-                if !matches!(
-                    is_slice_type,
-                    CheckableExprType::IntLiteral
-                        | CheckableExprType::NoneLiteral
-                        | CheckableExprType::BooleanLiteral
-                ) {
-                    checker.report_diagnostic(
-                        InvalidIndexType {
-                            value_type: value_type.to_string(),
-                            index_type: is_slice_type.to_string(),
-                            is_slice: true,
-                        },
-                        is_slice.range(),
-                    );
-                }
-            } else {
+            // A slice bound must be an integer, `None`, or a boolean.
+            if !matches!(
+                is_slice_type,
+                CheckableExprType::IntLiteral
+                    | CheckableExprType::NoneLiteral
+                    | CheckableExprType::BooleanLiteral
+            ) {
                 checker.report_diagnostic(
                     InvalidIndexType {
                         value_type: value_type.to_string(),
@@ -138,8 +113,11 @@ pub(crate) fn invalid_index_type(checker: &Checker, expr: &ExprSubscript) {
                 );
             }
         }
-    } else {
-        // If it's some other checkable data type, it's a violation
+    } else if !matches!(
+        index_type,
+        CheckableExprType::IntLiteral | CheckableExprType::BooleanLiteral
+    ) {
+        // A non-slice index must be an integer or a boolean.
         checker.report_diagnostic(
             InvalidIndexType {
                 value_type: value_type.to_string(),
@@ -234,19 +212,5 @@ impl CheckableExprType {
             Expr::Lambda(_) => Some(Self::Lambda),
             _ => None,
         }
-    }
-
-    fn is_literal(self) -> bool {
-        matches!(
-            self,
-            Self::StringLiteral
-                | Self::BytesLiteral
-                | Self::IntLiteral
-                | Self::FloatLiteral
-                | Self::ComplexLiteral
-                | Self::BooleanLiteral
-                | Self::NoneLiteral
-                | Self::EllipsisLiteral
-        )
     }
 }


### PR DESCRIPTION
## Summary

A small refactor for `invalid_index_type` rule code, no functional changes introduced.

The code has an `is_literal()` check that isn't actually needed - even when we matched literal, we still then match `Int | Bool` or `Int | Bool | None` explicitly, so we might as well drop `is_literal` completely. Other literals besides `Int | Bool | None` don't carry any meaning here, they're just other unexpected types from `CheckableExprType`, just as `List`, `Set`, etc.

https://github.com/astral-sh/ruff/blob/4fc9653b505dd7784f56afa574ccb11b602d675e/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs#L239-L242

https://github.com/astral-sh/ruff/blob/4fc9653b505dd7784f56afa574ccb11b602d675e/crates/ruff_linter/src/rules/ruff/rules/invalid_index_type.rs#L91-L104

Just a small leftover from the refactor in https://github.com/astral-sh/ruff/pull/8064/changes#diff-0a227bd56e5ecade9d52a2a29e98b681d03951897372742e42a55800481cf97f, when `is_literal` was introduced to replace the old `Expr::Constant`.

## Test Plan

No new tests needed, existing tests pass.

