### PR TITLE
[ty] Avoid expanding optional enum comparisons

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -681,26 +681,20 @@ fn benchmark_union_str_enum_comparison(criterion: &mut Criterion) {
 
     benchmark_enum_comparison(criterion, "ty_micro[optional_str_enum_comparison]", &code);
 
-    let mixed_code = code.replace("LargeEnum | None", "LargeEnum | int");
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[mixed_union_str_enum_comparison]",
-        &mixed_code,
-    );
-
-    let nested_dynamic_code = code.replace("LargeEnum | None", "LargeEnum | dict[str, Any]");
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[nested_dynamic_str_enum_comparison]",
-        &nested_dynamic_code,
-    );
-
-    let dynamic_code = code.replace("LargeEnum | None", "LargeEnum | Any");
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[dynamic_str_enum_comparison]",
-        &dynamic_code,
-    );
+    for (name, replacement) in [
+        (
+            "ty_micro[mixed_union_str_enum_comparison]",
+            "LargeEnum | int",
+        ),
+        (
+            "ty_micro[nested_dynamic_str_enum_comparison]",
+            "LargeEnum | dict[str, Any]",
+        ),
+        ("ty_micro[dynamic_str_enum_comparison]", "LargeEnum | Any"),
+    ] {
+        let code = code.replace("LargeEnum | None", replacement);
+        benchmark_enum_comparison(criterion, name, &code);
+    }
 }
 
 /// Ensure explicit enum-literal unions are compared as value sets, not member pairs.
@@ -767,19 +761,19 @@ fn benchmark_cross_str_enum_comparison(criterion: &mut Criterion) {
         &optional_code,
     );
 
-    let both_optional_code = optional_code.replace("right: Right", "right: Right | None");
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[both_optional_cross_str_enum_comparison]",
-        &both_optional_code,
-    );
-
-    let mixed_code = optional_code.replace("right: Right", "right: Right | int");
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[mixed_cross_str_enum_comparison]",
-        &mixed_code,
-    );
+    for (name, replacement) in [
+        (
+            "ty_micro[both_optional_cross_str_enum_comparison]",
+            "right: Right | None",
+        ),
+        (
+            "ty_micro[mixed_cross_str_enum_comparison]",
+            "right: Right | int",
+        ),
+    ] {
+        let code = optional_code.replace("right: Right", replacement);
+        benchmark_enum_comparison(criterion, name, &code);
+    }
 }
 
 /// Ensure comparisons of unions spanning several scalar enum classes avoid member-pair expansion.

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -669,7 +669,9 @@ fn benchmark_narrowed_str_enum_comparison(criterion: &mut Criterion) {
 fn benchmark_union_str_enum_comparison(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 256;
 
-    let mut code = "from enum import StrEnum\n\nclass LargeEnum(StrEnum):\n".to_string();
+    let mut code =
+        "from enum import StrEnum\nfrom typing import Any\n\nclass LargeEnum(StrEnum):\n"
+            .to_string();
     for index in 0..NUM_ENUM_MEMBERS {
         writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
     }
@@ -684,6 +686,20 @@ fn benchmark_union_str_enum_comparison(criterion: &mut Criterion) {
         criterion,
         "ty_micro[mixed_str_enum_comparison]",
         &mixed_code,
+    );
+
+    let nested_dynamic_code = code.replace("LargeEnum | None", "LargeEnum | dict[str, Any]");
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[nested_dynamic_str_enum_comparison]",
+        &nested_dynamic_code,
+    );
+
+    let dynamic_code = code.replace("LargeEnum | None", "LargeEnum | Any");
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[dynamic_str_enum_comparison]",
+        &dynamic_code,
     );
 }
 

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -684,7 +684,7 @@ fn benchmark_union_str_enum_comparison(criterion: &mut Criterion) {
     let mixed_code = code.replace("LargeEnum | None", "LargeEnum | int");
     benchmark_enum_comparison(
         criterion,
-        "ty_micro[mixed_str_enum_comparison]",
+        "ty_micro[mixed_union_str_enum_comparison]",
         &mixed_code,
     );
 

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -759,6 +759,27 @@ fn benchmark_cross_str_enum_comparison(criterion: &mut Criterion) {
     );
 
     benchmark_enum_comparison(criterion, "ty_micro[cross_str_enum_comparison]", &code);
+
+    let optional_code = code.replace("left: Left,", "left: Left | None,");
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[optional_cross_str_enum_comparison]",
+        &optional_code,
+    );
+
+    let both_optional_code = optional_code.replace("right: Right", "right: Right | None");
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[both_optional_cross_str_enum_comparison]",
+        &both_optional_code,
+    );
+
+    let mixed_code = optional_code.replace("right: Right", "right: Right | int");
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[mixed_cross_str_enum_comparison]",
+        &mixed_code,
+    );
 }
 
 /// Ensure comparisons of unions spanning several scalar enum classes avoid member-pair expansion.
@@ -785,15 +806,30 @@ fn benchmark_mixed_str_enum_comparison(criterion: &mut Criterion) {
             .collect::<Vec<_>>()
             .join(" | ")
     };
+    let left_union = class_union("Left");
+    let right_union = class_union("Right");
     writeln!(
         &mut code,
-        "\ndef compare(left: {}, right: {}):\n    if left != right:\n        return\n    return left == right",
-        class_union("Left"),
-        class_union("Right"),
+        "\ndef compare(left: {left_union}, right: {right_union}):\n    if left != right:\n        return\n    return left == right",
     )
     .ok();
 
     benchmark_enum_comparison(criterion, "ty_micro[mixed_str_enum_comparison]", &code);
+
+    let optional_code = code
+        .replace(
+            &format!("left: {left_union},"),
+            &format!("left: {left_union} | None,"),
+        )
+        .replace(
+            &format!("right: {right_union}):"),
+            &format!("right: {right_union} | None):"),
+        );
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[optional_mixed_str_enum_comparison]",
+        &optional_code,
+    );
 }
 
 /// Micro-benchmark that tests our performance when slicing and unpacking

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -665,6 +665,21 @@ fn benchmark_narrowed_str_enum_comparison(criterion: &mut Criterion) {
     benchmark_enum_comparison(criterion, "ty_micro[narrowed_str_enum_comparison]", &code);
 }
 
+/// Ensure optional enum comparisons do not expand the enum into all of its members.
+fn benchmark_optional_str_enum_comparison(criterion: &mut Criterion) {
+    const NUM_ENUM_MEMBERS: usize = 256;
+
+    let mut code = "from enum import StrEnum\n\nclass LargeEnum(StrEnum):\n".to_string();
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    code.push_str(
+        "\n\ndef compare(\n    slug: LargeEnum,\n    first: LargeEnum | None,\n    second: LargeEnum | None,\n    third: LargeEnum | None,\n    fourth: LargeEnum | None,\n    fifth: LargeEnum | None,\n) -> bool:\n    return first == slug or second == slug or third == slug or fourth == slug or fifth == slug\n",
+    );
+
+    benchmark_enum_comparison(criterion, "ty_micro[optional_str_enum_comparison]", &code);
+}
+
 /// Ensure explicit enum-literal unions are compared as value sets, not member pairs.
 fn benchmark_enum_literal_union_comparison(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 256;
@@ -2031,6 +2046,7 @@ criterion_group!(
     benchmark_large_enum_membership,
     benchmark_many_enum_members,
     benchmark_narrowed_str_enum_comparison,
+    benchmark_optional_str_enum_comparison,
     benchmark_enum_literal_union_comparison,
     benchmark_repeated_str_enum_comparisons,
     benchmark_cross_str_enum_comparison,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -665,7 +665,10 @@ fn benchmark_narrowed_str_enum_comparison(criterion: &mut Criterion) {
     benchmark_enum_comparison(criterion, "ty_micro[narrowed_str_enum_comparison]", &code);
 }
 
-/// Ensure enum unions are decomposed without expanding the enum into all of its members.
+/// Regression benchmark for <https://github.com/astral-sh/ty/issues/4069>.
+///
+/// Compare a large enum with unions containing `None`, an integer, a dictionary containing `Any`,
+/// or `Any`, without checking every enum member separately.
 fn benchmark_union_str_enum_comparison(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 256;
 

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -667,37 +667,40 @@ fn benchmark_narrowed_str_enum_comparison(criterion: &mut Criterion) {
 
 /// Regression benchmark for <https://github.com/astral-sh/ty/issues/4069>.
 ///
-/// Compare a large enum with unions containing `None`, an integer, a dictionary containing `Any`,
-/// or `Any`, without checking every enum member separately.
-fn benchmark_union_str_enum_comparison(criterion: &mut Criterion) {
+/// Compare a large enum with optional enum fields in a chain of conditions.
+fn benchmark_optional_str_enum_comparison(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 256;
 
     let mut code =
-        "from enum import StrEnum\nfrom typing import Any\n\nclass LargeEnum(StrEnum):\n"
+        "from dataclasses import dataclass\nfrom enum import StrEnum\n\nclass ModelSlug(StrEnum):\n"
             .to_string();
     for index in 0..NUM_ENUM_MEMBERS {
-        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+        writeln!(&mut code, "    M{index} = \"m{index}\"").ok();
     }
     code.push_str(
-        "\n\ndef compare(\n    slug: LargeEnum,\n    first: LargeEnum | None,\n    second: LargeEnum | None,\n    third: LargeEnum | None,\n    fourth: LargeEnum | None,\n    fifth: LargeEnum | None,\n) -> bool:\n    return first == slug or second == slug or third == slug or fourth == slug or fifth == slug\n",
+        r#"
+
+@dataclass
+class Category:
+    default_model: ModelSlug | None = None
+    browsing_model: ModelSlug | None = None
+    code_interpreter_model: ModelSlug | None = None
+    plugins_model: ModelSlug | None = None
+    dalle_model: ModelSlug | None = None
+
+
+def belongs(slug: ModelSlug, category: Category) -> bool:
+    return (
+        category.default_model == slug
+        or category.browsing_model == slug
+        or category.code_interpreter_model == slug
+        or category.plugins_model == slug
+        or category.dalle_model == slug
+    )
+"#,
     );
 
     benchmark_enum_comparison(criterion, "ty_micro[optional_str_enum_comparison]", &code);
-
-    for (name, replacement) in [
-        (
-            "ty_micro[mixed_union_str_enum_comparison]",
-            "LargeEnum | int",
-        ),
-        (
-            "ty_micro[nested_dynamic_str_enum_comparison]",
-            "LargeEnum | dict[str, Any]",
-        ),
-        ("ty_micro[dynamic_str_enum_comparison]", "LargeEnum | Any"),
-    ] {
-        let code = code.replace("LargeEnum | None", replacement);
-        benchmark_enum_comparison(criterion, name, &code);
-    }
 }
 
 /// Ensure explicit enum-literal unions are compared as value sets, not member pairs.
@@ -756,27 +759,6 @@ fn benchmark_cross_str_enum_comparison(criterion: &mut Criterion) {
     );
 
     benchmark_enum_comparison(criterion, "ty_micro[cross_str_enum_comparison]", &code);
-
-    let optional_code = code.replace("left: Left,", "left: Left | None,");
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[optional_cross_str_enum_comparison]",
-        &optional_code,
-    );
-
-    for (name, replacement) in [
-        (
-            "ty_micro[both_optional_cross_str_enum_comparison]",
-            "right: Right | None",
-        ),
-        (
-            "ty_micro[mixed_cross_str_enum_comparison]",
-            "right: Right | int",
-        ),
-    ] {
-        let code = optional_code.replace("right: Right", replacement);
-        benchmark_enum_comparison(criterion, name, &code);
-    }
 }
 
 /// Ensure comparisons of unions spanning several scalar enum classes avoid member-pair expansion.
@@ -803,30 +785,15 @@ fn benchmark_mixed_str_enum_comparison(criterion: &mut Criterion) {
             .collect::<Vec<_>>()
             .join(" | ")
     };
-    let left_union = class_union("Left");
-    let right_union = class_union("Right");
     writeln!(
         &mut code,
-        "\ndef compare(left: {left_union}, right: {right_union}):\n    if left != right:\n        return\n    return left == right",
+        "\ndef compare(left: {}, right: {}):\n    if left != right:\n        return\n    return left == right",
+        class_union("Left"),
+        class_union("Right"),
     )
     .ok();
 
     benchmark_enum_comparison(criterion, "ty_micro[mixed_str_enum_comparison]", &code);
-
-    let optional_code = code
-        .replace(
-            &format!("left: {left_union},"),
-            &format!("left: {left_union} | None,"),
-        )
-        .replace(
-            &format!("right: {right_union}):"),
-            &format!("right: {right_union} | None):"),
-        );
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[optional_mixed_str_enum_comparison]",
-        &optional_code,
-    );
 }
 
 /// Micro-benchmark that tests our performance when slicing and unpacking
@@ -2102,7 +2069,7 @@ criterion_group!(
     benchmark_large_enum_membership,
     benchmark_many_enum_members,
     benchmark_narrowed_str_enum_comparison,
-    benchmark_union_str_enum_comparison,
+    benchmark_optional_str_enum_comparison,
     benchmark_enum_literal_union_comparison,
     benchmark_repeated_str_enum_comparisons,
     benchmark_cross_str_enum_comparison,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -665,8 +665,8 @@ fn benchmark_narrowed_str_enum_comparison(criterion: &mut Criterion) {
     benchmark_enum_comparison(criterion, "ty_micro[narrowed_str_enum_comparison]", &code);
 }
 
-/// Ensure optional enum comparisons do not expand the enum into all of its members.
-fn benchmark_optional_str_enum_comparison(criterion: &mut Criterion) {
+/// Ensure enum unions are decomposed without expanding the enum into all of its members.
+fn benchmark_union_str_enum_comparison(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 256;
 
     let mut code = "from enum import StrEnum\n\nclass LargeEnum(StrEnum):\n".to_string();
@@ -678,6 +678,13 @@ fn benchmark_optional_str_enum_comparison(criterion: &mut Criterion) {
     );
 
     benchmark_enum_comparison(criterion, "ty_micro[optional_str_enum_comparison]", &code);
+
+    let mixed_code = code.replace("LargeEnum | None", "LargeEnum | int");
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[mixed_str_enum_comparison]",
+        &mixed_code,
+    );
 }
 
 /// Ensure explicit enum-literal unions are compared as value sets, not member pairs.
@@ -2046,7 +2053,7 @@ criterion_group!(
     benchmark_large_enum_membership,
     benchmark_many_enum_members,
     benchmark_narrowed_str_enum_comparison,
-    benchmark_optional_str_enum_comparison,
+    benchmark_union_str_enum_comparison,
     benchmark_enum_literal_union_comparison,
     benchmark_repeated_str_enum_comparisons,
     benchmark_cross_str_enum_comparison,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -466,6 +466,22 @@ def _(value: Foo | Bar):
         reveal_type(value)  # revealed: Literal[Foo.Y, Bar.B]
     else:
         reveal_type(value)  # revealed: Literal[Foo.X, Bar.A]
+
+def compare_optional_integer_enum_left(left: Foo | None, right: Bar):
+    if left == right:
+        reveal_type(left)  # revealed: Foo
+        reveal_type(right)  # revealed: Bar
+    else:
+        reveal_type(left)  # revealed: Foo | None
+        reveal_type(right)  # revealed: Bar
+
+def compare_optional_integer_enum_right(left: Foo, right: Bar | None):
+    if left == right:
+        reveal_type(left)  # revealed: Foo
+        reveal_type(right)  # revealed: Bar
+    else:
+        reveal_type(left)  # revealed: Foo
+        reveal_type(right)  # revealed: Bar | None
 ```
 
 `StrEnum` domains from different classes are compared by their string values. Equality retains the
@@ -474,7 +490,7 @@ member. Exact member comparisons are true or false when both values are known:
 
 ```py
 from enum import StrEnum
-from typing import Literal
+from typing import Any, Literal, TypeAlias
 
 class Left(StrEnum):
     A = "a"
@@ -485,6 +501,9 @@ class Right(StrEnum):
     SHARED = "shared"
     B = "b"
     D = "d"
+
+OptionalLeft: TypeAlias = Left | None
+OptionalRight: TypeAlias = Right | None
 
 reveal_type(Left.SHARED == Right.SHARED)  # revealed: Literal[True]
 reveal_type(Left.A == Right.B)  # revealed: Literal[False]
@@ -518,6 +537,127 @@ def compare_subsets(
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED]
         reveal_type(right)  # revealed: Literal[Right.SHARED]
+
+def compare_optional_cross_enum_left(left: Left | None, right: Right):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+        reveal_type(right)  # revealed: Literal[Right.SHARED]
+    else:
+        reveal_type(left)  # revealed: Left | None
+        reveal_type(right)  # revealed: Right
+
+def compare_optional_cross_enum_right(left: Left, right: Right | None):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+        reveal_type(right)  # revealed: Literal[Right.SHARED]
+    else:
+        reveal_type(left)  # revealed: Left
+        reveal_type(right)  # revealed: Right | None
+
+def compare_both_optional_cross_enums(left: Left | None, right: Right | None):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED] | None
+        reveal_type(right)  # revealed: Literal[Right.SHARED] | None
+    else:
+        reveal_type(left)  # revealed: Left | None
+        reveal_type(right)  # revealed: Right | None
+
+    if left != right:
+        reveal_type(left)  # revealed: Left | None
+        reveal_type(right)  # revealed: Right | None
+    else:
+        reveal_type(left)  # revealed: Literal[Left.SHARED] | None
+        reveal_type(right)  # revealed: Literal[Right.SHARED] | None
+
+def compare_optional_cross_enum_aliases(left: OptionalLeft, right: OptionalRight):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED] | None
+        reveal_type(right)  # revealed: Literal[Right.SHARED] | None
+
+def compare_mixed_cross_enum_residuals(left: Left | None, right: Right | int):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+        reveal_type(right)  # revealed: Literal[Right.SHARED]
+    else:
+        reveal_type(left)  # revealed: Left | None
+        reveal_type(right)  # revealed: Right | int
+
+    if left != right:
+        reveal_type(left)  # revealed: Left | None
+        reveal_type(right)  # revealed: Right | int
+    else:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+        reveal_type(right)  # revealed: Literal[Right.SHARED]
+
+def compare_reversed_mixed_cross_enum_residuals(left: Left | int, right: Right | None):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+        reveal_type(right)  # revealed: Literal[Right.SHARED]
+    else:
+        reveal_type(left)  # revealed: Left | int
+        reveal_type(right)  # revealed: Right | None
+
+def compare_overlapping_cross_enum_residual_left(left: Left | Literal["b"], right: Right):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED, "b"]
+        reveal_type(right)  # revealed: Literal[Right.SHARED, Right.B]
+    else:
+        reveal_type(left)  # revealed: Left | Literal["b"]
+        reveal_type(right)  # revealed: Right
+
+    if left != right:
+        reveal_type(left)  # revealed: Left | Literal["b"]
+        reveal_type(right)  # revealed: Right
+    else:
+        reveal_type(left)  # revealed: Literal[Left.SHARED, "b"]
+        reveal_type(right)  # revealed: Literal[Right.SHARED, Right.B]
+
+def compare_overlapping_cross_enum_residual_right(left: Left, right: Right | Literal["a"]):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED, Left.A]
+        reveal_type(right)  # revealed: Literal[Right.SHARED, "a"]
+    else:
+        reveal_type(left)  # revealed: Left
+        reveal_type(right)  # revealed: Right | Literal["a"]
+
+def compare_nested_dynamic_cross_enum_residual(left: Left | dict[str, Any], right: Right | None):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+        reveal_type(right)  # revealed: Literal[Right.SHARED]
+    else:
+        reveal_type(left)  # revealed: Left | dict[str, Any]
+        reveal_type(right)  # revealed: Right | None
+
+def compare_gradual_cross_enum_left(left: Left | Any, right: Right):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED] | Any
+        reveal_type(right)  # revealed: Right
+
+def compare_gradual_cross_enum_right(left: Left, right: Right | Any):
+    if left == right:
+        reveal_type(left)  # revealed: Left
+        reveal_type(right)  # revealed: Literal[Right.SHARED] | Any
+
+def compare_optional_against_gradual_cross_enum(left: Left | None, right: Right | Any):
+    if left == right:
+        reveal_type(left)  # revealed: Left | None
+        reveal_type(right)  # revealed: Literal[Right.SHARED] | Any
+
+def compare_gradual_against_optional_cross_enum(left: Left | Any, right: Right | None):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED] | Any
+        reveal_type(right)  # revealed: Right | None
+
+def compare_cross_enum_singletons_with_residuals(
+    left: Literal[Left.A, Left.SHARED] | None,
+    right: Literal[Right.SHARED, Right.B] | int,
+):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+        reveal_type(right)  # revealed: Literal[Right.SHARED]
+    else:
+        reveal_type(left)  # revealed: Literal[Left.A, Left.SHARED] | None
+        reveal_type(right)  # revealed: Literal[Right.SHARED, Right.B] | int
 ```
 
 The same comparison-key projection applies when each operand spans several enum classes. This
@@ -526,6 +666,7 @@ comparisons:
 
 ```py
 from enum import IntEnum
