### PR TITLE
[ty] Preserve correlated specialization paths

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -401,9 +401,9 @@ def partial_mutually_recursive_alias(x: RecursivePartialA) -> bool:  # error: [i
 
 These examples are minimized from ecosystem regressions seen while preserving explicit `Never` and
 `object` bounds through the constraint solver. The current solver picks callback parameter upper
-bounds as concrete solutions when the iterable argument is otherwise unknown. That overfits the
-result to `Sized` or `object`; ideally the element type would remain `Unknown`, while the callable
-return type would still be used where possible.
+bounds as concrete solutions when the iterable argument is otherwise unknown. That can overfit the
+element type to `Sized`; ideally it would remain `Unknown`, while the callable return type is still
+used where possible.
 
 ```py
 from ty_extensions import Unknown
@@ -412,12 +412,9 @@ def _(xs: Unknown):
     # TODO: should be `list[Unknown]`
     reveal_type(sorted(xs, key=len))  # revealed: list[Sized]
 
-    # TODO: should be `map[str]`
-    reveal_type(map("{}".format, xs))  # revealed: map[object]
+    reveal_type(map("{}".format, xs))  # revealed: map[str]
 
-    # TODO: should not emit an error and should reveal `str`
-    # error: [no-matching-overload]
-    reveal_type("".join(map("{}".format, xs)))  # revealed: Unknown
+    reveal_type("".join(map("{}".format, xs)))  # revealed: str
 ```
 
 ## Mapping methods accept arbitrary object types

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -282,8 +282,8 @@ reveal_type(Foo(1))  # revealed: Foo
 Adding an implicit `type[Self]` annotation for `cls` must not cause valid constructor calls to be
 rejected when a generic callback determines the class's type argument. These calls already pass on
 `main`; they guard against regressions when the implicit `__new__` receiver is added. The overloaded
-callback, protocol, and `Any` argument exercise the nested specialization that previously caused the
-synthetic `cls` argument to be specialized twice.
+callback, protocol, and `Any` argument exercise the nested specialization and correlated receiver
+constraints that previously caused the synthetic `cls` argument to be rejected.
 
 ```pyi
 from collections.abc import Callable

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -277,6 +277,119 @@ class Foo:
 reveal_type(Foo(1))  # revealed: Foo
 ```
 
+## Implicit `__new__` receivers
+
+Adding an implicit `type[Self]` annotation for `cls` must not cause valid constructor calls to be
+rejected when a generic callback determines the class's type argument. These calls already pass on
+`main`; they guard against regressions when the implicit `__new__` receiver is added. The overloaded
+callback, protocol, and `Any` argument exercise the nested specialization that previously caused the
+synthetic `cls` argument to be specialized twice.
+
+```pyi
+from collections.abc import Callable
+from typing import Any, Generic, Protocol, TypeVar, overload
+from typing_extensions import Self
+
+R_co = TypeVar("R_co", covariant=True)
+T = TypeVar("T")
+
+class Box(Protocol[R_co]):
+    def get(self) -> R_co: ...
+
+@overload
+def callback(value: Box[T]) -> T: ...
+@overload
+def callback(value: T) -> T: ...
+
+class Mapper(Generic[R_co]):
+    def __new__(cls, callback: Callable[[T], R_co], values: list[T], /) -> Self: ...
+
+values: Any
+
+# TODO: The doubled `Box` and `Never` are likely over-inferred, but the valid call must not be
+# rejected.
+reveal_type(Mapper(callback, values))  # revealed: Mapper[Box[Box[Never]]]
+```
+
+A signature-preserving decorator can turn `__new__` into a `Callable`:
+
+```pyi
+from typing import ParamSpec
+
+P = ParamSpec("P")
+
+def wrap(function: Callable[P, R_co]) -> Callable[P, R_co]: ...
+
+class Wrapped(Generic[R_co]):
+    @wrap
+    def __new__(cls, callback: Callable[[T], R_co], values: list[T]) -> Self: ...
+
+# TODO: The doubled `Box` and `Never` are likely over-inferred, but the valid call must not be
+# rejected.
+reveal_type(Wrapped(callback, values))  # revealed: Wrapped[Box[Box[Never]]]
+```
+
+A decorator can preserve `cls` explicitly with `Concatenate`. Inferred and explicit specializations
+are both valid:
+
+```pyi
+from typing_extensions import Concatenate
+
+def wrap_cls(function: Callable[Concatenate[type[T], P], R_co]) -> Callable[Concatenate[type[T], P], R_co]: ...
+
+class WrappedCls(Generic[R_co]):
+    @wrap_cls
+    def __new__(cls, callback: Callable[[T], R_co], values: list[T]) -> Self: ...
+
+# TODO: `Concatenate` loses constructor inference, even for a concrete callback and argument.
+reveal_type(WrappedCls(callback, values))  # revealed: WrappedCls[Unknown]
+reveal_type(WrappedCls[str](callback, values))  # revealed: WrappedCls[str]
+
+def concrete_callback(value: int) -> str: ...
+
+int_values: list[int]
+reveal_type(WrappedCls(concrete_callback, int_values))  # revealed: WrappedCls[Unknown]
+```
+
+A decorator can return a callback protocol instead of `Callable`:
+
+```pyi
+class CallableObject(Protocol[P, R_co]):
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R_co: ...
+
+def wrap_object(function: Callable[P, R_co]) -> CallableObject[P, R_co]: ...
+
+class WrappedObject(Generic[R_co]):
+    @wrap_object
+    def __new__(cls, callback: Callable[[T], R_co], values: list[T]) -> Self: ...
+
+# TODO: The doubled `Box` and `Never` are likely over-inferred, but the valid call must not be
+# rejected.
+reveal_type(WrappedObject(callback, values))  # revealed: WrappedObject[Box[Box[Never]]]
+```
+
+The explicit `cls` type in a signature-preserving decorator can also be expressed with a generic
+type alias:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```pyi
+type Receiver[X] = type[X]
+
+def preserve[U, **P, R](
+    function: Callable[Concatenate[Receiver[U], P], R],
+) -> Callable[Concatenate[Receiver[U], P], R]: ...
+
+class Simple:
+    @preserve
+    def __new__(cls) -> Self: ...
+
+reveal_type(Simple())  # revealed: Simple
+```
+
 ## `__new__` defined as a classmethod
 
 Marking it as a classmethod, on the other hand, breaks at runtime.

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -865,7 +865,7 @@ class C[T]:
     x: T
 
     def __new__[S](cls, x: S) -> "C[tuple[S, S]]":
