### PR TITLE
[ty] Support generic manual PEP 695 type aliases

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -110,7 +110,7 @@ static ALTAIR: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    3,
+    5,
 );
 
 static COLOUR_SCIENCE: Benchmark = Benchmark::new(

--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -227,7 +227,7 @@ static STATIC_FRAME: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    1950,
+    2000,
 );
 
 #[track_caller]

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -2814,7 +2814,7 @@ python-version = "3.12"
 ```
 
 ```python
-from typing import TypeAliasType
+from typing import TypeAliasType, TypeVar
 
 
 def get_name() -> str:
@@ -2824,6 +2824,11 @@ def get_name() -> str:
 IntOrStr = TypeAliasType("IntOrStr", int | str)  # okay
 # TypeAliasType name must be a string literal
 NewAlias = TypeAliasType(get_name(), int)  # error
+
+T = TypeVar("T")
+GenericAlias = TypeAliasType("GenericAlias", list[T], type_params=(T,))  # okay
+# TypeAliasType type parameters must be type variables
+InvalidAlias = TypeAliasType("InvalidAlias", list[T], type_params=(list[T],))  # error
 ```
 
 ## `invalid-type-arguments`

--- a/crates/ty_python_semantic/resources/lint_docs/invalid-type-alias-type.md
+++ b/crates/ty_python_semantic/resources/lint_docs/invalid-type-alias-type.md
@@ -14,7 +14,7 @@ python-version = "3.12"
 ```
 
 ```python
-from typing import TypeAliasType
+from typing import TypeAliasType, TypeVar
 
 
 def get_name() -> str:
@@ -24,4 +24,9 @@ def get_name() -> str:
 IntOrStr = TypeAliasType("IntOrStr", int | str)  # okay
 # TypeAliasType name must be a string literal
 NewAlias = TypeAliasType(get_name(), int)  # error
+
+T = TypeVar("T")
+GenericAlias = TypeAliasType("GenericAlias", list[T], type_params=(T,))  # okay
+# TypeAliasType type parameters must be type variables
+InvalidAlias = TypeAliasType("InvalidAlias", list[T], type_params=(list[T],))  # error
 ```

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -271,7 +271,7 @@ MyList = TypeAliasType("MyList", list[T], type_params=(T,))
 MyAlias5 = Callable[[MyList[T]], int]
 
 def _(c: MyAlias5[int]):
-    reveal_type(c)  # revealed: (list[int], /) -> int
+    reveal_type(c)  # revealed: (MyList[int], /) -> int
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -281,7 +281,7 @@ MyDict = TypeAliasType("MyDict", dict[K, V], type_params=(K, V))
 MyAlias6 = Callable[[MyDict[K, V]], int]
 
 def _(c: MyAlias6[str, bytes]):
-    reveal_type(c)  # revealed: (dict[str, bytes], /) -> int
+    reveal_type(c)  # revealed: (MyDict[str, bytes], /) -> int
 
 ListOrDict: TypeAlias = MyList[T] | dict[str, T]
 

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -271,8 +271,7 @@ MyList = TypeAliasType("MyList", list[T], type_params=(T,))
 MyAlias5 = Callable[[MyList[T]], int]
 
 def _(c: MyAlias5[int]):
-    # TODO: should be (list[int], /) -> int
-    reveal_type(c)  # revealed: (Unknown, /) -> int
+    reveal_type(c)  # revealed: (list[int], /) -> int
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -282,14 +281,12 @@ MyDict = TypeAliasType("MyDict", dict[K, V], type_params=(K, V))
 MyAlias6 = Callable[[MyDict[K, V]], int]
 
 def _(c: MyAlias6[str, bytes]):
-    # TODO: should be (dict[str, bytes], /) -> int
-    reveal_type(c)  # revealed: (Unknown, /) -> int
+    reveal_type(c)  # revealed: (dict[str, bytes], /) -> int
 
 ListOrDict: TypeAlias = MyList[T] | dict[str, T]
 
 def _(x: ListOrDict[int]):
-    # TODO: should be list[int] | dict[str, int]
-    reveal_type(x)  # revealed: Unknown | dict[str, int]
+    reveal_type(x)  # revealed: list[int] | dict[str, int]
 
 MyAlias7: TypeAlias = Callable[Concatenate[T, ...], None]
 

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -507,7 +507,7 @@ def recursive(value: Recursive[int]) -> None:
     reveal_type(value)  # revealed: int | list[Recursive[int]]
 
 def recursive_callable(value: RecursiveCallable[int]) -> None:
-    reveal_type(value)  # revealed: (int | list[Divergent], /) -> None
+    reveal_type(value)  # revealed: (Recursive[int], /) -> None
 ```
 
 ### Generic specialization errors
@@ -543,10 +543,12 @@ def non_generic(value: NonGenericAlias[int]) -> None:
 ### Invalid type parameters
 
 ```py
-from typing_extensions import TypeAliasType, TypeVar
+from typing_extensions import TypeAliasType, TypeVar, TypeVarTuple, Union, Unpack
 
 T = TypeVar("T")
 U = TypeVar("U")
+Ts = TypeVarTuple("Ts")
+Us = TypeVarTuple("Us")
 
 # error: [invalid-type-alias-type] "The `type_params` argument to `TypeAliasType` must be a tuple literal"
 InvalidList = TypeAliasType("InvalidList", list[T], type_params=[T])