+from typing import Literal
 
 class MixedLeft0(IntEnum):
     A = 0
@@ -577,6 +718,32 @@ def compare_mixed_domains(
 ):
     if left == right:
         reveal_type(left)  # revealed: MixedLeft0
+        reveal_type(right)  # revealed: MixedRight0
+
+def compare_mixed_domains_with_residuals(
+    left: MixedLeft0 | MixedLeft1 | None,
+    right: MixedRight0 | MixedRight1 | str,
+):
+    if left == right:
+        reveal_type(left)  # revealed: MixedLeft0
+        reveal_type(right)  # revealed: MixedRight0
+    else:
+        reveal_type(left)  # revealed: MixedLeft0 | MixedLeft1 | None
+        reveal_type(right)  # revealed: MixedRight0 | MixedRight1 | str
+
+    if left != right:
+        reveal_type(left)  # revealed: MixedLeft0 | MixedLeft1 | None
+        reveal_type(right)  # revealed: MixedRight0 | MixedRight1 | str
+    else:
+        reveal_type(left)  # revealed: MixedLeft0
+        reveal_type(right)  # revealed: MixedRight0
+
+def compare_boolean_integer_enum_residual(left: MixedLeft1 | Literal[False], right: MixedRight0):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[False]
+        reveal_type(right)  # revealed: Literal[MixedRight0.A]
+    else:
+        reveal_type(left)  # revealed: MixedLeft1 | Literal[False]
         reveal_type(right)  # revealed: MixedRight0
 ```
 
@@ -674,6 +841,22 @@ class OpenLeft(StrEnum):
 def compare_open(left: OpenLeft, right: CustomRight):
     if left == right:
         reveal_type(left)  # revealed: OpenLeft
+
+def compare_optional_custom(left: CustomLeft | None, right: CustomRight):
+    if left == right:
+        reveal_type(left)  # revealed: CustomLeft
+        reveal_type(right)  # revealed: CustomRight
+    else:
+        reveal_type(left)  # revealed: CustomLeft | None
+        reveal_type(right)  # revealed: CustomRight
+
+def compare_optional_open(left: OpenLeft | None, right: CustomRight):
+    if left == right:
+        reveal_type(left)  # revealed: OpenLeft
+        reveal_type(right)  # revealed: CustomRight
+    else:
+        reveal_type(left)  # revealed: OpenLeft | None
+        reveal_type(right)  # revealed: CustomRight
 ```
 
 The same narrowing applies when comparing enum members directly with their inherited integer or

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -168,6 +168,38 @@ def compare_non_overlapping_literal_unions(
     right: Literal[Choice.THIRD, Choice.FOURTH],
 ):
     reveal_type(left == right)  # revealed: Literal[False]
+
+def compare_optional_left(left: Choice | None, right: Choice):
+    if left == right:
+        reveal_type(left)  # revealed: Choice
+        reveal_type(right)  # revealed: Choice
+    else:
+        reveal_type(left)  # revealed: Choice | None
+        reveal_type(right)  # revealed: Choice
+
+def compare_optional_right(left: Choice, right: Choice | None):
+    if left == right:
+        reveal_type(left)  # revealed: Choice
+        reveal_type(right)  # revealed: Choice
+    else:
+        reveal_type(left)  # revealed: Choice
+        reveal_type(right)  # revealed: Choice | None
+
+def compare_optional_singleton(left: Choice | None, right: Literal[Choice.FIRST]):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Choice.FIRST]
+    else:
+        reveal_type(left)  # revealed: Literal[Choice.SECOND, Choice.THIRD, Choice.FOURTH] | None
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+def compare_optional_integer_enum(left: Number | None, right: Literal[1]):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Number.ONE]
+    else:
+        reveal_type(left)  # revealed: Literal[Number.TWO] | None
 ```
 
 Members with the same known value are aliases, even when one value comes from a function call.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -175,14 +175,12 @@ def compare_optional_left(left: Choice | None, right: Choice):
         reveal_type(right)  # revealed: Choice
     else:
         reveal_type(left)  # revealed: Choice | None
-        reveal_type(right)  # revealed: Choice
 
 def compare_optional_right(left: Choice, right: Choice | None):
     if left == right:
         reveal_type(left)  # revealed: Choice
         reveal_type(right)  # revealed: Choice
     else:
-        reveal_type(left)  # revealed: Choice
         reveal_type(right)  # revealed: Choice | None
 
 def compare_mixed_union_left(left: Choice | int, right: Choice):
@@ -191,20 +189,17 @@ def compare_mixed_union_left(left: Choice | int, right: Choice):
         reveal_type(right)  # revealed: Choice
     else:
         reveal_type(left)  # revealed: Choice | int
-        reveal_type(right)  # revealed: Choice
 
 def compare_mixed_union_right(left: Choice, right: Choice | int):
     if left == right:
         reveal_type(left)  # revealed: Choice
         reveal_type(right)  # revealed: Choice
     else:
-        reveal_type(left)  # revealed: Choice
         reveal_type(right)  # revealed: Choice | int
 
 def compare_multi_arm_union(left: Choice | int | None, right: Choice):
     if left != right:
         reveal_type(left)  # revealed: Choice | int | None
-        reveal_type(right)  # revealed: Choice
     else:
         reveal_type(left)  # revealed: Choice
         reveal_type(right)  # revealed: Choice
@@ -215,14 +210,12 @@ def compare_nested_dynamic_union_left(left: Choice | dict[str, Any], right: Choi
         reveal_type(right)  # revealed: Choice
     else:
         reveal_type(left)  # revealed: Choice | dict[str, Any]
-        reveal_type(right)  # revealed: Choice
 
 def compare_nested_dynamic_union_right(left: Choice, right: Choice | dict[str, Any]):
     if left == right:
         reveal_type(left)  # revealed: Choice
         reveal_type(right)  # revealed: Choice
     else:
-        reveal_type(left)  # revealed: Choice
         reveal_type(right)  # revealed: Choice | dict[str, Any]
 
 def compare_optional_singleton(left: Choice | None, right: Literal[Choice.FIRST]):
@@ -473,14 +466,12 @@ def compare_optional_integer_enum_left(left: Foo | None, right: Bar):
         reveal_type(right)  # revealed: Bar
     else:
         reveal_type(left)  # revealed: Foo | None
-        reveal_type(right)  # revealed: Bar
 
 def compare_optional_integer_enum_right(left: Foo, right: Bar | None):
     if left == right:
         reveal_type(left)  # revealed: Foo
         reveal_type(right)  # revealed: Bar
     else:
-        reveal_type(left)  # revealed: Foo
         reveal_type(right)  # revealed: Bar | None
 ```
 
@@ -538,20 +529,31 @@ def compare_subsets(
         reveal_type(left)  # revealed: Literal[Left.SHARED]
         reveal_type(right)  # revealed: Literal[Right.SHARED]
 
+def compare_cross_enum_residual_truthiness(
+    left: Literal[Left.A] | None,
+    disjoint: Literal[Right.B] | Literal[1],
+    overlapping: Literal[Right.B] | None,
+    matching_left: Literal[Left.SHARED] | Literal["shared"],
+    matching_right: Literal[Right.SHARED],
+):
+    reveal_type(left == disjoint)  # revealed: Literal[False]
+    reveal_type(left != disjoint)  # revealed: Literal[True]
+    reveal_type(left == overlapping)  # revealed: bool
+    reveal_type(matching_left == matching_right)  # revealed: Literal[True]
+    reveal_type(matching_left != matching_right)  # revealed: Literal[False]
+
 def compare_optional_cross_enum_left(left: Left | None, right: Right):
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED]
         reveal_type(right)  # revealed: Literal[Right.SHARED]
     else:
         reveal_type(left)  # revealed: Left | None
-        reveal_type(right)  # revealed: Right
 
 def compare_optional_cross_enum_right(left: Left, right: Right | None):
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED]
         reveal_type(right)  # revealed: Literal[Right.SHARED]
     else:
-        reveal_type(left)  # revealed: Left
         reveal_type(right)  # revealed: Right | None
 
 def compare_both_optional_cross_enums(left: Left | None, right: Right | None):
@@ -848,7 +850,6 @@ def compare_optional_custom(left: CustomLeft | None, right: CustomRight):
         reveal_type(right)  # revealed: CustomRight
     else:
         reveal_type(left)  # revealed: CustomLeft | None
-        reveal_type(right)  # revealed: CustomRight
 
 def compare_optional_open(left: OpenLeft | None, right: CustomRight):
     if left == right:
@@ -856,7 +857,6 @@ def compare_optional_open(left: OpenLeft | None, right: CustomRight):
         reveal_type(right)  # revealed: CustomRight
     else:
         reveal_type(left)  # revealed: OpenLeft | None
-        reveal_type(right)  # revealed: CustomRight
 ```
 
 The same narrowing applies when comparing enum members directly with their inherited integer or

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -126,7 +126,7 @@ members allowed by both. If the restrictions do not overlap, the comparison is a
 
 ```py
 from enum import Enum, IntEnum, StrEnum
-from typing import Literal
+from typing import Any, Literal
 
 class Choice(StrEnum):
     FIRST = "first"
@@ -208,6 +208,22 @@ def compare_multi_arm_union(left: Choice | int | None, right: Choice):
     else:
         reveal_type(left)  # revealed: Choice
         reveal_type(right)  # revealed: Choice
+
+def compare_nested_dynamic_union_left(left: Choice | dict[str, Any], right: Choice):
+    if left == right:
+        reveal_type(left)  # revealed: Choice
+        reveal_type(right)  # revealed: Choice
+    else:
+        reveal_type(left)  # revealed: Choice | dict[str, Any]
+        reveal_type(right)  # revealed: Choice
+
+def compare_nested_dynamic_union_right(left: Choice, right: Choice | dict[str, Any]):
+    if left == right:
+        reveal_type(left)  # revealed: Choice
+        reveal_type(right)  # revealed: Choice
+    else:
+        reveal_type(left)  # revealed: Choice
+        reveal_type(right)  # revealed: Choice | dict[str, Any]
 
 def compare_optional_singleton(left: Choice | None, right: Literal[Choice.FIRST]):
     if left == right:
@@ -1565,6 +1581,21 @@ def gradual_enum_union_against_enum(value: Color | Any, other: Color):
     if value == other:
         reveal_type(value)  # revealed: Color | Any
         assert_type(value, Color | Any)
