### PR TITLE
[ty] Add test expectations for scoped quantifiers

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -861,6 +861,34 @@ def same_typevar[T]():
     static_assert(constraints == expected)
 ```
 
+## Existential quantification
+
+Existential quantification removes the listed typevars from a constraint set while preserving any
+constraints on the remaining typevars. An uncertain disjunct becomes satisfiable when its typevar is
+removed.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+def preserves_remaining_conjunct[T, U]() -> None:
+    t_int = ConstraintSet.range(int, T, int)
+    u_str = ConstraintSet.range(str, U, str)
+    quantified = (t_int & u_str).exists(tuple[U])
+    static_assert(quantified == t_int)
+
+def satisfies_uncertain_disjunct[T, U]() -> None:
+    t_int = ConstraintSet.range(int, T, int)
+    u_str = ConstraintSet.range(str, U, str)
+    quantified = (t_int | u_str).exists(tuple[U])
+    static_assert(quantified == ConstraintSet.always())
+
+def no_typevars_is_identity[T]() -> None:
+    constraints = ConstraintSet.range(Never, T, int)
+    static_assert(constraints.exists(tuple[()]) == constraints)
+```
+
 ## Universal quantification
 
 Universal quantification removes the listed typevars from a constraint set. Any constraints that do
@@ -901,13 +929,12 @@ def quantifier_order[S, T]() -> None:
     target_is_int = ConstraintSet.range(int, T, int)
     equal = source_is_int.satisfies(target_is_int) & target_is_int.satisfies(source_is_int)
 
-    # ∀T.∃S.equal(S, T) = ∀T.¬∀S.¬equal(S, T)
-    forall_target_exists_source = (~((~equal).for_all(tuple[S]))).for_all(tuple[T])
+    # ∀T.∃S.equal(S, T)
+    forall_target_exists_source = equal.exists(tuple[S]).for_all(tuple[T])
     static_assert(forall_target_exists_source == ConstraintSet.always())
 
-    # ∃S.∀T.equal(S, T) = ¬∀S.¬∀T.equal(S, T)
-    forall_target = equal.for_all(tuple[T])
-    exists_source_forall_target = ~((~forall_target).for_all(tuple[S]))
+    # ∃S.∀T.equal(S, T)
+    exists_source_forall_target = equal.for_all(tuple[T]).exists(tuple[S])
     static_assert(exists_source_forall_target == ConstraintSet.never())
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -863,9 +863,9 @@ def same_typevar[T]():
 
 ## Existential quantification
 
-Existential quantification removes the listed typevars from a constraint set while preserving any
-constraints on the remaining typevars. An uncertain disjunct becomes satisfiable when its typevar is
-removed.
+Existential quantification removes the listed typevars from a constraint set. Any constraints that
+do not involve those typevars must remain in the result. The result holds whenever _at least one_
+valid assignment to the quantified variables satisfies the expression being quantified over.
 
 ```py
 from typing import Never
@@ -892,7 +892,8 @@ def no_typevars_is_identity[T]() -> None:
 ## Universal quantification
 
 Universal quantification removes the listed typevars from a constraint set. Any constraints that do
-not involve those typevars must remain in the result, including constraints in an uncertain branch.
+not involve those typevars must remain in the result. The result holds whenever _every_ valid
+assignment to the quantified variables satisfies the expression being quantified over.
 
 ```py
 from typing import Never

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
@@ -1,21 +1,18 @@
-# Scoped quantifiers
+# Quantification
 
-These tests establish a small behavior basis for eliminating callable-local type variables. The
-internal `ConstraintSet.exists` and `ConstraintSet.for_all` hooks express the intended existential
-and universal scopes without depending on how future scoped quantifiers are represented internally.
-Revealed solution expectations use the stable default constraint ordering; path and binding order
-can still vary when `TY_CONSTRAINT_SET_ORDER` is perturbed (as documented in
-`regression/constraint_set_ordering.md`).
+Quantification describes when an expression involving some type variables holds for the type
+variables that remain. `exists` requires at least one valid assignment to the quantified variables;
+`for_all` requires every valid assignment to satisfy the expression.
 
-| Case | Formula                          | Expected result                   |
-| ---- | -------------------------------- | --------------------------------- |
-| C0   | `∃X. X = int ∧ A ≤ Invariant[X]` | Exact substitution                |
-| E1   | `∃X. U ≤ X ∧ X = V`              | Exact relational cover            |
-| E2   | `∃X. A ≤ Invariant[X] ∧ X ≤ B`   | Residual invariant relation       |
-| E3   | `∃X. A ≤ X ∧ Invariant[X] ≤ B`   | Witness-sensitive residual        |
-| E4   | `∃X. C₁(X, Y) ∧ C₂(X, Z)`        | Correlated visible solutions      |
-| E5   | `∃X ∈ {int, str}. C(X, Y, Z)`    | Finite disjunctive cover          |
-| E6   | `∀T ∈ Dₜ. ∃S ∈ Dₛ. R(S, T)`      | Preserve alternation and polarity |
+| Case | Formula                          | Expected result                             |
+| ---- | -------------------------------- | ------------------------------------------- |
+| C0   | `∃X. X = int ∧ A ≤ Invariant[X]` | Equivalent to `A ≤ Invariant[int]`          |
+| E1   | `∃X. U ≤ X ∧ X = V`              | Equivalent to `U ≤ V`                       |
+| E2   | `∃X. A ≤ Invariant[X] ∧ X ≤ B`   | `A` and `B` must admit a common `X`         |
+| E3   | `∃X. A ≤ X ∧ Invariant[X] ≤ B`   | `A` and `B` must admit a common `X`         |
+| E4   | `∃X. C₁(X, Y) ∧ C₂(X, Z)`        | Solutions for `Y` and `Z` remain correlated |
+| E5   | `∃X ∈ {int, str}. C(X, Y, Z)`    | Solutions remain paired with each choice    |
+| E6   | `∀T ∈ Dₜ. ∃S ∈ Dₛ. R(S, T)`      | `S` may depend on the choice of `T`         |
 
 ```toml
 [environment]
@@ -24,8 +21,8 @@ python-version = "3.13"
 
 ## C0: grounded invariant
 
-An exact equality for the local witness permits substitution through an invariant constructor. The
-result is an ordinary constraint on the visible variable, and negation preserves that cover.
+If `X` must equal `int`, then `∃X. X = int ∧ A ≤ Invariant[X]` is equivalent to
+`A ≤ Invariant[int]`. The negated expressions are equivalent as well.
 
 ```py
 from typing import Never
@@ -40,22 +37,22 @@ class Invariant[T]:
 
 def grounded[X, A]() -> None:
     body = ConstraintSet.range(int, X, int) & ConstraintSet.range(Never, A, Invariant[X])
-    projected = body.exists(tuple[X])
+    quantified = body.exists(tuple[X])
     expected = ConstraintSet.range(Never, A, Invariant[int])
 
-    static_assert(projected == expected)
-    static_assert(~projected == ~expected)
+    static_assert(quantified == expected)
+    static_assert(~quantified == ~expected)
 
     # revealed: tuple[Solution[X=int, A=Never]]
     reveal_type(body.solutions(inferable=tuple[X, A]))
     # revealed: tuple[Solution[A=Never]]
-    reveal_type(projected.solutions(inferable=tuple[A]))
+    reveal_type(quantified.solutions(inferable=tuple[A]))
 ```
 
 ## E1: relational bridge
 
-A local witness between two visible variables has an exact cover: `U ≤ X ∧ X = V` projects to
-`U ≤ V`. No invariant residual is necessary.
+There is an `X` satisfying `U ≤ X ∧ X = V` exactly when `U ≤ V`. The negated expressions are
+equivalent as well.
 
 ```py
 from typing import Never
@@ -64,24 +61,21 @@ from ty_extensions._internal import ConstraintSet
 
 def relational_bridge[X, U, V]() -> None:
     body = ConstraintSet.range(Never, U, X) & ConstraintSet.range(V, X, V)
