### PR TITLE
[ty] Preserve receiver constraints when binding overloaded methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -3674,13 +3674,13 @@ dynamic construction of enums using the functional syntax:
 from enum import Enum, IntEnum, StrEnum
 from ty_extensions._internal import into_regular_callable
 
-# revealed: Overload[[_EnumMemberT](value: Any, names: None = None) -> _EnumMemberT, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
+# revealed: Overload[(value: Any, names: None = None) -> Enum, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
 reveal_type(into_regular_callable(Enum))
 
-# revealed: Overload[[_EnumMemberT](value: Any, names: None = None) -> _EnumMemberT, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
+# revealed: Overload[(value: Any, names: None = None) -> IntEnum, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
 reveal_type(into_regular_callable(IntEnum))
 
-# revealed: Overload[[_EnumMemberT](value: Any, names: None = None) -> _EnumMemberT, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
+# revealed: Overload[(value: Any, names: None = None) -> StrEnum, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
 reveal_type(into_regular_callable(StrEnum))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -2159,3 +2159,63 @@ class MaybeEqWhile:
         def __eq__(self, other: MaybeEqWhile) -> bool:
             return True
 ```
+
+## Overloaded generic receivers remain visible to override checks
+
+An override must still be checked against every applicable receiver-specialized overload when the
+subclass retains a covariant type parameter.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```pyi
+from typing import Any, Generic, Never, TypeVar, overload
+
+ScalarCo = TypeVar("ScalarCo", covariant=True)
+ShapeCo = TypeVar("ShapeCo", covariant=True)
+
+class Poly(Generic[ScalarCo, ShapeCo]):
+    @overload
+    def extend(self: "Poly[float, Any]", value: float) -> None: ...
+    @overload
+    def extend(self: "Poly[complex, Any]", value: complex) -> None: ...
+
+class Akima(Poly[float, ShapeCo], Generic[ShapeCo]):
+    def extend(self, value: Never) -> Never: ...  # error: [invalid-method-override]
+
+class Index(Generic[ScalarCo, ShapeCo]):
+    @overload
+    def set(self: "Index[Any, tuple[int]]", key: int, value: int) -> None: ...
+    @overload
+    def set(self: "Index[Any, tuple[int, int]]", key: str, value: int) -> None: ...
+
+class Matrix(Index[ScalarCo, tuple[int, int]], Generic[ScalarCo]):
+    def set(self, key: Never, value: Any) -> Never: ...  # error: [invalid-method-override]
+```
+
+## Equivalent overloaded protocol receivers are valid overrides
+
+A generic implementation can restate a protocol's receiver-specialized overload set using its own
+receiver type without changing the method contract.
+
+```py
+from typing import Generic, Protocol, TypeVar, overload
+
+T = TypeVar("T")
+TContra = TypeVar("TContra", contravariant=True)
+
+class TaskStatus(Protocol[TContra]):
+    @overload
+    def started(self: "TaskStatus[None]") -> None: ...
+    @overload
+    def started(self, value: TContra) -> None: ...
+
+class ConcreteStatus(Generic[T], TaskStatus[T]):
+    @overload
+    def started(self: "ConcreteStatus[None]") -> None: ...
+    @overload
+    def started(self: "ConcreteStatus[T]", value: T) -> None: ...
+    def started(self, value: T | None = None) -> None: ...
+```

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -2163,7 +2163,9 @@ class MaybeEqWhile:
 ## Overloaded generic receivers remain visible to override checks
 
 An override must still be checked against every applicable receiver-specialized overload when the
-subclass retains a covariant type parameter.
+subclass retains a covariant type parameter. A `str` receiver matches both the `str` and `object`
+overloads, so accepting only `str` is invalid. A two-item receiver excludes the one-item overload,
+so matching only that excluded overload is also invalid.
 
 ```toml
 [environment]
@@ -2171,28 +2173,26 @@ python-version = "3.12"
 ```
 
 ```pyi
-from typing import Any, Generic, Never, TypeVar, overload
+from typing import Any, Generic, TypeVar, overload
 
-ScalarCo = TypeVar("ScalarCo", covariant=True)
+ValueCo = TypeVar("ValueCo", covariant=True)
 ShapeCo = TypeVar("ShapeCo", covariant=True)
 