+
+def gradual_enum_union_inequality(value: Color | Any, other: Color):
+    if value != other:
+        reveal_type(value)  # revealed: Color | Any
+        assert_type(value, Color | Any)
+
+def enum_against_any(value: Color, other: Any):
+    if value != other:
+        reveal_type(other)  # revealed: Any
+        assert_type(other, Any)
+
+def any_against_enum(value: Any, other: Color):
+    if value != other:
+        reveal_type(value)  # revealed: Any
+        assert_type(value, Any)
 
 def custom_equality_enum_union(value: NonReflexive | int, other: NonReflexive):
     if value == other:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1627,8 +1627,10 @@ def tagged_union_with_unrelated_assignment(value: A | B):
 ```py
 import sys
 from enum import Enum, IntEnum
-from typing import Any, Literal, TypeVar
-from typing_extensions import assert_type
+from typing import Any, Literal, TypeAlias, TypeVar
+
+from ty_extensions import Unknown
+from typing_extensions import assert_never, assert_type
 
 T = TypeVar("T", bound=object)
 U = TypeVar("U")
@@ -1638,6 +1640,9 @@ RUNTIME_TYPE_VAR = TypeVar("RUNTIME_TYPE_VAR")
 class Color(Enum):
     RED = 1
     BLUE = 2
+
+class OtherColor(Enum):
+    RED = 1
 
 class NonReflexive(Enum):
     VALUE = 1
@@ -1735,12 +1740,10 @@ def _(x: Any):
 def enum_against_any(value: Color, other: Any):
     if value != other:
         reveal_type(other)  # revealed: Any
-        assert_type(other, Any)
 
 def any_against_enum(value: Any, other: Color):
     if value != other:
         reveal_type(value)  # revealed: Any
-        assert_type(value, Any)
 ```
 
 `Any` must also stay `Any` when the enum can be `None`:
@@ -1749,12 +1752,10 @@ def any_against_enum(value: Any, other: Color):
 def optional_enum_against_any(value: Color | None, other: Any):
     if value != other:
         reveal_type(other)  # revealed: Any
-        assert_type(other, Any)
 
 def any_against_optional_enum(value: Any, other: Color | None):
     if value != other:
         reveal_type(value)  # revealed: Any
-        assert_type(value, Any)
 ```
 
 `Any` must also stay `Any` when compared with `bool | None`:
@@ -1763,7 +1764,6 @@ def any_against_optional_enum(value: Any, other: Color | None):
 def optional_bool_against_any(value: bool | None, other: Any):
     if value != other:
         reveal_type(other)  # revealed: Any
-        assert_type(other, Any)
 ```
 
 Comparing `Color | Any` with `Color | None` must keep both `Color` and `Any`:
@@ -1772,7 +1772,95 @@ Comparing `Color | Any` with `Color | None` must keep both `Color` and `Any`:
 def gradual_enum_union(value: Color | Any, other: Color | None):
     if value != other:
         reveal_type(value)  # revealed: Color | Any
+```
+
+`Color | Any` must stay unchanged when the other value can be an enum member or `None`. This applies
+to `!=` and the false branch of `==`:
+
+```py
+def any_union_against_optional_enum_member(value: Color | Any, other: Literal[Color.RED] | None):
+    if value != other:
+        reveal_type(value)  # revealed: Color | Any
         assert_type(value, Color | Any)
+
+def any_union_against_optional_enum_member_equality_else(value: Color | Any, other: Literal[Color.RED] | None):
+    if value == other:
+        return
+    reveal_type(value)  # revealed: Color | Any
+```
+
+An alias for `Any` must preserve the same result:
+
+```py
+AnyAlias: TypeAlias = Any
+
+def any_alias_union_against_optional_enum_member(value: Color | AnyAlias, other: Literal[Color.RED] | None):
+    if value != other:
+        reveal_type(value)  # revealed: Color | Any
+```
+
+The same comparisons also preserve `Unknown`:
+
+```py
+def unknown_union_against_optional_enum_member(value: Color | Unknown, other: Literal[Color.RED] | None):
+    if value != other:
+        reveal_type(value)  # revealed: Color | Unknown
+        assert_type(value, Color | Unknown)
+
+def unknown_union_against_optional_enum_member_equality_else(value: Color | Unknown, other: Literal[Color.RED] | None):
+    if value == other:
+        return
+    reveal_type(value)  # revealed: Color | Unknown
+```
+
+When an enum check and a comparison are combined with `and`, either condition can be false. The
+original union must therefore be preserved:
+
+```py
+def any_union_after_enum_check(value: Color | Any, other: Color | Any):
+    if isinstance(value, Color) and value == other:
+        return
+    reveal_type(value)  # revealed: Color | Any
+    assert_type(value, Color | Any)
+
+def unknown_union_after_enum_check(value: Color | Unknown, other: Color | Unknown):
+    if isinstance(value, Color) and value == other:
+        return
+    reveal_type(value)  # revealed: Color | Unknown
+    assert_type(value, Color | Unknown)
+```
+
+The second comparison can fail even when the first one matches, so both possible types must remain:
+
+```py
+def any_union_after_failed_comparisons(value: Color | Any, other: OtherColor | None):
+    if value == Color.RED and value == other:
+        return
+    reveal_type(value)  # revealed: Color | Any
+    assert_type(value, Color | Any)
+
+def unknown_union_after_failed_comparisons(value: Color | Unknown, other: OtherColor | None):
+    if value == Color.RED and value == other:
+        return
+    reveal_type(value)  # revealed: Color | Unknown
+    assert_type(value, Color | Unknown)
+```
+
+These `Enum` classes compare by identity, so their members are not equal even when their underlying
+values match. Comparing with `OtherColor.RED` must therefore exclude every `Color` member:
+
+```py
+def any_comparison_with_other_enum(value: Color | OtherColor | Any):
+    if value == OtherColor.RED:
+        reveal_type(value)  # revealed: OtherColor | (Any & ~Color)
+        if isinstance(value, Color):
+            assert_never(value)
+
+def unknown_comparison_with_other_enum(value: Color | OtherColor | Unknown):
+    if value == OtherColor.RED:
+        reveal_type(value)  # revealed: OtherColor | (Unknown & ~Color)
+        if isinstance(value, Color):
+            assert_never(value)
 ```
 
 `Color | Any` must also stay unchanged after either `==` or `!=`:
@@ -1781,12 +1869,10 @@ def gradual_enum_union(value: Color | Any, other: Color | None):
 def gradual_enum_union_against_enum(value: Color | Any, other: Color):
     if value == other:
         reveal_type(value)  # revealed: Color | Any
-        assert_type(value, Color | Any)
 
 def gradual_enum_union_inequality(value: Color | Any, other: Color):
     if value != other:
         reveal_type(value)  # revealed: Color | Any
-        assert_type(value, Color | Any)
 ```
 
 ## Booleans and integers

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -184,7 +184,8 @@ def compare_optional_right(left: Choice, right: Choice | None):
         reveal_type(right)  # revealed: Choice
 ```
 
-Neither an integer nor `None` can compare equal to a string-valued enum member:
+With ty's default builtin-equality assumptions, neither an integer nor `None` matches a
+string-valued enum member:
 
 ```py
 def compare_enum_with_integer(left: Choice | int | None, right: Choice):
@@ -496,8 +497,8 @@ def compare_both_optional_cross_enums(left: Left | None, right: Right | None):
         reveal_type(right)  # revealed: Literal[Right.SHARED] | None
 ```
 
-An unrelated integer must not change which enum members match, whether the condition uses `==` or
-`!=`:
+Under the same assumptions, an unrelated integer does not change which enum members match, whether
+the condition uses `==` or `!=`:
 
 ```py
 def compare_cross_enums_with_integer(left: Left | None, right: Right | int):
