### PR TITLE
[ty] Bump ecosystem-analyzer

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -42,7 +42,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
-  ECOSYSTEM_ANALYZER_COMMIT: e2c5b76149b147fae104a7d8fa0997a9eb7f7754
+  ECOSYSTEM_ANALYZER_COMMIT: 263b5500881186e8c918193577c23b341e5b7237
 
 jobs:
   build-ty:


### PR DESCRIPTION
## Summary

Pull in [astral-sh/ecosystem-analyzer#130](https://github.com/astral-sh/ecosystem-analyzer/pull/130), which updates its mypy-primer pin to include [hauntsaninja/mypy_primer#256](https://github.com/hauntsaninja/mypy_primer/pull/256).

`svcs` moved its typing tests from `tests/typing` to `typing_tests` in [hynek/svcs#177](https://github.com/hynek/svcs/pull/177). The previous analyzer pin still used a mypy-primer entry with `paths=["src", "tests/typing"]`, so ty reported the missing path as an I/O error and ecosystem-analyzer recorded a persistent exit code 2 on both sides of PR comparisons.
