### PR TITLE
[ty] Handle generic stringified PEP 613 type aliases

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -198,7 +198,7 @@ static SYMPY: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    16500,
+    16617,
 );
 
 static TANJUN: Benchmark = Benchmark::new(

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -153,6 +153,8 @@ def _(list_of_int: MyList[int], list_or_set_of_str: ListOrSet[str]):
 
 ### Stringified generic alias
 
+#### Explicitly specialized
+
 ```py
 from typing import TypeAlias, TypeVar
 
@@ -163,7 +165,22 @@ TotallyStringifiedPEP613: TypeAlias = "dict[T, U]"
 TotallyStringifiedPartiallySpecialized: TypeAlias = "TotallyStringifiedPEP613[U, int]"
 
 def f(x: "TotallyStringifiedPartiallySpecialized[str]"):
-    reveal_type(x)  # revealed: @Todo(Generic stringified PEP-613 type alias)
+    reveal_type(x)  # revealed: dict[str, int]
+```
+
+#### Unsubscripted
+
+```py
+from typing import TypeAlias, TypeVar
+
+T = TypeVar("T")
+
+ListAlias: TypeAlias = "list[T]"
+
+def takes_list(value: ListAlias) -> None:
+    reveal_type(value)  # revealed: list[Unknown]
+
+takes_list([1])
 ```
 
 ## Subscripted generic alias in union

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6530,7 +6530,6 @@ impl<'db> Type<'db> {
                         | KnownInstanceType::GenericContext(_)
                         | KnownInstanceType::Specialization(_)
                         | KnownInstanceType::Literal(_)
-                        | KnownInstanceType::LiteralStringAlias(_)
                         | KnownInstanceType::NewType(_)
                         | KnownInstanceType::Sentinel(_)
                         | KnownInstanceType::NamedTupleSpec(_),
@@ -7131,7 +7130,8 @@ impl<'db> Type<'db> {
                 KnownInstanceType::Callable(callable_type) => {
                     callable_type.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
                 }
-                KnownInstanceType::TypeGenericAlias(ty) => {
+                KnownInstanceType::TypeGenericAlias(ty)
+                | KnownInstanceType::LiteralStringAlias(ty) => {
                     ty.inner(db)
                         .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
                 }
@@ -7146,7 +7146,6 @@ impl<'db> Type<'db> {
                 | KnownInstanceType::GenericContext(_)
                 | KnownInstanceType::Specialization(_)
                 | KnownInstanceType::Literal(_)
-                | KnownInstanceType::LiteralStringAlias(_)
                 | KnownInstanceType::NamedTupleSpec(_)
                 | KnownInstanceType::NewType(_)
                 | KnownInstanceType::Sentinel(_)

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1655,10 +1655,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         GenericContext::from_typevar_instances(self.db(), variables);
                     Type::Dynamic(DynamicType::UnknownGeneric(generic_context))
                 }
-                KnownInstanceType::LiteralStringAlias(_) => {
-                    self.infer_expression(slice, TypeContext::default());
-                    todo_type!("Generic stringified PEP-613 type alias")
-                }
                 KnownInstanceType::Literal(ty) => {
                     if !self.in_string_annotation() {
                         self.infer_expression(slice, TypeContext::default());
@@ -1695,7 +1691,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         Type::unknown()
                     }
                 }
-                KnownInstanceType::UnionType(_)
+                KnownInstanceType::LiteralStringAlias(_)
+                | KnownInstanceType::UnionType(_)
                 | KnownInstanceType::Callable(_)
                 | KnownInstanceType::Annotated(_)
                 | KnownInstanceType::TypeGenericAlias(_) => {

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -463,6 +463,13 @@ impl<'db> KnownInstanceType<'db> {
                         .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 )))
             }
+            KnownInstanceType::LiteralStringAlias(ty) => {
+                Type::KnownInstance(KnownInstanceType::LiteralStringAlias(InternedType::new(
+                    db,
+                    ty.inner(db)
+                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                )))
+            }
 
             KnownInstanceType::SubscriptedProtocol(_)
             | KnownInstanceType::SubscriptedGeneric(_)
@@ -474,7 +481,6 @@ impl<'db> KnownInstanceType<'db> {
             | KnownInstanceType::GenericContext(_)
             | KnownInstanceType::Specialization(_)
             | KnownInstanceType::Literal(_)
-            | KnownInstanceType::LiteralStringAlias(_)
             | KnownInstanceType::NamedTupleSpec(_)
             | KnownInstanceType::NewType(_)
             | KnownInstanceType::Sentinel(_) => {


### PR DESCRIPTION
## Summary

Fixes some issues with generic stringified PEP 613 type aliases:

```py
from typing import TypeAlias, TypeVar

T = TypeVar("T")

ListAlias: TypeAlias = "list[T]"

def takes_list(value: ListAlias) -> None:
    reveal_type(value)  # `list[Unknown]`, previously `list[T]`

takes_list([1])  # accepted, previously a cryptic error
```

closes https://github.com/astral-sh/ty/issues/4064

## Test Plan

Added regression test

## Ecosystem

Codex's summary: "favorable and fully explained by the intended fix"