### PR TITLE
[`ruff`] Fix pow with negative exponent coerced to int

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM113.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM113.py
@@ -227,3 +227,12 @@ async def func():
     async for x in async_gen():
         g(x, idx)
         idx += 1
+
+
+def func():
+    # OK (`2 ** -1` is a `float`, not a valid `enumerate` start value)
+    idx = 2**-1
+    for x in range(5):
+        g(x, idx)
+        idx += 1
+        h(x)

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM113_SIM113.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM113_SIM113.py.snap
@@ -87,13 +87,3 @@ SIM113 Use `enumerate()` for index variable `i` in `for` loop
 220 |         i += 1
     |         ^^^^^^
     |
-
-SIM113 Use `enumerate()` for index variable `idx` in `for` loop
-   --> SIM113.py:237:9
-    |
-235 |     for x in range(5):
-236 |         g(x, idx)
-237 |         idx += 1
-    |         ^^^^^^^^
-238 |         h(x)
-    |

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM113_SIM113.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__preview__SIM113_SIM113.py.snap
@@ -87,3 +87,13 @@ SIM113 Use `enumerate()` for index variable `i` in `for` loop
 220 |         i += 1
     |         ^^^^^^
     |
+
+SIM113 Use `enumerate()` for index variable `idx` in `for` loop
+   --> SIM113.py:237:9
+    |
+235 |     for x in range(5):
+236 |         g(x, idx)
+237 |         idx += 1
+    |         ^^^^^^^^
+238 |         h(x)
+    |

--- a/crates/ruff_python_semantic/src/analyze/type_inference.rs
+++ b/crates/ruff_python_semantic/src/analyze/type_inference.rs
@@ -67,6 +67,25 @@ impl ResolvedPythonType {
     }
 }
 
+/// Return `true` if the expression is a negated numeric expression, accounting for
+/// nested `+`/`-` unary operators (e.g. `-(-1)` is not negative).
+/// Doesn't account for constant arithmetic, like `2 - 3`, which is assumed to be positive.
+fn is_negative(expr: &Expr) -> bool {
+    match expr {
+        Expr::UnaryOp(ast::ExprUnaryOp {
+            op: UnaryOp::USub,
+            operand,
+            ..
+        }) => !is_negative(operand),
+        Expr::UnaryOp(ast::ExprUnaryOp {
+            op: UnaryOp::UAdd,
+            operand,
+            ..
+        }) => is_negative(operand),
+        _ => false,
+    }
+}
+
 impl From<&Expr> for ResolvedPythonType {
     fn from(expr: &Expr) -> Self {
         match expr {
@@ -269,13 +288,23 @@ impl From<&Expr> for ResolvedPythonType {
                         ResolvedPythonType::from(left.as_ref()),
                         ResolvedPythonType::from(right.as_ref()),
                     ) {
-                        // Ex) `2 ** 4`
+                        // Ex) `2 // 4` or `2 ** 4`
                         (
-                            ResolvedPythonType::Atom(PythonType::Number(left)),
-                            ResolvedPythonType::Atom(PythonType::Number(right)),
+                            ResolvedPythonType::Atom(PythonType::Number(left_type)),
+                            ResolvedPythonType::Atom(PythonType::Number(right_type)),
                         ) => {
+                            // Ex) `2 ** -1` is a `float`, unlike `2 ** 1`.
+                            if matches!(op, Operator::Pow)
+                                && left_type == NumberLike::Integer
+                                && right_type == NumberLike::Integer
+                                && is_negative(right.as_ref())
+                            {
+                                return ResolvedPythonType::Atom(PythonType::Number(
+                                    NumberLike::Float,
+                                ));
+                            }
                             return ResolvedPythonType::Atom(PythonType::Number(
-                                left.coerce(right),
+                                left_type.coerce(right_type),
                             ));
                         }
                         (ResolvedPythonType::Atom(_), ResolvedPythonType::Atom(_)) => {

--- a/crates/ruff_python_semantic/src/analyze/type_inference.rs
+++ b/crates/ruff_python_semantic/src/analyze/type_inference.rs
@@ -553,6 +553,43 @@ mod tests {
             ResolvedPythonType::Atom(PythonType::Number(NumberLike::Bool))
         );
 
+        // Floor division and exponentiation.
+        assert_eq!(
+            ResolvedPythonType::from(parse("2 // 4").expr()),
+            ResolvedPythonType::Atom(PythonType::Number(NumberLike::Integer))
+        );
+        assert_eq!(
+            ResolvedPythonType::from(parse("2 // -4").expr()),
+            ResolvedPythonType::Atom(PythonType::Number(NumberLike::Integer))
+        );
+        assert_eq!(
+            ResolvedPythonType::from(parse("2 ** 4").expr()),
+            ResolvedPythonType::Atom(PythonType::Number(NumberLike::Integer))
+        );
+        assert_eq!(
+            ResolvedPythonType::from(parse("2 ** -1").expr()),
+            ResolvedPythonType::Atom(PythonType::Number(NumberLike::Float))
+        );
+        assert_eq!(
+            ResolvedPythonType::from(parse("2 ** -True").expr()),
+            ResolvedPythonType::Atom(PythonType::Number(NumberLike::Float))
+        );
+        // Consider UAdd.
+        assert_eq!(
+            ResolvedPythonType::from(parse("2 ** +1").expr()),
+            ResolvedPythonType::Atom(PythonType::Number(NumberLike::Integer))
+        );
+        // Consider nested USub x2.
+        assert_eq!(
+            ResolvedPythonType::from(parse("2 ** -(-1)").expr()),
+            ResolvedPythonType::Atom(PythonType::Number(NumberLike::Integer))
+        );
+        // Consider nextesed USub x3.
+        assert_eq!(
+            ResolvedPythonType::from(parse("2 ** -(-(-1))").expr()),
+            ResolvedPythonType::Atom(PythonType::Number(NumberLike::Float))
+        );
+
         // Conditional expressions.
         assert_eq!(
             ResolvedPythonType::from(parse("1 if True else 2").expr()),


### PR DESCRIPTION
## Summary

Resolves https://github.com/astral-sh/ruff/issues/27025

`enumerate_for_loop` relies on `ResolvedPythonType::from` from `type_inference` to identify whether exponent is an integer.

https://github.com/astral-sh/ruff/blob/a415d0a065c085991ec3e2f6a77855b0b9635777/crates/ruff_linter/src/rules/flake8_simplify/rules/enumerate_for_loop.rs#L103-L105

But `from` is using simple number coercion for `Pow`, so `int ** int` always considered to be an int.

https://github.com/astral-sh/ruff/blob/a415d0a065c085991ec3e2f6a77855b0b9635777/crates/ruff_python_semantic/src/analyze/type_inference.rs#L268-L285

As a simple solution I've added `is_negative` check for `right` expression - we just recursively check expression for unary operators, which will be fine for simple cases like `2**-2`.

Though it won't cover hypothetical cases with constants arithmetic like `2**(2-5)` or `~5` or nested version of these expressions. If these need to be covered in the future, we can add some kind of calculator for those constant expressions.

## Test Plan

- added tests to `type_inference.rs`
- added test to `SIM113.py`, not necessarily needed, since the issue was deeper and probably affects more rules than just SIM113, but might be nice to have at least one test in rules for this
- all tests pass, clippy is happy