### PR TITLE
[ty] Contextually infer custom `__setattr__` assignments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2959,6 +2959,27 @@ c = CustomSetAttr()
 c.whatever = 42
 ```
 
+### Contextual inference
+
+The `__setattr__` value parameter provides the expected type when inferring the assigned value:
+
+```py
+from typing import Callable, TypedDict
+
+class Payload(TypedDict):
+    value: int
+
+class ContextSetAttr:
+    def __setattr__(self, name: str, value: Callable[[int], int] | Payload) -> None: ...
+
+instance = ContextSetAttr()
+instance.callback = lambda number: (
+    # error: [unresolved-attribute] "Object of type `int` has no attribute `missing`"
+    number.missing
+)
+instance.payload = {"value": 1}
+```
+
 ### Type of the `name` parameter
 
 If the `name` parameter of the `__setattr__` method is annotated with a (union of) literal type(s),

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -8,7 +8,7 @@ use crate::types::attribute_write::{
     FallbackAttributeWriteRequirement, InstanceAttributeWriteMember,
     ProtocolMemberWriteRequirement, attribute_write_requirement, property_setter_returns_never,
 };
-use crate::types::call::{CallArguments, CallError};
+use crate::types::call::{Bindings, CallArguments, CallError};
 use crate::types::diagnostic::{
     INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_ACCESS, UNRESOLVED_ATTRIBUTE, report_bad_dunder_set_call,
     report_invalid_attribute_assignment, report_possibly_missing_attribute,
@@ -95,6 +95,50 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
     /// The earlier inference was only a trial, so its result was not saved.
     fn infer_with_last_context(&mut self, emit_diagnostics: bool) -> Type<'db> {
         self.infer_value(self.infer_value_ty.last_tcx(), emit_diagnostics)
+    }
+
+    /// Infer an attribute-assignment value using the context provided by `__setattr__`, then
+    /// validate the synthesized setter call and return both its result and the inferred value type.
+    ///
+    /// ```python
+    /// from collections.abc import Callable
+    ///
+    /// class Custom:
+    ///     def __setattr__(self, name: str, value: Callable[[int], int]) -> None: ...
+    ///
+    /// instance = Custom()
+    /// instance.callback = lambda value: value + 1  # `value` is inferred as `int`.
+    /// ```
+    fn infer_and_try_call_setattr(
+        &mut self,
+        object_ty: Type<'db>,
+        emit_diagnostics: bool,
+    ) -> (Result<Bindings<'db>, CallDunderError<'db>>, Type<'db>) {
+        let db = self.builder.db();
+        let name_ty = Type::string_literal(db, self.attribute);
+        let ast_arguments = [
+            ast::ArgOrKeyword::Arg(self.target.value.as_ref()),
+            ast::ArgOrKeyword::Arg(self.value),
+        ];
+        let mut call_arguments = CallArguments::positional([name_ty, Type::unknown()]);
+        let setattr_result = self.builder.infer_and_try_call_dunder(
+            db,
+            object_ty,
+            "__setattr__",
+            MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+            ArgumentsIter::synthesized(&ast_arguments),
+            &mut call_arguments,
+            &mut |builder, (argument_index, _, tcx)| {
+                if argument_index == 0 {
+                    name_ty
+                } else {
+                    self.infer_value_ty.infer_silent(builder, tcx)
+                }
+            },
+            TypeContext::default(),
+        );
+        let value_ty = self.infer_with_last_context(emit_diagnostics);
+        (setattr_result, value_ty)
     }
 
     fn evaluate(
@@ -294,16 +338,25 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         emit_diagnostics: bool,
     ) -> bool {
         let db = self.builder.db();
-        let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
+        let (setattr_result, value_ty) = if matches!(member, InstanceAttributeWriteMember::SetAttr)
+        {
+            self.infer_and_try_call_setattr(object_ty, emit_diagnostics)
+        } else {
+            let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
+            let setattr_result = object_ty.try_call_dunder_with_policy(
+                db,
+                "__setattr__",
+                &mut CallArguments::positional([
+                    Type::string_literal(db, self.attribute),
+                    value_ty,
+                ]),
+                TypeContext::default(),
+                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+            );
+            (setattr_result, value_ty)
+        };
 
         // A terminal `__setattr__` blocks even explicitly declared attributes.
-        let setattr_result = object_ty.try_call_dunder_with_policy(
-            db,
-            "__setattr__",
-            &mut CallArguments::positional([Type::string_literal(db, self.attribute), value_ty]),
-            TypeContext::default(),
-            MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-        );
         let setattr_returns_never = match &setattr_result {
             Ok(bindings) => bindings.return_type(db).is_never(),
             Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
@@ -413,30 +466,8 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 has_instance_attribute,
             } => {
                 let db = self.builder.db();
-                let name_ty = Type::string_literal(db, self.attribute);
-                let ast_arguments = [
-                    ast::ArgOrKeyword::Arg(self.target.value.as_ref()),
-                    ast::ArgOrKeyword::Arg(self.value),
-                ];
-                let mut call_arguments = CallArguments::positional([name_ty, Type::unknown()]);
-                let setattr_result = self.builder.infer_and_try_call_dunder(
-                    db,
-                    object_ty,
-                    "__setattr__",
-                    MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
-                        | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
-                    ArgumentsIter::synthesized(&ast_arguments),
-                    &mut call_arguments,
-                    &mut |builder, (argument_index, _, tcx)| {
-                        if argument_index == 0 {
-                            name_ty
-                        } else {
-                            self.infer_value_ty.infer_silent(builder, tcx)
-                        }
-                    },
-                    TypeContext::default(),
-                );
-                let value_ty = self.infer_with_last_context(emit_diagnostics);
+                let (setattr_result, value_ty) =
+                    self.infer_and_try_call_setattr(object_ty, emit_diagnostics);
                 let setattr_returns_never = match &setattr_result {
                     Ok(bindings) => bindings.return_type(db).is_never(),
                     Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),


### PR DESCRIPTION
## Summary

Prior to this change, we inferred the right-hand side of an unresolved instance-attribute assignment before checking a custom `__setattr__`. That discarded the setter's expected type, leaving lambda parameters as `Unknown` and rejecting otherwise-valid `TypedDict` literals:

```py
class Payload(TypedDict):
    value: int

class Custom:
    def __setattr__(self, name: str, value: Callable[[int], int] | Payload) -> None: ...

instance = Custom()
instance.callback = lambda value: value.missing  # Previously: no diagnostic
instance.payload = {"value": 1}                 # Previously: unresolved-attribute
```

We now contextually infer unresolved instance assignments against the custom setter, so the lambda parameter is correctly inferred as `int` and the `TypedDict` literal is accepted. Explicit attributes and terminal setters retain their existing behavior.