@@ -528,7 +529,8 @@ def compare_right_string_against_enum_members(left: Left, right: Right | Literal
         assert_type(right, Literal[Right.SHARED, "a"])
 ```
 
-A dictionary containing `Any` is still a dictionary, so it cannot match a string-valued enum member:
+A `dict[str, Any]` is treated as having dictionary equality, so it cannot match a string-valued enum
+member:
 
 ```py
 def compare_cross_enum_with_dictionary(left: Left | dict[str, Any], right: Right | None):
@@ -637,7 +639,8 @@ def compare_mixed_domains(
         reveal_type(right)  # revealed: MixedRight0
 ```
 
-Adding `None` or a string must not prevent matches between members of integer-valued enum classes:
+Treating `str` as having builtin equality, adding `None` or `str` does not prevent matches between
+integer-valued enum classes:
 
 ```py
 def compare_multiple_integer_enums_with_other_values(
@@ -2087,17 +2090,22 @@ def _(x: A | B):
 
 ## Enabling strict equality narrowing
 
-The `strict-equality-semantics` option can be enabled to preserve broad builtin types and union
-members that a subclass could compare equal to. Narrowing types that are already literal unions
-remains safe and is unaffected. This also applies to tuples, whose subclasses can override equality.
+Enabling `strict-equality-semantics` accounts for builtin subclasses that override `__eq__` or
+compare equal to a literal without belonging to its `Literal` type. It preserves broad builtin types
+and union alternatives that could compare equal, including tuples. Literal unions and enum members
+are still narrowed when it is safe.
 
 ```toml
+[environment]
+python-version = "3.11"
+
 [analysis]
 strict-equality-semantics = true
 ```
 
 ```py
-from typing import Literal
+from enum import IntEnum, StrEnum
+from typing import Any, Literal
 
 def broad(value: str):
     if value == "a":
@@ -2114,6 +2122,64 @@ def inequality(value: str):
 def literal(value: Literal["a", "b"]):
     if value == "a":
         reveal_type(value)  # revealed: Literal["a"]
+
+class Left(StrEnum):
+    A = "a"
+    SHARED = "shared"
+
+class Right(StrEnum):
+    SHARED = "shared"
+    B = "b"
+
+def compare_enum_with_integer(left: Left | int | None, right: Left):
+    if left == right:
+        reveal_type(left)  # revealed: Left | int
+
+def compare_cross_enums_with_integer(left: Left | None, right: Right | int):
+    if left == right:
+        reveal_type(left)  # revealed: Left | None
+        reveal_type(right)  # revealed: Literal[Right.SHARED] | int
+
+    if left != right:
+        reveal_type(left)  # revealed: Left | None
+        reveal_type(right)  # revealed: Right | int
+    else:
+        reveal_type(left)  # revealed: Left | None
+        reveal_type(right)  # revealed: Literal[Right.SHARED] | int
+
+def compare_cross_enum_with_dictionary(left: Left | dict[str, Any], right: Right | None):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED] | dict[str, Any]
+        reveal_type(right)  # revealed: Right | None
+
+def compare_both_optional_cross_enums(left: Left | None, right: Right | None):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED] | None
+        reveal_type(right)  # revealed: Literal[Right.SHARED] | None
+
+class MixedLeft0(IntEnum):
+    ZERO = 0
+    ONE = 1
+
+class MixedLeft1(IntEnum):
+    TWO = 2
+    THREE = 3
+
+class MixedRight0(IntEnum):
+    ZERO = 0
+    ONE = 1
+
+class MixedRight1(IntEnum):
+    FOUR = 4
+    FIVE = 5
+
+def compare_multiple_integer_enums_with_other_values(
+    left: MixedLeft0 | MixedLeft1 | None,
+    right: MixedRight0 | MixedRight1 | str,
+):
+    if left == right:
+        reveal_type(left)  # revealed: MixedLeft0 | MixedLeft1 | None
+        reveal_type(right)  # revealed: MixedRight0 | str
 
 class Foo: ...
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -170,7 +170,7 @@ def compare_non_overlapping_literal_unions(
     reveal_type(left == right)  # revealed: Literal[False]
 ```
 
-Adding `None` to either operand must not change how equality narrows the enum:
+Adding `None` to either side must not change which enum values can match:
 
 ```py
 def compare_optional_left(left: Choice | None, right: Choice):
@@ -473,8 +473,7 @@ def compare_subsets(
         reveal_type(right)  # revealed: Literal[Right.SHARED]
 ```
 
-When only one operand can be `None`, equality still narrows both enums to their shared value. This
-works whichever operand contains `None`:
+When only one side can be `None`, equality still narrows both enums to their shared value:
 
 ```py
 def compare_optional_cross_enum_left(left: Left | None, right: Right):
@@ -488,7 +487,7 @@ def compare_optional_cross_enum_right(left: Left, right: Right | None):
         reveal_type(right)  # revealed: Literal[Right.SHARED]
 ```
 
-When both operands can be `None`, equality can match either `None` or the shared string value:
+When both sides can be `None`, equality can match `None` or the shared string:
 
 ```py
 def compare_both_optional_cross_enums(left: Left | None, right: Right | None):
@@ -497,8 +496,8 @@ def compare_both_optional_cross_enums(left: Left | None, right: Right | None):
         reveal_type(right)  # revealed: Literal[Right.SHARED] | None
 ```
 
-An unrelated integer must not prevent the matching enum members from being found. This must work
-whether the condition uses equality or inequality:
+An unrelated integer must not change which enum members match, whether the condition uses `==` or
+`!=`:
 
 ```py
 def compare_cross_enums_with_integer(left: Left | None, right: Right | int):
@@ -538,7 +537,7 @@ def compare_cross_enum_with_dictionary(left: Left | dict[str, Any], right: Right
         reveal_type(right)  # revealed: Literal[Right.SHARED]
 ```
 
-By contrast, `Any` can match any enum member. It must not exclude `None` from the other operand:
+By contrast, `Any` can match any enum member. It must not exclude `None` from the other side:
 
 ```py
 def compare_optional_enum_against_any(left: Left | None, right: Right | Any):
@@ -552,8 +551,8 @@ def compare_any_against_optional_enum(left: Left | Any, right: Right | None):
         reveal_type(right)  # revealed: Right | None
 ```
 
-When no alternatives can match, equality is always false and inequality is always true. A shared
-`None` makes equality uncertain:
+If the two sides have no matching values, `==` is always false and `!=` is always true. A shared
+`None` makes `==` uncertain:
 
 ```py
 def compare_disjoint_cross_enum_alternatives(
@@ -566,7 +565,7 @@ def compare_disjoint_cross_enum_alternatives(
     reveal_type(left == overlapping)  # revealed: bool
 ```
 
-When all alternatives have the same value, equality is always true:
+When all possible values match, `==` is always true:
 
 ```py
 def compare_matching_cross_enum_alternatives(
@@ -1730,8 +1729,7 @@ def _(x: Any):
         reveal_type(x)  # revealed: Any & ~TypeVar
 ```
 
-Comparing an enum with `Any` must not narrow `Any` by considering each enum member separately. This
-applies whichever operand contains `Any`:
+`Any` must stay `Any` when compared with an enum, on either side of the comparison:
 
 ```py
 def enum_against_any(value: Color, other: Any):
@@ -1745,7 +1743,7 @@ def any_against_enum(value: Any, other: Color):
         assert_type(value, Any)
 ```
 
-Adding `None` to the enum must not change how `Any` is preserved:
+`Any` must also stay `Any` when the enum can be `None`:
 
 ```py
 def optional_enum_against_any(value: Color | None, other: Any):
@@ -1759,7 +1757,7 @@ def any_against_optional_enum(value: Any, other: Color | None):
         assert_type(value, Any)
 ```
 
-Preserving `Any` in enum comparisons must not change how `Any` behaves with an optional boolean:
+`Any` must also stay `Any` when compared with `bool | None`:
 
 ```py
 def optional_bool_against_any(value: bool | None, other: Any):
@@ -1768,8 +1766,7 @@ def optional_bool_against_any(value: bool | None, other: Any):
         assert_type(other, Any)
 ```
 
-When an enum is combined with `Any`, comparing against an optional enum must retain both
-alternatives:
+Comparing `Color | Any` with `Color | None` must keep both `Color` and `Any`:
 
 ```py
 def gradual_enum_union(value: Color | Any, other: Color | None):
@@ -1778,7 +1775,7 @@ def gradual_enum_union(value: Color | Any, other: Color | None):
         assert_type(value, Color | Any)
 ```
 
-The same union must also remain unchanged after either an equality or inequality check:
+`Color | Any` must also stay unchanged after either `==` or `!=`:
 
 ```py
 def gradual_enum_union_against_enum(value: Color | Any, other: Color):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1492,6 +1492,7 @@ def tagged_union_with_unrelated_assignment(value: A | B):
 import sys
 from enum import Enum, IntEnum
 from typing import Any, Literal, TypeVar
+from typing_extensions import assert_type
 
 T = TypeVar("T", bound=object)
 U = TypeVar("U")
@@ -1515,6 +1516,26 @@ class Marker: ...
 
 class SingleIntEnum(IntEnum):
     VALUE = 1
+
+def optional_enum_against_any(value: Color | None, other: Any):
+    if value != other:
+        reveal_type(other)  # revealed: Any
+        assert_type(other, Any)
+
+def any_against_optional_enum(value: Any, other: Color | None):
+    if value != other:
+        reveal_type(value)  # revealed: Any
+        assert_type(value, Any)
+
+def optional_bool_against_any(value: bool | None, other: Any):
+    if value != other:
+        reveal_type(other)  # revealed: Any
+        assert_type(other, Any)
+
+def gradual_enum_union(value: Color | Any, other: Color | None):
+    if value != other:
+        reveal_type(value)  # revealed: Color | Any
+        assert_type(value, Color | Any)
 
 def _(x: Any | None, y: Any | None):
     if x != 1:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -126,7 +126,7 @@ members allowed by both. If the restrictions do not overlap, the comparison is a
 
 ```py
 from enum import Enum, IntEnum, StrEnum
-from typing import Any, Literal
+from typing import Literal
 
 class Choice(StrEnum):
     FIRST = "first"
@@ -168,71 +168,30 @@ def compare_non_overlapping_literal_unions(
     right: Literal[Choice.THIRD, Choice.FOURTH],
 ):
     reveal_type(left == right)  # revealed: Literal[False]
+```
 
+Adding `None` to either operand must not change how equality narrows the enum:
+
+```py
 def compare_optional_left(left: Choice | None, right: Choice):
     if left == right:
         reveal_type(left)  # revealed: Choice
-        reveal_type(right)  # revealed: Choice
     else:
         reveal_type(left)  # revealed: Choice | None
 
 def compare_optional_right(left: Choice, right: Choice | None):
     if left == right:
-        reveal_type(left)  # revealed: Choice
         reveal_type(right)  # revealed: Choice
-    else:
-        reveal_type(right)  # revealed: Choice | None
+```
 
-def compare_mixed_union_left(left: Choice | int, right: Choice):
+Neither an integer nor `None` can compare equal to a string-valued enum member:
+
+```py
+def compare_enum_with_integer(left: Choice | int | None, right: Choice):
     if left == right:
         reveal_type(left)  # revealed: Choice
-        reveal_type(right)  # revealed: Choice
     else:
-        reveal_type(left)  # revealed: Choice | int
-
-def compare_mixed_union_right(left: Choice, right: Choice | int):
-    if left == right:
-        reveal_type(left)  # revealed: Choice
-        reveal_type(right)  # revealed: Choice
-    else:
-        reveal_type(right)  # revealed: Choice | int
-
-def compare_multi_arm_union(left: Choice | int | None, right: Choice):
-    if left != right:
         reveal_type(left)  # revealed: Choice | int | None
-    else:
-        reveal_type(left)  # revealed: Choice
-        reveal_type(right)  # revealed: Choice
-
-def compare_nested_dynamic_union_left(left: Choice | dict[str, Any], right: Choice):
-    if left == right:
-        reveal_type(left)  # revealed: Choice
-        reveal_type(right)  # revealed: Choice
-    else:
-        reveal_type(left)  # revealed: Choice | dict[str, Any]
-
-def compare_nested_dynamic_union_right(left: Choice, right: Choice | dict[str, Any]):
-    if left == right:
-        reveal_type(left)  # revealed: Choice
-        reveal_type(right)  # revealed: Choice
-    else:
-        reveal_type(right)  # revealed: Choice | dict[str, Any]
-
-def compare_optional_singleton(left: Choice | None, right: Literal[Choice.FIRST]):
-    if left == right:
-        reveal_type(left)  # revealed: Literal[Choice.FIRST]
-    else:
-        reveal_type(left)  # revealed: Literal[Choice.SECOND, Choice.THIRD, Choice.FOURTH] | None
-
-class Number(IntEnum):
-    ONE = 1
-    TWO = 2
-
-def compare_optional_integer_enum(left: Number | None, right: Literal[1]):
-    if left == right:
-        reveal_type(left)  # revealed: Literal[Number.ONE]
-    else:
-        reveal_type(left)  # revealed: Literal[Number.TWO] | None
 ```
 
 Members with the same known value are aliases, even when one value comes from a function call.
@@ -459,20 +418,6 @@ def _(value: Foo | Bar):
         reveal_type(value)  # revealed: Literal[Foo.Y, Bar.B]
     else:
         reveal_type(value)  # revealed: Literal[Foo.X, Bar.A]
-
-def compare_optional_integer_enum_left(left: Foo | None, right: Bar):
-    if left == right:
-        reveal_type(left)  # revealed: Foo
-        reveal_type(right)  # revealed: Bar
-    else:
-        reveal_type(left)  # revealed: Foo | None
-
-def compare_optional_integer_enum_right(left: Foo, right: Bar | None):
-    if left == right:
-        reveal_type(left)  # revealed: Foo
-        reveal_type(right)  # revealed: Bar
-    else:
-        reveal_type(right)  # revealed: Bar | None
 ```
 
 `StrEnum` domains from different classes are compared by their string values. Equality retains the
@@ -481,7 +426,8 @@ member. Exact member comparisons are true or false when both values are known:
 
 ```py
 from enum import StrEnum
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal
+from typing_extensions import assert_type
 
 class Left(StrEnum):
     A = "a"
@@ -492,9 +438,6 @@ class Right(StrEnum):
     SHARED = "shared"
     B = "b"
     D = "d"
-
-OptionalLeft: TypeAlias = Left | None
-OptionalRight: TypeAlias = Right | None
 
 reveal_type(Left.SHARED == Right.SHARED)  # revealed: Literal[True]
 reveal_type(Left.A == Right.B)  # revealed: Literal[False]
@@ -528,61 +471,40 @@ def compare_subsets(
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED]
         reveal_type(right)  # revealed: Literal[Right.SHARED]
+```
 
-def compare_cross_enum_residual_truthiness(
-    left: Literal[Left.A] | None,
-    disjoint: Literal[Right.B] | Literal[1],
-    overlapping: Literal[Right.B] | None,
-    matching_left: Literal[Left.SHARED] | Literal["shared"],
-    matching_right: Literal[Right.SHARED],
-):
-    reveal_type(left == disjoint)  # revealed: Literal[False]
-    reveal_type(left != disjoint)  # revealed: Literal[True]
-    reveal_type(left == overlapping)  # revealed: bool
-    reveal_type(matching_left == matching_right)  # revealed: Literal[True]
-    reveal_type(matching_left != matching_right)  # revealed: Literal[False]
+When only one operand can be `None`, equality still narrows both enums to their shared value. This
+works whichever operand contains `None`:
 
+```py
 def compare_optional_cross_enum_left(left: Left | None, right: Right):
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED]
         reveal_type(right)  # revealed: Literal[Right.SHARED]
-    else:
-        reveal_type(left)  # revealed: Left | None
 
 def compare_optional_cross_enum_right(left: Left, right: Right | None):
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED]
         reveal_type(right)  # revealed: Literal[Right.SHARED]
-    else:
-        reveal_type(right)  # revealed: Right | None
+```
 
+When both operands can be `None`, equality can match either `None` or the shared string value:
+
+```py
 def compare_both_optional_cross_enums(left: Left | None, right: Right | None):
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED] | None
         reveal_type(right)  # revealed: Literal[Right.SHARED] | None
-    else:
-        reveal_type(left)  # revealed: Left | None
-        reveal_type(right)  # revealed: Right | None
+```
 
-    if left != right:
-        reveal_type(left)  # revealed: Left | None
-        reveal_type(right)  # revealed: Right | None
-    else:
-        reveal_type(left)  # revealed: Literal[Left.SHARED] | None
-        reveal_type(right)  # revealed: Literal[Right.SHARED] | None
+An unrelated integer must not prevent the matching enum members from being found. This must work
+whether the condition uses equality or inequality:
 
-def compare_optional_cross_enum_aliases(left: OptionalLeft, right: OptionalRight):
-    if left == right:
-        reveal_type(left)  # revealed: Literal[Left.SHARED] | None
-        reveal_type(right)  # revealed: Literal[Right.SHARED] | None
-
-def compare_mixed_cross_enum_residuals(left: Left | None, right: Right | int):
+```py
+def compare_cross_enums_with_integer(left: Left | None, right: Right | int):
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED]
         reveal_type(right)  # revealed: Literal[Right.SHARED]
-    else:
-        reveal_type(left)  # revealed: Left | None
-        reveal_type(right)  # revealed: Right | int
 
     if left != right:
         reveal_type(left)  # revealed: Left | None
@@ -590,76 +512,69 @@ def compare_mixed_cross_enum_residuals(left: Left | None, right: Right | int):
     else:
         reveal_type(left)  # revealed: Literal[Left.SHARED]
         reveal_type(right)  # revealed: Literal[Right.SHARED]
+```
 
-def compare_reversed_mixed_cross_enum_residuals(left: Left | int, right: Right | None):
-    if left == right:
-        reveal_type(left)  # revealed: Literal[Left.SHARED]
-        reveal_type(right)  # revealed: Literal[Right.SHARED]
-    else:
-        reveal_type(left)  # revealed: Left | int
-        reveal_type(right)  # revealed: Right | None
+A plain string can also match a member of the other enum. The string and every matching enum member
+must remain possible:
 
-def compare_overlapping_cross_enum_residual_left(left: Left | Literal["b"], right: Right):
+```py
+def compare_left_string_against_enum_members(left: Left | Literal["b"], right: Right):
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED, "b"]
         reveal_type(right)  # revealed: Literal[Right.SHARED, Right.B]
-    else:
-        reveal_type(left)  # revealed: Left | Literal["b"]
-        reveal_type(right)  # revealed: Right
 
-    if left != right:
-        reveal_type(left)  # revealed: Left | Literal["b"]
-        reveal_type(right)  # revealed: Right
-    else:
-        reveal_type(left)  # revealed: Literal[Left.SHARED, "b"]
-        reveal_type(right)  # revealed: Literal[Right.SHARED, Right.B]
-
-def compare_overlapping_cross_enum_residual_right(left: Left, right: Right | Literal["a"]):
+def compare_right_string_against_enum_members(left: Left, right: Right | Literal["a"]):
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED, Left.A]
-        reveal_type(right)  # revealed: Literal[Right.SHARED, "a"]
-    else:
-        reveal_type(left)  # revealed: Left
-        reveal_type(right)  # revealed: Right | Literal["a"]
+        assert_type(right, Literal[Right.SHARED, "a"])
+```
 
-def compare_nested_dynamic_cross_enum_residual(left: Left | dict[str, Any], right: Right | None):
+A dictionary containing `Any` is still a dictionary, so it cannot match a string-valued enum member:
+
+```py
+def compare_cross_enum_with_dictionary(left: Left | dict[str, Any], right: Right | None):
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED]
         reveal_type(right)  # revealed: Literal[Right.SHARED]
-    else:
-        reveal_type(left)  # revealed: Left | dict[str, Any]
-        reveal_type(right)  # revealed: Right | None
+```
 
-def compare_gradual_cross_enum_left(left: Left | Any, right: Right):
-    if left == right:
-        reveal_type(left)  # revealed: Literal[Left.SHARED] | Any
-        reveal_type(right)  # revealed: Right
+By contrast, `Any` can match any enum member. It must not exclude `None` from the other operand:
 
-def compare_gradual_cross_enum_right(left: Left, right: Right | Any):
-    if left == right:
-        reveal_type(left)  # revealed: Left
-        reveal_type(right)  # revealed: Literal[Right.SHARED] | Any
-
-def compare_optional_against_gradual_cross_enum(left: Left | None, right: Right | Any):
+```py
+def compare_optional_enum_against_any(left: Left | None, right: Right | Any):
     if left == right:
         reveal_type(left)  # revealed: Left | None
         reveal_type(right)  # revealed: Literal[Right.SHARED] | Any
 
-def compare_gradual_against_optional_cross_enum(left: Left | Any, right: Right | None):
+def compare_any_against_optional_enum(left: Left | Any, right: Right | None):
     if left == right:
         reveal_type(left)  # revealed: Literal[Left.SHARED] | Any
         reveal_type(right)  # revealed: Right | None
+```
 
-def compare_cross_enum_singletons_with_residuals(
-    left: Literal[Left.A, Left.SHARED] | None,
-    right: Literal[Right.SHARED, Right.B] | int,
+When no alternatives can match, equality is always false and inequality is always true. A shared
+`None` makes equality uncertain:
+
+```py
+def compare_disjoint_cross_enum_alternatives(
+    left: Literal[Left.A] | None,
+    disjoint: Literal[Right.B] | Literal[1],
+    overlapping: Literal[Right.B] | None,
 ):
-    if left == right:
-        reveal_type(left)  # revealed: Literal[Left.SHARED]
-        reveal_type(right)  # revealed: Literal[Right.SHARED]
-    else:
-        reveal_type(left)  # revealed: Literal[Left.A, Left.SHARED] | None
-        reveal_type(right)  # revealed: Literal[Right.SHARED, Right.B] | int
+    reveal_type(left == disjoint)  # revealed: Literal[False]
+    reveal_type(left != disjoint)  # revealed: Literal[True]
+    reveal_type(left == overlapping)  # revealed: bool
+```
+
+When all alternatives have the same value, equality is always true:
+
+```py
+def compare_matching_cross_enum_alternatives(
+    left: Literal[Left.SHARED] | Literal["shared"],
+    right: Literal[Right.SHARED],
+):
+    reveal_type(left == right)  # revealed: Literal[True]
+    reveal_type(left != right)  # revealed: Literal[False]
 ```
 
 The same comparison-key projection applies when each operand spans several enum classes. This
@@ -721,32 +636,28 @@ def compare_mixed_domains(
     if left == right:
         reveal_type(left)  # revealed: MixedLeft0
         reveal_type(right)  # revealed: MixedRight0
+```
 
-def compare_mixed_domains_with_residuals(
+Adding `None` or a string must not prevent matches between members of integer-valued enum classes:
+
+```py
+def compare_multiple_integer_enums_with_other_values(
     left: MixedLeft0 | MixedLeft1 | None,
     right: MixedRight0 | MixedRight1 | str,
 ):
     if left == right:
         reveal_type(left)  # revealed: MixedLeft0
         reveal_type(right)  # revealed: MixedRight0
-    else:
-        reveal_type(left)  # revealed: MixedLeft0 | MixedLeft1 | None
-        reveal_type(right)  # revealed: MixedRight0 | MixedRight1 | str
+```
 
-    if left != right:
-        reveal_type(left)  # revealed: MixedLeft0 | MixedLeft1 | None
-        reveal_type(right)  # revealed: MixedRight0 | MixedRight1 | str
-    else:
-        reveal_type(left)  # revealed: MixedLeft0
-        reveal_type(right)  # revealed: MixedRight0
+Python considers `False` equal to `0`, so a `False` alternative can match an integer-valued enum
+member even when the other enum has no matching members:
 
-def compare_boolean_integer_enum_residual(left: MixedLeft1 | Literal[False], right: MixedRight0):
+```py
+def compare_false_to_integer_enum(left: MixedLeft1 | Literal[False], right: MixedRight0):
     if left == right:
         reveal_type(left)  # revealed: Literal[False]
         reveal_type(right)  # revealed: Literal[MixedRight0.A]
-    else:
-        reveal_type(left)  # revealed: MixedLeft1 | Literal[False]
-        reveal_type(right)  # revealed: MixedRight0
 ```
 
 An open identity-comparing enum can still be narrowed to all of its declared members. Undeclared
@@ -843,20 +754,23 @@ class OpenLeft(StrEnum):
 def compare_open(left: OpenLeft, right: CustomRight):
     if left == right:
         reveal_type(left)  # revealed: OpenLeft
+```
 
+A custom equality method must still determine the result when the enum is combined with `None`:
+
+```py
 def compare_optional_custom(left: CustomLeft | None, right: CustomRight):
     if left == right:
         reveal_type(left)  # revealed: CustomLeft
-        reveal_type(right)  # revealed: CustomRight
-    else:
-        reveal_type(left)  # revealed: CustomLeft | None
+```
 
+An enum with `_missing_` may have members that do not appear in its definition. Adding `None` must
+not cause the comparison to assume that its declared member is the only possible match:
+
+```py
 def compare_optional_open(left: OpenLeft | None, right: CustomRight):
     if left == right:
         reveal_type(left)  # revealed: OpenLeft
-        reveal_type(right)  # revealed: CustomRight
-    else:
-        reveal_type(left)  # revealed: OpenLeft | None
 ```
 
 The same narrowing applies when comparing enum members directly with their inherited integer or
@@ -1740,51 +1654,6 @@ class Marker: ...
 class SingleIntEnum(IntEnum):
     VALUE = 1
 
-def optional_enum_against_any(value: Color | None, other: Any):
-    if value != other:
-        reveal_type(other)  # revealed: Any
-        assert_type(other, Any)
-
-def any_against_optional_enum(value: Any, other: Color | None):
-    if value != other:
-        reveal_type(value)  # revealed: Any
-        assert_type(value, Any)
-
-def optional_bool_against_any(value: bool | None, other: Any):
-    if value != other:
-        reveal_type(other)  # revealed: Any
-        assert_type(other, Any)
-
-def gradual_enum_union(value: Color | Any, other: Color | None):
-    if value != other:
-        reveal_type(value)  # revealed: Color | Any
-        assert_type(value, Color | Any)
-
-def gradual_enum_union_against_enum(value: Color | Any, other: Color):
-    if value == other:
-        reveal_type(value)  # revealed: Color | Any
-        assert_type(value, Color | Any)
-
-def gradual_enum_union_inequality(value: Color | Any, other: Color):
-    if value != other:
-        reveal_type(value)  # revealed: Color | Any
-        assert_type(value, Color | Any)
-
-def enum_against_any(value: Color, other: Any):
-    if value != other:
-        reveal_type(other)  # revealed: Any
-        assert_type(other, Any)
-
-def any_against_enum(value: Any, other: Color):
-    if value != other:
-        reveal_type(value)  # revealed: Any
-        assert_type(value, Any)
-
-def custom_equality_enum_union(value: NonReflexive | int, other: NonReflexive):
-    if value == other:
-        reveal_type(value)  # revealed: NonReflexive | int
-        reveal_type(other)  # revealed: NonReflexive
-
 def _(x: Any | None, y: Any | None):
     if x != 1:
         reveal_type(x)  # revealed: (Any & ~Literal[1] & ~Literal[True]) | None
@@ -1859,6 +1728,68 @@ def _(x: Any):
         pass
     else:
         reveal_type(x)  # revealed: Any & ~TypeVar
+```
+
+Comparing an enum with `Any` must not narrow `Any` by considering each enum member separately. This
+applies whichever operand contains `Any`:
+
+```py
+def enum_against_any(value: Color, other: Any):
+    if value != other:
+        reveal_type(other)  # revealed: Any
+        assert_type(other, Any)
+
+def any_against_enum(value: Any, other: Color):
+    if value != other:
+        reveal_type(value)  # revealed: Any
+        assert_type(value, Any)
+```
+
+Adding `None` to the enum must not change how `Any` is preserved:
+
+```py
+def optional_enum_against_any(value: Color | None, other: Any):
+    if value != other:
+        reveal_type(other)  # revealed: Any
+        assert_type(other, Any)
+
+def any_against_optional_enum(value: Any, other: Color | None):
+    if value != other:
+        reveal_type(value)  # revealed: Any
+        assert_type(value, Any)
+```
+
+Preserving `Any` in enum comparisons must not change how `Any` behaves with an optional boolean:
+
+```py
+def optional_bool_against_any(value: bool | None, other: Any):
+    if value != other:
+        reveal_type(other)  # revealed: Any
+        assert_type(other, Any)
+```
+
+When an enum is combined with `Any`, comparing against an optional enum must retain both
+alternatives:
+
+```py
+def gradual_enum_union(value: Color | Any, other: Color | None):
+    if value != other:
+        reveal_type(value)  # revealed: Color | Any
+        assert_type(value, Color | Any)
+```
+
+The same union must also remain unchanged after either an equality or inequality check:
+
+```py
+def gradual_enum_union_against_enum(value: Color | Any, other: Color):
+    if value == other:
+        reveal_type(value)  # revealed: Color | Any
+        assert_type(value, Color | Any)
+
+def gradual_enum_union_inequality(value: Color | Any, other: Color):
+    if value != other:
+        reveal_type(value)  # revealed: Color | Any
+        assert_type(value, Color | Any)
 ```
 
 ## Booleans and integers

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -185,6 +185,30 @@ def compare_optional_right(left: Choice, right: Choice | None):
         reveal_type(left)  # revealed: Choice
         reveal_type(right)  # revealed: Choice | None
 
+def compare_mixed_union_left(left: Choice | int, right: Choice):
+    if left == right:
+        reveal_type(left)  # revealed: Choice
+        reveal_type(right)  # revealed: Choice
+    else:
+        reveal_type(left)  # revealed: Choice | int
+        reveal_type(right)  # revealed: Choice
+
+def compare_mixed_union_right(left: Choice, right: Choice | int):
+    if left == right:
+        reveal_type(left)  # revealed: Choice
+        reveal_type(right)  # revealed: Choice
+    else:
+        reveal_type(left)  # revealed: Choice
+        reveal_type(right)  # revealed: Choice | int
+
+def compare_multi_arm_union(left: Choice | int | None, right: Choice):
+    if left != right:
+        reveal_type(left)  # revealed: Choice | int | None
+        reveal_type(right)  # revealed: Choice
+    else:
+        reveal_type(left)  # revealed: Choice
+        reveal_type(right)  # revealed: Choice
+
 def compare_optional_singleton(left: Choice | None, right: Literal[Choice.FIRST]):
     if left == right:
         reveal_type(left)  # revealed: Literal[Choice.FIRST]
@@ -1536,6 +1560,16 @@ def gradual_enum_union(value: Color | Any, other: Color | None):
     if value != other:
         reveal_type(value)  # revealed: Color | Any
         assert_type(value, Color | Any)
+
+def gradual_enum_union_against_enum(value: Color | Any, other: Color):
+    if value == other:
+        reveal_type(value)  # revealed: Color | Any
+        assert_type(value, Color | Any)
+
+def custom_equality_enum_union(value: NonReflexive | int, other: NonReflexive):
+    if value == other:
+        reveal_type(value)  # revealed: NonReflexive | int
+        reveal_type(other)  # revealed: NonReflexive
 
 def _(x: Any | None, y: Any | None):
     if x != 1:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -3101,6 +3101,13 @@ def cross_int_enum_members(value: First | Second) -> None:
         case _:
             reveal_type(value)  # revealed: Literal[First.TWO, Second.TWO]
 
+def optional_cross_int_enum_members(value: First | Second | None) -> None:
+    match value:
+        case First.ONE:
+            reveal_type(value)  # revealed: Literal[First.ONE, Second.ONE]
+        case _:
+            reveal_type(value)  # revealed: Literal[First.TWO, Second.TWO] | None
+
 class Warning(Enum):
     W1 = auto()
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -490,23 +490,21 @@ fn evaluate_comparison_once<'db>(
         return result;
     }
 
-    // Expand an optional enum before its peer's members to avoid repeatedly expanding the enum.
-    // Other unions must retain their normal evaluation order, especially around dynamic operands.
+    // Expand a union containing its enum peer before expanding that enum into individual members.
+    // Gradual unions must retain their normal evaluation order to preserve dynamic narrowing.
     match (left, right) {
         (Type::Union(union), other)
             if other.is_enum(db)
-                && union.elements(db).len() == 2
                 && union.elements(db).contains(&other)
-                && union.elements(db).iter().any(|element| element.is_none(db))
+                && !left.has_dynamic(db)
                 && KnownComparisonSemantics::of_type(db, other, operator).is_some() =>
         {
             return evaluate_union_left(evaluator, union.elements(db), other, branch, operator);
         }
         (other, Type::Union(union))
             if other.is_enum(db)
-                && union.elements(db).len() == 2
                 && union.elements(db).contains(&other)
-                && union.elements(db).iter().any(|element| element.is_none(db))
+                && !right.has_dynamic(db)
                 && KnownComparisonSemantics::of_type(db, other, operator).is_some() =>
         {
             return evaluate_union_right(evaluator, other, union.elements(db), branch, operator);

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -17,7 +17,7 @@ use super::{
 
 mod enums;
 
-use self::enums::evaluate_enum_domains;
+use self::enums::{evaluate_enum_domains, evaluate_partitioned_enum_domains};
 
 /// The result of evaluating a runtime comparison between two types.
 ///
@@ -168,6 +168,16 @@ pub(super) fn evaluate_type_equality<'db>(
     .or_else(|| {
         evaluate_enum_domains(db, left, right, branch, ComparisonOperator::Equality)
             .and_then(|result| result.constraint(branch))
+    })
+    .or_else(|| {
+        evaluate_partitioned_enum_domains(
+            &mut ComparisonEvaluator::new(db, soundness_policy),
+            left,
+            right,
+            branch,
+            ComparisonOperator::Equality,
+        )
+        .and_then(|result| result.constraint(branch))
     })
     .or_else(|| {
         if comparison_domain(
@@ -490,6 +500,12 @@ fn evaluate_comparison_once<'db>(
         return result;
     }
 
+    if let Some(result) =
+        evaluate_partitioned_enum_domains(evaluator, left, right, branch, operator)
+    {
+        return result;
+    }
+
     match (left, right) {
         (Type::Dynamic(_), other) => {
             return if !operator.condition_expects_equality(branch)
@@ -514,25 +530,6 @@ fn evaluate_comparison_once<'db>(
             };
         }
         (_, Type::Dynamic(_)) => return ComparisonResult::Ambiguous,
-        _ => {}
-    }
-
-    // Expand a union containing its enum peer before expanding that enum into individual members.
-    match (left, right) {
-        (Type::Union(union), other)
-            if other.is_enum(db)
-                && union.elements(db).contains(&other)
-                && KnownComparisonSemantics::of_type(db, other, operator).is_some() =>
-        {
-            return evaluate_union_left(evaluator, union.elements(db), other, branch, operator);
-        }
-        (other, Type::Union(union))
-            if other.is_enum(db)
-                && union.elements(db).contains(&other)
-                && KnownComparisonSemantics::of_type(db, other, operator).is_some() =>
-        {
-            return evaluate_union_right(evaluator, other, union.elements(db), branch, operator);
-        }
         _ => {}
     }
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -490,11 +490,25 @@ fn evaluate_comparison_once<'db>(
         return result;
     }
 
+    // Expand an optional enum before its peer's members to avoid repeatedly expanding the enum.
+    // Other unions must retain their normal evaluation order, especially around dynamic operands.
     match (left, right) {
-        (Type::Union(union), other) => {
+        (Type::Union(union), other)
+            if other.is_enum(db)
+                && union.elements(db).len() == 2
+                && union.elements(db).contains(&other)
+                && union.elements(db).iter().any(|element| element.is_none(db))
+                && KnownComparisonSemantics::of_type(db, other, operator).is_some() =>
+        {
             return evaluate_union_left(evaluator, union.elements(db), other, branch, operator);
         }
-        (other, Type::Union(union)) => {
+        (other, Type::Union(union))
+            if other.is_enum(db)
+                && union.elements(db).len() == 2
+                && union.elements(db).contains(&other)
+                && union.elements(db).iter().any(|element| element.is_none(db))
+                && KnownComparisonSemantics::of_type(db, other, operator).is_some() =>
+        {
             return evaluate_union_right(evaluator, other, union.elements(db), branch, operator);
         }
         _ => {}
@@ -576,6 +590,12 @@ fn evaluate_comparison_once<'db>(
             .evaluate(other, newtype.concrete_base_type(db), branch, operator)
             .discard_narrowing(),
 
+        (Type::Union(union), other) => {
+            evaluate_union_left(evaluator, union.elements(db), other, branch, operator)
+        }
+        (other, Type::Union(union)) => {
+            evaluate_union_right(evaluator, other, union.elements(db), branch, operator)
+        }
         (Type::Intersection(intersection), other) => evaluate_intersection_left(
             evaluator,
             Type::Intersection(intersection),

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -490,13 +490,38 @@ fn evaluate_comparison_once<'db>(
         return result;
     }
 
+    match (left, right) {
+        (Type::Dynamic(_), other) => {
+            return if !operator.condition_expects_equality(branch)
+                && all_values_compare_equal(evaluator, other, operator)
+            {
+                let excluded = if other.is_enum(db)
+                    && let Some(alternatives) = finite_alternatives(db, other, operator)
+                    && let [alternative] = alternatives.as_slice()
+                {
+                    *alternative
+                } else {
+                    other
+                };
+                ComparisonResult::CanNarrow(
+                    IntersectionBuilder::new(db)
+                        .add_positive(left)
+                        .add_negative(excluded)
+                        .build(),
+                )
+            } else {
+                ComparisonResult::Ambiguous
+            };
+        }
+        (_, Type::Dynamic(_)) => return ComparisonResult::Ambiguous,
+        _ => {}
+    }
+
     // Expand a union containing its enum peer before expanding that enum into individual members.
-    // Gradual unions must retain their normal evaluation order to preserve dynamic narrowing.
     match (left, right) {
         (Type::Union(union), other)
             if other.is_enum(db)
                 && union.elements(db).contains(&other)
-                && !left.has_dynamic(db)
                 && KnownComparisonSemantics::of_type(db, other, operator).is_some() =>
         {
             return evaluate_union_left(evaluator, union.elements(db), other, branch, operator);
@@ -504,7 +529,6 @@ fn evaluate_comparison_once<'db>(
         (other, Type::Union(union))
             if other.is_enum(db)
                 && union.elements(db).contains(&other)
-                && !right.has_dynamic(db)
                 && KnownComparisonSemantics::of_type(db, other, operator).is_some() =>
         {
             return evaluate_union_right(evaluator, other, union.elements(db), branch, operator);
@@ -542,22 +566,6 @@ fn evaluate_comparison_once<'db>(
             | Type::TypeGuard(_)
             | Type::TypeIs(_),
         ) => ComparisonResult::Ambiguous,
-
-        (Type::Dynamic(_), other) => {
-            if !operator.condition_expects_equality(branch)
-                && all_values_compare_equal(evaluator, other, operator)
-            {
-                ComparisonResult::CanNarrow(
-                    IntersectionBuilder::new(db)
-                        .add_positive(left)
-                        .add_negative(other)
-                        .build(),
-                )
-            } else {
-                ComparisonResult::Ambiguous
-            }
-        }
-        (_, Type::Dynamic(_)) => ComparisonResult::Ambiguous,
 
         (Type::TypeVar(var), other) => match var.typevar(db).bound_or_constraints(db) {
             None => ComparisonResult::Ambiguous,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -490,6 +490,16 @@ fn evaluate_comparison_once<'db>(
         return result;
     }
 
+    match (left, right) {
+        (Type::Union(union), other) => {
+            return evaluate_union_left(evaluator, union.elements(db), other, branch, operator);
+        }
+        (other, Type::Union(union)) => {
+            return evaluate_union_right(evaluator, other, union.elements(db), branch, operator);
+        }
+        _ => {}
+    }
+
     if let Some(alternatives) = finite_alternatives(db, left, operator) {
         return evaluate_union_left(evaluator, &alternatives, right, branch, operator);
     }
@@ -566,12 +576,6 @@ fn evaluate_comparison_once<'db>(
             .evaluate(other, newtype.concrete_base_type(db), branch, operator)
             .discard_narrowing(),
 
-        (Type::Union(union), other) => {
-            evaluate_union_left(evaluator, union.elements(db), other, branch, operator)
-        }
-        (other, Type::Union(union)) => {
-            evaluate_union_right(evaluator, other, union.elements(db), branch, operator)
-        }
         (Type::Intersection(intersection), other) => evaluate_intersection_left(
             evaluator,
             Type::Intersection(intersection),

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -480,7 +480,10 @@ impl<'db> ComparisonEvaluator<'db> {
     }
 }
 
-/// Evaluate a comparison whose aliases are resolved and whose key is registered as active.
+/// Evaluate one comparison after resolving aliases and checking for recursion.
+///
+/// Handle enums and dynamic values such as `Any` before checking individual enum members.
+/// Otherwise, checking each member separately can incorrectly narrow `Any`.
 ///
 /// Recursive comparisons must use [`ComparisonEvaluator::evaluate`] so cycles are detected.
 fn evaluate_comparison_once<'db>(
@@ -496,7 +499,10 @@ fn evaluate_comparison_once<'db>(
         .unwrap_or_else(|| evaluate_structural_comparison(evaluator, left, right, branch, operator))
 }
 
-/// Evaluate dynamic operands before finite expansion can narrow them member by member.
+/// Handle dynamic values such as `Any` before checking individual enum members.
+///
+/// A one-member enum can exclude that member from `Any`. An enum with several members must not
+/// exclude all of its members one at a time.
 fn evaluate_dynamic_comparison<'db>(
     evaluator: &mut ComparisonEvaluator<'db>,
     left: Type<'db>,
@@ -506,34 +512,33 @@ fn evaluate_dynamic_comparison<'db>(
 ) -> Option<ComparisonResult<'db>> {
     let db = evaluator.db;
     match (left, right) {
-        (Type::Dynamic(_), other) => Some(
+        (Type::Dynamic(_), other)
             if !operator.condition_expects_equality(branch)
-                && all_values_compare_equal(evaluator, other, operator)
+                && all_values_compare_equal(evaluator, other, operator) =>
+        {
+            let excluded = if other.is_enum(db)
+                && let Some(alternatives) = finite_alternatives(db, other, operator)
+                && let [alternative] = alternatives.as_slice()
             {
-                let excluded = if other.is_enum(db)
-                    && let Some(alternatives) = finite_alternatives(db, other, operator)
-                    && let [alternative] = alternatives.as_slice()
-                {
-                    *alternative
-                } else {
-                    other
-                };
-                ComparisonResult::CanNarrow(
-                    IntersectionBuilder::new(db)
-                        .add_positive(left)
-                        .add_negative(excluded)
-                        .build(),
-                )
+                *alternative
             } else {
-                ComparisonResult::Ambiguous
-            },
-        ),
-        (_, Type::Dynamic(_)) => Some(ComparisonResult::Ambiguous),
+                other
+            };
+            Some(ComparisonResult::CanNarrow(
+                IntersectionBuilder::new(db)
+                    .add_positive(left)
+                    .add_negative(excluded)
+                    .build(),
+            ))
+        }
+        (Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => Some(ComparisonResult::Ambiguous),
         _ => None,
     }
 }
 
-/// Expand finite alternatives in target-first order after handling dynamic operands.
+/// Compare finite sets of values after handling enums and dynamic values.
+///
+/// Start with the side being narrowed so its restrictions are not applied to the other side.
 fn evaluate_finite_comparison<'db>(
     evaluator: &mut ComparisonEvaluator<'db>,
     left: Type<'db>,
@@ -551,7 +556,7 @@ fn evaluate_finite_comparison<'db>(
         })
 }
 
-/// Compare the remaining operand kinds using their structural comparison semantics.
+/// Compare values not handled by the enum, dynamic, or finite-value stages.
 fn evaluate_structural_comparison<'db>(
     evaluator: &mut ComparisonEvaluator<'db>,
     left: Type<'db>,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -17,7 +17,7 @@ use super::{
 
 mod enums;
 
-use self::enums::{evaluate_enum_domains, evaluate_partitioned_enum_domains};
+use self::enums::evaluate_enum_comparison;
 
 /// The result of evaluating a runtime comparison between two types.
 ///
@@ -166,11 +166,7 @@ pub(super) fn evaluate_type_equality<'db>(
         )
     })
     .or_else(|| {
-        evaluate_enum_domains(db, left, right, branch, ComparisonOperator::Equality)
-            .and_then(|result| result.constraint(branch))
-    })
-    .or_else(|| {
-        evaluate_partitioned_enum_domains(
+        evaluate_enum_comparison(
             &mut ComparisonEvaluator::new(db, soundness_policy),
             left,
             right,
@@ -494,21 +490,24 @@ fn evaluate_comparison_once<'db>(
     branch: ComparisonBranch,
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
+    evaluate_enum_comparison(evaluator, left, right, branch, operator)
+        .or_else(|| evaluate_dynamic_comparison(evaluator, left, right, branch, operator))
+        .or_else(|| evaluate_finite_comparison(evaluator, left, right, branch, operator))
+        .unwrap_or_else(|| evaluate_structural_comparison(evaluator, left, right, branch, operator))
+}
+
+/// Evaluate dynamic operands before finite expansion can narrow them member by member.
+fn evaluate_dynamic_comparison<'db>(
+    evaluator: &mut ComparisonEvaluator<'db>,
+    left: Type<'db>,
+    right: Type<'db>,
+    branch: ComparisonBranch,
+    operator: ComparisonOperator,
+) -> Option<ComparisonResult<'db>> {
     let db = evaluator.db;
-
-    if let Some(result) = evaluate_enum_domains(db, left, right, branch, operator) {
-        return result;
-    }
-
-    if let Some(result) =
-        evaluate_partitioned_enum_domains(evaluator, left, right, branch, operator)
-    {
-        return result;
-    }
-
     match (left, right) {
-        (Type::Dynamic(_), other) => {
-            return if !operator.condition_expects_equality(branch)
+        (Type::Dynamic(_), other) => Some(
+            if !operator.condition_expects_equality(branch)
                 && all_values_compare_equal(evaluator, other, operator)
             {
                 let excluded = if other.is_enum(db)
@@ -527,19 +526,40 @@ fn evaluate_comparison_once<'db>(
                 )
             } else {
                 ComparisonResult::Ambiguous
-            };
-        }
-        (_, Type::Dynamic(_)) => return ComparisonResult::Ambiguous,
-        _ => {}
+            },
+        ),
+        (_, Type::Dynamic(_)) => Some(ComparisonResult::Ambiguous),
+        _ => None,
     }
+}
 
-    if let Some(alternatives) = finite_alternatives(db, left, operator) {
-        return evaluate_union_left(evaluator, &alternatives, right, branch, operator);
-    }
-    if let Some(alternatives) = finite_alternatives(db, right, operator) {
-        return evaluate_union_right(evaluator, left, &alternatives, branch, operator);
-    }
+/// Expand finite alternatives in target-first order after handling dynamic operands.
+fn evaluate_finite_comparison<'db>(
+    evaluator: &mut ComparisonEvaluator<'db>,
+    left: Type<'db>,
+    right: Type<'db>,
+    branch: ComparisonBranch,
+    operator: ComparisonOperator,
+) -> Option<ComparisonResult<'db>> {
+    let db = evaluator.db;
+    finite_alternatives(db, left, operator)
+        .map(|alternatives| evaluate_union_left(evaluator, &alternatives, right, branch, operator))
+        .or_else(|| {
+            finite_alternatives(db, right, operator).map(|alternatives| {
+                evaluate_union_right(evaluator, left, &alternatives, branch, operator)
+            })
+        })
+}
 
+/// Compare the remaining operand kinds using their structural comparison semantics.
+fn evaluate_structural_comparison<'db>(
+    evaluator: &mut ComparisonEvaluator<'db>,
+    left: Type<'db>,
+    right: Type<'db>,
+    branch: ComparisonBranch,
+    operator: ComparisonOperator,
+) -> ComparisonResult<'db> {
+    let db = evaluator.db;
     match (left, right) {
         (
             Type::Never

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -32,7 +32,14 @@ pub(super) fn evaluate_enum_domains<'db>(
 ) -> Option<ComparisonResult<'db>> {
     let target = EnumDomainSet::from_type(db, target)?;
     let other = EnumDomainSet::from_type(db, other)?;
-    evaluate_extracted_enum_domains(db, target, &other, branch, operator)
+    if let (Some(target), Some(other)) = (target.single(), other.single())
+        && target.enum_class == other.enum_class
+    {
+        return SameEnumComparison::new(db, target.clone(), other.clone(), operator)
+            .evaluate(db, branch, operator);
+    }
+
+    ProjectedEnumComparison::new(db, target, &other, operator)?.evaluate(db, branch, operator)
 }
 
 /// Compare unions that contain both enum domains and unrelated alternatives.
@@ -41,6 +48,26 @@ pub(super) fn evaluate_enum_domains<'db>(
 /// evaluated through the ordinary comparison evaluator. In particular, a gradual or scalar
 /// residual on either side can still satisfy the comparison and prevent the opposite operand from
 /// being narrowed to the enum domains' shared members.
+///
+/// ```python
+/// from enum import StrEnum
+///
+/// class Left(StrEnum):
+///     SHARED = "shared"
+///     LEFT = "left"
+///
+/// class Right(StrEnum):
+///     SHARED = "shared"
+///     RIGHT = "right"
+///
+/// def compare(left: Left | None, right: Right | None):
+///     if left == right:
+///         reveal_type(left)   # Literal[Left.SHARED] | None
+///         reveal_type(right)  # Literal[Right.SHARED] | None
+/// ```
+///
+/// Returns `None` when either operand lacks an enum domain, neither operand has a residual, or an
+/// enum has unmodeled comparison semantics.
 pub(super) fn evaluate_partitioned_enum_domains<'db>(
     evaluator: &mut ComparisonEvaluator<'db>,
     target: Type<'db>,
@@ -57,13 +84,11 @@ pub(super) fn evaluate_partitioned_enum_domains<'db>(
     }
 
     let EnumDomainPartition {
-        domains: target_domains,
         enum_type: target_enum,
         alternatives: target_alternatives,
         has_residual: target_has_residual,
     } = EnumDomainPartition::from_type(db, target)?;
     let EnumDomainPartition {
-        domains: other_domains,
         enum_type: other_enum,
         alternatives: other_alternatives,
         has_residual: other_has_residual,
@@ -75,8 +100,7 @@ pub(super) fn evaluate_partitioned_enum_domains<'db>(
 
     // Partitioning is only useful when the enum domains themselves have modeled comparison
     // semantics. Custom comparison methods must retain the ordinary evaluator's fallback.
-    let enum_result =
-        evaluate_extracted_enum_domains(db, target_domains, &other_domains, branch, operator)?;
+    let enum_result = evaluate_enum_domains(db, target_enum, other_enum, branch, operator)?;
 
     let evaluate_alternative =
         |evaluator: &mut ComparisonEvaluator<'db>, target: Type<'db>, other: Type<'db>| {
@@ -128,24 +152,6 @@ pub(super) fn evaluate_partitioned_enum_domains<'db>(
         branch,
         |target| evaluate_against_other(evaluator, target),
     ))
-}
-
-/// Evaluate already extracted enum domains without inspecting non-enum alternatives.
-fn evaluate_extracted_enum_domains<'db>(
-    db: &'db dyn Db,
-    target: EnumDomainSet<'db>,
-    other: &EnumDomainSet<'db>,
-    branch: ComparisonBranch,
-    operator: ComparisonOperator,
-) -> Option<ComparisonResult<'db>> {
-    if let (Some(target), Some(other)) = (target.single(), other.single())
-        && target.enum_class == other.enum_class
-    {
-        return SameEnumComparison::new(db, target.clone(), other.clone(), operator)
-            .evaluate(db, branch, operator);
-    }
-
-    ProjectedEnumComparison::new(db, target, other, operator)?.evaluate(db, branch, operator)
 }
 
 /// Two non-empty value domains from the same enum and the semantics used to compare them.
