### PR TITLE
[ty] Fix type and TypeForm intersections

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_form.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_form.md
@@ -439,10 +439,28 @@ argument.
 ```py
 from typing import Any
 from typing_extensions import TypeForm, TypeIs
+from ty_extensions import Intersection, static_assert
+from ty_extensions._internal import is_disjoint_from, is_equivalent_to, is_subtype_of
 
 def as_type[T](form: TypeForm[T]) -> type[T] | None:
     if isinstance(form, type):
         reveal_type(form)  # revealed: type[T@as_type]
+        return form
+    return None
+
+def is_runtime_type[T](form: TypeForm[T]) -> TypeIs[type[T]]:
+    return isinstance(form, type)
+
+def narrow_runtime_type[T](form: TypeForm[T]) -> type[T] | None:
+    static_assert(is_subtype_of(type[T], TypeForm[T]))
+    static_assert(not is_disjoint_from(type[T], TypeForm[T]))
+    static_assert(is_equivalent_to(Intersection[type[T], TypeForm[T]], type[T]))
+    static_assert(is_equivalent_to(Intersection[TypeForm[T], type[T]], type[T]))
+    static_assert(not is_disjoint_from(type[bool], TypeForm[int]))
+    static_assert(is_disjoint_from(type[int], TypeForm[str]))
+
+    if is_runtime_type(form):
+        reveal_type(form)  # revealed: type[T@narrow_runtime_type]
         return form
     return None
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2688,6 +2688,12 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 self.check_type_pair(db, other, complement.remaining_literal_union(db))
             }
 
+            // `type[T]` and `TypeForm[S]` overlap whenever their represented instance types do.
+            (Type::SubclassOf(subclass_of), Type::TypeForm(typeform))
+            | (Type::TypeForm(typeform), Type::SubclassOf(subclass_of)) => {
+                self.check_type_pair(db, subclass_of.to_instance(db), typeform.type_argument(db))
+            }
+
             // `type[T]` is disjoint from a callable or protocol instance if its upper bound or constraints are.
             (
                 Type::SubclassOf(subclass_of),


### PR DESCRIPTION
## Summary

Fix disjointness checking between `type[T]` and `TypeForm[S]` by comparing the represented instance types. PEP 747 defines `type[T]` as a subtype of `TypeForm[T]`, but the generic-subclass fallback could incorrectly report the pair as disjoint; intersection reduction then became order-dependent and generic `TypeIs[type[T]]` narrowing produced `Never`.

## Test plan

Added mdtest coverage for subtype and disjointness invariants, both intersection orders, overlapping and genuinely disjoint represented types, and generic `TypeIs` narrowing from `TypeForm[T]` to `type[T]`.