-    projected = body.exists(tuple[X])
+    quantified = body.exists(tuple[X])
     expected = ConstraintSet.range(Never, U, V)
 
-    # TODO: These exact-cover assertions currently fail for some perturbed constraint orders,
-    # despite both sides displaying as `U ≤ V`.
-    static_assert(projected == expected)
-    static_assert(~projected == ~expected)
+    static_assert(quantified == expected)
+    static_assert(~quantified == ~expected)
 
     # revealed: tuple[Solution[V=U@relational_bridge, U=Never]]
-    reveal_type(projected.solutions(inferable=tuple[U, V]))
+    reveal_type(quantified.solutions(inferable=tuple[U, V]))
 ```
 
 ## E2: open invariant inverse image
 
-There is no known finite ordinary cover for `A ≤ Invariant[X] ∧ X ≤ B`. Keeping the relation scoped
-is necessary: choosing `A = Invariant[str]` and `B ≤ int` cannot have a valid witness. Eager
-projection currently drops both constraints involving `X`, admits the invalid specialization, and
-also loses its negative-polarity counterpart.
+A specialization satisfies `∃X. A ≤ Invariant[X] ∧ X ≤ B` only if there is some `X` compatible with
+both `A` and `B`. `A = Invariant[str]` and `B ≤ int` cannot satisfy the expression, so they must
+satisfy its negation.
 
 ```py
 from typing import Never
@@ -96,33 +90,32 @@ class Invariant[T]:
 
 def inverse_image[X, A, B]() -> None:
     body = ConstraintSet.range(Never, A, Invariant[X]) & ConstraintSet.range(Never, X, B)
-    projected = body.exists(tuple[X])
+    quantified = body.exists(tuple[X])
     invalid = ConstraintSet.range(Invariant[str], A, object) & ConstraintSet.range(Never, B, int)
 
     # revealed: tuple[Solution[A=Never, B=X@inverse_image, X=Never]]
     reveal_type(body.solutions(inferable=tuple[X, A, B]))
-    # TODO: A scoped residual should retain the relationship between A and B.
+    # TODO: Quantifying X should leave restrictions on A and B.
     # revealed: tuple[()]
-    reveal_type(projected.solutions(inferable=tuple[A, B]))
+    reveal_type(quantified.solutions(inferable=tuple[A, B]))
 
-    # Keeping X until the visible constraints are known correctly rejects the path.
+    # The original expression has no solution for this specialization.
     # revealed: None
     reveal_type((body & invalid).solutions(inferable=tuple[X, A, B]))
-    # TODO: This should be `None`; eager projection incorrectly admits the path.
+    # TODO: The quantified expression should also have no solution for this specialization.
     # revealed: tuple[Solution[A=Invariant[str], B=Never]]
-    reveal_type((projected & invalid).solutions(inferable=tuple[A, B]))
+    reveal_type((quantified & invalid).solutions(inferable=tuple[A, B]))
 
-    # TODO: Both assertions should pass once the positive and negative residuals are preserved.
-    static_assert((projected & invalid) == ConstraintSet.never())  # error: [static-assert-error]
-    static_assert((~projected & invalid) == invalid)  # error: [static-assert-error]
+    # TODO: The positive expression should reject this specialization, and its negation should accept it.
+    static_assert((quantified & invalid) == ConstraintSet.never())  # error: [static-assert-error]
+    static_assert((~quantified & invalid) == invalid)  # error: [static-assert-error]
 ```
 
 ## E3: witness-sensitive image
 
-For `A ≤ X ∧ Invariant[X] ≤ B`, the chosen local witness determines the compatible visible upper
-bound. The constraint layer must preserve that family until inference policy chooses a witness.
-`A ≥ int` and `B ≤ Invariant[str]` demonstrate the same loss under eager projection and under its
-negation.
+For `∃X. A ≤ X ∧ Invariant[X] ≤ B`, each choice of `X` determines which values of `A` and `B` can
+satisfy the expression. `A ≥ int` and `B ≤ Invariant[str]` cannot satisfy it, so they must satisfy
+its negation.
 
 ```py
 from typing import Never
@@ -137,33 +130,32 @@ class Invariant[T]:
 
 def witness_sensitive[X, A, B]() -> None:
     body = ConstraintSet.range(A, X, object) & ConstraintSet.range(Invariant[X], B, object)
-    projected = body.exists(tuple[X])
+    quantified = body.exists(tuple[X])
     invalid = ConstraintSet.range(int, A, object) & ConstraintSet.range(Never, B, Invariant[str])
 
-    # The visible bound for B still refers to the local witness on the complete path.
+    # A solution for B depends on the compatible choice of X.
     # revealed: tuple[Solution[X=A@witness_sensitive, A=X@witness_sensitive, B=Invariant[X@witness_sensitive]]]
     reveal_type(body.solutions(inferable=tuple[X, A, B]))
-    # TODO: A scoped residual should preserve the witness-sensitive relationship.
+    # TODO: Quantifying X should leave restrictions on A and B.
     # revealed: tuple[()]
-    reveal_type(projected.solutions(inferable=tuple[A, B]))
+    reveal_type(quantified.solutions(inferable=tuple[A, B]))
 
     # revealed: None
     reveal_type((body & invalid).solutions(inferable=tuple[X, A, B]))
-    # TODO: This should be `None`; eager projection incorrectly admits the path.
+    # TODO: The quantified expression should also have no solution for this specialization.
     # revealed: tuple[Solution[A=int, B=Never]]
-    reveal_type((projected & invalid).solutions(inferable=tuple[A, B]))
+    reveal_type((quantified & invalid).solutions(inferable=tuple[A, B]))
 
-    # TODO: Both assertions should pass once the positive and negative residuals are preserved.
-    static_assert((projected & invalid) == ConstraintSet.never())  # error: [static-assert-error]
-    static_assert((~projected & invalid) == invalid)  # error: [static-assert-error]
+    # TODO: The positive expression should reject this specialization, and its negation should accept it.
+    static_assert((quantified & invalid) == ConstraintSet.never())  # error: [static-assert-error]
+    static_assert((~quantified & invalid) == invalid)  # error: [static-assert-error]
 ```
 
 ## E4: correlated visible outputs
 
-Eliminating a common witness must not solve visible variables independently. The two valid families
-are `(Y = int, Z = Invariant[int])` and `(Y = str, Z = Invariant[str])`; the cross-pairing
-`(Y = int, Z = Invariant[str])` is invalid. The disjunctive cover and its negation retain that
-correlation.
+The two valid solution families are `(Y = int, Z = Invariant[int])` and
+`(Y = str, Z = Invariant[str])`. The cross-pairing `(Y = int, Z = Invariant[str])` is invalid, so
+quantifying `X` and negating the result must both retain the correlation between `Y` and `Z`.
 
 ```py
 from ty_extensions import static_assert
@@ -187,29 +179,28 @@ def correlated_outputs[X, Y, Z]() -> None:
         & ConstraintSet.range(Invariant[str], Z, Invariant[str])
     )
     body = int_family | str_family
-    projected = body.exists(tuple[X])
+    quantified = body.exists(tuple[X])
     expected = (ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
         ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
     )
     invalid_cross = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
 
-    static_assert(projected == expected)
-    static_assert(~projected == ~expected)
-    static_assert((projected & invalid_cross) == ConstraintSet.never())
+    static_assert(quantified == expected)
+    static_assert(~quantified == ~expected)
+    static_assert((quantified & invalid_cross) == ConstraintSet.never())
 
     # revealed: tuple[Solution[X=int | Y@correlated_outputs, Y=int, Z=Invariant[int]], Solution[X=str | Y@correlated_outputs, Y=str, Z=Invariant[str]]]
     reveal_type(body.solutions(inferable=tuple[X, Y, Z]))
     # revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
-    reveal_type(projected.solutions(inferable=tuple[Y, Z]))
+    reveal_type(quantified.solutions(inferable=tuple[Y, Z]))
     # revealed: None
