### PR TITLE
Drop `TRY004` from default rules

### DIFF
--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -5182,7 +5182,6 @@ fn preview_default_rules() -> Result<()> {
     	redirected-noqa (RUF101),
     	invalid-pyproject-toml (RUF200),
     	raise-vanilla-class (TRY002),
-    	type-check-without-type-error (TRY004),
     	verbose-raise (TRY201),
     	useless-try-except (TRY203),
     	verbose-log-message (TRY401),

--- a/crates/ruff_linter/src/settings/mod.rs
+++ b/crates/ruff_linter/src/settings/mod.rs
@@ -723,7 +723,6 @@ pub const PREVIEW_DEFAULT_SELECTORS: &[RuleSelector] = &[
     RuleSelector::rule(Rule::UnquotedTypeAlias), // TC007
     RuleSelector::rule(Rule::RuntimeStringUnion), // TC010
     RuleSelector::rule(Rule::RaiseVanillaClass), // TRY002
-    RuleSelector::rule(Rule::TypeCheckWithoutTypeError), // TRY004
     RuleSelector::rule(Rule::VerboseRaise), // TRY201
     RuleSelector::rule(Rule::UselessTryExcept), // TRY203
     RuleSelector::rule(Rule::VerboseLogMessage), // TRY401


### PR DESCRIPTION
Summary
--

TRY004 just seems quite pedantic, as using `TypeError` over `ValueError` shouldn't matter in most practical cases and changes behavior in some cases (#12287). It also has no fix, so resolving it would be a pain.

I initially considered dropping three additional rules that together with TRY004 accounted for around 30% of new diagnostics on a large repo I was testing on, in descending order of new diagnostics:

- [BLE001](https://docs.astral.sh/ruff/rules/blind-except/) flags many cases where the exception is being "handled" somehow other than logging, such as printing or appending it to a collection of errors for later use.

- [TRY004](https://docs.astral.sh/ruff/rules/type-check-without-type-error/)

- [C408](https://docs.astral.sh/ruff/rules/unnecessary-collection-call/) seems okay in general, but the use of kwargs in `dict` is quite common and more annoying than the other suggested fixes, in my opinion. I personally have preferred using `dict(key=value)` over `{"key": value}` in the past.

- [C419](https://docs.astral.sh/ruff/rules/unnecessary-comprehension-in-call/) had a smaller ecosystem impact than the others, but it has a potentially severe issue that probably needs a decision before making it default (#10838)

However, upon closer inspection, I found the previous [discussion] of BLE001. To paraphrase/summarize Alex's response there, I think this is a case where the recommendation for new users and power users is probably a bit different, and BLE001 still makes sense to have in the default configuration for new users, while power users in some contexts will want to disable it. For that reason, I opted to keep it in the defaults.

Similarly, `C408` has a [configuration option](https://docs.astral.sh/ruff/settings/#lint_flake8-comprehensions_allow-dict-calls-with-keyword-arguments) specifically for the `dict` case that cleared most of the new diagnostics.

The `C419` issue I linked to corresponds to its preview behavior, not the stable behavior. So this inclusion in the defaults actually becomes less controversial after stabilization.

[discussion]: https://github.com/astral-sh/ruff/discussions/23203#discussioncomment-15772213

Test Plan
--

Stabilization