@@ -561,37 +567,33 @@ impl<'db> EnumValueSet<'db> {
 /// Original enum alternatives are grouped at the first enum position. Residual alternatives keep
 /// their union order, while all enum classes can share one compact comparison-key projection.
 struct EnumDomainPartition<'db> {
-    domains: EnumDomainSet<'db>,
     enum_type: Type<'db>,
     alternatives: Vec<Type<'db>>,
     has_residual: bool,
 }
 
-/// An original union alternative before the enum alternatives are grouped together.
-enum EnumDomainAlternative<'db> {
-    Enum(Type<'db>),
-    Residual(Type<'db>),
-}
-
 impl<'db> EnumDomainPartition<'db> {
+    /// Group structural enum alternatives at their first position and retain residual order.
+    ///
+    /// Returns `None` when no enum domain can be extracted or a recursive alias cannot be
+    /// partitioned safely.
     fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         fn collect<'db>(
             db: &'db dyn Db,
             ty: Type<'db>,
-            has_enum: &mut bool,
-            alternatives: &mut Vec<EnumDomainAlternative<'db>>,
-            residual_count: &mut usize,
+            enum_types: &mut Vec<Type<'db>>,
+            alternatives: &mut Vec<Type<'db>>,
+            enum_position: &mut Option<usize>,
             active_types: &mut FxHashSet<Type<'db>>,
         ) -> Option<()> {
             if EnumValueSet::from_type(db, ty, active_types).is_some() {
-                *has_enum = true;
-                alternatives.push(EnumDomainAlternative::Enum(ty));
+                enum_position.get_or_insert(alternatives.len());
+                enum_types.push(ty);
                 return Some(());
             }
 
             let Type::Union(union) = ty.resolve_type_alias(db) else {
-                alternatives.push(EnumDomainAlternative::Residual(ty));
-                *residual_count += 1;
+                alternatives.push(ty);
                 return Some(());
             };
 
@@ -599,73 +601,44 @@ impl<'db> EnumDomainPartition<'db> {
                 return None;
             }
 
-            for element in union.elements(db) {
-                if collect(
+            let result = union.elements(db).iter().try_for_each(|element| {
+                collect(
                     db,
                     *element,
-                    has_enum,
+                    enum_types,
                     alternatives,
-                    residual_count,
+                    enum_position,
                     active_types,
                 )
-                .is_none()
-                {
-                    active_types.remove(&ty);
-                    return None;
-                }
-            }
-
+            });
             active_types.remove(&ty);
-            Some(())
+            result
         }
 
-        let mut has_enum = false;
+        let mut enum_types = Vec::new();
         let mut alternatives = Vec::new();
-        let mut residual_count = 0;
+        let mut enum_position = None;
         let mut active_types = FxHashSet::default();
         collect(
             db,
             ty,
-            &mut has_enum,
+            &mut enum_types,
             &mut alternatives,
-            &mut residual_count,
+            &mut enum_position,
             &mut active_types,
         )?;
-
-        if !has_enum {
-            return None;
-        }
-
-        let enum_type = alternatives
-            .iter()
-            .fold(UnionBuilder::new(db), |builder, alternative| {
-                if let EnumDomainAlternative::Enum(ty) = alternative {
-                    builder.add(*ty)
-                } else {
-                    builder
-                }
-            })
+        let enum_position = enum_position?;
+        let enum_type = enum_types
+            .into_iter()
+            .fold(UnionBuilder::new(db), UnionBuilder::add)
             .build();
-        let domains = EnumDomainSet::from_type(db, enum_type)?;
-
-        let mut grouped_alternatives = Vec::with_capacity(residual_count + 1);
-        let mut included_enum = false;
-        for alternative in alternatives {
-            match alternative {
-                EnumDomainAlternative::Enum(_) if !included_enum => {
-                    grouped_alternatives.push(enum_type);
-                    included_enum = true;
-                }
-                EnumDomainAlternative::Enum(_) => {}
-                EnumDomainAlternative::Residual(ty) => grouped_alternatives.push(ty),
-            }
-        }
+        let has_residual = !alternatives.is_empty();
+        alternatives.insert(enum_position, enum_type);
 
         Some(Self {
-            domains,
             enum_type,
-            alternatives: grouped_alternatives,
-            has_residual: residual_count != 0,
+            alternatives,
+            has_residual,
         })
     }
 }

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -12,8 +12,9 @@ use crate::types::{
 use crate::{Db, FxOrderMap, FxOrderSet};
 
 use super::{
-    ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics,
-    enum_literal_value,
+    ComparisonBranch, ComparisonEvaluator, ComparisonGoal, ComparisonOperator, ComparisonResult,
+    KnownComparisonSemantics, combine_definite_truthiness, enum_literal_value,
+    evaluate_against_results, evaluate_target_union,
 };
 
 /// Compare two enum value domains without comparing every pair of members.
@@ -31,6 +32,112 @@ pub(super) fn evaluate_enum_domains<'db>(
 ) -> Option<ComparisonResult<'db>> {
     let target = EnumDomainSet::from_type(db, target)?;
     let other = EnumDomainSet::from_type(db, other)?;
