### PR TITLE
[pylint] Avoid false positive for augmented string assignment to `__all__` (PLE0605)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/invalid_all_format.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/invalid_all_format.py
@@ -47,3 +47,6 @@ __all__ = list[str](["Hello", "world"])
 __all__ = list[str](foo())
 
 __all__ = (foo := ["Hello", "world"])
+
+# https://github.com/astral-sh/ruff/issues/26817
+__all__ += "Hello"

--- a/crates/ruff_python_semantic/src/model/all.rs
+++ b/crates/ruff_python_semantic/src/model/all.rs
@@ -107,6 +107,9 @@ impl SemanticModel<'_> {
             Stmt::AugAssign(ast::StmtAugAssign { value, .. }) => Some(value),
             _ => None,
         } {
+            let is_augmented_string = matches!(stmt, Stmt::AugAssign(_))
+                && matches!(value.as_ref(), Expr::StringLiteral(_));
+
             if let Expr::BinOp(ast::ExprBinOp { left, right, .. }) = value.as_ref() {
                 let mut current_left = left;
                 let mut current_right = right;
@@ -132,7 +135,7 @@ impl SemanticModel<'_> {
                         break;
                     }
                 }
-            } else {
+            } else if !is_augmented_string {
                 let (elts, new_flags) = self.extract_dunder_all_elts(value);
                 flags |= new_flags;
                 if let Some(elts) = elts {


### PR DESCRIPTION
## Summary

Fixes #26817.

`__all__ += "..."` is currently reported as `PLE0605` (invalid `__all__` format):

```python
__all__ = ["a"]
__all__ += "b"   # PLE0605: Invalid format for `__all__`, must be `tuple` or `list`
```

But `list.__iadd__(str)` extends the list with the string's characters, so `__all__` stays a valid list of strings. This is the render-side of the case @ntBre noted was partially handled in #4967.

The fix skips the format check when the right-hand side of an **augmented** assignment is a string literal. It's scoped narrowly to the reported case:

- `__all__ += "b"` → no longer flagged ✅
- `__all__ += {"c"}` (set) → still flagged, unchanged (asserted in the existing fixture)
- `__all__ += ["d"]` / `__all__ = "CONST"` → unchanged

**Question on scope ("push it further"):** I intentionally left `__all__ += {set}` and other non-list/tuple iterables flagged, since the existing fixture asserts the set case and there's no clean principled line between `+= "str"` and `+= {set}` (both are valid iterables that extend the list). Happy to widen this to all iterables in augmented assignment, or to f-strings, if that's the direction you'd prefer — let me know.

## Test Plan

Added a regression line to `invalid_all_format.py`; the snapshot is unchanged (the string case emits no diagnostic). Verified the binary before/after (2 diagnostics → 1). `cargo test -p ruff_linter -- invalid_all_format`, `cargo fmt`, and `cargo clippy -p ruff_python_semantic -- -D warnings` all pass.

---

*Disclosure: I used an AI coding assistant (Claude Code) to help locate the relevant code and draft the fix. I reviewed, understand, and take responsibility for the change; this description is my own.*
