### PR TITLE
In CI, optimize linting cache use and show all results

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -299,11 +299,11 @@ jobs:
       - name: "Clippy"
         env:
           CARGO_BUILD_WARNINGS: deny
-        run: cargo clippy --workspace --all-targets --all-features --locked
+        run: cargo clippy --workspace --all-targets --all-features --locked --keep-going
       - name: "Clippy (wasm)"
         env:
           CARGO_BUILD_WARNINGS: deny
-        run: cargo clippy -p ruff_wasm -p ty_wasm --target wasm32-unknown-unknown --all-features --locked
+        run: cargo clippy -p ruff_wasm -p ty_wasm --target wasm32-unknown-unknown --all-features --locked --keep-going
 
   cargo-publish-dry-run:
     name: "cargo publish dry-run"
@@ -372,14 +372,14 @@ jobs:
       - name: Dogfood ty on ty_benchmark
         run: uv run --project=./scripts/ty_benchmark cargo run -p ty check --project=./scripts/ty_benchmark
       # Check for broken links in the documentation.
-      - run: cargo doc --all --no-deps
+      - run: cargo doc --all --no-deps --keep-going
         env:
           CARGO_BUILD_WARNINGS: deny
       # Use --document-private-items so that all our doc comments are kept in
       # sync, not just public items. Eventually we should do this for all
       # crates; for now add crates here as they are warning-clean to prevent
       # regression.
-      - run: cargo doc --no-deps -p ty_python_semantic -p ty_python_core -p ty_module_resolver -p ty_site_packages -p ty_combine -p ty_project -p ty_ide -p ty_wasm -p ty_vendored -p ty_static -p ty -p ty_test -p ruff_db -p ruff_python_formatter --document-private-items
+      - run: cargo doc --no-deps --keep-going -p ty_python_semantic -p ty_python_core -p ty_module_resolver -p ty_site_packages -p ty_combine -p ty_project -p ty_ide -p ty_wasm -p ty_vendored -p ty_static -p ty -p ty_test -p ruff_db -p ruff_python_formatter --document-private-items
         env:
           CARGO_BUILD_WARNINGS: deny
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -297,9 +297,13 @@ jobs:
           rustup component add clippy
           rustup target add wasm32-unknown-unknown
       - name: "Clippy"
-        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+        env:
+          CARGO_BUILD_WARNINGS: deny
+        run: cargo clippy --workspace --all-targets --all-features --locked
       - name: "Clippy (wasm)"
-        run: cargo clippy -p ruff_wasm -p ty_wasm --target wasm32-unknown-unknown --all-features --locked -- -D warnings
+        env:
+          CARGO_BUILD_WARNINGS: deny
+        run: cargo clippy -p ruff_wasm -p ty_wasm --target wasm32-unknown-unknown --all-features --locked
 
   cargo-publish-dry-run:
     name: "cargo publish dry-run"
@@ -370,15 +374,14 @@ jobs:
       # Check for broken links in the documentation.
       - run: cargo doc --all --no-deps
         env:
-          RUSTDOCFLAGS: "-D warnings"
+          CARGO_BUILD_WARNINGS: deny
       # Use --document-private-items so that all our doc comments are kept in
       # sync, not just public items. Eventually we should do this for all
       # crates; for now add crates here as they are warning-clean to prevent
       # regression.
       - run: cargo doc --no-deps -p ty_python_semantic -p ty_python_core -p ty_module_resolver -p ty_site_packages -p ty_combine -p ty_project -p ty_ide -p ty_wasm -p ty_vendored -p ty_static -p ty -p ty_test -p ruff_db -p ruff_python_formatter --document-private-items
         env:
-          # Setting RUSTDOCFLAGS because `cargo doc --check` isn't yet implemented (https://github.com/rust-lang/cargo/issues/10025).
-          RUSTDOCFLAGS: "-D warnings"
+          CARGO_BUILD_WARNINGS: deny
 
   cargo-test-linux-release:
     name: "cargo test (linux, release)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,6 +304,17 @@ jobs:
         env:
           CARGO_BUILD_WARNINGS: deny
         run: cargo clippy -p ruff_wasm -p ty_wasm --target wasm32-unknown-unknown --all-features --locked --keep-going
+      # Check for broken links in the documentation.
+      - run: cargo doc --all --no-deps --keep-going
+        env:
+          CARGO_BUILD_WARNINGS: deny
+      # Use --document-private-items so that all our doc comments are kept in
+      # sync, not just public items. Eventually we should do this for all
+      # crates; for now add crates here as they are warning-clean to prevent
+      # regression.
+      - run: cargo doc --no-deps --keep-going -p ty_python_semantic -p ty_python_core -p ty_module_resolver -p ty_site_packages -p ty_combine -p ty_project -p ty_ide -p ty_wasm -p ty_vendored -p ty_static -p ty -p ty_test -p ruff_db -p ruff_python_formatter --document-private-items
+        env:
+          CARGO_BUILD_WARNINGS: deny
 
   cargo-publish-dry-run:
     name: "cargo publish dry-run"
@@ -371,17 +382,6 @@ jobs:
         run: uv run --project=./scripts cargo run -p ty check --project=./scripts
       - name: Dogfood ty on ty_benchmark
         run: uv run --project=./scripts/ty_benchmark cargo run -p ty check --project=./scripts/ty_benchmark
-      # Check for broken links in the documentation.
-      - run: cargo doc --all --no-deps --keep-going
-        env:
-          CARGO_BUILD_WARNINGS: deny
-      # Use --document-private-items so that all our doc comments are kept in
-      # sync, not just public items. Eventually we should do this for all
-      # crates; for now add crates here as they are warning-clean to prevent
-      # regression.
-      - run: cargo doc --no-deps --keep-going -p ty_python_semantic -p ty_python_core -p ty_module_resolver -p ty_site_packages -p ty_combine -p ty_project -p ty_ide -p ty_wasm -p ty_vendored -p ty_static -p ty -p ty_test -p ruff_db -p ruff_python_formatter --document-private-items
-        env:
-          CARGO_BUILD_WARNINGS: deny
 
   cargo-test-linux-release:
     name: "cargo test (linux, release)"


### PR DESCRIPTION
## Summary

For `cargo doc`, dependencies only have a `cargo check` run on them. Nothing similar happens in the `test-linux` job but `cargo clippy` (and so the `cargo-clippy` job) do the same thing. rustdoc and rustc/clippy-driver lints are also more semantically related than they are with tests.

However, I suspect the way RUSTFLAGS are needed to be passed for `cargo doc` and `cargo clippy` still cause the caches to not be shared. Enter `CARGO_BUILD_WARNINGS=deny`, a new feature in 1.97 that operates at the Cargo reporting level. With this, the caches should be reused.

While switching to `CARGO_BUILD_WARNINGS=deny`, I went ahead and added `-keep-going`. On its own, `-keep-going` causes compilation to still happen for packages whose dependents succeeded despite an unrelated package erroring. `-Dwarnings` failures are not considered successful. With `CARGO_BUILD_WARNINGS=deny` failures are considered an error but only in the reporting layer, you will see all lint failures for the entire stack.

## Test Plan

Observe a CI run