### PR TITLE
[ty] Add error context to failed dunder call diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -3003,21 +3003,23 @@ date.tz = "UTC"  # snapshot: unresolved-attribute
 ```
 
 ```snapshot
-error[unresolved-attribute]: Cannot assign object of type `Literal["May"]` to attribute `month` on type `Date`. Call to `__setattr__` method failed.
+error[unresolved-attribute]: Cannot assign object of type `Literal["May"]` to attribute `month` on type `Date`
   --> src/mdtest_snippet.py:13:1
    |
 13 | date.month = "May"  # snapshot: unresolved-attribute
    | ^^^^^^^^^^
    |
+info: implicit call to `__setattr__` failed
 info: incompatible type for parameter `value`: `Literal["May"]` is not assignable to `int`
 
 
-error[unresolved-attribute]: Cannot assign object of type `Literal["UTC"]` to attribute `tz` on type `Date`. Call to `__setattr__` method failed.
+error[unresolved-attribute]: Cannot assign object of type `Literal["UTC"]` to attribute `tz` on type `Date`
   --> src/mdtest_snippet.py:14:1
    |
 14 | date.tz = "UTC"  # snapshot: unresolved-attribute
    | ^^^^^^^
    |
+info: implicit call to `__setattr__` failed
 info: incompatible type for parameter `name`: `Literal["tz"]` is not assignable to `Literal["day", "month", "year"]`
 ```
 
@@ -3136,7 +3138,7 @@ def use_module(m: MyModule, param: int) -> None:
 
     # But assigning to an attribute that's not explicitly defined will still
     # use `__setattr__` for validation.
-    # error: [unresolved-attribute] "Cannot assign object of type `int` to attribute `undefined_param` on type `MyModule`. Call to `__setattr__` method failed."
+    # error: [unresolved-attribute] "Cannot assign object of type `int` to attribute `undefined_param` on type `MyModule`"
     m.undefined_param = param
 ```
 
@@ -3177,7 +3179,7 @@ class Meta(type):
 class Foo(metaclass=Meta): ...
 
 Foo.whatever = 42
-Foo.whatever = "invalid"  # error: [unresolved-attribute] "Call to `__setattr__` method failed"
+Foo.whatever = "invalid"  # error: [unresolved-attribute]
 ```
 
 If both the metaclass and class define `__setattr__`, class-object assignments use the metaclass
@@ -3188,11 +3190,11 @@ class WithSetAttr(metaclass=Meta):
     def __setattr__(self, name: str, value: str) -> None: ...
 
 WithSetAttr.class_attribute = 42
-WithSetAttr.class_attribute = "invalid"  # error: [unresolved-attribute] "Call to `__setattr__` method failed"
+WithSetAttr.class_attribute = "invalid"  # error: [unresolved-attribute]
 
 instance = WithSetAttr()
 instance.instance_attribute = "valid"
-instance.instance_attribute = 42  # error: [unresolved-attribute] "Call to `__setattr__` method failed"
+instance.instance_attribute = 42  # error: [unresolved-attribute]
 ```
 
 The same applies when the class object is annotated as `type[Foo]`:
@@ -3200,7 +3202,7 @@ The same applies when the class object is annotated as `type[Foo]`:
 ```py
 def set_on_subclass(cls: type[Foo]) -> None:
     cls.whatever = 42
-    cls.whatever = "invalid"  # error: [unresolved-attribute] "Call to `__setattr__` method failed"
+    cls.whatever = "invalid"  # error: [unresolved-attribute]
 ```
 
 The setter also provides the expected type when inferring the assigned value:
@@ -3244,7 +3246,7 @@ OverloadedClass.callback = lambda number: (
     number.missing
 )
 OverloadedClass.payload = {"value": 1}
-OverloadedClass.callback = {"value": 1}  # error: [unresolved-attribute] "Call to `__setattr__` method failed"
+OverloadedClass.callback = {"value": 1}  # error: [unresolved-attribute]
 ```
 
 A metaclass `__setattr__` method returning `Never` prevents writes to undefined attributes:

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -3003,22 +3003,22 @@ date.tz = "UTC"  # snapshot: unresolved-attribute
 ```
 
 ```snapshot
-error[unresolved-attribute]: Cannot assign object of type `Literal["May"]` to attribute `month` on type `Date` with custom `__setattr__` method.
+error[unresolved-attribute]: Cannot assign object of type `Literal["May"]` to attribute `month` on type `Date`. Call to `__setattr__` method failed.
   --> src/mdtest_snippet.py:13:1
    |
 13 | date.month = "May"  # snapshot: unresolved-attribute
    | ^^^^^^^^^^
    |
-info: parameter `value` has an incompatible argument type: `Literal["May"]` is not assignable to `int`
+info: incompatible type for parameter `value`: `Literal["May"]` is not assignable to `int`
 
 
-error[unresolved-attribute]: Cannot assign object of type `Literal["UTC"]` to attribute `tz` on type `Date` with custom `__setattr__` method.
+error[unresolved-attribute]: Cannot assign object of type `Literal["UTC"]` to attribute `tz` on type `Date`. Call to `__setattr__` method failed.
   --> src/mdtest_snippet.py:14:1
    |
 14 | date.tz = "UTC"  # snapshot: unresolved-attribute
    | ^^^^^^^
    |
-info: parameter `name` has an incompatible argument type: `Literal["tz"]` is not assignable to `Literal["day", "month", "year"]`
+info: incompatible type for parameter `name`: `Literal["tz"]` is not assignable to `Literal["day", "month", "year"]`
 ```
 
 ### Return type of `__setattr__`
@@ -3136,7 +3136,7 @@ def use_module(m: MyModule, param: int) -> None:
 
     # But assigning to an attribute that's not explicitly defined will still
     # use `__setattr__` for validation.
-    # error: [unresolved-attribute] "Cannot assign object of type `int` to attribute `undefined_param` on type `MyModule` with custom `__setattr__` method."
+    # error: [unresolved-attribute] "Cannot assign object of type `int` to attribute `undefined_param` on type `MyModule`. Call to `__setattr__` method failed."
     m.undefined_param = param
 ```
 
@@ -3177,7 +3177,7 @@ class Meta(type):
 class Foo(metaclass=Meta): ...
 
 Foo.whatever = 42
-Foo.whatever = "invalid"  # error: [unresolved-attribute] "with custom `__setattr__` method"
+Foo.whatever = "invalid"  # error: [unresolved-attribute] "Call to `__setattr__` method failed"
 ```
 
 If both the metaclass and class define `__setattr__`, class-object assignments use the metaclass
