### PR TITLE
[ty] Simplify semantic type handling with `let` guards

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5944,13 +5944,10 @@ impl<'db> Type<'db> {
             Type::NominalInstance(instance) => {
                 instance.class(db).iter_mro(db).find_map(from_class_base)
             }
-            Type::ProtocolInstance(instance) => {
-                if let Protocol::FromClass(class) = instance.inner {
-                    class.iter_mro(db).find_map(from_class_base)
-                } else {
-                    None
-                }
-            }
+            Type::ProtocolInstance(ProtocolInstanceType {
+                inner: Protocol::FromClass(class),
+                ..
+            }) => class.iter_mro(db).find_map(from_class_base),
             Type::Union(union) => {
                 let mut yield_builder = Some(UnionBuilder::new(db));
                 let mut send_builder = Some(UnionBuilder::new(db));
@@ -7500,12 +7497,10 @@ impl<'db> Type<'db> {
     pub(crate) fn generic_origin(self, db: &'db dyn Db) -> Option<StaticClassLiteral<'db>> {
         match self {
             Type::GenericAlias(generic) => Some(generic.origin(db)),
-            Type::NominalInstance(instance) => {
-                if let ClassType::Generic(generic) = instance.class(db) {
-                    Some(generic.origin(db))
-                } else {
-                    None
-                }
+            Type::NominalInstance(instance)
+                if let ClassType::Generic(generic) = instance.class(db) =>
+            {
+                Some(generic.origin(db))
             }
             _ => None,
         }

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -97,53 +97,51 @@ impl<'db> Type<'db> {
                     Ok(Truthiness::Ambiguous)
                 }
 
-                Err(CallDunderError::MethodNotAvailable) => {
-                    // We only consider `__len__` for tuples and `@final` types,
-                    // since `__bool__` takes precedence
-                    // and a subclass could add a `__bool__` method.
-                    //
-                    // TODO: with regards to tuple types, we intend to emit a diagnostic
-                    // if a tuple subclass defines a `__bool__` method with a return type
-                    // that is inconsistent with the tuple's length. Otherwise, the special
-                    // handling for tuples here isn't sound.
-                    if let Some(instance) = self.as_nominal_instance() {
-                        if let Some(tuple_spec) = instance.tuple_spec(db) {
-                            Ok(tuple_spec.truthiness())
-                        } else if instance.class(db).is_final(db) {
-                            match self.try_call_dunder(
-                                db,
-                                "__len__",
-                                CallArguments::none(),
-                                TypeContext::default(),
-                            ) {
-                                Ok(outcome) => {
-                                    let return_type = outcome.return_type(db);
-                                    if return_type.is_assignable_to(
-                                        db,
-                                        KnownClass::SupportsIndex.to_instance(db),
-                                    ) {
-                                        Ok(type_to_truthiness(return_type))
-                                    } else {
-                                        // TODO: should report a diagnostic similar to if return type of `__bool__`
-                                        // is not assignable to `bool`
-                                        Ok(Truthiness::Ambiguous)
-                                    }
-                                }
-                                // if a `@final` type does not define `__bool__` or `__len__`, it is always truthy
-                                Err(CallDunderError::MethodNotAvailable) => {
-                                    Ok(Truthiness::AlwaysTrue)
-                                }
-                                // TODO: errors during a `__len__` call (if `__len__` exists) should be reported
-                                // as diagnostics similar to errors during a `__bool__` call (when `__bool__` exists)
-                                Err(_) => Ok(Truthiness::Ambiguous),
+                // TODO: with regards to tuple types, we intend to emit a diagnostic
+                // if a tuple subclass defines a `__bool__` method with a return type
+                // that is inconsistent with the tuple's length. Otherwise, the special
+                // handling for tuples here isn't sound.
+                Err(CallDunderError::MethodNotAvailable)
+                    if let Type::NominalInstance(instance) = self
+                        && let Some(tuple_spec) = instance.tuple_spec(db) =>
+                {
+                    Ok(tuple_spec.truthiness())
+                }
+
+                // We only consider `__len__` for tuples and `@final` types,
+                // since `__bool__` takes precedence
+                // and a subclass could add a `__bool__` method.
+                Err(CallDunderError::MethodNotAvailable)
+                    if let Type::NominalInstance(instance) = self
+                        && instance.class(db).is_final(db) =>
+                {
+                    match self.try_call_dunder(
+                        db,
+                        "__len__",
+                        CallArguments::none(),
+                        TypeContext::default(),
+                    ) {
+                        Ok(outcome) => {
+                            let return_type = outcome.return_type(db);
+                            if return_type
+                                .is_assignable_to(db, KnownClass::SupportsIndex.to_instance(db))
+                            {
+                                Ok(type_to_truthiness(return_type))
+                            } else {
+                                // TODO: should report a diagnostic similar to if return type of `__bool__`
+                                // is not assignable to `bool`
+                                Ok(Truthiness::Ambiguous)
                             }
-                        } else {
-                            Ok(Truthiness::Ambiguous)
                         }
-                    } else {
-                        Ok(Truthiness::Ambiguous)
+                        // if a `@final` type does not define `__bool__` or `__len__`, it is always truthy
+                        Err(CallDunderError::MethodNotAvailable) => Ok(Truthiness::AlwaysTrue),
+                        // TODO: errors during a `__len__` call (if `__len__` exists) should be reported
+                        // as diagnostics similar to errors during a `__bool__` call (when `__bool__` exists)
+                        Err(_) => Ok(Truthiness::Ambiguous),
                     }
                 }
+
+                Err(CallDunderError::MethodNotAvailable) => Ok(Truthiness::Ambiguous),
 
                 Err(CallDunderError::CallError(CallErrorKind::BindingError, bindings, _)) => {
                     Err(BoolError::IncorrectArguments {

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -300,9 +300,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
             match argument {
                 Argument::Variadic => {
                     if !matches!(
-                        argument_ty
-                            .as_nominal_instance()
-                            .and_then(|nominal| nominal.tuple_spec(db)),
+                        argument_ty.tuple_instance_spec(db),
                         Some(spec) if spec.as_fixed_length().is_some()
                     ) {
                         return None;
@@ -541,14 +539,18 @@ pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
         Type::Intersection(intersection) => intersection.finite_alternatives(db).is_some(),
         Type::NominalInstance(instance) => {
             let class = instance.class(db);
-            class.is_known(db, KnownClass::Bool)
-                || instance.tuple_spec(db).is_some_and(|spec| match &*spec {
-                    Tuple::Fixed(fixed_length_tuple) => fixed_length_tuple
-                        .iter_all_elements()
-                        .any(|element| is_expandable_type(db, element)),
-                    Tuple::Variable(_) => false,
-                })
-                || enum_metadata(db, class.class_literal(db)).is_some()
+            if class.is_known(db, KnownClass::Bool) {
+                return true;
+            }
+            if let Some(tuple_spec) = instance.tuple_spec(db)
+                && let Tuple::Fixed(fixed_length_tuple) = &*tuple_spec
+                && fixed_length_tuple
+                    .iter_all_elements()
+                    .any(|element| is_expandable_type(db, element))
+            {
+                return true;
+            }
+            enum_metadata(db, class.class_literal(db)).is_some()
         }
         Type::Union(_) => true,
         Type::TypeAlias(alias) => is_expandable_type(db, alias.value_type(db)),

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2232,10 +2232,10 @@ impl<'db> Bindings<'db> {
                         }
 
                         Some(KnownFunction::Len) => {
-                            if let [Some(first_arg)] = overload.parameter_types() {
-                                if let Some(len_ty) = first_arg.len(db) {
-                                    overload.set_return_type(len_ty);
-                                }
+                            if let [Some(first_arg)] = overload.parameter_types()
+                                && let Some(len_ty) = first_arg.len(db)
+                            {
+                                overload.set_return_type(len_ty);
                             }
                         }
 
@@ -2268,18 +2268,18 @@ impl<'db> Bindings<'db> {
                             // Similarly to `is_protocol`, we only evaluate to this a frozenset of literal strings if a
                             // class-literal is passed in, not if a generic alias is passed in, to emulate the behaviour
                             // of `typing.get_protocol_members` at runtime.
-                            if let [Some(Type::ClassLiteral(class))] = overload.parameter_types() {
-                                if let Some(protocol_class) = class.into_protocol_class(db) {
-                                    let member_names = protocol_class
-                                        .interface(db)
-                                        .members(db)
-                                        .map(|member| Type::string_literal(db, member.name()));
-                                    let specialization = UnionType::from_elements(db, member_names);
-                                    overload.set_return_type(
-                                        KnownClass::FrozenSet
-                                            .to_specialized_instance(db, &[specialization]),
-                                    );
-                                }
+                            if let [Some(Type::ClassLiteral(class))] = overload.parameter_types()
+                                && let Some(protocol_class) = class.into_protocol_class(db)
+                            {
+                                let member_names = protocol_class
+                                    .interface(db)
+                                    .members(db)
+                                    .map(|member| Type::string_literal(db, member.name()));
+                                let specialization = UnionType::from_elements(db, member_names);
+                                overload.set_return_type(
+                                    KnownClass::FrozenSet
+                                        .to_specialized_instance(db, &[specialization]),
+                                );
                             }
                         }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -813,30 +813,28 @@ impl<'db> StaticClassLiteral<'db> {
                 });
 
         // Dataclass transformer flags can be overwritten using class arguments.
-        if let Some(transformer_params) = transformer_params.as_mut() {
-            if let Some(class_def) = self.definition(db).kind(db).as_class() {
-                let module = parsed_module(db, self.file(db)).load(db);
+        if let Some(transformer_params) = transformer_params.as_mut()
+            && let Some(class_def) = self.definition(db).kind(db).as_class()
+        {
+            let module = parsed_module(db, self.file(db)).load(db);
 
-                if let Some(arguments) = &class_def.node(&module).arguments {
-                    let mut flags = transformer_params.flags(db);
+            if let Some(arguments) = &class_def.node(&module).arguments {
+                let mut flags = transformer_params.flags(db);
 
-                    for keyword in &arguments.keywords {
-                        if let Some(arg_name) = &keyword.arg {
-                            if let Some(is_set) =
-                                keyword.value.as_boolean_literal_expr().map(|b| b.value)
-                            {
-                                for (flag_name, flag) in DATACLASS_FLAGS {
-                                    if arg_name.as_str() == *flag_name {
-                                        flags.set(*flag, is_set);
-                                    }
-                                }
+                for ast::Keyword { arg, value, .. } in &arguments.keywords {
+                    if let Some(arg_name) = arg
+                        && let ast::Expr::BooleanLiteral(is_set) = value
+                    {
+                        for (flag_name, flag) in DATACLASS_FLAGS {
+                            if arg_name == *flag_name {
+                                flags.set(*flag, is_set.value);
                             }
                         }
                     }
-
-                    *transformer_params =
-                        DataclassParams::new(db, flags, transformer_params.field_specifiers(db));
                 }
+
+                *transformer_params =
+                    DataclassParams::new(db, flags, transformer_params.field_specifiers(db));
             }
         }
 
@@ -1305,12 +1303,11 @@ impl<'db> StaticClassLiteral<'db> {
         // For enum classes, `nonmember(value)` creates a non-member attribute.
         // At runtime, the enum metaclass unwraps the value, so accessing the attribute
         // returns the inner value, not the `nonmember` wrapper.
-        if let Some(ty) = member.inner.place.raw_type() {
-            if let Some(value_ty) = try_unwrap_nonmember_value(db, ty) {
-                if is_enum_class_by_inheritance(db, self) {
-                    return Member::definitely_declared(value_ty);
-                }
-            }
+        if let Some(ty) = member.inner.place.raw_type()
+            && let Some(value_ty) = try_unwrap_nonmember_value(db, ty)
+            && is_enum_class_by_inheritance(db, self)
+        {
+            return Member::definitely_declared(value_ty);
         }
 
         member
@@ -3158,8 +3155,7 @@ fn expanded_fixed_length_starred_class_base_tuple<'db>(
     };
 
     let starred_ty = definition_expression_type(db, class_definition, &starred.value);
-    let tuple_spec = starred_ty.tuple_instance_spec(db)?;
-    let Tuple::Fixed(tuple) = tuple_spec.into_owned() else {
+    let Tuple::Fixed(tuple) = starred_ty.tuple_instance_spec(db)?.into_owned() else {
         return None;
     };
     Some(tuple)

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -768,13 +768,12 @@ fn add_equal_enum_literals<'db>(
                 builder = builder.add(Type::LiteralValue(literal));
             }
         }
-        ty => {
-            if let Some(alternatives) = finite_alternatives(db, ty, operator) {
-                for alternative in alternatives {
-                    builder = add_equal_enum_literals(db, alternative, right, operator, builder);
-                }
+        ty if let Some(alternatives) = finite_alternatives(db, ty, operator) => {
+            for alternative in alternatives {
+                builder = add_equal_enum_literals(db, alternative, right, operator, builder);
             }
         }
+        _ => {}
     }
     builder
 }
@@ -1383,14 +1382,13 @@ impl KnownComparisonSemantics {
                 complement.enum_class(db).to_non_generic_instance(db),
                 operator,
             ),
+            Type::Intersection(intersection)
+                if let Some(complement) = intersection.enum_complement(db) =>
+            {
+                let instance = complement.enum_class(db).to_non_generic_instance(db);
+                Self::of_instance(db, instance, operator)
+            }
             Type::Intersection(intersection) => {
-                if let Some(complement) = intersection.enum_complement(db) {
-                    return Self::of_instance(
-                        db,
-                        complement.enum_class(db).to_non_generic_instance(db),
-                        operator,
-                    );
-                }
                 let mut semantics = intersection
                     .positive(db)
                     .iter()

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1627,25 +1627,24 @@ fn check_classinfo_in_isinstance<'db>(
                 classinfo_expr,
             );
         }
-        Type::NominalInstance(nominal) => {
-            if let Some(tuple_spec) = nominal.tuple_spec(db) {
-                let element_exprs = match classinfo_expr {
-                    Some(ast::Expr::Tuple(tuple_expr)) => Some(&tuple_expr.elts),
-                    _ => None,
-                };
-                for (index, element) in tuple_spec.iter_element_types(db).enumerate() {
-                    let element_expr = element_exprs.and_then(|elts| elts.get(index));
-                    check_classinfo_in_isinstance(
-                        db,
-                        context,
-                        call_expression,
-                        function,
-                        element,
-                        element_expr,
-                    );
-                }
+        Type::NominalInstance(nominal) if let Some(tuple_spec) = nominal.tuple_spec(db) => {
+            let element_exprs = match classinfo_expr {
+                Some(ast::Expr::Tuple(tuple_expr)) => Some(&tuple_expr.elts),
+                _ => None,
+            };
+            for (index, element) in tuple_spec.iter_element_types(db).enumerate() {
+                let element_expr = element_exprs.and_then(|elts| elts.get(index));
+                check_classinfo_in_isinstance(
+                    db,
+                    context,
+                    call_expression,
+                    function,
+                    element,
+                    element_expr,
+                );
             }
         }
+
         _ => {}
     }
 }
@@ -1901,10 +1900,7 @@ fn is_instance_truthiness<'db>(
 ///         return True
 /// ```
 fn is_instance_tuple_exhaustive<'db>(db: &'db dyn Db, ty: Type<'db>, classinfo: Type<'db>) -> bool {
-    let Some(tuple) = classinfo
-        .as_nominal_instance()
-        .and_then(|nominal| nominal.tuple_spec(db))
-    else {
+    let Some(tuple) = classinfo.tuple_instance_spec(db) else {
         return false;
     };
     if tuple.is_variadic() {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -3277,99 +3277,97 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
+            // Special case: `formal` and `actual` are both tuples.
+            (Type::NominalInstance(formal), Type::NominalInstance(actual))
+                if let Some(formal_tuple) = formal.tuple_spec(self.db)
+                    && let Some(actual_tuple) = actual.tuple_spec(self.db) =>
+            {
+                if let TupleSpec::Variable(formal_variable) = &*formal_tuple
+                    && let VariableSegment::TypeVarTuple(typevartuple) = formal_variable.variable()
+                {
+                    let formal_prefix_len = formal_variable.prefix_elements().len();
+                    let formal_suffix_len = formal_variable.suffix_elements().len();
+                    let (actual_prefix, packed, actual_suffix) = match &*actual_tuple {
+                        TupleSpec::Fixed(actual) => {
+                            let Some(middle_end) = actual.len().checked_sub(formal_suffix_len)
+                            else {
+                                return Ok(());
+                            };
+                            if middle_end < formal_prefix_len {
+                                return Ok(());
+                            }
+
+                            let elements = actual.elements_slice();
+                            (
+                                &elements[..formal_prefix_len],
+                                Type::heterogeneous_tuple(
+                                    self.db,
+                                    elements[formal_prefix_len..middle_end].iter().copied(),
+                                ),
+                                &elements[middle_end..],
+                            )
+                        }
+                        TupleSpec::Variable(actual) => {
+                            let actual_prefix_elements = actual.prefix_elements();
+                            let actual_suffix_elements = actual.suffix_elements();
+                            if actual_prefix_elements.len() < formal_prefix_len
+                                || actual_suffix_elements.len() < formal_suffix_len
+                            {
+                                return Ok(());
+                            }
+
+                            let suffix_start = actual_suffix_elements.len() - formal_suffix_len;
+                            (
+                                &actual_prefix_elements[..formal_prefix_len],
+                                Type::tuple(TupleType::mixed_with_segment(
+                                    self.db,
+                                    actual_prefix_elements[formal_prefix_len..].iter().copied(),
+                                    actual.variable(),
+                                    actual_suffix_elements[..suffix_start].iter().copied(),
+                                )),
+                                &actual_suffix_elements[suffix_start..],
+                            )
+                        }
+                    };
+                    let variance = TypeVarVariance::Covariant.compose(polarity);
+                    for (formal_element, actual_element) in
+                        formal_variable.prefix_elements().iter().zip(actual_prefix)
+                    {
+                        self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
+                    }
+                    for (formal_element, actual_element) in
+                        formal_variable.suffix_elements().iter().zip(actual_suffix)
+                    {
+                        self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
+                    }
+                    self.add_type_mapping(typevartuple, packed, variance);
+                    return Ok(());
+                }
+
+                let Some(most_precise_length) = formal_tuple.len().most_precise(actual_tuple.len())
+                else {
+                    return Ok(());
+                };
+                let Ok(formal_tuple) = formal_tuple.resize(self.db, most_precise_length) else {
+                    return Ok(());
+                };
+                let Ok(actual_tuple) = actual_tuple.resize(self.db, most_precise_length) else {
+                    return Ok(());
+                };
+                for (formal_element, actual_element) in formal_tuple
+                    .iter_element_types(self.db)
+                    .zip(actual_tuple.iter_element_types(self.db))
+                {
+                    let variance = TypeVarVariance::Covariant.compose(polarity);
+                    self.infer_map_impl(formal_element, actual_element, variance, seen)?;
+                }
+                return Ok(());
+            }
+
             (
                 formal @ (Type::NominalInstance(_) | Type::ProtocolInstance(_)),
                 Type::NominalInstance(actual_nominal),
             ) => {
-                // Special case: `formal` and `actual` are both tuples.
-                if let (Some(formal_tuple), Some(actual_tuple)) = (
-                    formal.tuple_instance_spec(self.db),
-                    actual_nominal.tuple_spec(self.db),
-                ) {
-                    if let TupleSpec::Variable(formal_variable) = formal_tuple.as_ref()
-                        && let VariableSegment::TypeVarTuple(typevartuple) =
-                            formal_variable.variable()
-                    {
-                        let formal_prefix_len = formal_variable.prefix_elements().len();
-                        let formal_suffix_len = formal_variable.suffix_elements().len();
-                        let (actual_prefix, packed, actual_suffix) = match actual_tuple.as_ref() {
-                            TupleSpec::Fixed(actual) => {
-                                let Some(middle_end) = actual.len().checked_sub(formal_suffix_len)
-                                else {
-                                    return Ok(());
-                                };
-                                if middle_end < formal_prefix_len {
-                                    return Ok(());
-                                }
-
-                                let elements = actual.elements_slice();
-                                (
-                                    &elements[..formal_prefix_len],
-                                    Type::heterogeneous_tuple(
-                                        self.db,
-                                        elements[formal_prefix_len..middle_end].iter().copied(),
-                                    ),
-                                    &elements[middle_end..],
-                                )
-                            }
-                            TupleSpec::Variable(actual) => {
-                                let actual_prefix_elements = actual.prefix_elements();
-                                let actual_suffix_elements = actual.suffix_elements();
-                                if actual_prefix_elements.len() < formal_prefix_len
-                                    || actual_suffix_elements.len() < formal_suffix_len
-                                {
-                                    return Ok(());
-                                }
-
-                                let suffix_start = actual_suffix_elements.len() - formal_suffix_len;
-                                (
-                                    &actual_prefix_elements[..formal_prefix_len],
-                                    Type::tuple(TupleType::mixed_with_segment(
-                                        self.db,
-                                        actual_prefix_elements[formal_prefix_len..].iter().copied(),
-                                        actual.variable(),
-                                        actual_suffix_elements[..suffix_start].iter().copied(),
-                                    )),
-                                    &actual_suffix_elements[suffix_start..],
-                                )
-                            }
-                        };
-                        let variance = TypeVarVariance::Covariant.compose(polarity);
-                        for (formal_element, actual_element) in
-                            formal_variable.prefix_elements().iter().zip(actual_prefix)
-                        {
-                            self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
-                        }
-                        for (formal_element, actual_element) in
-                            formal_variable.suffix_elements().iter().zip(actual_suffix)
-                        {
-                            self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
-                        }
-                        self.add_type_mapping(typevartuple, packed, variance);
-                        return Ok(());
-                    }
-
-                    let Some(most_precise_length) =
-                        formal_tuple.len().most_precise(actual_tuple.len())
-                    else {
-                        return Ok(());
-                    };
-                    let Ok(formal_tuple) = formal_tuple.resize(self.db, most_precise_length) else {
-                        return Ok(());
-                    };
-                    let Ok(actual_tuple) = actual_tuple.resize(self.db, most_precise_length) else {
-                        return Ok(());
-                    };
-                    for (formal_element, actual_element) in formal_tuple
-                        .iter_element_types(self.db)
-                        .zip(actual_tuple.iter_element_types(self.db))
-                    {
-                        let variance = TypeVarVariance::Covariant.compose(polarity);
-                        self.infer_map_impl(formal_element, actual_element, variance, seen)?;
-                    }
-                    return Ok(());
-                }
-
                 // Extract formal_alias if this is a generic class
                 let formal_alias = match formal {
                     Type::NominalInstance(formal_nominal) => {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
@@ -56,10 +56,10 @@ pub(crate) fn check_dynamic_class_definition<'db>(
 
         for (idx, base_type) in dynamic_class.explicit_bases(db).iter().enumerate() {
             // Convert to ClassType to access nearest_disjoint_base.
-            if let Some(class_type) = base_type.to_class_type(db) {
-                if let Some(disjoint_base) = class_type.nearest_disjoint_base(db) {
-                    disjoint_bases.insert(disjoint_base, idx, class_type.class_literal(db));
-                }
+            if let Some(class_type) = base_type.to_class_type(db)
+                && let Some(disjoint_base) = class_type.nearest_disjoint_base(db)
+            {
+                disjoint_bases.insert(disjoint_base, idx, class_type.class_literal(db));
             }
         }
 

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -219,7 +219,11 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
 
         (Type::Intersection(intersection), right)
-            if intersection.positive(db).iter().copied().any(Type::is_type_var) =>
+            if intersection
+                .positive(db)
+                .iter()
+                .copied()
+                .any(Type::is_type_var) =>
         {
             Some(infer_binary_type_comparison(
                 context,
@@ -227,11 +231,15 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 op,
                 right,
                 range,
-                visitor
+                visitor,
             ))
         }
         (left, Type::Intersection(intersection))
-            if intersection.positive(db).iter().copied().any(Type::is_type_var) =>
+            if intersection
+                .positive(db)
+                .iter()
+                .copied()
+                .any(Type::is_type_var) =>
         {
             Some(infer_binary_type_comparison(
                 context,
@@ -239,46 +247,42 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 op,
                 intersection.with_expanded_typevars_and_newtypes(db),
                 range,
-                visitor
+                visitor,
             ))
         }
 
-        (Type::Intersection(intersection), right) => {
-            Some(
-                infer_binary_intersection_type_comparison(
-                    context,
-                    intersection,
-                    op,
-                    right,
-                    IntersectionOn::Left,
-                    range,
-                    visitor,
-                )
-                .map_err(|err| UnsupportedComparisonError {
-                    op,
-                    left_ty: left,
-                    right_ty: err.right_ty,
-                }),
+        (Type::Intersection(intersection), right) => Some(
+            infer_binary_intersection_type_comparison(
+                context,
+                intersection,
+                op,
+                right,
+                IntersectionOn::Left,
+                range,
+                visitor,
             )
-        }
-        (left, Type::Intersection(intersection)) => {
-            Some(
-                infer_binary_intersection_type_comparison(
-                    context,
-                    intersection,
-                    op,
-                    left,
-                    IntersectionOn::Right,
-                    range,
-                    visitor,
-                )
-                .map_err(|err| UnsupportedComparisonError {
-                    op,
-                    left_ty: err.left_ty,
-                    right_ty: right,
-                }),
+            .map_err(|err| UnsupportedComparisonError {
+                op,
+                left_ty: left,
+                right_ty: err.right_ty,
+            }),
+        ),
+        (left, Type::Intersection(intersection)) => Some(
+            infer_binary_intersection_type_comparison(
+                context,
+                intersection,
+                op,
+                left,
+                IntersectionOn::Right,
+                range,
+                visitor,
             )
-        }
+            .map_err(|err| UnsupportedComparisonError {
+                op,
+                left_ty: err.left_ty,
+                right_ty: right,
+            }),
+        ),
 
         (Type::TypeAlias(alias), right) => Some(visitor.visit(db, (left, op, right), || {
             infer_binary_type_comparison(context, alias.value_type(db), op, right, range, visitor)
@@ -294,8 +298,8 @@ pub(super) fn infer_binary_type_comparison<'db>(
         // the same `int | float` and `int | float | complex` special treatment that the
         // positional arguments get. In those cases we need to explicitly delegate to the base
         // type, so that it hits the `Type::Union` branches above.
-        (Type::NewTypeInstance(newtype), right) => Some(
-            try_dunder(MemberLookupPolicy::default()).or_else(|_| {
+        (Type::NewTypeInstance(newtype), right) => {
+            Some(try_dunder(MemberLookupPolicy::default()).or_else(|_| {
                 visitor.visit(db, (left, op, right), || {
                     infer_binary_type_comparison(
                         context,
@@ -306,10 +310,10 @@ pub(super) fn infer_binary_type_comparison<'db>(
                         visitor,
                     )
                 })
-            }),
-        ),
-        (left, Type::NewTypeInstance(newtype)) => Some(
-            try_dunder(MemberLookupPolicy::default()).or_else(|_| {
+            }))
+        }
+        (left, Type::NewTypeInstance(newtype)) => {
+            Some(try_dunder(MemberLookupPolicy::default()).or_else(|_| {
                 visitor.visit(db, (left, op, right), || {
                     infer_binary_type_comparison(
                         context,
@@ -320,8 +324,8 @@ pub(super) fn infer_binary_type_comparison<'db>(
                         visitor,
                     )
                 })
-            }),
-        ),
+            }))
+        }
 
         // Similar to `NewType`s, `TypeVar`s with union bounds (like `bound=float` which becomes
         // `int | float`) need to delegate to the bound type.
@@ -332,15 +336,13 @@ pub(super) fn infer_binary_type_comparison<'db>(
             if left_tvar.identity(db) == right_tvar.identity(db) =>
         {
             match left_tvar.typevar(db).bound_or_constraints(db) {
-                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => Some(
-                    try_dunder(MemberLookupPolicy::default()).or_else(|_| {
+                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                    Some(try_dunder(MemberLookupPolicy::default()).or_else(|_| {
                         visitor.visit(db, (left, op, right), || {
-                            infer_binary_type_comparison(
-                                context, bound, op, bound, range, visitor,
-                            )
+                            infer_binary_type_comparison(context, bound, op, bound, range, visitor)
                         })
-                    }),
-                ),
+                    }))
+                }
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                     // For constrained TypeVars, check each constraint paired with itself.
                     let mut builder = UnionBuilder::new(db);
@@ -358,15 +360,13 @@ pub(super) fn infer_binary_type_comparison<'db>(
         // delegate to the bound type.
         (Type::TypeVar(left_tvar), right) if !right.is_type_var() => {
             match left_tvar.typevar(db).bound_or_constraints(db) {
-                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => Some(
-                    try_dunder(MemberLookupPolicy::default()).or_else(|_| {
+                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                    Some(try_dunder(MemberLookupPolicy::default()).or_else(|_| {
                         visitor.visit(db, (left, op, right), || {
-                            infer_binary_type_comparison(
-                                context, bound, op, right, range, visitor,
-                            )
+                            infer_binary_type_comparison(context, bound, op, right, range, visitor)
                         })
-                    }),
-                ),
+                    }))
+                }
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                     let mut builder = UnionBuilder::new(db);
                     for &constraint in constraints.elements(db) {
@@ -383,15 +383,13 @@ pub(super) fn infer_binary_type_comparison<'db>(
         // delegate to the bound type.
         (left, Type::TypeVar(right_tvar)) if !left.is_type_var() => {
             match right_tvar.typevar(db).bound_or_constraints(db) {
-                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => Some(
-                    try_dunder(MemberLookupPolicy::default()).or_else(|_| {
+                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                    Some(try_dunder(MemberLookupPolicy::default()).or_else(|_| {
                         visitor.visit(db, (left, op, right), || {
-                            infer_binary_type_comparison(
-                                context, left, op, bound, range, visitor,
-                            )
+                            infer_binary_type_comparison(context, left, op, bound, range, visitor)
                         })
-                    }),
-                ),
+                    }))
+                }
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                     let mut builder = UnionBuilder::new(db);
                     for &constraint in constraints.elements(db) {
@@ -519,10 +517,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                     Some(Ok(result))
                 }
 
-                (
-                    LiteralValueTypeKind::Bytes(salsa_b1),
-                    LiteralValueTypeKind::Bytes(salsa_b2),
-                ) => {
+                (LiteralValueTypeKind::Bytes(salsa_b1), LiteralValueTypeKind::Bytes(salsa_b2)) => {
                     let b1 = salsa_b1.value(db);
                     let b2 = salsa_b2.value(db);
                     let result = match op {
@@ -604,82 +599,85 @@ pub(super) fn infer_binary_type_comparison<'db>(
             }
         }
 
-        (Type::NominalInstance(nominal1), Type::NominalInstance(nominal2)) => nominal1
-            .tuple_spec(db)
-            .and_then(|lhs_tuple| Some((lhs_tuple, nominal2.tuple_spec(db)?)))
-            .map(|(lhs_tuple, rhs_tuple)| {
-                let tuple_rich_comparison = |rich_op| {
-                    visitor.visit(db, (left, op, right), || {
-                        infer_tuple_rich_comparison(
-                            context, &lhs_tuple, rich_op, &rhs_tuple, range, visitor,
+        (Type::NominalInstance(nominal1), Type::NominalInstance(nominal2))
+            if let Some(lhs_tuple) = nominal1.tuple_spec(db)
+                && let Some(rhs_tuple) = nominal2.tuple_spec(db) =>
+        {
+            let tuple_rich_comparison = |rich_op| {
+                visitor.visit(db, (left, op, right), || {
+                    infer_tuple_rich_comparison(
+                        context, &lhs_tuple, rich_op, &rhs_tuple, range, visitor,
+                    )
+                })
+            };
+
+            let result = match op {
+                ast::CmpOp::Eq => tuple_rich_comparison(RichCompareOperator::Eq),
+                ast::CmpOp::NotEq => tuple_rich_comparison(RichCompareOperator::Ne),
+                ast::CmpOp::Lt => tuple_rich_comparison(RichCompareOperator::Lt),
+                ast::CmpOp::LtE => tuple_rich_comparison(RichCompareOperator::Le),
+                ast::CmpOp::Gt => tuple_rich_comparison(RichCompareOperator::Gt),
+                ast::CmpOp::GtE => tuple_rich_comparison(RichCompareOperator::Ge),
+                ast::CmpOp::In | ast::CmpOp::NotIn => {
+                    let mut any_eq = false;
+                    let mut any_ambiguous = false;
+
+                    for ty in rhs_tuple.iter_element_types(db) {
+                        let eq_result = infer_binary_type_comparison(
+                            context,
+                            left,
+                            ast::CmpOp::Eq,
+                            ty,
+                            range,
+                            visitor,
                         )
-                    })
-                };
+                        .expect(
+                            "infer_binary_type_comparison should never return None for `CmpOp::Eq`",
+                        );
 
-                match op {
-                    ast::CmpOp::Eq => tuple_rich_comparison(RichCompareOperator::Eq),
-                    ast::CmpOp::NotEq => tuple_rich_comparison(RichCompareOperator::Ne),
-                    ast::CmpOp::Lt => tuple_rich_comparison(RichCompareOperator::Lt),
-                    ast::CmpOp::LtE => tuple_rich_comparison(RichCompareOperator::Le),
-                    ast::CmpOp::Gt => tuple_rich_comparison(RichCompareOperator::Gt),
-                    ast::CmpOp::GtE => tuple_rich_comparison(RichCompareOperator::Ge),
-                    ast::CmpOp::In | ast::CmpOp::NotIn => {
-                        let mut any_eq = false;
-                        let mut any_ambiguous = false;
-
-                        for ty in rhs_tuple.iter_element_types(db) {
-                            let eq_result = infer_binary_type_comparison(
-                                context,
-                                left,
-                                ast::CmpOp::Eq,
-                                ty,
-                                range,
-                                visitor,
-                            )
-                            .expect("infer_binary_type_comparison should never return None for `CmpOp::Eq`");
-
-                            match eq_result {
-                                todo @ Type::Dynamic(DynamicType::Todo(_)) => return Ok(todo),
-                                // It's okay to ignore errors here because Python doesn't call `__bool__`
-                                // for different union variants. Instead, this is just for us to
-                                // evaluate a possibly truthy value to `false` or `true`.
-                                ty => match ty.bool(db) {
-                                    Truthiness::AlwaysTrue => any_eq = true,
-                                    Truthiness::AlwaysFalse => (),
-                                    Truthiness::Ambiguous => any_ambiguous = true,
-                                },
-                            }
-                        }
-
-                        if any_eq {
-                            Ok(Type::bool_literal(op.is_in()))
-                        } else if !any_ambiguous {
-                            Ok(Type::bool_literal(op.is_not_in()))
-                        } else {
-                            Ok(KnownClass::Bool.to_instance(db))
+                        match eq_result {
+                            todo @ Type::Dynamic(DynamicType::Todo(_)) => return Ok(todo),
+                            // It's okay to ignore errors here because Python doesn't call `__bool__`
+                            // for different union variants. Instead, this is just for us to
+                            // evaluate a possibly truthy value to `false` or `true`.
+                            ty => match ty.bool(db) {
+                                Truthiness::AlwaysTrue => any_eq = true,
+                                Truthiness::AlwaysFalse => (),
+                                Truthiness::Ambiguous => any_ambiguous = true,
+                            },
                         }
                     }
-                    ast::CmpOp::Is | ast::CmpOp::IsNot => {
-                        // - `[ast::CmpOp::Is]`: returns `false` if the elements are definitely unequal, otherwise `bool`
-                        // - `[ast::CmpOp::IsNot]`: returns `true` if the elements are definitely unequal, otherwise `bool`
-                        let eq_result =
-                            tuple_rich_comparison(RichCompareOperator::Eq).expect(
-                                "infer_binary_type_comparison should never return None for `CmpOp::Eq`",
-                            );
 
-                        Ok(match eq_result {
-                            todo @ Type::Dynamic(DynamicType::Todo(_)) => todo,
-                            // It's okay to ignore errors here because Python doesn't call `__bool__`
-                            // for `is` and `is not` comparisons. This is an implementation detail
-                            // for how we determine the truthiness of a type.
-                            ty => match ty.bool(db) {
-                                Truthiness::AlwaysFalse => Type::bool_literal(op.is_is_not()),
-                                _ => KnownClass::Bool.to_instance(db),
-                            },
-                        })
+                    if any_eq {
+                        Ok(Type::bool_literal(op.is_in()))
+                    } else if !any_ambiguous {
+                        Ok(Type::bool_literal(op.is_not_in()))
+                    } else {
+                        Ok(KnownClass::Bool.to_instance(db))
                     }
                 }
-            }),
+                ast::CmpOp::Is | ast::CmpOp::IsNot => {
+                    // - `[ast::CmpOp::Is]`: returns `false` if the elements are definitely unequal, otherwise `bool`
+                    // - `[ast::CmpOp::IsNot]`: returns `true` if the elements are definitely unequal, otherwise `bool`
+                    let eq_result = tuple_rich_comparison(RichCompareOperator::Eq).expect(
+                        "infer_binary_type_comparison should never return None for `CmpOp::Eq`",
+                    );
+
+                    Ok(match eq_result {
+                        todo @ Type::Dynamic(DynamicType::Todo(_)) => todo,
+                        // It's okay to ignore errors here because Python doesn't call `__bool__`
+                        // for `is` and `is not` comparisons. This is an implementation detail
+                        // for how we determine the truthiness of a type.
+                        ty => match ty.bool(db) {
+                            Truthiness::AlwaysFalse => Type::bool_literal(op.is_is_not()),
+                            _ => KnownClass::Bool.to_instance(db),
+                        },
+                    })
+                }
+            };
+
+            Some(result)
+        }
 
         _ => None,
     };

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -794,15 +794,15 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         if left.is_object() || right.is_object() {
             return result;
         }
-        if let Some(left_spec) = left.tuple_spec(db) {
-            if let Some(right_spec) = right.tuple_spec(db) {
-                let compatible = self.check_tuple_spec_pair(db, &left_spec, &right_spec);
-                if result
-                    .union(db, self.constraints, compatible)
-                    .is_always_satisfied(db)
-                {
-                    return result;
-                }
+        if let Some(left_spec) = left.tuple_spec(db)
+            && let Some(right_spec) = right.tuple_spec(db)
+        {
+            let compatible = self.check_tuple_spec_pair(db, &left_spec, &right_spec);
+            if result
+                .union(db, self.constraints, compatible)
+                .is_always_satisfied(db)
+            {
+                return result;
             }
         }
 

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -266,20 +266,13 @@ impl<'db> AllMembers<'db> {
                     self.extend_with_type(db, KnownClass::Type.to_instance(db));
                 }
                 _ => {
-                    if let Some(class_type) = subclass_of_type.subclass_of().into_class(db) {
-                        if let Some((class_literal, _)) = class_type.static_class_literal(db) {
-                            self.extend_with_class_members(
-                                db,
-                                ty,
-                                ClassLiteral::Static(class_literal),
-                            );
-                            self.extend_with_synthetic_members(
-                                db,
-                                ty,
-                                ClassLiteral::Static(class_literal),
-                            );
-                            self.extend_with_metaclass_members(db, ty, class_literal.metaclass(db));
-                        }
+                    if let Some(class_type) = subclass_of_type.subclass_of().into_class(db)
+                        && let Some((class_literal, _)) = class_type.static_class_literal(db)
+                    {
+                        let static_class = ClassLiteral::Static(class_literal);
+                        self.extend_with_class_members(db, ty, static_class);
+                        self.extend_with_synthetic_members(db, ty, static_class);
+                        self.extend_with_metaclass_members(db, ty, class_literal.metaclass(db));
                     }
                 }
             },

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -527,14 +527,14 @@ impl ClassInfoConstraintFunction {
             // e.g. `isinstance(x, list[int])` fails at runtime.
             Type::GenericAlias(_) => None,
 
-            Type::NominalInstance(nominal) => nominal.tuple_spec(db).and_then(|tuple| {
+            Type::NominalInstance(nominal) if let Some(tuple) = nominal.tuple_spec(db) => {
                 UnionType::try_from_elements(
                     db,
                     tuple
                         .iter_element_types(db)
                         .map(|element| self.generate_constraint(db, element, is_positive)),
                 )
-            }),
+            }
 
             Type::KnownInstance(KnownInstanceType::UnionType(instance)) => {
                 UnionType::try_from_elements(
@@ -607,6 +607,7 @@ impl ClassInfoConstraintFunction {
             | Type::WrapperDescriptor(_)
             | Type::DataclassTransformer(_)
             | Type::TypedDict(_)
+            | Type::NominalInstance(_)
             | Type::NewTypeInstance(_) => None,
         }
     }
@@ -2846,10 +2847,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         Err(_) => Type::Never,
                     }
                 } else {
-                    let tuple_length = resolved
-                        .as_nominal_instance()
-                        .and_then(|instance| instance.tuple_spec(db))
-                        .map(|spec| spec.len());
+                    let tuple_length = resolved.tuple_instance_spec(db).map(|spec| spec.len());
                     let satisfies_comparison = |length_type: Type<'db>| {
                         length_type
                             .as_int_literal()
@@ -3218,8 +3216,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         {
             let is_positive_check = is_positive == (ops[0] == ast::CmpOp::Is);
             let filtered = union.filter(self.db, |elem| {
-                elem.as_nominal_instance()
-                    .and_then(|inst| inst.tuple_spec(self.db))
+                elem.tuple_instance_spec(self.db)
                     .and_then(|spec| spec.py_index(self.db, index).ok())
                     .is_none_or(|el_ty| {
                         if is_positive_check {
@@ -4197,8 +4194,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         // Filter the union based on whether each tuple element at the index could match the rhs.
         let filtered = union.filter(self.db, |elem| {
-            elem.as_nominal_instance()
-                .and_then(|inst| inst.tuple_spec(self.db))
+            elem.tuple_instance_spec(self.db)
                 .and_then(|spec| spec.py_index(self.db, index).ok())
                 .is_none_or(|el_ty| {
                     if is_equality {
@@ -4532,8 +4528,7 @@ fn any_tuple_has_out_of_bounds_index<'db>(
     index: i32,
 ) -> bool {
     union.elements(db).iter().any(|elem| {
-        elem.as_nominal_instance()
-            .and_then(|inst| inst.tuple_spec(db))
+        elem.tuple_instance_spec(db)
             .is_some_and(|spec| spec.py_index(db, index).is_err())
     })
 }
@@ -4550,8 +4545,7 @@ fn all_matching_tuple_elements_have_literal_types<'db>(
     index: i32,
 ) -> bool {
     union.elements(db).iter().all(|elem| {
-        elem.as_nominal_instance()
-            .and_then(|inst| inst.tuple_spec(db))
+        elem.tuple_instance_spec(db)
             .and_then(|spec| spec.py_index(db, index).ok())
             .is_none_or(is_supported_tag_literal)
     })

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -1867,16 +1867,14 @@ fn check_enum_member_against_constructor_method<'db>(
     // The enum metaclass unpacks tuple values as positional args:
     //   MEMBER = (a, b, c)  →  __new__(cls, a, b, c) / __init__(self, a, b, c)
     //   MEMBER = x          →  __new__(cls, x) / __init__(self, x)
-    let args: Vec<Type<'db>> = if let Type::NominalInstance(instance) = member_value_type {
-        if let Some(spec) = instance.tuple_spec(db) {
-            if let Tuple::Fixed(fixed) = &*spec {
-                fixed.all_elements().to_vec()
-            } else {
-                // Variable-length tuples: can't determine exact args, skip validation.
-                return;
-            }
+    let args: Vec<Type<'db>> = if let Type::NominalInstance(instance) = member_value_type
+        && let Some(spec) = instance.tuple_spec(db)
+    {
+        if let Tuple::Fixed(fixed) = &*spec {
+            fixed.all_elements().to_vec()
         } else {
-            vec![member_value_type]
+            // Variable-length tuples: can't determine exact args, skip validation.
+            return;
         }
     } else {
         vec![member_value_type]

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -266,7 +266,8 @@ impl<'db> SubscriptErrorKind<'db> {
                 CallErrorKind::NotCallable => {
                     if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, value_node) {
                         builder.into_diagnostic(format_args!(
-                            "Method `{method}` of type `{}` is not callable on object of type `{}`",
+                            "Method `{method}` of type `{}` is not callable \
+                            on object of type `{}`",
                             bindings.callable_type().display(db),
                             value_ty.display(db),
                         ));
@@ -287,7 +288,8 @@ impl<'db> SubscriptErrorKind<'db> {
                         context.report_lint(&INVALID_ARGUMENT_TYPE, value_node)
                     {
                         builder.into_diagnostic(format_args!(
-                            "Method `{method}` of type `{}` cannot be called with key of type `{}` on object of type `{}`",
+                            "Method `{method}` of type `{}` cannot be called \
+                            with key of type `{}` on object of type `{}`",
                             bindings.callable_type().display(db),
                             slice_ty.display(db),
                             value_ty.display(db),
@@ -297,7 +299,8 @@ impl<'db> SubscriptErrorKind<'db> {
                 CallErrorKind::PossiblyNotCallable => {
                     if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, value_node) {
                         builder.into_diagnostic(format_args!(
-                            "Method `{method}` of type `{}` may not be callable on object of type `{}`",
+                            "Method `{method}` of type `{}` may not be callable \
+                            on object of type `{}`",
                             bindings.callable_type().display(db),
                             value_ty.display(db),
                         ));
@@ -356,7 +359,8 @@ impl<'db> SubscriptErrorKind<'db> {
             Self::MultipleTypeVarTuples { origin } => {
                 if let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, subscript) {
                     builder.into_diagnostic(format_args!(
-                        "Only one `TypeVarTuple` parameter is allowed in a `{origin}` subscription",
+                        "Only one `TypeVarTuple` parameter is allowed \
+                        in a `{origin}` subscription",
                     ));
                 }
             }
@@ -567,9 +571,11 @@ impl<'db> Type<'db> {
                 value_ty.subscript(db, element, expr_context)
             })),
 
-            (Type::EnumComplement(complement), _) => {
-                Some(complement.remaining_literal_union(db).subscript(db, slice_ty, expr_context))
-            }
+            (Type::EnumComplement(complement), _) => Some(
+                complement
+                    .remaining_literal_union(db)
+                    .subscript(db, slice_ty, expr_context),
+            ),
 
             (_, Type::EnumComplement(complement)) => {
                 Some(value_ty.subscript(db, complement.remaining_literal_union(db), expr_context))
@@ -606,10 +612,8 @@ impl<'db> Type<'db> {
                         | KnownClass::Range
                         | KnownClass::Memoryview
                 )
-            )
-                && maybe_slice_nominal
-                    .slice_literal(db)
-                    .is_some_and(|slice| slice.step == Some(0)) =>
+            ) && let Some(SliceLiteral { step: Some(0), .. }) =
+                maybe_slice_nominal.slice_literal(db) =>
             {
                 Some(Err(SubscriptError::new(
                     value_ty,
@@ -619,85 +623,88 @@ impl<'db> Type<'db> {
 
             // Ex) Given `("a", "b", "c", "d")[1]`, return `"b"`
             (Type::NominalInstance(nominal), Type::LiteralValue(literal))
-                if let Some(i64_int) = literal.as_int() =>
+                if let Some(i64_int) = literal.as_int()
+                    && let Some(tuple) = nominal.tuple_spec(db)
+                    && let Ok(i32_int) = i32::try_from(i64_int) =>
             {
-                nominal
-                    .tuple_spec(db)
-                    .and_then(|tuple| Some((tuple, i32::try_from(i64_int).ok()?)))
-                    .map(|(tuple, i32_int)| match tuple.py_index(db, i32_int) {
-                        Ok(result) => Ok(result),
-                        Err(_) => Err(SubscriptError::new(
-                            Type::unknown(),
-                            SubscriptErrorKind::IndexOutOfBounds {
-                                kind: SubscriptKind::Tuple,
-                                tuple_ty: value_ty,
-                                length: tuple.len().display_minimum().into(),
-                                index: i64_int,
-                            },
-                        )),
-                    })
+                let result = tuple.py_index(db, i32_int).map_err(|_| {
+                    SubscriptError::new(
+                        Type::unknown(),
+                        SubscriptErrorKind::IndexOutOfBounds {
+                            kind: SubscriptKind::Tuple,
+                            tuple_ty: value_ty,
+                            length: tuple.len().display_minimum().into(),
+                            index: i64_int,
+                        },
+                    )
+                });
+
+                Some(result)
             }
 
             // Ex) Given `("a", 1, Null)[0:2]`, return `("a", 1)`
             (
                 Type::NominalInstance(maybe_tuple_nominal),
                 Type::NominalInstance(maybe_slice_nominal),
-            ) => maybe_tuple_nominal
-                .tuple_spec(db)
-                .as_deref()
-                .and_then(|tuple_spec| Some((tuple_spec, maybe_slice_nominal.slice_literal(db)?)))
-                .map(|(tuple, SliceLiteral { start, stop, step })| {
-                    tuple.py_slice_type(db, start, stop, step).map_err(|_| {
-                        SubscriptError::new(Type::unknown(), SubscriptErrorKind::SliceStepSizeZero)
-                    })
-                }),
+            ) if let Some(tuple) = maybe_tuple_nominal.tuple_spec(db)
+                && let Some(SliceLiteral { start, stop, step }) =
+                    maybe_slice_nominal.slice_literal(db) =>
+            {
+                Some(tuple.py_slice_type(db, start, stop, step).map_err(|_| {
+                    SubscriptError::new(Type::unknown(), SubscriptErrorKind::SliceStepSizeZero)
+                }))
+            }
 
             // Ex) Given `"value"[1]`, return `"a"`
             (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal))
                 if let Some(literal_ty) = lhs_literal.as_string()
-                    && let Some(i64_int) = rhs_literal.as_int() =>
+                    && let Some(i64_int) = rhs_literal.as_int()
+                    && let Ok(i32_int) = i32::try_from(i64_int) =>
             {
-                i32::try_from(i64_int).ok().map(|i32_int| {
-                    let literal_value = literal_ty.value(db);
-                    match (&mut literal_value.chars()).py_index(db, i32_int) {
-                        Ok(ch) => Ok(Type::string_literal(db, ch.to_compact_string())),
-                        Err(_) => Err(SubscriptError::new(
-                            Type::unknown(),
-                            SubscriptErrorKind::IndexOutOfBounds {
-                                kind: SubscriptKind::String,
-                                tuple_ty: value_ty,
-                                length: literal_value.chars().count().to_string().into(),
-                                index: i64_int,
-                            },
-                        )),
-                    }
-                })
+                let literal_value = literal_ty.value(db);
+
+                let result = match (&mut literal_value.chars()).py_index(db, i32_int) {
+                    Ok(ch) => Ok(Type::string_literal(db, ch.to_compact_string())),
+                    Err(_) => Err(SubscriptError::new(
+                        Type::unknown(),
+                        SubscriptErrorKind::IndexOutOfBounds {
+                            kind: SubscriptKind::String,
+                            tuple_ty: value_ty,
+                            length: literal_value.chars().count().to_string().into(),
+                            index: i64_int,
+                        },
+                    )),
+                };
+
+                Some(result)
             }
 
             // Ex) Given `"value"[1:3]`, return `"al"`
             (Type::LiteralValue(literal), Type::NominalInstance(nominal))
-                if let Some(literal_ty) = literal.as_string() =>
+                if let Some(literal_ty) = literal.as_string()
+                    && let Some(SliceLiteral { start, stop, step }) = nominal.slice_literal(db) =>
             {
-                nominal
-                .slice_literal(db)
-                .map(|SliceLiteral { start, stop, step }| {
-                    let literal_value = literal_ty.value(db);
-                    let chars: Vec<_> = literal_value.chars().collect();
+                let literal_value = literal_ty.value(db);
+                let chars: Vec<_> = literal_value.chars().collect();
 
-                    match chars.py_slice(db, start, stop, step) {
-                        Ok(new_chars) => {
-                            let literal = new_chars.collect::<CompactString>();
-                            Ok(Type::string_literal(db, literal))
-                        }
-                        Err(_) => Err(SubscriptError::new(
-                            Type::unknown(),
-                            SubscriptErrorKind::SliceStepSizeZero,
-                        )),
+                let result = match chars.py_slice(db, start, stop, step) {
+                    Ok(new_chars) => {
+                        let literal = new_chars.collect::<CompactString>();
+                        Ok(Type::string_literal(db, literal))
                     }
-                })
-            },
+                    Err(_) => Err(SubscriptError::new(
+                        Type::unknown(),
+                        SubscriptErrorKind::SliceStepSizeZero,
+                    )),
+                };
 
-            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if lhs_literal.is_literal_string() && (rhs_literal.is_int() || rhs_literal.is_bool()) => {
+                Some(result)
+            }
+
+            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal))
+                if lhs_literal.is_literal_string()
+                    && (rhs_literal.is_int() || rhs_literal.is_bool()) =>
+            {
                 Some(Ok(Type::literal_string()))
             }
 
@@ -710,46 +717,47 @@ impl<'db> Type<'db> {
             // Ex) Given `b"value"[1]`, return `97` (i.e., `ord(b"a")`)
             (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal))
                 if let Some(literal_ty) = lhs_literal.as_bytes()
-                    && let Some(i64_int) = rhs_literal.as_int() =>
+                    && let Some(i64_int) = rhs_literal.as_int()
+                    && let Ok(i32_int) = i32::try_from(i64_int) =>
             {
-                i32::try_from(i64_int).ok().map(|i32_int| {
-                    let literal_value = literal_ty.value(db);
-                    match literal_value.py_index(db, i32_int) {
-                        Ok(byte) => Ok(Type::int_literal((*byte).into())),
-                        Err(_) => Err(SubscriptError::new(
-                            Type::unknown(),
-                            SubscriptErrorKind::IndexOutOfBounds {
-                                kind: SubscriptKind::BytesLiteral,
-                                tuple_ty: value_ty,
-                                length: literal_value.len().to_string().into(),
-                                index: i64_int,
-                            },
-                        )),
-                    }
-                })
+                let literal_value = literal_ty.value(db);
+
+                let result = match literal_value.py_index(db, i32_int) {
+                    Ok(byte) => Ok(Type::int_literal((*byte).into())),
+                    Err(_) => Err(SubscriptError::new(
+                        Type::unknown(),
+                        SubscriptErrorKind::IndexOutOfBounds {
+                            kind: SubscriptKind::BytesLiteral,
+                            tuple_ty: value_ty,
+                            length: literal_value.len().to_string().into(),
+                            index: i64_int,
+                        },
+                    )),
+                };
+
+                Some(result)
             }
 
             // Ex) Given `b"value"[1:3]`, return `b"al"`
             (Type::LiteralValue(literal), Type::NominalInstance(nominal))
-                if let Some(literal_ty) = literal.as_bytes() =>
+                if let Some(literal_ty) = literal.as_bytes()
+                    && let Some(SliceLiteral { start, stop, step }) = nominal.slice_literal(db) =>
             {
-                nominal
-                .slice_literal(db)
-                .map(|SliceLiteral { start, stop, step }| {
-                    let literal_value = literal_ty.value(db);
+                let literal_value = literal_ty.value(db);
 
-                    match literal_value.py_slice(db, start, stop, step) {
-                        Ok(new_bytes) => {
-                            let new_bytes = new_bytes.collect::<Vec<u8>>();
-                            Ok(Type::bytes_literal(db, &new_bytes))
-                        }
-                        Err(_) => Err(SubscriptError::new(
-                            Type::unknown(),
-                            SubscriptErrorKind::SliceStepSizeZero,
-                        )),
+                let result = match literal_value.py_slice(db, start, stop, step) {
+                    Ok(new_bytes) => {
+                        let new_bytes = new_bytes.collect::<Vec<u8>>();
+                        Ok(Type::bytes_literal(db, &new_bytes))
                     }
-                })
-            },
+                    Err(_) => Err(SubscriptError::new(
+                        Type::unknown(),
+                        SubscriptErrorKind::SliceStepSizeZero,
+                    )),
+                };
+
+                Some(result)
+            }
 
             // Ex) Given `"value"[True]`, return `"a"`
             (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal))
@@ -805,10 +813,13 @@ impl<'db> Type<'db> {
                 Some(Ok(todo_type!("Inference of subscript on special form")))
             }
 
-            (Type::KnownInstance(known_instance), _) if known_instance.class(db).is_special_form() => {
+            (Type::KnownInstance(known_instance), _)
+                if known_instance.class(db).is_special_form() =>
+            {
                 Some(Ok(todo_type!("Inference of subscript on special form")))
             }
 
+            // TODO: more complex logic required for the `Type::TypeVar(_) branch!
             (
                 Type::FunctionLiteral(_)
                 | Type::WrapperDescriptor(_)
@@ -834,7 +845,7 @@ impl<'db> Type<'db> {
                 | Type::SpecialForm(_)
                 | Type::KnownInstance(_)
                 | Type::LiteralValue(_)
-                | Type::TypeVar(_)  // TODO: more complex logic required here!
+                | Type::TypeVar(_)
                 | Type::KnownBoundMethod(_),
                 _,
             ) => None,


### PR DESCRIPTION
## Summary

Reduce nesting across semantic type handling by using `let` guards, direct pattern matching, and the existing `tuple_instance_spec` helper. Preserve existing tuple specialization, comparison, narrowing, and subscript behavior.