+    evaluate_extracted_enum_domains(db, target, &other, branch, operator)
+}
+
+/// Compare unions that contain both enum domains and unrelated alternatives.
+///
+/// Enum alternatives retain their compact comparison domains, while residual alternatives are
+/// evaluated through the ordinary comparison evaluator. In particular, a gradual or scalar
+/// residual on either side can still satisfy the comparison and prevent the opposite operand from
+/// being narrowed to the enum domains' shared members.
+pub(super) fn evaluate_partitioned_enum_domains<'db>(
+    evaluator: &mut ComparisonEvaluator<'db>,
+    target: Type<'db>,
+    other: Type<'db>,
+    branch: ComparisonBranch,
+    operator: ComparisonOperator,
+) -> Option<ComparisonResult<'db>> {
+    let db = evaluator.db;
+
+    if !matches!(target.resolve_type_alias(db), Type::Union(_))
+        && !matches!(other.resolve_type_alias(db), Type::Union(_))
+    {
+        return None;
+    }
+
+    let EnumDomainPartition {
+        domains: target_domains,
+        enum_type: target_enum,
+        alternatives: target_alternatives,
+        has_residual: target_has_residual,
+    } = EnumDomainPartition::from_type(db, target)?;
+    let EnumDomainPartition {
+        domains: other_domains,
+        enum_type: other_enum,
+        alternatives: other_alternatives,
+        has_residual: other_has_residual,
+    } = EnumDomainPartition::from_type(db, other)?;
+
+    if !target_has_residual && !other_has_residual {
+        return None;
+    }
+
+    // Partitioning is only useful when the enum domains themselves have modeled comparison
+    // semantics. Custom comparison methods must retain the ordinary evaluator's fallback.
+    let enum_result =
+        evaluate_extracted_enum_domains(db, target_domains, &other_domains, branch, operator)?;
+
+    let evaluate_alternative =
+        |evaluator: &mut ComparisonEvaluator<'db>, target: Type<'db>, other: Type<'db>| {
+            if target == target_enum && other == other_enum {
+                enum_result
+            } else {
+                evaluator.evaluate(target, other, branch, operator)
+            }
+        };
+
+    let evaluate_against_other = |evaluator: &mut ComparisonEvaluator<'db>, target: Type<'db>| {
+        if let [other] = other_alternatives.as_slice() {
+            return evaluate_alternative(evaluator, target, *other);
+        }
+
+        if evaluator.goal == ComparisonGoal::Truthiness {
+            return combine_definite_truthiness(
+                other_alternatives
+                    .iter()
+                    .map(|other| evaluate_alternative(evaluator, target, *other)),
+            );
+        }
+
+        evaluate_against_results(
+            db,
+            target,
+            branch,
+            other_alternatives
+                .iter()
+                .map(|other| evaluate_alternative(evaluator, target, *other)),
+        )
+    };
+
+    if let [target] = target_alternatives.as_slice() {
+        return Some(evaluate_against_other(evaluator, *target));
+    }
+
+    if evaluator.goal == ComparisonGoal::Truthiness {
+        return Some(combine_definite_truthiness(
+            target_alternatives
+                .iter()
+                .map(|target| evaluate_against_other(evaluator, *target)),
+        ));
+    }
+
+    Some(evaluate_target_union(
+        db,
+        &target_alternatives,
+        branch,
+        |target| evaluate_against_other(evaluator, target),
+    ))
+}
+
+/// Evaluate already extracted enum domains without inspecting non-enum alternatives.
+fn evaluate_extracted_enum_domains<'db>(
+    db: &'db dyn Db,
+    target: EnumDomainSet<'db>,
+    other: &EnumDomainSet<'db>,
+    branch: ComparisonBranch,
+    operator: ComparisonOperator,
+) -> Option<ComparisonResult<'db>> {
     if let (Some(target), Some(other)) = (target.single(), other.single())
         && target.enum_class == other.enum_class
     {
@@ -38,7 +145,7 @@ pub(super) fn evaluate_enum_domains<'db>(
             .evaluate(db, branch, operator);
     }
 
