### PR TITLE
[ty] Ignore bound receiver graduality during overload selection

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -1710,7 +1710,80 @@ def _(a_int: A[int], a_str: A[str], a_any: A[Any]):
 def _(b_int: B[int], b_str: B[str], b_any: B[Any]):
     reveal_type(b_int.method())  # revealed: int
     reveal_type(b_str.method())  # revealed: str
-    reveal_type(b_any.method())  # revealed: Unknown
+    reveal_type(b_any.method())  # revealed: int
+```
+
+### Gradual bound receiver
+
+A gradual type argument in a bound receiver can make multiple receiver-specialized overloads
+applicable. For compatibility with other type checkers, the synthetic receiver does not participate
+in step 5, so the first applicable overload is selected. Gradual arguments supplied explicitly at
+the call site still participate and can make the result ambiguous.
+
+`overloaded.pyi`:
+
+```pyi
+from typing import Generic, TypeVar, overload
+
+T = TypeVar("T")
+
+class Timestamp: ...
+class Timedelta: ...
+
+class Series(Generic[T]):
+    @overload
+    def __sub__(self: "Series[Timestamp]", other: Timedelta) -> "Series[Timestamp]": ...
+    @overload
+    def __sub__(self: "Series[Timedelta]", other: Timedelta) -> "Series[Timedelta]": ...
+    @overload
+    def sub(self: "Series[Timestamp]", other: Timedelta) -> "Series[Timestamp]": ...
+    @overload
+    def sub(self: "Series[Timedelta]", other: Timedelta) -> "Series[Timedelta]": ...
+    @overload
+    def ambiguous(self: "Series[Timestamp]", other: "Series[Timestamp]") -> Timestamp: ...
+    @overload
+    def ambiguous(self: "Series[Timedelta]", other: "Series[Timedelta]") -> Timedelta: ...
+
+class ReversedSeries(Generic[T]):
+    @overload
+    def sub(self: "ReversedSeries[Timedelta]", other: Timedelta) -> "ReversedSeries[Timedelta]": ...
+    @overload
+    def sub(self: "ReversedSeries[Timestamp]", other: Timedelta) -> "ReversedSeries[Timestamp]": ...
+
+@overload
+def free_sub(series: Series[Timestamp], other: Timedelta) -> Series[Timestamp]: ...
+@overload
+def free_sub(series: Series[Timedelta], other: Timedelta) -> Series[Timedelta]: ...
+```
+
+```py
+from typing import Any
+from ty_extensions import Unknown
+
+from overloaded import ReversedSeries, Series, Timedelta, Timestamp, free_sub
+
+def gradual_receiver(
+    any_series: Series[Any],
+    unknown_series: Series[Unknown],
+    reversed_series: ReversedSeries[Any],
+    delta: Timedelta,
+):
+    reveal_type(any_series - delta)  # revealed: Series[Timestamp]
+    reveal_type(any_series.__sub__(delta))  # revealed: Series[Timestamp]
+    reveal_type(any_series.sub(delta))  # revealed: Series[Timestamp]
+    reveal_type(unknown_series.sub(delta))  # revealed: Series[Timestamp]
+    reveal_type(reversed_series.sub(delta))  # revealed: ReversedSeries[Timedelta]
+
+    # The receiver is explicit in these calls and therefore still participates in step 5.
+    reveal_type(Series.sub(any_series, delta))  # revealed: Unknown
+    reveal_type(free_sub(any_series, delta))  # revealed: Unknown
+
+    # A gradual non-receiver argument can still make a bound-method call ambiguous.
+    reveal_type(any_series.ambiguous(any_series))  # revealed: Unknown
+
+def concrete_receiver(timestamps: Series[Timestamp], timedeltas: Series[Timedelta], delta: Timedelta):
+    reveal_type(timestamps.sub(delta))  # revealed: Series[Timestamp]
+    reveal_type(timedeltas.sub(delta))  # revealed: Series[Timedelta]
 ```
 
 ### Variadic argument

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -225,10 +225,6 @@ impl<'a, 'db> CallArguments<'a, 'db> {
             .types = CallArgumentTypes::default();
     }
 
-    pub(crate) fn iter_types(&self) -> impl Iterator<Item = &CallArgumentTypes<'db>> + '_ {
-        self.items.iter().map(|item| &item.types)
-    }
-
     /// Returns `true` if the inferred types are equal for the given set of argument indices.
     pub(crate) fn inferred_types_equal_at(&self, other: &Self, argument_indices: &[usize]) -> bool {
         argument_indices.iter().all(|&index| {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3832,8 +3832,11 @@ impl<'db> CallableBinding<'db> {
                 let slots = overload
                     .argument_matches
                     .iter()
-                    .zip(arguments.iter_types())
-                    .flat_map(move |(matched_argument, argument_types)| {
+                    .zip(arguments.iter())
+                    // A bound receiver participates in overload applicability, but its graduality
+                    // does not make otherwise-applicable overloads ambiguous.
+                    .filter(|(_, (argument, _))| !matches!(argument, Argument::Synthetic))
+                    .flat_map(move |(matched_argument, (_, argument_types))| {
                         matched_argument.iter().map(move |matched_parameter| {
                             // TODO: For an unannotated `self` / `cls` parameter, the type should be
                             // `typing.Self` / `type[typing.Self]`


### PR DESCRIPTION
Closes astral-sh/ty#4055.

## Summary

A gradual type argument in a bound receiver can make multiple receiver-specialized overloads applicable. ty was including the synthetic `self` argument in overload-evaluation step 5, so calls such as `Series[Any]() - Timedelta()` produced an ambiguous `Unknown` even though mypy, Pyright, and Pyrefly select the first applicable receiver overload.

Exclude only the synthetic bound receiver (`self`/`cls`) from step-5 ambiguity filtering. Receiver constraints still determine applicability, while gradual arguments that are explicitly supplied at the call site continue to participate normally. This deliberately adopts the narrow compatibility heuristic without copying Pyright's broader nested-`Any` behavior for ordinary calls.

## Test plan

The test coverage includes:

- binary operators, direct dunder calls, and ordinary bound methods;
- `Any` and `Unknown` receiver specializations;
- reversed overload order;
- unbound and equivalent free-function calls, which remain ambiguous;
- gradual non-receiver arguments and satisfiable concrete receivers.