-    reveal_type((projected & invalid_cross).solutions(inferable=tuple[Y, Z]))
+    reveal_type((quantified & invalid_cross).solutions(inferable=tuple[Y, Z]))
 ```
 
 ## E5: finite domain
 
-A finite constrained domain permits an exact disjunctive cover with branch-local witnesses. The
-domain is included explicitly because the current quantification hooks do not implicitly apply
-declared TypeVar constraints. As in E4, the visible solutions remain paired after `X` is eliminated.
+When `X` is either `int` or `str`, each choice gives a separate valid solution family. After `X` is
+quantified, `Y` and `Z` must remain paired with the same choice; the cross-pairing is invalid.
 
 ```py
 from ty_extensions import static_assert
@@ -228,30 +219,30 @@ def finite_domain[X: (int, str), Y, Z]() -> None:
     body = (x_int & ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
         x_str & ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
     )
-    projected = (domain & body).exists(tuple[X])
+    quantified = (domain & body).exists(tuple[X])
     expected = (ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
         ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
     )
     invalid_cross = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
 
-    static_assert(projected == expected)
-    static_assert(~projected == ~expected)
-    static_assert((projected & invalid_cross) == ConstraintSet.never())
+    static_assert(quantified == expected)
+    static_assert(~quantified == ~expected)
+    static_assert((quantified & invalid_cross) == ConstraintSet.never())
 
     # revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
     reveal_type((domain & body).solutions(inferable=tuple[X, Y, Z]))
     # revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
-    reveal_type(projected.solutions(inferable=tuple[Y, Z]))
+    reveal_type(quantified.solutions(inferable=tuple[Y, Z]))
     # revealed: None
-    reveal_type((projected & invalid_cross).solutions(inferable=tuple[Y, Z]))
+    reveal_type((quantified & invalid_cross).solutions(inferable=tuple[Y, Z]))
 ```
 
 ## E6: alternation and negative polarity
 
-For each valid target specialization, a matching source witness exists. Reversing the quantifiers
-would require one source specialization to work for every target specialization and is therefore
-false. The explicit counterexample formula checks the negative polarity of the same nested relation,
-and an `int`-only relation confirms that a missing target case is rejected.
+For every valid choice of `T`, there is a matching choice of `S`. Reversing the quantifiers would
+require one choice of `S` to work for every `T` and is therefore false. Negating the relation asks
+whether there is a `T` with no matching `S`; an `int`-only relation shows that a missing `str` case
+is rejected.
 
 ```py
 from ty_extensions import static_assert

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
@@ -1,8 +1,12 @@
 # Quantification
 
-Quantification describes when an expression involving some type variables holds for the type
-variables that remain. `exists` requires at least one valid assignment to the quantified variables;
-`for_all` requires every valid assignment to satisfy the expression.
+Quantification removes typevars from a constraint set, returning a new equivalent constraint set
+that only references the remaining typevars. With existential quantification (`exists`), the result
+holds when there is _at least one_ valid assignment of the removed variables satisfies the
+quantified expression. With universal quantification (`for_all`), the result holds when _every_
+valid assignment satisfies the quantified expression.
+
+This file contains several baseline test cases that validate our implementation of quantification.
 
 | Case | Formula                          | Expected result                             |
 | ---- | -------------------------------- | ------------------------------------------- |
@@ -12,7 +16,7 @@ variables that remain. `exists` requires at least one valid assignment to the qu
 | E3   | `∃X. A ≤ X ∧ Invariant[X] ≤ B`   | `A` and `B` must admit a common `X`         |
 | E4   | `∃X. C₁(X, Y) ∧ C₂(X, Z)`        | Solutions for `Y` and `Z` remain correlated |
 | E5   | `∃X ∈ {int, str}. C(X, Y, Z)`    | Solutions remain paired with each choice    |
-| E6   | `∀T ∈ Dₜ. ∃S ∈ Dₛ. R(S, T)`      | `S` may depend on the choice of `T`         |
+| E6   | `∀Y ∈ Dᵧ. ∃X ∈ Dₓ. R(X, Y)`      | `X` may depend on the choice of `Y`         |
 
 ```toml
 [environment]
@@ -21,8 +25,9 @@ python-version = "3.13"
 
 ## C0: grounded invariant
 
-If `X` must equal `int`, then `∃X. X = int ∧ A ≤ Invariant[X]` is equivalent to
-`A ≤ Invariant[int]`. The negated expressions are equivalent as well.
+In `∃X. X = int ∧ A ≤ Invariant[X]`, every assignment of `X` is _valid_ (i.e., satisfies the
+implicit upper bound of `object`), but the only _satisfying_ assignment is `X = int`. That means the
+result should be equivalent to `A ≤ Invariant[int]`.
 
 ```py
 from typing import Never
@@ -36,23 +41,26 @@ class Invariant[T]:
     def set(self, value: T) -> None: ...
 
 def grounded[X, A]() -> None:
+    # ∃X. X = int ∧ A ≤ Invariant[X]
     body = ConstraintSet.range(int, X, int) & ConstraintSet.range(Never, A, Invariant[X])
     quantified = body.exists(tuple[X])
-    expected = ConstraintSet.range(Never, A, Invariant[int])
 
-    static_assert(quantified == expected)
-    static_assert(~quantified == ~expected)
-
+    # TODO: revealed: tuple[Solution[X=int, A=list[int]]]
     # revealed: tuple[Solution[X=int, A=Never]]
     reveal_type(body.solutions(inferable=tuple[X, A]))
+    # TODO: revealed: tuple[Solution[A=list[int]]]
     # revealed: tuple[Solution[A=Never]]
     reveal_type(quantified.solutions(inferable=tuple[A]))
+
+    # A ≤ Invariant[int]
+    expected = ConstraintSet.range(Never, A, Invariant[int])
+    static_assert(quantified == expected)
+    static_assert(~quantified == ~expected)
 ```
 
 ## E1: relational bridge
 
-There is an `X` satisfying `U ≤ X ∧ X = V` exactly when `U ≤ V`. The negated expressions are
-equivalent as well.
+There is an `X` satisfying `U ≤ X ∧ X = V` exactly when `U ≤ V`.
 
 ```py
 from typing import Never
@@ -60,15 +68,18 @@ from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
 def relational_bridge[X, U, V]() -> None:
+    # ∃X. U ≤ X ∧ X = V
     body = ConstraintSet.range(Never, U, X) & ConstraintSet.range(V, X, V)
     quantified = body.exists(tuple[X])
-    expected = ConstraintSet.range(Never, U, V)
 
-    static_assert(quantified == expected)
-    static_assert(~quantified == ~expected)
-
+    # TODO: revealed: tuple[Solution[V=object, U=object]]
     # revealed: tuple[Solution[V=U@relational_bridge, U=Never]]
     reveal_type(quantified.solutions(inferable=tuple[U, V]))