-class Poly(Generic[ScalarCo, ShapeCo]):
+class Receiver(Generic[ValueCo, ShapeCo]):
     @overload
-    def extend(self: "Poly[float, Any]", value: float) -> None: ...
+    def by_value(self: "Receiver[str, Any]", value: str) -> None: ...
     @overload
-    def extend(self: "Poly[complex, Any]", value: complex) -> None: ...
+    def by_value(self: "Receiver[object, Any]", value: object) -> None: ...
+    @overload
+    def by_shape(self: "Receiver[Any, tuple[str]]", value: str) -> None: ...
+    @overload
+    def by_shape(self: "Receiver[Any, tuple[str, str]]", value: bytes) -> None: ...
 
-class Akima(Poly[float, ShapeCo], Generic[ShapeCo]):
-    def extend(self, value: Never) -> Never: ...  # error: [invalid-method-override]
+class NarrowValueOverride(Receiver[str, ShapeCo], Generic[ShapeCo]):
+    def by_value(self, value: str) -> None: ...  # error: [invalid-method-override]
 
-class Index(Generic[ScalarCo, ShapeCo]):
-    @overload
-    def set(self: "Index[Any, tuple[int]]", key: int, value: int) -> None: ...
-    @overload
-    def set(self: "Index[Any, tuple[int, int]]", key: str, value: int) -> None: ...
-
-class Matrix(Index[ScalarCo, tuple[int, int]], Generic[ScalarCo]):
-    def set(self, key: Never, value: Any) -> Never: ...  # error: [invalid-method-override]
+class WrongShapeOverride(Receiver[ValueCo, tuple[str, str]], Generic[ValueCo]):
+    def by_shape(self, value: str) -> None: ...  # error: [invalid-method-override]
 ```
 
 ## Equivalent overloaded protocol receivers are valid overrides

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -1385,3 +1385,41 @@ def baz(x, y, z=None) -> bytes | list[str]:
 # revealed: Overload[(x, y) -> bytes, (x, y, z) -> list[str]]
 reveal_type(baz)
 ```
+
+## Generic overloaded protocol members preserve receiver relationships
+
+An overloaded method used to satisfy a protocol receiver can relate a method-scoped type variable to
+a concrete generic receiver. Binding that member must retain the scalar return type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```pyi
+from typing import Any, Generic, Protocol, TypeVar, assert_type, overload
+
+class ScalarBase: ...
+class Scalar(ScalarBase): ...
+
+ScalarCo = TypeVar("ScalarCo", bound=ScalarBase, covariant=True, default=ScalarBase)
+ShapeCo = TypeVar("ShapeCo", bound=tuple[int, ...], covariant=True, default=tuple[Any, ...])
+
+class HasPhantom[T](Protocol):
+    def phantom(self) -> T: ...
+
+class Phantom(Generic[ShapeCo, ScalarCo]):
+    @overload
+    def phantom[T: ScalarBase](self: "Phantom[tuple[()], T]") -> T: ...
+    @overload
+    def phantom[Shape: tuple[int, *tuple[int, ...]], T: ScalarBase](
+        self: "Phantom[Shape, T]",
+    ) -> list[T]: ...
+
+class Normal(Phantom[ShapeCo, ScalarCo], Generic[ShapeCo, ScalarCo]):
+    @property
+    def value[T](self: "HasPhantom[T]") -> T: ...
+
+normal: Normal[tuple[()], Scalar]
+assert_type(normal.value, Scalar)
+```

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -275,9 +275,7 @@ def union_receiver(reader: Reader[int | str]):
 ## Method type variables inferred from `self`
 
 Binding an overload whose explicit receiver introduces a method type variable should infer that