@@ -559,16 +561,10 @@ InvalidTupleVariable = TypeAliasType("InvalidTupleVariable", list[T], type_param
 InvalidUnpack = TypeAliasType("InvalidUnpack", list[T], type_params=(*params,))
 
 # error: [invalid-type-alias-type] "Each `type_params` entry for `TypeAliasType` must be a type variable"
-InvalidInt = TypeAliasType("InvalidInt", list[int], type_params=(int,))
-
-# error: [invalid-type-alias-type] "Each `type_params` entry for `TypeAliasType` must be a type variable"
 InvalidNested = TypeAliasType("InvalidNested", list[T], type_params=(list[T],))
 
 # error: [invalid-type-alias-type] "Each `type_params` entry for `TypeAliasType` must be a type variable"
 InvalidMixed = TypeAliasType("InvalidMixed", list[T], type_params=(int, T))
-
-# error: [invalid-type-alias-type] "Each `type_params` entry for `TypeAliasType` must be a type variable"
-InvalidString = TypeAliasType("InvalidString", list[int], type_params=("T",))
 
 # error: [invalid-type-alias-type] "Type parameter `U` used in the alias value must be included in `type_params`"
 Missing = TypeAliasType("Missing", dict[T, U], type_params=(T,))
@@ -578,6 +574,69 @@ MissingAll = TypeAliasType("MissingAll", list[T])
 
 # error: [invalid-type-alias-type] "Type parameter `T` is duplicated in `type_params`"
 Duplicate = TypeAliasType("Duplicate", list[T], type_params=(T, T))
+
+MultipleTypeVarTuples = TypeAliasType(
+    "MultipleTypeVarTuples",
+    Union[tuple[Unpack[Ts]], tuple[Unpack[Us]]],
+    # error: [invalid-type-alias-type] "Only one `TypeVarTuple` parameter is allowed in `type_params`"
+    type_params=(Ts, Us),
+)
+
+DefaultedT = TypeVar("DefaultedT", default=int)
+
+DefaultAfterTypeVarTuple = TypeAliasType(
+    "DefaultAfterTypeVarTuple",
+    tuple[Unpack[Ts], DefaultedT],
+    # error: [invalid-type-variable-default] "Type parameter `DefaultedT` with a default follows TypeVarTuple `Ts`"
+    type_params=(Ts, DefaultedT),
+)
+
+InvalidOrderAndEntries = TypeAliasType(
+    "InvalidOrderAndEntries",
+    tuple[DefaultedT, T],
+    # error: [invalid-type-variable-default] "Type parameter `T` without a default cannot follow earlier parameter `DefaultedT` with a default"
+    # error: [invalid-type-alias-type] "Type parameter `T` is duplicated in `type_params`"
+    # error: [invalid-type-alias-type] "Each `type_params` entry for `TypeAliasType` must be a type variable"
+    type_params=(DefaultedT, T, T, "V"),
+)
+```
+
+### Scoped type parameters
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable
+from typing_extensions import TypeAliasType, TypeVar
+
+LegacyT = TypeVar("LegacyT")
+
+def pep695_outer[T]() -> None:
+    # error: [invalid-type-alias-type] "Type parameter `T` is bound in an outer scope and cannot be used in `type_params`"
+    Pep695Alias = TypeAliasType("Pep695Alias", list[T], type_params=(T,))
+    # error: [not-subscriptable] "Cannot specialize non-generic type alias `Pep695Alias`"
+    def check(value: Pep695Alias[int]) -> None: ...
+
+def legacy_outer(value: LegacyT) -> None:
+    # error: [invalid-type-alias-type] "Type parameter `LegacyT` is bound in an outer scope and cannot be used in `type_params`"
+    LegacyAlias = TypeAliasType("LegacyAlias", list[LegacyT], type_params=(LegacyT,))
+    # error: [not-subscriptable] "Cannot specialize non-generic type alias `LegacyAlias`"
+    def check(value: LegacyAlias[int]) -> None: ...
+
+class Pep695Outer[T]:
+    # error: [invalid-type-alias-type] "Type parameter `T` is bound in an outer scope and cannot be used in `type_params`"
+    ClassAlias = TypeAliasType("ClassAlias", list[T], type_params=(T,))
+
+def paramspec_outer[**P]() -> None:
+    # error: [invalid-type-alias-type] "Type parameter `P` is bound in an outer scope and cannot be used in `type_params`"
+    ParamSpecAlias = TypeAliasType("ParamSpecAlias", Callable[P, int], type_params=(P,))
+
+def variadic_outer[*Ts]() -> None:
+    # error: [invalid-type-alias-type] "Type parameter `Ts` is bound in an outer scope and cannot be used in `type_params`"
+    VariadicAlias = TypeAliasType("VariadicAlias", tuple[*Ts], type_params=(Ts,))
 ```
 
 ### Generic alias from `typing`
@@ -596,6 +655,35 @@ MyDict = TypeAliasType("MyDict", dict[K, V], type_params=(K, V))
 
 def generic_from_typing(value: MyDict[str, int]) -> None:
     reveal_type(value)  # revealed: dict[str, int]
+```
+
+### PEP 695 aliases in `Callable`
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+type Pep695List[A] = list[A]
+Pep695ConcreteCallable = Callable[[Pep695List[int]], None]
+Pep695GenericCallable = Callable[[Pep695List[T]], None]
+
+type Recursive[A] = A | list[Recursive[A]]
+RecursiveCallable = Callable[[Recursive[int]], None]
+
+def _(
+    concrete: Pep695ConcreteCallable,
+    generic: Pep695GenericCallable[str],
+    recursive: RecursiveCallable,
+) -> None:
+    reveal_type(concrete)  # revealed: (Pep695List[int], /) -> None
+    reveal_type(generic)  # revealed: (Pep695List[str], /) -> None
+    reveal_type(recursive)  # revealed: (Recursive[int], /) -> None
 ```
 
 ### Generic value binds type variables to alias definition

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -420,15 +420,182 @@ def f(x: IntOrStr) -> None:
 ### Generic example
 
 ```py
-from typing_extensions import TypeAliasType, TypeVar
+from typing import Callable, Concatenate, Generic
+from typing_extensions import ParamSpec, TypeAliasType, TypeVar, TypeVarTuple, Union, Unpack
 
 T = TypeVar("T")
 
 IntAndT = TypeAliasType("IntAndT", tuple[int, T], type_params=(T,))
 
 def f(x: IntAndT[str]) -> None:
-    # TODO: This should be `tuple[int, str]`
-    reveal_type(x)  # revealed: Unknown
+    reveal_type(x)  # revealed: tuple[int, str]
+
+reveal_type(IntAndT[str])  # revealed: <type alias 'IntAndT[str]'>
+
+def generic_meta(value: type[IntAndT[str]]) -> None:
+    reveal_type(value)  # revealed: type[tuple[int, str]]
+
+Nested = TypeAliasType("Nested", list[IntAndT[T]], type_params=(T,))
+
+def nested(value: Nested[str]) -> None:
+    reveal_type(value)  # revealed: list[IntAndT[str]]
+
+U = TypeVar("U", default=str)
+
+ListOrSet = TypeAliasType("ListOrSet", Union[list[U], set[U]], type_params=(U,))
+MyDict = TypeAliasType("MyDict", dict[T, U], type_params=(T, U))
+Reordered = TypeAliasType("Reordered", tuple[U, T], type_params=(T, U))
+
+def g(
+    list_or_set_of_int: ListOrSet[int],
+    list_or_set_of_str: ListOrSet,
+    dict_int_str: MyDict[int, str],
+    dict_unknown_str: MyDict,
+    reordered: Reordered[int, str],
+) -> None:
+    reveal_type(list_or_set_of_int)  # revealed: list[int] | set[int]
+    reveal_type(list_or_set_of_str)  # revealed: list[str] | set[str]
+    reveal_type(dict_int_str)  # revealed: dict[int, str]
+    reveal_type(dict_unknown_str)  # revealed: dict[Unknown, str]
+    reveal_type(reordered)  # revealed: tuple[str, int]
+
+ModelAlias = TypeAliasType("ModelAlias", type[T], type_params=(T,))
+
+class Model: ...
+
+class ViaAlias(Generic[T]):
+    def __init__(self, value: ModelAlias[T]) -> None: ...
+
+reveal_type(ViaAlias(Model))  # revealed: ViaAlias[Model]
+
+P = ParamSpec("P")
+R = TypeVar("R")
+WrappedMethod = TypeAliasType("WrappedMethod", Callable[Concatenate[T, P], R], type_params=(T, P, R))
+
+def wrapped_method(value: WrappedMethod[int, P, str]) -> None:
+    reveal_type(value)  # revealed: (int, /, *args: P@wrapped_method.args, **kwargs: P@wrapped_method.kwargs) -> str
+
+WrapsMethod = TypeAliasType("WrapsMethod", Callable[Concatenate[T, ...], R], type_params=(T, R))
+
+def decorate(value: WrapsMethod[T, R], /) -> WrappedMethod[T, P, R]:
+    return value
+
+@decorate
+def decorated(value: int) -> int:
+    return value
+
+reveal_type(decorated)  # revealed: [**P'return](int, /, *args: P'return.args, **kwargs: P'return.kwargs) -> int
+
+Ts = TypeVarTuple("Ts")
+Variadic = TypeAliasType("Variadic", tuple[Unpack[Ts]], type_params=(Ts,))
+
+def variadic(value: Variadic[int, str]) -> None:
+    reveal_type(value)  # revealed: tuple[int, str]
+```
+
+### Recursive generic example
+
+```py
+from typing import Callable
+from typing_extensions import TypeAliasType, TypeVar, Union
+
+T = TypeVar("T")
+Recursive = TypeAliasType("Recursive", Union[T, list["Recursive[T]"]], type_params=(T,))
+RecursiveCallable = Callable[[Recursive[T]], None]
+
+def recursive(value: Recursive[int]) -> None:
+    reveal_type(value)  # revealed: int | list[Recursive[int]]
+
+def recursive_callable(value: RecursiveCallable[int]) -> None:
+    reveal_type(value)  # revealed: (int | list[Divergent], /) -> None
+```
+
+### Generic specialization errors
+
+```py
+from typing_extensions import TypeAliasType, TypeVar
+
+T = TypeVar("T")
+BoundedT = TypeVar("BoundedT", bound=int)
+
+GenericAlias = TypeAliasType("GenericAlias", list[T], type_params=(T,))
+BoundedAlias = TypeAliasType("BoundedAlias", list[BoundedT], type_params=(BoundedT,))
+NonGenericAlias = TypeAliasType("NonGenericAlias", list[int])
+DefaultedT = TypeVar("DefaultedT", default=str)
+
+# error: [invalid-type-variable-default] "Type parameter `T` without a default cannot follow earlier parameter `DefaultedT` with a default"
+InvalidOrder = TypeAliasType("InvalidOrder", tuple[DefaultedT, T], type_params=(DefaultedT, T))
+
+# error: [invalid-type-arguments] "Too many type arguments: expected 1, got 2"
+reveal_type(GenericAlias[int, str])  # revealed: <type alias 'GenericAlias[Unknown]'>
+
+# error: [invalid-type-arguments] "Type `str` is not assignable to upper bound `int` of type variable `BoundedT@BoundedAlias`"
+reveal_type(BoundedAlias[str])  # revealed: <type alias 'BoundedAlias[Unknown]'>
+
+# error: [not-subscriptable] "Cannot subscript non-generic type alias `NonGenericAlias`"
+reveal_type(NonGenericAlias[int])  # revealed: Unknown
+
+# error: [not-subscriptable] "Cannot specialize non-generic type alias `NonGenericAlias`"
+def non_generic(value: NonGenericAlias[int]) -> None:
+    reveal_type(value)  # revealed: Unknown
+```
+
+### Invalid type parameters
+
+```py
+from typing_extensions import TypeAliasType, TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+# error: [invalid-type-alias-type] "The `type_params` argument to `TypeAliasType` must be a tuple literal"
+InvalidList = TypeAliasType("InvalidList", list[T], type_params=[T])
+
+params = (T,)
+# error: [invalid-type-alias-type] "The `type_params` argument to `TypeAliasType` must be a tuple literal"
+InvalidTupleVariable = TypeAliasType("InvalidTupleVariable", list[T], type_params=params)
+
+# error: [invalid-type-alias-type] "Each `type_params` entry for `TypeAliasType` must be a type variable"
+InvalidUnpack = TypeAliasType("InvalidUnpack", list[T], type_params=(*params,))
+
+# error: [invalid-type-alias-type] "Each `type_params` entry for `TypeAliasType` must be a type variable"
+InvalidInt = TypeAliasType("InvalidInt", list[int], type_params=(int,))
+
+# error: [invalid-type-alias-type] "Each `type_params` entry for `TypeAliasType` must be a type variable"
+InvalidNested = TypeAliasType("InvalidNested", list[T], type_params=(list[T],))
+
+# error: [invalid-type-alias-type] "Each `type_params` entry for `TypeAliasType` must be a type variable"
+InvalidMixed = TypeAliasType("InvalidMixed", list[T], type_params=(int, T))
+
+# error: [invalid-type-alias-type] "Each `type_params` entry for `TypeAliasType` must be a type variable"
+InvalidString = TypeAliasType("InvalidString", list[int], type_params=("T",))
+
+# error: [invalid-type-alias-type] "Type parameter `U` used in the alias value must be included in `type_params`"
+Missing = TypeAliasType("Missing", dict[T, U], type_params=(T,))
+
+# error: [invalid-type-alias-type] "Type parameter `T` used in the alias value must be included in `type_params`"
+MissingAll = TypeAliasType("MissingAll", list[T])
+
+# error: [invalid-type-alias-type] "Type parameter `T` is duplicated in `type_params`"
+Duplicate = TypeAliasType("Duplicate", list[T], type_params=(T, T))
+```
+
+### Generic alias from `typing`
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypeAliasType, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+MyDict = TypeAliasType("MyDict", dict[K, V], type_params=(K, V))
+
+def generic_from_typing(value: MyDict[str, int]) -> None:
+    reveal_type(value)  # revealed: dict[str, int]
 ```
 
 ### Generic value binds type variables to alias definition

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -419,6 +419,9 @@ def f(x: IntOrStr) -> None:
 
 ### Generic example
 
+Manual aliases can be specialized in annotations and value positions, including when they are used
+in `type[...]` or nested inside another alias.
+
 ```py
 from typing import Callable, Concatenate, Generic
 from typing_extensions import ParamSpec, TypeAliasType, TypeVar, TypeVarTuple, Union, Unpack
@@ -439,7 +442,12 @@ Nested = TypeAliasType("Nested", list[IntAndT[T]], type_params=(T,))
 
 def nested(value: Nested[str]) -> None:
     reveal_type(value)  # revealed: list[IntAndT[str]]
+```
 
+Defaults apply to unspecialized aliases, and the order of `type_params` determines how type
+arguments are mapped even if the parameters appear in a different order in the alias value.
+
+```py
 U = TypeVar("U", default=str)
 
 ListOrSet = TypeAliasType("ListOrSet", Union[list[U], set[U]], type_params=(U,))
@@ -458,7 +466,12 @@ def g(
     reveal_type(dict_int_str)  # revealed: dict[int, str]
     reveal_type(dict_unknown_str)  # revealed: dict[Unknown, str]
     reveal_type(reordered)  # revealed: tuple[str, int]
+```
 
+Constructor inference sees through the specialized `ModelAlias[T]`: passing `Model` infers `T` as
+`Model` in `ViaAlias[T]`.
+
+```py
 ModelAlias = TypeAliasType("ModelAlias", type[T], type_params=(T,))
 
 class Model: ...
@@ -467,7 +480,12 @@ class ViaAlias(Generic[T]):
     def __init__(self, value: ModelAlias[T]) -> None: ...
 
 reveal_type(ViaAlias(Model))  # revealed: ViaAlias[Model]
+```
 
+`ParamSpec` parameters can be specialized alongside regular type variables and are preserved when a
+callable alias is used as a decorator return type.
+
+```py
 P = ParamSpec("P")
 R = TypeVar("R")
 WrappedMethod = TypeAliasType("WrappedMethod", Callable[Concatenate[T, P], R], type_params=(T, P, R))
@@ -485,7 +503,11 @@ def decorated(value: int) -> int:
     return value
 
 reveal_type(decorated)  # revealed: [**P'return](int, /, *args: P'return.args, **kwargs: P'return.kwargs) -> int
+```
 
+`TypeVarTuple` parameters accept multiple type arguments when specializing a variadic alias.
+
+```py
 Ts = TypeVarTuple("Ts")
 Variadic = TypeAliasType("Variadic", tuple[Unpack[Ts]], type_params=(Ts,))
 
@@ -576,7 +598,7 @@ Missing = TypeAliasType("Missing", dict[T, U], type_params=(T,))
 MissingAll = TypeAliasType("MissingAll", list[T])
 
 # error: [invalid-type-alias-type] "Type parameter `T` is duplicated in `type_params`"
-Duplicate = TypeAliasType("Duplicate", list[T], type_params=(T, T))
+Duplicate = TypeAliasType("Duplicate", tuple[T, U], type_params=(T, U, T))
 
 MultipleTypeVarTuples = TypeAliasType(
     "MultipleTypeVarTuples",

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -553,6 +553,9 @@ Us = TypeVarTuple("Us")
 # error: [invalid-type-alias-type] "The `type_params` argument to `TypeAliasType` must be a tuple literal"
 InvalidList = TypeAliasType("InvalidList", list[T], type_params=[T])
 
+# error: [invalid-type-alias-type] "The `type_params` argument to `TypeAliasType` must be a tuple literal"
+InvalidBare = TypeAliasType("InvalidBare", list[T], type_params=T)
+
 params = (T,)
 # error: [invalid-type-alias-type] "The `type_params` argument to `TypeAliasType` must be a tuple literal"
 InvalidTupleVariable = TypeAliasType("InvalidTupleVariable", list[T], type_params=params)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6267,7 +6267,9 @@ impl<'db> Type<'db> {
 
                     Ok(instance.inner(db).to_meta_type(db))
                 }
-                KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
+                KnownInstanceType::Callable(callable) => {
+                    Ok(Type::Callable(*callable).expand_eagerly(db))
+                }
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
                 KnownInstanceType::Sentinel(sentinel) => {
                     Ok(Type::KnownInstance(KnownInstanceType::Sentinel(*sentinel)))
@@ -6793,11 +6795,17 @@ impl<'db> Type<'db> {
 
             Type::TypeAlias(alias) => {
                 match type_mapping {
-                    // For EagerExpansion, expand the raw value type. This path relies on Salsa's cycle
-                    // detection rather than the visitor's cycle detection, because the visitor tracks
-                    // Type values and `RecursiveList` is different from `RecursiveList[T]`.
                     TypeMapping::EagerExpansion => {
-                        alias.raw_value_type(db).expand_eagerly(db)
+                        if matches!(alias, TypeAliasType::ManualPEP695(_))
+                            && alias.specialization(db).is_some()
+                        {
+                            alias.value_type(db).expand_eagerly(db)
+                        } else {
+                            // This path relies on Salsa's cycle detection rather than the visitor's
+                            // cycle detection, because the visitor tracks Type values and
+                            // `RecursiveList` is different from `RecursiveList[T]`.
+                            alias.raw_value_type(db).expand_eagerly(db)
+                        }
                     },
                     // When specializing a generic type alias, instead of specializing the expanded type, the type alias itself is specialized.
                     // Without this special handling, recursive type aliases would result in cycles, returning an unspecialized fallback type.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6267,9 +6267,7 @@ impl<'db> Type<'db> {
 
                     Ok(instance.inner(db).to_meta_type(db))
                 }
-                KnownInstanceType::Callable(callable) => {
-                    Ok(Type::Callable(*callable).expand_eagerly(db))
-                }
+                KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
                 KnownInstanceType::Sentinel(sentinel) => {
                     Ok(Type::KnownInstance(KnownInstanceType::Sentinel(*sentinel)))
@@ -6795,17 +6793,11 @@ impl<'db> Type<'db> {
 
             Type::TypeAlias(alias) => {
                 match type_mapping {
+                    // For EagerExpansion, expand the raw value type. This path relies on Salsa's cycle
+                    // detection rather than the visitor's cycle detection, because the visitor tracks
+                    // Type values and `RecursiveList` is different from `RecursiveList[T]`.
                     TypeMapping::EagerExpansion => {
-                        if matches!(alias, TypeAliasType::ManualPEP695(_))
-                            && alias.specialization(db).is_some()
-                        {
-                            alias.value_type(db).expand_eagerly(db)
-                        } else {
-                            // This path relies on Salsa's cycle detection rather than the visitor's
-                            // cycle detection, because the visitor tracks Type values and
-                            // `RecursiveList` is different from `RecursiveList[T]`.
-                            alias.raw_value_type(db).expand_eagerly(db)
-                        }
+                        alias.raw_value_type(db).expand_eagerly(db)
                     },
                     // When specializing a generic type alias, instead of specializing the expanded type, the type alias itself is specialized.
                     // Without this special handling, recursive type aliases would result in cycles, returning an unspecialized fallback type.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -67,9 +67,9 @@ use crate::types::{
     BindingContext, BoundMethodType, BoundTypeVarInstance, CallableType, CallableTypes,
     ClassLiteral, DATACLASS_FLAGS, DataclassFlags, DataclassParams, DynamicType, GenericAlias,
     InternedConstraintSet, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
-    LiteralValueTypeKind, NominalInstanceType, PropertyInstanceType, SpecialFormType,
-    TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance,
-    UnionAccumulator, UnionBuilder, UnionType, WrapperDescriptorKind, enums, list_members,
+    LiteralValueTypeKind, NominalInstanceType, PropertyInstanceType, SpecialFormType, TypeContext,
+    TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance, UnionAccumulator, UnionBuilder,
+    UnionType, WrapperDescriptorKind, enums, list_members,
 };
 use crate::{DisplaySettings, FxOrderSet, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
@@ -2124,7 +2124,7 @@ impl<'db> Bindings<'db> {
                                     }
 
                                     Type::KnownInstance(KnownInstanceType::TypeAliasType(
-                                        TypeAliasType::PEP695(alias),
+                                        alias,
                                     )) => alias.generic_context(db).map(wrap_generic_context),
 
                                     _ => None,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -57,11 +57,12 @@ use crate::types::diagnostic::{
     GeneratorMismatchKind, INEFFECTIVE_FINAL, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT,
     INVALID_DECLARATION, INVALID_ENUM_MEMBER_ANNOTATION, INVALID_LEGACY_TYPE_VARIABLE,
     INVALID_NEWTYPE, INVALID_PARAMSPEC, INVALID_TYPE_ALIAS_TYPE, INVALID_TYPE_FORM,
-    INVALID_TYPE_VARIABLE_BOUND, INVALID_TYPE_VARIABLE_CONSTRAINTS, POSSIBLY_MISSING_IMPLICIT_CALL,
-    POSSIBLY_MISSING_SUBMODULE, TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE,
-    UNRESOLVED_GLOBAL, UNRESOLVED_REFERENCE, UNSUPPORTED_OPERATOR, UNUSED_AWAITABLE,
-    hint_if_stdlib_attribute_exists_on_other_versions, report_attempted_protocol_instantiation,
-    report_bad_dunder_delattr_call, report_bad_dunder_delete_call, report_call_to_abstract_method,
+    INVALID_TYPE_VARIABLE_BOUND, INVALID_TYPE_VARIABLE_CONSTRAINTS, INVALID_TYPE_VARIABLE_DEFAULT,
+    POSSIBLY_MISSING_IMPLICIT_CALL, POSSIBLY_MISSING_SUBMODULE, TypeCheckDiagnostics,
+    UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE, UNRESOLVED_GLOBAL, UNRESOLVED_REFERENCE,
+    UNSUPPORTED_OPERATOR, UNUSED_AWAITABLE, hint_if_stdlib_attribute_exists_on_other_versions,
+    report_attempted_protocol_instantiation, report_bad_dunder_delattr_call,
+    report_bad_dunder_delete_call, report_call_to_abstract_method,
     report_cannot_pop_required_field_on_typed_dict, report_invalid_assignment,
     report_invalid_class_match_pattern, report_invalid_exception_caught,
     report_invalid_exception_cause, report_invalid_exception_raised,
@@ -116,7 +117,7 @@ use crate::types::{
     any_over_type, binding_type, extract_fixed_length_iterable_element_types,
     infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
-use crate::{AnalysisSettings, Db, FxIndexSet, Program};
+use crate::{AnalysisSettings, Db, FxIndexSet, FxOrderSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
 use ty_python_core::definition::{
     AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
@@ -3741,7 +3742,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.deferred.insert(definition);
 
         Type::KnownInstance(KnownInstanceType::TypeAliasType(
-            TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(db, name, definition)),
+            TypeAliasType::ManualPEP695(ManualPEP695TypeAliasType::new(db, name, definition, None)),
         ))
     }
 
@@ -3755,10 +3756,104 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // in the alias value are bound to the alias definition.
         let previous_context = self.typevar_binding_context.replace(definition);
 
-        self.infer_type_expression(&arguments.args[1]);
+        let value_ty = self.infer_type_expression(&arguments.args[1]);
+        let mut type_params = FxHashSet::default();
+        let mut valid_type_params = true;
         // Infer keyword arguments (e.g. `type_params`) so their types are stored.
         for keyword in &arguments.keywords {
             self.infer_expression(&keyword.value, TypeContext::default());
+
+            if !keyword
+                .arg
+                .as_ref()
+                .is_some_and(|name| name.id == "type_params")
+            {
+                continue;
+            }
+
+            let Some(tuple) = keyword.value.as_tuple_expr() else {
+                valid_type_params = false;
+                if let Some(builder) = self
+                    .context
+                    .report_lint(&INVALID_TYPE_ALIAS_TYPE, &keyword.value)
+                {
+                    builder.into_diagnostic(
+                        "The `type_params` argument to `TypeAliasType` must be a tuple literal",
+                    );
+                }
+                continue;
+            };
+
+            let db = self.db();
+            let mut typevar_with_default = None;
+
+            for element in &tuple.elts {
+                let bound_typevar = match self.expression_type(element) {
+                    Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
+                        typevar.with_binding_context(db, definition)
+                    }
+                    Type::TypeVar(typevar) => typevar,
+                    _ => {
+                        valid_type_params = false;
+                        if let Some(builder) =
+                            self.context.report_lint(&INVALID_TYPE_ALIAS_TYPE, element)
+                        {
+                            builder.into_diagnostic(
+                                "Each `type_params` entry for `TypeAliasType` must be a type variable",
+                            );
+                        }
+                        continue;
+                    }
+                };
+                let typevar = bound_typevar.typevar(db);
+
+                if !type_params.insert(bound_typevar.identity(db)) {
+                    valid_type_params = false;
+                    if let Some(builder) =
+                        self.context.report_lint(&INVALID_TYPE_ALIAS_TYPE, element)
+                    {
+                        builder.into_diagnostic(format_args!(
+                            "Type parameter `{}` is duplicated in `type_params`",
+                            typevar.name(db),
+                        ));
+                    }
+                }
+
+                if typevar.default_type(db).is_some() {
+                    typevar_with_default.get_or_insert(typevar);
+                } else if let Some(typevar_with_default) = typevar_with_default {
+                    valid_type_params = false;
+                    if let Some(builder) = self
+                        .context
+                        .report_lint(&INVALID_TYPE_VARIABLE_DEFAULT, element)
+                    {
+                        builder.into_diagnostic(format_args!(
+                            "Type parameter `{}` without a default cannot follow earlier parameter `{}` with a default",
+                            typevar.name(db),
+                            typevar_with_default.name(db),
+                        ));
+                    }
+                    break;
+                }
+            }
+        }
+
+        if valid_type_params {
+            let mut value_typevars = FxOrderSet::default();
+            value_ty.find_legacy_typevars(self.db(), Some(definition), &mut value_typevars);
+
+            for typevar in value_typevars {
+                if !type_params.contains(&typevar.identity(self.db()))
+                    && let Some(builder) = self
+                        .context
+                        .report_lint(&INVALID_TYPE_ALIAS_TYPE, &arguments.args[1])
+                {
+                    builder.into_diagnostic(format_args!(
+                        "Type parameter `{}` used in the alias value must be included in `type_params`",
+                        typevar.name(self.db()),
+                    ));
+                }
+            }
         }
 
         self.typevar_binding_context = previous_context;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -104,14 +104,16 @@ use crate::types::tuple::promotion::TupleSizePromotionConstraints;
 use crate::types::tuple::{Tuple, TupleLength, TupleSpecBuilder, TupleType, VariableSegment};
 use crate::types::type_alias::{ManualPEP695TypeAliasType, PEP695TypeAliasType};
 use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
-use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
+use crate::types::typevar::{
+    BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity, TypeVarInstance,
+};
 use crate::types::unpacker::UnpackResult;
 use crate::types::{
-    BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
-    DynamicType, InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder,
-    IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueType,
-    LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters,
-    SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
+    BindingContext, BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType,
+    CallableTypes, ClassType, DynamicType, InferenceFlags, InternedConstraintSet, InternedType,
+    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, KnownUnion,
+    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter,
+    Parameters, SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
     TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind,
     TypeVarVariance, TypedDictModule, TypedDictType, UnionAccumulator, UnionBuilder, UnionType,
     any_over_type, binding_type, extract_fixed_length_iterable_element_types,
@@ -3763,11 +3765,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         for keyword in &arguments.keywords {
             self.infer_expression(&keyword.value, TypeContext::default());
 
-            if !keyword
-                .arg
-                .as_ref()
-                .is_some_and(|name| name.id == "type_params")
-            {
+            if keyword.arg.as_deref() != Some("type_params") {
                 continue;
             }
 
@@ -3786,26 +3784,45 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             let db = self.db();
             let mut typevar_with_default = None;
+            let mut typevar_tuple: Option<TypeVarInstance> = None;
+            let mut reported_default_order_error = false;
 
             for element in &tuple.elts {
                 let bound_typevar = match self.expression_type(element) {
-                    Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
-                        typevar.with_binding_context(db, definition)
+                    Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => bind_typevar(
+                        db,
+                        self.index,
+                        definition.file_scope(db),
+                        Some(definition),
+                        typevar,
+                    ),
+                    _ => None,
+                };
+                let Some(bound_typevar) = bound_typevar else {
+                    valid_type_params = false;
+                    if let Some(builder) =
+                        self.context.report_lint(&INVALID_TYPE_ALIAS_TYPE, element)
+                    {
+                        builder.into_diagnostic(
+                            "Each `type_params` entry for `TypeAliasType` must be a type variable",
+                        );
                     }
-                    Type::TypeVar(typevar) => typevar,
-                    _ => {
-                        valid_type_params = false;
-                        if let Some(builder) =
-                            self.context.report_lint(&INVALID_TYPE_ALIAS_TYPE, element)
-                        {
-                            builder.into_diagnostic(
-                                "Each `type_params` entry for `TypeAliasType` must be a type variable",
-                            );
-                        }
-                        continue;
-                    }
+                    continue;
                 };
                 let typevar = bound_typevar.typevar(db);
+
+                if bound_typevar.binding_context(db) != BindingContext::Definition(definition) {
+                    valid_type_params = false;
+                    if let Some(builder) =
+                        self.context.report_lint(&INVALID_TYPE_ALIAS_TYPE, element)
+                    {
+                        builder.into_diagnostic(format_args!(
+                            "Type parameter `{}` is bound in an outer scope and cannot be used in `type_params`",
+                            typevar.name(db),
+                        ));
+                    }
+                    continue;
+                }
 
                 if !type_params.insert(bound_typevar.identity(db)) {
                     valid_type_params = false;
@@ -3820,20 +3837,49 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
 
                 if typevar.default_type(db).is_some() {
+                    if let Some(typevar_tuple) = typevar_tuple {
+                        valid_type_params = false;
+                        if let Some(builder) = self
+                            .context
+                            .report_lint(&INVALID_TYPE_VARIABLE_DEFAULT, element)
+                        {
+                            builder.into_diagnostic(format_args!(
+                                "Type parameter `{}` with a default follows TypeVarTuple `{}`",
+                                typevar.name(db),
+                                typevar_tuple.name(db),
+                            ));
+                        }
+                    }
                     typevar_with_default.get_or_insert(typevar);
                 } else if let Some(typevar_with_default) = typevar_with_default {
                     valid_type_params = false;
-                    if let Some(builder) = self
-                        .context
-                        .report_lint(&INVALID_TYPE_VARIABLE_DEFAULT, element)
+                    if !reported_default_order_error
+                        && let Some(builder) = self
+                            .context
+                            .report_lint(&INVALID_TYPE_VARIABLE_DEFAULT, element)
                     {
+                        reported_default_order_error = true;
                         builder.into_diagnostic(format_args!(
                             "Type parameter `{}` without a default cannot follow earlier parameter `{}` with a default",
                             typevar.name(db),
                             typevar_with_default.name(db),
                         ));
                     }
-                    break;
+                }
+
+                if typevar.is_typevartuple(db) {
+                    if typevar_tuple.is_some() {
+                        valid_type_params = false;
+                        if let Some(builder) =
+                            self.context.report_lint(&INVALID_TYPE_ALIAS_TYPE, element)
+                        {
+                            builder.into_diagnostic(
+                                "Only one `TypeVarTuple` parameter is allowed in `type_params`",
+                            );
+                        }
+                    } else {
+                        typevar_tuple = Some(typevar);
+                    }
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -240,19 +240,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     );
                 }
             }
-            Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::ManualPEP695(
-                _,
-            ))) => {
-                let slice_ty = self.infer_expression(slice, TypeContext::default());
-                let mut variables = FxOrderSet::default();
-                slice_ty.bind_and_find_all_legacy_typevars(
-                    db,
-                    self.typevar_binding_context,
-                    &mut variables,
-                );
-                let generic_context = GenericContext::from_typevar_instances(db, variables);
-                return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
-            }
             Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
                 if let Some(generic_context) = type_alias.generic_context(db) {
                     return self.infer_explicit_type_alias_type_specialization(

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -23,9 +23,9 @@ use ty_python_core::scope::ScopeKind;
 use crate::types::{
     BindingContext, CallableType, DynamicType, GenericContext, IntersectionBuilder,
     IntersectionType, KnownClass, KnownInstanceType, LintDiagnosticGuard, LiteralValueTypeKind,
-    Parameter, Parameters, SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeContext,
-    TypeFormType, TypeGuardType, TypeIsType, TypeMapping, TypeVarKind, UnionBuilder, UnionType,
-    any_over_type, todo_type,
+    Parameter, Parameters, SpecialFormType, SubclassOfType, Type, TypeContext, TypeFormType,
+    TypeGuardType, TypeIsType, TypeMapping, TypeVarKind, UnionBuilder, UnionType, any_over_type,
+    todo_type,
 };
 use crate::{FxOrderSet, Program, add_inferred_python_version_hint_to_diagnostic};
 
@@ -1357,9 +1357,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         );
                         invalid_type_argument(self, slice)
                     }
-                    value_ty @ Type::KnownInstance(KnownInstanceType::TypeAliasType(
-                        TypeAliasType::PEP695(_),
-                    )) => {
+                    value_ty @ Type::KnownInstance(KnownInstanceType::TypeAliasType(_)) => {
                         let slice_ty = self.infer_subscript_type_expression(subscript, value_ty);
                         subclass_of_type_argument(self, slice, slice_ty)
                     }
@@ -1592,7 +1590,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     Type::unknown()
                 }
-                KnownInstanceType::TypeAliasType(type_alias @ TypeAliasType::PEP695(_)) => {
+                KnownInstanceType::TypeAliasType(type_alias) => {
                     match type_alias.generic_context(self.db()) {
                         Some(generic_context) => {
                             let specialized_type_alias = self
@@ -1641,19 +1639,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             Type::unknown()
                         }
                     }
-                }
-                KnownInstanceType::TypeAliasType(TypeAliasType::ManualPEP695(_)) => {
-                    // TODO: support generic "manual" PEP 695 type aliases
-                    let slice_ty = self.infer_expression(slice, TypeContext::default());
-                    let mut variables = FxOrderSet::default();
-                    slice_ty.bind_and_find_all_legacy_typevars(
-                        self.db(),
-                        self.typevar_binding_context,
-                        &mut variables,
-                    );
-                    let generic_context =
-                        GenericContext::from_typevar_instances(self.db(), variables);
-                    Type::Dynamic(DynamicType::UnknownGeneric(generic_context))
                 }
                 KnownInstanceType::Literal(ty) => {
                     if !self.in_string_annotation() {

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -309,7 +309,7 @@ impl<'db> KnownInstanceType<'db> {
                 KnownClass::TypeVarTuple
             }
             Self::TypeVar(_) => KnownClass::TypeVar,
-            Self::TypeAliasType(TypeAliasType::PEP695(alias)) if alias.is_specialized(db) => {
+            Self::TypeAliasType(alias) if alias.specialization(db).is_some() => {
                 KnownClass::GenericAlias
             }
             Self::TypeAliasType(_) => KnownClass::TypeAliasType,

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -779,16 +779,13 @@ impl<'db> Type<'db> {
                 Some(Ok(todo_type!("doubly-specialized typing.Protocol")))
             }
 
-            (
-                Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias))),
-                _,
-            ) if alias.generic_context(db).is_none() => {
+            (Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)), _)
+                if alias.generic_context(db).is_none() =>
+            {
                 debug_assert!(alias.specialization(db).is_none());
                 Some(Err(SubscriptError::new(
                     Type::unknown(),
-                    SubscriptErrorKind::NonGenericTypeAlias {
-                        alias: TypeAliasType::PEP695(alias),
-                    },
+                    SubscriptErrorKind::NonGenericTypeAlias { alias },
                 )))
             }
 

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -1,10 +1,10 @@
 use std::fmt::Write;
 
 use crate::{
-    Db,
+    Db, FxOrderSet,
     types::{
-        ApplyTypeMappingVisitor, BoundTypeVarIdentity, GenericContext, Type, TypeContext,
-        TypeMapping, TypeVarVariance, definition_expression_type,
+        ApplyTypeMappingVisitor, BoundTypeVarIdentity, GenericContext, KnownInstanceType, Type,
+        TypeContext, TypeMapping, TypeVarVariance, definition_expression_type,
         display::qualified_name_components_from_scope,
         generics::{ApplySpecialization, Specialization},
         variance::VarianceInferable,
@@ -54,7 +54,12 @@ impl<'db> PEP695TypeAliasType<'db> {
 
     /// The RHS type of a PEP-695 style type alias with specialization applied.
     pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
-        self.apply_function_specialization(db, self.raw_value_type(db))
+        apply_type_alias_specialization(
+            db,
+            self.raw_value_type(db),
+            self.generic_context(db),
+            self.specialization(db),
+        )
     }
 
     /// The RHS type of a PEP-695 style type alias with *no* specialization applied.
@@ -74,32 +79,6 @@ impl<'db> PEP695TypeAliasType<'db> {
         let definition = self.definition(db);
 
         definition_expression_type(db, definition, &type_alias_stmt_node.node(&module).value)
-    }
-
-    fn apply_function_specialization(self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-        if let Some(generic_context) = self.generic_context(db) {
-            let specialization = self
-                .specialization(db)
-                .unwrap_or_else(|| generic_context.default_specialization(db, None));
-            let type_mapping = match specialization.materialization_kind(db) {
-                None => {
-                    TypeMapping::ApplySpecialization(ApplySpecialization::TypeAlias(specialization))
-                }
-                Some(materialization_kind) => TypeMapping::ApplySpecializationWithMaterialization {
-                    specialization: ApplySpecialization::TypeAlias(specialization),
-                    materialization_kind,
-                },
-            };
-
-            ty.apply_type_mapping_impl(
-                db,
-                &type_mapping,
-                TypeContext::default(),
-                &ApplyTypeMappingVisitor::default(),
-            )
-        } else {
-            ty
-        }
     }
 
     pub(crate) fn apply_specialization(
@@ -125,10 +104,6 @@ impl<'db> PEP695TypeAliasType<'db> {
                 )
             }
         }
-    }
-
-    pub(crate) fn is_specialized(self, db: &'db dyn Db) -> bool {
-        self.specialization(db).is_some()
     }
 
     #[salsa::tracked(returns(copy), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
@@ -160,6 +135,9 @@ pub struct ManualPEP695TypeAliasType<'db> {
     pub name: Name,
     #[returns(copy)]
     pub definition: Definition<'db>,
+
+    #[returns(copy)]
+    pub(super) specialization: Option<Specialization<'db>>,
 }
 
 // The Salsa heap is tracked separately.
@@ -177,6 +155,18 @@ pub(super) fn walk_manual_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> +
 impl<'db> ManualPEP695TypeAliasType<'db> {
     /// The value type of this manual type alias.
     ///
+    /// Computed lazily from the definition with specialization applied.
+    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+        apply_type_alias_specialization(
+            db,
+            self.raw_value_type(db),
+            self.generic_context(db),
+            self.specialization(db),
+        )
+    }
+
+    /// The value type of this manual type alias with no specialization applied.
+    ///
     /// Computed lazily from the definition to avoid including the value in the interned
     /// struct's identity. Returns `Divergent` if the type alias is defined cyclically.
     #[salsa::tracked(
@@ -187,7 +177,7 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
         },
         heap_size=ruff_memory_usage::heap_size
     )]
-    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
         let definition = self.definition(db);
         let file = definition.file(db);
         let module = parsed_module(db, file).load(db);
@@ -204,6 +194,82 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
         };
         definition_expression_type(db, definition, value_arg)
     }
+
+    pub(crate) fn apply_specialization(
+        self,
+        db: &'db dyn Db,
+        f: impl FnOnce(GenericContext<'db>) -> Specialization<'db>,
+    ) -> Self {
+        let Some(generic_context) = self.generic_context(db) else {
+            return self;
+        };
+
+        Self::new(
+            db,
+            self.name(db),
+            self.definition(db),
+            Some(f(generic_context)),
+        )
+    }
+
+    #[salsa::tracked(returns(copy), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+    pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
+        let definition = self.definition(db);
+        let file = definition.file(db);
+        let module = parsed_module(db, file).load(db);
+        let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
+            return None;
+        };
+        let ast::Expr::Call(call) = assignment.value(&module) else {
+            return None;
+        };
+        let type_params = call
+            .arguments
+            .find_argument_value("type_params", 2)?
+            .as_tuple_expr()?;
+
+        let mut variables = FxOrderSet::default();
+        for element in &type_params.elts {
+            let typevar = match definition_expression_type(db, definition, element) {
+                Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
+                    typevar.with_binding_context(db, definition)
+                }
+                Type::TypeVar(typevar) => typevar,
+                _ => return None,
+            };
+            variables.insert(typevar);
+        }
+
+        (!variables.is_empty()).then(|| GenericContext::from_typevar_instances(db, variables))
+    }
+}
+
+fn apply_type_alias_specialization<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    generic_context: Option<GenericContext<'db>>,
+    specialization: Option<Specialization<'db>>,
+) -> Type<'db> {
+    let Some(generic_context) = generic_context else {
+        return ty;
+    };
+
+    let specialization =
+        specialization.unwrap_or_else(|| generic_context.default_specialization(db, None));
+    let type_mapping = match specialization.materialization_kind(db) {
+        None => TypeMapping::ApplySpecialization(ApplySpecialization::TypeAlias(specialization)),
+        Some(materialization_kind) => TypeMapping::ApplySpecializationWithMaterialization {
+            specialization: ApplySpecialization::TypeAlias(specialization),
+            materialization_kind,
+        },
+    };
+
+    ty.apply_type_mapping_impl(
+        db,
+        &type_mapping,
+        TypeContext::default(),
+        &ApplyTypeMappingVisitor::default(),
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
@@ -258,7 +324,7 @@ impl<'db> TypeAliasType<'db> {
     pub(crate) fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.raw_value_type(db),
-            TypeAliasType::ManualPEP695(type_alias) => type_alias.value_type(db),
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.raw_value_type(db),
         }
     }
 
@@ -271,7 +337,9 @@ impl<'db> TypeAliasType<'db> {
                 alias.rhs_scope(db),
                 None,
             )),
-            TypeAliasType::ManualPEP695(_) => self,
+            TypeAliasType::ManualPEP695(alias) => TypeAliasType::ManualPEP695(
+                ManualPEP695TypeAliasType::new(db, alias.name(db), alias.definition(db), None),
+            ),
         }
     }
 