@@ -3188,11 +3188,11 @@ class WithSetAttr(metaclass=Meta):
     def __setattr__(self, name: str, value: str) -> None: ...
 
 WithSetAttr.class_attribute = 42
-WithSetAttr.class_attribute = "invalid"  # error: [unresolved-attribute] "with custom `__setattr__` method"
+WithSetAttr.class_attribute = "invalid"  # error: [unresolved-attribute] "Call to `__setattr__` method failed"
 
 instance = WithSetAttr()
 instance.instance_attribute = "valid"
-instance.instance_attribute = 42  # error: [unresolved-attribute] "with custom `__setattr__` method"
+instance.instance_attribute = 42  # error: [unresolved-attribute] "Call to `__setattr__` method failed"
 ```
 
 The same applies when the class object is annotated as `type[Foo]`:
@@ -3200,7 +3200,7 @@ The same applies when the class object is annotated as `type[Foo]`:
 ```py
 def set_on_subclass(cls: type[Foo]) -> None:
     cls.whatever = 42
-    cls.whatever = "invalid"  # error: [unresolved-attribute] "with custom `__setattr__` method"
+    cls.whatever = "invalid"  # error: [unresolved-attribute] "Call to `__setattr__` method failed"
 ```
 
 The setter also provides the expected type when inferring the assigned value:
@@ -3244,7 +3244,7 @@ OverloadedClass.callback = lambda number: (
     number.missing
 )
 OverloadedClass.payload = {"value": 1}
-OverloadedClass.callback = {"value": 1}  # error: [unresolved-attribute] "with custom `__setattr__` method"
+OverloadedClass.callback = {"value": 1}  # error: [unresolved-attribute] "Call to `__setattr__` method failed"
 ```
 
 A metaclass `__setattr__` method returning `Never` prevents writes to undefined attributes:

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2998,8 +2998,27 @@ date.day = 8
 date.month = 4
 date.year = 2025
 
-# error: [unresolved-attribute] "Cannot assign object of type `Literal["UTC"]` to attribute `tz` on type `Date` with custom `__setattr__` method."
-date.tz = "UTC"
+date.month = "May"  # snapshot: unresolved-attribute
+date.tz = "UTC"  # snapshot: unresolved-attribute
+```
+
+```snapshot
+error[unresolved-attribute]: Cannot assign object of type `Literal["May"]` to attribute `month` on type `Date` with custom `__setattr__` method.
+  --> src/mdtest_snippet.py:13:1
+   |
+13 | date.month = "May"  # snapshot: unresolved-attribute
+   | ^^^^^^^^^^
+   |
+info: parameter `value` has an incompatible argument type: `Literal["May"]` is not assignable to `int`
+
+
+error[unresolved-attribute]: Cannot assign object of type `Literal["UTC"]` to attribute `tz` on type `Date` with custom `__setattr__` method.
+  --> src/mdtest_snippet.py:14:1
+   |
+14 | date.tz = "UTC"  # snapshot: unresolved-attribute
+   | ^^^^^^^
+   |
+info: parameter `name` has an incompatible argument type: `Literal["tz"]` is not assignable to `Literal["day", "month", "year"]`
 ```
 
 ### Return type of `__setattr__`

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -35,7 +35,7 @@ reveal_type(C.ten)  # revealed: Literal[10]
 # This is fine:
 c.ten = 10
 
-# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `ten` on type `C`. Call to `__set__` method failed."
+# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `ten` on type `C`"
 c.ten = 11
 ```
 
@@ -78,7 +78,7 @@ c.flexible_int = "42"  # also okay!
 
 reveal_type(c.flexible_int)  # revealed: int | None
 
-# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `flexible_int` on type `C`. Call to `__set__` method failed."
+# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `flexible_int` on type `C`"
 c.flexible_int = None  # not okay
 
 reveal_type(c.flexible_int)  # revealed: int | None
@@ -215,7 +215,7 @@ def f1(flag: bool):
             attr = DataDescriptor()
 
         def f(self):
-            # error: [invalid-assignment] "Invalid assignment to data descriptor attribute `attr` on type `Self@f`. Call to `__set__` method failed."
+            # error: [invalid-assignment] "Invalid assignment to data descriptor attribute `attr` on type `Self@f`"
             self.attr = b"foo"
 
     reveal_type(C1().attr)  # revealed: Literal["data"] | bytes
@@ -480,7 +480,7 @@ on the metaclass:
 ```py
 C1.meta_data_descriptor = 1
 
-# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `meta_data_descriptor` on type `<class 'C1'>`. Call to `__set__` method failed."
+# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `meta_data_descriptor` on type `<class 'C1'>`"
 C1.meta_data_descriptor = "invalid"
 ```
 
@@ -586,7 +586,7 @@ def _(flag: bool):
     # TODO: We currently emit two diagnostics here, corresponding to the two states of `flag`. The diagnostics are not
     # wrong, but they could be subsumed under a higher-level diagnostic.
 
-    # error: [invalid-assignment] "Invalid assignment to data descriptor attribute `meta_data_descriptor1` on type `<class 'C5'>`. Call to `__set__` method failed."
+    # error: [invalid-assignment] "Invalid assignment to data descriptor attribute `meta_data_descriptor1` on type `<class 'C5'>`"
     # error: [invalid-assignment] "Object of type `None` is not assignable to attribute `meta_data_descriptor1` of type `Literal["value on class"]`"
     C5.meta_data_descriptor1 = None
 
@@ -735,7 +735,7 @@ reveal_type(C.name)  # revealed: property
 c.name = "new"
 c.name = None
 
-# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `name` on type `C`. Call to `__set__` method failed."
+# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `name` on type `C`"
 c.name = 42
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -35,7 +35,7 @@ reveal_type(C.ten)  # revealed: Literal[10]
 # This is fine:
 c.ten = 10
 
-# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `ten` on type `C` with custom `__set__` method"
+# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `ten` on type `C`. Call to `__set__` method failed."
 c.ten = 11
 ```
 
@@ -78,7 +78,7 @@ c.flexible_int = "42"  # also okay!
 
 reveal_type(c.flexible_int)  # revealed: int | None
 
-# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `flexible_int` on type `C` with custom `__set__` method"
+# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `flexible_int` on type `C`. Call to `__set__` method failed."
 c.flexible_int = None  # not okay
 
 reveal_type(c.flexible_int)  # revealed: int | None
@@ -215,7 +215,7 @@ def f1(flag: bool):
             attr = DataDescriptor()
 
         def f(self):
-            # error: [invalid-assignment] "Invalid assignment to data descriptor attribute `attr` on type `Self@f` with custom `__set__` method"
+            # error: [invalid-assignment] "Invalid assignment to data descriptor attribute `attr` on type `Self@f`. Call to `__set__` method failed."
             self.attr = b"foo"
 
     reveal_type(C1().attr)  # revealed: Literal["data"] | bytes
@@ -480,7 +480,7 @@ on the metaclass:
 ```py
 C1.meta_data_descriptor = 1
 
-# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `meta_data_descriptor` on type `<class 'C1'>` with custom `__set__` method"
+# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `meta_data_descriptor` on type `<class 'C1'>`. Call to `__set__` method failed."
 C1.meta_data_descriptor = "invalid"
 ```
 
@@ -586,7 +586,7 @@ def _(flag: bool):
     # TODO: We currently emit two diagnostics here, corresponding to the two states of `flag`. The diagnostics are not
     # wrong, but they could be subsumed under a higher-level diagnostic.
 
-    # error: [invalid-assignment] "Invalid assignment to data descriptor attribute `meta_data_descriptor1` on type `<class 'C5'>` with custom `__set__` method"
+    # error: [invalid-assignment] "Invalid assignment to data descriptor attribute `meta_data_descriptor1` on type `<class 'C5'>`. Call to `__set__` method failed."
     # error: [invalid-assignment] "Object of type `None` is not assignable to attribute `meta_data_descriptor1` of type `Literal["value on class"]`"
     C5.meta_data_descriptor1 = None
 
@@ -735,7 +735,7 @@ reveal_type(C.name)  # revealed: property
 c.name = "new"
 c.name = None
 
-# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `name` on type `C` with custom `__set__` method"
+# error: [invalid-assignment] "Invalid assignment to data descriptor attribute `name` on type `C`. Call to `__set__` method failed."
 c.name = 42
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
@@ -274,17 +274,17 @@ class C:
 instance = C()
 instance.attr = 1  # fine
 
-# TODO: ideally, we would mention why this is an invalid assignment (wrong argument type for `value` parameter)
 instance.attr = "wrong"  # snapshot: invalid-assignment
 ```
 
 ```snapshot
 error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
-  --> src/mdtest_snippet.py:12:1
+  --> src/mdtest_snippet.py:11:1
    |
-12 | instance.attr = "wrong"  # snapshot: invalid-assignment
+11 | instance.attr = "wrong"  # snapshot: invalid-assignment
    | ^^^^^^^^^^^^^
    |
+info: parameter `value` has an incompatible argument type: `Literal["wrong"]` is not assignable to `int`
 ```
 
 ### Invalid `__set__` method signature
@@ -299,7 +299,7 @@ class C:
 
 instance = C()
 
-# TODO: ideally, we would mention why this is an invalid assignment (wrong number of arguments for `__set__`)
+# TODO: Ideally, we would emit the error on the wrong `__set__` function, and not emit an error here
 instance.attr = 1  # snapshot: invalid-assignment
 ```
 
@@ -310,6 +310,7 @@ error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr
 11 | instance.attr = 1  # snapshot: invalid-assignment
    | ^^^^^^^^^^^^^
    |
+info: no argument provided for parameter `extra`
 ```
 
 ## Setting attributes on union types

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
@@ -278,13 +278,13 @@ instance.attr = "wrong"  # snapshot: invalid-assignment
 ```
 
 ```snapshot
-error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
+error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C`. Call to `__set__` method failed.
   --> src/mdtest_snippet.py:11:1
    |
 11 | instance.attr = "wrong"  # snapshot: invalid-assignment
    | ^^^^^^^^^^^^^
    |
-info: parameter `value` has an incompatible argument type: `Literal["wrong"]` is not assignable to `int`
+info: incompatible type for parameter `value`: `Literal["wrong"]` is not assignable to `int`
 ```
 
 ### Invalid `__set__` method signature
@@ -304,7 +304,7 @@ instance.attr = 1  # snapshot: invalid-assignment
 ```
 
 ```snapshot
-error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C` with custom `__set__` method
+error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C`. Call to `__set__` method failed.
   --> src/mdtest_snippet.py:11:1
    |
 11 | instance.attr = 1  # snapshot: invalid-assignment

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
@@ -278,12 +278,13 @@ instance.attr = "wrong"  # snapshot: invalid-assignment
 ```
 
 ```snapshot
-error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C`. Call to `__set__` method failed.
+error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C`
   --> src/mdtest_snippet.py:11:1
    |
 11 | instance.attr = "wrong"  # snapshot: invalid-assignment
    | ^^^^^^^^^^^^^
    |
+info: implicit call to `__set__` failed
 info: incompatible type for parameter `value`: `Literal["wrong"]` is not assignable to `int`
 ```
 
@@ -291,6 +292,7 @@ info: incompatible type for parameter `value`: `Literal["wrong"]` is not assigna
 
 ```py
 class WrongDescriptor:
+    # TODO: Ideally, we would also emit an error on the invalid `__set__` definition
     def __set__(self, instance: object, value: int, extra: int) -> None:
         pass
 
@@ -299,17 +301,17 @@ class C:
 
 instance = C()
 
-# TODO: Ideally, we would emit the error on the wrong `__set__` function, and not emit an error here
 instance.attr = 1  # snapshot: invalid-assignment
 ```
 
 ```snapshot
-error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C`. Call to `__set__` method failed.
+error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr` on type `C`
   --> src/mdtest_snippet.py:11:1
    |
 11 | instance.attr = 1  # snapshot: invalid-assignment
    | ^^^^^^^^^^^^^
    |