-variable from the concrete receiver and apply it to the remainder of the signature. At present,
-receiver matching retains the overload, but does not yet apply the inferred `S = str`
-specialization.
+variable from the concrete receiver and apply it to the remainder of the signature.
 
 ```toml
 [environment]
@@ -285,9 +283,11 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import overload
+from typing import Any, Callable, overload
 
 class ReceiverGeneric[T]:
+    value: T
+
     @overload
     def method[S](self: "ReceiverGeneric[S]", value: S) -> S: ...
     @overload
@@ -295,18 +295,20 @@ class ReceiverGeneric[T]:
     def method(self, value: object) -> object:
         return value
 
-# Receiver constraints are preserved for later relation checks, but are not yet solved into the
-# displayed bound signature.
-# TODO: revealed: Overload[(value: str) -> str, (value: bytes) -> bytes]
-reveal_type(ReceiverGeneric[str]().method)  # revealed: Overload[[S](value: S) -> S, (value: bytes) -> bytes]
+reveal_type(ReceiverGeneric[str]().method)  # revealed: Overload[(value: str) -> str, (value: bytes) -> bytes]
+
+def takes_callable(fn: Callable[..., Any]) -> None: ...
+def use_generic_receiver[T](value: ReceiverGeneric[T]) -> None:
+    # revealed: Overload[(value: T@use_generic_receiver) -> T@use_generic_receiver, (value: bytes) -> bytes]
+    reveal_type(value.method)
+    takes_callable(value.method)
 ```
 
 ## Structural protocol receivers
 
 Checking a generic protocol receiver requires solving all uses of its type variable together. Here
 `get()` would require `int` to be assignable to `T`, while `put()` would require `T` to be
-assignable to `str`, so no `T` can satisfy `ProtocolSelf[T]`. At present, the incompatible overload
-is retained because structural receiver specialization is not yet supported.
+assignable to `str`, so no `T` can satisfy `ProtocolSelf[T]`.
 
 ```py
 from typing import Callable, Protocol, TypeVar, overload
@@ -331,12 +333,45 @@ class ProtocolSelfImplementation(BaseWithProtocolSelf):
 
     def put(self, x: str) -> None: ...
 
-# TODO: The first overload should be eliminated, leaving `bound method
-# BaseWithProtocolSelf.method() -> bytes`.
-reveal_type(ProtocolSelfImplementation().method)  # revealed: Overload[[ProtocolSelfT]() -> ProtocolSelfT, () -> bytes]
+reveal_type(ProtocolSelfImplementation().method)  # revealed: bound method ProtocolSelfImplementation.method() -> bytes
 
 good_protocol_receiver: Callable[[], bytes] = ProtocolSelfImplementation().method
 bad_protocol_receiver: Callable[[], int] = ProtocolSelfImplementation().method  # error: [invalid-assignment]
+```
+
+## One-sided constraints from protocol receivers
+
+An explicit protocol receiver can constrain a method type variable without determining an exact
+specialization. Keep that type variable generic so that compatible callbacks remain valid while the
+receiver constraint rejects incompatible ones.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, Protocol, overload
+
+class Producer[T](Protocol):
+    def get(self) -> T: ...
+
+class BaseWithProducer:
+    @overload
+    def method[S](self: Producer[S], value: S) -> S: ...
+    @overload
+    def method(self, value: bytes) -> bytes: ...
+    def method(self, value: object) -> object:
+        return value
+
+class ProducerImplementation(BaseWithProducer):
+    def get(self) -> str:
+        return ""
+
+reveal_type(ProducerImplementation().method)  # revealed: Overload[[S](value: S) -> S, (value: bytes) -> bytes]
+producer_callback: Callable[[object], object] = ProducerImplementation().method
+bad_producer_callback: Callable[[int], int] = ProducerImplementation().method  # error: [invalid-assignment]
+reveal_type(ProducerImplementation().method(1))  # revealed: str | Literal[1]
 ```
 
 ## Constructor

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -495,9 +495,13 @@ class ProducerImplementation(BaseWithProducer):
     def get(self) -> str:
         return ""
 
+# `Producer` is covariant, so binding records `str <: S` without specializing `S` to `str`.
 reveal_type(ProducerImplementation().method)  # revealed: Overload[[S](value: S) -> S, (value: bytes) -> bytes]
+# `S = object` satisfies the receiver constraint.
 producer_callback: Callable[[object], object] = ProducerImplementation().method
+# `S = int` violates the receiver constraint, and the `bytes` overload is also incompatible.
 bad_producer_callback: Callable[[int], int] = ProducerImplementation().method  # error: [invalid-assignment]
