### PR TITLE
[ty] Pydantic: Support special underscore parameters in `BaseSettings` models

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -1091,7 +1091,7 @@ class DerivedSettings(CustomInit):
 DerivedSettings(1)
 
 # `CustomInit.__init__` overrides the constructor, so `_secrets_dir` is not accepted.
-DerivedSettings(_secrets_dir="./secrets")  # error: [unknown-argument]
+DerivedSettings(1, _secrets_dir="./secrets")  # error: [unknown-argument]
 ```
 
 ## Root models

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -1047,6 +1047,7 @@ A model derived from `BaseSettings` can use environment variables, so we assume 
 to provide their values:
 
 ```py
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
@@ -1062,10 +1063,35 @@ Settings(host=None)  # error: [invalid-argument-type]
 
 # `BaseSettings` accepts underscore-prefixed parameters that override settings configuration.
 Settings(_secrets_dir="./secrets")
-Settings(_secrets_dir=1)  # error: [invalid-argument-type]
+# An unknown leading-underscore keyword is not a control argument and is still rejected.
+Settings(_not_a_control_kwarg=1)  # error: [unknown-argument]
+
+class AliasedSettings(BaseSettings):
+    env_file: int = Field(alias="_env_file")
+
+# `_env_file` binds the control argument (not the `int` field).
+AliasedSettings(_env_file=".env")
+AliasedSettings(_env_file=1)  # error: [invalid-argument-type]
 
 # `BaseSettings` defines a specialized constructor and forbids extra values by default.
 Settings(host="localhost", port=8000, something_else=7)  # error: [unknown-argument]