+info: implicit call to `__set__` failed
 info: no argument provided for parameter `extra`
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -1582,6 +1582,85 @@ error[invalid-assignment]: Object of type `tuple[Literal[1], Literal[b""]]` is n
 info: the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
 ```
 
+### In `invalid-assignment` for failed `__set__` calls
+
+```py
+class Descriptor:
+    def __set__(self, instance, value: tuple[int, str]) -> None:
+        ...
+
+class C:
+    x = Descriptor()
+
+c = C()
+c.x = (1, b"")  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Invalid assignment to data descriptor attribute `x` on type `C` with custom `__set__` method
+ --> src/mdtest_snippet.py:9:1
+  |
+9 | c.x = (1, b"")  # snapshot
+  | ^^^
+  |
+info: parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
+info: └── the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
+```
+
+### In `invalid-assignment` for failed `__setattr__` calls
+
+```py
+class C:
+    def __setattr__(self, name: str, value: tuple[int, str]):
+        ...
+
+c = C()
+c.x = (1, b"")  # snapshot
+```
+
+```snapshot
+error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `C` with custom `__setattr__` method.
+ --> src/mdtest_snippet.py:6:1
+  |
+6 | c.x = (1, b"")  # snapshot
+  | ^^^
+  |
+info: parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
+info: └── the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
+```
+
+This also works for overloaded `__setattr__` methods:
+
+```py
+from typing import overload
+
+class D:
+    @overload
+    def __setattr__(self, name: str, value: tuple[int, str]):
+        ...
+
+    @overload
+    def __setattr__(self, name: str, value: int):
+        ...
+
+    def __setattr__(self, name: str, value: tuple[int, str] | int):
+        ...
+
+d = D()
+d.x = (1, b"")  # snapshot
+```
+
+```snapshot
+error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `D` with custom `__setattr__` method.
+  --> src/mdtest_snippet.py:22:1
+   |
+22 | d.x = (1, b"")  # snapshot
+   | ^^^
+   |
+info: parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
+info: └── the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
+```
+
 ### In `invalid-yield` diagnostics
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -1596,12 +1596,13 @@ c.x = (1, b"")  # snapshot
 ```
 
 ```snapshot
-error[invalid-assignment]: Invalid assignment to data descriptor attribute `x` on type `C`. Call to `__set__` method failed.
+error[invalid-assignment]: Invalid assignment to data descriptor attribute `x` on type `C`
  --> src/mdtest_snippet.py:8:1
   |
 8 | c.x = (1, b"")  # snapshot
   | ^^^
   |
+info: implicit call to `__set__` failed
 info: incompatible type for parameter `value`: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
 info: └── the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
 ```
@@ -1617,12 +1618,13 @@ c.x = (1, b"")  # snapshot
 ```
 
 ```snapshot
-error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `C`. Call to `__setattr__` method failed.
+error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `C`
  --> src/mdtest_snippet.py:5:1
   |
 5 | c.x = (1, b"")  # snapshot
   | ^^^
   |
+info: implicit call to `__setattr__` failed
 info: incompatible type for parameter `value`: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
 info: └── the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
 ```
@@ -1644,12 +1646,13 @@ d.x = (1, b"")  # snapshot
 ```
 
 ```snapshot
-error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `D`. Call to `__setattr__` method failed.
+error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `D`
   --> src/mdtest_snippet.py:16:1
    |
 16 | d.x = (1, b"")  # snapshot
    | ^^^
    |
+info: implicit call to `__setattr__` failed
 info: no overload matches the call
 info: ├── overload `(self, name: str, value: tuple[int, str]) -> Unknown`
 info: │   └── incompatible type for parameter `value`: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -1586,8 +1586,7 @@ info: the second tuple element is not compatible: `Literal[b""]` is not assignab
 
 ```py
 class Descriptor:
-    def __set__(self, instance, value: tuple[int, str]) -> None:
-        ...
+    def __set__(self, instance, value: tuple[int, str]) -> None: ...
 
 class C:
     x = Descriptor()
@@ -1598,9 +1597,9 @@ c.x = (1, b"")  # snapshot
 
 ```snapshot
 error[invalid-assignment]: Invalid assignment to data descriptor attribute `x` on type `C` with custom `__set__` method
- --> src/mdtest_snippet.py:9:1
+ --> src/mdtest_snippet.py:8:1
   |
-9 | c.x = (1, b"")  # snapshot
+8 | c.x = (1, b"")  # snapshot
   | ^^^
   |
 info: parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
@@ -1611,8 +1610,7 @@ info: └── the second tuple element is not compatible: `Literal[b""]` is no
 
 ```py
 class C:
-    def __setattr__(self, name: str, value: tuple[int, str]):
-        ...
+    def __setattr__(self, name: str, value: tuple[int, str]): ...
 
 c = C()
 c.x = (1, b"")  # snapshot
@@ -1620,9 +1618,9 @@ c.x = (1, b"")  # snapshot
 
 ```snapshot
 error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `C` with custom `__setattr__` method.
- --> src/mdtest_snippet.py:6:1
+ --> src/mdtest_snippet.py:5:1
   |
-6 | c.x = (1, b"")  # snapshot
+5 | c.x = (1, b"")  # snapshot
   | ^^^
   |
 info: parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
@@ -1636,15 +1634,10 @@ from typing import overload
 
 class D:
     @overload
-    def __setattr__(self, name: str, value: tuple[int, str]):
-        ...
-
+    def __setattr__(self, name: str, value: tuple[int, str]): ...
     @overload
-    def __setattr__(self, name: str, value: int):
-        ...
-
-    def __setattr__(self, name: str, value: tuple[int, str] | int):
-        ...
+    def __setattr__(self, name: str, value: int): ...
+    def __setattr__(self, name: str, value: tuple[int, str] | int): ...
 
 d = D()
 d.x = (1, b"")  # snapshot
@@ -1652,13 +1645,17 @@ d.x = (1, b"")  # snapshot
 
 ```snapshot
 error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `D` with custom `__setattr__` method.
-  --> src/mdtest_snippet.py:22:1
+  --> src/mdtest_snippet.py:16:1
    |
-22 | d.x = (1, b"")  # snapshot
+16 | d.x = (1, b"")  # snapshot
    | ^^^
    |
