### PR TITLE
[ty] Check inherited method conflicts via the MRO

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -211,7 +211,7 @@ static TANJUN: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    120,
+    124,
 );
 
 static STATIC_FRAME: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -635,6 +635,179 @@ class ProtocolWithClassVarImpl(ProtocolBase):
     instance_attr = 0
 ```
 
+## Inherited method conflicts in a resolved MRO
+
+Every method definition in a resolved MRO must be Liskov-compatible with later definitions of the
+same method. This also applies when the subclass does not define the method itself, when the
+conflicting definitions occur on later bases, and when an earlier method happens to satisfy both
+contracts.
+
+```pyi
+from typing import Any, Generic, NoReturn, TypeVar, overload
+
+T = TypeVar("T")
+
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class ReturnsBool:
+    def method(self) -> bool: ...
+
+class Compatible(ReturnsBool, ReturnsInt): ...
+class BasicConflict(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
+class Empty: ...
+class LaterBaseConflict(Empty, ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+
+class SatisfiesBoth:
+    def method(self) -> NoReturn: ...
+
+# `SatisfiesBoth.method` is compatible with both definitions, but the resolved MRO still puts
+# `ReturnsStr.method` before the incompatible `ReturnsInt.method`.
+class HiddenConflict(SatisfiesBoth, ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+
+class GenericReturn(Generic[T]):
+    def method(self) -> T: ...
+
+class SpecializedConflict(ReturnsStr, GenericReturn[int]): ...  # error: [invalid-method-override]
+
+class AcceptsInt:
+    def accepts(self, value: int) -> None: ...
+
+class AcceptsAny(AcceptsInt):
+    def accepts(self, value: Any) -> None: ...
+
+class AcceptsStr:
+    def accepts(self, value: str) -> None: ...
+
+# Assignability through `Any` is not transitive, so the full MRO suffix must be checked.
+class GradualConflict(AcceptsStr, AcceptsAny): ...  # error: [invalid-method-override]
+
+class ReceiverBase:
+    @overload
+    @classmethod
+    def selected(cls: type[ReceiverConflict]) -> int: ...
+    @overload
+    @classmethod
+    def selected(cls) -> str: ...
+
+class Left(ReceiverBase): ...
+
+class Right(ReceiverBase):
+    @classmethod
+    def selected(cls) -> str: ...
+
+# The classmethod contracts must be bound using the class whose MRO is being checked.
+class ReceiverConflict(Left, Right): ...  # error: [invalid-method-override]
+```
+
+```snapshot
+error[invalid-method-override]: Base classes for class `BasicConflict` define method `method` incompatibly
+  --> src/mdtest_snippet.pyi:15:7
+   |
+15 | class BasicConflict(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ReturnsStr.method` is incompatible with `ReturnsInt.method`
+   |
+  ::: src/mdtest_snippet.pyi:6:9
+   |
+ 6 |     def method(self) -> str: ...
+   |         ------ `ReturnsStr.method` defined here
+ 7 |
+ 8 | class ReturnsInt:
+ 9 |     def method(self) -> int: ...
+   |         ------ `ReturnsInt.method` defined here
+   |
+info: incompatible return types: `str` is not assignable to `int`
+info: This violates the Liskov Substitution Principle
+```
+
+The MRO walk must preserve the ordinary source-method cases too: assigned functions, indirect and
+generic bases, ordinary dunder methods, descriptor kinds, and classmethod lookup in the presence of
+a same-named metaclass descriptor. The shared `object` tail must not create a duplicate error.
+
+`edge_cases.pyi`:
+
+```pyi
+from typing import Any, Generic, Iterator, TypeVar
+
+T = TypeVar("T")
+
+def returns_str(self) -> str: ...
+
+class Assigned:
+    method = returns_str
+
+class Defined:
+    def method(self) -> int: ...
+
+class AssignedFirst(Assigned, Defined): ...  # error: [invalid-method-override]
+class AssignedSecond(Defined, Assigned): ...  # error: [invalid-method-override]
+
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class Intermediate(ReturnsStr): ...
+class IndirectConflict(Intermediate, ReturnsInt): ...  # error: [invalid-method-override]
+
+class UnreachableShadow(ReturnsStr):
+    if False:
+        method = 0
+
+class UnreachableConflict(ReturnsInt, UnreachableShadow): ...  # error: [invalid-method-override]
+class GenericConflict(Generic[T], ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+
+class IteratesStr:
+    def __iter__(self) -> Iterator[str]: ...
+
+class IteratesInt:
+    def __iter__(self) -> Iterator[int]: ...
+
+class IteratorConflict(IteratesStr, IteratesInt): ...  # error: [invalid-method-override]
+
+class InstanceMethod:
+    def kind(self, value: int) -> int: ...
+
+class StaticMethod:
+    @staticmethod
+    def kind(value: int) -> int: ...
+
+class ClassMethod:
+    @classmethod
+    def kind(cls, value: int) -> int: ...
+
+class InstanceStaticConflict(InstanceMethod, StaticMethod): ...  # error: [invalid-method-override]
+class StaticInstanceConflict(StaticMethod, InstanceMethod): ...  # error: [invalid-method-override]
+class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid-method-override]
+class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # error: [invalid-method-override]
+class StaticClassConflict(StaticMethod, ClassMethod): ...  # error: [invalid-method-override]
+class ClassStaticConflict(ClassMethod, StaticMethod): ...  # error: [invalid-method-override]
+
+class Meta(type):
+    @property
+    def class_method(cls) -> Any: ...
+
+class ReturnsIntClassMethod(metaclass=Meta):
+    @classmethod
+    def class_method(cls) -> int: ...
+
+class ReturnsStrClassMethod:
+    @classmethod
+    def class_method(cls) -> str: ...
+
+class MetaclassConflict(ReturnsIntClassMethod, ReturnsStrClassMethod): ...  # error: [invalid-method-override]
+class Empty: ...
+
+class InvalidStr:
+    def __str__(self) -> int: ...  # error: [invalid-method-override]
+
+class DoesNotRepeatObjectConflict(Empty, InvalidStr): ...
+```
+
 ## The entire class hierarchy is checked
 
 If a child class's method definition is Liskov-compatible with the method definition on its parent

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -680,9 +680,9 @@ info: incompatible return types: `str` is not assignable to `int`
 info: This violates the Liskov Substitution Principle
 ```
 
-### Conflicts between later bases
+### Empty bases do not hide conflicts
 
-An earlier base without the method does not prevent a conflict between the second and third bases.
+An empty base can appear before, between, or after the bases that define the conflicting methods.
 
 ```pyi
 class Empty: ...
@@ -693,7 +693,9 @@ class ReturnsStr:
 class ReturnsInt:
     def method(self) -> int: ...
 
-class LaterBaseConflict(Empty, ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+class EmptyFirst(Empty, ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+class EmptyMiddle(ReturnsStr, Empty, ReturnsInt): ...  # error: [invalid-method-override]
+class EmptyLast(ReturnsStr, ReturnsInt, Empty): ...  # error: [invalid-method-override]
 ```
 
 ### An earlier compatible method satisfies both contracts
@@ -761,6 +763,29 @@ class AcceptsStr:
     def accepts(self, value: str) -> None: ...
 
 class AnyConflict(AcceptsStr, AcceptsAny): ...  # error: [invalid-method-override]
+```
+
+### Dynamic bases only hide later conflicts
+
+An intermediate `Any` base cannot hide a conflict when the effective method is already known. An
+earlier `Any` base can define the effective method, so later base definitions cannot be checked.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```pyi
+from typing import Any
+
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class DynamicMiddle(ReturnsStr, Any, ReturnsInt): ...  # error: [invalid-method-override]
+class DynamicFirst(Any, ReturnsStr, ReturnsInt): ...
 ```
 
 ### Generic bases
@@ -848,40 +873,6 @@ class StringConflict(FirstString, SecondString, Enum):  # error: [invalid-method
     MEMBER = 1
 ```
 
-### Unreachable definitions do not shadow inherited methods
-
-An assignment in an unreachable branch does not replace the method inherited from `ReturnsStr`.
-
-```pyi
-class ReturnsStr:
-    def method(self) -> str: ...
-
-class UnreachableShadow(ReturnsStr):
-    if False:
-        method = 0
-
-class ReturnsInt:
-    def method(self) -> int: ...
-
-class UnreachableConflict(ReturnsInt, UnreachableShadow): ...  # error: [invalid-method-override]
-```
-
-### Special methods
-
-Special methods such as `__iter__` participate in the same compatibility check as other methods.
-
-```pyi
-from typing import Iterator
-
-class IteratesStr:
-    def __iter__(self) -> Iterator[str]: ...
-
-class IteratesInt:
-    def __iter__(self) -> Iterator[int]: ...
-
-class IteratorConflict(IteratesStr, IteratesInt): ...  # error: [invalid-method-override]
-```
-
 ### Instance, static, and class methods
 
 Instance methods, static methods, and class methods are bound differently. Each pair can therefore
@@ -927,7 +918,8 @@ info: This violates the Liskov Substitution Principle
 ### Class methods use the subclass as their receiver
 
 The signature selected for a class method overload can depend on the class used as the receiver.
-Here, binding through `Combined` selects the `int` overload, which conflicts with `Right.selected`.
+Binding through `Combined` selects the `int` overload, which conflicts with `Right.selected`.
+Binding through `Compatible` selects the compatible `str` overload.
 
 ```pyi
 from typing import overload
@@ -947,6 +939,7 @@ class Right(ReceiverBase):
     def selected(cls) -> str: ...
 
 class Combined(Left, Right): ...  # error: [invalid-method-override]
+class Compatible(Left, Right): ...
 ```
 
 ### Metaclass descriptors do not replace class method contracts

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -637,8 +637,8 @@ class ProtocolWithClassVarImpl(ProtocolBase):
 
 ## Inherited method conflicts in multiple inheritance
 
-Every method definition in a class's resolved MRO must be compatible with the later definitions of
-that method. This matters even when the class does not define the method itself.
+The effective method definition in a class's resolved MRO must be compatible with the later
+definitions of that method. This matters even when the class does not define the method itself.
 
 ### Basic conflicts
 
@@ -696,10 +696,10 @@ class ReturnsInt:
 class LaterBaseConflict(Empty, ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
 ```
 
-### An earlier compatible method does not hide a conflict
+### An earlier compatible method satisfies both contracts
 
-`SatisfiesBoth.method` is compatible with both later definitions because it returns `NoReturn`.
-`ReturnsStr.method` is still incompatible with the later `ReturnsInt.method`.
+`SatisfiesBoth.method` is compatible with both later definitions because it returns `NoReturn`. It
+is the effective method for `Compatible`, so the later definitions do not conflict.
 
 ```pyi
 from typing import NoReturn
@@ -713,7 +713,33 @@ class ReturnsStr:
 class ReturnsInt:
     def method(self) -> int: ...
 
-class HiddenConflict(SatisfiesBoth, ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+class Compatible(SatisfiesBoth, ReturnsStr, ReturnsInt): ...
+```
+
+### A compatible subclass override satisfies both contracts
+
+A subclass can provide an implementation that satisfies otherwise-incompatible base definitions.
+
+```pyi
+from typing import NoReturn
+
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class CompatibleReturn(ReturnsStr, ReturnsInt):
+    def method(self) -> NoReturn: ...
+
+class AcceptsStr:
+    def accepts(self, value: str) -> None: ...
+
+class AcceptsInt:
+    def accepts(self, value: int) -> None: ...
+
+class CompatibleParameter(AcceptsStr, AcceptsInt):
+    def accepts(self, value: str | int) -> None: ...
 ```
 
 ### An intermediate `Any` does not hide a conflict

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -635,18 +635,17 @@ class ProtocolWithClassVarImpl(ProtocolBase):
     instance_attr = 0
 ```
 
-## Inherited method conflicts in a resolved MRO
+## Inherited method conflicts in multiple inheritance
 
-Every method definition in a resolved MRO must be Liskov-compatible with later definitions of the
-same method. This also applies when the subclass does not define the method itself, when the
-conflicting definitions occur on later bases, and when an earlier method happens to satisfy both
-contracts.
+Every method definition in a class's resolved MRO must be compatible with the later definitions of
+that method. This matters even when the class does not define the method itself.
+
+### Basic conflicts
+
+`ReturnsStr.method` cannot satisfy the contract inherited from `ReturnsInt`. Returning `bool` is
+compatible because `bool` is a subtype of `int`.
 
 ```pyi
-from typing import Any, Generic, NoReturn, TypeVar, overload
-
-T = TypeVar("T")
-
 class ReturnsStr:
     def method(self) -> str: ...
 
@@ -656,22 +655,75 @@ class ReturnsInt:
 class ReturnsBool:
     def method(self) -> bool: ...
 
-class Compatible(ReturnsBool, ReturnsInt): ...
 class BasicConflict(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
+class Compatible(ReturnsBool, ReturnsInt): ...
+```
+
+```snapshot
+error[invalid-method-override]: Base classes for class `BasicConflict` define method `method` incompatibly
+  --> src/mdtest_snippet.pyi:2:9
+   |
+ 2 |     def method(self) -> str: ...
+   |         ------ `ReturnsStr.method` defined here
+ 3 |
+ 4 | class ReturnsInt:
+ 5 |     def method(self) -> int: ...
+   |         ------ `ReturnsInt.method` defined here
+ 6 |
+ 7 | class ReturnsBool:
+ 8 |     def method(self) -> bool: ...
+ 9 |
+10 | class BasicConflict(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ReturnsStr.method` is incompatible with `ReturnsInt.method`
+   |
+info: incompatible return types: `str` is not assignable to `int`
+info: This violates the Liskov Substitution Principle
+```
+
+### Conflicts between later bases
+
+An earlier base without the method does not prevent a conflict between the second and third bases.
+
+```pyi
 class Empty: ...
+
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
 class LaterBaseConflict(Empty, ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+```
+
+### An earlier compatible method does not hide a conflict
+
+`SatisfiesBoth.method` is compatible with both later definitions because it returns `NoReturn`.
+`ReturnsStr.method` is still incompatible with the later `ReturnsInt.method`.
+
+```pyi
+from typing import NoReturn
 
 class SatisfiesBoth:
     def method(self) -> NoReturn: ...
 
-# `SatisfiesBoth.method` is compatible with both definitions, but the resolved MRO still puts
-# `ReturnsStr.method` before the incompatible `ReturnsInt.method`.
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
 class HiddenConflict(SatisfiesBoth, ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+```
 
-class GenericReturn(Generic[T]):
-    def method(self) -> T: ...
+### An intermediate `Any` does not hide a conflict
 
-class SpecializedConflict(ReturnsStr, GenericReturn[int]): ...  # error: [invalid-method-override]
+`AcceptsAny.accepts` can accept either parameter type, so it is compatible with both adjacent
+definitions. That does not allow `AcceptsStr.accepts` to accept the `int` values required by
+`AcceptsInt.accepts`.
+
+```pyi
+from typing import Any
 
 class AcceptsInt:
     def accepts(self, value: int) -> None: ...
@@ -682,58 +734,54 @@ class AcceptsAny(AcceptsInt):
 class AcceptsStr:
     def accepts(self, value: str) -> None: ...
 
-# Assignability through `Any` is not transitive, so the full MRO suffix must be checked.
-class GradualConflict(AcceptsStr, AcceptsAny): ...  # error: [invalid-method-override]
-
-class ReceiverBase:
-    @overload
-    @classmethod
-    def selected(cls: type[ReceiverConflict]) -> int: ...
-    @overload
-    @classmethod
-    def selected(cls) -> str: ...
-
-class Left(ReceiverBase): ...
-
-class Right(ReceiverBase):
-    @classmethod
-    def selected(cls) -> str: ...
-
-# The classmethod contracts must be bound using the class whose MRO is being checked.
-class ReceiverConflict(Left, Right): ...  # error: [invalid-method-override]
+class AnyConflict(AcceptsStr, AcceptsAny): ...  # error: [invalid-method-override]
 ```
 
-```snapshot
-error[invalid-method-override]: Base classes for class `BasicConflict` define method `method` incompatibly
-  --> src/mdtest_snippet.pyi:15:7
-   |
-15 | class BasicConflict(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ReturnsStr.method` is incompatible with `ReturnsInt.method`
-   |
-  ::: src/mdtest_snippet.pyi:6:9
-   |
- 6 |     def method(self) -> str: ...
-   |         ------ `ReturnsStr.method` defined here
- 7 |
- 8 | class ReturnsInt:
- 9 |     def method(self) -> int: ...
-   |         ------ `ReturnsInt.method` defined here
-   |
-info: incompatible return types: `str` is not assignable to `int`
-info: This violates the Liskov Substitution Principle
-```
+### Generic bases
 
-The MRO walk must preserve the ordinary source-method cases too: assigned functions, indirect and
-generic bases, ordinary dunder methods, descriptor kinds, and classmethod lookup in the presence of
-a same-named metaclass descriptor. The shared `object` tail must not create a duplicate error.
-
-`edge_cases.pyi`:
+A method inherited from `GenericReturn[int]` returns `int`. A plain `Generic[T]` base adds no
+method, but it must not prevent the remaining bases from being checked.
 
 ```pyi
-from typing import Any, Generic, Iterator, TypeVar
+from typing import Generic, TypeVar
 
 T = TypeVar("T")
 
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class GenericReturn(Generic[T]):
+    def method(self) -> T: ...
+
+class SpecializedConflict(ReturnsStr, GenericReturn[int]): ...  # error: [invalid-method-override]
+class GenericBaseConflict(Generic[T], ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+```
+
+### Methods inherited by a direct base
+
+A direct base can inherit the method from one of its own bases.
+
+```pyi
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class Intermediate(ReturnsStr): ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class IndirectConflict(Intermediate, ReturnsInt): ...  # error: [invalid-method-override]
+```
+
+### Functions assigned in a class body
+
+A function assigned in a class body is bound as a method. It can conflict with a method definition
+in either base order.
+
+```pyi
 def returns_str(self) -> str: ...
 
 class Assigned:
@@ -744,22 +792,32 @@ class Defined:
 
 class AssignedFirst(Assigned, Defined): ...  # error: [invalid-method-override]
 class AssignedSecond(Defined, Assigned): ...  # error: [invalid-method-override]
+```
 
+### Unreachable definitions do not shadow inherited methods
+
+An assignment in an unreachable branch does not replace the method inherited from `ReturnsStr`.
+
+```pyi
 class ReturnsStr:
     def method(self) -> str: ...
-
-class ReturnsInt:
-    def method(self) -> int: ...
-
-class Intermediate(ReturnsStr): ...
-class IndirectConflict(Intermediate, ReturnsInt): ...  # error: [invalid-method-override]
 
 class UnreachableShadow(ReturnsStr):
     if False:
         method = 0
 
+class ReturnsInt:
+    def method(self) -> int: ...
+
 class UnreachableConflict(ReturnsInt, UnreachableShadow): ...  # error: [invalid-method-override]
-class GenericConflict(Generic[T], ReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+```
+
+### Special methods
+
+Special methods such as `__iter__` participate in the same compatibility check as other methods.
+
+```pyi
+from typing import Iterator
 
 class IteratesStr:
     def __iter__(self) -> Iterator[str]: ...
@@ -768,7 +826,14 @@ class IteratesInt:
     def __iter__(self) -> Iterator[int]: ...
 
 class IteratorConflict(IteratesStr, IteratesInt): ...  # error: [invalid-method-override]
+```
 
+### Instance, static, and class methods
+
+Instance methods, static methods, and class methods are bound differently. Each pair can therefore
+conflict even when the callable signatures look compatible.
+
+```pyi
 class InstanceMethod:
     def kind(self, value: int) -> int: ...
 
@@ -781,31 +846,91 @@ class ClassMethod:
     def kind(cls, value: int) -> int: ...
 
 class InstanceStaticConflict(InstanceMethod, StaticMethod): ...  # error: [invalid-method-override]
-class StaticInstanceConflict(StaticMethod, InstanceMethod): ...  # error: [invalid-method-override]
-class InstanceClassConflict(InstanceMethod, ClassMethod): ...  # error: [invalid-method-override]
-class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # error: [invalid-method-override]
+class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # snapshot: invalid-method-override
 class StaticClassConflict(StaticMethod, ClassMethod): ...  # error: [invalid-method-override]
-class ClassStaticConflict(ClassMethod, StaticMethod): ...  # error: [invalid-method-override]
+```
+
+```snapshot
+error[invalid-method-override]: Base classes for class `ClassInstanceConflict` define method `kind` incompatibly
+  --> src/mdtest_snippet.pyi:10:9
+   |
+10 |     def kind(cls, value: int) -> int: ...
+   |         ---- `ClassMethod.kind` defined here
+11 |
+12 | class InstanceStaticConflict(InstanceMethod, StaticMethod): ...  # error: [invalid-method-override]
+13 | class ClassInstanceConflict(ClassMethod, InstanceMethod): ...  # snapshot: invalid-method-override
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ClassMethod.kind` is incompatible with `InstanceMethod.kind`
+   |
+  ::: src/mdtest_snippet.pyi:2:9
+   |
+ 2 |     def kind(self, value: int) -> int: ...
+   |         ---- `InstanceMethod.kind` defined here
+   |
+info: `ClassMethod.kind` is a classmethod but `InstanceMethod.kind` is an instance method
+info: This violates the Liskov Substitution Principle
+```
+
+### Class methods use the subclass as their receiver
+
+The signature selected for a class method overload can depend on the class used as the receiver.
+Here, binding through `Combined` selects the `int` overload, which conflicts with `Right.selected`.
+
+```pyi
+from typing import overload
+
+class ReceiverBase:
+    @overload
+    @classmethod
+    def selected(cls: type[Combined]) -> int: ...
+    @overload
+    @classmethod
+    def selected(cls) -> str: ...
+
+class Left(ReceiverBase): ...
+
+class Right(ReceiverBase):
+    @classmethod
+    def selected(cls) -> str: ...
+
+class Combined(Left, Right): ...  # error: [invalid-method-override]
+```
+
+### Metaclass descriptors do not replace class method contracts
+
+Looking up a class method by name on a class object can invoke a same-named descriptor on its
+metaclass. The inherited contract still comes from the class method defined in the class body.
+
+```pyi
+from typing import Any
 
 class Meta(type):
     @property
     def class_method(cls) -> Any: ...
 
-class ReturnsIntClassMethod(metaclass=Meta):
+class ReturnsInt(metaclass=Meta):
     @classmethod
     def class_method(cls) -> int: ...
 
-class ReturnsStrClassMethod:
+class ReturnsStr:
     @classmethod
     def class_method(cls) -> str: ...
 
-class MetaclassConflict(ReturnsIntClassMethod, ReturnsStrClassMethod): ...  # error: [invalid-method-override]
+class MetaclassConflict(ReturnsInt, ReturnsStr): ...  # error: [invalid-method-override]
+```
+
+### The implicit `object` base does not repeat an existing error
+
+Every class eventually inherits from `object`. An otherwise empty base does not add another contract
+for `__str__`: `InvalidStr` receives the ordinary override error, and `Combined` receives no second
+error.
+
+```pyi
 class Empty: ...
 
 class InvalidStr:
     def __str__(self) -> int: ...  # error: [invalid-method-override]
 
-class DoesNotRepeatObjectConflict(Empty, InvalidStr): ...
+class Combined(Empty, InvalidStr): ...
 ```
 
 ## The entire class hierarchy is checked

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -988,6 +988,55 @@ class Parent[U](Base):
 class Child(Parent[str], object): ...
 ```
 
+### Bases with the same name are distinguished
+
+When two bases have the same name, their qualified names make the incompatible methods clear in both
+the primary message and the definition annotations.
+
+`left.pyi`:
+
+```pyi
+class Base:
+    def method(self) -> str: ...
+```
+
+`right.pyi`:
+
+```pyi
+class Base:
+    def method(self) -> int: ...
+```
+
+`main.pyi`:
+
+```pyi
+from left import Base as LeftBase
+from right import Base as RightBase
+
+class Combined(LeftBase, RightBase): ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Base classes for class `Combined` define method `method` incompatibly
+ --> src/main.pyi:4:7
+  |
+4 | class Combined(LeftBase, RightBase): ...  # snapshot: invalid-method-override
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `left.Base.method` is incompatible with `right.Base.method`
+  |
+ ::: src/left.pyi:2:9
+  |
+2 |     def method(self) -> str: ...
+  |         ------ `left.Base.method` defined here
+  |
+ ::: src/right.pyi:2:9
+  |
+2 |     def method(self) -> int: ...
+  |         ------ `right.Base.method` defined here
+  |
+info: incompatible return types: `str` is not assignable to `int`
+info: This violates the Liskov Substitution Principle
+```
+
 ### Inconsistent generic bases do not produce override errors
 
 The type arguments are already inconsistent, so there is no resolved generic MRO to check. The same

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -794,6 +794,34 @@ class AssignedFirst(Assigned, Defined): ...  # error: [invalid-method-override]
 class AssignedSecond(Defined, Assigned): ...  # error: [invalid-method-override]
 ```
 
+### Enum mixins
+
+Ordinary mixin methods continue to contribute inherited contracts when the resulting class is an
+enum, including methods with names that `EnumType` can replace.
+
+```pyi
+from enum import Enum
+from typing import Literal
+
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class MixedEnum(ReturnsStr, ReturnsInt, Enum):  # error: [invalid-method-override]
+    MEMBER = 1
+
+class FirstString:
+    def __str__(self) -> Literal["first"]: ...
+
+class SecondString:
+    def __str__(self) -> Literal["second"]: ...
+
+class StringConflict(FirstString, SecondString, Enum):  # error: [invalid-method-override]
+    MEMBER = 1
+```
+
 ### Unreachable definitions do not shadow inherited methods
 
 An assignment in an unreachable branch does not replace the method inherited from `ReturnsStr`.

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -827,22 +827,21 @@ class ReturnsInt:
 class IndirectConflict(Intermediate, ReturnsInt): ...  # error: [invalid-method-override]
 ```
 
-### Functions assigned in a class body
+### Properties
 
-A function assigned in a class body is bound as a method. It can conflict with a method definition
-in either base order.
+Incompatible properties inherited from different bases are not yet checked.
 
 ```pyi
-def returns_str(self) -> str: ...
+class ReturnsStr:
+    @property
+    def value(self) -> str: ...
 
-class Assigned:
-    method = returns_str
+class ReturnsInt:
+    @property
+    def value(self) -> int: ...
 
-class Defined:
-    def method(self) -> int: ...
-
-class AssignedFirst(Assigned, Defined): ...  # error: [invalid-method-override]
-class AssignedSecond(Defined, Assigned): ...  # error: [invalid-method-override]
+# TODO: Incompatible inherited properties should be reported here.
+class PropertyConflict(ReturnsStr, ReturnsInt): ...
 ```
 
 ### Enum mixins
@@ -1641,6 +1640,24 @@ class DataSub(DataSuper):
     def __post_init__(self, x: int, y: str) -> None:
         self.y = y
         super().__post_init__(x)
+```
+
+## Functions assigned in a class body
+
+A function assigned in a class body is bound as a method. It can conflict with a method definition
+in either base order.
+
+```pyi
+def returns_str(self) -> str: ...
+
+class Assigned:
+    method = returns_str
+
+class Defined:
+    def method(self) -> int: ...
+
+class AssignedFirst(Assigned, Defined): ...  # error: [invalid-method-override]
+class AssignedSecond(Defined, Assigned): ...  # error: [invalid-method-override]
 ```
 
 ## Edge case: function defined in another module and then assigned in a class body

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -988,6 +988,28 @@ class Parent[U](Base):
 class Child(Parent[str], object): ...
 ```
 
+### Inconsistent generic bases do not produce override errors
+
+The type arguments are already inconsistent, so there is no resolved generic MRO to check. The same
+is true for a descendant of the invalid class.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```pyi
+class User: ...
+class Member(User): ...
+
+class Base[T]:
+    def method(self) -> T: ...
+
+class UserBase(Base[User]): ...
+class MemberBase(UserBase, Base[Member]): ...  # error: [invalid-generic-class]
+class MemberChild(MemberBase, object): ...
+```
+
 ## The entire class hierarchy is checked
 
 If a child class's method definition is Liskov-compatible with the method definition on its parent

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -844,6 +844,24 @@ class ReturnsInt:
 class PropertyConflict(ReturnsStr, ReturnsInt): ...
 ```
 
+### Synthesized members
+
+Methods synthesized on an earlier base can conflict with methods defined on a later base.
+
+```pyi
+from functools import total_ordering
+
+@total_ordering
+class Ordered:
+    def __lt__(self, other: Ordered) -> bool: ...
+
+class AcceptsObject:
+    def __gt__(self, other: object) -> bool: ...
+
+# TODO: The synthesized `Ordered.__gt__` method conflicts with `AcceptsObject.__gt__`.
+class SynthesizedConflict(Ordered, AcceptsObject): ...
+```
+
 ### Enum mixins
 
 Ordinary mixin methods continue to contribute inherited contracts when the resulting class is an

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -961,6 +961,33 @@ class InvalidStr:
 class Combined(Empty, InvalidStr): ...
 ```
 
+### Existing violations on generic parents are not repeated
+
+An invalid override on a generic parent is already reported at its definition. Specializing that
+parent and adding another base to a descendant must not report the same violation again.
+
+```toml
+[environment]
+python-version = "3.12"
+
+[rules]
+missing-type-argument = "ignore"
+```
+
+```pyi
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Base(Generic[T]):
+    def method(self, value: object) -> None: ...
+
+class Parent[U](Base):
+    def method(self, value: U) -> None: ...  # error: [invalid-method-override]
+
+class Child(Parent[str], object): ...
+```
+
 ## The entire class hierarchy is checked
 
 If a child class's method definition is Liskov-compatible with the method definition on its parent

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3935,8 +3935,17 @@ pub(super) fn report_incompatible_base_method<'db>(
 
     let (selected_owner, selected_definition, selected_decorator) = selected;
     let (contract_owner, contract_definition, contract_decorator) = contract;
-    let selected_name = selected_owner.name(db);
-    let contract_name = contract_owner.name(db);
+    let (selected_name, contract_name) = if selected_owner.name(db) == contract_owner.name(db) {
+        (
+            selected_owner.qualified_name(db).to_string(),
+            contract_owner.qualified_name(db).to_string(),
+        )
+    } else {
+        (
+            selected_owner.name(db).to_string(),
+            contract_owner.name(db).to_string(),
+        )
+    };
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Base classes for class `{}` define method `{member}` incompatibly",
         class.name(db)

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3559,12 +3559,15 @@ pub(crate) fn report_invalid_typevar_default_reference<'db>(
 /// class Parent(Grandparent[T1, T2]): ...
 /// class BadChild(Parent[T1, T2], Grandparent[T2, T1]): ...  # Error
 /// ```
+///
+/// Returns `true` if an inconsistency was found, even when it is inherited or the diagnostic is
+/// disabled.
 pub(crate) fn report_inconsistent_generic_bases<'db>(
     context: &InferContext<'db, '_>,
     header_range: TextRange,
     explicit_bases: &[Type<'db>],
     base_nodes: Option<&[ast::Expr]>,
-) {
+) -> bool {
     let db = context.db();
     // Maps each generic ancestor's class literal to the first
     // specialization seen and the index of the explicit base it
@@ -3572,7 +3575,7 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
     let mut ancestor_specs =
         FxHashMap::<StaticClassLiteral<'db>, (GenericAlias<'db>, usize)>::default();
 
-    'outer: for (i, base) in explicit_bases.iter().enumerate() {
+    for (i, base) in explicit_bases.iter().enumerate() {
         let base_class = match base {
             Type::GenericAlias(alias) => ClassType::Generic(*alias),
             Type::ClassLiteral(class) if class.generic_context(db).is_none() => {
@@ -3588,17 +3591,19 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
             let origin = supercls_alias.origin(db);
 
             if let Some(&(earlier_alias, earlier_idx)) = ancestor_specs.get(&origin) {
-                if earlier_idx != i
-                    && earlier_alias
-                        .specialization(db)
-                        .types(db)
-                        .iter()
-                        .zip(supercls_alias.specialization(db).types(db))
-                        .any(|(t1, t2)| !t1.is_dynamic() && !t2.is_dynamic() && t1 != t2)
+                if earlier_alias
+                    .specialization(db)
+                    .types(db)
+                    .iter()
+                    .zip(supercls_alias.specialization(db).types(db))
+                    .any(|(t1, t2)| !t1.is_dynamic() && !t2.is_dynamic() && t1 != t2)
                 {
+                    if earlier_idx == i {
+                        return true;
+                    }
                     let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, header_range)
                     else {
-                        break 'outer;
+                        return true;
                     };
                     let mut diagnostic = builder.into_diagnostic(format_args!(
                         "Inconsistent type arguments for `{}` among class bases",
@@ -3651,7 +3656,7 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
                         supercls_alias.display(db),
                         earlier_alias.display(db)
                     ));
-                    break 'outer;
+                    return true;
                 }
             } else if !supercls_alias
                 .specialization(db)
@@ -3663,6 +3668,8 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
             }
         }
     }
+
+    false
 }
 
 pub(crate) fn report_shadowed_type_variable<'db>(

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3911,6 +3911,54 @@ pub(super) fn report_invalid_method_override<'db>(
     }
 }
 
+/// Reports an incompatible pair of source-defined methods in a resolved MRO.
+pub(super) fn report_incompatible_base_method<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+    member: &str,
+    selected: (ClassType<'db>, Definition<'db>, MethodDecorator),
+    contract: (ClassType<'db>, Definition<'db>, MethodDecorator),
+    error_context: impl FnOnce() -> ErrorContextTree<'db>,
+) {
+    let db = context.db();
+    let Some(builder) = context.report_lint(&INVALID_METHOD_OVERRIDE, class.header_range(db))
+    else {
+        return;
+    };
+
+    let (selected_owner, selected_definition, selected_decorator) = selected;
+    let (contract_owner, contract_definition, contract_decorator) = contract;
+    let selected_name = selected_owner.name(db);
+    let contract_name = contract_owner.name(db);
+    let mut diagnostic = builder.into_diagnostic(format_args!(
+        "Base classes for class `{}` define method `{member}` incompatibly",
+        class.name(db)
+    ));
+    diagnostic.set_primary_message(format_args!(
+        "`{selected_name}.{member}` is incompatible with `{contract_name}.{member}`"
+    ));
+    if selected_decorator != contract_decorator {
+        diagnostic.info(format_args!(
+            "`{selected_name}.{member}` is {} but `{contract_name}.{member}` is {}",
+            selected_decorator.description(),
+            contract_decorator.description(),
+        ));
+    }
+    error_context().attach_to(db, &mut diagnostic);
+    diagnostic.info("This violates the Liskov Substitution Principle");
+
+    for (definition, owner_name) in [
+        (selected_definition, selected_name),
+        (contract_definition, contract_name),
+    ] {
+        let module = parsed_module(db, definition.file(db)).load(db);
+        diagnostic.annotate(
+            Annotation::secondary(Span::from(definition.focus_range(db, &module)))
+                .message(format_args!("`{owner_name}.{member}` defined here")),
+        );
+    }
+}
+
 pub(super) fn report_overridden_final_method<'db>(
     context: &InferContext<'db, '_>,
     member: &str,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -444,6 +444,7 @@ pub(crate) fn check_static_class_definitions<'db>(
     }
 
     // Check that the class's MRO is resolvable
+    let mut inconsistent_generic_bases = false;
     match class.try_mro(db, None) {
         Err(mro_error) => match mro_error.reason() {
             StaticMroErrorKind::DuplicateBases(duplicates) => {
@@ -530,7 +531,7 @@ pub(crate) fn check_static_class_definitions<'db>(
             let base_nodes = (class_node.bases().len() == explicit_bases.len()
                 && !class_node.bases().iter().any(ast::Expr::is_starred_expr))
             .then_some(class_node.bases());
-            report_inconsistent_generic_bases(
+            inconsistent_generic_bases = report_inconsistent_generic_bases(
                 context,
                 class.header_range(db),
                 explicit_bases,
@@ -1004,7 +1005,7 @@ pub(crate) fn check_static_class_definitions<'db>(
 
     // (13) Check for violations of the Liskov Substitution Principle,
     // and for violations of other rules relating to invalid overrides of some sort.
-    overrides::check_class(context, class);
+    overrides::check_class(context, class, inconsistent_generic_bases);
 
     // (14) Check compatibility between class namespace values and metaclass-populated attributes.
     check_class_namespace_against_metaclass_members(context, class, index);

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -68,7 +68,11 @@ const PROHIBITED_NAMEDTUPLE_ATTRS: &[&str] = &[
 // TODO: Support dynamic class literals. If we allow dynamic classes to define attributes in their
 // namespace dictionary, we should also check whether those attributes are valid overrides of
 // attributes in their superclasses.
-pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticClassLiteral<'db>) {
+pub(super) fn check_class<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+    inconsistent_generic_bases: bool,
+) {
     let db = context.db();
     let configuration = OverrideRulesConfig::from(context);
     if configuration.no_rules_enabled() {
@@ -76,7 +80,7 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     }
 
     let class_specialized = class.identity_specialization(db);
-    if configuration.check_method_liskov_violations() {
+    if configuration.check_method_liskov_violations() && !inconsistent_generic_bases {
         check_inherited_method_conflicts(context, class, class_specialized);
     }
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -197,7 +197,14 @@ fn check_inherited_method_conflicts<'db>(
                 // This matters for intentionally suppressed typeshed overrides such as
                 // `str.__contains__` versus `Sequence.__contains__`, while still allowing a
                 // receiver-sensitive incompatibility that appears only when rebound to `class`.
-                if owner.is_subclass_of(db, contract_owner) {
+                // Resolve the ancestor in the parent's own MRO so that its generic specialization
+                // matches the one used by the normal Liskov check on the parent.
+                if let Some(parent_contract_owner) = owner
+                    .iter_mro(db)
+                    .skip(1)
+                    .filter_map(ClassBase::into_class)
+                    .find(|ancestor| ancestor.class_literal(db) == contract_owner.class_literal(db))
+                {
                     let parent_receiver = Type::instance(db, owner);
                     let Some((parent_decorator, parent_ty)) =
                         source_method_contract(db, owner, parent_receiver, name)
@@ -205,7 +212,7 @@ fn check_inherited_method_conflicts<'db>(
                         continue;
                     };
                     let Some((ancestor_decorator, ancestor_ty)) =
-                        source_method_contract(db, contract_owner, parent_receiver, name)
+                        source_method_contract(db, parent_contract_owner, parent_receiver, name)
                     else {
                         continue;
                     };

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -136,7 +136,13 @@ fn check_inherited_method_conflicts<'db>(
             Some(ClassBase::Class(base)) if base.static_class_literal(db).is_some() => {
                 direct_bases.push(base);
             }
-            Some(ClassBase::Generic | ClassBase::Protocol) => {}
+            Some(
+                ClassBase::Generic
+                | ClassBase::Protocol
+                | ClassBase::Any
+                | ClassBase::Dynamic(_)
+                | ClassBase::Divergent(_),
+            ) => {}
             _ => return,
         }
     }
@@ -154,16 +160,16 @@ fn check_inherited_method_conflicts<'db>(
     }
 
     let mut mro = Vec::new();
+    let mut first_dynamic_base = None;
     for base in class_specialized.iter_mro(db).skip(1) {
         match base {
             ClassBase::Class(base) if base.is_object(db) => break,
             ClassBase::Class(base) if base.static_class_literal(db).is_some() => mro.push(base),
             ClassBase::Protocol | ClassBase::Generic => {}
-            ClassBase::Any
-            | ClassBase::Dynamic(_)
-            | ClassBase::Divergent(_)
-            | ClassBase::TypedDict(_)
-            | ClassBase::Class(_) => return,
+            ClassBase::Any | ClassBase::Dynamic(_) | ClassBase::Divergent(_) => {
+                first_dynamic_base.get_or_insert(mro.len());
+            }
+            ClassBase::TypedDict(_) | ClassBase::Class(_) => return,
         }
     }
     let receiver = Type::instance(db, class_specialized);
@@ -173,6 +179,9 @@ fn check_inherited_method_conflicts<'db>(
         .collect();
 
     for (index, owner) in mro.iter().copied().enumerate() {
+        if first_dynamic_base.is_some_and(|dynamic_index| index >= dynamic_index) {
+            break;
+        }
         let Some((owner_literal, _)) = owner.static_class_literal(db) else {
             continue;
         };

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -79,13 +79,13 @@ pub(super) fn check_class<'db>(
         return;
     }
 
-    let class_specialized = class.identity_specialization(db);
-    if configuration.check_method_liskov_violations() && !inconsistent_generic_bases {
-        check_inherited_method_conflicts(context, class, class_specialized);
-    }
-
     let scope = class.body_scope(db);
     let own_class_members: FxHashSet<_> = all_end_of_scope_members(db, scope).collect();
+    let class_specialized = class.identity_specialization(db);
+    if configuration.check_method_liskov_violations() && !inconsistent_generic_bases {
+        check_inherited_method_conflicts(context, class, class_specialized, &own_class_members);
+    }
+
     let enum_info = enum_metadata(db, class.into());
 
     #[expect(
@@ -106,9 +106,9 @@ pub(super) fn check_class<'db>(
 
 /// Rechecks methods defined on parents against the remainder of the resolved MRO.
 ///
-/// A multiple-inheritance join can place two otherwise-unrelated classes in the same MRO. Every
-/// source-defined method in that ordering must be compatible with each later definition of the
-/// same method, even if an earlier method happens to satisfy both contracts:
+/// A multiple-inheritance join can place two otherwise-unrelated classes in the same MRO. The
+/// effective source-defined method in that ordering must be compatible with each later definition
+/// of the same method:
 ///
 /// ```python
 /// class ReturnsStr:
@@ -126,6 +126,7 @@ fn check_inherited_method_conflicts<'db>(
     context: &InferContext<'db, '_>,
     class: StaticClassLiteral<'db>,
     class_specialized: ClassType<'db>,
+    own_class_members: &FxHashSet<MemberWithDefinition<'db>>,
 ) {
     let db = context.db();
 
@@ -166,6 +167,10 @@ fn check_inherited_method_conflicts<'db>(
         }
     }
     let receiver = Type::instance(db, class_specialized);
+    let mut seen_names: FxHashSet<_> = own_class_members
+        .iter()
+        .map(|member| member.member.name.clone())
+        .collect();
 
     for (index, owner) in mro.iter().copied().enumerate() {
         let Some((owner_literal, _)) = owner.static_class_literal(db) else {
@@ -180,7 +185,10 @@ fn check_inherited_method_conflicts<'db>(
         )]
         'members: for member in members {
             let name = &member.member.name;
-            if is_mangled_private(name.as_str()) || is_constructor_like_method(name.as_str()) {
+            if is_mangled_private(name.as_str())
+                || is_constructor_like_method(name.as_str())
+                || !seen_names.insert(name.clone())
+            {
                 continue;
             }
             let Some((selected_decorator, selected_ty)) =

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -22,17 +22,18 @@ use crate::{
         CallableType, ClassBase, ClassLiteral, ClassType, IntersectionType, KnownClass, Parameter,
         Parameters, Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
         call::CallArguments,
-        class::{CodeGeneratorKind, FieldKind},
+        class::{CodeGeneratorKind, FieldKind, MethodDecorator},
         constraints::ConstraintSetBuilder,
         context::InferContext,
         diagnostic::{
             INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_OVERRIDE, INVALID_DATACLASS,
             INVALID_EXPLICIT_OVERRIDE, INVALID_METHOD_OVERRIDE, INVALID_NAMED_TUPLE,
             INVALID_NAMED_TUPLE_OVERRIDE, MISSING_OVERRIDE_DECORATOR, OVERRIDE_OF_FINAL_METHOD,
-            OVERRIDE_OF_FINAL_VARIABLE, report_invalid_method_override,
-            report_overridden_final_method, report_overridden_final_variable,
+            OVERRIDE_OF_FINAL_VARIABLE, report_incompatible_base_method,
+            report_invalid_method_override, report_overridden_final_method,
+            report_overridden_final_variable,
         },
-        enums::{EnumMetadata, enum_metadata},
+        enums::{EnumMetadata, enum_metadata, is_enum_class_by_inheritance},
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
         infer::infer_definition_types,
         list_members::{Member, MemberWithDefinition, all_end_of_scope_members},
@@ -75,6 +76,10 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     }
 
     let class_specialized = class.identity_specialization(db);
+    if configuration.check_method_liskov_violations() {
+        check_inherited_method_conflicts(context, class, class_specialized);
+    }
+
     let scope = class.body_scope(db);
     let own_class_members: FxHashSet<_> = all_end_of_scope_members(db, scope).collect();
     let enum_info = enum_metadata(db, class.into());
@@ -93,6 +98,168 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
             &member,
         );
     }
+}
+
+/// Rechecks methods defined on parents against the remainder of the resolved MRO.
+///
+/// A multiple-inheritance join can place two otherwise-unrelated classes in the same MRO. Every
+/// source-defined method in that ordering must be compatible with each later definition of the
+/// same method, even if an earlier method happens to satisfy both contracts.
+fn check_inherited_method_conflicts<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+    class_specialized: ClassType<'db>,
+) {
+    let db = context.db();
+    if is_enum_class_by_inheritance(db, class) {
+        return;
+    }
+
+    let mut direct_bases = Vec::new();
+    for base in class.explicit_bases(db) {
+        match ClassBase::try_from_explicit_base(db, *base, Some(class.into())) {
+            Some(ClassBase::Class(base)) if base.static_class_literal(db).is_some() => {
+                direct_bases.push(base);
+            }
+            Some(ClassBase::Generic | ClassBase::Protocol) => {}
+            _ => return,
+        }
+    }
+    if direct_bases.len() < 2 || class.try_mro(db, None).is_err() {
+        return;
+    }
+
+    let constraints = ConstraintSetBuilder::new();
+    if direct_bases.iter().enumerate().any(|(index, left)| {
+        direct_bases[index + 1..]
+            .iter()
+            .any(|right| !left.could_coexist_in_mro_with(db, *right, &constraints))
+    }) {
+        return;
+    }
+
+    let mut mro = Vec::new();
+    for base in class_specialized.iter_mro(db).skip(1) {
+        match base {
+            ClassBase::Class(base) if base.is_object(db) => break,
+            ClassBase::Class(base) if base.static_class_literal(db).is_some() => mro.push(base),
+            ClassBase::Protocol | ClassBase::Generic => {}
+            ClassBase::Any
+            | ClassBase::Dynamic(_)
+            | ClassBase::Divergent(_)
+            | ClassBase::TypedDict(_)
+            | ClassBase::Class(_) => return,
+        }
+    }
+    let receiver = Type::instance(db, class_specialized);
+
+    for (index, owner) in mro.iter().copied().enumerate() {
+        let Some((owner_literal, _)) = owner.static_class_literal(db) else {
+            continue;
+        };
+        let scope = owner_literal.body_scope(db);
+        let mut members: Vec<_> = all_end_of_scope_members(db, scope)
+            .collect::<FxHashSet<_>>()
+            .into_iter()
+            .collect();
+        members.sort_unstable_by(|left, right| left.member.name.cmp(&right.member.name));
+
+        'members: for member in members {
+            let name = &member.member.name;
+            if is_mangled_private(name.as_str()) || is_constructor_like_method(name.as_str()) {
+                continue;
+            }
+            let Some((selected_decorator, selected_ty)) =
+                source_method_contract(db, owner, receiver, name)
+            else {
+                continue;
+            };
+
+            for contract_owner in mro[index + 1..].iter().copied() {
+                let Some((contract_decorator, contract_ty)) =
+                    source_method_contract(db, contract_owner, receiver, name)
+                else {
+                    continue;
+                };
+                let Some((selected_ty, contract_ty)) =
+                    method_override_types(db, selected_ty, contract_ty)
+                else {
+                    continue;
+                };
+                if selected_decorator == contract_decorator
+                    && selected_ty.is_assignable_to(db, contract_ty)
+                {
+                    continue;
+                }
+
+                // Do not re-emit an incompatibility that already exists in the parent's own MRO.
+                // This matters for intentionally suppressed typeshed overrides such as
+                // `str.__contains__` versus `Sequence.__contains__`, while still allowing a
+                // receiver-sensitive incompatibility that appears only when rebound to `class`.
+                if owner.is_subclass_of(db, contract_owner) {
+                    let parent_receiver = Type::instance(db, owner);
+                    let Some((parent_decorator, parent_ty)) =
+                        source_method_contract(db, owner, parent_receiver, name)
+                    else {
+                        continue;
+                    };
+                    let Some((ancestor_decorator, ancestor_ty)) =
+                        source_method_contract(db, contract_owner, parent_receiver, name)
+                    else {
+                        continue;
+                    };
+                    if parent_decorator != ancestor_decorator
+                        || !is_assignable_method_override(db, parent_ty, ancestor_ty)
+                    {
+                        continue;
+                    }
+                }
+
+                let Some((contract_literal, _)) = contract_owner.static_class_literal(db) else {
+                    continue;
+                };
+                let contract_scope = contract_literal.body_scope(db);
+                let Some(contract_symbol) = place_table(db, contract_scope).symbol_id(name) else {
+                    continue;
+                };
+                let Some(contract_definition) =
+                    symbol_definition(db, contract_scope, contract_symbol)
+                else {
+                    continue;
+                };
+                report_incompatible_base_method(
+                    context,
+                    class,
+                    name,
+                    (owner, member.first_reachable_definition, selected_decorator),
+                    (contract_owner, contract_definition, contract_decorator),
+                    || selected_ty.assignability_error_context(db, contract_ty),
+                );
+                continue 'members;
+            }
+        }
+    }
+}
+
+/// Returns a source-defined method bound to the class whose MRO is being checked.
+fn source_method_contract<'db>(
+    db: &'db dyn Db,
+    owner: ClassType<'db>,
+    receiver: Type<'db>,
+    name: &Name,
+) -> Option<(MethodDecorator, Type<'db>)> {
+    let Type::FunctionLiteral(function) = owner
+        .own_class_member(db, None, name)
+        .inner
+        .place
+        .raw_type()?
+    else {
+        return None;
+    };
+    let ty = Type::FunctionLiteral(function)
+        .try_call_dunder_get(db, Some(receiver), receiver.to_meta_type(db))?
+        .0;
+    Some((MethodDecorator::try_from_fn_type(db, function)?, ty))
 }
 
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -108,7 +108,20 @@ pub(super) fn check_class<'db>(
 ///
 /// A multiple-inheritance join can place two otherwise-unrelated classes in the same MRO. Every
 /// source-defined method in that ordering must be compatible with each later definition of the
-/// same method, even if an earlier method happens to satisfy both contracts.
+/// same method, even if an earlier method happens to satisfy both contracts:
+///
+/// ```python
+/// class ReturnsStr:
+///     def method(self) -> str: ...
+///
+/// class ReturnsInt:
+///     def method(self) -> int: ...
+///
+/// class Combined(ReturnsStr, ReturnsInt): ...  # Error
+/// ```
+///
+/// The caller skips classes with inconsistent generic bases, since their specialized MRO is not a
+/// valid contract to check.
 fn check_inherited_method_conflicts<'db>(
     context: &InferContext<'db, '_>,
     class: StaticClassLiteral<'db>,
@@ -159,12 +172,12 @@ fn check_inherited_method_conflicts<'db>(
             continue;
         };
         let scope = owner_literal.body_scope(db);
-        let mut members: Vec<_> = all_end_of_scope_members(db, scope)
-            .collect::<FxHashSet<_>>()
-            .into_iter()
-            .collect();
-        members.sort_unstable_by(|left, right| left.member.name.cmp(&right.member.name));
+        let members: FxHashSet<_> = all_end_of_scope_members(db, scope).collect();
 
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "each class member is checked independently"
+        )]
         'members: for member in members {
             let name = &member.member.name;
             if is_mangled_private(name.as_str()) || is_constructor_like_method(name.as_str()) {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -206,6 +206,19 @@ fn check_inherited_method_conflicts<'db>(
                     continue;
                 }
 
