### PR TITLE
Exclude Markdown files from `format-dev` runs

### DIFF
--- a/crates/ruff_dev/src/format_dev.rs
+++ b/crates/ruff_dev/src/format_dev.rs
@@ -40,7 +40,8 @@ fn parse_cli(dirs: &[PathBuf]) -> anyhow::Result<(FormatArguments, ConfigArgumen
     let args_matches = FormatCommand::command()
         .no_binary_name(true)
         .get_matches_from(dirs);
-    let arguments: FormatCommand = FormatCommand::from_arg_matches(&args_matches)?;
+    let mut arguments: FormatCommand = FormatCommand::from_arg_matches(&args_matches)?;
+    arguments.extend_exclude = Some(vec![FilePattern::Builtin("*.md")]);
     let (cli, config_arguments) = arguments.partition(GlobalConfigArgs::default())?;
     Ok((cli, config_arguments))
 }

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -18,6 +18,8 @@
 //! * [`format!`]: Formats a formattable object
 //! * [`format_args!`]: Concatenates a sequence of Format objects.
 //! * [`write!`]: Writes a sequence of formattable objects into an output buffer.
+//!
+//! tmp delete this
 
 mod arguments;
 mod buffer;

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -18,8 +18,6 @@
 //! * [`format!`]: Formats a formattable object
 //! * [`format_args!`]: Concatenates a sequence of Format objects.
 //! * [`write!`]: Writes a sequence of formattable objects into an output buffer.
-//!
-//! tmp delete this
 
 mod arguments;
 mod buffer;


### PR DESCRIPTION
Summary
--

This should fix the CI failures I was seeing in #27035:

https://github.com/astral-sh/ruff/actions/runs/29854835643/job/88716871906?pr=27035

I guess this didn't appear in #27018 because no formatter files were modified.

Test Plan
--

CI on this PR, success: https://github.com/astral-sh/ruff/actions/runs/29861350490/job/88738651835?pr=27052