+
+    # U ≤ V
+    expected = ConstraintSet.range(Never, U, V)
+    static_assert(quantified == expected)
+    static_assert(~quantified == ~expected)
 ```
 
 ## E2: open invariant inverse image
@@ -89,26 +100,29 @@ class Invariant[T]:
     def set(self, value: T) -> None: ...
 
 def inverse_image[X, A, B]() -> None:
+    # ∃X. A ≤ Invariant[X] ∧ X ≤ B
     body = ConstraintSet.range(Never, A, Invariant[X]) & ConstraintSet.range(Never, X, B)
     quantified = body.exists(tuple[X])
-    invalid = ConstraintSet.range(Invariant[str], A, object) & ConstraintSet.range(Never, B, int)
 
+    # TODO: revealed: tuple[Solution[A=Invariant[object], B=object, X=object]]
     # revealed: tuple[Solution[A=Never, B=X@inverse_image, X=Never]]
     reveal_type(body.solutions(inferable=tuple[X, A, B]))
-    # TODO: Quantifying X should leave restrictions on A and B.
+    # TODO: revealed: tuple[Solution[A=Invariant[object], B=object]]
     # revealed: tuple[()]
     reveal_type(quantified.solutions(inferable=tuple[A, B]))
 
-    # The original expression has no solution for this specialization.
+    # Invariant[str] ≤ A ∧ B ≤ int
+    invalid = ConstraintSet.range(Invariant[str], A, object) & ConstraintSet.range(Never, B, int)
     # revealed: None
     reveal_type((body & invalid).solutions(inferable=tuple[X, A, B]))
-    # TODO: The quantified expression should also have no solution for this specialization.
+    # TODO: revealed: None
     # revealed: tuple[Solution[A=Invariant[str], B=Never]]
     reveal_type((quantified & invalid).solutions(inferable=tuple[A, B]))
 
-    # TODO: The positive expression should reject this specialization, and its negation should accept it.
-    static_assert((quantified & invalid) == ConstraintSet.never())  # error: [static-assert-error]
-    static_assert((~quantified & invalid) == invalid)  # error: [static-assert-error]
+    static_assert(not (quantified & invalid))
+    # TODO: no error
+    # error: [static-assert-error]
+    static_assert((~quantified & invalid) == invalid)
 ```
 
 ## E3: witness-sensitive image
@@ -129,33 +143,37 @@ class Invariant[T]:
     def set(self, value: T) -> None: ...
 
 def witness_sensitive[X, A, B]() -> None:
+    # ∃X. A ≤ X ∧ Invariant[X] ≤ B
     body = ConstraintSet.range(A, X, object) & ConstraintSet.range(Invariant[X], B, object)
     quantified = body.exists(tuple[X])
-    invalid = ConstraintSet.range(int, A, object) & ConstraintSet.range(Never, B, Invariant[str])
 
-    # A solution for B depends on the compatible choice of X.
+    # Each solution for A and B depends on the compatible choice of X.
+    # TODO: revealed: tuple[Solution[X=object, A=object, B=Invariant[object]]]
     # revealed: tuple[Solution[X=A@witness_sensitive, A=X@witness_sensitive, B=Invariant[X@witness_sensitive]]]
     reveal_type(body.solutions(inferable=tuple[X, A, B]))
-    # TODO: Quantifying X should leave restrictions on A and B.
+    # TODO: revealed: tuple[Solution[A=object, B=Invariant[object]]]
     # revealed: tuple[()]
     reveal_type(quantified.solutions(inferable=tuple[A, B]))
 
+    # int ≤ A ∧ B ≤ Invariant[str]
+    invalid = ConstraintSet.range(int, A, object) & ConstraintSet.range(Never, B, Invariant[str])
     # revealed: None
     reveal_type((body & invalid).solutions(inferable=tuple[X, A, B]))
-    # TODO: The quantified expression should also have no solution for this specialization.
+    # TODO: revealed: None
     # revealed: tuple[Solution[A=int, B=Never]]
     reveal_type((quantified & invalid).solutions(inferable=tuple[A, B]))
 
-    # TODO: The positive expression should reject this specialization, and its negation should accept it.
-    static_assert((quantified & invalid) == ConstraintSet.never())  # error: [static-assert-error]
-    static_assert((~quantified & invalid) == invalid)  # error: [static-assert-error]
+    static_assert(not (quantified & invalid))
+    # TODO: no error
+    # error: [static-assert-error]
+    static_assert((~quantified & invalid) == invalid)
 ```
 
 ## E4: correlated visible outputs
 
-The two valid solution families are `(Y = int, Z = Invariant[int])` and
-`(Y = str, Z = Invariant[str])`. The cross-pairing `(Y = int, Z = Invariant[str])` is invalid, so
-quantifying `X` and negating the result must both retain the correlation between `Y` and `Z`.
+`C₁` relates `X` to `Y`, while `C₂` relates `X` to `Z`. Both constraints must hold for the same
+choice of `X`. The two valid solution families are `(Y = int, Z = Invariant[int])` and
+`(Y = str, Z = Invariant[str])`; the cross-pairing `(Y = int, Z = Invariant[str])` is invalid.
 
 ```py
 from ty_extensions import static_assert
@@ -168,39 +186,43 @@ class Invariant[T]:
     def set(self, value: T) -> None: ...
 
 def correlated_outputs[X, Y, Z]() -> None:
-    int_family = (
-        ConstraintSet.range(int, X, int)
-        & ConstraintSet.range(int, Y, int)
-        & ConstraintSet.range(Invariant[int], Z, Invariant[int])
-    )
-    str_family = (
-        ConstraintSet.range(str, X, str)
-        & ConstraintSet.range(str, Y, str)
-        & ConstraintSet.range(Invariant[str], Z, Invariant[str])
-    )
-    body = int_family | str_family
-    quantified = body.exists(tuple[X])
-    expected = (ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
-        ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
-    )
-    invalid_cross = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    # C₁(X, Y) = (X = int ∧ Y = int) ∨ (X = str ∧ Y = str)
+    c1_int = ConstraintSet.range(int, X, int) & ConstraintSet.range(int, Y, int)
+    c1_str = ConstraintSet.range(str, X, str) & ConstraintSet.range(str, Y, str)
+    c1 = c1_int | c1_str
 
+    # C₂(X, Z) = (Z = Invariant[X])
+    c2 = ConstraintSet.range(Invariant[X], Z, Invariant[X])
+
+    # ∃X. C₁(X, Y) ∧ C₂(X, Z)
+    body = c1 & c2
+    quantified = body.exists(tuple[X])
+
+    # TODO: revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
+    # revealed: tuple[Solution[X=int | Y@correlated_outputs, Z=Invariant[X@correlated_outputs] | Invariant[int], Y=int], Solution[X=str | Y@correlated_outputs, Z=Invariant[X@correlated_outputs] | Invariant[str], Y=str]]
+    reveal_type(body.solutions(inferable=tuple[X, Y, Z]))
+    # revealed: tuple[Solution[Z=Invariant[int], Y=int], Solution[Z=Invariant[str], Y=str]]
+    reveal_type(quantified.solutions(inferable=tuple[Y, Z]))
+
+    # (Y = int ∧ Z = Invariant[int]) ∨ (Y = str ∧ Z = Invariant[str])
+    expected_int = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])
+    expected_str = ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    expected = expected_int | expected_str
     static_assert(quantified == expected)
     static_assert(~quantified == ~expected)
-    static_assert((quantified & invalid_cross) == ConstraintSet.never())
 
-    # revealed: tuple[Solution[X=int | Y@correlated_outputs, Y=int, Z=Invariant[int]], Solution[X=str | Y@correlated_outputs, Y=str, Z=Invariant[str]]]
-    reveal_type(body.solutions(inferable=tuple[X, Y, Z]))
-    # revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
-    reveal_type(quantified.solutions(inferable=tuple[Y, Z]))
+    # (Y = int ∧ Z = Invariant[str])
+    invalid_cross = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    static_assert(not (quantified & invalid_cross))
     # revealed: None
     reveal_type((quantified & invalid_cross).solutions(inferable=tuple[Y, Z]))
 ```
 
 ## E5: finite domain
 
-When `X` is either `int` or `str`, each choice gives a separate valid solution family. After `X` is
-quantified, `Y` and `Z` must remain paired with the same choice; the cross-pairing is invalid.
+The declaration of `X` constrains it to be either `int` or `str`. Each valid choice gives a separate
+solution family. After `X` is quantified, `Y` and `Z` must remain correlated in each solution, and
+specializations outside the declared domain must be rejected.
 
 ```py
 from ty_extensions import static_assert
@@ -213,65 +235,83 @@ class Invariant[T]:
     def set(self, value: T) -> None: ...
 
 def finite_domain[X: (int, str), Y, Z]() -> None:
-    x_int = ConstraintSet.range(int, X, int)
-    x_str = ConstraintSet.range(str, X, str)
-    domain = x_int | x_str
-    body = (x_int & ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
-        x_str & ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
-    )
-    quantified = (domain & body).exists(tuple[X])
-    expected = (ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
-        ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
-    )
-    invalid_cross = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    # ∃X ∈ {int, str}. C(X, Y, Z)
+    # C(X, Y, Z) = (Y = X) ∧ (Z = Invariant[X])
+    body = ConstraintSet.range(X, Y, X) & ConstraintSet.range(Invariant[X], Z, Invariant[X])
+    quantified = body.exists(tuple[X])
 
-    static_assert(quantified == expected)
-    static_assert(~quantified == ~expected)
-    static_assert((quantified & invalid_cross) == ConstraintSet.never())
-
-    # revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
-    reveal_type((domain & body).solutions(inferable=tuple[X, Y, Z]))
-    # revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
+    # TODO: revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
+    # revealed: tuple[Solution[X=Y@finite_domain, Y=X@finite_domain, Z=Invariant[X@finite_domain] | Invariant[Y@finite_domain]]]
+    reveal_type(body.solutions(inferable=tuple[X, Y, Z]))
+    # TODO: revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
+    # revealed: tuple[Solution[Z=Invariant[Y@finite_domain]]]
     reveal_type(quantified.solutions(inferable=tuple[Y, Z]))
+
+    # (Y = int ∧ Z = Invariant[int]) ∨ (Y = str ∧ Z = Invariant[str])
+    expected_int = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])
+    expected_str = ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    expected = expected_int | expected_str
+    # TODO: no error
+    # error: [static-assert-error]
+    static_assert(quantified == expected)
+    # TODO: no error
+    # error: [static-assert-error]
+    static_assert(~quantified == ~expected)
+
+    # (Y = int ∧ Z = Invariant[str])
+    invalid_cross = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    static_assert(not (quantified & invalid_cross))
     # revealed: None
     reveal_type((quantified & invalid_cross).solutions(inferable=tuple[Y, Z]))
+
+    # (Y = bytes ∧ Z = Invariant[bytes])
+    invalid_domain = ConstraintSet.range(bytes, Y, bytes) & ConstraintSet.range(Invariant[bytes], Z, Invariant[bytes])
+    static_assert(not (quantified & invalid_domain))
+    # TODO: revealed: None
+    # revealed: tuple[Solution[Z=Invariant[Y@finite_domain] | Invariant[bytes], Y=bytes]]
+    reveal_type((quantified & invalid_domain).solutions(inferable=tuple[Y, Z]))
 ```
 
 ## E6: alternation and negative polarity
 
-For every valid choice of `T`, there is a matching choice of `S`. Reversing the quantifiers would
-require one choice of `S` to work for every `T` and is therefore false. Negating the relation asks
-whether there is a `T` with no matching `S`; an `int`-only relation shows that a missing `str` case
-is rejected.
+The declarations of `X` and `Y` constrain both variables to `int` or `str`. For every valid choice
+of `Y`, there is a matching choice of `X`. Reversing the quantifiers would require one choice of `X`
+to work for every `Y` and is therefore false. Negating the relation asks whether there is a `Y` with
+no matching `X`; an `int`-only relation shows that a missing `str` case is rejected.
 
 ```py
 from ty_extensions import static_assert
 from ty_extensions._internal import ConstraintSet
 
-def alternation[S, T]() -> None:
-    s_int = ConstraintSet.range(int, S, int)
-    s_str = ConstraintSet.range(str, S, str)
-    t_int = ConstraintSet.range(int, T, int)
-    t_str = ConstraintSet.range(str, T, str)
-    source_domain = s_int | s_str
-    target_domain = t_int | t_str
-    relation = (s_int & t_int) | (s_str & t_str)
+def alternation[X: (int, str), Y: (int, str)]() -> None:
+    # R(X, Y) = (X = int ∧ Y = int) ∨ (X = str ∧ Y = str)
+    x_int = ConstraintSet.range(int, X, int)
+    x_str = ConstraintSet.range(str, X, str)
+    y_int = ConstraintSet.range(int, Y, int)
+    y_str = ConstraintSet.range(str, Y, str)
+    relation = (x_int & y_int) | (x_str & y_str)
 
-    source_exists = (source_domain & relation).exists(tuple[S])
-    forall_target_exists_source = target_domain.satisfies(source_exists).for_all(tuple[T])
-    exists_source_forall_target = (source_domain & target_domain.satisfies(relation).for_all(tuple[T])).exists(tuple[S])
+    # ∀Y. ∃X. R(X, Y)
+    forall_y_exists_x = relation.exists(tuple[X]).for_all(tuple[Y])
+    # TODO: no error
+    # error: [static-assert-error]
+    static_assert(forall_y_exists_x)
+    # TODO: no error
+    # error: [static-assert-error]
+    static_assert(not ~forall_y_exists_x)
 
-    static_assert(forall_target_exists_source == ConstraintSet.always())
-    static_assert(~forall_target_exists_source == ConstraintSet.never())
-    static_assert(exists_source_forall_target == ConstraintSet.never())
+    # ∃X. ∀Y. R(X, Y)
+    exists_x_forall_y = relation.for_all(tuple[Y]).exists(tuple[X])
+    static_assert(not exists_x_forall_y)
 
-    source_has_no_witness = (~(source_domain & relation)).for_all(tuple[S])
-    target_counterexample = (target_domain & source_has_no_witness).exists(tuple[T])
-    static_assert(target_counterexample == ConstraintSet.never())
-    static_assert(target_counterexample == ~forall_target_exists_source)
+    # ∃Y. ∀X. ¬R(X, Y)
+    counterexample = (~relation).for_all(tuple[X]).exists(tuple[Y])
+    # TODO: no error
+    # error: [static-assert-error]
+    static_assert(not counterexample)
+    static_assert(counterexample == ~forall_y_exists_x)
 
-    int_only = s_int & t_int
-    int_source_exists = (source_domain & int_only).exists(tuple[S])
-    missing_str = target_domain.satisfies(int_source_exists).for_all(tuple[T])
-    static_assert(missing_str == ConstraintSet.never())
+    int_only = x_int & y_int
+    missing_str = int_only.exists(tuple[X]).for_all(tuple[Y])
+    static_assert(not missing_str)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
@@ -2,7 +2,7 @@
 
 Quantification removes typevars from a constraint set, returning a new equivalent constraint set
 that only references the remaining typevars. With existential quantification (`exists`), the result