+                // `EnumType` can replace mixin dunders while constructing the enum, so the
+                // inherited definitions do not necessarily describe the resulting method. For
+                // example, `Status.__format__` is supplied during class creation here:
+                //
+                // ```python
+                // from enum import Enum
+                //
+                // class Status(int, Enum):
+                //     READY = 1
+                // ```
+                //
+                // Keep this check specific to the enum definition so conflicts between two
+                // ordinary mixins are still reported.
                 if enum_class_creation_manages_conflict(db, class, name, owner, contract_owner) {
                     continue;
                 }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -208,11 +208,14 @@ fn check_inherited_method_conflicts<'db>(
 
                 // `EnumType` can replace mixin dunders while constructing the enum, so the
                 // inherited definitions do not necessarily describe the resulting method. For
-                // example, `Status.__format__` is supplied during class creation here:
+                // example, the inherited check would otherwise compare the incompatible
+                // `int.__format__` and `Enum.__format__` definitions here:
                 //
                 // ```python
                 // from enum import Enum
                 //
+                // # int.__format__(self, format_spec: str, /) -> str
+                // # Enum.__format__(self, format_spec: str) -> str
                 // class Status(int, Enum):
                 //     READY = 1
                 // ```

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -306,6 +306,19 @@ fn source_method_contract<'db>(
     receiver: Type<'db>,
     name: &Name,
 ) -> Option<(MethodDecorator, Type<'db>)> {
+    // TODO: Check inherited conflicts involving properties and other attributes. For example:
+    //
+    // ```python
+    // class ReturnsStr:
+    //     @property
+    //     def value(self) -> str: ...
+    //
+    // class ReturnsInt:
+    //     @property
+    //     def value(self) -> int: ...
+    //
+    // class Conflict(ReturnsStr, ReturnsInt): ...
+    // ```
     let Type::FunctionLiteral(function) = owner
         .own_class_member(db, None, name)
         .inner

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -9,12 +9,12 @@ use ruff_db::{
     files::FileRange,
     parsed::ParsedModuleRef,
 };
-use ruff_python_ast::name::Name;
+use ruff_python_ast::{PythonVersion, name::Name};
 use ruff_python_stdlib::identifiers::is_mangled_private;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    Db,
+    Db, Program,
     lint::LintId,
     place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin},
     reachability::ReachabilityConstraintsExtension,
