### PR TITLE
[ty] Fix double specialization of generic type aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -103,6 +103,14 @@ def _(l: ListOfInts[int]):
 
 type List[T] = list[T]
 
+# error: [not-subscriptable] "Cannot specialize non-generic type alias: Double specialization is not allowed"
+reveal_type(List[int][str])  # revealed: Unknown
+
+SpecializedList = List[int]
+
+# error: [not-subscriptable] "Cannot specialize non-generic type alias: Double specialization is not allowed"
+reveal_type(SpecializedList[str])  # revealed: Unknown
+
 # error: [invalid-type-form] "Only simple names and dotted names can be subscripted in parameter annotations"
 def _(l: List[int][int]):
     reveal_type(l)  # revealed: Unknown

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -523,6 +523,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         generic_context: GenericContext<'db>,
     ) -> Type<'db> {
         let db = self.db();
+        if generic_type_alias.specialization(db).is_some() {
+            if !self.in_string_annotation() {
+                self.infer_expression(&subscript.slice, TypeContext::default());
+            }
+            if let Some(builder) = self.context.report_lint(&NOT_SUBSCRIPTABLE, subscript) {
+                let mut diagnostic =
+                    builder.into_diagnostic("Cannot specialize non-generic type alias");
+                diagnostic.set_primary_message("Double specialization is not allowed");
+            }
+            return Type::unknown();
+        }
+
         let specialize = &|types: &[Option<Type<'db>>]| {
             let type_alias = generic_type_alias.apply_specialization(db, |_| {
                 generic_context.specialize_partial(db, types.iter().copied())

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1593,19 +1593,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     Type::unknown()
                 }
                 KnownInstanceType::TypeAliasType(type_alias @ TypeAliasType::PEP695(_)) => {
-                    if type_alias.specialization(self.db()).is_some() {
-                        if !self.in_string_annotation() {
-                            self.infer_expression(slice, TypeContext::default());
-                        }
-                        if let Some(builder) =
-                            self.context.report_lint(&NOT_SUBSCRIPTABLE, subscript)
-                        {
-                            let mut diagnostic =
-                                builder.into_diagnostic("Cannot specialize non-generic type alias");
-                            diagnostic.set_primary_message("Double specialization is not allowed");
-                        }
-                        return Type::unknown();
-                    }
                     match type_alias.generic_context(self.db()) {
                         Some(generic_context) => {
                             let specialized_type_alias = self


### PR DESCRIPTION
## Summary

Fix value-context double specialization of generic PEP 695 type aliases. Expressions such as `A[int][str]` previously overwrote the first specialization and were inferred as `A[str]`; they now report the existing `not-subscriptable` diagnostic and infer `Unknown`.

Move the existing double-specialization guard into the specialization helper shared by value and annotation inference, preserving the annotation-path diagnostic, too.

## Test plan

Added mdtest coverage for direct value-context double specialization and for resubscripting a stored specialization. Existing annotation, implicit-alias, and PEP 695 alias scenarios continue to pass, including the full semantic mdtest suite.