### PR TITLE
[ty] Fix Just[float] protocol matching

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2236,6 +2236,66 @@ int_value: JustInt = 1
 bool_value: JustInt = True  # error: [invalid-assignment]
 ```
 
+Explicitly specializing a protocol whose `__class__` write type is `type[T]` for one of its type
+parameters does not apply the `int`/`float` special case to its type arguments. This allows such
+protocols to distinguish an actual `float` from an `int`. This is a narrowly-focused special case to
+better support the `Just` type in pandas-stubs:
+
+```py
+from typing import Generic, TypeVar
+from typing_extensions import Self
+
+JustT = TypeVar("JustT")
+JustT_co = TypeVar("JustT_co", covariant=True)
+
+class Just(Protocol, Generic[JustT]):
+    @property
+    def __class__(self, /) -> type[JustT]: ...
+    @__class__.setter
+    def __class__(self, value: type[JustT], /) -> None: ...
+
+def takes_just_int(value: Just[int]) -> None: ...
+def takes_just_float(value: Just[float]) -> None: ...
+def takes_just_union(value: Just[int | float]) -> None: ...
+
+takes_just_int(1)
+takes_just_int(True)  # error: [invalid-argument-type]
+takes_just_int(1.0)  # error: [invalid-argument-type]
+
+takes_just_float(1.0)
+takes_just_float(1)  # error: [invalid-argument-type]
+takes_just_float(True)  # error: [invalid-argument-type]
+
+# An explicit union remains a union; disabling the special case must not erase its `int` member.
+takes_just_union(1)  # error: [invalid-argument-type]
+takes_just_union(1.0)  # error: [invalid-argument-type]
+
+class Timestamp:
+    def __mul__(self, other: Just[float], /) -> Self:
+        return self
+
+reveal_type(Timestamp() * 1.0)  # revealed: Timestamp
+
+class ReadClass(Protocol[JustT_co]):
+    @property
+    def __class__(self, /) -> type[JustT_co]: ...
+
+def takes_read_class(value: ReadClass[float]) -> None:
+    reveal_type(value)  # revealed: ReadClass[int | float]
+
+takes_read_class(1)
+takes_read_class(1.0)
+
+class WritableValue(Protocol[JustT]):
+    @property
+    def value(self) -> type[JustT]: ...
+    @value.setter
+    def value(self, value: type[JustT], /) -> None: ...
+
+def takes_writable_value(value: WritableValue[float]) -> None:
+    reveal_type(value)  # revealed: WritableValue[int | float]
+```
+
 A read/write property on a protocol, where the setter accepts a subtype of the type returned by the
 getter, can be satisfied by a mutable attribute of any type bounded by the upper bound of the
 getter-returned type and the lower bound of the setter-accepted type.

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2237,9 +2237,9 @@ bool_value: JustInt = True  # error: [invalid-assignment]
 ```
 
 Explicitly specializing a protocol that directly declares a `__class__` write type of `type[T]` for
-one of its type parameters does not apply the `int`/`float` special case to its type arguments.
-This allows such protocols to distinguish an actual `float` from an `int`. This is a
-narrowly-focused special case to better support the `Just` type in pandas-stubs:
+one of its type parameters does not apply the `int`/`float` special case to its type arguments. This
+allows such protocols to distinguish an actual `float` from an `int`. This is a narrowly-focused
+special case to better support the `Just` type in pandas-stubs:
 
 ```py
 from typing import Generic, TypeVar

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -2236,10 +2236,10 @@ int_value: JustInt = 1
 bool_value: JustInt = True  # error: [invalid-assignment]
 ```
 
