### PR TITLE
Flatten formatter tags into format elements

### DIFF
--- a/crates/ruff_formatter/src/arguments.rs
+++ b/crates/ruff_formatter/src/arguments.rs
@@ -96,7 +96,6 @@ impl<'fmt, Context> From<&'fmt Argument<'fmt, Context>> for Arguments<'fmt, Cont
 
 #[cfg(test)]
 mod tests {
-    use crate::format_element::tag::Tag;
     use crate::prelude::*;
     use crate::{FormatState, VecBuffer, format_args, write};
 
@@ -125,10 +124,10 @@ mod tests {
                 FormatElement::Token { text: "a" },
                 FormatElement::Space,
                 // Group
-                FormatElement::Tag(Tag::StartGroup(tag::Group::new())),
+                FormatElement::StartGroup(tag::Group::new()),
                 FormatElement::Token { text: "(" },
                 FormatElement::Token { text: ")" },
-                FormatElement::Tag(Tag::EndGroup)
+                FormatElement::EndGroup
             ]
         );
     }

--- a/crates/ruff_formatter/src/buffer.rs
+++ b/crates/ruff_formatter/src/buffer.rs
@@ -1,6 +1,6 @@
 use super::{Arguments, FormatElement, write};
 use crate::format_element::Interned;
-use crate::prelude::{LineMode, Tag};
+use crate::prelude::LineMode;
 use crate::{FormatResult, FormatState};
 use rustc_hash::FxHashMap;
 use std::any::{Any, TypeId};
@@ -532,14 +532,14 @@ impl RemoveSoftLineBreaksState {
 
                 // `BestFitting` is resolved to its most-flat entry by this buffer, so we can drop
                 // the start and end tags, leaving only their contents.
-                FormatElement::Tag(Tag::StartBestFittingEntry | Tag::EndBestFittingEntry) => true,
+                FormatElement::StartBestFittingEntry | FormatElement::EndBestFittingEntry => true,
 
                 // Entered the start of an `if_group_breaks` or `if_group_fits`
                 // For `if_group_breaks`: Remove the start and end tag and all content in between.
                 // For `if_group_fits_on_line`: Unwrap the content. This is important because the enclosing group
                 // might still *expand* if the content exceeds the line width limit, in which case the
                 // `if_group_fits_on_line` content would be removed.
-                FormatElement::Tag(Tag::StartConditionalContent(condition)) => {
+                FormatElement::StartConditionalContent(condition) => {
                     if condition.mode.is_expanded() {
                         *self = Self::InIfGroupBreaks {
                             conditional_content_level: NonZeroUsize::new(1).unwrap(),
@@ -547,7 +547,7 @@ impl RemoveSoftLineBreaksState {
                     }
                     true
                 }
-                FormatElement::Tag(Tag::EndConditionalContent) => true,
+                FormatElement::EndConditionalContent => true,
                 _ => false,
             },
             Self::InIfGroupBreaks {
@@ -555,11 +555,11 @@ impl RemoveSoftLineBreaksState {
             } => {
                 match element {
                     // A nested `if_group_breaks` or `if_group_fits_on_line`
-                    FormatElement::Tag(Tag::StartConditionalContent(_)) => {
+                    FormatElement::StartConditionalContent(_) => {
                         *conditional_content_level = conditional_content_level.saturating_add(1);
                     }
                     // The end of an `if_group_breaks` or `if_group_fits_on_line`.
-                    FormatElement::Tag(Tag::EndConditionalContent) => {
+                    FormatElement::EndConditionalContent => {
                         if let Some(level) = NonZeroUsize::new(conditional_content_level.get() - 1)
                         {
                             *conditional_content_level = level;

--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -2,11 +2,9 @@ use std::cell::Cell;
 use std::marker::PhantomData;
 use std::num::NonZeroU8;
 
-#[allow(clippy::enum_glob_use)]
-use Tag::*;
 use ruff_text_size::TextRange;
 
-use crate::format_element::tag::{Condition, Tag};
+use crate::format_element::tag::Condition;
 use crate::prelude::tag::{DedentMode, GroupMode, LabelId};
 use crate::prelude::*;
 use crate::{Argument, Arguments, FormatContext, FormatOptions, GroupId, TextSize, write};
@@ -480,11 +478,11 @@ pub struct LineSuffix<'a, Context> {
 
 impl<Context> Format<Context> for LineSuffix<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartLineSuffix {
+        f.write_element(FormatElement::StartLineSuffix {
             reserved_width: self.reserved_width,
-        }));
+        });
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndLineSuffix));
+        f.write_element(FormatElement::EndLineSuffix);
 
         Ok(())
     }
@@ -540,7 +538,7 @@ impl<Context> Format<Context> for LineSuffixBoundary {
 /// Marks some content with a label.
 ///
 /// This does not directly influence how this content will be printed, but some
-/// parts of the formatter may inspect the [labelled element](Tag::StartLabelled)
+/// parts of the formatter may inspect the [labelled element](crate::Tag::StartLabelled)
 /// using [`FormatElements::has_label`].
 ///
 /// ## Examples
@@ -621,9 +619,9 @@ pub struct FormatLabelled<'a, Context> {
 
 impl<Context> Format<Context> for FormatLabelled<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartLabelled(self.label_id)));
+        f.write_element(FormatElement::StartLabelled(self.label_id));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndLabelled));
+        f.write_element(FormatElement::EndLabelled);
 
         Ok(())
     }
@@ -722,9 +720,9 @@ pub struct Indent<'a, Context> {
 
 impl<Context> Format<Context> for Indent<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartIndent));
+        f.write_element(FormatElement::StartIndent);
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndIndent));
+        f.write_element(FormatElement::EndIndent);
 
         Ok(())
     }
@@ -795,9 +793,9 @@ pub struct Dedent<'a, Context> {
 
 impl<Context> Format<Context> for Dedent<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartDedent(self.mode)));
+        f.write_element(FormatElement::StartDedent(self.mode));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndDedent));
+        f.write_element(FormatElement::EndDedent);
 
         Ok(())
     }
@@ -984,9 +982,9 @@ pub struct Align<'a, Context> {
 
 impl<Context> Format<Context> for Align<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartAlign(tag::Align(self.count))));
+        f.write_element(FormatElement::StartAlign(tag::Align(self.count)));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndAlign));
+        f.write_element(FormatElement::EndAlign);
 
         Ok(())
     }
@@ -1208,7 +1206,7 @@ impl<Context> Format<Context> for BlockIndent<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         let snapshot = f.snapshot();
 
-        f.write_element(FormatElement::Tag(StartIndent));
+        f.write_element(FormatElement::StartIndent);
 
         match self.mode {
             IndentMode::Soft => write!(f, [soft_line_break()])?,
@@ -1229,7 +1227,7 @@ impl<Context> Format<Context> for BlockIndent<'_, Context> {
             return Ok(());
         }
 
-        f.write_element(FormatElement::Tag(EndIndent));
+        f.write_element(FormatElement::EndIndent);
 
         match self.mode {
             IndentMode::Soft => write!(f, [soft_line_break()]),
@@ -1441,13 +1439,13 @@ impl<Context> Format<Context> for Group<'_, Context> {
             GroupMode::Flat
         };
 
-        f.write_element(FormatElement::Tag(StartGroup(
+        f.write_element(FormatElement::StartGroup(
             tag::Group::new().with_id(self.id).with_mode(mode),
-        )));
+        ));
 
         Arguments::from(&self.content).fmt(f)?;
 
-        f.write_element(FormatElement::Tag(EndGroup));
+        f.write_element(FormatElement::EndGroup);
 
         Ok(())
     }
@@ -1586,13 +1584,11 @@ impl<Context> BestFitParenthesize<'_, Context> {
 
 impl<Context> Format<Context> for BestFitParenthesize<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartBestFitParenthesize {
-            id: self.group_id,
-        }));
+        f.write_element(FormatElement::StartBestFitParenthesize { id: self.group_id });
 
         Arguments::from(&self.content).fmt(f)?;
 
-        f.write_element(FormatElement::Tag(EndBestFitParenthesize));
+        f.write_element(FormatElement::EndBestFitParenthesize);
 
         Ok(())
     }