-        return object.__new__(cls)
+        raise NotImplementedError()
 
 reveal_type(C(1))  # revealed: C[tuple[int, int]]
 reveal_type(C("hello"))  # revealed: C[tuple[str, str]]

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -1019,6 +1019,48 @@ class X:
         return self.__new__(type(self))
 ```
 
+Calling `object.__new__` from an overriding `__new__` method preserves `Self`, so an invalid
+attribute access on the result is reported:
+
+```py
+class Item:
+    def __new__(cls) -> Self:
+        result = object.__new__(cls)
+        reveal_type(result)  # revealed: Self@__new__
+        # error: [unresolved-attribute]
+        result.nonexistent()
+        return result
+```
+
+Explicitly marking `__new__` as a static method does not change the inferred result:
+
+```py
+class StaticItem:
+    @staticmethod
+    def __new__(cls) -> Self:
+        result = object.__new__(cls)
+        reveal_type(result)  # revealed: Self@__new__
+        return result
+```
+
+`Self` is also preserved through a chain of inherited `__new__` calls:
+
+```py
+class Foo: ...
+
+class Bar(Foo):
+    def __new__(cls) -> Self:
+        return Foo.__new__(cls)
+
+class Baz(Bar):
+    def __new__(cls) -> Self:
+        result = Bar.__new__(cls)
+        reveal_type(result)  # revealed: Self@__new__
+        # error: [unresolved-attribute]
+        result.nonexistent()
+        return result
+```
+
 ## Bound-method attribute fallback
 
 Bound-method attributes are resolved first on `types.MethodType`, then, if absent, on the underlying

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -527,6 +527,8 @@ to `Any`:
 from enum import Enum
 
 class Connector(Enum):
+    connector_id: int
+
     def __new__(cls, value: str, connector_id: int) -> "Connector":
         obj = object.__new__(cls)
         obj._value_ = value
@@ -546,6 +548,7 @@ from enum import Enum
 
 class AnnotatedConnector(Enum):
     _value_: str
+    connector_id: int
 
     def __new__(cls, value: str, connector_id: int = 0) -> "AnnotatedConnector":
         obj = object.__new__(cls)
@@ -661,6 +664,8 @@ annotation, subclass member values remain dynamic:
 from enum import Enum
 
 class Base(Enum):
+    connector_id: int
+
     def __new__(cls, value: str, connector_id: int) -> "Base":
         obj = object.__new__(cls)
         obj._value_ = value
@@ -680,6 +685,8 @@ An explicit `_value_` annotation on the subclass still takes precedence:
 from enum import Enum
 
 class Base(Enum):
+    connector_id: int
+
     def __new__(cls, value: str, connector_id: int = 0) -> "Base":
         obj = object.__new__(cls)
         obj._value_ = value
@@ -702,6 +709,8 @@ explicitly annotated:
 from enum import Enum
 
 class Base(Enum):
+    connector_id: int
+
     def __new__(cls, value: int, connector_id: int = 0) -> "Base":
         obj = object.__new__(cls)
         obj._value_ = value

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1881,7 +1881,7 @@ class MetaWithIntReturn(type):
 
 class F(metaclass=MetaWithIntReturn):
     def __new__(cls) -> str:
-        return super().__new__(cls)
+        return ""
 
 class Returns[T](Protocol):
     def __call__(self) -> T: ...
@@ -1960,7 +1960,7 @@ static_assert(not is_subtype_of(TypeOf[A], Returns[A]))
 
 class B:
     def __new__(cls, a: int) -> int:
-        return super().__new__(cls)
+        return 0
 
     def __init__(self, a: str) -> None: ...
 
@@ -2031,7 +2031,7 @@ class MetaWithIntReturn(type):
 
 class F(metaclass=MetaWithIntReturn):
     def __new__(cls) -> str:
-        return super().__new__(cls)
+        return ""
 
     def __init__(self, x: int) -> None: ...
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5448,34 +5448,21 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             return;
         }
 
-        // The synthetic `cls` already carries the constructor's identity specialization.
-        // For example, typeshed's `map` constructor is roughly:
-        //
-        // ```py
-        // class map[S]:
-        //     def __new__[T](cls, callback: Callable[[T], S], values: Iterable[T], /) -> Self: ...
-        //
-        // map(os.path.abspath, list_fonts("fonts"))
-        // ```
-        //
-        // Once the call specializes `S` to `PathLike[Never]`, applying that specialization to
-        // `cls` again produces `map[PathLike[PathLike[Never]]]` instead of
-        // `map[PathLike[Never]]`, causing a spurious argument error. Decorators can also
-        // re-express the `cls` annotation using their own TypeVar, possibly through a type alias.
-        let constructor_receiver = matches!(argument, Argument::Synthetic)
-            && self.constructor_kind == Some(ConstructorCallableKind::New)
-            && matches!(
-                parameter.annotated_type().resolve_type_alias(self.db),
-                Type::SubclassOf(subclass_of) if subclass_of.into_type_var().is_some()
-            );
-
         let mut expected_ty = parameter.annotated_type();
         if let Some(specialization) = self.specialization() {
-            if !constructor_receiver {
-                argument_type = argument_type.apply_specialization(self.db, specialization);
-            }
+            argument_type = argument_type.apply_specialization(self.db, specialization);
             expected_ty = expected_ty.apply_specialization(self.db, specialization);
         }