-holds when there is _at least one_ valid assignment of the removed variables satisfies the
+holds when there is _at least one_ valid assignment of the removed variables that satisfies the
 quantified expression. With universal quantification (`for_all`), the result holds when _every_
 valid assignment satisfies the quantified expression.
 

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/scoped_quantifiers.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/scoped_quantifiers.md
@@ -1,0 +1,286 @@
+# Scoped quantifiers
+
+These tests establish a small behavior basis for eliminating callable-local type variables. An
+existential is written using the currently exposed universal-quantification hook and Boolean
+duality: `∃X.C = ¬∀X.¬C`. This exercises the semantics without depending on how a future scoped
+quantifier is represented internally. Revealed solution expectations use the stable default
+constraint ordering; path and binding order can still vary when `TY_CONSTRAINT_SET_ORDER` is
+perturbed (as documented in `regression/constraint_set_ordering.md`).
+
+| Case | Formula                          | Expected result                   |
+| ---- | -------------------------------- | --------------------------------- |
+| C0   | `∃X. X = int ∧ A ≤ Invariant[X]` | Exact substitution                |
+| E1   | `∃X. U ≤ X ∧ X = V`              | Exact relational cover            |
+| E2   | `∃X. A ≤ Invariant[X] ∧ X ≤ B`   | Residual invariant relation       |
+| E3   | `∃X. A ≤ X ∧ Invariant[X] ≤ B`   | Witness-sensitive residual        |
+| E4   | `∃X. C₁(X, Y) ∧ C₂(X, Z)`        | Correlated visible solutions      |
+| E5   | `∃X ∈ {int, str}. C(X, Y, Z)`    | Finite disjunctive cover          |
+| E6   | `∀T ∈ Dₜ. ∃S ∈ Dₛ. R(S, T)`      | Preserve alternation and polarity |
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+## C0: grounded invariant
+
+An exact equality for the local witness permits substitution through an invariant constructor. The
+result is an ordinary constraint on the visible variable, and negation preserves that cover.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+class Invariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def set(self, value: T) -> None: ...
+
+def grounded[X, A]() -> None:
+    body = ConstraintSet.range(int, X, int) & ConstraintSet.range(Never, A, Invariant[X])
+    projected = ~((~body).for_all(tuple[X]))
+    expected = ConstraintSet.range(Never, A, Invariant[int])
+
+    static_assert(projected == expected)
+    static_assert(~projected == ~expected)
+
+    # revealed: tuple[Solution[X=int, A=Never]]
+    reveal_type(body.solutions(inferable=tuple[X, A]))
+    # revealed: tuple[Solution[A=Never]]
+    reveal_type(projected.solutions(inferable=tuple[A]))
+```
+
+## E1: relational bridge
+
+A local witness between two visible variables has an exact cover: `U ≤ X ∧ X = V` projects to
+`U ≤ V`. No invariant residual is necessary.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+def relational_bridge[X, U, V]() -> None:
+    body = ConstraintSet.range(Never, U, X) & ConstraintSet.range(V, X, V)
+    projected = ~((~body).for_all(tuple[X]))
+    expected = ConstraintSet.range(Never, U, V)
+
+    # TODO: These exact-cover assertions currently fail for some perturbed constraint orders,
+    # despite both sides displaying as `U ≤ V`.
+    static_assert(projected == expected)
+    static_assert(~projected == ~expected)
+
+    # revealed: tuple[Solution[V=U@relational_bridge, U=Never]]
+    reveal_type(projected.solutions(inferable=tuple[U, V]))
+```
+
+## E2: open invariant inverse image
+
+There is no known finite ordinary cover for `A ≤ Invariant[X] ∧ X ≤ B`. Keeping the relation scoped
+is necessary: choosing `A = Invariant[str]` and `B ≤ int` cannot have a valid witness. Eager
+projection currently drops both constraints involving `X`, admits the invalid specialization, and
+also loses its negative-polarity counterpart.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+class Invariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def set(self, value: T) -> None: ...
+
+def inverse_image[X, A, B]() -> None:
+    body = ConstraintSet.range(Never, A, Invariant[X]) & ConstraintSet.range(Never, X, B)
+    projected = ~((~body).for_all(tuple[X]))
+    invalid = ConstraintSet.range(Invariant[str], A, object) & ConstraintSet.range(Never, B, int)
+
+    # revealed: tuple[Solution[A=Never, B=X@inverse_image, X=Never]]
+    reveal_type(body.solutions(inferable=tuple[X, A, B]))
+    # TODO: A scoped residual should retain the relationship between A and B.
+    # revealed: tuple[()]
+    reveal_type(projected.solutions(inferable=tuple[A, B]))
+
+    # Keeping X until the visible constraints are known correctly rejects the path.
+    # revealed: None
+    reveal_type((body & invalid).solutions(inferable=tuple[X, A, B]))
+    # TODO: This should be `None`; eager projection incorrectly admits the path.
+    # revealed: tuple[Solution[A=Invariant[str], B=Never]]
+    reveal_type((projected & invalid).solutions(inferable=tuple[A, B]))
+
+    # TODO: Both assertions should pass once the positive and negative residuals are preserved.
+    static_assert((projected & invalid) == ConstraintSet.never())  # error: [static-assert-error]
+    static_assert((~projected & invalid) == invalid)  # error: [static-assert-error]
+```
+
+## E3: witness-sensitive image
+
+For `A ≤ X ∧ Invariant[X] ≤ B`, the chosen local witness determines the compatible visible upper
+bound. The constraint layer must preserve that family until inference policy chooses a witness.
+`A ≥ int` and `B ≤ Invariant[str]` demonstrate the same loss under eager projection and under its
+negation.
+
+```py
+from typing import Never
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+class Invariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def set(self, value: T) -> None: ...
+
+def witness_sensitive[X, A, B]() -> None:
+    body = ConstraintSet.range(A, X, object) & ConstraintSet.range(Invariant[X], B, object)
+    projected = ~((~body).for_all(tuple[X]))
+    invalid = ConstraintSet.range(int, A, object) & ConstraintSet.range(Never, B, Invariant[str])
+
+    # The visible bound for B still refers to the local witness on the complete path.
+    # revealed: tuple[Solution[X=A@witness_sensitive, A=X@witness_sensitive, B=Invariant[X@witness_sensitive]]]
+    reveal_type(body.solutions(inferable=tuple[X, A, B]))
+    # TODO: A scoped residual should preserve the witness-sensitive relationship.
+    # revealed: tuple[()]
+    reveal_type(projected.solutions(inferable=tuple[A, B]))
+
+    # revealed: None
+    reveal_type((body & invalid).solutions(inferable=tuple[X, A, B]))
+    # TODO: This should be `None`; eager projection incorrectly admits the path.
+    # revealed: tuple[Solution[A=int, B=Never]]
+    reveal_type((projected & invalid).solutions(inferable=tuple[A, B]))
+
+    # TODO: Both assertions should pass once the positive and negative residuals are preserved.
+    static_assert((projected & invalid) == ConstraintSet.never())  # error: [static-assert-error]
+    static_assert((~projected & invalid) == invalid)  # error: [static-assert-error]
+```
+
+## E4: correlated visible outputs
+
+Eliminating a common witness must not solve visible variables independently. The two valid families
+are `(Y = int, Z = Invariant[int])` and `(Y = str, Z = Invariant[str])`; the cross-pairing
+`(Y = int, Z = Invariant[str])` is invalid. The disjunctive cover and its negation retain that
+correlation.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+class Invariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def set(self, value: T) -> None: ...
+
+def correlated_outputs[X, Y, Z]() -> None:
+    int_family = (
+        ConstraintSet.range(int, X, int)
+        & ConstraintSet.range(int, Y, int)
+        & ConstraintSet.range(Invariant[int], Z, Invariant[int])
+    )
+    str_family = (
+        ConstraintSet.range(str, X, str)
+        & ConstraintSet.range(str, Y, str)
+        & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    )
+    body = int_family | str_family
+    projected = ~((~body).for_all(tuple[X]))
+    expected = (ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
+        ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    )
+    invalid_cross = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+
+    static_assert(projected == expected)
+    static_assert(~projected == ~expected)
+    static_assert((projected & invalid_cross) == ConstraintSet.never())
+
+    # revealed: tuple[Solution[X=int | Y@correlated_outputs, Y=int, Z=Invariant[int]], Solution[X=str | Y@correlated_outputs, Y=str, Z=Invariant[str]]]
+    reveal_type(body.solutions(inferable=tuple[X, Y, Z]))
+    # revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
+    reveal_type(projected.solutions(inferable=tuple[Y, Z]))
+    # revealed: None
+    reveal_type((projected & invalid_cross).solutions(inferable=tuple[Y, Z]))
+```
+
+## E5: finite domain
+
+A finite constrained domain permits an exact disjunctive cover with branch-local witnesses. The
+domain is included explicitly because the current `for_all` hook does not implicitly apply declared
+TypeVar constraints. As in E4, the visible solutions remain paired after `X` is eliminated.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+class Invariant[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def set(self, value: T) -> None: ...
+
+def finite_domain[X: (int, str), Y, Z]() -> None:
+    x_int = ConstraintSet.range(int, X, int)
+    x_str = ConstraintSet.range(str, X, str)
+    domain = x_int | x_str
+    body = (x_int & ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
+        x_str & ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    )
+    projected = ~((~(domain & body)).for_all(tuple[X]))
+    expected = (ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
+        ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+    )
+    invalid_cross = ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
+
+    static_assert(projected == expected)
+    static_assert(~projected == ~expected)
+    static_assert((projected & invalid_cross) == ConstraintSet.never())
+
+    # revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
+    reveal_type((domain & body).solutions(inferable=tuple[X, Y, Z]))
+    # revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
+    reveal_type(projected.solutions(inferable=tuple[Y, Z]))
+    # revealed: None
+    reveal_type((projected & invalid_cross).solutions(inferable=tuple[Y, Z]))
+```
+
+## E6: alternation and negative polarity
+
+For each valid target specialization, a matching source witness exists. Reversing the quantifiers
+would require one source specialization to work for every target specialization and is therefore
+false. The explicit counterexample formula checks the negative polarity of the same nested relation,
+and an `int`-only relation confirms that a missing target case is rejected.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import ConstraintSet
+
+def alternation[S, T]() -> None:
+    s_int = ConstraintSet.range(int, S, int)
+    s_str = ConstraintSet.range(str, S, str)
+    t_int = ConstraintSet.range(int, T, int)
+    t_str = ConstraintSet.range(str, T, str)
+    source_domain = s_int | s_str
+    target_domain = t_int | t_str
+    relation = (s_int & t_int) | (s_str & t_str)
+
+    source_exists = ~((~(source_domain & relation)).for_all(tuple[S]))
+    forall_target_exists_source = target_domain.satisfies(source_exists).for_all(tuple[T])
+    exists_source_forall_target = ~((~(source_domain & target_domain.satisfies(relation).for_all(tuple[T]))).for_all(tuple[S]))
+
+    static_assert(forall_target_exists_source == ConstraintSet.always())
+    static_assert(~forall_target_exists_source == ConstraintSet.never())
+    static_assert(exists_source_forall_target == ConstraintSet.never())
+
+    source_has_no_witness = (~(source_domain & relation)).for_all(tuple[S])
+    target_counterexample = ~((~(target_domain & source_has_no_witness)).for_all(tuple[T]))
+    static_assert(target_counterexample == ConstraintSet.never())
+    static_assert(target_counterexample == ~forall_target_exists_source)
+
+    int_only = s_int & t_int
+    int_source_exists = ~((~(source_domain & int_only)).for_all(tuple[S]))
+    missing_str = target_domain.satisfies(int_source_exists).for_all(tuple[T])
+    static_assert(missing_str == ConstraintSet.never())
+```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/scoped_quantifiers.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/scoped_quantifiers.md
@@ -1,11 +1,11 @@
 # Scoped quantifiers
 
-These tests establish a small behavior basis for eliminating callable-local type variables. An
-existential is written using the currently exposed universal-quantification hook and Boolean
-duality: `∃X.C = ¬∀X.¬C`. This exercises the semantics without depending on how a future scoped
-quantifier is represented internally. Revealed solution expectations use the stable default
-constraint ordering; path and binding order can still vary when `TY_CONSTRAINT_SET_ORDER` is
-perturbed (as documented in `regression/constraint_set_ordering.md`).
+These tests establish a small behavior basis for eliminating callable-local type variables. The
+internal `ConstraintSet.exists` and `ConstraintSet.for_all` hooks express the intended existential
+and universal scopes without depending on how future scoped quantifiers are represented internally.
+Revealed solution expectations use the stable default constraint ordering; path and binding order
+can still vary when `TY_CONSTRAINT_SET_ORDER` is perturbed (as documented in
+`regression/constraint_set_ordering.md`).
 
 | Case | Formula                          | Expected result                   |
 | ---- | -------------------------------- | --------------------------------- |
@@ -40,7 +40,7 @@ class Invariant[T]:
 
 def grounded[X, A]() -> None:
     body = ConstraintSet.range(int, X, int) & ConstraintSet.range(Never, A, Invariant[X])
-    projected = ~((~body).for_all(tuple[X]))
+    projected = body.exists(tuple[X])
     expected = ConstraintSet.range(Never, A, Invariant[int])
 
     static_assert(projected == expected)
@@ -64,7 +64,7 @@ from ty_extensions._internal import ConstraintSet
 
 def relational_bridge[X, U, V]() -> None:
     body = ConstraintSet.range(Never, U, X) & ConstraintSet.range(V, X, V)
-    projected = ~((~body).for_all(tuple[X]))
+    projected = body.exists(tuple[X])
     expected = ConstraintSet.range(Never, U, V)
 
     # TODO: These exact-cover assertions currently fail for some perturbed constraint orders,
@@ -96,7 +96,7 @@ class Invariant[T]:
 
 def inverse_image[X, A, B]() -> None:
     body = ConstraintSet.range(Never, A, Invariant[X]) & ConstraintSet.range(Never, X, B)
-    projected = ~((~body).for_all(tuple[X]))
+    projected = body.exists(tuple[X])
     invalid = ConstraintSet.range(Invariant[str], A, object) & ConstraintSet.range(Never, B, int)
 
     # revealed: tuple[Solution[A=Never, B=X@inverse_image, X=Never]]
@@ -137,7 +137,7 @@ class Invariant[T]:
 
 def witness_sensitive[X, A, B]() -> None:
     body = ConstraintSet.range(A, X, object) & ConstraintSet.range(Invariant[X], B, object)
-    projected = ~((~body).for_all(tuple[X]))
+    projected = body.exists(tuple[X])
     invalid = ConstraintSet.range(int, A, object) & ConstraintSet.range(Never, B, Invariant[str])
 
     # The visible bound for B still refers to the local witness on the complete path.
@@ -187,7 +187,7 @@ def correlated_outputs[X, Y, Z]() -> None:
         & ConstraintSet.range(Invariant[str], Z, Invariant[str])
     )
     body = int_family | str_family