+# The argument adds `Literal[1] <: S`, so the combined lower bound is `str | Literal[1]`.
 reveal_type(ProducerImplementation().method(1))  # revealed: str | Literal[1]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -1528,7 +1528,7 @@ python-version = "3.12"
 ```
 
 ```pyi
-from typing import Any, Generic, Protocol, TypeVar, assert_type, overload
+from typing import Any, Generic, Protocol, TypeVar, assert_type, overload, reveal_type
 
 class ScalarBase: ...
 class Scalar(ScalarBase): ...
@@ -1540,17 +1540,27 @@ class HasPhantom[T](Protocol):
     def phantom(self) -> T: ...
 
 class Phantom(Generic[ShapeCo, ScalarCo]):
+    # An empty shape selects the scalar overload and relates its return type to the receiver.
     @overload
     def phantom[T: ScalarBase](self: "Phantom[tuple[()], T]") -> T: ...
+    # A non-empty shape selects the list-valued overload instead.
     @overload
     def phantom[Shape: tuple[int, *tuple[int, ...]], T: ScalarBase](
         self: "Phantom[Shape, T]",
     ) -> list[T]: ...
 
 class Normal(Phantom[ShapeCo, ScalarCo], Generic[ShapeCo, ScalarCo]):
+    # Matching this protocol receiver requires binding the inherited `phantom` overloads.
     @property
     def value[T](self: "HasPhantom[T]") -> T: ...
 
+# The empty shape selects `phantom() -> Scalar`, so the protocol and property type is `Scalar`.
 normal: Normal[tuple[()], Scalar]
 assert_type(normal.value, Scalar)
+
+# A non-empty shape selects `phantom() -> list[Scalar]`, so the property type is `list[Scalar]`.
+shaped: Normal[tuple[int], Scalar]
+assert_type(shaped.phantom(), list[Scalar])
+# TODO: The receiver constraint `Scalar <: T` should propagate through invariant `list[T]`.
+reveal_type(shaped.value)  # revealed: Unknown
 ```

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -304,6 +304,133 @@ def use_generic_receiver[T](value: ReceiverGeneric[T]) -> None:
     takes_callable(value.method)
 ```
 