@@ -111,9 +111,6 @@ fn check_inherited_method_conflicts<'db>(
     class_specialized: ClassType<'db>,
 ) {
     let db = context.db();
-    if is_enum_class_by_inheritance(db, class) {
-        return;
-    }
 
     let mut direct_bases = Vec::new();
     for base in class.explicit_bases(db) {
@@ -192,6 +189,10 @@ fn check_inherited_method_conflicts<'db>(
                     continue;
                 }
 
+                if enum_class_creation_manages_conflict(db, class, name, owner, contract_owner) {
+                    continue;
+                }
+
                 // Do not re-emit an incompatibility that already exists in the parent's own MRO.
                 // This matters for intentionally suppressed typeshed overrides such as
                 // `str.__contains__` versus `Sequence.__contains__`, while still allowing a
@@ -260,6 +261,40 @@ fn source_method_contract<'db>(
         .try_call_dunder_get(db, Some(receiver), receiver.to_meta_type(db))?
         .0;
     Some((MethodDecorator::try_from_fn_type(db, function)?, ty))
+}
+
+/// Returns `true` when this source-level conflict involves a method replaced by `EnumType` during
+/// class creation.
+///
+/// Restricting this to a known enum implementation still allows two ordinary mixins to contribute
+/// conflicting contracts for the same method name.
+fn enum_class_creation_manages_conflict<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+    name: &Name,
+    selected_owner: ClassType<'db>,
+    contract_owner: ClassType<'db>,
+) -> bool {
+    if !is_enum_class_by_inheritance(db, class) {
+        return false;
+    }
+
+    if matches!(
+        name.as_str(),
+        "__repr__" | "__str__" | "__format__" | "__reduce_ex__"
+    ) {
+        return selected_owner.is_known(db, KnownClass::Enum)
+            || contract_owner.is_known(db, KnownClass::Enum);
+    }
+
+    Program::get(db).python_version(db) >= PythonVersion::PY311
+        && Type::ClassLiteral(class.into()).is_subtype_of(db, KnownClass::Flag.to_subclass_of(db))
+        && matches!(
+            name.as_str(),
+            "__or__" | "__and__" | "__xor__" | "__ror__" | "__rand__" | "__rxor__" | "__invert__"
+        )
+        && (selected_owner.is_known(db, KnownClass::Flag)
+            || contract_owner.is_known(db, KnownClass::Flag))
 }
 
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -186,6 +186,21 @@ fn check_inherited_method_conflicts<'db>(
             continue;
         };
         let scope = owner_literal.body_scope(db);