@@ -1719,11 +1715,11 @@ pub struct ConditionalGroup<'content, Context> {
 
 impl<Context> Format<Context> for ConditionalGroup<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartConditionalGroup(
+        f.write_element(FormatElement::StartConditionalGroup(
             tag::ConditionalGroup::new(self.condition),
-        )));
+        ));
         f.write_fmt(Arguments::from(&self.content))?;
-        f.write_element(FormatElement::Tag(EndConditionalGroup));
+        f.write_element(FormatElement::EndConditionalGroup);
 
         Ok(())
     }
@@ -2024,11 +2020,11 @@ impl<Context> IfGroupBreaks<'_, Context> {
 
 impl<Context> Format<Context> for IfGroupBreaks<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartConditionalContent(
+        f.write_element(FormatElement::StartConditionalContent(
             Condition::new(self.mode).with_group_id(self.group_id),
-        )));
+        ));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndConditionalContent));
+        f.write_element(FormatElement::EndConditionalContent);
 
         Ok(())
     }
@@ -2150,9 +2146,9 @@ pub struct IndentIfGroupBreaks<'a, Context> {
 
 impl<Context> Format<Context> for IndentIfGroupBreaks<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartIndentIfGroupBreaks(self.group_id)));
+        f.write_element(FormatElement::StartIndentIfGroupBreaks(self.group_id));
         Arguments::from(&self.content).fmt(f)?;
-        f.write_element(FormatElement::Tag(EndIndentIfGroupBreaks));
+        f.write_element(FormatElement::EndIndentIfGroupBreaks);
 
         Ok(())
     }
@@ -2243,11 +2239,11 @@ impl<Context> FitsExpanded<'_, Context> {
 
 impl<Context> Format<Context> for FitsExpanded<'_, Context> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(StartFitsExpanded(
+        f.write_element(FormatElement::StartFitsExpanded(
             tag::FitsExpanded::new().with_condition(self.condition),
-        )));
+        ));
         f.write_fmt(Arguments::from(&self.content))?;
-        f.write_element(FormatElement::Tag(EndFitsExpanded));
+        f.write_element(FormatElement::EndFitsExpanded);
 
         Ok(())
     }