-Explicitly specializing a protocol whose `__class__` write type is `type[T]` for one of its type
-parameters does not apply the `int`/`float` special case to its type arguments. This allows such
-protocols to distinguish an actual `float` from an `int`. This is a narrowly-focused special case to
-better support the `Just` type in pandas-stubs:
+Explicitly specializing a protocol that directly declares a `__class__` write type of `type[T]` for
+one of its type parameters does not apply the `int`/`float` special case to its type arguments.
+This allows such protocols to distinguish an actual `float` from an `int`. This is a
+narrowly-focused special case to better support the `Just` type in pandas-stubs:
 
 ```py
 from typing import Generic, TypeVar

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6137,7 +6137,12 @@ impl<'db> Type<'db> {
             Type::ClassLiteral(class) => {
                 let ty = match class.known(db) {
                     Some(KnownClass::Complex) => KnownUnion::Complex.to_type(db),
-                    Some(KnownClass::Float) => KnownUnion::Float.to_type(db),
+                    Some(KnownClass::Float)
+                        if !inference_flags
+                            .contains(InferenceFlags::DISABLE_INT_FLOAT_SPECIAL_CASE) =>
+                    {
+                        KnownUnion::Float.to_type(db)
+                    }
                     _ => Type::instance(db, class.default_specialization(db)),
                 };
                 Ok(ty)

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1876,6 +1876,9 @@ bitflags::bitflags! {
         /// Whether we're in a context where `Unpack` can be legal.
         const IN_VALID_UNPACK_CONTEXT = 1 << 10;
 
+        /// Whether to disable the `int`/`float` special case in a type expression.
+        const DISABLE_INT_FLOAT_SPECIAL_CASE = 1 << 11;
+
         /// Whether the visitor is currently visiting a type expression.
         const IN_TYPE_EXPRESSION = 1 << 12;
 

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -475,12 +475,38 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }))
         };
 
-        self.infer_explicit_callable_specialization(
+        let disable_int_float_special_case = generic_class
+            .identity_specialization(db)
+            .into_protocol_class(db)
+            .is_some_and(|protocol| {
+                protocol
+                    .interface(db)
+                    .includes_generic_writable_instance_member(db, "__class__", generic_context)
+            });
+        let previously_disabled_int_float_special_case =
+            disable_int_float_special_case.then(|| {
+                self.context
+                    .inference_flags
+                    .replace(InferenceFlags::DISABLE_INT_FLOAT_SPECIAL_CASE, true)
+            });
+
+        let result = self.infer_explicit_callable_specialization(
             subscript,
             value_ty,
             generic_context,
             specialize,
-        )
+        );
+
+        if let Some(previously_disabled_int_float_special_case) =
+            previously_disabled_int_float_special_case
+        {
+            self.context.inference_flags.set(
+                InferenceFlags::DISABLE_INT_FLOAT_SPECIAL_CASE,
+                previously_disabled_int_float_special_case,
+            );
+        }
+
+        result
     }
 
     pub(super) fn infer_explicit_type_alias_type_specialization(

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -32,10 +32,10 @@ use crate::types::{
     UnionTypeInstance, any_over_type, todo_type,
 };
 use crate::{Db, FxOrderSet};
-use ty_python_core::SemanticIndex;
 use ty_python_core::definition::Definition;
 use ty_python_core::place::{PlaceExpr, PlaceExprRef};
 use ty_python_core::scope::FileScopeId;
+use ty_python_core::{SemanticIndex, place_table};
 
 /// Given a string literal or a union of string literals, return an iterator over the contained
 /// strings, or `None` if the type is neither.
@@ -475,14 +475,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }))
         };
 
-        let disable_int_float_special_case = generic_class
-            .identity_specialization(db)
-            .into_protocol_class(db)
-            .is_some_and(|protocol| {
-                protocol
-                    .interface(db)
-                    .includes_generic_writable_instance_member(db, "__class__", generic_context)
-            });
+        // Avoid constructing an identity specialization and a full protocol interface for the
+        // many generic protocols that do not directly declare `__class__`.
+        let disable_int_float_special_case = generic_class.is_protocol(db)
+            && place_table(db, generic_class.body_scope(db))
+                .symbol_id("__class__")
+                .is_some()
+            && generic_class
+                .identity_specialization(db)
+                .into_protocol_class(db)
+                .is_some_and(|protocol| {
+                    protocol
+                        .interface(db)
+                        .includes_generic_writable_instance_member(db, "__class__", generic_context)
+                });
         let previously_disabled_int_float_special_case =
             disable_int_float_special_case.then(|| {
                 self.context

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -24,9 +24,9 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, BoundTypeVarInstance,
         CallableType, ClassBase, ClassType, ErrorContext, FindLegacyTypeVarsVisitor,
-        InstanceFallbackShadowsNonDataDescriptor, IntersectionType, KnownFunction, MemberLookupKey,
-        MemberLookupPolicy, Parameter, PropertyInstanceType, ProtocolInstanceType, SelfBinding,
-        Signature, StaticClassLiteral, Type, TypeMapping, TypeQualifiers,
+        GenericContext, InstanceFallbackShadowsNonDataDescriptor, IntersectionType, KnownFunction,
+        MemberLookupKey, MemberLookupPolicy, Parameter, PropertyInstanceType, ProtocolInstanceType,
+        SelfBinding, Signature, StaticClassLiteral, Type, TypeMapping, TypeQualifiers,
         TypeVarBoundOrConstraints, TypeVarVariance, UnionType, VarianceInferable,
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
@@ -382,6 +382,29 @@ impl<'db> ProtocolInterface<'db> {
 
     pub(super) fn includes_member(self, db: &'db dyn Db, name: &str) -> bool {
         self.inner(db).contains_key(name)
+    }
+
+    /// Returns whether `name` has an instance-write requirement of `type[T]`, where `T` belongs
+    /// to `generic_context`.
+    pub(super) fn includes_generic_writable_instance_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        generic_context: GenericContext<'db>,
+    ) -> bool {
+        self.member_by_name(db, name)
+            .and_then(|member| member.capabilities(db).instance.write)
+            .and_then(ProtocolMemberWrite::domain)
+            .and_then(|write| write.resolve(db))
+            .is_some_and(|write| {
+                matches!(
+                    write.ty(),
+                    Type::SubclassOf(subclass_of)
+                        if subclass_of.into_type_var().is_some_and(|typevar| {
+                            generic_context.contains(db, typevar.identity(db))
+                        })
+                )
+            })
     }
 
     /// Returns the declared instance-write requirement for a protocol member.


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4053.

`float` in a type expression normally expands to `int | float`. For an explicitly specialized protocol that contravariantly matches a writable `__class__: type[T]`, that expansion makes `Just[float]` require a setter accepting both `int` and `float`, so an actual `float` no longer satisfies the protocol.

This adds a narrow structural special case for protocols whose `__class__` instance-write requirement is `type[T]` for one of their type parameters. While inferring their explicit type arguments, ty disables only the `float`-to-`int | float` expansion. This supports the `Just` type without depending on its specific name or module, while preserving unrelated writable-`__class__` protocols and normal numeric promotion.

## Test plan

Added mdtest covers `Just[int]`, `Just[float]`, bool/int/float values, explicit unions, multiplication, and read-only/unrelated writable-member controls.