-    ProjectedEnumComparison::new(db, target, &other, operator)?.evaluate(db, branch, operator)
+    ProjectedEnumComparison::new(db, target, other, operator)?.evaluate(db, branch, operator)
 }
 
 /// Two non-empty value domains from the same enum and the semantics used to compare them.
@@ -446,6 +553,120 @@ impl<'db> EnumValueSet<'db> {
 
     fn member_type(&self, db: &'db dyn Db, name: &Name, promotable: bool) -> Type<'db> {
         LiteralValueType::new(EnumLiteralType::new(db, self.enum_class, name), promotable).into()
+    }
+}
+
+/// Enum domains and original non-enum alternatives extracted from an operand.
+///
+/// Original enum alternatives are grouped at the first enum position. Residual alternatives keep
+/// their union order, while all enum classes can share one compact comparison-key projection.
+struct EnumDomainPartition<'db> {
+    domains: EnumDomainSet<'db>,
+    enum_type: Type<'db>,
+    alternatives: Vec<Type<'db>>,
+    has_residual: bool,
+}
+
+/// An original union alternative before the enum alternatives are grouped together.
+enum EnumDomainAlternative<'db> {
+    Enum(Type<'db>),
+    Residual(Type<'db>),
+}
+
+impl<'db> EnumDomainPartition<'db> {
+    fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+        fn collect<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            has_enum: &mut bool,
+            alternatives: &mut Vec<EnumDomainAlternative<'db>>,
+            residual_count: &mut usize,
+            active_types: &mut FxHashSet<Type<'db>>,
+        ) -> Option<()> {
+            if EnumValueSet::from_type(db, ty, active_types).is_some() {
+                *has_enum = true;
+                alternatives.push(EnumDomainAlternative::Enum(ty));
+                return Some(());
+            }
+
+            let Type::Union(union) = ty.resolve_type_alias(db) else {
+                alternatives.push(EnumDomainAlternative::Residual(ty));
+                *residual_count += 1;
+                return Some(());
+            };
+
+            if !active_types.insert(ty) {
+                return None;
+            }
+
+            for element in union.elements(db) {
+                if collect(
+                    db,
+                    *element,
+                    has_enum,
+                    alternatives,
+                    residual_count,
+                    active_types,
+                )
+                .is_none()
+                {
+                    active_types.remove(&ty);
+                    return None;
+                }
+            }
+
+            active_types.remove(&ty);
+            Some(())
+        }
+
+        let mut has_enum = false;
+        let mut alternatives = Vec::new();
+        let mut residual_count = 0;
+        let mut active_types = FxHashSet::default();
+        collect(
+            db,
+            ty,
+            &mut has_enum,
+            &mut alternatives,
+            &mut residual_count,
+            &mut active_types,
+        )?;
+
+        if !has_enum {
+            return None;
+        }
+
+        let enum_type = alternatives
+            .iter()
+            .fold(UnionBuilder::new(db), |builder, alternative| {
+                if let EnumDomainAlternative::Enum(ty) = alternative {
+                    builder.add(*ty)
+                } else {
+                    builder
+                }
+            })
+            .build();
+        let domains = EnumDomainSet::from_type(db, enum_type)?;
+
+        let mut grouped_alternatives = Vec::with_capacity(residual_count + 1);
+        let mut included_enum = false;
+        for alternative in alternatives {
+            match alternative {
+                EnumDomainAlternative::Enum(_) if !included_enum => {
+                    grouped_alternatives.push(enum_type);
+                    included_enum = true;
+                }
+                EnumDomainAlternative::Enum(_) => {}
+                EnumDomainAlternative::Residual(ty) => grouped_alternatives.push(ty),
+            }
+        }
+
+        Some(Self {
+            domains,
+            enum_type,
+            alternatives: grouped_alternatives,
+            has_residual: residual_count != 0,
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -17,10 +17,11 @@ use super::{
     evaluate_against_results, evaluate_target_union,
 };
 
-/// Compare enum operands without expanding every pair of members.
+/// Compare enum values without checking every pair of members.
 ///
-/// Enum-only operands are compared using compact member sets and runtime comparison keys. Mixed
-/// enum unions retain the ordinary comparison semantics of their non-enum alternatives.
+/// If either side also contains other values, compare those values normally.
+///
+/// Return `None` when the enum comparison does not apply.
 pub(super) fn evaluate_enum_comparison<'db>(
     evaluator: &mut ComparisonEvaluator<'db>,
     target: Type<'db>,
@@ -29,16 +30,15 @@ pub(super) fn evaluate_enum_comparison<'db>(
     operator: ComparisonOperator,
 ) -> Option<ComparisonResult<'db>> {
     evaluate_enum_domains(evaluator.db, target, other, branch, operator).or_else(|| {
-        let comparison =
-            PartitionedEnumComparison::new(evaluator.db, target, other, branch, operator)?;
-        Some(comparison.evaluate(evaluator, branch, operator))
+        PartitionedEnumComparison::new(evaluator.db, target, other, branch, operator)
+            .map(|comparison| comparison.evaluate(evaluator, branch, operator))
     })
 }
 
-/// Compare two enum-only domains using compact member sets or runtime comparison keys.
+/// Compare values that are all enum members.
 ///
-/// The resulting constraint contains only enum-membership facts. Equality never transfers gradual
-/// or nominal intersection state between operands.
+/// Describe the result using enum members only. Do not copy other restrictions from one side to
+/// the other.
 fn evaluate_enum_domains<'db>(
     db: &'db dyn Db,
     target: Type<'db>,
@@ -58,12 +58,12 @@ fn evaluate_enum_domains<'db>(
     ProjectedEnumComparison::new(db, target, &other, operator)?.evaluate(db, branch, operator)
 }
 
-/// Compare unions that contain both enum domains and unrelated alternatives.
+/// Compare unions that contain enums and other values.
 ///
-/// Enum alternatives retain their compact comparison domains, while residual alternatives are
-/// evaluated through the ordinary comparison evaluator. In particular, a gradual or scalar
-/// residual on either side can still satisfy the comparison and prevent the opposite operand from
-/// being narrowed to the enum domains' shared members.
+/// Compare enum members together and compare other values normally. Values such as `None`,
+/// `Any`, or a matching string can also affect which values match.
+///
+/// Compare the enum members only once.
 ///
 /// ```python
 /// from enum import StrEnum
@@ -88,7 +88,10 @@ struct PartitionedEnumComparison<'db> {
 }
 
 impl<'db> PartitionedEnumComparison<'db> {
-    /// Extract a mixed comparison only when its enum domains have modeled semantics.
+    /// Prepare a comparison when both sides contain enums and at least one side also contains
+    /// another value.
+    ///
+    /// Return `None` if either enum has unsupported comparison behavior.
     fn new(
         db: &'db dyn Db,
         target: Type<'db>,
@@ -119,7 +122,7 @@ impl<'db> PartitionedEnumComparison<'db> {
         })
     }
 
-    /// Reuse the compact enum result while evaluating residual pairs normally.
+    /// Reuse the saved enum result and compare all other values normally.
     fn evaluate_pair(
         &self,
         evaluator: &mut ComparisonEvaluator<'db>,
@@ -135,7 +138,9 @@ impl<'db> PartitionedEnumComparison<'db> {
         }
     }
 
-    /// Combine one target alternative against the non-target alternatives.
+    /// Compare one possible value with every value on the other side.
+    ///
+    /// Return whether the result is certain or which values can still match.
     fn evaluate_against_other(
         &self,
         evaluator: &mut ComparisonEvaluator<'db>,
@@ -167,7 +172,9 @@ impl<'db> PartitionedEnumComparison<'db> {
         )
     }
 
-    /// Preserve the caller's truthiness goal or target-specific narrowing.
+    /// Compare all possible values.
+    ///
+    /// Return whether the result is certain or which values can still match.
     fn evaluate(
         &self,
         evaluator: &mut ComparisonEvaluator<'db>,
@@ -600,20 +607,18 @@ impl<'db> EnumValueSet<'db> {
     }
 }
 
-/// Enum domains and original non-enum alternatives extracted from an operand.
+/// The enum members and other values on one side of a comparison.
 ///
-/// Original enum alternatives are grouped at the first enum position. Residual alternatives keep
-/// their union order, while all enum classes can share one compact comparison-key projection.
+/// Place enum members at the first enum's position and keep other values in their original order.
 struct EnumDomainPartition<'db> {
     enum_type: Type<'db>,
     alternatives: Vec<Type<'db>>,
 }
 
 impl<'db> EnumDomainPartition<'db> {
-    /// Group structural enum alternatives at their first position and retain residual order.
+    /// Combine enum values while keeping other values in their original order.
     ///
-    /// Returns `None` when no enum domain can be extracted or a recursive alias cannot be
-    /// partitioned safely.
+    /// Return `None` when there is no enum or a type alias refers to itself.
     fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         fn collect<'db>(
             db: &'db dyn Db,
@@ -677,7 +682,6 @@ impl<'db> EnumDomainPartition<'db> {
         })
     }
 
-    /// Return whether the partition contains non-enum alternatives.
     fn has_residual(&self) -> bool {
         self.alternatives.len() > 1
     }

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -17,13 +17,29 @@ use super::{
     evaluate_against_results, evaluate_target_union,
 };
 
-/// Compare two enum value domains without comparing every pair of members.
+/// Compare enum operands without expanding every pair of members.
 ///
-/// Any narrowing constraint produced here contains only enum-membership facts. In particular,
-/// equality never transfers gradual or nominal intersection state from one operand to the other.
-/// Same-class domains compare compact member sets directly, while comparisons spanning multiple
-/// classes project their members onto runtime comparison keys.
-pub(super) fn evaluate_enum_domains<'db>(
+/// Enum-only operands are compared using compact member sets and runtime comparison keys. Mixed
+/// enum unions retain the ordinary comparison semantics of their non-enum alternatives.
+pub(super) fn evaluate_enum_comparison<'db>(
+    evaluator: &mut ComparisonEvaluator<'db>,
+    target: Type<'db>,
+    other: Type<'db>,
+    branch: ComparisonBranch,
+    operator: ComparisonOperator,
+) -> Option<ComparisonResult<'db>> {
+    evaluate_enum_domains(evaluator.db, target, other, branch, operator).or_else(|| {
+        let comparison =
+            PartitionedEnumComparison::new(evaluator.db, target, other, branch, operator)?;
+        Some(comparison.evaluate(evaluator, branch, operator))
+    })
+}
+
+/// Compare two enum-only domains using compact member sets or runtime comparison keys.
+///
+/// The resulting constraint contains only enum-membership facts. Equality never transfers gradual
+/// or nominal intersection state between operands.
+fn evaluate_enum_domains<'db>(
     db: &'db dyn Db,
     target: Type<'db>,
     other: Type<'db>,