+## Constrained method type variables inferred from `self`
+
+Matching a receiver against a value-constrained method type variable must reject values outside that
+variable's constraints. A subclass of an allowed value must be promoted to the declared constraint
+rather than appearing as the specialized return type.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, Generic, TypeVar, overload
+
+BoxT = TypeVar("BoxT", covariant=True)
+Constrained = TypeVar("Constrained", str, bytes)
+
+class ConstrainedReceiverBox(Generic[BoxT]):
+    @overload
+    def method(self: "ConstrainedReceiverBox[Constrained]", value: Constrained) -> Constrained: ...
+    @overload
+    def method(self: "ConstrainedReceiverBox[Constrained]", value: Constrained, repeat: int = ...) -> Constrained: ...
+    def method(self, value: str | bytes, repeat: int = 1) -> str | bytes:
+        return value
+
+invalid_receiver = ConstrainedReceiverBox[int]()
+invalid_method = invalid_receiver.method
+reveal_type(invalid_method)  # revealed: Overload[]
+
+# error: [no-matching-overload]
+reveal_type(invalid_method(1))  # revealed: Unknown
+
+# error: [invalid-assignment]
+invalid_callback: Callable[[int], int] = invalid_method
+
+class SubStr(str): ...
+
+subclass_receiver = ConstrainedReceiverBox[SubStr]()
+reveal_type(subclass_receiver.method(SubStr()))  # revealed: str
+promoted_callback: Callable[[SubStr], str] = subclass_receiver.method
+```
+
+## Disjunctive generic receivers
+
+A receiver may satisfy both sides of a union without constraining both sides' type variables on the
+same path. In particular, matching `Left[int]` leaves the `Right` type variable available to
+specialize from the method arguments.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, overload
+
+class Left[T]:
+    left: T
+
+class Right[T]:
+    right: T
+
+class BaseWithDisjunctiveReceiver:
+    @overload
+    def method[S, U](self: "Left[S] | Right[U]", first: S, second: U) -> tuple[S, U]: ...
+    @overload
+    def method(self, first: bytes, second: bytes) -> tuple[bytes, bytes]: ...
+    def method(self, first: object, second: object) -> tuple[object, object]:
+        return first, second
+
+class Both(BaseWithDisjunctiveReceiver, Left[int], Right[str]): ...
+
+receiver = Both()
+receiver.method(1, b"value")
+valid_callback: Callable[[int, bytes], tuple[int, bytes]] = receiver.method
+```
+
+## Receiver type variables alongside variadic type parameters
+
+A method's `ParamSpec` or `TypeVarTuple` must not prevent an ordinary type variable from being
+specialized by its receiver. The variadic parameters remain available for argument inference;
+neither method can be converted into a callback with a return type incompatible with the receiver.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, overload
+
+class VariadicReceiverBox[T]:
+    value: T
+
+    @overload
+    def with_paramspec[**P, S](self: "VariadicReceiverBox[S]", callback: Callable[P, object]) -> S: ...
+    @overload
+    def with_paramspec(self, callback: bytes) -> bytes: ...
+    def with_paramspec(self, callback: object) -> object:
+        return callback
+
+    @overload
+    def with_typevartuple[*Ts, S](self: "VariadicReceiverBox[S]", first: int, *values: *Ts) -> S: ...
+    @overload
+    def with_typevartuple(self, first: bytes) -> bytes: ...
+    def with_typevartuple(self, first: object, *values: object) -> object:
+        return first
+
+def accepts_int(value: int) -> object:
+    return value
+
+receiver = VariadicReceiverBox[str]()
+
+# revealed: Overload[[**P](callback: (**P) -> object) -> str, (callback: bytes) -> bytes]
+reveal_type(receiver.with_paramspec)
+reveal_type(receiver.with_paramspec(accepts_int))  # revealed: str
+
+# error: [invalid-assignment]
+bad_paramspec_callback: Callable[[Callable[[int], object]], int] = receiver.with_paramspec
+
+reveal_type(receiver.with_typevartuple(1, b"value"))  # revealed: str
+typevartuple_callback: Callable[[int, bytes], str] = receiver.with_typevartuple
+
+# error: [invalid-assignment]
+bad_typevartuple_callback: Callable[[int, bytes], int] = receiver.with_typevartuple
+```
+
 ## Structural protocol receivers
 
 Checking a generic protocol receiver requires solving all uses of its type variable together. Here

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1519,7 +1519,7 @@ impl<'db> UpperBound<'db> {
         !self.is_empty()
     }
 
-    fn as_single_bound(&self) -> Option<Type<'db>> {
+    pub(crate) fn as_single_bound(&self) -> Option<Type<'db>> {
         if self.clauses.len() != 1 {
             return None;
         }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2123,6 +2123,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
     }
 
+    /// Adds a constraint set to the specialization that this builder is building up.
+    pub(crate) fn add_constraint_set(&mut self, set: ConstraintSet<'db, 'c>) {
+        self.pending.intersect(self.db, self.constraints, set);
+    }
+
     /// Build a specialization, using a caller-provided hook to select the solution for each
     /// typevar.
     ///

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2123,9 +2123,13 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
     }
 
-    /// Adds a constraint set to the specialization that this builder is building up.
-    pub(crate) fn add_constraint_set(&mut self, set: ConstraintSet<'db, 'c>) {
-        self.pending.intersect(self.db, self.constraints, set);
+    /// Adds a constraint set to the pending specialization and projects its valid solutions into
+    /// the legacy type mappings.
+    pub(crate) fn add_constraint_set(
+        &mut self,
+        set: ConstraintSet<'db, 'c>,
+    ) -> Result<(), SpecializationError<'db>> {
+        self.infer_from_constraint_set(set)
     }
 
     /// Build a specialization, using a caller-provided hook to select the solution for each

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -138,17 +138,9 @@ impl<'db> BoundMethodType<'db> {
             }
 
             return CallableSignature::from_overloads(
-                function_signature
-                    .overloads
-                    .iter()
-                    .filter(|signature| signature.can_bind_self_to(db, receiver_type))
-                    .map(|signature| {
-                        signature.bind_self_with_receiver(
-                            db,
-                            Some(receiver_type),
-                            Some(typing_self_type),
-                        )
-                    }),
+                function_signature.overloads.iter().filter_map(|signature| {
+                    signature.bind_self_if_compatible(db, receiver_type, typing_self_type)
+                }),
             );
         };
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -22,11 +22,12 @@ use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
+    PathBounds,
 };
 use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::generics::{
-    ApplySpecialization, GenericContext, InferableTypeVars, Specialization, TypeVarInference,
-    walk_generic_context,
+    ApplySpecialization, GenericContext, InferableTypeVars, Specialization, SpecializationBuilder,
+    TypeVarInference, walk_generic_context,
 };
 use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
 use crate::types::relation::{
@@ -1150,71 +1151,69 @@ impl<'db> Signature<'db> {
         }
     }
 
-    /// Returns `true` if this signature's first parameter can accept the bound `self` type.
+    /// Returns this signature bound to `receiver_type` if its explicit receiver annotation is
+    /// compatible with the bound receiver.
     ///
-    /// This is used to prune impossible overloads when a method is bound to a concrete receiver.
-    /// If a signature has no positional first parameter, we conservatively keep it.
-    pub(crate) fn can_bind_self_to(&self, db: &'db dyn Db, self_type: Type<'db>) -> bool {
-        // A dynamic receiver might be compatible with any explicit receiver annotation.
-        if self_type.is_dynamic() {
-            return true;
-        }
-
-        // Without a first parameter, there is no receiver annotation to check.
-        let Some(first_parameter) = self.parameters.get(0) else {
-            return true;
+    /// Matching the receiver can constrain type variables that occur elsewhere in the signature.
+    /// Exact bounds determine an unambiguous specialization; one-sided constraints remain attached
+    /// to the bound signature for later relation checks.
+    pub(crate) fn bind_self_if_compatible(
+        &self,
+        db: &'db dyn Db,
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) -> Option<Self> {
+        let bound_signature =
+            self.bind_self_with_receiver(db, Some(receiver_type), Some(typing_self_type));
+        let Some(receiver_constraints) = bound_signature.receiver_constraints.as_ref() else {
+            return Some(bound_signature);
         };
 
-        // If there is no positional receiver, this signature cannot be pruned based on `self`.
-        if !first_parameter.is_positional() {
-            return true;
-        }
-
-        // Inferred receiver annotations describe the method owner, rather than constraining which
-        // overload is exposed for a bound receiver. Only explicit receiver annotations can prune.
-        if first_parameter.inferred_annotation {
-            return true;
-        }
-
-        let mut expected_self_ty = first_parameter.annotated_type();
-        let accepts_any_or_exact_self =
-            |ty: Type<'db>| ty.is_dynamic() || ty.is_object() || ty == self_type;
-
-        // Avoid the more expensive normalization below for receiver annotations that already
-        // accept all values, or already exactly match the bound receiver.
-        if accepts_any_or_exact_self(expected_self_ty) {
-            return true;
-        }
-
-        // TODO: Expand type aliases here so `type Alias = Self` in a class body
-        // participates in receiver-specific overload pruning.
-        expected_self_ty = expected_self_ty.bind_self_typevars(db, self_type);
-
-        // `Self` binding can make the receiver annotation trivially compatible.
-        if accepts_any_or_exact_self(expected_self_ty) {
-            return true;
-        }
-
-        // A specialized receiver can make generic receiver annotations concrete enough to compare.
-        if let Some((_, self_specialization)) = self_type.class_specialization(db) {
-            expected_self_ty =
-                expected_self_ty.apply_optional_specialization(db, Some(self_specialization));
-
-            // Specialization can also make the receiver annotation trivially compatible.
-            if accepts_any_or_exact_self(expected_self_ty) {
-                return true;
-            }
-        }
-
         let constraints = ConstraintSetBuilder::new();
-        self_type
-            .when_assignable_to(
-                db,
-                expected_self_ty,
-                &constraints,
-                self.inferable_typevars(db),
-            )
+        let when = constraints.load(db, receiver_constraints);
+        let inferable = self.inferable_typevars(db);
+        if !when
+            .reduce_inferable(db, &constraints, inferable)
             .is_always_satisfied(db)
+        {
+            return None;
+        }
+
+        let Some(generic_context) = self.generic_context else {
+            return Some(bound_signature);
+        };
+
+        let mut builder = SpecializationBuilder::new(db, &constraints, inferable);
+        builder.add_constraint_set(when);
+        let concrete_class_receiver =
+            matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
+        let specialization = builder.build_with(generic_context, |typevar, bounds| {
+            if let Some(bounds) = bounds
+                && let Some(lower) = bounds.lower
+                && let Some(upper) = bounds.upper.as_single_bound()
+                && lower.is_equivalent_to(db, upper)
+            {
+                return Some(lower);
+            }
+
+            if let Some(bounds) = bounds
+                && concrete_class_receiver
+                && bound_signature
+                    .variance_of(db, typevar.identity(db))
+                    .is_covariant()
+                && bounds.lower.is_some_and(|lower| !lower.is_never())
+                && let Ok(Some(solution)) = PathBounds::default_solve(db, &constraints, bounds)
+            {
+                return Some(solution);
+            }
+
+            Some(Type::TypeVar(typevar))
+        });
+
+        Some(
+            self.apply_specialization(db, specialization)
+                .bind_self_with_receiver(db, Some(receiver_type), Some(typing_self_type)),
+        )
     }
 
     pub(crate) fn has_explicit_positional_receiver_annotation(&self) -> bool {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1163,6 +1163,10 @@ impl<'db> Signature<'db> {
         receiver_type: Type<'db>,
         typing_self_type: Type<'db>,
     ) -> Option<Self> {
+        if !self.can_bind_self_to(db, receiver_type) {
+            return None;
+        }
+
         let bound_signature =
             self.bind_self_with_receiver(db, Some(receiver_type), Some(typing_self_type));
         let Some(receiver_constraints) = bound_signature.receiver_constraints.as_ref() else {
@@ -1172,10 +1176,9 @@ impl<'db> Signature<'db> {
         let constraints = ConstraintSetBuilder::new();
         let when = constraints.load(db, receiver_constraints);
         let inferable = self.inferable_typevars(db);
-        if !when
-            .reduce_inferable(db, &constraints, inferable)
-            .is_always_satisfied(db)
-        {
+        // Structural receiver checks can produce an unsatisfiable constraint set even when the
+        // eager applicability check above cannot rule out the overload.
+        if when.is_never_satisfied(db) {
             return None;
         }
 
@@ -1214,6 +1217,73 @@ impl<'db> Signature<'db> {
             self.apply_specialization(db, specialization)
                 .bind_self_with_receiver(db, Some(receiver_type), Some(typing_self_type)),
         )
+    }
+
+    /// Returns `true` if this signature's first parameter can accept the bound `self` type.
+    ///
+    /// This is used to prune impossible overloads when a method is bound to a concrete receiver.
+    /// If a signature has no positional first parameter, we conservatively keep it.
+    fn can_bind_self_to(&self, db: &'db dyn Db, self_type: Type<'db>) -> bool {
+        // A dynamic receiver might be compatible with any explicit receiver annotation.
+        if self_type.is_dynamic() {
+            return true;
+        }
+
+        // Without a first parameter, there is no receiver annotation to check.
+        let Some(first_parameter) = self.parameters.get(0) else {
+            return true;
+        };
+
+        // If there is no positional receiver, this signature cannot be pruned based on `self`.
+        if !first_parameter.is_positional() {
+            return true;
+        }
+
+        // Inferred receiver annotations describe the method owner, rather than constraining which
+        // overload is exposed for a bound receiver. Only explicit receiver annotations can prune.
+        if first_parameter.inferred_annotation {
+            return true;
+        }
+
+        let mut expected_self_ty = first_parameter.annotated_type();
+        let accepts_any_or_exact_self =
+            |ty: Type<'db>| ty.is_dynamic() || ty.is_object() || ty == self_type;
+
+        // Avoid the more expensive normalization below for receiver annotations that already
+        // accept all values, or already exactly match the bound receiver.
+        if accepts_any_or_exact_self(expected_self_ty) {
+            return true;
+        }
+
+        // TODO: Expand type aliases here so `type Alias = Self` in a class body
+        // participates in receiver-specific overload pruning.
+        expected_self_ty = expected_self_ty.bind_self_typevars(db, self_type);
+
+        // `Self` binding can make the receiver annotation trivially compatible.
+        if accepts_any_or_exact_self(expected_self_ty) {
+            return true;
+        }
+
+        // A specialized receiver can make generic receiver annotations concrete enough to compare.
+        if let Some((_, self_specialization)) = self_type.class_specialization(db) {
+            expected_self_ty =
+                expected_self_ty.apply_optional_specialization(db, Some(self_specialization));
+
+            // Specialization can also make the receiver annotation trivially compatible.
+            if accepts_any_or_exact_self(expected_self_ty) {
+                return true;
+            }
+        }
+
+        let constraints = ConstraintSetBuilder::new();
+        self_type
+            .when_assignable_to(
+                db,
+                expected_self_ty,
+                &constraints,
+                self.inferable_typevars(db),
+            )
+            .is_always_satisfied(db)
     }
 
     pub(crate) fn has_explicit_positional_receiver_annotation(&self) -> bool {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -22,7 +22,7 @@ use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
-    PathBounds,
+    PathBounds, Solutions,
 };
 use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::generics::{
@@ -1176,10 +1176,16 @@ impl<'db> Signature<'db> {
         let constraints = ConstraintSetBuilder::new();
         let when = constraints.load(db, receiver_constraints);
         let inferable = self.inferable_typevars(db);
-        // Structural receiver checks can produce an unsatisfiable constraint set even when the
-        // eager applicability check above cannot rule out the overload.
-        if when.is_never_satisfied(db) {
-            return None;
+
+        match when.solutions(db, &constraints, inferable) {
+            Solutions::Unsatisfiable => return None,
+            Solutions::Unconstrained => return Some(bound_signature),
+            // Each receiver path can leave a different type variable unconstrained. Preserve the
+            // original relation instead of combining those independent solutions.
+            Solutions::Constrained(solutions) if solutions.len() > 1 => {
+                return Some(bound_signature);
+            }
+            Solutions::Constrained(_) => {}
         }
 
         let Some(generic_context) = self.generic_context else {
@@ -1187,7 +1193,7 @@ impl<'db> Signature<'db> {
         };
 
         let mut builder = SpecializationBuilder::new(db, &constraints, inferable);
-        builder.add_constraint_set(when);
+        builder.add_constraint_set(when).ok()?;
         let concrete_class_receiver =
             matches!(receiver_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
         let specialization = builder.build_with(generic_context, |typevar, bounds| {
@@ -1195,8 +1201,9 @@ impl<'db> Signature<'db> {
                 && let Some(lower) = bounds.lower
                 && let Some(upper) = bounds.upper.as_single_bound()
                 && lower.is_equivalent_to(db, upper)
+                && let Ok(Some(solution)) = PathBounds::default_solve(db, &constraints, bounds)
             {
-                return Some(lower);
+                return Some(solution);
             }
 
             if let Some(bounds) = bounds


### PR DESCRIPTION
## Summary

Follow-up to [the receiver-constraint review discussion in #24707](https://github.com/astral-sh/ruff/pull/24707#discussion_r3326577303).

Prior to this change, we reduced overload receiver matching to a boolean before binding the method. That kept overloads with satisfiable generic receivers, but discarded the constraints needed to specialize the remainder of the signature; structural receivers with contradictory constraints could also remain visible.

We now reuse the receiver constraint set produced during binding, existentially prune impossible overloads, and solve exact receiver bounds into the bound signature while retaining one-sided constraints for later callable comparisons. For example:

```py
from typing import overload

class Box[T]:
    value: T

    @overload
    def method[S](self: "Box[S]", value: S) -> S: ...
    @overload
    def method(self, value: bytes) -> bytes: ...
    def method(self, value: object) -> object: ...

reveal_type(Box[str]().method)
# Overload[(value: str) -> str, (value: bytes) -> bytes]
```
