### PR TITLE
[ruff] Mark RUF055 bytes-pattern fixes as unsafe

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF055_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF055_0.py
@@ -103,3 +103,9 @@ re.sub(r'''abc''', "", s)
 # str.split("") raises ValueError while re.split("", s) succeeds
 re.split("", s)
 re.split(r"", s)
+
+
+# RUF055 should not offer a *safe* fix for bytes patterns against buffer objects:
+# re.search accepts memoryview, but `in` does not do a byte-subsequence search (#27024).
+assert re.search(b"ab", memoryview(b"abc"))
+assert re.search(b"ab", memoryview(b"abc")) is not None

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -49,8 +49,15 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 ///
 /// ## Fix safety
 ///
-/// This rule's fix is marked as unsafe if the affected expression contains comments. Otherwise,
-/// the fix can be applied safely.
+/// This rule's fix is marked as unsafe if the affected expression contains comments, or if the
+/// pattern is a **bytes** literal. Bytes patterns are unsafe to rewrite because `re` accepts any
+/// bytes-like object (including `memoryview`), while the equivalent `str`/`bytes` methods and
+/// membership tests do not behave the same for all buffer objects.
+///
+/// For example, `re.search(b"ab", memoryview(b"abc"))` is true, but
+/// `b"ab" in memoryview(b"abc")` is false.
+///
+/// Otherwise, the fix can be applied safely.
 ///
 /// ## References
 /// - [Python Regular Expression HOWTO: Common Problems - Use String Methods](https://docs.python.org/3/howto/regex.html#use-string-methods)
@@ -137,9 +144,12 @@ pub(crate) fn unnecessary_regular_expression(checker: &Checker, call: &ExprCall)
     );
 
     if let Some(repl) = repl {
+        // Bytes patterns are unsafe: `re` accepts buffer-protocol objects (e.g. memoryview)
+        // where membership / str methods do not (#27024).
+        let bytes_pattern = matches!(literal, Literal::Bytes(_));
         diagnostic.set_fix(Fix::applicable_edit(
             Edit::range_replacement(repl, re_func.range),
-            if checker.comment_ranges().intersects(re_func.range) {
+            if bytes_pattern || checker.comment_ranges().intersects(re_func.range) {
                 Applicability::Unsafe
             } else {
                 Applicability::Safe

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF055_RUF055_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF055_RUF055_0.py.snap
@@ -257,3 +257,37 @@ help: Replace with `s.replace(r'''abc''', "")`
 100 + s.replace(r'''abc''', "")
 101 |
     |
+
+RUF055 [*] Plain string pattern passed to `re` function
+   --> RUF055_0.py:110:8
+    |
+108 | # RUF055 should not offer a *safe* fix for bytes patterns against buffer objects:
+109 | # re.search accepts memoryview, but `in` does not do a byte-subsequence search (#27024).
+110 | assert re.search(b"ab", memoryview(b"abc"))
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+111 | assert re.search(b"ab", memoryview(b"abc")) is not None
+    |
+help: Replace with `b"ab" in memoryview(b"abc")`
+    |
+109 | # re.search accepts memoryview, but `in` does not do a byte-subsequence search (#27024).
+    - assert re.search(b"ab", memoryview(b"abc"))
+110 + assert b"ab" in memoryview(b"abc")
+111 | assert re.search(b"ab", memoryview(b"abc")) is not None
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF055 [*] Plain string pattern passed to `re` function
+   --> RUF055_0.py:111:8
+    |
+109 | # re.search accepts memoryview, but `in` does not do a byte-subsequence search (#27024).
+110 | assert re.search(b"ab", memoryview(b"abc"))
+111 | assert re.search(b"ab", memoryview(b"abc")) is not None
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+help: Replace with `b"ab" in memoryview(b"abc")`
+    |
+110 | assert re.search(b"ab", memoryview(b"abc"))
+    - assert re.search(b"ab", memoryview(b"abc")) is not None
+111 + assert b"ab" in memoryview(b"abc")
+    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF055_RUF055_3.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF055_RUF055_3.py.snap
@@ -17,6 +17,7 @@ help: Replace with `b_src.replace(rb"x", b"y")`
 6 + b_src.replace(rb"x", b"y")
 7 |
   |
+note: This is an unsafe fix and may change runtime behavior
 
 RUF055 [*] Plain string pattern passed to `re` function
   --> RUF055_3.py:9:4
@@ -33,6 +34,7 @@ help: Replace with `b_src.startswith(rb"abc")`
 9  + if b_src.startswith(rb"abc"):
 10 |     pass
    |
+note: This is an unsafe fix and may change runtime behavior
 
 RUF055 [*] Plain string pattern passed to `re` function
   --> RUF055_3.py:13:4
@@ -49,6 +51,7 @@ help: Replace with `rb"x" in b_src`
 13 + if rb"x" in b_src:
 14 |     pass
    |
+note: This is an unsafe fix and may change runtime behavior
 
 RUF055 [*] Plain string pattern passed to `re` function
   --> RUF055_3.py:17:1
@@ -66,3 +69,4 @@ help: Replace with `b_src.split(rb"abc")`
 17 + b_src.split(rb"abc")
 18 |
    |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

RUF055 rewrites plain-pattern `re.search`/`re.match`/… calls to `str` methods / membership tests. For **bytes** patterns this was marked **safe**, but:

```python
assert re.search(b"ab", memoryview(b"abc"))  # True
assert b"ab" in memoryview(b"abc")           # False
```

`re` accepts buffer-protocol objects; membership does not do a byte-subsequence search.

## Change

- Mark RUF055 autofixes as **unsafe** when the pattern is a bytes literal (and keep unsafe for comments).
- Document the memoryview edge case in the rule docs.
- Extend `RUF055_0.py` with the regression cases and refresh snapshots.

## Test plan

```bash
cargo test -p ruff_linter --lib preview_rules::rule_unnecessaryregularexpression_path_new_ruf055
# 4 passed
```

## Linked Issue

Closes #27024
