### PR TITLE
[ty] Allow interpolated string literals to be promoted to `str`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -61,6 +61,15 @@ reveal_type(promote(x5))  # revealed: list[int | float]
 x6 = 3.14j
 reveal_type(x6)  # revealed: complex
 reveal_type(promote(x6))  # revealed: list[int | float | complex]
+
+def _(source: Literal["foo", "bar"]):
+    x7 = f"hello"
+    reveal_type(x7)  # revealed: Literal["hello"]
+    reveal_type(promote(x7))  # revealed: list[str]
+
+    x8 = f"hello:{source}"
+    reveal_type(x8)  # revealed: LiteralString
+    reveal_type(promote(x8))  # revealed: list[str]
 ```
 
 Function types are also promoted to their `Callable` form:

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -108,13 +108,13 @@ use crate::types::unpacker::UnpackResult;
 use crate::types::{
     BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
     DynamicType, InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder,
-    IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind,
-    MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters, SentinelInstance, Signature,
-    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
-    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictModule,
-    TypedDictType, UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
-    extract_fixed_length_iterable_element_types, infer_complete_scope_types, infer_scope_types,
-    is_discarded_dict_key_assignment, todo_type,
+    IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueType,
+    LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters,
+    SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
+    TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind,
+    TypeVarVariance, TypedDictModule, TypedDictType, UnionAccumulator, UnionBuilder, UnionType,
+    any_over_type, binding_type, extract_fixed_length_iterable_element_types,
+    infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
@@ -11615,7 +11615,9 @@ impl StringPartsCollector {
         } else if let Some(concatenated) = self.concatenated {
             Type::string_literal(db, &concatenated)
         } else {
-            Type::literal_string()
+            Type::LiteralValue(LiteralValueType::promotable(
+                LiteralValueTypeKind::LiteralString,
+            ))
         }
     }
 }


### PR DESCRIPTION
We currently infer interpolated string literals as `LiteralString`, but do not allow them to be later promoted to `str` if used in invariant position. Interpolated string literals should be promotable like any other string literal form:

```py
from typing import Literal

def _(source: Literal["foo", "bar"]):
    x = f"hello:{source}"
    reveal_type(x)  # revealed: LiteralString
    reveal_type([x])  # revealed: list[str]
```