-info: parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
-info: └── the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
+info: no overload matches the call
+info: ├── overload `(self, name: str, value: tuple[int, str]) -> Unknown`
+info: │   └── parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
+info: │       └── the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
+info: └── overload `(self, name: str, value: int) -> Unknown`
+info:     └── parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `int`
 ```
 
 ### In `invalid-yield` diagnostics

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -1596,13 +1596,13 @@ c.x = (1, b"")  # snapshot
 ```
 
 ```snapshot
-error[invalid-assignment]: Invalid assignment to data descriptor attribute `x` on type `C` with custom `__set__` method
+error[invalid-assignment]: Invalid assignment to data descriptor attribute `x` on type `C`. Call to `__set__` method failed.
  --> src/mdtest_snippet.py:8:1
   |
 8 | c.x = (1, b"")  # snapshot
   | ^^^
   |
-info: parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
+info: incompatible type for parameter `value`: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
 info: └── the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
 ```
 
@@ -1617,13 +1617,13 @@ c.x = (1, b"")  # snapshot
 ```
 
 ```snapshot
-error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `C` with custom `__setattr__` method.
+error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `C`. Call to `__setattr__` method failed.
  --> src/mdtest_snippet.py:5:1
   |
 5 | c.x = (1, b"")  # snapshot
   | ^^^
   |
-info: parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
+info: incompatible type for parameter `value`: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
 info: └── the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
 ```
 
@@ -1644,7 +1644,7 @@ d.x = (1, b"")  # snapshot
 ```
 
 ```snapshot
-error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `D` with custom `__setattr__` method.
+error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Literal[b""]]` to attribute `x` on type `D`. Call to `__setattr__` method failed.
   --> src/mdtest_snippet.py:16:1
    |
 16 | d.x = (1, b"")  # snapshot
