### PR TITLE
[ty] Avoid recursive TypeVarTuple alias expansion

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -317,6 +317,32 @@ def _(p: P) -> None:
     pass
 ```
 
+## Recursive TypeVarTuple alias defaults
+
+Recursive aliases that extend a `TypeVarTuple` specialization must not recursively expand while
+checking their defaults.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+# error: [invalid-legacy-type-variable]
+# error: [invalid-type-form]
+type Nested[*Ts = Nested[*Ts]] = tuple[Nested[*Ts, Nested[*Ts]]]
+
+# error: [invalid-legacy-type-variable]
+# error: [invalid-type-form]
+type Suffix[*Ts = Suffix[*Ts]] = list[Suffix[*Ts, int]]
+
+# error: [invalid-legacy-type-variable]
+# error: [invalid-type-form]
+type Prefix[*Ts = Prefix[*Ts]] = tuple[Prefix[int, *Ts]]
+
+type ValidDefault[*Ts = *tuple[ValidDefault[int]]] = tuple[ValidDefault[*Ts, int]]
+```
+
 ## Snapshots of verbose diagnostics
 
 ```py

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -365,7 +365,7 @@ impl<'db> TypeVarInstance<'db> {
         ty: Type<'db>,
         visitor: &TypeVarDefaultVisitor<'db>,
     ) -> bool {
-        type SeenTypeAliases<'db> = SmallVec<[TypeAliasType<'db>; 1]>;
+        type SeenTypeAliases<'db> = SmallVec<[Definition<'db>; 1]>;
 
         #[derive(Copy, Clone)]
         struct State<'db, 'a> {
@@ -402,10 +402,13 @@ impl<'db> TypeVarInstance<'db> {
         ) -> bool {
             {
                 let mut seen_type_aliases = state.seen_type_aliases.borrow_mut();
-                if seen_type_aliases.contains(&type_alias) {
+                let definition = type_alias.definition(state.db);
+                // A recursive alias can produce a new specialization every time its body is
+                // expanded, so use its definition as the stable recursion key.
+                if seen_type_aliases.contains(&definition) {
                     return false;
                 }
-                seen_type_aliases.push(type_alias);
+                seen_type_aliases.push(definition);
             }
 
             let value_type = if let Some(specialization) = type_alias.specialization(state.db) {


### PR DESCRIPTION
## Summary

Closes astral-sh/ty#4045.

Recursive aliases that extend a `TypeVarTuple` specialization can create a fresh specialized alias on every expansion while ty checks a type-parameter default. The self-reference guard previously keyed on the complete specialized alias, so it never recognized the repeated alias origin and could hang or overflow the stack.

This keys the guard on the stable alias definition while preserving the existing specialized-argument checks.

## Test Plan

Add mdtest regression coverage for the original nested case, prefix/suffix pack growth, and a well-formed recursive TypeVarTuple default.