-    projected = ~((~body).for_all(tuple[X]))
+    projected = body.exists(tuple[X])
     expected = (ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
         ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
     )
@@ -208,8 +208,8 @@ def correlated_outputs[X, Y, Z]() -> None:
 ## E5: finite domain
 
 A finite constrained domain permits an exact disjunctive cover with branch-local witnesses. The
-domain is included explicitly because the current `for_all` hook does not implicitly apply declared
-TypeVar constraints. As in E4, the visible solutions remain paired after `X` is eliminated.
+domain is included explicitly because the current quantification hooks do not implicitly apply
+declared TypeVar constraints. As in E4, the visible solutions remain paired after `X` is eliminated.
 
 ```py
 from ty_extensions import static_assert
@@ -228,7 +228,7 @@ def finite_domain[X: (int, str), Y, Z]() -> None:
     body = (x_int & ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
         x_str & ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
     )
-    projected = ~((~(domain & body)).for_all(tuple[X]))
+    projected = (domain & body).exists(tuple[X])
     expected = (ConstraintSet.range(int, Y, int) & ConstraintSet.range(Invariant[int], Z, Invariant[int])) | (
         ConstraintSet.range(str, Y, str) & ConstraintSet.range(Invariant[str], Z, Invariant[str])
     )
@@ -266,21 +266,21 @@ def alternation[S, T]() -> None:
     target_domain = t_int | t_str
     relation = (s_int & t_int) | (s_str & t_str)
 
-    source_exists = ~((~(source_domain & relation)).for_all(tuple[S]))
+    source_exists = (source_domain & relation).exists(tuple[S])
     forall_target_exists_source = target_domain.satisfies(source_exists).for_all(tuple[T])
-    exists_source_forall_target = ~((~(source_domain & target_domain.satisfies(relation).for_all(tuple[T]))).for_all(tuple[S]))
+    exists_source_forall_target = (source_domain & target_domain.satisfies(relation).for_all(tuple[T])).exists(tuple[S])
 
     static_assert(forall_target_exists_source == ConstraintSet.always())
     static_assert(~forall_target_exists_source == ConstraintSet.never())
     static_assert(exists_source_forall_target == ConstraintSet.never())
 
     source_has_no_witness = (~(source_domain & relation)).for_all(tuple[S])
-    target_counterexample = ~((~(target_domain & source_has_no_witness)).for_all(tuple[T]))
+    target_counterexample = (target_domain & source_has_no_witness).exists(tuple[T])
     static_assert(target_counterexample == ConstraintSet.never())
     static_assert(target_counterexample == ~forall_target_exists_source)
 
     int_only = s_int & t_int
-    int_source_exists = ~((~(source_domain & int_only)).for_all(tuple[S]))
+    int_source_exists = (source_domain & int_only).exists(tuple[S])
     missing_str = target_domain.satisfies(int_source_exists).for_all(tuple[T])
     static_assert(missing_str == ConstraintSet.never())
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4074,6 +4074,14 @@ impl<'db> Type<'db> {
                     .into()
                 }
                 Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
+                    if name == "exists" =>
+                {
+                    Place::bound(Type::KnownBoundMethod(
+                        KnownBoundMethodType::ConstraintSetExists(tracked),
+                    ))
+                    .into()
+                }
+                Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
                     if name == "for_all" =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -6538,6 +6546,7 @@ impl<'db> Type<'db> {
                         | KnownBoundMethodType::ConstraintSetNever
                         | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                         | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                        | KnownBoundMethodType::ConstraintSetExists(_)
                         | KnownBoundMethodType::ConstraintSetForAll(_)
                         | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                         | KnownBoundMethodType::ConstraintSetSolutionsFor(_)
@@ -6905,6 +6914,7 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                | KnownBoundMethodType::ConstraintSetExists(_)
                 | KnownBoundMethodType::ConstraintSetForAll(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetSolutionsFor(_)
@@ -7173,6 +7183,7 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                | KnownBoundMethodType::ConstraintSetExists(_)
                 | KnownBoundMethodType::ConstraintSetForAll(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetSolutionsFor(_)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2756,7 +2756,10 @@ impl<'db> Bindings<'db> {
                         ));
                     }
 
-                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetForAll(tracked)) => {
+                    Type::KnownBoundMethod(
+                        method @ (KnownBoundMethodType::ConstraintSetExists(tracked)
+                        | KnownBoundMethodType::ConstraintSetForAll(tracked)),
+                    ) => {
                         let [Some(typevars)] = overload.parameter_types() else {
                             continue;
                         };
@@ -2769,11 +2772,12 @@ impl<'db> Bindings<'db> {
 
                         let constraints = ConstraintSetBuilder::new();
                         let result = constraints.into_owned(|constraints| {
-                            constraints.load(db, tracked.constraints(db)).for_all(
-                                db,
-                                constraints,
-                                typevars,
-                            )
+                            let set = constraints.load(db, tracked.constraints(db));
+                            if matches!(method, KnownBoundMethodType::ConstraintSetExists(_)) {
+                                set.reduce_inferable(db, constraints, typevars)
+                            } else {
+                                set.for_all(db, constraints, typevars)
+                            }
                         });
                         let tracked = InternedConstraintSet::new(db, result);
                         overload.set_return_type(Type::KnownInstance(

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1219,6 +1219,9 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     KnownBoundMethodType::ConstraintSetSatisfies(_) => {
                         return f.write_str("bound method `ConstraintSet.satisfies`");
                     }
+                    KnownBoundMethodType::ConstraintSetExists(_) => {
+                        return f.write_str("bound method `ConstraintSet.exists`");
+                    }
                     KnownBoundMethodType::ConstraintSetForAll(_) => {
                         return f.write_str("bound method `ConstraintSet.for_all`");
                     }

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -222,6 +222,7 @@ pub enum KnownBoundMethodType<'db> {
     ConstraintSetNever,
     ConstraintSetImpliesSubtypeOf(InternedConstraintSet<'db>),
     ConstraintSetSatisfies(InternedConstraintSet<'db>),
+    ConstraintSetExists(InternedConstraintSet<'db>),
     ConstraintSetForAll(InternedConstraintSet<'db>),
     ConstraintSetSatisfiedByAllTypeVars(InternedConstraintSet<'db>),
     ConstraintSetSolutionsFor(InternedConstraintSet<'db>),
@@ -261,6 +262,7 @@ pub(super) fn walk_method_wrapper_type<'db, V: visitor::TypeVisitor<'db> + ?Size
         | KnownBoundMethodType::ConstraintSetNever
         | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
         | KnownBoundMethodType::ConstraintSetSatisfies(_)
+        | KnownBoundMethodType::ConstraintSetExists(_)
         | KnownBoundMethodType::ConstraintSetForAll(_)
         | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
         | KnownBoundMethodType::ConstraintSetSolutionsFor(_)
@@ -308,6 +310,7 @@ impl<'db> KnownBoundMethodType<'db> {
             | KnownBoundMethodType::ConstraintSetNever
             | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
             | KnownBoundMethodType::ConstraintSetSatisfies(_)
+            | KnownBoundMethodType::ConstraintSetExists(_)
             | KnownBoundMethodType::ConstraintSetForAll(_)
             | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
             | KnownBoundMethodType::ConstraintSetSolutionsFor(_)
@@ -330,6 +333,7 @@ impl<'db> KnownBoundMethodType<'db> {
             | KnownBoundMethodType::ConstraintSetNever
             | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
             | KnownBoundMethodType::ConstraintSetSatisfies(_)
+            | KnownBoundMethodType::ConstraintSetExists(_)
             | KnownBoundMethodType::ConstraintSetForAll(_)
             | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
             | KnownBoundMethodType::ConstraintSetSolutionsFor(_)
@@ -490,7 +494,8 @@ impl<'db> KnownBoundMethodType<'db> {
                 )))
             }
 
-            KnownBoundMethodType::ConstraintSetForAll(_) => {
+            KnownBoundMethodType::ConstraintSetExists(_)
+            | KnownBoundMethodType::ConstraintSetForAll(_) => {
                 Either::Right(std::iter::once(Signature::new(
                     Parameters::standard([Parameter::positional_only(Some(Name::new_static(
                         "typevars",
@@ -626,6 +631,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 KnownBoundMethodType::ConstraintSetSatisfies(_),
             )
             | (
+                KnownBoundMethodType::ConstraintSetExists(_),
+                KnownBoundMethodType::ConstraintSetExists(_),
+            )
+            | (
                 KnownBoundMethodType::ConstraintSetForAll(_),
                 KnownBoundMethodType::ConstraintSetForAll(_),
             )
@@ -658,6 +667,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                | KnownBoundMethodType::ConstraintSetExists(_)
                 | KnownBoundMethodType::ConstraintSetForAll(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetSolutionsFor(_)
@@ -674,6 +684,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                | KnownBoundMethodType::ConstraintSetExists(_)
                 | KnownBoundMethodType::ConstraintSetForAll(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetSolutionsFor(_)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -262,6 +262,7 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                | KnownBoundMethodType::ConstraintSetExists(_)
                 | KnownBoundMethodType::ConstraintSetForAll(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetSolutionsFor(_)

--- a/crates/ty_vendored/ty_extensions/_internal.pyi
+++ b/crates/ty_vendored/ty_extensions/_internal.pyi
@@ -117,6 +117,11 @@ class ConstraintSet:
         `other`.
         """
 
+    def exists(self, typevars: TypeForm[tuple[object, ...]]) -> Self:
+        """
+        Existentially abstracts the given type variables from this constraint set.
+        """
+
     def for_all(self, typevars: TypeForm[tuple[object, ...]]) -> Self:
         """
         Universally abstracts the given type variables from this constraint set.


### PR DESCRIPTION
This PR adds a suite of tests for the [scoped quantifier](https://gist.github.com/dcreager/679132607be4c7cfb08ddc8ad1076982) work. Many of these tests are currently failing; the ones that are passing are likely doing so for the wrong reasons.

As part of adding these tests, we also add a new `Constraint.exists` extension method, to go along with the existing `ConstraintSet.for_all`.