### PR TITLE
[ty] Prefer static constrained TypeVar solutions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1087,7 +1087,7 @@ When inference provides only an upper bound, we prefer the most general compatib
 constraint. This also does not depend on declaration order.
 
 ```py
-from typing import Any, Callable, TypeVar
+from typing import Callable, TypeVar
 
 NarrowFirst = TypeVar("NarrowFirst", int, object)
 BroadFirst = TypeVar("BroadFirst", object, int)
@@ -1102,33 +1102,6 @@ def accepts_object(value: object) -> None: ...
 
 reveal_type(narrow_first(accepts_object))  # revealed: object
 reveal_type(broad_first(accepts_object))  # revealed: object
-
-class Row(tuple[Any, ...]): ...
-
-GradualFirst = TypeVar("GradualFirst", tuple[Any, ...], Row)
-RowFirst = TypeVar("RowFirst", Row, tuple[Any, ...])
-AnyFirst = TypeVar("AnyFirst", Any, int)
-IntFirst = TypeVar("IntFirst", int, Any)
-
-def gradual_first(callback: Callable[[GradualFirst], None]) -> GradualFirst:
-    raise NotImplementedError
-
-def row_first(callback: Callable[[RowFirst], None]) -> RowFirst:
-    raise NotImplementedError
-
-def any_first(callback: Callable[[AnyFirst], None]) -> AnyFirst:
-    raise NotImplementedError
-
-def int_first(callback: Callable[[IntFirst], None]) -> IntFirst:
-    raise NotImplementedError
-
-def accepts_tuple(value: tuple[object, ...]) -> None: ...
-def accepts_int(value: int) -> None: ...
-
-reveal_type(gradual_first(accepts_tuple))  # revealed: tuple[Any, ...]
-reveal_type(row_first(accepts_tuple))  # revealed: tuple[Any, ...]
-reveal_type(any_first(accepts_int))  # revealed: int
-reveal_type(int_first(accepts_int))  # revealed: int
 ```
 
 ## Ambiguous constrained TypeVar inference from `Any`

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -440,10 +440,10 @@ def consume_callback(callback: Callable[[Row], None]) -> Row:
 reveal_type(consume_callback(callback))  # revealed: tuple[Any, ...]
 ```
 
-## Gradual constraints can obscure a more specific constraint
+## Prefer specific compatible constraints over gradual constraints
 
-A gradual constraint that is compatible with a concrete argument can be selected before a more
-specific constraint. This makes inference depend on the order in which the constraints are declared.
+A gradual constraint can be compatible with a concrete argument and a more specific declared
+constraint. We prefer the more specific constraint regardless of declaration order.
 
 ```py
 from typing import Any, TypeVar
@@ -454,6 +454,8 @@ class Row(tuple[Any, ...]):
 
 GradualFirst = TypeVar("GradualFirst", list[Any], tuple[Any, ...], Row)
 RowFirst = TypeVar("RowFirst", Row, tuple[Any, ...], list[Any])
+AnyFirst = TypeVar("AnyFirst", Any, int)
+IntFirst = TypeVar("IntFirst", int, Any)
 
 def gradual_first(row: GradualFirst) -> GradualFirst:
     return row
@@ -461,15 +463,22 @@ def gradual_first(row: GradualFirst) -> GradualFirst:
 def row_first(row: RowFirst) -> RowFirst:
     return row
 
+def any_first(value: AnyFirst) -> AnyFirst:
+    return value
+
+def int_first(value: IntFirst) -> IntFirst:
+    return value
+
 gradual = gradual_first(Row())
-# TODO: revealed: Row
-reveal_type(gradual)  # revealed: tuple[Any, ...]
-# error: [unresolved-attribute] "Object of type `tuple[Any, ...]` has no attribute `asDict`"
+reveal_type(gradual)  # revealed: Row
 gradual.asDict()
 
 specific = row_first(Row())
 reveal_type(specific)  # revealed: Row
 specific.asDict()
+
+reveal_type(any_first(1))  # revealed: int
+reveal_type(int_first(1))  # revealed: int
 ```
 
 ## Typevar inference is a unification problem
@@ -1078,7 +1087,7 @@ When inference provides only an upper bound, we prefer the most general compatib
 constraint. This also does not depend on declaration order.
 
 ```py