@@ -2503,7 +2499,7 @@ pub struct FillBuilder<'fmt, 'buf, Context> {
 
 impl<'a, 'buf, Context> FillBuilder<'a, 'buf, Context> {
     pub(crate) fn new(fmt: &'a mut Formatter<'buf, Context>) -> Self {
-        fmt.write_element(FormatElement::Tag(StartFill));
+        fmt.write_element(FormatElement::StartFill);
 
         Self {
             result: Ok(()),
@@ -2535,14 +2531,14 @@ impl<'a, 'buf, Context> FillBuilder<'a, 'buf, Context> {
             if self.empty {
                 self.empty = false;
             } else {
-                self.fmt.write_element(FormatElement::Tag(StartEntry));
+                self.fmt.write_element(FormatElement::StartEntry);
                 separator.fmt(self.fmt)?;
-                self.fmt.write_element(FormatElement::Tag(EndEntry));
+                self.fmt.write_element(FormatElement::EndEntry);
             }
 
-            self.fmt.write_element(FormatElement::Tag(StartEntry));
+            self.fmt.write_element(FormatElement::StartEntry);
             entry.fmt(self.fmt)?;
-            self.fmt.write_element(FormatElement::Tag(EndEntry));
+            self.fmt.write_element(FormatElement::EndEntry);
             Ok(())
         });
 
@@ -2552,7 +2548,7 @@ impl<'a, 'buf, Context> FillBuilder<'a, 'buf, Context> {
     /// Finishes the output and returns any error encountered
     pub fn finish(&mut self) -> FormatResult<()> {
         if self.result.is_ok() {
-            self.fmt.write_element(FormatElement::Tag(EndFill));
+            self.fmt.write_element(FormatElement::EndFill);
         }
         self.result
     }
@@ -2703,9 +2699,9 @@ impl<Context> Format<Context> for BestFitting<'_, Context> {
         let mut buffer = VecBuffer::with_capacity(variants.len() * 8, f.state_mut());
 
         for variant in variants {
-            buffer.write_element(FormatElement::Tag(StartBestFittingEntry));
+            buffer.write_element(FormatElement::StartBestFittingEntry);
             buffer.write_fmt(Arguments::from(variant))?;
-            buffer.write_element(FormatElement::Tag(EndBestFittingEntry));
+            buffer.write_element(FormatElement::EndBestFittingEntry);
         }
 
         // OK because the constructor guarantees that there are always at

--- a/crates/ruff_formatter/src/format_element.rs
+++ b/crates/ruff_formatter/src/format_element.rs
@@ -9,9 +9,12 @@ use std::ops::Deref;
 use std::rc::Rc;
 use unicode_width::UnicodeWidthChar;
 
-use crate::format_element::tag::{GroupMode, LabelId, Tag};
+use crate::format_element::tag::{
+    Align, Condition, ConditionalGroup, DedentMode, FitsExpanded, Group, GroupMode, LabelId,
+    VerbatimKind,
+};
 use crate::source_code::SourceCodeSlice;
-use crate::{IndentWidth, TagKind};
+use crate::{GroupId, IndentWidth, TagKind};
 use ruff_text_size::TextSize;
 
 /// Language agnostic IR for formatting source code.
@@ -34,7 +37,9 @@ pub enum FormatElement {
     SourcePosition(TextSize),
 
     /// A ASCII only Token that contains no line breaks or tab characters.
-    Token { text: &'static str },
+    Token {
+        text: &'static str,
+    },
 
     /// An arbitrary text that can contain tabs, newlines, and unicode characters.
     Text {
@@ -64,17 +69,68 @@ pub enum FormatElement {
         mode: BestFittingMode,
     },
 
-    /// A [Tag] that marks the start/end of some content to which some special formatting is applied.
-    Tag(Tag),
+    StartIndent,
+    EndIndent,
+    StartAlign(Align),
+    EndAlign,
+    StartDedent(DedentMode),
+    EndDedent,
+    StartGroup(Group),
+    EndGroup,
+    StartConditionalGroup(ConditionalGroup),
+    EndConditionalGroup,
+    StartConditionalContent(Condition),
+    EndConditionalContent,
+    StartIndentIfGroupBreaks(GroupId),
+    EndIndentIfGroupBreaks,
+    StartFill,
+    EndFill,
+    StartEntry,
+    EndEntry,
+    StartLineSuffix {
+        reserved_width: u32,
+    },
+    EndLineSuffix,
+    StartVerbatim(VerbatimKind),
+    EndVerbatim,
+    StartLabelled(LabelId),
+    EndLabelled,
+    StartFitsExpanded(FitsExpanded),
+    EndFitsExpanded,
+    StartBestFittingEntry,
+    EndBestFittingEntry,
+    StartBestFitParenthesize {
+        id: Option<GroupId>,
+    },
+    EndBestFitParenthesize,
 }
 
 impl FormatElement {
     pub fn tag_kind(&self) -> Option<TagKind> {
-        if let FormatElement::Tag(tag) = self {
-            Some(tag.kind())
-        } else {
-            None
-        }
+        Some(match self {
+            Self::StartIndent | Self::EndIndent => TagKind::Indent,
+            Self::StartAlign(_) | Self::EndAlign => TagKind::Align,
+            Self::StartDedent(_) | Self::EndDedent => TagKind::Dedent,
+            Self::StartGroup(_) | Self::EndGroup => TagKind::Group,
+            Self::StartConditionalGroup(_) | Self::EndConditionalGroup => TagKind::ConditionalGroup,
+            Self::StartConditionalContent(_) | Self::EndConditionalContent => {
+                TagKind::ConditionalContent
+            }
+            Self::StartIndentIfGroupBreaks(_) | Self::EndIndentIfGroupBreaks => {
+                TagKind::IndentIfGroupBreaks
+            }
+            Self::StartFill | Self::EndFill => TagKind::Fill,
+            Self::StartEntry | Self::EndEntry => TagKind::Entry,
+            Self::StartLineSuffix { .. } | Self::EndLineSuffix => TagKind::LineSuffix,
+            Self::StartVerbatim(_) | Self::EndVerbatim => TagKind::Verbatim,
+            Self::StartLabelled(_) | Self::EndLabelled => TagKind::Labelled,
+            Self::StartFitsExpanded(_) | Self::EndFitsExpanded => TagKind::FitsExpanded,
+            Self::StartBestFittingEntry | Self::EndBestFittingEntry => TagKind::BestFittingEntry,
+            Self::StartBestFitParenthesize { .. } | Self::EndBestFitParenthesize => {
+                TagKind::BestFitParenthesize
+            }
+            _ => return None,
+        })
     }
 }
 
@@ -98,10 +154,14 @@ impl std::fmt::Debug for FormatElement {
                 .field("mode", &mode)
                 .finish(),
             FormatElement::Interned(interned) => fmt.debug_list().entries(&**interned).finish(),
-            FormatElement::Tag(tag) => fmt.debug_tuple("Tag").field(tag).finish(),
             FormatElement::SourcePosition(position) => {
                 fmt.debug_tuple("SourcePosition").field(position).finish()
             }
+            element => fmt
+                .debug_struct("Tag")
+                .field("kind", &element.tag_kind())
+                .field("start", &element.is_start_tag())
+                .finish(),
         }
     }
 }
@@ -224,25 +284,65 @@ pub fn normalize_newlines<const N: usize>(text: &str, terminators: [char; N]) ->
 }
 
 impl FormatElement {
-    /// Returns `true` if self is a [`FormatElement::Tag`]
     pub const fn is_tag(&self) -> bool {
-        matches!(self, FormatElement::Tag(_))
+        matches!(
+            self,
+            Self::StartIndent
+                | Self::EndIndent
+                | Self::StartAlign(_)
+                | Self::EndAlign
+                | Self::StartDedent(_)
+                | Self::EndDedent
+                | Self::StartGroup(_)
+                | Self::EndGroup
+                | Self::StartConditionalGroup(_)
+                | Self::EndConditionalGroup
+                | Self::StartConditionalContent(_)
+                | Self::EndConditionalContent
+                | Self::StartIndentIfGroupBreaks(_)
+                | Self::EndIndentIfGroupBreaks
+                | Self::StartFill
+                | Self::EndFill
+                | Self::StartEntry
+                | Self::EndEntry
+                | Self::StartLineSuffix { .. }
+                | Self::EndLineSuffix
+                | Self::StartVerbatim(_)
+                | Self::EndVerbatim
+                | Self::StartLabelled(_)
+                | Self::EndLabelled
+                | Self::StartFitsExpanded(_)
+                | Self::EndFitsExpanded
+                | Self::StartBestFittingEntry
+                | Self::EndBestFittingEntry
+                | Self::StartBestFitParenthesize { .. }
+                | Self::EndBestFitParenthesize
+        )
     }
 
-    /// Returns `true` if self is a [`FormatElement::Tag`] and [`Tag::is_start`] is `true`.
     pub const fn is_start_tag(&self) -> bool {
-        match self {
-            FormatElement::Tag(tag) => tag.is_start(),
-            _ => false,
-        }
+        matches!(
+            self,
+            Self::StartIndent
+                | Self::StartAlign(_)
+                | Self::StartDedent(_)
+                | Self::StartGroup(_)
+                | Self::StartConditionalGroup(_)
+                | Self::StartConditionalContent(_)
+                | Self::StartIndentIfGroupBreaks(_)
+                | Self::StartFill
+                | Self::StartEntry
+                | Self::StartLineSuffix { .. }
+                | Self::StartVerbatim(_)
+                | Self::StartLabelled(_)
+                | Self::StartFitsExpanded(_)
+                | Self::StartBestFittingEntry
+                | Self::StartBestFitParenthesize { .. }
+        )
     }
 
-    /// Returns `true` if self is a [`FormatElement::Tag`] and [`Tag::is_end`] is `true`.
     pub const fn is_end_tag(&self) -> bool {
-        match self {
-            FormatElement::Tag(tag) => tag.is_end(),
-            _ => false,
-        }
+        self.is_tag() && !self.is_start_tag()
     }
 
     pub const fn is_text(&self) -> bool {
@@ -263,7 +363,7 @@ impl FormatElements for FormatElement {
     fn will_break(&self) -> bool {
         match self {
             FormatElement::ExpandParent => true,
-            FormatElement::Tag(Tag::StartGroup(group)) => !group.mode().is_flat(),
+            FormatElement::StartGroup(group) => !group.mode().is_flat(),
             FormatElement::Line(line_mode) => matches!(line_mode, LineMode::Hard | LineMode::Empty),
             FormatElement::Text { text_width, .. } => text_width.is_multiline(),
             FormatElement::SourceCodeSlice { text_width, .. } => text_width.is_multiline(),
@@ -274,29 +374,25 @@ impl FormatElements for FormatElement {
                 variants: best_fitting,
                 ..
             } => best_fitting.most_flat().will_break(),
-            FormatElement::LineSuffixBoundary
-            | FormatElement::Space
-            | FormatElement::Tag(_)
-            | FormatElement::Token { .. }
-            | FormatElement::SourcePosition(_) => false,
+            _ => false,
         }
     }
 
     fn has_label(&self, label_id: LabelId) -> bool {
         match self {
-            FormatElement::Tag(Tag::StartLabelled(actual)) => *actual == label_id,
+            FormatElement::StartLabelled(actual) => *actual == label_id,
             FormatElement::Interned(interned) => interned.deref().has_label(label_id),
             _ => false,
         }
     }
 
-    fn start_tag(&self, _: TagKind) -> Option<&Tag> {
+    fn start_tag(&self, _: TagKind) -> Option<&FormatElement> {
         None
     }
 
-    fn end_tag(&self, kind: TagKind) -> Option<&Tag> {
+    fn end_tag(&self, kind: TagKind) -> Option<&FormatElement> {
         match self {
-            FormatElement::Tag(tag) if tag.kind() == kind && tag.is_end() => Some(tag),
+            element if element.tag_kind() == Some(kind) && element.is_end_tag() => Some(element),
             _ => None,
         }
     }
@@ -343,7 +439,7 @@ impl BestFittingVariants {
         debug_assert!(
             variants
                 .iter()
-                .filter(|element| matches!(element, FormatElement::Tag(Tag::StartBestFittingEntry)))
+                .filter(|element| matches!(element, FormatElement::StartBestFittingEntry))
                 .count()
                 >= 2,
             "Requires at least the least expanded and most expanded variants"
@@ -360,7 +456,7 @@ impl BestFittingVariants {
         assert!(
             self.as_slice()
                 .iter()
-                .filter(|element| matches!(element, FormatElement::Tag(Tag::StartBestFittingEntry)))
+                .filter(|element| matches!(element, FormatElement::StartBestFittingEntry))
                 .count()
                 >= 2,
             "Requires at least the least expanded and most expanded variants"
@@ -381,7 +477,7 @@ impl BestFittingVariants {
         assert!(
             self.as_slice()
                 .iter()
-                .filter(|element| matches!(element, FormatElement::Tag(Tag::StartBestFittingEntry)))
+                .filter(|element| matches!(element, FormatElement::StartBestFittingEntry))
                 .count()
                 >= 2,
             "Requires at least the least expanded and most expanded variants"
@@ -416,13 +512,11 @@ impl<'a> Iterator for BestFittingVariantsIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.elements.first()? {
-            FormatElement::Tag(Tag::StartBestFittingEntry) => {
+            FormatElement::StartBestFittingEntry => {
                 let end = self
                     .elements
                     .iter()
-                    .position(|element| {
-                        matches!(element, FormatElement::Tag(Tag::EndBestFittingEntry))
-                    })
+                    .position(|element| matches!(element, FormatElement::EndBestFittingEntry))
                     .map_or(self.elements.len(), |position| position + 1);
 
                 let (variant, rest) = self.elements.split_at(end);
@@ -444,9 +538,10 @@ impl<'a> Iterator for BestFittingVariantsIter<'a> {
 
 impl DoubleEndedIterator for BestFittingVariantsIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let start_position = self.elements.iter().rposition(|element| {
-            matches!(element, FormatElement::Tag(Tag::StartBestFittingEntry))
-        })?;
+        let start_position = self
+            .elements
+            .iter()
+            .rposition(|element| matches!(element, FormatElement::StartBestFittingEntry))?;
 
         let (rest, variant) = self.elements.split_at(start_position);
         self.elements = rest;
@@ -472,11 +567,11 @@ pub trait FormatElements {
     /// Returns the start tag of `kind` if:
     /// - the last element is an end tag of `kind`.
     /// - there's a matching start tag in this document (may not be true if this slice is an interned element and the `start` is in the document storing the interned element).
-    fn start_tag(&self, kind: TagKind) -> Option<&Tag>;
+    fn start_tag(&self, kind: TagKind) -> Option<&FormatElement>;
 
     /// Returns the end tag if:
     /// - the last element is an end tag of `kind`
-    fn end_tag(&self, kind: TagKind) -> Option<&Tag>;
+    fn end_tag(&self, kind: TagKind) -> Option<&FormatElement>;
 }
 
 /// New-type wrapper for a single-line text unicode width.
@@ -613,7 +708,7 @@ mod sizes {
     assert_eq_size!(crate::SourceCodeSlice, [u8; 8]);
 
     #[cfg(not(debug_assertions))]
-    assert_eq_size!(super::Tag, [u8; 16]);
+    assert_eq_size!(super::tag::Tag, [u8; 16]);
 
     #[cfg(not(debug_assertions))]
     assert_eq_size!(super::FormatElement, [u8; 24]);

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -12,8 +12,6 @@ use crate::{
     IndentStyle, IndentWidth, LineWidth, PrinterOptions, format, write,
 };
 
-use super::tag::Tag;
-
 /// A formatted document.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct Document {
@@ -62,31 +60,31 @@ impl Document {
             let mut expands = false;
             for element in elements {
                 let element_expands = match element {
-                    FormatElement::Tag(Tag::StartGroup(group)) => {
+                    FormatElement::StartGroup(group) => {
                         enclosing.push(Enclosing::Group(group));
                         false
                     }
-                    FormatElement::Tag(Tag::EndGroup) => match enclosing.pop() {
+                    FormatElement::EndGroup => match enclosing.pop() {
                         Some(Enclosing::Group(group)) => !group.mode().is_flat(),
                         _ => false,
                     },
-                    FormatElement::Tag(Tag::StartBestFitParenthesize { .. }) => {
+                    FormatElement::StartBestFitParenthesize { .. } => {
                         enclosing.push(Enclosing::BestFitParenthesize { expanded: expands });
                         expands = false;
                         continue;
                     }
 
-                    FormatElement::Tag(Tag::EndBestFitParenthesize) => {
+                    FormatElement::EndBestFitParenthesize => {
                         if let Some(Enclosing::BestFitParenthesize { expanded }) = enclosing.pop() {
                             expands = expanded;
                         }
                         continue;
                     }
-                    FormatElement::Tag(Tag::StartConditionalGroup(group)) => {
+                    FormatElement::StartConditionalGroup(group) => {
                         enclosing.push(Enclosing::ConditionalGroup(group));
                         false
                     }
-                    FormatElement::Tag(Tag::EndConditionalGroup) => match enclosing.pop() {
+                    FormatElement::EndConditionalGroup => match enclosing.pop() {
                         Some(Enclosing::ConditionalGroup(group)) => !group.mode().is_flat(),
                         _ => false,
                     },
@@ -107,14 +105,14 @@ impl Document {
                         enclosing.pop();
                         continue;
                     }
-                    FormatElement::Tag(Tag::StartFitsExpanded(fits_expanded)) => {
+                    FormatElement::StartFitsExpanded(fits_expanded) => {
                         enclosing.push(Enclosing::FitsExpanded {
                             tag: fits_expanded,
                             expands_before: expands,
                         });
                         false
                     }
-                    FormatElement::Tag(Tag::EndFitsExpanded) => {
+                    FormatElement::EndFitsExpanded => {
                         if let Some(Enclosing::FitsExpanded { expands_before, .. }) =
                             enclosing.pop()
                         {
@@ -255,7 +253,7 @@ impl FormatOptions for IrFormatOptions {
 impl Format<IrFormatContext<'_>> for &[FormatElement] {
     fn fmt(&self, f: &mut Formatter<IrFormatContext>) -> FormatResult<()> {
         #[allow(clippy::enum_glob_use)]
-        use Tag::*;
+        use FormatElement::*;
 
         write!(f, [ContentArrayStart])?;
 
@@ -362,7 +360,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
 
                     write!(f, [token("[")])?;
                     f.write_elements([
-                        FormatElement::Tag(StartIndent),
+                        FormatElement::StartIndent,
                         FormatElement::Line(LineMode::Hard),
                     ]);
 
@@ -371,7 +369,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                     }
 
                     f.write_elements([
-                        FormatElement::Tag(EndIndent),
+                        FormatElement::EndIndent,
                         FormatElement::Line(LineMode::Hard),
                     ]);
 
@@ -401,10 +399,12 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                     }
                 }
 
-                FormatElement::Tag(tag) => {
-                    if tag.is_start() {
+                tag => {
+                    let kind = tag.tag_kind().expect("matched a tag");
+
+                    if tag.is_start_tag() {
                         first_element = true;
-                        tag_stack.push(tag.kind());
+                        tag_stack.push(kind);
                     }
                     // Handle documents with mismatching start/end or superfluous end tags
                     else {
@@ -415,14 +415,14 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                                     f,
                                     [
                                         token("<END_TAG_WITHOUT_START<"),
-                                        text(&std::format!("{:?}", tag.kind())),
+                                        text(&std::format!("{kind:?}")),
                                         token(">>"),
                                     ]
                                 )?;
                                 first_element = false;
                                 continue;
                             }
-                            Some(start_kind) if start_kind != tag.kind() => {
+                            Some(start_kind) if start_kind != kind => {
                                 write!(
                                     f,
                                     [
@@ -432,7 +432,7 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                                         token("ERROR<START_END_TAG_MISMATCH<start: "),
                                         text(&std::format!("{start_kind:?}")),
                                         token(", end: "),
-                                        text(&std::format!("{:?}", tag.kind())),
+                                        text(&std::format!("{kind:?}")),
                                         token(">>")
                                     ]
                                 )?;
@@ -630,9 +630,10 @@ impl Format<IrFormatContext<'_>> for &[FormatElement] {
                         | EndVerbatim => {
                             write!(f, [ContentArrayEnd, token(")")])?;
                         }
+                        _ => {}
                     }
 
-                    if tag.is_start() {
+                    if tag.is_start_tag() {
                         write!(f, [ContentArrayStart])?;
                     }
                 }
@@ -659,13 +660,11 @@ struct ContentArrayStart;
 
 impl Format<IrFormatContext<'_>> for ContentArrayStart {
     fn fmt(&self, f: &mut Formatter<IrFormatContext>) -> FormatResult<()> {
-        use Tag::{StartGroup, StartIndent};
-
         write!(f, [token("[")])?;
 
         f.write_elements([
-            FormatElement::Tag(StartGroup(tag::Group::new())),
-            FormatElement::Tag(StartIndent),
+            FormatElement::StartGroup(tag::Group::new()),
+            FormatElement::StartIndent,
             FormatElement::Line(LineMode::Soft),
         ]);
 
@@ -677,11 +676,10 @@ struct ContentArrayEnd;
 
 impl Format<IrFormatContext<'_>> for ContentArrayEnd {
     fn fmt(&self, f: &mut Formatter<IrFormatContext>) -> FormatResult<()> {
-        use Tag::{EndGroup, EndIndent};
         f.write_elements([
-            FormatElement::Tag(EndIndent),
+            FormatElement::EndIndent,
             FormatElement::Line(LineMode::Soft),
-            FormatElement::Tag(EndGroup),
+            FormatElement::EndGroup,
         ]);
 
         write!(f, [token("]")])
@@ -696,12 +694,11 @@ impl FormatElements for [FormatElement] {
             match element {
                 // Line suffix
                 // Ignore if any of its content breaks
-                FormatElement::Tag(
-                    Tag::StartLineSuffix { reserved_width: _ } | Tag::StartFitsExpanded(_),
-                ) => {
+                FormatElement::StartLineSuffix { reserved_width: _ }
+                | FormatElement::StartFitsExpanded(_) => {
                     ignore_depth += 1;
                 }
-                FormatElement::Tag(Tag::EndLineSuffix | Tag::EndFitsExpanded) => {
+                FormatElement::EndLineSuffix | FormatElement::EndFitsExpanded => {
                     ignore_depth = ignore_depth.saturating_sub(1);
                 }
                 FormatElement::Interned(interned) if ignore_depth == 0 => {
@@ -727,16 +724,16 @@ impl FormatElements for [FormatElement] {
             .is_some_and(|element| element.has_label(expected))
     }
 
-    fn start_tag(&self, kind: TagKind) -> Option<&Tag> {
+    fn start_tag(&self, kind: TagKind) -> Option<&FormatElement> {
         fn traverse_slice<'a>(
             slice: &'a [FormatElement],
             kind: TagKind,
             depth: &mut usize,
-        ) -> Option<&'a Tag> {
+        ) -> Option<&'a FormatElement> {
             for element in slice.iter().rev() {
                 match element {
-                    FormatElement::Tag(tag) if tag.kind() == kind => {
-                        if tag.is_start() {
+                    tag if tag.tag_kind() == Some(kind) => {
+                        if tag.is_start_tag() {
                             if *depth == 0 {
                                 // Invalid document
                                 return None;
@@ -776,7 +773,7 @@ impl FormatElements for [FormatElement] {
         traverse_slice(self, kind, &mut depth)
     }
 
-    fn end_tag(&self, kind: TagKind) -> Option<&Tag> {
+    fn end_tag(&self, kind: TagKind) -> Option<&FormatElement> {
         self.last().and_then(|element| element.end_tag(kind))
     }
 }
@@ -907,23 +904,21 @@ mod tests {
 
     #[test]
     fn display_invalid_document() {
-        use Tag::*;
-
         let document = Document::from(vec![
             FormatElement::Token { text: "[" },
-            FormatElement::Tag(StartGroup(tag::Group::new())),
-            FormatElement::Tag(StartIndent),
+            FormatElement::StartGroup(tag::Group::new()),
+            FormatElement::StartIndent,
             FormatElement::Line(LineMode::Soft),
             FormatElement::Token { text: "a" },
             // Close group instead of indent
-            FormatElement::Tag(EndGroup),
+            FormatElement::EndGroup,
             FormatElement::Line(LineMode::Soft),
-            FormatElement::Tag(EndIndent),
+            FormatElement::EndIndent,
             FormatElement::Token { text: "]" },
             // End tag without start
-            FormatElement::Tag(EndIndent),
+            FormatElement::EndIndent,
             // Start tag without an end
-            FormatElement::Tag(StartIndent),
+            FormatElement::StartIndent,
         ]);
 
         assert_eq!(

--- a/crates/ruff_formatter/src/printer/call_stack.rs
+++ b/crates/ruff_formatter/src/printer/call_stack.rs
@@ -94,8 +94,8 @@ impl Default for PrintElementArgs {
 
 /// Call stack that stores the [`PrintElementCallArgs`].
 ///
-/// New [`PrintElementCallArgs`] are pushed onto the stack for every [`start`](Tag::is_start) [`Tag`](FormatElement::Tag)
-/// and popped when reaching the corresponding [`end`](Tag::is_end) [`Tag`](FormatElement::Tag).
+/// New [`PrintElementCallArgs`] are pushed onto the stack for every [`start tag`](crate::FormatElement::is_start_tag)
+/// and popped when reaching the corresponding [`end tag`](crate::FormatElement::is_end_tag).
 pub(super) trait CallStack {
     type Stack: Stack<StackFrame> + Debug;
 
@@ -179,7 +179,7 @@ pub(super) trait CallStack {
         }
     }
 
-    /// Creates a new stack frame for a [`FormatElement::Tag`] of `kind` with `args` as the call arguments.
+    /// Creates a new stack frame for a [`crate::FormatElement`] tag of `kind` with `args` as the call arguments.
     fn push(&mut self, kind: TagKind, args: PrintElementArgs) {
         self.stack_mut().push(StackFrame {
             kind: StackFrameKind::Tag(kind),

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -9,7 +9,7 @@ use ruff_text_size::{TextLen, TextSize};
 use crate::format_element::document::Document;
 use crate::format_element::tag::{Condition, GroupMode};
 use crate::format_element::{BestFittingMode, BestFittingVariants, LineMode, PrintMode};
-use crate::prelude::tag::{DedentMode, Tag, TagKind, VerbatimKind};
+use crate::prelude::tag::{DedentMode, TagKind, VerbatimKind};
 use crate::prelude::{TextWidth, tag};
 use crate::printer::call_stack::{
     CallStack, FitsCallStack, PrintCallStack, PrintElementArgs, StackFrame,
@@ -90,6 +90,7 @@ impl<'a> Printer<'a> {
     /// Prints a single element and push the following elements to queue
     // LLVM considers this function too large to inline on its own, but it is called for every
     // element visited by the printing loop.
+    #[expect(clippy::inline_always, reason = "called for every printed element")]
     #[inline(always)]
     fn print_element(
         &mut self,
@@ -97,9 +98,6 @@ impl<'a> Printer<'a> {
         queue: &mut PrintQueue<'a>,
         element: &'a FormatElement,
     ) -> PrintResult<()> {
-        #[allow(clippy::enum_glob_use)]
-        use Tag::*;
-
         let args = stack.top();
 
         match element {
@@ -167,7 +165,7 @@ impl<'a> Printer<'a> {
                 queue.extend_back(content);
             }
 
-            FormatElement::Tag(StartGroup(group)) => {
+            FormatElement::StartGroup(group) => {
                 let print_mode = match group.mode() {
                     GroupMode::Expand | GroupMode::Propagated => PrintMode::Expanded,
                     GroupMode::Flat => {
@@ -182,9 +180,9 @@ impl<'a> Printer<'a> {
                 stack.push(TagKind::Group, args.with_print_mode(print_mode));
             }
 
-            FormatElement::Tag(StartBestFitParenthesize { id }) => {
+            FormatElement::StartBestFitParenthesize { id } => {
                 const OPEN_PAREN: FormatElement = FormatElement::Token { text: "(" };
-                const INDENT: FormatElement = FormatElement::Tag(Tag::StartIndent);
+                const INDENT: FormatElement = FormatElement::StartIndent;
                 const HARD_LINE_BREAK: FormatElement = FormatElement::Line(LineMode::Hard);
 
                 let fits_flat = self.flat_group_print_mode(
@@ -238,7 +236,7 @@ impl<'a> Printer<'a> {
                 );
             }
 
-            FormatElement::Tag(EndBestFitParenthesize) => {
+            FormatElement::EndBestFitParenthesize => {
                 if args.mode().is_expanded() {
                     const HARD_LINE_BREAK: FormatElement = FormatElement::Line(LineMode::Hard);
                     const CLOSE_PAREN: FormatElement = FormatElement::Token { text: ")" };
@@ -251,7 +249,7 @@ impl<'a> Printer<'a> {
                 stack.pop(TagKind::BestFitParenthesize)?;
             }
 
-            FormatElement::Tag(StartConditionalGroup(group)) => {
+            FormatElement::StartConditionalGroup(group) => {
                 let condition = group.condition();
                 let expected_mode = match condition.group_id {
                     None => args.mode(),
@@ -277,18 +275,18 @@ impl<'a> Printer<'a> {
                 }
             }
 
-            FormatElement::Tag(StartFill) => {
+            FormatElement::StartFill => {
                 self.print_fill_entries(queue, stack)?;
             }
 
-            FormatElement::Tag(StartIndent) => {
+            FormatElement::StartIndent => {
                 stack.push(
                     TagKind::Indent,
                     args.increment_indent_level(self.options.indent_style()),
                 );
             }
 
-            FormatElement::Tag(StartDedent(mode)) => {
+            FormatElement::StartDedent(mode) => {
                 let args = match mode {
                     DedentMode::Level => args.decrement_indent(),
                     DedentMode::Root => args.reset_indent(),
@@ -296,11 +294,11 @@ impl<'a> Printer<'a> {
                 stack.push(TagKind::Dedent, args);
             }
 
-            FormatElement::Tag(StartAlign(align)) => {
+            FormatElement::StartAlign(align) => {
                 stack.push(TagKind::Align, args.set_indent_align(align.count()));
             }
 
-            FormatElement::Tag(StartConditionalContent(Condition { mode, group_id })) => {
+            FormatElement::StartConditionalContent(Condition { mode, group_id }) => {
                 let group_mode = match group_id {
                     None => args.mode(),
                     Some(id) => self.state.group_modes.get_print_mode(*id)?,
@@ -313,7 +311,7 @@ impl<'a> Printer<'a> {
                 }
             }
 
-            FormatElement::Tag(StartIndentIfGroupBreaks(group_id)) => {
+            FormatElement::StartIndentIfGroupBreaks(group_id) => {
                 let group_mode = self.state.group_modes.get_print_mode(*group_id)?;
 
                 let args = match group_mode {
@@ -324,14 +322,14 @@ impl<'a> Printer<'a> {
                 stack.push(TagKind::IndentIfGroupBreaks, args);
             }
 
-            FormatElement::Tag(StartLineSuffix { reserved_width }) => {
+            FormatElement::StartLineSuffix { reserved_width } => {
                 self.state.line_width += reserved_width;
                 self.state
                     .line_suffixes
                     .extend(args, queue.iter_content(TagKind::LineSuffix));
             }
 
-            FormatElement::Tag(StartVerbatim(kind)) => {
+            FormatElement::StartVerbatim(kind) => {
                 if let VerbatimKind::Verbatim { length } = kind {
                     // SAFETY: Ruff only supports formatting files <= 4GB
                     #[expect(clippy::cast_possible_truncation)]
@@ -344,7 +342,7 @@ impl<'a> Printer<'a> {
                 stack.push(TagKind::Verbatim, args);
             }
 
-            FormatElement::Tag(StartFitsExpanded(tag::FitsExpanded { condition, .. })) => {
+            FormatElement::StartFitsExpanded(tag::FitsExpanded { condition, .. }) => {
                 let condition_met = match condition {
                     Some(condition) => {
                         let group_mode = match condition.group_id {
@@ -365,27 +363,27 @@ impl<'a> Printer<'a> {
                 stack.push(TagKind::FitsExpanded, args);
             }
 
-            FormatElement::Tag(tag @ (StartLabelled(_) | StartEntry | StartBestFittingEntry)) => {
-                stack.push(tag.kind(), args);
+            tag @ (FormatElement::StartLabelled(_)
+            | FormatElement::StartEntry
+            | FormatElement::StartBestFittingEntry) => {
+                stack.push(tag.tag_kind().expect("matched a start tag"), args);
             }
 
-            FormatElement::Tag(
-                tag @ (EndLabelled
-                | EndEntry
-                | EndGroup
-                | EndConditionalGroup
-                | EndIndent
-                | EndDedent
-                | EndAlign
-                | EndConditionalContent
-                | EndIndentIfGroupBreaks
-                | EndFitsExpanded
-                | EndVerbatim
-                | EndLineSuffix
-                | EndBestFittingEntry
-                | EndFill),
-            ) => {
-                stack.pop(tag.kind())?;
+            tag @ (FormatElement::EndLabelled
+            | FormatElement::EndEntry
+            | FormatElement::EndGroup
+            | FormatElement::EndConditionalGroup
+            | FormatElement::EndIndent
+            | FormatElement::EndDedent
+            | FormatElement::EndAlign
+            | FormatElement::EndConditionalContent
+            | FormatElement::EndIndentIfGroupBreaks
+            | FormatElement::EndFitsExpanded
+            | FormatElement::EndVerbatim
+            | FormatElement::EndLineSuffix
+            | FormatElement::EndBestFittingEntry
+            | FormatElement::EndFill) => {
+                stack.pop(tag.tag_kind().expect("matched an end tag"))?;
             }
         }
 
@@ -530,8 +528,7 @@ impl<'a> Printer<'a> {
                         queue.push(suffix);
                     }
                     LineSuffixEntry::Args(args) => {
-                        const LINE_SUFFIX_END: &FormatElement =
-                            &FormatElement::Tag(Tag::EndLineSuffix);
+                        const LINE_SUFFIX_END: &FormatElement = &FormatElement::EndLineSuffix;
 
                         stack.push(TagKind::LineSuffix, args);
 
@@ -568,10 +565,7 @@ impl<'a> Printer<'a> {
                 // variant.
 
                 // Try to fit only the first variant on a single line
-                if !matches!(
-                    current.first(),
-                    Some(&FormatElement::Tag(Tag::StartBestFittingEntry))
-                ) {
+                if !matches!(current.first(), Some(&FormatElement::StartBestFittingEntry)) {
                     return invalid_start_tag(TagKind::BestFittingEntry, current.first());
                 }
 
@@ -652,7 +646,7 @@ impl<'a> Printer<'a> {
 
         stack.push(TagKind::Fill, args);
 
-        while matches!(queue.top(), Some(FormatElement::Tag(Tag::StartEntry))) {
+        while matches!(queue.top(), Some(FormatElement::StartEntry)) {
             let mut measurer = FitsMeasurer::new_flat(queue, stack, self);
 
             // The number of item/separator pairs that fit on the same line.
@@ -666,10 +660,7 @@ impl<'a> Printer<'a> {
                 // * A second time when measuring if *next-item*, *separator*, *next-next-item* fit.
                 loop {
                     // Item that fits without a following separator.
-                    if !matches!(
-                        measurer.queue.top(),
-                        Some(FormatElement::Tag(Tag::StartEntry))
-                    ) {
+                    if !matches!(measurer.queue.top(), Some(FormatElement::StartEntry)) {
                         break FillPairLayout::Flat;
                     }
 
@@ -681,10 +672,7 @@ impl<'a> Printer<'a> {
                     }
 
                     // Last item/separator pair that both fit
-                    if !matches!(
-                        measurer.queue.top(),
-                        Some(FormatElement::Tag(Tag::StartEntry))
-                    ) {
+                    if !matches!(measurer.queue.top(), Some(FormatElement::StartEntry)) {
                         break FillPairLayout::Flat;
                     }
 
@@ -735,7 +723,7 @@ impl<'a> Printer<'a> {
 
             self.print_fill_item(queue, stack, args.with_print_mode(item_mode))?;
 
-            if matches!(queue.top(), Some(FormatElement::Tag(Tag::StartEntry))) {
+            if matches!(queue.top(), Some(FormatElement::StartEntry)) {
                 let separator_mode = match last_pair_layout {
                     FillPairLayout::Flat => PrintMode::Flat,
                     FillPairLayout::ItemFlatSeparatorExpanded
@@ -751,7 +739,7 @@ impl<'a> Printer<'a> {
             }
         }
 
-        if queue.top() == Some(&FormatElement::Tag(Tag::EndFill)) {
+        if queue.top() == Some(&FormatElement::EndFill) {
             Ok(())
         } else {
             invalid_end_tag(TagKind::Fill, stack.top_kind())
@@ -804,14 +792,14 @@ impl<'a> Printer<'a> {
 
         while let Some(element) = queue.pop() {
             match element {
-                FormatElement::Tag(Tag::StartEntry | Tag::StartBestFittingEntry) => {
+                FormatElement::StartEntry | FormatElement::StartBestFittingEntry => {
                     depth += 1;
                 }
-                FormatElement::Tag(end_tag @ (Tag::EndEntry | Tag::EndBestFittingEntry)) => {
+                end_tag @ (FormatElement::EndEntry | FormatElement::EndBestFittingEntry) => {
                     depth -= 1;
                     // Reached the end entry, pop the entry from the stack and return.
                     if depth == 0 {
-                        stack.pop(end_tag.kind())?;
+                        stack.pop(end_tag.tag_kind().expect("matched an end tag"))?;
                         return Ok(());
                     }
                 }
@@ -1121,7 +1109,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
 
     /// Tests if the content of a `Fill` item fits in [`PrintMode::Flat`].
     ///
-    /// Returns `Err` if the top element of the queue is not a [`Tag::StartEntry`]
+    /// Returns `Err` if the top element of the queue is not a [`crate::Tag::StartEntry`]
     /// or if the document has any mismatching start/end tags.
     fn fill_item_fits(&mut self) -> PrintResult<bool> {
         self.fill_entry_fits(PrintMode::Flat)
@@ -1129,21 +1117,21 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
 
     /// Tests if the content of a `Fill` separator fits with `mode`.
     ///
-    /// Returns `Err` if the top element of the queue is not a [`Tag::StartEntry`]
+    /// Returns `Err` if the top element of the queue is not a [`crate::Tag::StartEntry`]
     /// or if the document has any mismatching start/end tags.
     fn fill_separator_fits(&mut self, mode: PrintMode) -> PrintResult<bool> {
         self.fill_entry_fits(mode)
     }
 
-    /// Tests if the elements between the [`Tag::StartEntry`] and [`Tag::EndEntry`]
+    /// Tests if the elements between the [`crate::Tag::StartEntry`] and [`crate::Tag::EndEntry`]
     /// of a fill item or separator fits with `mode`.
     ///
-    /// Returns `Err` if the queue isn't positioned at a [`Tag::StartEntry`] or if
-    /// the matching [`Tag::EndEntry`] is missing.
+    /// Returns `Err` if the queue isn't positioned at a [`crate::Tag::StartEntry`] or if
+    /// the matching [`crate::Tag::EndEntry`] is missing.
     fn fill_entry_fits(&mut self, mode: PrintMode) -> PrintResult<bool> {
         let start_entry = self.queue.top();
 
-        if !matches!(start_entry, Some(&FormatElement::Tag(Tag::StartEntry))) {
+        if !matches!(start_entry, Some(&FormatElement::StartEntry)) {
             return invalid_start_tag(TagKind::Entry, start_entry);
         }
 
@@ -1162,11 +1150,9 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
     /// Tests if the passed element fits on the current line or not.
     // LLVM considers this function too large to inline on its own, but it is called for every
     // element visited by the fitting loop.
+    #[expect(clippy::inline_always, reason = "called for every measured element")]
     #[inline(always)]
     fn fits_element(&mut self, element: &'a FormatElement) -> PrintResult<Fits> {
-        #[allow(clippy::enum_glob_use)]
-        use Tag::*;
-
         let args = self.stack.top();
 
         match element {
@@ -1247,10 +1233,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                     PrintMode::Expanded => (variants.most_expanded(), args),
                 };
 
-                if !matches!(
-                    slice.first(),
-                    Some(FormatElement::Tag(Tag::StartBestFittingEntry))
-                ) {
+                if !matches!(slice.first(), Some(FormatElement::StartBestFittingEntry)) {
                     return invalid_start_tag(TagKind::BestFittingEntry, slice.first());
                 }
 
@@ -1260,14 +1243,14 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
 
             FormatElement::Interned(content) => self.queue.extend_back(content),
 
-            FormatElement::Tag(StartIndent) => {
+            FormatElement::StartIndent => {
                 self.stack.push(
                     TagKind::Indent,
                     args.increment_indent_level(self.options().indent_style()),
                 );
             }
 
-            FormatElement::Tag(StartDedent(mode)) => {
+            FormatElement::StartDedent(mode) => {
                 let args = match mode {
                     DedentMode::Level => args.decrement_indent(),
                     DedentMode::Root => args.reset_indent(),
@@ -1275,16 +1258,16 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 self.stack.push(TagKind::Dedent, args);
             }
 
-            FormatElement::Tag(StartAlign(align)) => {
+            FormatElement::StartAlign(align) => {
                 self.stack
                     .push(TagKind::Align, args.set_indent_align(align.count()));
             }
 
-            FormatElement::Tag(StartGroup(group)) => {
+            FormatElement::StartGroup(group) => {
                 return Ok(self.fits_group(TagKind::Group, group.mode(), group.id(), args));
             }
 
-            FormatElement::Tag(StartBestFitParenthesize { id }) => {
+            FormatElement::StartBestFitParenthesize { id } => {
                 if let Some(id) = id {
                     self.printer
                         .state
@@ -1297,7 +1280,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 self.stack.push(TagKind::BestFitParenthesize, args);
             }
 
-            FormatElement::Tag(EndBestFitParenthesize) => {
+            FormatElement::EndBestFitParenthesize => {
                 // If this is the end tag of the outer most parentheses for which we measure if it fits,
                 // pop the indent.
                 if args.mode().is_expanded() && self.stack.top_kind() == Some(TagKind::Indent) {
@@ -1316,7 +1299,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 self.stack.pop(TagKind::BestFitParenthesize)?;
             }
 
-            FormatElement::Tag(StartConditionalGroup(group)) => {
+            FormatElement::StartConditionalGroup(group) => {
                 let condition = group.condition();
 
                 let print_mode = match condition.group_id {
@@ -1335,7 +1318,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 self.stack.push(TagKind::ConditionalGroup, args);
             }
 
-            FormatElement::Tag(StartConditionalContent(condition)) => {
+            FormatElement::StartConditionalContent(condition) => {
                 let print_mode = match condition.group_id {
                     None => args.mode(),
                     Some(group_id) => self.group_modes().get_print_mode(group_id)?,
@@ -1348,7 +1331,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 }
             }
 
-            FormatElement::Tag(StartIndentIfGroupBreaks(id)) => {
+            FormatElement::StartIndentIfGroupBreaks(id) => {
                 let print_mode = self.group_modes().get_print_mode(*id)?;
 
                 match print_mode {
@@ -1364,7 +1347,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 }
             }
 
-            FormatElement::Tag(StartLineSuffix { reserved_width }) => {
+            FormatElement::StartLineSuffix { reserved_width } => {
                 if *reserved_width > 0 {
                     self.state.line_width += reserved_width;
                     if self.state.line_width > self.options().line_width.into() {
@@ -1375,14 +1358,14 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 self.state.has_line_suffix = true;
             }
 
-            FormatElement::Tag(EndLineSuffix) => {
+            FormatElement::EndLineSuffix => {
                 return invalid_end_tag(TagKind::LineSuffix, self.stack.top_kind());
             }
 
-            FormatElement::Tag(StartFitsExpanded(tag::FitsExpanded {
+            FormatElement::StartFitsExpanded(tag::FitsExpanded {
                 condition,
                 propagate_expand,
-            })) => {
+            }) => {
                 match args.mode() {
                     PrintMode::Expanded => {
                         // As usual, nothing to measure
@@ -1422,32 +1405,30 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 }
             }
 
-            FormatElement::Tag(
-                tag @ (StartFill
-                | StartVerbatim(_)
-                | StartLabelled(_)
-                | StartEntry
-                | StartBestFittingEntry),
-            ) => {
-                self.stack.push(tag.kind(), args);
+            tag @ (FormatElement::StartFill
+            | FormatElement::StartVerbatim(_)
+            | FormatElement::StartLabelled(_)
+            | FormatElement::StartEntry
+            | FormatElement::StartBestFittingEntry) => {
+                self.stack
+                    .push(tag.tag_kind().expect("matched a start tag"), args);
             }
 
-            FormatElement::Tag(
-                tag @ (EndFill
-                | EndVerbatim
-                | EndLabelled
-                | EndEntry
-                | EndGroup
-                | EndConditionalGroup
-                | EndIndentIfGroupBreaks
-                | EndConditionalContent
-                | EndAlign
-                | EndDedent
-                | EndIndent
-                | EndBestFittingEntry
-                | EndFitsExpanded),
-            ) => {
-                self.stack.pop(tag.kind())?;
+            tag @ (FormatElement::EndFill
+            | FormatElement::EndVerbatim
+            | FormatElement::EndLabelled
+            | FormatElement::EndEntry
+            | FormatElement::EndGroup
+            | FormatElement::EndConditionalGroup
+            | FormatElement::EndIndentIfGroupBreaks
+            | FormatElement::EndConditionalContent
+            | FormatElement::EndAlign
+            | FormatElement::EndDedent
+            | FormatElement::EndIndent
+            | FormatElement::EndBestFittingEntry
+            | FormatElement::EndFitsExpanded) => {
+                self.stack
+                    .pop(tag.tag_kind().expect("matched an end tag"))?;
             }
         }
 
@@ -1580,11 +1561,13 @@ fn invalid_end_tag<R>(end_tag: TagKind, start_tag: Option<TagKind>) -> PrintResu
 fn invalid_start_tag<R>(expected: TagKind, actual: Option<&FormatElement>) -> PrintResult<R> {
     let start = match actual {
         None => ActualStart::EndOfDocument,
-        Some(FormatElement::Tag(tag)) => {
-            if tag.is_start() {
-                ActualStart::Start(tag.kind())
+        Some(tag) if tag.is_tag() => {
+            let kind = tag.tag_kind().expect("matched a tag");
+
+            if tag.is_start_tag() {
+                ActualStart::Start(kind)
             } else {
-                ActualStart::End(tag.kind())
+                ActualStart::End(kind)
             }
         }
         Some(_) => ActualStart::Content,

--- a/crates/ruff_formatter/src/printer/queue.rs
+++ b/crates/ruff_formatter/src/printer/queue.rs
@@ -1,5 +1,4 @@
 use crate::format_element::tag::TagKind;
-use crate::prelude::Tag;
 use crate::printer::{invalid_end_tag, invalid_start_tag};
 use crate::{FormatElement, PrintResult};
 use std::fmt::Debug;
@@ -228,8 +227,8 @@ where
             }
 
             match top.expect("Missing end signal.") {
-                element @ FormatElement::Tag(tag) if tag.kind() == self.kind => {
-                    if tag.is_start() {
+                element if element.tag_kind() == Some(self.kind) => {
+                    if element.is_start_tag() {
                         self.depth += 1;
                     } else {
                         self.depth -= 1;
@@ -267,7 +266,7 @@ impl FitsEndPredicate for AllPredicate {
     }
 }
 
-/// Filter that takes all elements between two matching [`Tag::StartEntry`] and [`Tag::EndEntry`] tags.
+/// Filter that takes all elements between two matching [`crate::Tag::StartEntry`] and [`crate::Tag::EndEntry`] tags.
 #[derive(Debug)]
 pub(super) enum SingleEntryPredicate {
     Entry { depth: usize },
@@ -291,12 +290,12 @@ impl FitsEndPredicate for SingleEntryPredicate {
         let result = match self {
             SingleEntryPredicate::Done => true,
             SingleEntryPredicate::Entry { depth } => match element {
-                FormatElement::Tag(Tag::StartEntry) => {
+                FormatElement::StartEntry => {
                     *depth += 1;
 
                     false
                 }
-                FormatElement::Tag(Tag::EndEntry) => {
+                FormatElement::EndEntry => {
                     if *depth == 0 {
                         return invalid_end_tag(TagKind::Entry, None);
                     }
@@ -327,15 +326,13 @@ impl FitsEndPredicate for SingleEntryPredicate {
 mod tests {
     use crate::FormatElement;
     use crate::format_element::LineMode;
-    use crate::prelude::Tag;
     use crate::printer::queue::{PrintQueue, Queue};
 
     #[test]
     fn extend_back_pop_last() {
-        let mut queue =
-            PrintQueue::new(&[FormatElement::Tag(Tag::StartEntry), FormatElement::Space]);
+        let mut queue = PrintQueue::new(&[FormatElement::StartEntry, FormatElement::Space]);
 
-        assert_eq!(queue.pop(), Some(&FormatElement::Tag(Tag::StartEntry)));
+        assert_eq!(queue.pop(), Some(&FormatElement::StartEntry));
 
         queue.extend_back(&[FormatElement::Line(LineMode::SoftOrSpace)]);
 
@@ -350,10 +347,9 @@ mod tests {
 
     #[test]
     fn extend_back_empty_queue() {
-        let mut queue =
-            PrintQueue::new(&[FormatElement::Tag(Tag::StartEntry), FormatElement::Space]);
+        let mut queue = PrintQueue::new(&[FormatElement::StartEntry, FormatElement::Space]);
 
-        assert_eq!(queue.pop(), Some(&FormatElement::Tag(Tag::StartEntry)));
+        assert_eq!(queue.pop(), Some(&FormatElement::StartEntry));
         assert_eq!(queue.pop(), Some(&FormatElement::Space));
 
         queue.extend_back(&[FormatElement::Line(LineMode::SoftOrSpace)]);

--- a/crates/ruff_python_formatter/src/expression/parentheses.rs
+++ b/crates/ruff_python_formatter/src/expression/parentheses.rs
@@ -321,13 +321,13 @@ impl<'ast> Format<PyFormatContext<'ast>> for FormatInParenthesesOnlyGroup<'_, 'a
 pub(super) fn write_in_parentheses_only_group_start_tag(f: &mut PyFormatter) {
     match f.context().node_level() {
         NodeLevel::Expression(Some(parentheses_id)) => {
-            f.write_element(FormatElement::Tag(tag::Tag::StartConditionalGroup(
+            f.write_element(FormatElement::StartConditionalGroup(
                 tag::ConditionalGroup::new(Condition::if_group_breaks(parentheses_id)),
-            )));
+            ));
         }
         NodeLevel::ParenthesizedExpression => {
             // Unconditionally group the content if it is not enclosed by an optional parentheses group.
-            f.write_element(FormatElement::Tag(tag::Tag::StartGroup(tag::Group::new())));
+            f.write_element(FormatElement::StartGroup(tag::Group::new()));
         }
         NodeLevel::Expression(None) | NodeLevel::TopLevel(_) | NodeLevel::CompoundStatement => {
             // No group
@@ -338,11 +338,11 @@ pub(super) fn write_in_parentheses_only_group_start_tag(f: &mut PyFormatter) {
 pub(super) fn write_in_parentheses_only_group_end_tag(f: &mut PyFormatter) {
     match f.context().node_level() {
         NodeLevel::Expression(Some(_)) => {
-            f.write_element(FormatElement::Tag(tag::Tag::EndConditionalGroup));
+            f.write_element(FormatElement::EndConditionalGroup);
         }
         NodeLevel::ParenthesizedExpression => {
             // Unconditionally group the content if it is not enclosed by an optional parentheses group.
-            f.write_element(FormatElement::Tag(tag::Tag::EndGroup));
+            f.write_element(FormatElement::EndGroup);
         }
         NodeLevel::Expression(None) | NodeLevel::TopLevel(_) | NodeLevel::CompoundStatement => {
             // No group

--- a/crates/ruff_python_formatter/src/verbatim.rs
+++ b/crates/ruff_python_formatter/src/verbatim.rs
@@ -908,11 +908,9 @@ where
 
 impl Format<PyFormatContext<'_>> for VerbatimText {
     fn fmt(&self, f: &mut PyFormatter) -> FormatResult<()> {
-        f.write_element(FormatElement::Tag(Tag::StartVerbatim(
-            tag::VerbatimKind::Verbatim {
-                length: self.verbatim_range.len(),
-            },
-        )));
+        f.write_element(FormatElement::StartVerbatim(tag::VerbatimKind::Verbatim {
+            length: self.verbatim_range.len(),
+        }));
 
         match normalize_newlines(&f.context().source()[self.verbatim_range], ['\r']) {
             Cow::Borrowed(_) => {
@@ -923,7 +921,7 @@ impl Format<PyFormatContext<'_>> for VerbatimText {
             }
         }
 
-        f.write_element(FormatElement::Tag(Tag::EndVerbatim));
+        f.write_element(FormatElement::EndVerbatim);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Flatten formatter tag variants into `FormatElement` to remove nested tag dispatch while retaining ahead-of-time buffer allocation.
Profiling the formatter shows roughly 1–4% faster formatting across the benchmark inputs.

## Test Plan

Testing: Formatter tests, doctests, Clippy, and formatting hooks pass.