### PR TITLE
[ty] Cache protocol assignability checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -119,54 +119,6 @@ def _(flag: bool) -> None:
     accepts_int(callback)  # error: [invalid-argument-type]
 ```
 
-## Conditional callable arguments
-
-Call binding asks whether an argument can ever satisfy the parameter type. A conditional
-assignability result must not be treated as never assignable.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from collections.abc import Awaitable, Callable, Coroutine
-from enum import Enum
-from typing import Any, Concatenate, TypeVar
-
-def callback[F: Callable[..., Any]](func: F) -> F:
-    return func
-
-type Func[T, **P, R] = Callable[Concatenate[T, P], Awaitable[R]]
-type ReturnFunc[T, **P, R] = Callable[Concatenate[T, P], Coroutine[Any, Any, R]]
-
-def api_error[T, **P, R]() -> Callable[[Func[T, P, R]], ReturnFunc[T, P, R]]:
-    raise NotImplementedError
-
-class Manager:
-    @api_error()
-    async def install(self) -> None: ...
-    @callback
-    def schedule(self, *funcs: Callable) -> None: ...  # error: [missing-type-argument]
-    def run(self) -> None:
-        self.schedule(self.install)
-
-E = TypeVar("E", bound=Enum)
-
-def accepts_enum_converter(converter: Callable[[Any], Enum]) -> None: ...
-def configure(enum: type[E]) -> None:
-    if issubclass(enum, float):
-        pass
-    elif issubclass(enum, int):
-        pass
-    elif issubclass(enum, str):
-        pass
-    else:
-        return
-
-    accepts_enum_converter(enum)
-```
-
 ## Union of class constructors uses strict checking
 
 A call on a union of class objects must satisfy every constructor.

--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -119,6 +119,54 @@ def _(flag: bool) -> None:
     accepts_int(callback)  # error: [invalid-argument-type]
 ```
 
+## Conditional callable arguments
+
+Call binding asks whether an argument can ever satisfy the parameter type. A conditional
+assignability result must not be treated as never assignable.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from collections.abc import Awaitable, Callable, Coroutine
+from enum import Enum
+from typing import Any, Concatenate, TypeVar
+
+def callback[F: Callable[..., Any]](func: F) -> F:
+    return func
+
+type Func[T, **P, R] = Callable[Concatenate[T, P], Awaitable[R]]
+type ReturnFunc[T, **P, R] = Callable[Concatenate[T, P], Coroutine[Any, Any, R]]
+
+def api_error[T, **P, R]() -> Callable[[Func[T, P, R]], ReturnFunc[T, P, R]]:
+    raise NotImplementedError
+
+class Manager:
+    @api_error()
+    async def install(self) -> None: ...
+    @callback
+    def schedule(self, *funcs: Callable) -> None: ...  # error: [missing-type-argument]
+    def run(self) -> None:
+        self.schedule(self.install)
+
+E = TypeVar("E", bound=Enum)
+
+def accepts_enum_converter(converter: Callable[[Any], Enum]) -> None: ...
+def configure(enum: type[E]) -> None:
+    if issubclass(enum, float):
+        pass
+    elif issubclass(enum, int):
+        pass
+    elif issubclass(enum, str):
+        pass
+    else:
+        return
+
+    accepts_enum_converter(enum)
+```
+
 ## Union of class constructors uses strict checking
 
 A call on a union of class objects must satisfy every constructor.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -15,6 +15,7 @@ use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
 use crate::types::tuple::TupleType;
+use crate::types::visitor::any_over_type;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -417,6 +418,51 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        #[salsa::tracked(
+            returns(copy),
+            cycle_initial=|_, _, _| Some(true),
+            heap_size=ruff_memory_usage::heap_size,
+        )]
+        fn protocol_assignability_terminal<'db>(
+            db: &'db dyn Db,
+            types: TypePair<'db>,
+        ) -> Option<bool> {
+            let constraints = ConstraintSetBuilder::new();
+            let result = types.first(db).has_relation_to(
+                db,
+                types.second(db),
+                &constraints,
+                InferableTypeVars::None,
+                TypeRelation::Assignability,
+            );
+
+            if result.is_always_satisfied(db) {
+                Some(true)
+            } else if result.is_never_satisfied(db) {
+                Some(false)
+            } else {
+                None
+            }
+        }
+
+        // Protocol relations are expensive and frequently repeated, but caching every eager
+        // relation retains many one-off type pairs. Preserve conditional results because call
+        // binding needs to distinguish "not always" from "never" assignable.
+        if inferable == InferableTypeVars::None
+            && any_over_type(db, target.resolve_type_alias(db), false, |ty| {
+                matches!(ty, Type::ProtocolInstance(_))
+                    || matches!(
+                        ty,
+                        Type::SubclassOf(target)
+                            if matches!(target.subclass_of(), SubclassOfInner::Protocol(_))
+                    )
+            })
+            && let Some(result) =
+                protocol_assignability_terminal(db, TypePair::new(db, self, target))
+        {
+            return ConstraintSet::from_bool(constraints, result);
+        }
+
         self.has_relation_to(
             db,
             target,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -449,8 +449,8 @@ impl<'db> Type<'db> {
         // relation retains many one-off type pairs. Preserve conditional results because call
         // binding needs to distinguish "not always" from "never" assignable.
         if inferable == InferableTypeVars::None
-            && any_over_type(db, target.resolve_type_alias(db), false, |ty| {
-                matches!(ty, Type::ProtocolInstance(_))
+            && any_over_type(db, target, false, |ty| {
+                matches!(ty, Type::ProtocolInstance(_) | Type::TypeAlias(_))
                     || matches!(
                         ty,
                         Type::SubclassOf(target)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -449,8 +449,8 @@ impl<'db> Type<'db> {
         // relation retains many one-off type pairs. Preserve conditional results because call
         // binding needs to distinguish "not always" from "never" assignable.
         if inferable == InferableTypeVars::None
-            && any_over_type(db, target, false, |ty| {
-                matches!(ty, Type::ProtocolInstance(_) | Type::TypeAlias(_))
+            && any_over_type(db, target.resolve_type_alias(db), false, |ty| {
+                matches!(ty, Type::ProtocolInstance(_))
                     || matches!(
                         ty,
                         Type::SubclassOf(target)


### PR DESCRIPTION
## Summary

Prior to this change, protocol-heavy checking repeated eager assignability checks even when there were no inferable type variables. We now add a narrow Salsa-tracked assignability cache for targets containing a protocol, including nested protocols and `type[Protocol]`, reusing the existing `TypePair` ingredient.

Only terminal `always` or `never` results are cached, so conditional results continue through the relation checker and call binding can distinguish "not always" from "never" assignable.

(In [#27043](https://github.com/astral-sh/ruff/pull/27043), tried replacing alias resolution and the recursive target walk with a cheap top-level protocol/alias check, but this moved `colour_science` by 16.33% vs. 4.82%).)