-from typing import Callable, TypeVar
+from typing import Any, Callable, TypeVar
 
 NarrowFirst = TypeVar("NarrowFirst", int, object)
 BroadFirst = TypeVar("BroadFirst", object, int)
@@ -1093,6 +1102,33 @@ def accepts_object(value: object) -> None: ...
 
 reveal_type(narrow_first(accepts_object))  # revealed: object
 reveal_type(broad_first(accepts_object))  # revealed: object
+
+class Row(tuple[Any, ...]): ...
+
+GradualFirst = TypeVar("GradualFirst", tuple[Any, ...], Row)
+RowFirst = TypeVar("RowFirst", Row, tuple[Any, ...])
+AnyFirst = TypeVar("AnyFirst", Any, int)
+IntFirst = TypeVar("IntFirst", int, Any)
+
+def gradual_first(callback: Callable[[GradualFirst], None]) -> GradualFirst:
+    raise NotImplementedError
+
+def row_first(callback: Callable[[RowFirst], None]) -> RowFirst:
+    raise NotImplementedError
+
+def any_first(callback: Callable[[AnyFirst], None]) -> AnyFirst:
+    raise NotImplementedError
+
+def int_first(callback: Callable[[IntFirst], None]) -> IntFirst:
+    raise NotImplementedError
+
+def accepts_tuple(value: tuple[object, ...]) -> None: ...
+def accepts_int(value: int) -> None: ...
+
+reveal_type(gradual_first(accepts_tuple))  # revealed: tuple[Any, ...]
+reveal_type(row_first(accepts_tuple))  # revealed: tuple[Any, ...]
+reveal_type(any_first(accepts_int))  # revealed: int
+reveal_type(int_first(accepts_int))  # revealed: int
 ```
 
 ## Ambiguous constrained TypeVar inference from `Any`

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -4053,14 +4053,26 @@ impl<'db> PathBounds<'db> {
                     // Lower-bound evidence asks for the narrowest compatible declared constraint
                     // above the lower bound. With only upper-bound evidence, ask for the widest
                     // compatible declared constraint below the upper bound. If the candidates are
-                    // equivalent or incomparable, keep the current best to preserve the TypeVar's
+                    // assignable in both directions, prefer a fully static constraint over a
+                    // gradual one. Otherwise, keep the current best to preserve the TypeVar's
                     // declared constraint order.
-                    if path_bound.lower.is_some() {
-                        candidate.is_subtype_of(db, current_best)
-                            && !current_best.is_subtype_of(db, candidate)
+                    let candidate_assignable_to_best = candidate.is_assignable_to(db, current_best);
+                    let best_assignable_to_candidate = current_best.is_assignable_to(db, candidate);
+
+                    if candidate_assignable_to_best != best_assignable_to_candidate {
+                        if path_bound.lower.is_some() {
+                            candidate_assignable_to_best
+                        } else {
+                            best_assignable_to_candidate
+                        }
+                    } else if candidate_assignable_to_best {
+                        let candidate_is_static = candidate.bottom_materialization(db)
+                            == candidate.top_materialization(db);
+                        let best_is_static = current_best.bottom_materialization(db)
+                            == current_best.top_materialization(db);
+                        candidate_is_static && !best_is_static
                     } else {
-                        current_best.is_subtype_of(db, candidate)
-                            && !candidate.is_subtype_of(db, current_best)
+                        false
                     }
                 };
 


### PR DESCRIPTION
## Summary

Follow-up to [#26965](https://github.com/astral-sh/ruff/pull/26965).

After accepting gradual constrained-TypeVar solutions, a gradual constraint can match before a more-specific constraint. The existing subtype-based tie-breaker cannot order these candidates, so inference depends on declaration order and can discard members of the concrete type:

```py
from typing import Any, TypeVar

class Row(tuple[Any, ...]):
    def asDict(self) -> dict[str, Any]: ...

RowLike = TypeVar("RowLike", list[Any], tuple[Any, ...], Row)

def identity(value: RowLike) -> RowLike: ...

result = identity(Row())
result.asDict()  # Previously: unresolved-attribute on tuple[Any, ...]
```

We now compare compatible constraints using assignability. When only one direction is assignable, lower-bound inference prefers the more-specific constraint and upper-bound-only inference preserves its existing preference for the more-general one. When both directions are assignable, we prefer a fully static constraint over a gradual constraint, which also makes `TypeVar("T", Any, int)` select `int` for a concrete integer argument. Incomparable constraints retain declaration order.