+
+        // Decorators can re-express `cls` using a type variable that is not inferable from the
+        // constructor call. In that case, the constraint solver is the authority for the receiver;
+        // a final assignability check against the unsolved type variable would be misleading.
+        let unsolved_constructor_receiver = matches!(argument, Argument::Synthetic)
+            && self.constructor_kind == Some(ConstructorCallableKind::New)
+            && matches!(
+                expected_ty.resolve_type_alias(self.db),
+                Type::SubclassOf(subclass_of) if subclass_of.into_type_var().is_some()
+            );
 
         // Some typing special forms are valid class-info arguments at runtime but are not
         // assignable to typeshed's `isinstance`/`issubclass` class-info annotation.
@@ -5508,7 +5495,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         //
         // TODO: handle starred annotations, e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...]]`
         if !self.constraint_set_errors[argument_index]
-            && !constructor_receiver
+            && !unsolved_constructor_receiver
             && !parameter.has_starred_annotation()
             && !is_valid_isinstance_target()
             && argument_type

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4981,6 +4981,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
 struct ArgumentTypeChecker<'a, 'db> {
     db: &'db dyn Db,
     signature_type: Type<'db>,
+    constructor_kind: Option<ConstructorCallableKind>,
     signature: &'a Signature<'db>,
     arguments: &'a CallArguments<'a, 'db>,
     argument_matches: &'a [MatchedArgument<'db>],
@@ -5049,6 +5050,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     fn new(
         db: &'db dyn Db,
         signature_type: Type<'db>,
+        constructor_kind: Option<ConstructorCallableKind>,
         signature: &'a Signature<'db>,
         arguments: &'a CallArguments<'a, 'db>,
         argument_matches: &'a [MatchedArgument<'db>],
@@ -5060,6 +5062,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         Self {
             db,
             signature_type,
+            constructor_kind,
             signature,
             arguments,
             argument_matches,
@@ -5445,9 +5448,32 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             return;
         }
 
