### PR TITLE
[ty] Avoid exponential inference for mixed TypedDict unions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2610,7 +2610,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 A = TypedDict("A", {"type": Literal["a"]})
 B = TypedDict("B", {"type": Literal["b"]})
@@ -2646,6 +2646,12 @@ def _(item: Item) -> None:
 # Those intersections should still reuse the common protocol constraints of the union.
 # Regression test for https://github.com/astral-sh/ty/issues/3974.
 def _(item: Item | str) -> None:
+    if isinstance(item, dict):
+        reveal_type(dict(item))  # revealed: dict[str, object]
+
+# A single plain-dict member must not make combining the shared `TypedDict` constraints exponential.
+def _(item: Item | dict[str, Any]) -> None:
+    reveal_type(dict(item))  # revealed: dict[str, object]
     if isinstance(item, dict):
         reveal_type(dict(item))  # revealed: dict[str, object]
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2651,7 +2651,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
     }
 
-    /// Returns common protocol constraints for a union containing only `TypedDict`s when every
+    /// Returns common protocol constraints for the `TypedDict` members of a union when every such
     /// member has the same constraints as their shared `Mapping[str, object]` fallback.
     fn common_typed_dict_protocol_constraints(
         &self,
@@ -2664,6 +2664,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             resolving: &mut FxHashSet<Type<'db>>,
             completed: &mut FxHashMap<Type<'db>, bool>,
             typed_dicts: &mut FxHashSet<Type<'db>>,
+            other_types: &mut FxOrderSet<Type<'db>>,
         ) -> bool {
             let ty = ty.resolve_type_alias(db);
             if let Some(result) = completed.get(&ty) {
@@ -2680,7 +2681,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         return false;
                     }
                     let result = union.elements(db).iter().all(|element| {
-                        collect_typed_dicts(db, *element, resolving, completed, typed_dicts)
+                        collect_typed_dicts(
+                            db,
+                            *element,
+                            resolving,
+                            completed,
+                            typed_dicts,
+                            other_types,
+                        )
                     });
                     resolving.remove(&ty);
                     result
@@ -2696,7 +2704,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     typed_dicts.insert(ty);
                     true
                 }
-                _ => false,
+                _ => {
+                    other_types.insert(ty);
+                    true
+                }
             };
             completed.insert(ty, result);
             result
@@ -2705,6 +2716,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mut resolving = FxHashSet::default();
         let mut completed = FxHashMap::default();
         let mut typed_dicts = FxHashSet::default();
+        let mut other_types = FxOrderSet::default();
         if !actual.elements(self.db).iter().all(|element| {
             collect_typed_dicts(
                 self.db,
@@ -2712,8 +2724,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 &mut resolving,
                 &mut completed,
                 &mut typed_dicts,
+                &mut other_types,
             )
         }) {
+            return None;
+        }
+        if typed_dicts.is_empty() {
             return None;
         }
 
@@ -2724,18 +2740,28 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mapping = KnownClass::Mapping.to_specialized_instance(self.db, spec);
         let mapping_when = mapping.when_constraint_set_assignable_to_owned(self.db, formal);
         let mapping_when = self.constraints.load(self.db, &mapping_when);
-        typed_dicts
-            .into_iter()
-            .all(|element| {
-                let element_when = self.constraints.load(
-                    self.db,
-                    &element.when_constraint_set_assignable_to_owned(self.db, formal),
-                );
-                element_when
-                    .iff(self.db, self.constraints, mapping_when)
-                    .is_always_satisfied(self.db)
-            })
-            .then_some(mapping_when)
+        if !typed_dicts.into_iter().all(|element| {
+            let element_when = self.constraints.load(
+                self.db,
+                &element.when_constraint_set_assignable_to_owned(self.db, formal),
+            );
+            element_when
+                .iff(self.db, self.constraints, mapping_when)
+                .is_always_satisfied(self.db)
+        }) {
+            return None;
+        }
+
+        Some(mapping_when.and(self.db, self.constraints, || {
+            other_types
+                .into_iter()
+                .when_all(self.db, self.constraints, |element| {
+                    self.constraints.load(
+                        self.db,
+                        &element.when_constraint_set_assignable_to_owned(self.db, formal),
+                    )
+                })
+        }))
     }
 
     /// Infer type mappings by comparing formal callable signatures against actual callables.


### PR DESCRIPTION
## Summary

One non-TypedDict union member bypassed the shared Mapping[str, object] constraint fast path, causing exponential dict(...) overload inference.

To fix, reuse equivalent TypedDict constraints, intersect remaining members with short-circuiting when_all, and cover direct and isinstance(..., dict) calls.

## Test Plan

28-arm repro >25–45s → ~0.13s; real Responses union >8–12s → ~0.5s, ~80 MiB.

```
cargo test --locked -p ty_python_semantic
QUICKCHECK_TESTS=1000 cargo test --locked -p ty_python_semantic --lib -- --ignored types::property_tests::stable
cargo clippy --locked -p ty_python_semantic --all-targets -- -D warnings
uv tool run --from prek==0.4.9 prek run --files \
  crates/ty_python_semantic/src/types/generics.rs \
  crates/ty_python_semantic/resources/mdtest/typed_dict.md
```