@@ -1652,10 +1652,10 @@ error[unresolved-attribute]: Cannot assign object of type `tuple[Literal[1], Lit
    |
 info: no overload matches the call
 info: ├── overload `(self, name: str, value: tuple[int, str]) -> Unknown`
-info: │   └── parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
+info: │   └── incompatible type for parameter `value`: `tuple[Literal[1], Literal[b""]]` is not assignable to `tuple[int, str]`
 info: │       └── the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
 info: └── overload `(self, name: str, value: int) -> Unknown`
-info:     └── parameter `value` has an incompatible argument type: `tuple[Literal[1], Literal[b""]]` is not assignable to `int`
+info:     └── incompatible type for parameter `value`: `tuple[Literal[1], Literal[b""]]` is not assignable to `int`
 ```
 
 ### In `invalid-yield` diagnostics

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -279,49 +279,56 @@ impl<'db> CallError<'db> {
     /// represent unions, intersections, and overloaded callables, but these diagnostics only need
     /// a concise explanation for a failed synthetic call.
     pub(crate) fn to_error_context(&self, db: &'db dyn Db) -> ErrorContextTree<'db> {
-        if self.0 != CallErrorKind::BindingError {
-            return ErrorContextTree::new();
+        match self.0 {
+            CallErrorKind::NotCallable => ErrorContext::CallNotCallable {
+                callable: self.1.callable_type(),
+            }
+            .into(),
+            CallErrorKind::PossiblyNotCallable => ErrorContext::CallPossiblyNotCallable {
+                callable: self.1.callable_type(),
+            }
+            .into(),
+            CallErrorKind::BindingError => self
+                .1
+                .iter_flat()
+                .flatten()
+                .flat_map(bind::Binding::errors)
+                .find_map(|error| match error {
+                    BindingError::InvalidArgumentType {
+                        parameter,
+                        expected_ty,
+                        provided_ty,
+                        ..
+                    } => {
+                        let context = provided_ty.assignability_error_context(db, *expected_ty);
+                        context.push(ErrorContext::InvalidCallArgumentType {
+                            provided: *provided_ty,
+                            expected: *expected_ty,
+                            parameter: parameter.description(),
+                        });
+                        Some(context)
+                    }
+                    BindingError::MissingArguments { parameters, .. } => Some(
+                        ErrorContext::MissingCallArguments {
+                            parameters: parameters.descriptions(),
+                        }
+                        .into(),
+                    ),
+                    BindingError::TooManyPositionalArguments {
+                        expected_positional_count,
+                        provided_positional_count,
+                        ..
+                    } => Some(
+                        ErrorContext::TooManyCallPositionalArguments {
+                            expected: *expected_positional_count,
+                            provided: *provided_positional_count,
+                        }
+                        .into(),
+                    ),
+                    _ => None,
+                })
+                .unwrap_or_else(ErrorContextTree::new),
         }
-
-        self.1
-            .iter_flat()
-            .flatten()
-            .flat_map(bind::Binding::errors)
-            .find_map(|error| match error {
-                BindingError::InvalidArgumentType {
-                    parameter,
-                    expected_ty,
-                    provided_ty,
-                    ..
-                } => {
-                    let context = provided_ty.assignability_error_context(db, *expected_ty);
-                    context.push(ErrorContext::InvalidCallArgumentType {
-                        provided: *provided_ty,
-                        expected: *expected_ty,
-                        parameter: parameter.description(),
-                    });
-                    Some(context)
-                }
-                BindingError::MissingArguments { parameters, .. } => Some(
-                    ErrorContext::MissingCallArguments {
-                        parameters: parameters.descriptions(),
-                    }
-                    .into(),
-                ),
-                BindingError::TooManyPositionalArguments {
-                    expected_positional_count,
-                    provided_positional_count,
-                    ..
-                } => Some(
-                    ErrorContext::TooManyCallPositionalArguments {
-                        expected: *expected_positional_count,
-                        provided: *provided_positional_count,
-                    }
-                    .into(),
-                ),
-                _ => None,
-            })
-            .unwrap_or_else(ErrorContextTree::new)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -1,5 +1,5 @@
 use super::context::InferContext;
-use super::{ClassType, Signature, Type, TypeContext, UnionType};
+use super::{ClassType, ErrorContext, ErrorContextTree, Signature, Type, TypeContext, UnionType};
 use crate::Db;
 use crate::place::Provenance;
 use crate::types::call::bind::BindingError;
@@ -270,6 +270,58 @@ impl<'db> CallError<'db> {
                 BindingError::PropertyHasNoDeleter(property) => Some(*property),
                 _ => None,
             })
+    }
+
+    /// Collect the most useful part of a failed call for diagnostics that cannot point at the
+    /// individual call arguments, such as an implicit descriptor `__set__` call.
+    ///
+    /// This deliberately does not try to reproduce the full call diagnostic. Call errors can
+    /// represent unions, intersections, and overloaded callables, but these diagnostics only need
+    /// a concise explanation for a failed synthetic call.
+    pub(crate) fn to_error_context(&self, db: &'db dyn Db) -> ErrorContextTree<'db> {
+        if self.0 != CallErrorKind::BindingError {
+            return ErrorContextTree::new();
+        }
+
+        self.1
+            .iter_flat()
+            .flatten()
+            .flat_map(bind::Binding::errors)
+            .find_map(|error| match error {
+                BindingError::InvalidArgumentType {
+                    parameter,
+                    expected_ty,
+                    provided_ty,
+                    ..
+                } => {
+                    let context = provided_ty.assignability_error_context(db, *expected_ty);
+                    context.push(ErrorContext::InvalidCallArgumentType {
+                        provided: *provided_ty,
+                        expected: *expected_ty,
+                        parameter: parameter.description(),
+                    });
+                    Some(context)
+                }
+                BindingError::MissingArguments { parameters, .. } => Some(
+                    ErrorContext::MissingCallArguments {
+                        parameters: parameters.descriptions(),
+                    }
+                    .into(),
+                ),
+                BindingError::TooManyPositionalArguments {
+                    expected_positional_count,
+                    provided_positional_count,
+                    ..
+                } => Some(
+                    ErrorContext::TooManyCallPositionalArguments {
+                        expected: *expected_positional_count,
+                        provided: *provided_positional_count,
+                    }
+                    .into(),
+                ),
+                _ => None,
+            })
+            .unwrap_or_else(ErrorContextTree::new)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -272,12 +272,12 @@ impl<'db> CallError<'db> {
             })
     }
 
-    /// Collect the most useful part of a failed call for diagnostics that cannot point at the
-    /// individual call arguments, such as an implicit descriptor `__set__` call.
+    /// Transform this call error into a simplified error context tree that can be
+    /// attached to diagnostics that are not directly related to the call itself,
+    /// e.g. implicit dunder calls that are triggered by attribute assignments.
     ///
-    /// This deliberately does not try to reproduce the full call diagnostic. Call errors can
-    /// represent unions, intersections, and overloaded callables, but these diagnostics only need
-    /// a concise explanation for a failed synthetic call.
+    /// Note: This does not retain the full structure of a call error. Avoid this
+    /// if the full call diagnostic can be emitted instead.
     pub(crate) fn to_error_context(&self, db: &'db dyn Db) -> ErrorContextTree<'db> {
         match self.0 {
             CallErrorKind::NotCallable => ErrorContext::CallNotCallable {
@@ -288,46 +288,81 @@ impl<'db> CallError<'db> {
                 callable: self.1.callable_type(),
             }
             .into(),
-            CallErrorKind::BindingError => self
-                .1
-                .iter_flat()
-                .flatten()
-                .flat_map(bind::Binding::errors)
-                .find_map(|error| match error {
-                    BindingError::InvalidArgumentType {
-                        parameter,
-                        expected_ty,
-                        provided_ty,
-                        ..
-                    } => {
-                        let context = provided_ty.assignability_error_context(db, *expected_ty);
-                        context.push(ErrorContext::InvalidCallArgumentType {
-                            provided: *provided_ty,
-                            expected: *expected_ty,
-                            parameter: parameter.description(),
-                        });
-                        Some(context)
+            CallErrorKind::BindingError => {
+                fn error_context<'db>(
+                    db: &'db dyn Db,
+                    error: &BindingError<'db>,
+                ) -> Option<ErrorContextTree<'db>> {
+                    match error {
+                        BindingError::InvalidArgumentType {
+                            parameter,
+                            expected_ty,
+                            provided_ty,
+                            ..
+                        } => {
+                            let context = provided_ty.assignability_error_context(db, *expected_ty);
+                            context.push(ErrorContext::InvalidCallArgumentType {
+                                provided: *provided_ty,
+                                expected: *expected_ty,
+                                parameter: parameter.description(),
+                            });
+                            Some(context)
+                        }
+                        BindingError::MissingArguments { parameters, .. } => Some(
+                            ErrorContext::MissingCallArguments {
+                                parameters: parameters.descriptions(),
+                            }
+                            .into(),
+                        ),
+                        BindingError::TooManyPositionalArguments {
+                            expected_positional_count,
+                            provided_positional_count,
+                            ..
+                        } => Some(
+                            ErrorContext::TooManyCallPositionalArguments {
+                                expected: *expected_positional_count,
+                                provided: *provided_positional_count,
+                            }
+                            .into(),
+                        ),
+                        _ => None,
                     }
-                    BindingError::MissingArguments { parameters, .. } => Some(
-                        ErrorContext::MissingCallArguments {
-                            parameters: parameters.descriptions(),
+                }
+
+                self.1
+                    .iter_flat()
+                    .find_map(|callable| {
+                        let is_overloaded = callable.overloads().len() > 1;
+                        let mut overload_contexts = callable
+                            .into_iter()
+                            .filter_map(|overload| {
+                                let context = overload
+                                    .errors()
+                                    .iter()
+                                    .find_map(|error| error_context(db, error))
+                                    .unwrap_or_else(ErrorContextTree::new);
+
+                                if is_overloaded {
+                                    context.push(ErrorContext::CallOverload {
+                                        signature: overload.signature.display(db).to_string(),
+                                    });
+                                    Some(context)
+                                } else {
+                                    (!context.is_empty()).then_some(context)
+                                }
+                            })
+                            .collect::<Vec<_>>();
+
+                        if is_overloaded {
+                            let context = ErrorContextTree::new();
+                            context.set(ErrorContext::NoMatchingCallOverload, overload_contexts);
+                            Some(context)
+                        } else {
+                            overload_contexts.pop()
                         }
-                        .into(),
-                    ),
-                    BindingError::TooManyPositionalArguments {
-                        expected_positional_count,
-                        provided_positional_count,
-                        ..
-                    } => Some(
-                        ErrorContext::TooManyCallPositionalArguments {
-                            expected: *expected_positional_count,
-                            provided: *provided_positional_count,
-                        }
-                        .into(),
-                    ),
-                    _ => None,
-                })
-                .unwrap_or_else(ErrorContextTree::new),
+                    })
+                    .unwrap_or_else(ErrorContextTree::new)
+            }
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -67,9 +67,10 @@ use crate::types::{
     BindingContext, BoundMethodType, BoundTypeVarInstance, CallableType, CallableTypes,
     ClassLiteral, DATACLASS_FLAGS, DataclassFlags, DataclassParams, DynamicType, GenericAlias,
     InternedConstraintSet, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
-    LiteralValueTypeKind, NominalInstanceType, PropertyInstanceType, SpecialFormType,
-    TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance,
-    UnionAccumulator, UnionBuilder, UnionType, WrapperDescriptorKind, enums, list_members,
+    LiteralValueTypeKind, NominalInstanceType, ParameterDescription, PropertyInstanceType,
+    SpecialFormType, TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
+    TypeVarVariance, UnionAccumulator, UnionBuilder, UnionType, WrapperDescriptorKind, enums,
+    list_members,
 };
 use crate::{DisplaySettings, FxOrderSet, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
@@ -7242,6 +7243,13 @@ impl ParameterContext {
             positional,
         }
     }
+
+    pub(crate) fn description(&self) -> ParameterDescription {
+        self.name.as_ref().map_or_else(
+            || ParameterDescription::Index(self.index),
+            |name| ParameterDescription::Named(name.name().clone()),
+        )
+    }
 }
 
 impl std::fmt::Display for ParameterContext {
@@ -7260,6 +7268,12 @@ impl std::fmt::Display for ParameterContext {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ParameterContexts(Vec<ParameterContext>);
+
+impl ParameterContexts {
+    pub(crate) fn descriptions(&self) -> Box<[ParameterDescription]> {
+        self.0.iter().map(ParameterContext::description).collect()
+    }
+}
 
 impl std::fmt::Display for ParameterContexts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1739,8 +1739,8 @@ pub(super) fn report_bad_dunder_set_call<'db>(
         }
     } else {
         let mut diagnostic = builder.into_diagnostic(format_args!(
-            "Invalid assignment to data descriptor attribute \
-            `{attribute}` on type `{}` with custom `__set__` method",
+            "Invalid assignment to data descriptor attribute `{attribute}` on type `{}`. \
+            Call to `__set__` method failed.",
             object_type.display(db)
         ));
         dunder_set_failure

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1738,13 +1738,14 @@ pub(super) fn report_bad_dunder_set_call<'db>(
             ));
         }
     } else {
-        // TODO: Here, it would be nice to emit an additional diagnostic
-        // that explains why the call failed
-        builder.into_diagnostic(format_args!(
+        let mut diagnostic = builder.into_diagnostic(format_args!(
             "Invalid assignment to data descriptor attribute \
             `{attribute}` on type `{}` with custom `__set__` method",
             object_type.display(db)
         ));
+        dunder_set_failure
+            .to_error_context(db)
+            .attach_to(db, &mut diagnostic);
     }
 }
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1739,10 +1739,10 @@ pub(super) fn report_bad_dunder_set_call<'db>(
         }
     } else {
         let mut diagnostic = builder.into_diagnostic(format_args!(
-            "Invalid assignment to data descriptor attribute `{attribute}` on type `{}`. \
-            Call to `__set__` method failed.",
+            "Invalid assignment to data descriptor attribute `{attribute}` on type `{}`",
             object_type.display(db)
         ));
+        diagnostic.info("implicit call to `__set__` failed");
         dunder_set_failure
             .to_error_context(db)
             .attach_to(db, &mut diagnostic);

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -807,11 +807,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     .report_lint(&UNRESOLVED_ATTRIBUTE, self.target)
                 {
                     let mut diagnostic = builder.into_diagnostic(format_args!(
-                        "Cannot assign object of type `{}` to attribute `{}` on type `{}`. Call to `__setattr__` method failed.",
+                        "Cannot assign object of type `{}` to attribute `{}` on type `{}`",
                         value_ty.display(db),
                         self.attribute,
                         self.object_ty.display(db)
                     ));
+                    diagnostic.info("implicit call to `__setattr__` failed");
                     failure.to_error_context(db).attach_to(db, &mut diagnostic);
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -807,7 +807,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     .report_lint(&UNRESOLVED_ATTRIBUTE, self.target)
                 {
                     let mut diagnostic = builder.into_diagnostic(format_args!(
-                        "Cannot assign object of type `{}` to attribute `{}` on type `{}` with custom `__setattr__` method.",
+                        "Cannot assign object of type `{}` to attribute `{}` on type `{}`. Call to `__setattr__` method failed.",
                         value_ty.display(db),
                         self.attribute,
                         self.object_ty.display(db)

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -59,6 +59,7 @@ enum AssignmentAttributeWriteDiagnostic<'db> {
     PossiblyMissing,
     BadSetAttr {
         value_ty: Type<'db>,
+        failure: CallError<'db>,
     },
     Unresolved {
         with_period: bool,
@@ -410,9 +411,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             }
             InstanceAttributeWriteMember::SetAttr => match setattr_result {
                 Ok(_) | Err(CallDunderError::PossiblyUnbound { .. }) => true,
-                Err(CallDunderError::CallError(..)) => {
+                Err(CallDunderError::CallError(kind, bindings, _)) => {
                     if emit_diagnostics {
-                        self.report(AssignmentAttributeWriteDiagnostic::BadSetAttr { value_ty });
+                        self.report(AssignmentAttributeWriteDiagnostic::BadSetAttr {
+                            value_ty,
+                            failure: CallError(kind, bindings),
+                        });
                     }
                     false
                 }
@@ -484,10 +488,11 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
 
                 match setattr_result {
                     Ok(_) | Err(CallDunderError::PossiblyUnbound { .. }) => true,
-                    Err(CallDunderError::CallError(..)) => {
+                    Err(CallDunderError::CallError(kind, bindings, _)) => {
                         if emit_diagnostics {
                             self.report(AssignmentAttributeWriteDiagnostic::BadSetAttr {
                                 value_ty,
+                                failure: CallError(kind, bindings),
                             });
                         }
                         false
@@ -795,18 +800,19 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     self.object_ty,
                 );
             }
-            AssignmentAttributeWriteDiagnostic::BadSetAttr { value_ty } => {
+            AssignmentAttributeWriteDiagnostic::BadSetAttr { value_ty, failure } => {
                 if let Some(builder) = self
                     .builder
                     .context
                     .report_lint(&UNRESOLVED_ATTRIBUTE, self.target)
                 {
-                    builder.into_diagnostic(format_args!(
+                    let mut diagnostic = builder.into_diagnostic(format_args!(
                         "Cannot assign object of type `{}` to attribute `{}` on type `{}` with custom `__setattr__` method.",
                         value_ty.display(db),
                         self.attribute,
                         self.object_ty.display(db)
                     ));
+                    failure.to_error_context(db).attach_to(db, &mut diagnostic);
                 }
             }
             AssignmentAttributeWriteDiagnostic::Unresolved { with_period } => {

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -100,6 +100,18 @@ pub(crate) enum ErrorContext<'db> {
         target: Type<'db>,
         parameter: ParameterDescription,
     },
+    InvalidCallArgumentType {
+        provided: Type<'db>,
+        expected: Type<'db>,
+        parameter: ParameterDescription,
+    },
+    MissingCallArguments {
+        parameters: Box<[ParameterDescription]>,
+    },
+    TooManyCallPositionalArguments {
+        expected: usize,
+        provided: usize,
+    },
     InferredCallableType {
         source: Type<'db>,
         callable: Type<'db>,
@@ -280,6 +292,30 @@ impl<'db> ErrorContext<'db> {
                     source = source.display(db),
                     target = target.display(db),
                 )
+            }
+            Self::InvalidCallArgumentType {
+                provided,
+                expected,
+                parameter,
+            } => format!(
+                "{parameter} has an incompatible argument type: `{}` is not assignable to `{}`",
+                provided.display(db),
+                expected.display(db),
+            ),
+            Self::MissingCallArguments { parameters } => {
+                let parameter_count = parameters.len();
+                let parameters = parameters
+                    .iter()
+                    .map(ParameterDescription::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "no argument{} provided for {parameters}",
+                    if parameter_count == 1 { "" } else { "s" },
+                )
+            }
+            Self::TooManyCallPositionalArguments { expected, provided } => {
+                format!("too many positional arguments: expected {expected}, got {provided}")
             }
             Self::InferredCallableType { source, callable } => format!(
                 "type `{}` has inferred callable type `{}`",

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -118,6 +118,10 @@ pub(crate) enum ErrorContext<'db> {
     CallPossiblyNotCallable {
         callable: Type<'db>,
     },
+    NoMatchingCallOverload,
+    CallOverload {
+        signature: String,
+    },
     InferredCallableType {
         source: Type<'db>,
         callable: Type<'db>,
@@ -329,6 +333,8 @@ impl<'db> ErrorContext<'db> {
             Self::CallPossiblyNotCallable { callable } => {
                 format!("type `{}` may not be callable", callable.display(db))
             }
+            Self::NoMatchingCallOverload => "no overload matches the call".to_string(),
+            Self::CallOverload { signature } => format!("overload `{signature}`"),
             Self::InferredCallableType { source, callable } => format!(
                 "type `{}` has inferred callable type `{}`",
                 source.display(db),

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -308,7 +308,7 @@ impl<'db> ErrorContext<'db> {
                 expected,
                 parameter,
             } => format!(
-                "{parameter} has an incompatible argument type: `{}` is not assignable to `{}`",
+                "incompatible type for {parameter}: `{}` is not assignable to `{}`",
                 provided.display(db),
                 expected.display(db),
             ),

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -112,6 +112,12 @@ pub(crate) enum ErrorContext<'db> {
         expected: usize,
         provided: usize,
     },
+    CallNotCallable {
+        callable: Type<'db>,
+    },
+    CallPossiblyNotCallable {
+        callable: Type<'db>,
+    },
     InferredCallableType {
         source: Type<'db>,
         callable: Type<'db>,
@@ -316,6 +322,12 @@ impl<'db> ErrorContext<'db> {
             }
             Self::TooManyCallPositionalArguments { expected, provided } => {
                 format!("too many positional arguments: expected {expected}, got {provided}")
+            }
+            Self::CallNotCallable { callable } => {
+                format!("type `{}` is not callable", callable.display(db))
+            }
+            Self::CallPossiblyNotCallable { callable } => {
+                format!("type `{}` may not be callable", callable.display(db))
             }
             Self::InferredCallableType { source, callable } => format!(
                 "type `{}` has inferred callable type `{}`",

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -4539,6 +4539,12 @@ impl ParameterDisplayName<&Name> {
     }
 }
 
+impl<N> ParameterDisplayName<N> {
+    pub(crate) fn name(&self) -> &N {
+        &self.name
+    }
+}
+
 impl<N: AsRef<str>> fmt::Display for ParameterDisplayName<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.prefix.as_str())?;


### PR DESCRIPTION
## Summary

We recently discussed that it would be good to surface full call errors for failed implicit dunder calls, such as to `__set__` or `__setattr__`, when creating a higher-level diagnostic (e.g. `invalid-assignment` for the failed assignment to the attribute).

Since this is a hard problem, I'm proposing that we implement a pragmatic solution for now: we turn the full call error into an error context tree that preserves information for the most common scenarios. Since it's easy to attach error context trees to diagnostics, this let's us surface information about the failed call in these diagnostics.

Consider this example (which also illustrates how sub-trees nicely fit into this):

```py
class C:
    def __setattr__(self, name: str, value: tuple[int, str]): ...

def _(c: C, x: int, y: bytes):
    c.attr = (x, y)
```

**Before**:

<img width="1119" height="155" alt="image" src="https://github.com/user-attachments/assets/da757a9e-cebc-4a8c-aefe-72f16be30433" />


**After**:

<img width="1097" height="195" alt="image" src="https://github.com/user-attachments/assets/48a0eaff-a7a7-492c-9364-ef3af31c59e1" />

## Test Plan

New and updated Markdown tests.
