### PR TITLE
[ty] Fix Self binding for classmethod __new__ constructors

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -282,6 +282,8 @@ reveal_type(Foo(1))  # revealed: Foo
 Marking it as a classmethod, on the other hand, breaks at runtime.
 
 ```py
+from typing_extensions import Self
+
 class Foo:
     @classmethod
     def __new__(cls, x: int):
@@ -290,6 +292,14 @@ class Foo:
 # error: [invalid-argument-type] "Argument to bound method `Foo.__new__` is incorrect: Expected `int`, found `<class 'Foo'>`"
 # error: [too-many-positional-arguments] "Too many positional arguments to bound method `Foo.__new__`: expected 1, got 2"
 Foo(1)
+
+class Bar:
+    @classmethod
+    def __new__(cls) -> Self:
+        raise NotImplementedError
+
+# error: [too-many-positional-arguments] "Too many positional arguments to bound method `Bar.__new__`: expected 0, got 1"
+reveal_type(Bar())  # revealed: Bar
 ```
 
 ## A callable instance in place of `__new__`

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3072,13 +3072,20 @@ impl<'db> CallableBinding<'db> {
         let Some(bound_self) = self.bound_type.take() else {
             return;
         };
+        let typing_self = match self.callable_type {
+            Type::BoundMethod(bound_method) => bound_method.typing_self_type(db),
+            _ => bound_self,
+        };
         for overload in &mut self.overloads {
             let removed_receiver = overload
                 .signature
                 .parameters()
                 .get(0)
                 .is_some_and(Parameter::is_positional);
-            overload.signature = overload.signature.bind_self(db, Some(bound_self));
+            overload.signature =
+                overload
+                    .signature
+                    .bind_self_with_receiver(db, Some(bound_self), Some(typing_self));
             overload.return_ty = overload.initial_return_type(db);
             overload.source_parameter_index_offset += usize::from(removed_receiver);
         }


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4043.

When `__new__` is incorrectly decorated with `@classmethod`, descriptor binding produces a class-object receiver. Constructor inference correctly supplies the additional implicit `cls` and reports the invalid call, but baking the descriptor receiver previously also substituted `typing.Self` with the class object. That caused the failed constructor call to reveal `<class 'Foo'>` instead of `Foo`.

Keep the runtime receiver and the classmethod-aware `Self` type separate while baking bound overloads. Add a focused constructor mdtest that preserves the expected arity diagnostic and verifies the recovered instance type.

## Test Plan

Added mdtest.
