### PR TITLE
Stabilize Markdown formatting

### DIFF
--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -489,12 +489,6 @@ pub(crate) fn format_source(
             )))
         }
         SourceKind::Markdown(unformatted_document) => {
-            if !settings.preview.is_enabled() {
-                return Err(FormatCommandError::MarkdownExperimental(
-                    path.map(Path::to_path_buf),
-                ));
-            }
-
             if range.is_some() {
                 return Err(FormatCommandError::RangeFormatNotSupported(
                     path.map(Path::to_path_buf),
@@ -830,7 +824,6 @@ pub(crate) enum FormatCommandError {
     Format(Option<PathBuf>, FormatModuleError),
     Write(Option<PathBuf>, SourceError),
     RangeFormatNotSupported(Option<PathBuf>),
-    MarkdownExperimental(Option<PathBuf>),
 }
 
 impl FormatCommandError {
@@ -848,8 +841,7 @@ impl FormatCommandError {
             | Self::Read(path, _)
             | Self::Format(path, _)
             | Self::Write(path, _)
-            | Self::RangeFormatNotSupported(path)
-            | Self::MarkdownExperimental(path) => path.as_deref(),
+            | Self::RangeFormatNotSupported(path) => path.as_deref(),
         }
     }
 }
@@ -885,11 +877,6 @@ impl From<&FormatCommandError> for Diagnostic {
                 DiagnosticId::InvalidCliOption,
                 Severity::Error,
                 "Range formatting is only supported for Python files.",
-            ),
-            FormatCommandError::MarkdownExperimental(_) => Diagnostic::new(
-                DiagnosticId::PreviewFeature,
-                Severity::Warning,
-                "Markdown formatting is experimental, enable preview mode.",
             ),
         };
 
@@ -981,23 +968,6 @@ impl Display for FormatCommandError {
                     write!(
                         f,
                         "{header} Range formatting is only supported for Python files",
-                        header = "Failed to format:".bold()
-                    )
-                }
-            }
-            Self::MarkdownExperimental(path) => {
-                if let Some(path) = path {
-                    write!(
-                        f,
-                        "{header}{path}{colon} Markdown formatting is experimental, enable preview mode.",
-                        header = "Failed to format ".bold(),
-                        path = fs::relativize_path(path).bold(),
-                        colon = ":".bold()
-                    )
-                } else {
-                    write!(
-                        f,
-                        "{header} Markdown formatting is experimental, enable preview mode",
                         header = "Failed to format:".bold()
                     )
                 }

--- a/crates/ruff/tests/cli/format.rs
+++ b/crates/ruff/tests/cli/format.rs
@@ -2504,31 +2504,12 @@ fn cookiecutter_globbing() -> Result<()> {
 }
 
 #[test]
-fn markdown_formatting_preview_disabled() -> Result<()> {
+fn markdown_formatting() -> Result<()> {
     let test = CliTest::new()?;
     let unformatted = test.fixture_path("unformatted.md");
 
     assert_cmd_snapshot!(test.format_command()
-        .args(["--isolated", "--no-preview", "--diff"])
-        .arg(unformatted),
-        @"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: Failed to format CRATE_ROOT/resources/test/fixtures/unformatted.md: Markdown formatting is experimental, enable preview mode.
-    ");
-    Ok(())
-}
-
-#[test]
-fn markdown_formatting_preview_enabled() -> Result<()> {
-    let test = CliTest::new()?;
-    let unformatted = test.fixture_path("unformatted.md");
-
-    assert_cmd_snapshot!(test.format_command()
-        .args(["--isolated", "--preview", "--check"])
+        .args(["--isolated", "--check"])
         .arg(unformatted),
         @r#"
     success: false
@@ -2570,7 +2551,7 @@ fn markdown_formatting_stdin() -> Result<()> {
     let unformatted = fs::read(test.fixture_path("unformatted.md")).unwrap();
 
     assert_cmd_snapshot!(test.format_command()
-        .args(["--isolated", "--preview", "--stdin-filename", "unformatted.md"])
+        .args(["--isolated", "--stdin-filename", "unformatted.md"])
         .arg("-")
         .pass_stdin(unformatted), @r#"
     success: true
@@ -2613,7 +2594,7 @@ print( 'hello' )
     ])?;
 
     assert_cmd_snapshot!(
-        test.format_command().args(["--preview", "--diff", "test.qmd"]),
+        test.format_command().args(["--diff", "test.qmd"]),
         @r#"
     success: false
     exit_code: 1
@@ -2666,14 +2647,11 @@ print( 'hello' )
 
     assert_cmd_snapshot!(
             test.format_command()
-                .args(["format", "--preview", "--check", "."]),
+                .args(["--check", "."]),
             @r#"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
-    io: [TMP]/format: No such file or directory (os error 2)
-    --> format:1:1
-
     unformatted: File would be reformatted
      --> test.bar:1:1
       |

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_extend_from_shared_config.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_extend_from_shared_config.snap
@@ -61,6 +61,7 @@ file_resolver.include = [
 	"**/pyproject.toml",
 	"**/ruff.toml",
 	"**/.ruff.toml",
+	"*.md",
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool.snap
@@ -63,6 +63,7 @@ file_resolver.include = [
 	"**/pyproject.toml",
 	"**/ruff.toml",
 	"**/.ruff.toml",
+	"*.md",
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_target_version_override.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_no_tool_target_version_override.snap
@@ -65,6 +65,7 @@ file_resolver.include = [
 	"**/pyproject.toml",
 	"**/ruff.toml",
 	"**/.ruff.toml",
+	"*.md",
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above.snap
@@ -62,6 +62,7 @@ file_resolver.include = [
 	"**/pyproject.toml",
 	"**/ruff.toml",
 	"**/.ruff.toml",
+	"*.md",
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above_with_tool.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_pyproject_toml_above_with_tool.snap
@@ -63,6 +63,7 @@ file_resolver.include = [
 	"**/pyproject.toml",
 	"**/ruff.toml",
 	"**/.ruff.toml",
+	"*.md",
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above-2.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above-2.snap
@@ -61,6 +61,7 @@ file_resolver.include = [
 	"**/pyproject.toml",
 	"**/ruff.toml",
 	"**/.ruff.toml",
+	"*.md",
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_above.snap
@@ -61,6 +61,7 @@ file_resolver.include = [
 	"**/pyproject.toml",
 	"**/ruff.toml",
 	"**/.ruff.toml",
+	"*.md",
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true

--- a/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_no_target_fallback.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__requires_python_ruff_toml_no_target_fallback.snap
@@ -61,6 +61,7 @@ file_resolver.include = [
 	"**/pyproject.toml",
 	"**/ruff.toml",
 	"**/.ruff.toml",
+	"*.md",
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true

--- a/crates/ruff/tests/cli/snapshots/cli__show_settings__display_default_settings.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__show_settings__display_default_settings.snap
@@ -58,6 +58,7 @@ file_resolver.include = [
 	"**/pyproject.toml",
 	"**/ruff.toml",
 	"**/.ruff.toml",
+	"*.md",
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true

--- a/crates/ruff/tests/cli/snapshots/cli__show_settings__display_settings_from_nested_directory.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__show_settings__display_settings_from_nested_directory.snap
@@ -58,6 +58,7 @@ file_resolver.include = [
 	"**/pyproject.toml",
 	"**/ruff.toml",
 	"**/.ruff.toml",
+	"*.md",
 ]
 file_resolver.extend_include = []
 file_resolver.respect_gitignore = true

--- a/crates/ruff_server/src/format.rs
+++ b/crates/ruff_server/src/format.rs
@@ -33,14 +33,13 @@ pub(crate) enum FormatBackend {
 pub(crate) enum FormatResult {
     Formatted(String),
     Unchanged,
-    PreviewOnly { file_format: &'static str },
 }
 
 impl FormatResult {
     fn into_formatted(self) -> Option<String> {
         match self {
             Self::Formatted(formatted) => Some(formatted),
-            Self::Unchanged | Self::PreviewOnly { .. } => None,
+            Self::Unchanged => None,
         }
     }
 }
@@ -91,13 +90,6 @@ fn format_internal(
             }
         }
         SourceType::Markdown => {
-            if !formatter_settings.preview.is_enabled() {
-                tracing::warn!("Markdown formatting is experimental, enable preview mode.");
-                return Ok(FormatResult::PreviewOnly {
-                    file_format: "Markdown",
-                });
-            }
-
             match format_code_blocks(document.contents(), Some(path), formatter_settings) {
                 MarkdownResult::Formatted(formatted) => Ok(FormatResult::Formatted(formatted)),
                 MarkdownResult::Unchanged => Ok(FormatResult::Unchanged),

--- a/crates/ruff_server/src/server/api/requests/execute_command.rs
+++ b/crates/ruff_server/src/server/api/requests/execute_command.rs
@@ -99,7 +99,7 @@ impl super::SyncRequestHandler for ExecuteCommand {
                         .with_failure_code(ErrorCode::InternalError)?;
                 }
                 SupportedCommand::Format => {
-                    let fixes = super::format::format_full_document(&snapshot, client)?;
+                    let fixes = super::format::format_full_document(&snapshot)?;
                     edit_tracker
                         .set_fixes_for_document(fixes, version)
                         .with_failure_code(ErrorCode::InternalError)?;

--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -24,7 +24,7 @@ impl super::BackgroundDocumentRequestHandler for Format {
 
     fn run_with_snapshot(
         snapshot: Self::Snapshot,
-        client: &Client,
+        _client: &Client,
         _params: types::DocumentFormattingParams,
     ) -> Result<super::FormatResponse> {
         let snapshot = match snapshot {
@@ -37,12 +37,12 @@ impl super::BackgroundDocumentRequestHandler for Format {
             }
         };
 
-        format_document(&snapshot, client)
+        format_document(&snapshot)
     }
 }
 
 /// Formats either a full text document or each individual cell in a single notebook document.
-pub(super) fn format_full_document(snapshot: &DocumentSnapshot, client: &Client) -> Result<Fixes> {
+pub(super) fn format_full_document(snapshot: &DocumentSnapshot) -> Result<Fixes> {
     let mut fixes = Fixes::default();
     let query = snapshot.query();
     let backend = snapshot
@@ -56,21 +56,16 @@ pub(super) fn format_full_document(snapshot: &DocumentSnapshot, client: &Client)
                 .uris()
                 .map(|uri| (uri.clone(), notebook.cell_document_by_uri(uri).unwrap()))
             {
-                if let Some(changes) = format_text_document(
-                    text_document,
-                    query,
-                    snapshot.encoding(),
-                    true,
-                    backend,
-                    client,
-                )? {
+                if let Some(changes) =
+                    format_text_document(text_document, query, snapshot.encoding(), true, backend)?
+                {
                     fixes.insert(uri, changes);
                 }
             }
         }
         DocumentQuery::Text { document, .. } => {
             if let Some(changes) =
-                format_text_document(document, query, snapshot.encoding(), false, backend, client)?
+                format_text_document(document, query, snapshot.encoding(), false, backend)?
             {
                 fixes.insert(snapshot.query().make_key().into_uri(), changes);
             }
@@ -82,10 +77,7 @@ pub(super) fn format_full_document(snapshot: &DocumentSnapshot, client: &Client)
 
 /// Formats either a full text document or an specific notebook cell. If the query within the snapshot is a notebook document
 /// with no selected cell, this will throw an error.
-pub(super) fn format_document(
-    snapshot: &DocumentSnapshot,
-    client: &Client,
-) -> Result<super::FormatResponse> {
+pub(super) fn format_document(snapshot: &DocumentSnapshot) -> Result<super::FormatResponse> {
     let text_document = snapshot
         .query()
         .as_single_document()
@@ -102,7 +94,6 @@ pub(super) fn format_document(
         snapshot.encoding(),
         query.as_notebook().is_some(),
         backend,
-        client,
     )
 }
 
@@ -112,7 +103,6 @@ fn format_text_document(
     encoding: PositionEncoding,
     is_notebook: bool,
     backend: crate::format::FormatBackend,
-    client: &Client,
 ) -> Result<super::FormatResponse> {
     let settings = query.settings();
     let file_path = query.virtual_file_path();
@@ -140,14 +130,6 @@ fn format_text_document(
     let mut formatted = match formatted {
         FormatResult::Formatted(formatted) => formatted,
         FormatResult::Unchanged => return Ok(None),
-        FormatResult::PreviewOnly { file_format } => {
-            client.show_warning_message(
-                format_args!(
-                    "{file_format} formatting is available only in preview mode. Enable `format.preview = true` in your Ruff configuration."
-                ),
-            );
-            return Ok(None);
-        }
     };
 
     // special case - avoid adding a newline to a notebook cell if it didn't already exist

--- a/crates/ruff_server/tests/e2e/custom_extension.rs
+++ b/crates/ruff_server/tests/e2e/custom_extension.rs
@@ -5,11 +5,7 @@ use lsp_types::{Position, Range};
 use crate::TestServerBuilder;
 
 const CUSTOM_EXTENSION_CONFIG: &str = r#"[tool.ruff]
-preview = true
 extension = { thing = "markdown" }
-
-[tool.ruff.format]
-preview = true
 "#;
 
 const CUSTOM_EXTENSION_MARKDOWN: &str = "# title\n\n```python\nx='hi'\n```\n";

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -335,24 +335,20 @@ impl Configuration {
                 extend_exclude: FilePatternSet::try_from_iter(self.extend_exclude)?,
                 extend_include: FilePatternSet::try_from_iter(self.extend_include)?,
                 force_exclude: self.force_exclude.unwrap_or(false),
-                include: match global_preview {
-                    PreviewMode::Disabled => FilePatternSet::try_from_iter(
-                        self.include.unwrap_or_else(|| INCLUDE.to_vec()),
-                    )?,
-                    PreviewMode::Enabled => {
-                        FilePatternSet::try_from_iter(self.include.unwrap_or_else(|| {
-                            let mut patterns = INCLUDE_PREVIEW.to_vec();
-                            if let Some(extension_map) = &self.extension {
-                                patterns.extend(
-                                    extension_map
-                                        .extensions()
-                                        .map(|ext| FilePattern::Config(format!("*.{ext}"))),
-                                );
-                            }
-                            patterns
-                        }))?
+                include: FilePatternSet::try_from_iter(self.include.unwrap_or_else(|| {
+                    let mut patterns = match global_preview {
+                        PreviewMode::Disabled => INCLUDE.to_vec(),
+                        PreviewMode::Enabled => INCLUDE_PREVIEW.to_vec(),
+                    };
+                    if let Some(extension_map) = &self.extension {
+                        patterns.extend(
+                            extension_map
+                                .extensions()
+                                .map(|ext| FilePattern::Config(format!("*.{ext}"))),
+                        );
                     }
-                },
+                    patterns
+                }))?,
                 respect_gitignore: self.respect_gitignore.unwrap_or(true),
                 project_root: project_root.to_path_buf(),
             },

--- a/crates/ruff_workspace/src/settings.rs
+++ b/crates/ruff_workspace/src/settings.rs
@@ -145,6 +145,7 @@ pub(crate) static INCLUDE: &[FilePattern] = &[
     FilePattern::Builtin("**/pyproject.toml"),
     FilePattern::Builtin("**/ruff.toml"),
     FilePattern::Builtin("**/.ruff.toml"),
+    FilePattern::Builtin("*.md"),
 ];
 pub(crate) static INCLUDE_PREVIEW: &[FilePattern] = &[
     FilePattern::Builtin("*.py"),

--- a/docs/editors/features.md
+++ b/docs/editors/features.md
@@ -41,9 +41,6 @@ alt="Formatting a document in VS Code"
 
 ### Markdown code blocks
 
-*This feature is currently only available in
-[preview mode](https://docs.astral.sh/ruff/preview/#preview).*
-
 The Ruff formatter can also format Python code blocks in Markdown files.
 The Ruff VS Code extension provides the `Format Document` command for
 Markdown files, which will then format the code blocks with the same settings
@@ -54,15 +51,6 @@ to use Ruff formatting in addition to another Markdown formatting extension,
 then you will need to set one as the default in VS Code, and manually run
 the `Format Document With...` (or `Ruff: Format document`) command to run any
 other formatters separately.
-
-To enable preview mode for formatting in VS Code, add the following to your
-`settings.json`:
-
-```json
-{
-  "ruff.format.preview": true,
-}
-```
 
 To set Ruff as the default formatter for Markdown files in VS Code, add the
 following to your `settings.json`:

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -227,8 +227,6 @@ def f(x):
 
 ## Markdown code formatting
 
-*This feature is currently only available in [preview mode](preview.md#preview).*
-
 The Ruff formatter can also format Python code blocks in Markdown files.
 In these files, Ruff will format any CommonMark [fenced code blocks][] with
 the following info strings: `python`, `py`, `python3`, `py3`, or `pyi`. The


### PR DESCRIPTION
Summary
--

This PR stabilizes the Markdown formatting initially added in #22470. It also reverts much of the
error plumbing in the LSP that was added in #24150. I considered keeping the
`FormatResult::PreviewOnly` variant but went ahead and dropped it since it was unused.

Closes #26866.

Test Plan
--

Updated existing snapshots, dropping `--preview` in some cases