+        // The synthetic `cls` already carries the constructor's identity specialization.
+        // For example, typeshed's `map` constructor is roughly:
+        //
+        // ```py
+        // class map[S]:
+        //     def __new__[T](cls, callback: Callable[[T], S], values: Iterable[T], /) -> Self: ...
+        //
+        // map(os.path.abspath, list_fonts("fonts"))
+        // ```
+        //
+        // Once the call specializes `S` to `PathLike[Never]`, applying that specialization to
+        // `cls` again produces `map[PathLike[PathLike[Never]]]` instead of
+        // `map[PathLike[Never]]`, causing a spurious argument error. Decorators can also
+        // re-express the `cls` annotation using their own TypeVar, possibly through a type alias.
+        let constructor_receiver = matches!(argument, Argument::Synthetic)
+            && self.constructor_kind == Some(ConstructorCallableKind::New)
+            && matches!(
+                parameter.annotated_type().resolve_type_alias(self.db),
+                Type::SubclassOf(subclass_of) if subclass_of.into_type_var().is_some()
+            );
+
         let mut expected_ty = parameter.annotated_type();
         if let Some(specialization) = self.specialization() {
-            argument_type = argument_type.apply_specialization(self.db, specialization);
+            if !constructor_receiver {
+                argument_type = argument_type.apply_specialization(self.db, specialization);
+            }
             expected_ty = expected_ty.apply_specialization(self.db, specialization);
         }
 
@@ -5482,6 +5508,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         //
         // TODO: handle starred annotations, e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...]]`
         if !self.constraint_set_errors[argument_index]
+            && !constructor_receiver
             && !parameter.has_starred_annotation()
             && !is_valid_isinstance_target()
             && argument_type