@@ -65,93 +81,115 @@ pub(super) fn evaluate_enum_domains<'db>(
 ///         reveal_type(left)   # Literal[Left.SHARED] | None
 ///         reveal_type(right)  # Literal[Right.SHARED] | None
 /// ```
-///
-/// Returns `None` when either operand lacks an enum domain, neither operand has a residual, or an
-/// enum has unmodeled comparison semantics.
-pub(super) fn evaluate_partitioned_enum_domains<'db>(
-    evaluator: &mut ComparisonEvaluator<'db>,
-    target: Type<'db>,
-    other: Type<'db>,
-    branch: ComparisonBranch,
-    operator: ComparisonOperator,
-) -> Option<ComparisonResult<'db>> {
-    let db = evaluator.db;
+struct PartitionedEnumComparison<'db> {
+    target: EnumDomainPartition<'db>,
+    other: EnumDomainPartition<'db>,
+    enum_result: ComparisonResult<'db>,
+}
 
-    if !matches!(target.resolve_type_alias(db), Type::Union(_))
-        && !matches!(other.resolve_type_alias(db), Type::Union(_))
-    {
-        return None;
+impl<'db> PartitionedEnumComparison<'db> {
+    /// Extract a mixed comparison only when its enum domains have modeled semantics.
+    fn new(
+        db: &'db dyn Db,
+        target: Type<'db>,
+        other: Type<'db>,
+        branch: ComparisonBranch,
+        operator: ComparisonOperator,
+    ) -> Option<Self> {
+        if !matches!(target.resolve_type_alias(db), Type::Union(_))
+            && !matches!(other.resolve_type_alias(db), Type::Union(_))
+        {
+            return None;
+        }
+
+        let target = EnumDomainPartition::from_type(db, target)?;
+        let other = EnumDomainPartition::from_type(db, other)?;
+
+        if !target.has_residual() && !other.has_residual() {
+            return None;
+        }
+
+        let enum_result =
+            evaluate_enum_domains(db, target.enum_type, other.enum_type, branch, operator)?;
+
+        Some(Self {
+            target,
+            other,
+            enum_result,
+        })
     }
 
-    let EnumDomainPartition {
-        enum_type: target_enum,
-        alternatives: target_alternatives,
-        has_residual: target_has_residual,
-    } = EnumDomainPartition::from_type(db, target)?;
-    let EnumDomainPartition {
-        enum_type: other_enum,
-        alternatives: other_alternatives,
-        has_residual: other_has_residual,
-    } = EnumDomainPartition::from_type(db, other)?;
-
-    if !target_has_residual && !other_has_residual {
-        return None;
+    /// Reuse the compact enum result while evaluating residual pairs normally.
+    fn evaluate_pair(
+        &self,
+        evaluator: &mut ComparisonEvaluator<'db>,
+        target: Type<'db>,
+        other: Type<'db>,
+        branch: ComparisonBranch,
+        operator: ComparisonOperator,
+    ) -> ComparisonResult<'db> {
+        if target == self.target.enum_type && other == self.other.enum_type {
+            self.enum_result
+        } else {
+            evaluator.evaluate(target, other, branch, operator)
+        }
     }
 
-    // Partitioning is only useful when the enum domains themselves have modeled comparison
-    // semantics. Custom comparison methods must retain the ordinary evaluator's fallback.
-    let enum_result = evaluate_enum_domains(db, target_enum, other_enum, branch, operator)?;
-
-    let evaluate_alternative =
-        |evaluator: &mut ComparisonEvaluator<'db>, target: Type<'db>, other: Type<'db>| {
-            if target == target_enum && other == other_enum {
-                enum_result
-            } else {
-                evaluator.evaluate(target, other, branch, operator)
-            }
-        };
-
-    let evaluate_against_other = |evaluator: &mut ComparisonEvaluator<'db>, target: Type<'db>| {
-        if let [other] = other_alternatives.as_slice() {
-            return evaluate_alternative(evaluator, target, *other);
+    /// Combine one target alternative against the non-target alternatives.
+    fn evaluate_against_other(
+        &self,
+        evaluator: &mut ComparisonEvaluator<'db>,
+        target: Type<'db>,
+        branch: ComparisonBranch,
+        operator: ComparisonOperator,
+    ) -> ComparisonResult<'db> {
+        if let [other] = self.other.alternatives.as_slice() {
+            return self.evaluate_pair(evaluator, target, *other, branch, operator);
         }
 
         if evaluator.goal == ComparisonGoal::Truthiness {
             return combine_definite_truthiness(
-                other_alternatives
+                self.other
+                    .alternatives
                     .iter()
-                    .map(|other| evaluate_alternative(evaluator, target, *other)),
+                    .map(|other| self.evaluate_pair(evaluator, target, *other, branch, operator)),
             );
         }
 
         evaluate_against_results(
-            db,
+            evaluator.db,
             target,
             branch,
-            other_alternatives
+            self.other
+                .alternatives
                 .iter()
-                .map(|other| evaluate_alternative(evaluator, target, *other)),
+                .map(|other| self.evaluate_pair(evaluator, target, *other, branch, operator)),
         )
-    };
-
-    if let [target] = target_alternatives.as_slice() {
-        return Some(evaluate_against_other(evaluator, *target));
     }
 
-    if evaluator.goal == ComparisonGoal::Truthiness {
-        return Some(combine_definite_truthiness(
-            target_alternatives
-                .iter()
-                .map(|target| evaluate_against_other(evaluator, *target)),
-        ));
-    }
+    /// Preserve the caller's truthiness goal or target-specific narrowing.
+    fn evaluate(
+        &self,
+        evaluator: &mut ComparisonEvaluator<'db>,
+        branch: ComparisonBranch,
+        operator: ComparisonOperator,
+    ) -> ComparisonResult<'db> {
+        if let [target] = self.target.alternatives.as_slice() {
+            return self.evaluate_against_other(evaluator, *target, branch, operator);
+        }
 
-    Some(evaluate_target_union(
-        db,
-        &target_alternatives,
-        branch,
-        |target| evaluate_against_other(evaluator, target),
-    ))
+        if evaluator.goal == ComparisonGoal::Truthiness {
+            return combine_definite_truthiness(
+                self.target.alternatives.iter().map(|target| {
+                    self.evaluate_against_other(evaluator, *target, branch, operator)
+                }),
+            );
+        }
+
+        evaluate_target_union(evaluator.db, &self.target.alternatives, branch, |target| {
+            self.evaluate_against_other(evaluator, target, branch, operator)
+        })
+    }
 }
 
 /// Two non-empty value domains from the same enum and the semantics used to compare them.
@@ -569,7 +607,6 @@ impl<'db> EnumValueSet<'db> {
 struct EnumDomainPartition<'db> {
     enum_type: Type<'db>,
     alternatives: Vec<Type<'db>>,
-    has_residual: bool,
 }
 
 impl<'db> EnumDomainPartition<'db> {
@@ -632,14 +669,17 @@ impl<'db> EnumDomainPartition<'db> {
             .into_iter()
             .fold(UnionBuilder::new(db), UnionBuilder::add)
             .build();
-        let has_residual = !alternatives.is_empty();
         alternatives.insert(enum_position, enum_type);
 
         Some(Self {
             enum_type,
             alternatives,
-            has_residual,
         })
+    }
+
+    /// Return whether the partition contains non-enum alternatives.
+    fn has_residual(&self) -> bool {
+        self.alternatives.len() > 1
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -118,7 +118,7 @@ impl<'db> PartitionedEnumComparison<'db> {
         let other_type = other;
         let other = EnumDomainPartition::from_type(db, other)?;
 
-        if !target.has_residual() && !other.has_residual() {
+        if !target.has_other_values() && !other.has_other_values() {
             return None;
         }
 
@@ -242,27 +242,12 @@ impl<'db> PartitionedEnumComparison<'db> {
                 })
                 .build();
             if !excluded.is_never() {
-                let exclude = |alternative: Type<'db>| {
-                    if alternative.is_disjoint_from(evaluator.db, excluded) {
-                        alternative
-                    } else {
-                        IntersectionBuilder::new(evaluator.db)
-                            .add_positive(alternative)
-                            .add_negative(excluded)
-                            .build()
-                    }
-                };
-                let narrowed = match narrowed {
-                    Type::Union(union) => union
-                        .elements(evaluator.db)
-                        .iter()
-                        .fold(UnionBuilder::new(evaluator.db), |builder, alternative| {
-                            builder.add(exclude(*alternative))
-                        })
+                return ComparisonResult::CanNarrow(
+                    IntersectionBuilder::new(evaluator.db)
+                        .add_positive(narrowed)
+                        .add_negative(excluded)
                         .build(),
-                    alternative => exclude(alternative),
-                };
-                return ComparisonResult::CanNarrow(narrowed);
+                );
             }
         }
 
@@ -753,7 +738,7 @@ impl<'db> EnumDomainPartition<'db> {
         })
     }
 
-    fn has_residual(&self) -> bool {
+    fn has_other_values(&self) -> bool {
         self.alternatives.len() > 1
     }
 }

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -30,8 +30,16 @@ pub(super) fn evaluate_enum_comparison<'db>(
     operator: ComparisonOperator,
 ) -> Option<ComparisonResult<'db>> {
     evaluate_enum_domains(evaluator.db, target, other, branch, operator).or_else(|| {
-        PartitionedEnumComparison::new(evaluator.db, target, other, branch, operator)
-            .map(|comparison| comparison.evaluate(evaluator, branch, operator))
+        PartitionedEnumComparison::new(evaluator.db, target, other, branch, operator).map(
+            |comparison| match comparison.evaluate(evaluator, branch, operator) {
+                ComparisonResult::CanNarrow(narrowed)
+                    if narrowed == target.resolve_type_alias(evaluator.db) =>
+                {
+                    ComparisonResult::Ambiguous
+                }
+                result => result,
+            },
+        )
     })
 }
 
@@ -84,6 +92,7 @@ fn evaluate_enum_domains<'db>(
 struct PartitionedEnumComparison<'db> {
     target: EnumDomainPartition<'db>,
     other: EnumDomainPartition<'db>,
+    other_type: Type<'db>,
     enum_result: ComparisonResult<'db>,
 }
 
@@ -106,6 +115,7 @@ impl<'db> PartitionedEnumComparison<'db> {
         }
 
         let target = EnumDomainPartition::from_type(db, target)?;
+        let other_type = other;
         let other = EnumDomainPartition::from_type(db, other)?;
 
         if !target.has_residual() && !other.has_residual() {
@@ -118,6 +128,7 @@ impl<'db> PartitionedEnumComparison<'db> {
         Some(Self {
             target,
             other,
+            other_type,
             enum_result,
         })
     }
@@ -138,7 +149,9 @@ impl<'db> PartitionedEnumComparison<'db> {
         }
     }
 
-    /// Compare one possible value with every value on the other side.
+    /// Compare one possible value with the other side.
+    ///
+    /// Compare `Any` and `Unknown` with the whole union so neither is narrowed by separate values.
     ///
     /// Return whether the result is certain or which values can still match.
     fn evaluate_against_other(
@@ -161,6 +174,10 @@ impl<'db> PartitionedEnumComparison<'db> {
             );
         }
 
+        if matches!(target.resolve_type_alias(evaluator.db), Type::Dynamic(_)) {
+            return evaluator.evaluate(target, self.other_type, branch, operator);
+        }
+
         evaluate_against_results(
             evaluator.db,
             target,
@@ -173,6 +190,8 @@ impl<'db> PartitionedEnumComparison<'db> {
     }
 
     /// Compare all possible values.
+    ///
+    /// If no member of an enum can match, exclude it from the other possible values.
     ///
     /// Return whether the result is certain or which values can still match.
     fn evaluate(
@@ -193,9 +212,61 @@ impl<'db> PartitionedEnumComparison<'db> {
             );
         }
 
-        evaluate_target_union(evaluator.db, &self.target.alternatives, branch, |target| {
-            self.evaluate_against_other(evaluator, target, branch, operator)
-        })
+        let mut narrowed_enum = None;
+        let result =
+            evaluate_target_union(evaluator.db, &self.target.alternatives, branch, |target| {
+                let result = self.evaluate_against_other(evaluator, target, branch, operator);
+                if target == self.target.enum_type
+                    && let ComparisonResult::CanNarrow(narrowed) = result
+                    && narrowed != target
+                {
+                    narrowed_enum = Some(narrowed);
+                }
+                result
+            });
+
+        if let ComparisonResult::CanNarrow(narrowed) = result
+            && let Some(narrowed_enum) = narrowed_enum
+            && let Some(domains) = EnumDomainSet::from_type(evaluator.db, self.target.enum_type)
+        {
+            let excluded = domains
+                .domains
+                .iter()
+                .fold(UnionBuilder::new(evaluator.db), |builder, domain| {
+                    let domain_type = domain.restriction_type(evaluator.db);
+                    if domain_type.is_disjoint_from(evaluator.db, narrowed_enum) {
+                        builder.add(domain_type)
+                    } else {
+                        builder
+                    }
+                })
+                .build();
+            if !excluded.is_never() {
+                let exclude = |alternative: Type<'db>| {
+                    if alternative.is_disjoint_from(evaluator.db, excluded) {
+                        alternative
+                    } else {
+                        IntersectionBuilder::new(evaluator.db)
+                            .add_positive(alternative)
+                            .add_negative(excluded)
+                            .build()
+                    }
+                };
+                let narrowed = match narrowed {
+                    Type::Union(union) => union
+                        .elements(evaluator.db)
+                        .iter()
+                        .fold(UnionBuilder::new(evaluator.db), |builder, alternative| {
+                            builder.add(exclude(*alternative))
+                        })
+                        .build(),
+                    alternative => exclude(alternative),
+                };
+                return ComparisonResult::CanNarrow(narrowed);
+            }
+        }
+
+        result
     }
 }
 


### PR DESCRIPTION
## Summary

We already have an efficient way to compare enums as a whole. However, this fast path only applies when both sides contain nothing but enum values. An extra value such as `None` causes `ModelSlug | None` to miss it:

```python
def matches(slug: ModelSlug, candidate: ModelSlug | None) -> bool:
    return candidate == slug
```

Instead of comparing `ModelSlug` once, we expanded it into individual members. Repeated comparisons in a boolean chain made large enums especially expensive.

We now group the enum values on each side, compare the groups once using the existing enum comparison logic, and evaluate any other union members normally. This fixes optional enums without special-casing `None`; the same approach handles integers, strings, `Any`, `Unknown`, and unions containing several enum classes.

For an optional enum, separate the enum from the other possible value:

```text
ModelSlug | None
    → grouped enum: ModelSlug
    → other value: None
```

The same approach works for several enum classes:

```text
LeftEnum | RightEnum | None
    → grouped enums: LeftEnum | RightEnum
    → other value: None
```

Specifically, we evaluate comparisons in this order:

1. Compare enum values, including enums inside unions.
2. Handle `Any` and `Unknown`.
3. Expand finite alternatives only when necessary.
4. Fall back to ordinary structural comparison.

The 406-member cross-enum case improves from approximately 4.95 seconds to 0.05 seconds.

Closes https://github.com/astral-sh/ty/issues/4069.