### PR TITLE
[ty] Respect bounded typevars in union inference

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -211,7 +211,7 @@ static TANJUN: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    110,
+    120,
 );
 
 static STATIC_FRAME: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -510,6 +510,26 @@ def _(list_ofstr: list[str], list_of_int: list[int]):
     reveal_type(accepts_t_or_list_of_t(list_of_int))  # revealed: Unknown
 ```
 
+A union argument must not widen a bounded type variable with an incompatible union element:
+
+```py
+class MyClass: ...
+
+T_bounded = TypeVar("T_bounded", bound=MyClass)
+
+def accepts_instance_or_int(instance: T_bounded, x: T_bounded | int) -> T_bounded:
+    return instance
+
+def _(x: int | None, valid: MyClass | int) -> MyClass:
+    # TODO: avoid the duplicate diagnostic when we move to new constraint solver for unions
+    # error: [invalid-argument-type] "Argument type `None` does not satisfy upper bound `MyClass` of type variable `T_bounded`"
+    # error: [invalid-argument-type] "Expected `MyClass | int`, found `int | None`"
+    result = accepts_instance_or_int(MyClass(), x)
+    reveal_type(result)  # revealed: MyClass
+    reveal_type(accepts_instance_or_int(MyClass(), valid))  # revealed: MyClass
+    return result
+```
+
 Here, we make sure that `S` is solved as `Literal[1]` instead of a union of the two literals, which
 would also be a valid solution:
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -456,6 +456,24 @@ def _(list_ofstr: list[str], list_of_int: list[int]):
     reveal_type(accepts_t_or_list_of_t(list_of_int))  # revealed: Unknown
 ```
 
+A union argument must not widen a bounded type variable with an incompatible union element:
+
+```py
+class MyClass: ...
+
+def accepts_instance_or_int[T: MyClass](instance: T, x: T | int) -> T:
+    return instance
+
+def _(x: int | None, valid: MyClass | int) -> MyClass:
+    # TODO: avoid the duplicate diagnostic when we move to new constraint solver for unions
+    # error: [invalid-argument-type] "Argument type `None` does not satisfy upper bound `MyClass` of type variable `T`"
+    # error: [invalid-argument-type] "Expected `MyClass | int`, found `int | None`"
+    result = accepts_instance_or_int(MyClass(), x)
+    reveal_type(result)  # revealed: MyClass
+    reveal_type(accepts_instance_or_int(MyClass(), valid))  # revealed: MyClass
+    return result
+```
+
 Here, we make sure that `S` is solved as `Literal[1]` instead of a union of the two literals, which
 would also be a valid solution:
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2832,7 +2832,13 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 if remaining_actual.is_never() {
                     return Ok(());
                 }
-                self.add_type_mapping(*formal_bound_typevar, remaining_actual, polarity);
+                // Infer through the TypeVar arm so its bound or constraints are still enforced.
+                return self.infer_map_impl(
+                    Type::TypeVar(*formal_bound_typevar),
+                    remaining_actual,
+                    polarity,
+                    seen,
+                );
             }
             (Type::Union(union_formal), _) => {
                 // If the formal is a union and the actual is a bare inferable TypeVar in an


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/4036.

When both the parameter and argument types are unions, the legacy generic solver removes argument union elements already covered by the parameter and directly adds the remainder as a type-variable mapping. That bypasses the type variable's upper bound, allowing an invalid element such as `None` to widen `T: MyClass` and consequently mask the call error and pollute the inferred return type.

Route the remaining argument type through normal type-variable inference so bounds and constraints are enforced.  There's a duplicate diagnostic which would require non-trivial machinery to remove; defer addressing it until union inference moves to the new constraint solver.

## Test plan

Add focused PEP 695 and legacy-TypeVar regressions covering the invalid argument, precise return type, and a valid-union control.

Ecosystem changes are correct/expected.