@@ -6650,6 +6677,7 @@ impl<'db> Binding<'db> {
         let mut checker = ArgumentTypeChecker::new(
             db,
             self.signature_type,
+            self.constructor_context.map(ConstructorContext::kind),
             &self.signature,
             arguments,
             &self.argument_matches,

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -553,7 +553,7 @@ impl<'db> ConstructorContext<'db> {
         self.instance_type
     }
 
-    fn kind(self) -> ConstructorCallableKind {
+    pub(super) fn kind(self) -> ConstructorCallableKind {
         self.kind
     }
 }
@@ -635,7 +635,7 @@ impl<'db> Binding<'db> {
             return false;
         };
 
-        let Type::SubclassOf(subclass_of) = cls_parameter_ty else {
+        let Type::SubclassOf(subclass_of) = cls_parameter_ty.resolve_type_alias(db) else {
             return false;
         };
         let Some(cls_typevar) = subclass_of.into_type_var() else {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -606,7 +606,9 @@ impl<'db> OverloadLiteral<'db> {
 
         let generic_context = raw_signature.generic_context;
         raw_signature.add_implicit_self_annotation(db, || {
-            if self.is_staticmethod(db) {
+            let is_staticmethod = self.is_staticmethod(db);
+            let is_dunder_new = self.name(db) == "__new__";
+            if is_staticmethod && !is_dunder_new {
                 return None;
             }
 
@@ -654,7 +656,7 @@ impl<'db> OverloadLiteral<'db> {
                      for an implicit self: Self annotation",
                     );
 
-                if self.is_classmethod(db) {
+                if self.is_classmethod(db) || is_dunder_new {
                     Some(SubclassOfType::from(
                         db,
                         SubclassOfInner::TypeVar(typing_self),
@@ -665,7 +667,7 @@ impl<'db> OverloadLiteral<'db> {
             } else {
                 // If skip creating the typevar, we use "instance of class" or "subclass of
                 // class" as the implicit annotation instead.
-                if self.is_classmethod(db) {
+                if self.is_classmethod(db) || is_dunder_new {
                     Some(SubclassOfType::from(
                         db,
                         SubclassOfInner::Class(ClassType::NonGeneric(class_literal)),

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2206,44 +2206,69 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
         let mut types = FxHashMap::default();
         for solution in solutions {
-            for binding in solution {
-                let identity = binding.bound_typevar.identity(self.db);
+            let mut path_types: FxHashMap<_, _> = solution
+                .into_iter()
+                .map(|binding| (binding.bound_typevar.identity(self.db), binding.solution))
+                .collect();
+
+            // Sequent-map transitivity can add relationships between inferable typevars to path
+            // bounds. Those relationships are important while solving, but should not become
+            // recursive specialization outputs when concrete bounds are available. (This is
+            // tested in "Generic callable chains" in the call/function.md mdtest.)
+            //
+            // TODO: This is a solution-level projection. A more principled version would live in
+            // the constraint-set solution extraction layer, taking an explicit domain of typevars
+            // to solve for and existentially quantifying away the other typevars in that domain.
+            for (identity, variable) in generic_context.variables_inner(self.db) {
+                if let Some(ty) = path_types.get_mut(identity) {
+                    *ty = self.remove_inferable_typevar_artifacts_from_solution(*variable, *ty);
+                }
+            }
+
+            // Resolve relationships while the type mappings still belong to the same BDD path.
+            // Combining paths first can manufacture an expanding cycle by mixing unrelated
+            // solutions for different type variables. An expanding cycle within a single path
+            // still cannot reach a fixed point and must use the legacy solver for now.
+            if path_types.iter().any(|(identity, ty)| {
+                self.has_expanding_cycle(generic_context, &path_types, *identity, *ty)
+            }) {
+                return self.solve_hash_map_with(generic_context, choose);
+            }
+
+            let path_specialization = generic_context.specialize_recursive(
+                self.db,
+                generic_context
+                    .variables_inner(self.db)
+                    .iter()
+                    .map(|(identity, variable)| {
+                        Some(
+                            path_types
+                                .get(identity)
+                                .copied()
+                                .unwrap_or(Type::TypeVar(*variable)),
+                        )
+                    }),
+            );
+
+            for ((identity, _), solution) in generic_context
+                .variables_inner(self.db)
+                .iter()
+                .zip(path_specialization.types(self.db))
+            {
+                if !path_types.contains_key(identity) {
+                    continue;
+                }
+
                 types
-                    .entry(identity)
+                    .entry(*identity)
                     .and_modify(|existing| {
-                        *existing =
-                            UnionType::from_two_elements(self.db, *existing, binding.solution);
+                        *existing = UnionType::from_two_elements(self.db, *existing, *solution);
                     })
-                    .or_insert(binding.solution);
+                    .or_insert(*solution);
             }
         }
 
-        // Sequent-map transitivity can add relationships between inferable typevars to path
-        // bounds. Those relationships are important while solving, but should not become recursive
-        // specialization outputs when concrete bounds are available. (This is tested in "Generic
-        // callable chains" in the call/function.md mdtest.)
-        //
-        // TODO: This is a solution-level projection. A more principled version would live in the
-        // constraint-set solution extraction layer, taking an explicit domain of typevars to solve
-        // for and existentially quantifying away the other typevars in that domain.
-        for (identity, variable) in generic_context.variables_inner(self.db) {
-            if let Some(ty) = types.get_mut(identity) {
-                *ty = self.remove_inferable_typevar_artifacts_from_solution(*variable, *ty);
-            }
-        }
-
-        // TODO: Replace this fallback with expanding-cycle detection in the constraint-set
-        // solution layer.
-        if types
-            .iter()
-            .any(|(identity, ty)| self.has_expanding_cycle(generic_context, &types, *identity, *ty))
-        {
-            // Recursive specialization cannot reach a fixed point when a cycle grows through an
-            // embedded generic type, such as `SupportsAdd[T, S]`.
-            self.solve_hash_map_with(generic_context, choose)
-        } else {
-            types
-        }
+        types
     }
 
     fn has_expanding_cycle(

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -1004,7 +1004,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .as_class_literal()
                 .and_then(|class| class.known(db))
             {
-                if known_class == KnownClass::Staticmethod {
+                if known_class == KnownClass::Staticmethod && function_name != "__new__" {
                     return None;
                 }
 


### PR DESCRIPTION
## Summary

Follow-up to [#27003](https://github.com/astral-sh/ruff/pull/27003).

Prior to this change, `SpecializationBuilder` combined type-variable solutions from independent constraint-set paths before recursively resolving them. For an overloaded callback in a generic constructor, this could mix `T` and `R_co` from different paths, manufacture an expanding cycle, and fall back to legacy inference. The resulting specialization could disagree with `Self`, forcing #27003 to skip specialization and checking for the synthetic `cls` argument.

We now project and recursively resolve mappings within each path, then union the resolved results. This preserves relationships like `Self = Mapper[R_co]`, avoids manufactured cycles, and permits normal specialization and checking of inferred constructor receivers. A narrow guard remains for decorator-reexpressed receivers whose type variable is genuinely unsolved.

This also fixes the existing `map("{}".format, Unknown)` inference limitation: the result now correctly reveals `map[str]`, and passing it to `str.join` no longer emits a false `no-matching-overload` diagnostic.

The full `ty_python_semantic` suite, Clippy, formatting, and file-scoped hooks pass.