@@ -283,17 +351,16 @@ impl<'db> TypeAliasType<'db> {
     }
 
     pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
-        // TODO: Add support for generic non-PEP695 type aliases.
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.generic_context(db),
-            TypeAliasType::ManualPEP695(_) => None,
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.generic_context(db),
         }
     }
 
     pub(crate) fn specialization(self, db: &'db dyn Db) -> Option<Specialization<'db>> {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.specialization(db),
-            TypeAliasType::ManualPEP695(_) => None,
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.specialization(db),
         }
     }
 
@@ -306,7 +373,9 @@ impl<'db> TypeAliasType<'db> {
             TypeAliasType::PEP695(type_alias) => {
                 TypeAliasType::PEP695(type_alias.apply_specialization(db, f))
             }
-            TypeAliasType::ManualPEP695(_) => self,
+            TypeAliasType::ManualPEP695(type_alias) => {
+                TypeAliasType::ManualPEP695(type_alias.apply_specialization(db, f))
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -3,10 +3,11 @@ use std::fmt::Write;
 use crate::{
     Db, FxOrderSet,
     types::{
-        ApplyTypeMappingVisitor, BoundTypeVarIdentity, GenericContext, KnownInstanceType, Type,
-        TypeContext, TypeMapping, TypeVarVariance, definition_expression_type,
+        ApplyTypeMappingVisitor, BindingContext, BoundTypeVarIdentity, GenericContext,
+        KnownInstanceType, Type, TypeContext, TypeMapping, TypeVarVariance,
+        definition_expression_type,
         display::qualified_name_components_from_scope,
-        generics::{ApplySpecialization, Specialization},
+        generics::{ApplySpecialization, Specialization, bind_typevar},
         variance::VarianceInferable,
         visitor,
     },
@@ -227,16 +228,23 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
             .arguments
             .find_argument_value("type_params", 2)?
             .as_tuple_expr()?;
+        let index = semantic_index(db, file);
 
         let mut variables = FxOrderSet::default();
         for element in &type_params.elts {
             let typevar = match definition_expression_type(db, definition, element) {
-                Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
-                    typevar.with_binding_context(db, definition)
-                }
-                Type::TypeVar(typevar) => typevar,
+                Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => bind_typevar(
+                    db,
+                    index,
+                    definition.file_scope(db),
+                    Some(definition),
+                    typevar,
+                )?,
                 _ => return None,
             };
+            if typevar.binding_context(db) != BindingContext::Definition(definition) {
+                return None;
+            }
             variables.insert(typevar);
         }
 

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -959,7 +959,7 @@
         },
         "invalid-type-alias-type": {
           "title": "detects invalid TypeAliasType definitions",
-          "description": "## What it does\n\nChecks for the creation of invalid `TypeAliasType`s\n\n## Why is this bad?\n\nThere are several requirements that you must follow when creating a `TypeAliasType`.\n\n## Examples\n\n```toml\n[environment]\npython-version = \"3.12\"\n```\n\n```python\nfrom typing import TypeAliasType\n\n\ndef get_name() -> str:\n    return \"NewAlias\"\n\n\nIntOrStr = TypeAliasType(\"IntOrStr\", int | str)  # okay\n# TypeAliasType name must be a string literal\nNewAlias = TypeAliasType(get_name(), int)  # error\n```",
+          "description": "## What it does\n\nChecks for the creation of invalid `TypeAliasType`s\n\n## Why is this bad?\n\nThere are several requirements that you must follow when creating a `TypeAliasType`.\n\n## Examples\n\n```toml\n[environment]\npython-version = \"3.12\"\n```\n\n```python\nfrom typing import TypeAliasType, TypeVar\n\n\ndef get_name() -> str:\n    return \"NewAlias\"\n\n\nIntOrStr = TypeAliasType(\"IntOrStr\", int | str)  # okay\n# TypeAliasType name must be a string literal\nNewAlias = TypeAliasType(get_name(), int)  # error\n\nT = TypeVar(\"T\")\nGenericAlias = TypeAliasType(\"GenericAlias\", list[T], type_params=(T,))  # okay\n# TypeAliasType type parameters must be type variables\nInvalidAlias = TypeAliasType(\"InvalidAlias\", list[T], type_params=(list[T],))  # error\n```",
           "default": "error",
           "oneOf": [
             {


### PR DESCRIPTION
## Summary

Add specialization support for generic aliases created with `TypeAliasType`, including defaults, reordered parameters, `ParamSpec`, `TypeVarTuple`, nested aliases, constructor inference, and recursive aliases. Validate malformed `type_params` declarations.

Closes https://github.com/astral-sh/ty/issues/1737.

## Test plan

Added and updated mdtests covering manual-alias specialization in annotations and value positions, defaults and bounds, nested and recursive aliases, `Callable`/`ParamSpec` and variadic aliases, constructor inference, invalid and scoped type parameters, duplicate/default-order/variadic validation, non-generic and double specialization errors, and preservation of native PEP 695 aliases in `Callable` types.

Ecosystem impact is large because scipy-stubs makes extensive use of generic `TypeAliasType`, and several other ecosystem projects depend on it. Ecosystem changes look correct/expected for newly understanding these aliases; some reveal existing limitations of PEP 695 type aliases that should be fixed separately.