+```
+
+A custom initializer continues to control the accepted arguments:
+
+```py
+from pydantic_settings import BaseSettings
+
+class CustomInit(BaseSettings):
+    def __init__(self, value: int) -> None: ...
+
+class DerivedSettings(CustomInit):
+    host: str
+
+DerivedSettings(1)
+
+# `CustomInit.__init__` overrides the constructor, so `_secrets_dir` is not accepted.
+DerivedSettings(_secrets_dir="./secrets")  # error: [unknown-argument]
 ```
 
 ## Root models

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -1060,6 +1060,10 @@ Settings(port=8000)
 Settings(host="localhost", port=8000)
 Settings(host=None)  # error: [invalid-argument-type]
 
+# `BaseSettings` accepts underscore-prefixed parameters that override settings configuration.
+Settings(_secrets_dir="./secrets")
+Settings(_secrets_dir=1)  # error: [invalid-argument-type]
+
 # `BaseSettings` defines a specialized constructor and forbids extra values by default.
 Settings(host="localhost", port=8000, something_else=7)  # error: [unknown-argument]
 ```

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -298,8 +298,16 @@ impl<'db> CodeGeneratorKind<'db> {
     ///
     /// C(value=42)
     /// ```
-    pub(super) const fn synthesizes_constructor_signature_from_fields(self) -> bool {
-        matches!(self, Self::DataclassLike(_) | Self::Pydantic(_))
+    pub(super) fn synthesizes_constructor_signature_from_fields(
+        self,
+        db: &'db dyn Db,
+        class: StaticClassLiteral<'db>,
+    ) -> bool {
+        match self {
+            Self::DataclassLike(_) => true,
+            Self::Pydantic(_) => pydantic::synthesizes_constructor_signature_from_fields(db, class),
+            Self::NamedTuple | Self::TypedDict => false,
+        }
     }
 
     pub(super) const fn pydantic_metadata(self) -> Option<pydantic::ModelMetadata<'db>> {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1400,6 +1400,10 @@ impl<'db> StaticClassLiteral<'db> {
             Type::instance(db, self.apply_optional_specialization(db, specialization));
 
         let signature_from_fields = |mut parameters: Vec<_>, return_ty: Type<'db>| {
+            if name == "__init__" && field_policy.is_pydantic() {
+                parameters.extend(pydantic::settings_constructor_parameters(db, self));
+            }
+
             for (field_name, field) in self.fields(db, specialization, field_policy) {
                 let (init, mut default_ty, kw_only, alias, converter, strict) = match &field.kind {
                     FieldKind::NamedTuple { default_ty } => (

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1610,7 +1610,7 @@ impl<'db> StaticClassLiteral<'db> {
 
         match (field_policy, name) {
             (field_policy, "__init__")
-                if field_policy.synthesizes_constructor_signature_from_fields() =>
+                if field_policy.synthesizes_constructor_signature_from_fields(db, self) =>
             {
                 if field_policy.is_dataclass_like()
                     && !self.has_dataclass_param(db, field_policy, DataclassFlags::INIT)

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1401,7 +1401,7 @@ impl<'db> StaticClassLiteral<'db> {
 
         let signature_from_fields = |mut parameters: Vec<_>, return_ty: Type<'db>| {
             if name == "__init__" && field_policy.is_pydantic() {
-                parameters.extend(pydantic::settings_constructor_parameters(db, self));
+                pydantic::extend_settings_constructor_parameters(db, self, &mut parameters);
             }
 
             for (field_name, field) in self.fields(db, specialization, field_policy) {

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -518,15 +518,16 @@ pub(in crate::types) fn constructor_fields_are_optional(
         .any(|base| base.is_known(db, KnownClass::PydanticBaseSettings))
 }
 
-/// Return the specialized constructor parameters accepted by a settings model.
+/// Add the specialized constructor parameters accepted by a settings model.
 ///
 /// Pydantic settings models accept underscore-prefixed parameters that override values from
 /// `model_config` for a single instantiation. These parameters are defined on
 /// `BaseSettings.__init__`, so we reuse them instead of duplicating their names and types.
-pub(in crate::types) fn settings_constructor_parameters<'db>(
+pub(in crate::types) fn extend_settings_constructor_parameters<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
-) -> Box<[Parameter<'db>]> {
+    parameters: &mut Vec<Parameter<'db>>,
+) {
     let Some(base_settings) = class
         .iter_mro(db, None)
         .filter_map(ClassBase::into_class)
@@ -534,29 +535,30 @@ pub(in crate::types) fn settings_constructor_parameters<'db>(
         .map(|(base, _)| base)
         .find(|base| base.is_known(db, KnownClass::PydanticBaseSettings))
     else {
-        return Box::default();
+        return;
     };
 
     let Some(init) = class_member(db, base_settings.body_scope(db), "__init__")
         .ignore_possibly_undefined()
         .and_then(Type::as_function_literal)
     else {
-        return Box::default();
+        return;
     };
     let Some(signature) = init.signature(db).iter().next() else {
-        return Box::default();
+        return;
     };
 
-    signature
-        .parameters()
-        .iter()
-        .filter(|parameter| {
-            parameter.name().is_some_and(|name| {
-                name.as_str().starts_with('_') && !name.as_str().starts_with("__")
+    parameters.extend(
+        signature
+            .parameters()
+            .iter()
+            .filter(|parameter| {
+                parameter.name().is_some_and(|name| {
+                    name.as_str().starts_with('_') && !name.as_str().starts_with("__")
+                })
             })
-        })
-        .cloned()
-        .collect()
+            .cloned(),
+    );
 }
 
 #[salsa::tracked(

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -996,8 +996,13 @@ fn lax_alias<'db>(db: &'db dyn Db, name: &str) -> Type<'db> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ModelInitBehavior {
+    /// The model inherits Pydantic's ordinary `BaseModel` initializer.
     BaseModel,
+    /// The first custom initializer in the MRO accepts arbitrary keyword arguments.
     CustomVariadic,
+    /// The first custom initializer in the MRO has a fixed parameter list.
+    CustomFixed,
+    /// The model has a specialized Pydantic initializer or no recognized initializer.
     Other,
 }
 
@@ -1031,12 +1036,24 @@ fn model_init_behavior(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelInitB
                 }) {
                 ModelInitBehavior::CustomVariadic
             } else {
-                ModelInitBehavior::Other
+                ModelInitBehavior::CustomFixed
             };
         }
     }
 
     ModelInitBehavior::Other
+}
+
+/// Return `true` if `class` should synthesize a field-derived constructor signature.
+///
+/// A fixed custom initializer on an intermediate base class controls the constructor accepted by
+/// its subclasses. A variadic custom initializer still allows Pydantic to validate field values
+/// passed via keyword arguments.
+pub(in crate::types) fn synthesizes_constructor_signature_from_fields(
+    db: &dyn Db,
+    class: StaticClassLiteral<'_>,
+) -> bool {
+    model_init_behavior(db, class) != ModelInitBehavior::CustomFixed
 }
 
 /// Return `true` if `class` should accept extra keywords in its synthesized constructor.

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -518,6 +518,47 @@ pub(in crate::types) fn constructor_fields_are_optional(
         .any(|base| base.is_known(db, KnownClass::PydanticBaseSettings))
 }
 
+/// Return the specialized constructor parameters accepted by a settings model.
+///
+/// Pydantic settings models accept underscore-prefixed parameters that override values from
+/// `model_config` for a single instantiation. These parameters are defined on
+/// `BaseSettings.__init__`, so we reuse them instead of duplicating their names and types.
+pub(in crate::types) fn settings_constructor_parameters<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> Box<[Parameter<'db>]> {
+    let Some(base_settings) = class
+        .iter_mro(db, None)
+        .filter_map(ClassBase::into_class)
+        .filter_map(|base| base.static_class_literal(db))
+        .map(|(base, _)| base)
+        .find(|base| base.is_known(db, KnownClass::PydanticBaseSettings))
+    else {
+        return Box::default();
+    };
+
+    let Some(init) = class_member(db, base_settings.body_scope(db), "__init__")
+        .ignore_possibly_undefined()
+        .and_then(Type::as_function_literal)
+    else {
+        return Box::default();
+    };
+    let Some(signature) = init.signature(db).iter().next() else {
+        return Box::default();
+    };
+
+    signature
+        .parameters()
+        .iter()
+        .filter(|parameter| {
+            parameter.name().is_some_and(|name| {
+                name.as_str().starts_with('_') && !name.as_str().starts_with("__")
+            })
+        })
+        .cloned()
+        .collect()
+}
+
 #[salsa::tracked(
     returns(copy),
     cycle_initial=|_, _, _| ModelConfig::unknown(),


### PR DESCRIPTION
## Summary

Copy the underscore-prefixed parameters like `_secrets_dir` from `BaseSettings.__init__` when synthesizing constructors Pydantic models derived from for `BaseSettings`. This allows us to type check valid code like this without any errors:

```py
class Settings(BaseSettings):
    host: str
    port: int

Settings(_secrets_dir="./secrets")
```

closes https://github.com/astral-sh/ty/issues/4067

## Test plan

New Markdown test