### PR TITLE
[ty] Pydantic: Stricter validation of sub-model fields in lax mode

### DIFF
--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -347,6 +347,8 @@ pub enum KnownModule {
     PydanticConfig,
     #[strum(serialize = "pydantic.fields")]
     PydanticFields,
+    #[strum(serialize = "pydantic.functional_validators")]
+    PydanticFunctionalValidators,
     #[strum(serialize = "pydantic.main")]
     PydanticMain,
     #[strum(serialize = "pydantic.root_model")]
@@ -394,6 +396,7 @@ impl KnownModule {
             Self::Struct => "struct",
             Self::PydanticConfig => "pydantic.config",
             Self::PydanticFields => "pydantic.fields",
+            Self::PydanticFunctionalValidators => "pydantic.functional_validators",
             Self::PydanticMain => "pydantic.main",
             Self::PydanticRootModel => "pydantic.root_model",
             Self::PydanticSettingsMain => "pydantic_settings.main",
@@ -423,6 +426,7 @@ impl KnownModule {
         match self {
             Self::PydanticConfig
             | Self::PydanticFields
+            | Self::PydanticFunctionalValidators
             | Self::PydanticMain
             | Self::PydanticRootModel
             | Self::PydanticSettingsMain

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -469,6 +469,77 @@ Nested(value=[{"a": 1}, {"b": "2", "c": 3.0}])
 Nested(value=[{"a": 1}, {"b": None}])  # error: [invalid-argument-type]
 ```
 
+In lax mode, fields that refer to an ordinary Pydantic model accept either an instance of that model
+or a mapping:
+
+```py
+class Child(BaseModel):
+    value: int
+
+class Stranger(BaseModel):
+    value: int
+
+class Parent(BaseModel):
+    child: Child
+    children: list[Child]
+
+# revealed: (self: Parent, *, child: Child | Mapping[str, Any], children: Iterable[Child | Mapping[str, Any]], **extra: Any) -> None
+reveal_type(Parent.__init__)
+
+child_input = {"value": "1"}
+
+Parent(child=Child(value=1), children=[Child(value=2), Child(value=3)])
+Parent(child={"value": "1"}, children=[{"value": "2"}, {"value": "3"}])
+
+Parent(child=Stranger(value=1), children=[])  # error: [invalid-argument-type]
+Parent(child=1, children=[])  # error: [invalid-argument-type]
+Parent(child={"value": 1}, children=[Stranger(value=2)])  # error: [invalid-argument-type]
+Parent(child={"value": 1}, children=[2])  # error: [invalid-argument-type]
+```
+
+For fields that refer to generic models, we widen to a gradual specialization, since Pydantic
+revalidates same-origin generic model instances against the target specialization:
+
+```py
+class Box[T](BaseModel):
+    value: T
+
+class HasBox(BaseModel):
+    box: Box[int]
+
+# revealed: (self: HasBox, *, box: Box[Unknown] | Mapping[str, Any], **extra: Any) -> None
+reveal_type(HasBox.__init__)
+
+HasBox(box=Box(value=1))
+HasBox(box=Box(value="1"))
+HasBox(box=1)  # error: [invalid-argument-type]
+
+# This would ideally be an error, but we currently do not attempt to detect this:
+HasBox(box=Box(value=None))
+```
+
+Models configured to validate from attributes can accept arbitrary objects, so their field
+parameters remain `Any`:
+
+```py
+class AttributeChild(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    value: int
+
+class AttributeParent(BaseModel):
+    child: AttributeChild
+
+class AttributeSource:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+# revealed: (self: AttributeParent, *, child: Any, **extra: Any) -> None
+reveal_type(AttributeParent.__init__)
+
+AttributeParent(child=AttributeSource(1))
+```
+
 For enums, we currently fall back to a very permissive `Any`, because Pydantic allows certain
 conversions that are not further specified in the documentation.
 
@@ -1111,6 +1182,21 @@ Model(int_list=[1, 2, 3])
 Model(int_list=["1", "2", "3"])
 
 Model(int_list=1)  # error: [invalid-argument-type]
+```
+
+Generic root models can accept root models with a different specialization:
+
+```py
+class GenericRoot[T](RootModel[T]): ...
+
+class HasGenericRoot(BaseModel):
+    root: GenericRoot[int]
+
+HasGenericRoot(root=GenericRoot(1))
+HasGenericRoot(root=GenericRoot("1"))
+
+# This would ideally be an error, but we currently do not attempt to detect this:
+HasGenericRoot(root=GenericRoot(None))
 ```
 
 ## Model configuration

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -497,6 +497,84 @@ Parent(child={"value": 1}, children=[Stranger(value=2)])  # error: [invalid-argu
 Parent(child={"value": 1}, children=[2])  # error: [invalid-argument-type]
 ```
 
+A "before" field validator can accept input of a different type, so for now, we widen the input
+types of affected fields to `Any`:
+
+```py
+from pydantic import field_validator
+
+class BeforeValidatedParent(BaseModel):
+    child: Child
+    untouched_child: Child
+
+    @field_validator("child", mode="before")
+    @classmethod
+    def coerce_child(cls, value: object) -> object:
+        if isinstance(value, int):
+            return {"value": value}
+        return value
+
+# revealed: (self: BeforeValidatedParent, *, child: Any, untouched_child: Child | Mapping[str, Any], **extra: Any) -> None
+reveal_type(BeforeValidatedParent.__init__)
+
+BeforeValidatedParent(child=1, untouched_child={"value": "2"})
+BeforeValidatedParent(child=1, untouched_child=1)  # error: [invalid-argument-type]
+```
+
+"before" field validators are inherited:
+
+```py
+class BeforeValidatorBase(BaseModel):
+    @field_validator("child", mode="before", check_fields=False)
+    @classmethod
+    def coerce_child(cls, value: object) -> object:
+        if isinstance(value, int):
+            return {"value": value}
+        return value
+
+class InheritedBeforeValidatedParent(BeforeValidatorBase):
+    child: Child
+
+# revealed: (self: InheritedBeforeValidatedParent, *, child: Any, **extra: Any) -> None
+reveal_type(InheritedBeforeValidatedParent.__init__)
+```
+
+A wildcard "before" validator applies to every field:
+
+```py
+class WildcardBeforeValidatedParent(BaseModel):
+    child: Child
+
+    @field_validator("*", mode="before")
+    @classmethod
+    def coerce_fields(cls, value: object) -> object:
+        if isinstance(value, int):
+            return {"value": value}
+        return value
+
+# revealed: (self: WildcardBeforeValidatedParent, *, child: Any, **extra: Any) -> None
+reveal_type(WildcardBeforeValidatedParent.__init__)
+
+WildcardBeforeValidatedParent(child=1)
+```
+
+An "after" field validator does not change the raw input accepted by the field:
+
+```py
+class AfterValidatedParent(BaseModel):
+    child: Child
+
+    @field_validator("child", mode="after")
+    @classmethod
+    def validate_child(cls, value: Child) -> Child:
+        return value
+
+# revealed: (self: AfterValidatedParent, *, child: Child | Mapping[str, Any], **extra: Any) -> None
+reveal_type(AfterValidatedParent.__init__)
+
+AfterValidatedParent(child=1)  # error: [invalid-argument-type]
+```
+
 For fields that refer to generic models, we widen to a gradual specialization, since Pydantic
 revalidates same-origin generic model instances against the target specialization:
 

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -497,8 +497,8 @@ Parent(child={"value": 1}, children=[Stranger(value=2)])  # error: [invalid-argu
 Parent(child={"value": 1}, children=[2])  # error: [invalid-argument-type]
 ```
 
-A "before" field validator can accept input of a different type, so for now, we widen the input
-types of affected fields to `Any`:
+"before" and "plain" field validators can accept input of a different type, so for now, we widen the
+input types of affected fields to `Any`:
 
 ```py
 from pydantic import field_validator
@@ -556,6 +556,25 @@ class WildcardBeforeValidatedParent(BaseModel):
 reveal_type(WildcardBeforeValidatedParent.__init__)
 
 WildcardBeforeValidatedParent(child=1)
+```
+
+A "plain" field validator also bypasses Pydantic's validation against the field's declared type:
+
+```py
+class PlainValidatedParent(BaseModel):
+    child: Child
+    untouched_child: Child
+
+    @field_validator("child", mode="plain")
+    @classmethod
+    def accept_child(cls, value: object) -> object:
+        return value
+
+# revealed: (self: PlainValidatedParent, *, child: Any, untouched_child: Child | Mapping[str, Any], **extra: Any) -> None
+reveal_type(PlainValidatedParent.__init__)
+
+PlainValidatedParent(child=1, untouched_child={"value": "2"})
+PlainValidatedParent(child=1, untouched_child=1)  # error: [invalid-argument-type]
 ```
 
 An "after" field validator does not change the raw input accepted by the field:

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1507,7 +1507,9 @@ impl<'db> StaticClassLiteral<'db> {
                 if name == "__init__"
                     && let Some(metadata) = field_policy.pydantic_metadata()
                 {
-                    field_ty = pydantic::constructor_parameter_type(db, field_ty, strict, metadata);
+                    field_ty = pydantic::constructor_parameter_type(
+                        db, self, field_name, field_ty, strict, metadata,
+                    );
                 }
 
                 if pydantic_constructor_fields_are_optional && default_ty.is_none() {

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -332,6 +332,8 @@ pub(crate) struct ModelConfig {
     /// The `strict` configuration controls whether constructor parameters accept values that
     /// Pydantic can coerce to the declared field type.
     strict: ConfigBoolean,
+    /// Whether model fields can be populated from attributes on arbitrary objects.
+    from_attributes: ConfigBoolean,
     /// Whether assignments to fields on model instances are forbidden.
     frozen: ConfigBoolean,
     /// Whether fields with aliases can be initialized by their alias.
@@ -347,6 +349,7 @@ impl ModelConfig {
         Self {
             extra: Some(ExtraBehavior::Unknown),
             strict: ConfigBoolean::Unknown,
+            from_attributes: ConfigBoolean::Unknown,
             frozen: ConfigBoolean::Unknown,
             validate_by_alias: ConfigBoolean::Unknown,
             validate_by_name: ConfigBoolean::Unknown,
@@ -358,6 +361,7 @@ impl ModelConfig {
     fn merge(&mut self, other: Self) {
         self.extra = other.extra.or(self.extra);
         self.strict = other.strict.or(self.strict);
+        self.from_attributes = other.from_attributes.or(self.from_attributes);
         self.frozen = other.frozen.or(self.frozen);
         self.validate_by_alias = other.validate_by_alias.or(self.validate_by_alias);
         self.validate_by_name = other.validate_by_name.or(self.validate_by_name);
@@ -636,6 +640,11 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
         ExtraBehavior::from_value(extra)
     });
     let strict = config_boolean(db, definition, call.arguments.find_keyword("strict"));
+    let from_attributes = config_boolean(
+        db,
+        definition,
+        call.arguments.find_keyword("from_attributes"),
+    );
     let frozen = config_boolean(db, definition, call.arguments.find_keyword("frozen"));
     let validate_by_alias = config_boolean(
         db,
@@ -656,6 +665,7 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
     Some(ModelConfig {
         extra,
         strict,
+        from_attributes,
         frozen,
         validate_by_alias,
         validate_by_name,
@@ -687,6 +697,7 @@ fn model_config_from_dict(db: &dyn Db, definition: Definition<'_>, dict: &ExprDi
                 ));
             }
             "strict" => config.strict = ConfigBoolean::from_type(value),
+            "from_attributes" => config.from_attributes = ConfigBoolean::from_type(value),
             "frozen" => config.frozen = ConfigBoolean::from_type(value),
             "validate_by_alias" => config.validate_by_alias = ConfigBoolean::from_type(value),
             "validate_by_name" => config.validate_by_name = ConfigBoolean::from_type(value),
@@ -725,6 +736,7 @@ fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelConf
         ExtraBehavior::from_value(extra)
     });
     let strict = config_boolean(db, definition, arguments.find_keyword("strict"));
+    let from_attributes = config_boolean(db, definition, arguments.find_keyword("from_attributes"));
     let frozen = config_boolean(db, definition, arguments.find_keyword("frozen"));
     let validate_by_alias =
         config_boolean(db, definition, arguments.find_keyword("validate_by_alias"));
@@ -736,6 +748,7 @@ fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelConf
     ModelConfig {
         extra,
         strict,
+        from_attributes,
         frozen,
         validate_by_alias,
         validate_by_name,
@@ -795,6 +808,10 @@ fn lax_input_type_impl<'db>(
     }
 
     if let Some(input_type) = root_model_input_type(db, field_type, expanding_types) {
+        return input_type;
+    }
+
+    if let Some(input_type) = model_input_type(db, field_type) {
         return input_type;
     }
 
@@ -928,11 +945,39 @@ fn root_model_input_type<'db>(
     let root_input_type = lax_input_type_impl(db, root_field.declared_ty, expanding_types);
 
     expanding_types.remove(&field_type);
+    // In lax mode, Pydantic accepts a Box[str] when a Box[int] is expected, so we widen
+    // to a gradual specialization here. Widening to `Box[LaxStr]` would only work for
+    // covariant generics.
+    let model_instance = Type::instance(db, class.unknown_specialization(db));
     Some(UnionType::from_two_elements(
         db,
-        field_type,
+        model_instance,
         root_input_type,
     ))
+}
+
+/// Return the input type accepted for an ordinary Pydantic model field.
+///
+/// By default, Pydantic accepts either an instance of the model or a mapping of string keys to
+/// input values. Custom validators can accept additional input types, which are not modeled here.
+fn model_input_type<'db>(db: &'db dyn Db, field_type: Type<'db>) -> Option<Type<'db>> {
+    let (class, _) = field_type.nominal_class(db)?.static_class_literal(db)?;
+    if !is_model(db, class) || is_root_model(db, class) {
+        return None;
+    }
+
+    // Attribute-based validation can accept arbitrary objects that do not implement `Mapping`.
+    if model_config(db, class).from_attributes.enabled_or(false) {
+        return Some(Type::any());
+    }
+
+    // In lax mode, Pydantic accepts a Box[str] when a Box[int] is expected, so we widen
+    // to a gradual specialization here. Widening to `Box[LaxStr]` would only work for
+    // covariant generics.
+    let model_instance = Type::instance(db, class.unknown_specialization(db));
+    let mapping = KnownClass::Mapping
+        .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
+    Some(UnionType::from_two_elements(db, model_instance, mapping))
 }
 
 /// Return the known module, name, and class literal for an instance's nominal class.

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -771,7 +771,7 @@ pub(in crate::types) fn constructor_parameter_type<'db>(
     field_strict: ConfigBoolean,
     metadata: ModelMetadata<'db>,
 ) -> Type<'db> {
-    if has_before_field_validator(db, class, field_name.clone()) {
+    if has_before_or_plain_field_validator(db, class, field_name.clone()) {
         return Type::any();
     }
 
@@ -782,13 +782,13 @@ pub(in crate::types) fn constructor_parameter_type<'db>(
     lax_input_type(db, field_type)
 }
 
-/// Return whether `field_name` has a Pydantic field validator that runs before normal validation.
+/// Return whether `field_name` has a Pydantic field validator that receives the raw input.
 ///
-/// A before validator receives the raw input and can transform arbitrary values before Pydantic
-/// validates them against the declared field type. We therefore cannot derive a useful input type
-/// from the field annotation alone.
+/// A before validator can transform arbitrary values before Pydantic validates them against the
+/// declared field type, while a plain validator bypasses that validation entirely. We therefore
+/// cannot derive a useful input type from the field annotation alone.
 #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
-pub(in crate::types) fn has_before_field_validator<'db>(
+pub(in crate::types) fn has_before_or_plain_field_validator<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
     field_name: Name,
@@ -816,7 +816,11 @@ pub(in crate::types) fn has_before_field_validator<'db>(
             }
             if declarations.any_reachable(db, |declaration| {
                 declaration.is_defined_and(|definition| {
-                    function_has_before_field_validator(db, definition, field_name.as_str())
+                    function_has_before_or_plain_field_validator(
+                        db,
+                        definition,
+                        field_name.as_str(),
+                    )
                 })
             }) {
                 return true;
@@ -827,7 +831,7 @@ pub(in crate::types) fn has_before_field_validator<'db>(
     false
 }
 
-fn function_has_before_field_validator<'db>(
+fn function_has_before_or_plain_field_validator<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
     field_name: &str,
@@ -860,7 +864,7 @@ fn function_has_before_field_validator<'db>(
         if decorators
             .expression_type(&mode.value)
             .and_then(Type::as_string_literal)
-            .is_none_or(|mode| mode.value(db) != "before")
+            .is_none_or(|mode| !matches!(mode.value(db), "before" | "plain"))
         {
             return false;
         }

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -1,16 +1,22 @@
+use char_str::CharStr;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::{ArgOrKeyword, Arguments, Expr, ExprCall, ExprDict, Keyword, name::Name};
 use rustc_hash::FxHashSet;
 use ty_module_resolver::{KnownModule, file_to_module};
-use ty_python_core::definition::{Definition, DefinitionKind};
+use ty_python_core::{
+    definition::{Definition, DefinitionKind},
+    place_table, use_def_map,
+};
 
 use crate::diagnostic::format_enumeration;
 use crate::place::{DefinedPlace, Definedness, Place, Provenance, known_module_symbol};
+use crate::reachability::DeclarationsIteratorExtension;
 use crate::types::call::Bindings;
 use crate::types::class::CodeGeneratorKind;
 use crate::types::context::InferContext;
 use crate::types::diagnostic::PYDANTIC_DISCARDED_EXTRA_ARGUMENT;
 use crate::types::ide_support::{ImportAliasResolution, definitions_for_name};
+use crate::types::infer::function_known_decorators;
 use crate::types::known_instance::FieldInstance;
 use crate::types::member::class_member;
 use crate::types::special_form::SpecialFormType;
@@ -759,15 +765,116 @@ fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelConf
 /// Return the input type accepted by a Pydantic field's synthesized constructor parameter.
 pub(in crate::types) fn constructor_parameter_type<'db>(
     db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+    field_name: &Name,
     field_type: Type<'db>,
     field_strict: ConfigBoolean,
     metadata: ModelMetadata<'db>,
 ) -> Type<'db> {
+    if has_before_field_validator(db, class, field_name.clone()) {
+        return Type::any();
+    }
+
     if field_strict.or(metadata.config(db).strict).is_enabled() {
         return field_type;
     }
 
     lax_input_type(db, field_type)
+}
+
+/// Return whether `field_name` has a Pydantic field validator that runs before normal validation.
+///
+/// A before validator receives the raw input and can transform arbitrary values before Pydantic
+/// validates them against the declared field type. We therefore cannot derive a useful input type
+/// from the field annotation alone.
+#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+pub(in crate::types) fn has_before_field_validator<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+    field_name: Name,
+) -> bool {
+    let field_name = CharStr::from(field_name);
+
+    // Pydantic inherits validators unless a subclass defines a symbol with the same method name.
+    let mut shadowed_symbols = FxHashSet::default();
+
+    for base in class.iter_mro(db, None).filter_map(ClassBase::into_class) {
+        if base.is_known(db, KnownClass::PydanticBaseModel) {
+            break;
+        }
+        let Some((base, _)) = base.static_class_literal(db) else {
+            continue;
+        };
+        let body_scope = base.body_scope(db);
+        let use_def = use_def_map(db, body_scope);
+        let table = place_table(db, body_scope);
+
+        for (symbol_id, declarations) in use_def.all_end_of_scope_symbol_declarations() {
+            let name = table.symbol(symbol_id).name().clone();
+            if !shadowed_symbols.insert(name) {
+                continue;
+            }
+            if declarations.any_reachable(db, |declaration| {
+                declaration.is_defined_and(|definition| {
+                    function_has_before_field_validator(db, definition, field_name.as_str())
+                })
+            }) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn function_has_before_field_validator<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+    field_name: &str,
+) -> bool {
+    let DefinitionKind::Function(function) = definition.kind(db) else {
+        return false;
+    };
+    let module = parsed_module(db, definition.file(db)).load(db);
+    let function_node = function.node(&module);
+    if function_node.decorator_list.is_empty() {
+        return false;
+    }
+    let decorators = function_known_decorators(db, definition);
+
+    function_node.decorator_list.iter().any(|decorator| {
+        let Some(call) = decorator.expression.as_call_expr() else {
+            return false;
+        };
+        let Some(Type::FunctionLiteral(function)) = decorators.expression_type(call.func.as_ref())
+        else {
+            return false;
+        };
+        if !function.is_known(db, KnownFunction::PydanticFieldValidator) {
+            return false;
+        }
+
+        let Some(mode) = call.arguments.find_keyword("mode") else {
+            return false;
+        };
+        if decorators
+            .expression_type(&mode.value)
+            .and_then(Type::as_string_literal)
+            .is_none_or(|mode| mode.value(db) != "before")
+        {
+            return false;
+        }
+
+        call.arguments.args.iter().any(|field| {
+            decorators
+                .expression_type(field)
+                .and_then(Type::as_string_literal)
+                .is_some_and(|field| {
+                    let field = field.value(db);
+                    field == "*" || field == field_name
+                })
+        })
+    })
 }
 
 /// Return the documented Python input type accepted by Pydantic for `field_type` in lax mode.
@@ -959,7 +1066,8 @@ fn root_model_input_type<'db>(
 /// Return the input type accepted for an ordinary Pydantic model field.
 ///
 /// By default, Pydantic accepts either an instance of the model or a mapping of string keys to
-/// input values. Custom validators can accept additional input types, which are not modeled here.
+/// input values. Other custom validators can accept additional input types, which are not modeled
+/// here.
 fn model_input_type<'db>(db: &'db dyn Db, field_type: Type<'db>) -> Option<Type<'db>> {
     let (class, _) = field_type.nominal_class(db)?.static_class_literal(db)?;
     if !is_model(db, class) || is_root_model(db, class) {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2099,6 +2099,9 @@ pub enum KnownFunction {
     /// `pydantic.fields.Field`
     #[strum(serialize = "Field")]
     PydanticField,
+    /// `pydantic.functional_validators.field_validator`
+    #[strum(serialize = "field_validator")]
+    PydanticFieldValidator,
 
     /// `functools.total_ordering`
     TotalOrdering,
@@ -2219,6 +2222,9 @@ impl KnownFunction {
                 matches!(module, KnownModule::Dataclasses)
             }
             Self::PydanticField => matches!(module, KnownModule::PydanticFields),
+            Self::PydanticFieldValidator => {
+                matches!(module, KnownModule::PydanticFunctionalValidators)
+            }
             Self::TotalOrdering => module.is_functools(),
             Self::GetattrStatic => module.is_inspect(),
             Self::StaticAssert => module.is_ty_extensions(),
@@ -2761,6 +2767,7 @@ pub(crate) mod tests {
                 KnownFunction::Dataclass | KnownFunction::Field => KnownModule::Dataclasses,
 
                 KnownFunction::PydanticField => KnownModule::PydanticFields,
+                KnownFunction::PydanticFieldValidator => KnownModule::PydanticFunctionalValidators,
 
                 KnownFunction::GetattrStatic => KnownModule::Inspect,
 


### PR DESCRIPTION
## Summary

For lax-mode models, we try to model Pydantic's coercion behavior by promoting some types like `int` to `LaxInt = int | str | ...`. When a field referred to a non-builtin type, we previously widened the corresponding constructor parameter type to `Any`, since we didn't know what that field would accept. However, there is one case where we can be more strict: if the field refers to another Pydantic model, we can widen `Child` to `Child | Mapping[str, Any]`, since that represents all possible values that Pydantic can accept for a field like this:

```py
class Child(BaseModel):
    value: int

class Stranger(BaseModel): ...

class Parent(BaseModel):
    child: Child

Parent(child=Child(value=1))

Parent(child=Stranger())  # previously accepted, now an error
```

Adding support for this also required proper modeling of a few other behaviors, or otherwise this would have caused false positives:
- Detecting the [`from_attributes` setting](https://pydantic.dev/docs/validation/dev/api/pydantic/config/#pydantic.config.ConfigDict.from_attributes). Models that use this setting still use `Any` as the input type.
- Detecting ["before" validators](https://pydantic.dev/docs/validation/latest/concepts/validators/#field-before-validator) which can change the input type. For now, affected fields also still use `Any` as the input type.
- Handling generic models. `Box[int]` can accept a `Box[str]`, so we currently use the `Unknown` specialization `Box[Unknown]` for the input type.

closes https://github.com/astral-sh/ty/issues/3947
closes https://github.com/astral-sh/ty/issues/3510

## Test Plan

- New Markdown tests
- validated all new test assertions against Pydantic runtime behavior

## Ecosystem

The new hits on Prefect are all expected.