### PR TITLE
[ty] Cache top-level protocol assignability checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -119,6 +119,54 @@ def _(flag: bool) -> None:
     accepts_int(callback)  # error: [invalid-argument-type]
 ```
 
+## Conditional callable arguments
+
+Call binding asks whether an argument can ever satisfy the parameter type. A conditional
+assignability result must not be treated as never assignable.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from collections.abc import Awaitable, Callable, Coroutine
+from enum import Enum
+from typing import Any, Concatenate, TypeVar
+
+def callback[F: Callable[..., Any]](func: F) -> F:
+    return func
+
+type Func[T, **P, R] = Callable[Concatenate[T, P], Awaitable[R]]
+type ReturnFunc[T, **P, R] = Callable[Concatenate[T, P], Coroutine[Any, Any, R]]
+
+def api_error[T, **P, R]() -> Callable[[Func[T, P, R]], ReturnFunc[T, P, R]]:
+    raise NotImplementedError
+
+class Manager:
+    @api_error()
+    async def install(self) -> None: ...
+    @callback
+    def schedule(self, *funcs: Callable) -> None: ...  # error: [missing-type-argument]
+    def run(self) -> None:
+        self.schedule(self.install)
+
+E = TypeVar("E", bound=Enum)
+
+def accepts_enum_converter(converter: Callable[[Any], Enum]) -> None: ...
+def configure(enum: type[E]) -> None:
+    if issubclass(enum, float):
+        pass
+    elif issubclass(enum, int):
+        pass
+    elif issubclass(enum, str):
+        pass
+    else:
+        return
+
+    accepts_enum_converter(enum)
+```
+
 ## Union of class constructors uses strict checking
 
 A call on a union of class objects must satisfy every constructor.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -417,6 +417,50 @@ impl<'db> Type<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        #[salsa::tracked(
+            returns(copy),
+            cycle_initial=|_, _, _| Some(true),
+            heap_size=ruff_memory_usage::heap_size,
+        )]
+        fn protocol_assignability_terminal<'db>(
+            db: &'db dyn Db,
+            types: TypePair<'db>,
+        ) -> Option<bool> {
+            let constraints = ConstraintSetBuilder::new();
+            let result = types.first(db).has_relation_to(
+                db,
+                types.second(db),
+                &constraints,
+                InferableTypeVars::None,
+                TypeRelation::Assignability,
+            );
+
+            if result.is_always_satisfied(db) {
+                Some(true)
+            } else if result.is_never_satisfied(db) {
+                Some(false)
+            } else {
+                None
+            }
+        }
+
+        // Protocol relations are expensive and frequently repeated, but caching every eager
+        // relation retains many one-off type pairs. Preserve conditional results because call
+        // binding needs to distinguish "not always" from "never" assignable.
+        if inferable == InferableTypeVars::None
+            && match target {
+                Type::ProtocolInstance(_) | Type::TypeAlias(_) => true,
+                Type::SubclassOf(target) => {
+                    matches!(target.subclass_of(), SubclassOfInner::Protocol(_))
+                }
+                _ => false,
+            }
+            && let Some(result) =
+                protocol_assignability_terminal(db, TypePair::new(db, self, target))
+        {
+            return ConstraintSet::from_bool(constraints, result);
+        }
+
         self.has_relation_to(
             db,
             target,


### PR DESCRIPTION
## Summary

This is the simpler assignability-cache experiment suggested in the [review of #26997](https://github.com/astral-sh/ruff/pull/26997#discussion_r3621742636), for comparison with [#27042](https://github.com/astral-sh/ruff/pull/27042).

Prior to this change, protocol-heavy checking repeated eager assignability checks even when there were no inferable type variables. We now add a narrow Salsa-tracked assignability cache, but gate it with a cheap top-level match for protocol instances, `type[Protocol]`, and type aliases instead of resolving aliases and recursively walking every target.

This deliberately skips protocols nested inside other types while treating aliases conservatively as cache candidates, allowing the performance and memory tradeoff to be measured independently. As in #27042, only terminal `always` or `never` results are cached, and the conditional-callable mdtest preserves the distinction between "not always" and "never" assignable.