+        // TODO: Include synthesized members when checking inherited conflicts. For example,
+        // `Ordered.__gt__` is synthesized here and is incompatible with `AcceptsObject.__gt__`:
+        //
+        // ```python
+        // from functools import total_ordering
+        //
+        // @total_ordering
+        // class Ordered:
+        //     def __lt__(self, other: Ordered) -> bool: ...
+        //
+        // class AcceptsObject:
+        //     def __gt__(self, other: object) -> bool: ...
+        //
+        // class Conflict(Ordered, AcceptsObject): ...
+        // ```
         let members: FxHashSet<_> = all_end_of_scope_members(db, scope).collect();
 
         #[expect(


### PR DESCRIPTION
## Summary

Prior to this change, we only performed Liskov checks for methods defined directly on the subclass. A multiple-inheritance join could therefore silently place incompatible methods in the same MRO:

```python
class ReturnsStr:
    def method(self) -> str: ...

class ReturnsInt:
    def method(self) -> int: ...

class Child(ReturnsStr, ReturnsInt): ...  # Previously: no error
```

We now walk the resolved MRO, bind each source-defined parent method to the final receiver, and check it against later definitions of the same method. This catches conflicts on later bases and conflicts hidden by an earlier compatible definition. It also checks the full suffix rather than only effective definitions, which matters because assignability through `Any` is not transitive:

```python
from typing import Any

class AcceptsInt:
    def method(self, value: int) -> None: ...

class AcceptsAny(AcceptsInt):
    def method(self, value: Any) -> None: ...

class AcceptsStr:
    def method(self, value: str) -> None: ...

class Child(AcceptsStr, AcceptsAny): ...  # Now: invalid-method-override against AcceptsInt
```

Closes https://github.com/astral-sh/ty/issues/3751.