### PR TITLE
[ty] Avoid exponential inference when copying mixed TypedDict unions

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1542,6 +1542,79 @@ fn benchmark_pandas_tdd(criterion: &mut Criterion) {
     });
 }
 
+fn benchmark_mixed_typed_dict_union_copy(criterion: &mut Criterion) {
+    const NUM_VARIANTS: usize = 12;
+
+    setup_rayon();
+
+    let mut code = concat!(
+        "from collections import ChainMap, OrderedDict, defaultdict\n",
+        "from collections.abc import Mapping, MutableMapping\n",
+        "from typing import Any, Literal, TypedDict\n\n",
+    )
+    .to_string();
+
+    for i in 0..NUM_VARIANTS {
+        writeln!(
+            &mut code,
+            "class Item{i}(TypedDict):\n    type: Literal[{i}]"
+        )
+        .ok();
+        if i == 0 {
+            code.push_str("    other: Any\n");
+        }
+        code.push('\n');
+    }
+
+    code.push_str("type Item = ");
+    for i in 0..NUM_VARIANTS {
+        if i > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "Item{i}").ok();
+    }
+
+    code.push_str(
+        r#"
+
+def copy_dict(value: Item | dict[str, Any]) -> dict[str, object]:
+    return dict(value)
+
+def copy_mapping(value: Item | Mapping[str, Any]) -> dict[str, object]:
+    return dict(value)
+
+def copy_mutable_mapping(value: Item | MutableMapping[str, Any]) -> dict[str, object]:
+    return dict(value)
+
+def copy_ordered_dict(value: Item | OrderedDict[str, Any]) -> dict[str, object]:
+    return dict(value)
+
+def copy_default_dict(value: Item | defaultdict[str, Any]) -> dict[str, object]:
+    return dict(value)
+
+def copy_chain_map(value: Item | ChainMap[str, Any]) -> dict[str, object]:
+    return dict(value)
+
+def copy_narrowed_mapping(value: Item | Mapping[str, Any]) -> dict[str, object] | None:
+    if isinstance(value, dict):
+        return dict(value)
+    return None
+"#,
+    );
+
+    criterion.bench_function("ty_micro[mixed_typed_dict_union_copy]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 fn benchmark_recursive_typed_dict_union_contextual_inference(criterion: &mut Criterion) {
     const NUM_BRANCHES: usize = 11;
 
@@ -1978,6 +2051,7 @@ criterion_group!(
     benchmark_repeated_statement_calls,
     benchmark_factored_upper_bounds,
     benchmark_pandas_tdd,
+    benchmark_mixed_typed_dict_union_copy,
     benchmark_recursive_typed_dict_union_contextual_inference,
     benchmark_invariant_generic_return_union,
     benchmark_invariant_generic_union_bound,

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2610,6 +2610,8 @@ python-version = "3.12"
 ```
 
 ```py
+from collections import OrderedDict
+from collections.abc import Mapping
 from typing import Any, Literal, TypedDict
 
 A = TypedDict("A", {"type": Literal["a"], "irrelevant": Any})
@@ -2639,6 +2641,15 @@ X = TypedDict("X", {"type": Literal["x"], "irrelevant": Any})
 
 Item = A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X
 
+class StringDict(dict[str, Any]): ...
+
+class StringMapping:
+    def keys(self) -> list[str]:
+        return ["type"]
+
+    def __getitem__(self, key: str, /) -> Any:
+        return "value"
+
 def _(item: Item) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
 
@@ -2655,6 +2666,18 @@ def _(item: Item | dict[str, Any]) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
     if isinstance(item, dict):
         reveal_type(dict(item))  # revealed: dict[str, object]
+
+def _(item: Item | OrderedDict[str, Any]) -> None:
+    reveal_type(dict(item))  # revealed: dict[str, object]
+
+def _(item: Item | Mapping[str, Any]) -> None:
+    reveal_type(dict(item))  # revealed: dict[str, object]
+
+def _(item: Item | StringDict) -> None:
+    reveal_type(dict(item))  # revealed: dict[str, object]
+
+def _(item: Item | StringMapping) -> None:
+    reveal_type(dict(item))  # revealed: dict[str, object]
 
 type FirstGroup = A | B | C | D | E | F | G | H
 type SecondGroup = I | J | K | L | M | N | O | P
@@ -2772,8 +2795,9 @@ def _(value: ClearA | ClearB) -> None:
 Mixed unions must retain gradual evidence from their `TypedDict` members:
 
 ```py
-from typing import Any, Literal, Protocol, TypeVar, TypedDict
-from typing_extensions import TypeAliasType
+from _typeshed import SupportsKeysAndGetItem
+from typing import Any, Literal, Protocol, TypeVar, TypedDict, runtime_checkable
+from typing_extensions import TypeAliasType, TypedDict as ExtensionsTypedDict
 
 GradualValueT = TypeVar("GradualValueT", covariant=True)
 GradualBoundedValueT = TypeVar("GradualBoundedValueT", bound=str, covariant=True)
@@ -2791,6 +2815,27 @@ class StaticValue(TypedDict):
 class GenericValue[GenericItem](TypedDict):
     value: GenericItem
 
+class GradualExtras(ExtensionsTypedDict, extra_items=Any): ...
+class StringExtras(ExtensionsTypedDict, extra_items=str): ...
+
+class DynamicKeys:
+    def keys(self) -> Any:
+        return [1]
+
+    def __getitem__(self, key: int, /) -> str:
+        return "value"
+
+class DynamicStringDict(dict[str, str]):
+    def keys(self) -> Any:
+        return [1]
+
+    def __getitem__(self, key: Any, /) -> str:
+        return "value"
+
+@runtime_checkable
+class DynamicGetValue(Protocol):
+    def __getitem__(self, key: Literal["value"], /) -> Any: ...
+
 def get_gradual_value(value: GradualGetValue[GradualValueT]) -> GradualValueT:
     raise NotImplementedError
 
@@ -2802,38 +2847,70 @@ def get_constrained_value(
 ) -> GradualConstrainedValueT:
     raise NotImplementedError
 
+def get_bounded_mapping_value(
+    value: SupportsKeysAndGetItem[str, GradualBoundedValueT],
+) -> GradualBoundedValueT:
+    raise NotImplementedError
+
+def get_constrained_mapping_value(
+    value: SupportsKeysAndGetItem[str, GradualConstrainedValueT],
+) -> GradualConstrainedValueT:
+    raise NotImplementedError
+
 def _(value: dict[str, Any] | GradualValue) -> None:
     reveal_type(get_gradual_value(value))  # revealed: Any
     get_gradual_value(value).strip()
     reveal_type(get_bounded_value(value))  # revealed: Any
     reveal_type(get_constrained_value(value))  # revealed: Any
 
-def _(value: dict[str, str] | GradualValue | StaticValue) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: str | Any
-    get_bounded_value(value).strip()
-    get_constrained_value(value).strip()
+def _(value: DynamicKeys | StaticValue) -> None:
+    reveal_type(dict(value))  # revealed: dict[Unknown, Unknown]
 
-def _(value: dict[str, str] | GradualValue) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: str | Any
-    get_bounded_value(value).strip()
-    get_constrained_value(value).strip()
+def _(value: DynamicStringDict | StaticValue) -> None:
+    reveal_type(dict(value))  # revealed: dict[Unknown, Unknown]
 
-def _(value: GradualValue | dict[str, str]) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: str | Any
-    get_bounded_value(value).strip()
-    get_constrained_value(value).strip()
+def _(value: GradualExtras | dict[str, str]) -> None:
+    reveal_type(dict(value))  # revealed: dict[str, Any | str]
+    next(iter(dict(value).values())).strip()
+    get_bounded_mapping_value(value).strip()
+    get_constrained_mapping_value(value).strip()
+
+def _(value: dict[str, str] | GradualExtras) -> None:
+    reveal_type(dict(value))  # revealed: dict[str, Any | str]
+    next(iter(dict(value).values())).strip()
+    get_bounded_mapping_value(value).strip()
+    get_constrained_mapping_value(value).strip()
+
+def _(value: StringExtras | dict[str, str]) -> None:
+    reveal_type(dict(value))  # revealed: dict[str, str]
+    get_bounded_mapping_value(value).strip()
+    get_constrained_mapping_value(value).strip()
+
+def _(value: dict[str, Any] | StaticValue) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: object
+    get_bounded_value(value)  # error: [invalid-argument-type]
+
+def _(value: StaticValue | dict[str, Any]) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: object
+    get_bounded_value(value)  # error: [invalid-argument-type]
+
+def _(value: dict[str, Any] | StaticValue) -> None:
+    if isinstance(value, DynamicGetValue):
+        reveal_type(get_gradual_value(value))  # revealed: Any
+        get_gradual_value(value).strip()
+        get_bounded_value(value).strip()
 
 def _(value: GenericValue[int]) -> None:
     reveal_type(value.__getitem__("value"))  # revealed: int
 
 def _(value: dict[str, str] | GenericValue[int]) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: str | int
+    reveal_type(get_gradual_value(value))  # revealed: object
     get_gradual_value(value).strip()  # error: [unresolved-attribute]
     get_bounded_value(value)  # error: [invalid-argument-type]
     get_constrained_value(value)  # error: [invalid-argument-type]
 
 def _(value: GenericValue[int] | dict[str, str]) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: int | str
+    reveal_type(get_gradual_value(value))  # revealed: object
     get_gradual_value(value).strip()  # error: [unresolved-attribute]
     get_bounded_value(value)  # error: [invalid-argument-type]
     get_constrained_value(value)  # error: [invalid-argument-type]
@@ -2843,18 +2920,81 @@ type GradualValueAlias = Any
 class AliasedGradualValue(TypedDict):
     value: GradualValueAlias
 
+class AliasedGradualExtras(ExtensionsTypedDict, extra_items=GradualValueAlias): ...
+
 def _(value: dict[str, Any] | AliasedGradualValue) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: Any
-    get_bounded_value(value).strip()
+    reveal_type(dict(value))  # revealed: dict[str, object]
+
+def _(value: AliasedGradualExtras | dict[str, str]) -> None:
+    reveal_type(dict(value))  # revealed: dict[str, Any | str]
+    get_bounded_mapping_value(value).strip()
 
 ManualGradualValueAlias = TypeAliasType("ManualGradualValueAlias", Any)
 
 class ManuallyAliasedGradualValue(TypedDict):
     value: ManualGradualValueAlias
 
+class ManuallyAliasedGradualExtras(
+    ExtensionsTypedDict,
+    extra_items=ManualGradualValueAlias,
+): ...
+
 def _(value: dict[str, Any] | ManuallyAliasedGradualValue) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: Any
-    get_bounded_value(value).strip()
+    reveal_type(dict(value))  # revealed: dict[str, object]
+
+def _(value: ManuallyAliasedGradualExtras | dict[str, str]) -> None:
+    reveal_type(dict(value))  # revealed: dict[str, Any | str]
+    get_bounded_mapping_value(value).strip()
+
+type ManyGenericValues = (
+    GenericValue[Literal[0]]
+    | GenericValue[Literal[1]]
+    | GenericValue[Literal[2]]
+    | GenericValue[Literal[3]]
+    | GenericValue[Literal[4]]
+    | GenericValue[Literal[5]]
+    | GenericValue[Literal[6]]
+    | GenericValue[Literal[7]]
+    | GenericValue[Literal[8]]
+    | GenericValue[Literal[9]]
+    | GenericValue[Literal[10]]
+    | GenericValue[Literal[11]]
+    | GenericValue[Literal[12]]
+    | GenericValue[Literal[13]]
+    | GenericValue[Literal[14]]
+    | GenericValue[Literal[15]]
+    | GenericValue[Literal[16]]
+    | GenericValue[Literal[17]]
+    | GenericValue[Literal[18]]
+    | GenericValue[Literal[19]]
+    | GenericValue[Literal[20]]
+    | GenericValue[Literal[21]]
+    | GenericValue[Literal[22]]
+    | GenericValue[Literal[23]]
+    | GenericValue[Literal[24]]
+    | GenericValue[Literal[25]]
+    | GenericValue[Literal[26]]
+    | GenericValue[Literal[27]]
+    | GenericValue[Literal[28]]
+    | GenericValue[Literal[29]]
+    | GenericValue[Literal[30]]
+    | GenericValue[Literal[31]]
+    | GenericValue[Literal[32]]
+    | GenericValue[Literal[33]]
+    | GenericValue[Literal[34]]
+    | GenericValue[Literal[35]]
+    | GenericValue[Literal[36]]
+    | GenericValue[Literal[37]]
+    | GenericValue[Literal[38]]
+    | GenericValue[Literal[39]]
+)
+
+def _(value: ManyGenericValues | dict[str, Any]) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: object
+    reveal_type(dict(value))  # revealed: dict[str, object]
+
+def _(value: dict[str, Any] | ManyGenericValues) -> None:
+    reveal_type(dict(value))  # revealed: dict[str, object]
 ```
 
 Mixed-union protocol constraints must also preserve their original source ordering:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2610,7 +2610,7 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 A = TypedDict("A", {"type": Literal["a"]})
 B = TypedDict("B", {"type": Literal["b"]})
@@ -2646,6 +2646,12 @@ def _(item: Item) -> None:
 # Those intersections should still reuse the common protocol constraints of the union.
 # Regression test for https://github.com/astral-sh/ty/issues/3974.
 def _(item: Item | str) -> None:
+    if isinstance(item, dict):
+        reveal_type(dict(item))  # revealed: dict[str, object]
+
+# A single plain-dict member must not make combining the shared `TypedDict` constraints exponential.
+def _(item: Item | dict[str, Any]) -> None:
+    reveal_type(dict(item))  # revealed: dict[str, object]
     if isinstance(item, dict):
         reveal_type(dict(item))  # revealed: dict[str, object]
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2615,40 +2615,31 @@ from collections.abc import Mapping
 from typing import Any, Literal, TypedDict
 
 A = TypedDict("A", {"type": Literal["a"], "irrelevant": Any})
-B = TypedDict("B", {"type": Literal["b"], "irrelevant": Any})
-C = TypedDict("C", {"type": Literal["c"], "irrelevant": Any})
-D = TypedDict("D", {"type": Literal["d"], "irrelevant": Any})
-E = TypedDict("E", {"type": Literal["e"], "irrelevant": Any})
-F = TypedDict("F", {"type": Literal["f"], "irrelevant": Any})
-G = TypedDict("G", {"type": Literal["g"], "irrelevant": Any})
-H = TypedDict("H", {"type": Literal["h"], "irrelevant": Any})
-I = TypedDict("I", {"type": Literal["i"], "irrelevant": Any})
-J = TypedDict("J", {"type": Literal["j"], "irrelevant": Any})
-K = TypedDict("K", {"type": Literal["k"], "irrelevant": Any})
-L = TypedDict("L", {"type": Literal["l"], "irrelevant": Any})
-M = TypedDict("M", {"type": Literal["m"], "irrelevant": Any})
-N = TypedDict("N", {"type": Literal["n"], "irrelevant": Any})
-O = TypedDict("O", {"type": Literal["o"], "irrelevant": Any})
-P = TypedDict("P", {"type": Literal["p"], "irrelevant": Any})
-Q = TypedDict("Q", {"type": Literal["q"], "irrelevant": Any})
-R = TypedDict("R", {"type": Literal["r"], "irrelevant": Any})
-S = TypedDict("S", {"type": Literal["s"], "irrelevant": Any})
-T = TypedDict("T", {"type": Literal["t"], "irrelevant": Any})
-U = TypedDict("U", {"type": Literal["u"], "irrelevant": Any})
-V = TypedDict("V", {"type": Literal["v"], "irrelevant": Any})
-W = TypedDict("W", {"type": Literal["w"], "irrelevant": Any})
-X = TypedDict("X", {"type": Literal["x"], "irrelevant": Any})
+B = TypedDict("B", {"type": Literal["b"]})
+C = TypedDict("C", {"type": Literal["c"]})
+D = TypedDict("D", {"type": Literal["d"]})
+E = TypedDict("E", {"type": Literal["e"]})
+F = TypedDict("F", {"type": Literal["f"]})
+G = TypedDict("G", {"type": Literal["g"]})
+H = TypedDict("H", {"type": Literal["h"]})
+I = TypedDict("I", {"type": Literal["i"]})
+J = TypedDict("J", {"type": Literal["j"]})
+K = TypedDict("K", {"type": Literal["k"]})
+L = TypedDict("L", {"type": Literal["l"]})
+M = TypedDict("M", {"type": Literal["m"]})
+N = TypedDict("N", {"type": Literal["n"]})
+O = TypedDict("O", {"type": Literal["o"]})
+P = TypedDict("P", {"type": Literal["p"]})
+Q = TypedDict("Q", {"type": Literal["q"]})
+R = TypedDict("R", {"type": Literal["r"]})
+S = TypedDict("S", {"type": Literal["s"]})
+T = TypedDict("T", {"type": Literal["t"]})
+U = TypedDict("U", {"type": Literal["u"]})
+V = TypedDict("V", {"type": Literal["v"]})
+W = TypedDict("W", {"type": Literal["w"]})
+X = TypedDict("X", {"type": Literal["x"]})
 
 Item = A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X
-
-class StringDict(dict[str, Any]): ...
-
-class StringMapping:
-    def keys(self) -> list[str]:
-        return ["type"]
-
-    def __getitem__(self, key: str, /) -> Any:
-        return "value"
 
 def _(item: Item) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
@@ -2659,26 +2650,31 @@ def _(item: Item) -> None:
 def _(item: Item | str) -> None:
     if isinstance(item, dict):
         reveal_type(dict(item))  # revealed: dict[str, object]
+```
 
-# A single plain-dict member must not make combining the shared `TypedDict` constraints
-# exponential, even when the `TypedDict`s contain unrelated gradual fields.
+A union can also contain a regular dictionary. Copying the union remains fast even when a
+`TypedDict` has an unrelated `Any` field:
+
+```py
 def _(item: Item | dict[str, Any]) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
     if isinstance(item, dict):
-        reveal_type(dict(item))  # revealed: dict[str, object]
+        dict(item)
+```
+
+The same performance guarantee applies to `Mapping` and `OrderedDict`:
+
+```py
+def _(item: Item | Mapping[str, Any]) -> None:
+    dict(item)
 
 def _(item: Item | OrderedDict[str, Any]) -> None:
-    reveal_type(dict(item))  # revealed: dict[str, object]
+    dict(item)
+```
 
-def _(item: Item | Mapping[str, Any]) -> None:
-    reveal_type(dict(item))  # revealed: dict[str, object]
+The union can also be assembled from type aliases:
 
-def _(item: Item | StringDict) -> None:
-    reveal_type(dict(item))  # revealed: dict[str, object]
-
-def _(item: Item | StringMapping) -> None:
-    reveal_type(dict(item))  # revealed: dict[str, object]
-
+```py
 type FirstGroup = A | B | C | D | E | F | G | H
 type SecondGroup = I | J | K | L | M | N | O | P
 type AliasedItem = FirstGroup | SecondGroup | Q | R | S | T | U | V | W | X
@@ -2792,237 +2788,62 @@ def _(value: ClearA | ClearB) -> None:
         reveal_type(clear_result(value))  # revealed: None
 ```
 
-Mixed unions must retain gradual evidence from their `TypedDict` members:
+An `isinstance()` check against a protocol can establish that `__getitem__()` returns `Any`. That
+return type must be preserved for unions containing a `TypedDict`:
+
+```py
+from typing import Any, Literal, Protocol, TypeVar, TypedDict, runtime_checkable
+
+ValueT = TypeVar("ValueT", covariant=True)
+
+class GetValue(Protocol[ValueT]):
+    def __getitem__(self, key: Literal["value"], /) -> ValueT: ...
+
+class StringValue(TypedDict):
+    value: str
+
+@runtime_checkable
+class GetAnyValue(Protocol):
+    def __getitem__(self, key: Literal["value"], /) -> Any: ...
+
+def get_value(value: GetValue[ValueT]) -> ValueT:
+    raise NotImplementedError
+
+def _(value: StringValue | dict[str, Any]) -> None:
+    if isinstance(value, GetAnyValue):
+        reveal_type(get_value(value))  # revealed: Any
+```
+
+The same `Any` result must remain valid when the mapping protocol uses a bounded type variable:
 
 ```py
 from _typeshed import SupportsKeysAndGetItem
-from typing import Any, Literal, Protocol, TypeVar, TypedDict, runtime_checkable
-from typing_extensions import TypeAliasType, TypedDict as ExtensionsTypedDict
+from collections.abc import Iterable
 
-GradualValueT = TypeVar("GradualValueT", covariant=True)
-GradualBoundedValueT = TypeVar("GradualBoundedValueT", bound=str, covariant=True)
-GradualConstrainedValueT = TypeVar("GradualConstrainedValueT", str, bytes, covariant=True)
-
-class GradualGetValue(Protocol[GradualValueT]):
-    def __getitem__(self, key: Literal["value"], /) -> GradualValueT: ...
-
-class GradualValue(TypedDict):
-    value: Any
-
-class StaticValue(TypedDict):
-    value: str
-
-class GenericValue[GenericItem](TypedDict):
-    value: GenericItem
-
-class GradualExtras(ExtensionsTypedDict, extra_items=Any): ...
-class StringExtras(ExtensionsTypedDict, extra_items=str): ...
-
-class DynamicKeys:
-    def keys(self) -> Any:
-        return [1]
-
-    def __getitem__(self, key: int, /) -> str:
-        return "value"
-
-class DynamicStringDict(dict[str, str]):
-    def keys(self) -> Any:
-        return [1]
-
-    def __getitem__(self, key: Any, /) -> str:
-        return "value"
+BoundedValueT = TypeVar("BoundedValueT", bound=str)
 
 @runtime_checkable
-class DynamicGetValue(Protocol):
-    def __getitem__(self, key: Literal["value"], /) -> Any: ...
+class AnyValueMapping(Protocol):
+    def keys(self) -> Iterable[str]: ...
+    def __getitem__(self, key: str, /) -> Any: ...
 
-def get_gradual_value(value: GradualGetValue[GradualValueT]) -> GradualValueT:
+def get_bounded_mapping(value: SupportsKeysAndGetItem[str, BoundedValueT]) -> BoundedValueT:
     raise NotImplementedError
 
-def get_bounded_value(value: GradualGetValue[GradualBoundedValueT]) -> GradualBoundedValueT:
-    raise NotImplementedError
-
-def get_constrained_value(
-    value: GradualGetValue[GradualConstrainedValueT],
-) -> GradualConstrainedValueT:
-    raise NotImplementedError
-
-def get_bounded_mapping_value(
-    value: SupportsKeysAndGetItem[str, GradualBoundedValueT],
-) -> GradualBoundedValueT:
-    raise NotImplementedError
-
-def get_constrained_mapping_value(
-    value: SupportsKeysAndGetItem[str, GradualConstrainedValueT],
-) -> GradualConstrainedValueT:
-    raise NotImplementedError
-
-def _(value: dict[str, Any] | GradualValue) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: Any
-    get_gradual_value(value).strip()
-    reveal_type(get_bounded_value(value))  # revealed: Any
-    reveal_type(get_constrained_value(value))  # revealed: Any
-
-def _(value: DynamicKeys | StaticValue) -> None:
-    reveal_type(dict(value))  # revealed: dict[Unknown, Unknown]
-
-def _(value: DynamicStringDict | StaticValue) -> None:
-    reveal_type(dict(value))  # revealed: dict[Unknown, Unknown]
-
-def _(value: GradualExtras | dict[str, str]) -> None:
-    reveal_type(dict(value))  # revealed: dict[str, Any | str]
-    next(iter(dict(value).values())).strip()
-    get_bounded_mapping_value(value).strip()
-    get_constrained_mapping_value(value).strip()
-
-def _(value: dict[str, str] | GradualExtras) -> None:
-    reveal_type(dict(value))  # revealed: dict[str, Any | str]
-    next(iter(dict(value).values())).strip()
-    get_bounded_mapping_value(value).strip()
-    get_constrained_mapping_value(value).strip()
-
-def _(value: StringExtras | dict[str, str]) -> None:
-    reveal_type(dict(value))  # revealed: dict[str, str]
-    get_bounded_mapping_value(value).strip()
-    get_constrained_mapping_value(value).strip()
-
-def _(value: dict[str, Any] | StaticValue) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: object
-    get_bounded_value(value)  # error: [invalid-argument-type]
-
-def _(value: StaticValue | dict[str, Any]) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: object
-    get_bounded_value(value)  # error: [invalid-argument-type]
-
-def _(value: dict[str, Any] | StaticValue) -> None:
-    if isinstance(value, DynamicGetValue):
-        reveal_type(get_gradual_value(value))  # revealed: Any
-        get_gradual_value(value).strip()
-        get_bounded_value(value).strip()
-
-def _(value: GenericValue[int]) -> None:
-    reveal_type(value.__getitem__("value"))  # revealed: int
-
-def _(value: dict[str, str] | GenericValue[int]) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: object
-    get_gradual_value(value).strip()  # error: [unresolved-attribute]
-    get_bounded_value(value)  # error: [invalid-argument-type]
-    get_constrained_value(value)  # error: [invalid-argument-type]
-
-def _(value: GenericValue[int] | dict[str, str]) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: object
-    get_gradual_value(value).strip()  # error: [unresolved-attribute]
-    get_bounded_value(value)  # error: [invalid-argument-type]
-    get_constrained_value(value)  # error: [invalid-argument-type]
-
-type GradualValueAlias = Any
-
-class AliasedGradualValue(TypedDict):
-    value: GradualValueAlias
-
-class AliasedGradualExtras(ExtensionsTypedDict, extra_items=GradualValueAlias): ...
-
-def _(value: dict[str, Any] | AliasedGradualValue) -> None:
-    reveal_type(dict(value))  # revealed: dict[str, object]
-
-def _(value: AliasedGradualExtras | dict[str, str]) -> None:
-    reveal_type(dict(value))  # revealed: dict[str, Any | str]
-    get_bounded_mapping_value(value).strip()
-
-ManualGradualValueAlias = TypeAliasType("ManualGradualValueAlias", Any)
-
-class ManuallyAliasedGradualValue(TypedDict):
-    value: ManualGradualValueAlias
-
-class ManuallyAliasedGradualExtras(
-    ExtensionsTypedDict,
-    extra_items=ManualGradualValueAlias,
-): ...
-
-def _(value: dict[str, Any] | ManuallyAliasedGradualValue) -> None:
-    reveal_type(dict(value))  # revealed: dict[str, object]
-
-def _(value: ManuallyAliasedGradualExtras | dict[str, str]) -> None:
-    reveal_type(dict(value))  # revealed: dict[str, Any | str]
-    get_bounded_mapping_value(value).strip()
-
-type ManyGenericValues = (
-    GenericValue[Literal[0]]
-    | GenericValue[Literal[1]]
-    | GenericValue[Literal[2]]
-    | GenericValue[Literal[3]]
-    | GenericValue[Literal[4]]
-    | GenericValue[Literal[5]]
-    | GenericValue[Literal[6]]
-    | GenericValue[Literal[7]]
-    | GenericValue[Literal[8]]
-    | GenericValue[Literal[9]]
-    | GenericValue[Literal[10]]
-    | GenericValue[Literal[11]]
-    | GenericValue[Literal[12]]
-    | GenericValue[Literal[13]]
-    | GenericValue[Literal[14]]
-    | GenericValue[Literal[15]]
-    | GenericValue[Literal[16]]
-    | GenericValue[Literal[17]]
-    | GenericValue[Literal[18]]
-    | GenericValue[Literal[19]]
-    | GenericValue[Literal[20]]
-    | GenericValue[Literal[21]]
-    | GenericValue[Literal[22]]
-    | GenericValue[Literal[23]]
-    | GenericValue[Literal[24]]
-    | GenericValue[Literal[25]]
-    | GenericValue[Literal[26]]
-    | GenericValue[Literal[27]]
-    | GenericValue[Literal[28]]
-    | GenericValue[Literal[29]]
-    | GenericValue[Literal[30]]
-    | GenericValue[Literal[31]]
-    | GenericValue[Literal[32]]
-    | GenericValue[Literal[33]]
-    | GenericValue[Literal[34]]
-    | GenericValue[Literal[35]]
-    | GenericValue[Literal[36]]
-    | GenericValue[Literal[37]]
-    | GenericValue[Literal[38]]
-    | GenericValue[Literal[39]]
-)
-
-def _(value: ManyGenericValues | dict[str, Any]) -> None:
-    reveal_type(get_gradual_value(value))  # revealed: object
-    reveal_type(dict(value))  # revealed: dict[str, object]
-
-def _(value: dict[str, Any] | ManyGenericValues) -> None:
-    reveal_type(dict(value))  # revealed: dict[str, object]
+def _(value: StringValue | dict[str, Any]) -> None:
+    if isinstance(value, AnyValueMapping):
+        reveal_type(get_bounded_mapping(value))  # revealed: Any
 ```
 
-Mixed-union protocol constraints must also preserve their original source ordering:
+A `TypedDict` that permits extra items of type `Any` keeps that type when copied:
 
 ```py
-from collections.abc import Iterator
-from typing import Protocol, TypeVar, TypedDict
+from typing_extensions import TypedDict as ExtensionsTypedDict
 
-IterationValueT = TypeVar("IterationValueT", covariant=True)
+class AnyExtraItems(ExtensionsTypedDict, extra_items=Any): ...
 
-class IterableValues(Protocol[IterationValueT]):
-    def __iter__(self) -> Iterator[IterationValueT]: ...
-
-class Integers:
-    def __iter__(self) -> Iterator[int]:
-        raise NotImplementedError
-
-class StringValues(TypedDict):
-    value: str
-
-def get_iterated_value(value: IterableValues[IterationValueT]) -> IterationValueT:
-    raise NotImplementedError
-
-def integers_first(value: Integers | StringValues) -> None:
-    reveal_type(get_iterated_value(value))  # revealed: int | str
-
-def typed_dict_first(value: StringValues | Integers) -> None:
-    reveal_type(get_iterated_value(value))  # revealed: str | int
+def _(value: AnyExtraItems | dict[str, str]) -> None:
+    reveal_type(dict(value))  # revealed: dict[str, Any | str]
 ```
 
 Rejected common-constraint probes must not affect fallback protocol inference:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2611,7 +2611,7 @@ python-version = "3.12"
 
 ```py
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any, Literal, TypedDict
 
 A = TypedDict("A", {"type": Literal["a"], "irrelevant": Any})
@@ -2662,10 +2662,13 @@ def _(item: Item | dict[str, Any]) -> None:
         dict(item)
 ```
 
-The same performance guarantee applies to `Mapping` and `OrderedDict`:
+The same performance guarantee applies to `Mapping`, `MutableMapping`, and `OrderedDict`:
 
 ```py
 def _(item: Item | Mapping[str, Any]) -> None:
+    dict(item)
+
+def _(item: Item | MutableMapping[str, Any]) -> None:
     dict(item)
 
 def _(item: Item | OrderedDict[str, Any]) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2612,30 +2612,30 @@ python-version = "3.12"
 ```py
 from typing import Any, Literal, TypedDict
 
-A = TypedDict("A", {"type": Literal["a"]})
-B = TypedDict("B", {"type": Literal["b"]})
-C = TypedDict("C", {"type": Literal["c"]})
-D = TypedDict("D", {"type": Literal["d"]})
-E = TypedDict("E", {"type": Literal["e"]})
-F = TypedDict("F", {"type": Literal["f"]})
-G = TypedDict("G", {"type": Literal["g"]})
-H = TypedDict("H", {"type": Literal["h"]})
-I = TypedDict("I", {"type": Literal["i"]})
-J = TypedDict("J", {"type": Literal["j"]})
-K = TypedDict("K", {"type": Literal["k"]})
-L = TypedDict("L", {"type": Literal["l"]})
-M = TypedDict("M", {"type": Literal["m"]})
-N = TypedDict("N", {"type": Literal["n"]})
-O = TypedDict("O", {"type": Literal["o"]})
-P = TypedDict("P", {"type": Literal["p"]})
-Q = TypedDict("Q", {"type": Literal["q"]})
-R = TypedDict("R", {"type": Literal["r"]})
-S = TypedDict("S", {"type": Literal["s"]})
-T = TypedDict("T", {"type": Literal["t"]})
-U = TypedDict("U", {"type": Literal["u"]})
-V = TypedDict("V", {"type": Literal["v"]})
-W = TypedDict("W", {"type": Literal["w"]})
-X = TypedDict("X", {"type": Literal["x"]})
+A = TypedDict("A", {"type": Literal["a"], "irrelevant": Any})
+B = TypedDict("B", {"type": Literal["b"], "irrelevant": Any})
+C = TypedDict("C", {"type": Literal["c"], "irrelevant": Any})
+D = TypedDict("D", {"type": Literal["d"], "irrelevant": Any})
+E = TypedDict("E", {"type": Literal["e"], "irrelevant": Any})
+F = TypedDict("F", {"type": Literal["f"], "irrelevant": Any})
+G = TypedDict("G", {"type": Literal["g"], "irrelevant": Any})
+H = TypedDict("H", {"type": Literal["h"], "irrelevant": Any})
+I = TypedDict("I", {"type": Literal["i"], "irrelevant": Any})
+J = TypedDict("J", {"type": Literal["j"], "irrelevant": Any})
+K = TypedDict("K", {"type": Literal["k"], "irrelevant": Any})
+L = TypedDict("L", {"type": Literal["l"], "irrelevant": Any})
+M = TypedDict("M", {"type": Literal["m"], "irrelevant": Any})
+N = TypedDict("N", {"type": Literal["n"], "irrelevant": Any})
+O = TypedDict("O", {"type": Literal["o"], "irrelevant": Any})
+P = TypedDict("P", {"type": Literal["p"], "irrelevant": Any})
+Q = TypedDict("Q", {"type": Literal["q"], "irrelevant": Any})
+R = TypedDict("R", {"type": Literal["r"], "irrelevant": Any})
+S = TypedDict("S", {"type": Literal["s"], "irrelevant": Any})
+T = TypedDict("T", {"type": Literal["t"], "irrelevant": Any})
+U = TypedDict("U", {"type": Literal["u"], "irrelevant": Any})
+V = TypedDict("V", {"type": Literal["v"], "irrelevant": Any})
+W = TypedDict("W", {"type": Literal["w"], "irrelevant": Any})
+X = TypedDict("X", {"type": Literal["x"], "irrelevant": Any})
 
 Item = A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X
 
@@ -2649,7 +2649,8 @@ def _(item: Item | str) -> None:
     if isinstance(item, dict):
         reveal_type(dict(item))  # revealed: dict[str, object]
 
-# A single plain-dict member must not make combining the shared `TypedDict` constraints exponential.
+# A single plain-dict member must not make combining the shared `TypedDict` constraints
+# exponential, even when the `TypedDict`s contain unrelated gradual fields.
 def _(item: Item | dict[str, Any]) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
     if isinstance(item, dict):
@@ -2772,6 +2773,7 @@ Mixed unions must retain gradual evidence from their `TypedDict` members:
 
 ```py
 from typing import Any, Literal, Protocol, TypeVar, TypedDict
+from typing_extensions import TypeAliasType
 
 GradualValueT = TypeVar("GradualValueT", covariant=True)
 GradualBoundedValueT = TypeVar("GradualBoundedValueT", bound=str, covariant=True)
@@ -2782,6 +2784,12 @@ class GradualGetValue(Protocol[GradualValueT]):
 
 class GradualValue(TypedDict):
     value: Any
+
+class StaticValue(TypedDict):
+    value: str
+
+class GenericValue[GenericItem](TypedDict):
+    value: GenericItem
 
 def get_gradual_value(value: GradualGetValue[GradualValueT]) -> GradualValueT:
     raise NotImplementedError
@@ -2799,6 +2807,54 @@ def _(value: dict[str, Any] | GradualValue) -> None:
     get_gradual_value(value).strip()
     reveal_type(get_bounded_value(value))  # revealed: Any
     reveal_type(get_constrained_value(value))  # revealed: Any
+
+def _(value: dict[str, str] | GradualValue | StaticValue) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: str | Any
+    get_bounded_value(value).strip()
+    get_constrained_value(value).strip()
+
+def _(value: dict[str, str] | GradualValue) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: str | Any
+    get_bounded_value(value).strip()
+    get_constrained_value(value).strip()
+
+def _(value: GradualValue | dict[str, str]) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: str | Any
+    get_bounded_value(value).strip()
+    get_constrained_value(value).strip()
+
+def _(value: GenericValue[int]) -> None:
+    reveal_type(value.__getitem__("value"))  # revealed: int
+
+def _(value: dict[str, str] | GenericValue[int]) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: str | int
+    get_gradual_value(value).strip()  # error: [unresolved-attribute]
+    get_bounded_value(value)  # error: [invalid-argument-type]
+    get_constrained_value(value)  # error: [invalid-argument-type]
+
+def _(value: GenericValue[int] | dict[str, str]) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: int | str
+    get_gradual_value(value).strip()  # error: [unresolved-attribute]
+    get_bounded_value(value)  # error: [invalid-argument-type]
+    get_constrained_value(value)  # error: [invalid-argument-type]
+
+type GradualValueAlias = Any
+
+class AliasedGradualValue(TypedDict):
+    value: GradualValueAlias
+
+def _(value: dict[str, Any] | AliasedGradualValue) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: Any
+    get_bounded_value(value).strip()
+
+ManualGradualValueAlias = TypeAliasType("ManualGradualValueAlias", Any)
+
+class ManuallyAliasedGradualValue(TypedDict):
+    value: ManualGradualValueAlias
+
+def _(value: dict[str, Any] | ManuallyAliasedGradualValue) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: Any
+    get_bounded_value(value).strip()
 ```
 
 Mixed-union protocol constraints must also preserve their original source ordering:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2768,6 +2768,67 @@ def _(value: ClearA | ClearB) -> None:
         reveal_type(clear_result(value))  # revealed: None
 ```
 
+Mixed unions must retain gradual evidence from their `TypedDict` members:
+
+```py
+from typing import Any, Literal, Protocol, TypeVar, TypedDict
+
+GradualValueT = TypeVar("GradualValueT", covariant=True)
+GradualBoundedValueT = TypeVar("GradualBoundedValueT", bound=str, covariant=True)
+GradualConstrainedValueT = TypeVar("GradualConstrainedValueT", str, bytes, covariant=True)
+
+class GradualGetValue(Protocol[GradualValueT]):
+    def __getitem__(self, key: Literal["value"], /) -> GradualValueT: ...
+
+class GradualValue(TypedDict):
+    value: Any
+
+def get_gradual_value(value: GradualGetValue[GradualValueT]) -> GradualValueT:
+    raise NotImplementedError
+
+def get_bounded_value(value: GradualGetValue[GradualBoundedValueT]) -> GradualBoundedValueT:
+    raise NotImplementedError
+
+def get_constrained_value(
+    value: GradualGetValue[GradualConstrainedValueT],
+) -> GradualConstrainedValueT:
+    raise NotImplementedError
+
+def _(value: dict[str, Any] | GradualValue) -> None:
+    reveal_type(get_gradual_value(value))  # revealed: Any
+    get_gradual_value(value).strip()
+    reveal_type(get_bounded_value(value))  # revealed: Any
+    reveal_type(get_constrained_value(value))  # revealed: Any
+```
+
+Mixed-union protocol constraints must also preserve their original source ordering:
+
+```py
+from collections.abc import Iterator
+from typing import Protocol, TypeVar, TypedDict
+
+IterationValueT = TypeVar("IterationValueT", covariant=True)
+
+class IterableValues(Protocol[IterationValueT]):
+    def __iter__(self) -> Iterator[IterationValueT]: ...
+
+class Integers:
+    def __iter__(self) -> Iterator[int]:
+        raise NotImplementedError
+
+class StringValues(TypedDict):
+    value: str
+
+def get_iterated_value(value: IterableValues[IterationValueT]) -> IterationValueT:
+    raise NotImplementedError
+
+def integers_first(value: Integers | StringValues) -> None:
+    reveal_type(get_iterated_value(value))  # revealed: int | str
+
+def typed_dict_first(value: StringValues | Integers) -> None:
+    reveal_type(get_iterated_value(value))  # revealed: str | int
+```
+
 Rejected common-constraint probes must not affect fallback protocol inference:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2614,7 +2614,7 @@ from collections import OrderedDict
 from collections.abc import Mapping, MutableMapping
 from typing import Any, Literal, TypedDict
 
-A = TypedDict("A", {"type": Literal["a"], "irrelevant": Any})
+A = TypedDict("A", {"type": Literal["a"]})
 B = TypedDict("B", {"type": Literal["b"]})
 C = TypedDict("C", {"type": Literal["c"]})
 D = TypedDict("D", {"type": Literal["d"]})
@@ -2652,8 +2652,7 @@ def _(item: Item | str) -> None:
         reveal_type(dict(item))  # revealed: dict[str, object]
 ```
 
-A union can also contain a regular dictionary. Copying the union remains fast even when a
-`TypedDict` has an unrelated `Any` field:
+Adding a regular dictionary to the union should not make copying it slow:
 
 ```py
 def _(item: Item | dict[str, Any]) -> None:
@@ -2662,7 +2661,18 @@ def _(item: Item | dict[str, Any]) -> None:
         dict(item)
 ```
 
-The same performance guarantee applies to `Mapping`, `MutableMapping`, and `OrderedDict`:
+An unrelated `Any` field on a `TypedDict` should not disable this optimization:
+
+```py
+class ItemWithAny(TypedDict):
+    type: Literal["any"]
+    other: Any
+
+def _(item: Item | ItemWithAny | dict[str, Any]) -> None:
+    dict(item)
+```
+
+`Mapping`, `MutableMapping`, and `OrderedDict` should also be copied efficiently:
 
 ```py
 def _(item: Item | Mapping[str, Any]) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2658,7 +2658,7 @@ Adding a regular dictionary to the union should not make copying it slow:
 def _(item: Item | dict[str, Any]) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
     if isinstance(item, dict):
-        dict(item)
+        reveal_type(dict(item))  # revealed: dict[str, object]
 ```
 
 An unrelated `Any` field on a `TypedDict` should not disable this optimization:
@@ -2669,20 +2669,28 @@ class ItemWithAny(TypedDict):
     other: Any
 
 def _(item: Item | ItemWithAny | dict[str, Any]) -> None:
-    dict(item)
+    reveal_type(dict(item))  # revealed: dict[str, object]
 ```
 
 `Mapping`, `MutableMapping`, and `OrderedDict` should also be copied efficiently:
 
 ```py
 def _(item: Item | Mapping[str, Any]) -> None:
-    dict(item)
+    reveal_type(dict(item))  # revealed: dict[str, object]
 
 def _(item: Item | MutableMapping[str, Any]) -> None:
-    dict(item)
+    reveal_type(dict(item))  # revealed: dict[str, object]
 
 def _(item: Item | OrderedDict[str, Any]) -> None:
-    dict(item)
+    reveal_type(dict(item))  # revealed: dict[str, object]
+```
+
+A mapping should still be copied efficiently after `isinstance()` narrows it to a dictionary:
+
+```py
+def _(item: Item | Mapping[str, Any]) -> None:
+    if isinstance(item, dict):
+        reveal_type(dict(item))  # revealed: dict[str, object]
 ```
 
 The union can also be assembled from type aliases:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2610,7 +2610,7 @@ python-version = "3.12"
 ```
 
 ```py
-from collections import OrderedDict
+from collections import ChainMap, OrderedDict, defaultdict
 from collections.abc import Mapping, MutableMapping
 from typing import Any, Literal, TypedDict
 
@@ -2672,7 +2672,7 @@ def _(item: Item | ItemWithAny | dict[str, Any]) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
 ```
 
-`Mapping`, `MutableMapping`, and `OrderedDict` should also be copied efficiently:
+`Mapping`, `MutableMapping`, and other standard-library mappings should also be copied efficiently:
 
 ```py
 def _(item: Item | Mapping[str, Any]) -> None:
@@ -2682,6 +2682,12 @@ def _(item: Item | MutableMapping[str, Any]) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
 
 def _(item: Item | OrderedDict[str, Any]) -> None:
+    reveal_type(dict(item))  # revealed: dict[str, object]
+
+def _(item: Item | defaultdict[str, Any]) -> None:
+    reveal_type(dict(item))  # revealed: dict[str, object]
+
+def _(item: Item | ChainMap[str, Any]) -> None:
     reveal_type(dict(item))  # revealed: dict[str, object]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2859,6 +2859,18 @@ def _(value: AnyExtraItems | dict[str, str]) -> None:
     reveal_type(dict(value))  # revealed: dict[str, Any | str]
 ```
 
+A union of two such `TypedDict`s must also preserve `Any` when copied or passed to a mapping
+protocol with a bounded type variable:
+
+```py
+class OtherAnyExtraItems(ExtensionsTypedDict, extra_items=Any): ...
+
+def _(value: AnyExtraItems | OtherAnyExtraItems) -> None:
+    reveal_type(dict(value))  # revealed: dict[str, Any]
+    dict(value)["x"].strip()
+    reveal_type(get_bounded_mapping(value))  # revealed: Any
+```
+
 Rejected common-constraint probes must not affect fallback protocol inference:
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2895,17 +2895,6 @@ impl<'db> Type<'db> {
                     .class_namespace_member(db, instance.class(db), name, policy)
             }
 
-            // The generic TypedDict's meta-type does not retain its specialization, so synthesize
-            // members from the specialized defining class before performing descriptor binding.
-            Type::TypedDict(typed_dict)
-                if let Some((class, specialization)) = typed_dict
-                    .defining_class()
-                    .and_then(|class| class.static_class_literal(db))
-                    && specialization.is_some() =>
-            {
-                class.typed_dict_member(db, specialization, name, policy)
-            }
-
             Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => {
                 ty.to_meta_type(db).class_object_member(db, name, policy)
             }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2895,6 +2895,17 @@ impl<'db> Type<'db> {
                     .class_namespace_member(db, instance.class(db), name, policy)
             }
 
+            // The generic TypedDict's meta-type does not retain its specialization, so synthesize
+            // members from the specialized defining class before performing descriptor binding.
+            Type::TypedDict(typed_dict)
+                if let Some((class, specialization)) = typed_dict
+                    .defining_class()
+                    .and_then(|class| class.static_class_literal(db))
+                    && specialization.is_some() =>
+            {
+                class.typed_dict_member(db, specialization, name, policy)
+            }
+
             Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => {
                 ty.to_meta_type(db).class_object_member(db, name, policy)
             }

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -122,6 +122,7 @@ pub enum KnownClass {
     AsyncIterator,
     Sequence,
     Mapping,
+    MutableMapping,
     // typing_extensions
     ExtensionsTypeVar, // must be distinct from typing.TypeVar, backports new features
     ExtensionTypedDictFallback,
@@ -269,6 +270,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::MutableMapping
             | Self::SupportsKeysAndGetItem
             // Evaluating `NotImplementedType` in a boolean context was deprecated in Python 3.9
             // and raises a `TypeError` in Python >=3.14
@@ -384,6 +386,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::MutableMapping
             | KnownClass::SupportsKeysAndGetItem
             | KnownClass::ChainMap
             | KnownClass::Counter
@@ -497,6 +500,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::MutableMapping
             | KnownClass::SupportsKeysAndGetItem
             | KnownClass::ChainMap
             | KnownClass::Counter
@@ -611,6 +615,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::MutableMapping
             | KnownClass::SupportsKeysAndGetItem
             | KnownClass::ChainMap
             | KnownClass::Counter
@@ -758,6 +763,7 @@ impl KnownClass {
             | Self::Path
             | Self::FunctoolsPartial
             | Self::Mapping
+            | Self::MutableMapping
             | Self::Sequence
             | Self::PydanticBaseModel
             | Self::PydanticBaseSettings
@@ -856,6 +862,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::MutableMapping
             | KnownClass::SupportsKeysAndGetItem
             | KnownClass::ChainMap
             | KnownClass::Counter
@@ -976,6 +983,7 @@ impl KnownClass {
             Self::AsyncIterator => "AsyncIterator",
             Self::Sequence => "Sequence",
             Self::Mapping => "Mapping",
+            Self::MutableMapping => "MutableMapping",
             // For example, `typing.List` is defined as `List = _Alias()` in typeshed
             Self::StdlibAlias => "_Alias",
             // This is the name the type of `sys.version_info` has in typeshed,
@@ -1343,6 +1351,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::MutableMapping
             | Self::ProtocolMeta
             | Self::ParamSpec
             | Self::Hashable
@@ -1501,6 +1510,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::MutableMapping
             | Self::SupportsKeysAndGetItem
             | Self::NamedTupleFallback
             | Self::NamedTupleLike
@@ -1620,6 +1630,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::MutableMapping
             | Self::SupportsKeysAndGetItem
             | Self::NamedTupleFallback
             | Self::NamedTupleLike
@@ -1702,6 +1713,7 @@ impl KnownClass {
             "AsyncIterator" => &[Self::AsyncIterator, Self::TyExtensionsAsyncIterator],
             "Sequence" => &[Self::Sequence],
             "Mapping" => &[Self::Mapping],
+            "MutableMapping" => &[Self::MutableMapping],
             "ParamSpec" => &[Self::ParamSpec, Self::ExtensionsParamSpec],
             "ParamSpecArgs" => &[Self::ParamSpecArgs],
             "ParamSpecKwargs" => &[Self::ParamSpecKwargs],
@@ -1875,6 +1887,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::MutableMapping
             | Self::ProtocolMeta
             | Self::NewType => matches!(module, KnownModule::Typing | KnownModule::TypingExtensions),
             Self::Deprecated => matches!(module, KnownModule::Warnings | KnownModule::TypingExtensions),

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -95,6 +95,7 @@ pub enum KnownClass {
     EllipsisType,
     // Typeshed
     NoneType, // Part of `types` for Python >= 3.10
+    SupportsKeysAndGetItem,
     // Typing
     Awaitable,
     Generator,
@@ -268,6 +269,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::SupportsKeysAndGetItem
             // Evaluating `NotImplementedType` in a boolean context was deprecated in Python 3.9
             // and raises a `TypeError` in Python >=3.14
             // (see https://docs.python.org/3/library/constants.html#NotImplemented)
@@ -382,6 +384,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::SupportsKeysAndGetItem
             | KnownClass::ChainMap
             | KnownClass::Counter
             | KnownClass::DefaultDict
@@ -494,6 +497,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::SupportsKeysAndGetItem
             | KnownClass::ChainMap
             | KnownClass::Counter
             | KnownClass::DefaultDict
@@ -607,6 +611,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::SupportsKeysAndGetItem
             | KnownClass::ChainMap
             | KnownClass::Counter
             | KnownClass::DefaultDict
@@ -653,6 +658,7 @@ impl KnownClass {
         match self {
             Self::Hashable
             | Self::SupportsIndex
+            | Self::SupportsKeysAndGetItem
             | Self::Iterable
             | Self::TyExtensionsAsyncIterable
             | Self::TyExtensionsAsyncIterator
@@ -850,6 +856,7 @@ impl KnownClass {
             | KnownClass::AsyncIterator
             | KnownClass::Sequence
             | KnownClass::Mapping
+            | KnownClass::SupportsKeysAndGetItem
             | KnownClass::ChainMap
             | KnownClass::Counter
             | KnownClass::DefaultDict
@@ -921,6 +928,7 @@ impl KnownClass {
             Self::AsyncGeneratorType => "AsyncGeneratorType",
             Self::CoroutineType => "CoroutineType",
             Self::NoneType => "NoneType",
+            Self::SupportsKeysAndGetItem => "SupportsKeysAndGetItem",
             Self::SpecialForm => "_SpecialForm",
             Self::TypeVar => "TypeVar",
             Self::ExtensionsTypeVar => "TypeVar",
@@ -1323,7 +1331,7 @@ impl KnownClass {
             | Self::EllipsisType
             | Self::NotImplementedType
             | Self::WrapperDescriptorType => KnownModule::Types,
-            Self::NoneType => KnownModule::Typeshed,
+            Self::NoneType | Self::SupportsKeysAndGetItem => KnownModule::Typeshed,
             Self::Awaitable
             | Self::Generator
             | Self::AsyncGenerator
@@ -1493,6 +1501,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::SupportsKeysAndGetItem
             | Self::NamedTupleFallback
             | Self::NamedTupleLike
             | Self::ConstraintSet
@@ -1611,6 +1620,7 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Sequence
             | Self::Mapping
+            | Self::SupportsKeysAndGetItem
             | Self::NamedTupleFallback
             | Self::NamedTupleLike
             | Self::ConstraintSet
@@ -1672,6 +1682,7 @@ impl KnownClass {
             "deprecated" => &[Self::Deprecated],
             "GenericAlias" => &[Self::GenericAlias],
             "NoneType" => &[Self::NoneType],
+            "SupportsKeysAndGetItem" => &[Self::SupportsKeysAndGetItem],
             "ModuleType" => &[Self::ModuleType],
             "GeneratorType" => &[Self::GeneratorType],
             "AsyncGeneratorType" => &[Self::AsyncGeneratorType],
@@ -1821,6 +1832,7 @@ impl KnownClass {
             | Self::Field
             | Self::KwOnly
             | Self::NamedTupleFallback
+            | Self::SupportsKeysAndGetItem
             | Self::TypedDictFallback
             | Self::ExtensionTypedDictFallback
             | Self::TypeVar

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2716,7 +2716,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 Type::NominalInstance(instance)
                     if matches!(
                         instance.class(db).known(db),
-                        Some(KnownClass::Dict | KnownClass::Mapping | KnownClass::OrderedDict)
+                        Some(
+                            KnownClass::Dict
+                                | KnownClass::Mapping
+                                | KnownClass::MutableMapping
+                                | KnownClass::OrderedDict
+                        )
                     ) && let Some(alias) = instance.class(db).into_generic_alias()
                         && let [key, _] = alias.specialization(db).types(db)
                         && key.resolve_type_alias(db) == KnownClass::Str.to_instance(db) =>

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2717,13 +2717,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     if matches!(
                         instance.class(db).known(db),
                         Some(KnownClass::Dict | KnownClass::Mapping | KnownClass::OrderedDict)
-                    ) && instance
-                        .class(db)
-                        .into_generic_alias()
-                        .is_some_and(|alias| {
-                            matches!(alias.specialization(db).types(db), [key, _]
-                                if key.resolve_type_alias(db) == KnownClass::Str.to_instance(db))
-                        }) =>
+                    ) && let Some(alias) = instance.class(db).into_generic_alias()
+                        && let [key, _] = alias.specialization(db).types(db)
+                        && key.resolve_type_alias(db) == KnownClass::Str.to_instance(db) =>
                 {
                     other_types.insert(ty);
                     true
@@ -2757,8 +2753,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // fallback erases; restrict mixed unions to the protocol used by dictionary constructors.
         if !other_types.is_empty()
             && !matches!(formal, Type::ProtocolInstance(protocol)
-            if protocol.to_nominal_instance().is_some_and(|instance| {
-                instance.class(self.db).is_known(self.db, KnownClass::SupportsKeysAndGetItem)
+            if protocol.class_origin().is_some_and(|class| {
+                class.is_known(self.db, KnownClass::SupportsKeysAndGetItem)
             }))
         {
             return None;

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2663,8 +2663,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             ty: Type<'db>,
             resolving: &mut FxHashSet<Type<'db>>,
             completed: &mut FxHashMap<Type<'db>, bool>,
-            typed_dicts: &mut FxHashSet<Type<'db>>,
-            ordered_types: &mut FxOrderSet<Type<'db>>,
+            typed_dicts: &mut FxOrderSet<Type<'db>>,
+            other_types: &mut FxOrderSet<Type<'db>>,
         ) -> bool {
             let ty = ty.resolve_type_alias(db);
             if let Some(result) = completed.get(&ty) {
@@ -2674,7 +2674,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             let result = match ty {
                 Type::TypedDict(_) => {
                     typed_dicts.insert(ty);
-                    ordered_types.insert(ty);
                     true
                 }
                 Type::Union(union) => {
@@ -2688,7 +2687,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                             resolving,
                             completed,
                             typed_dicts,
-                            ordered_types,
+                            other_types,
                         )
                     });
                     resolving.remove(&ty);
@@ -2703,11 +2702,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     // `Top[dict[Unknown, Unknown]]`. Keep the full intersection so the normal
                     // constraint-equivalence check below remains authoritative.
                     typed_dicts.insert(ty);
-                    ordered_types.insert(ty);
                     true
                 }
                 _ => {
-                    ordered_types.insert(ty);
+                    other_types.insert(ty);
                     true
                 }
             };
@@ -2717,8 +2715,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
         let mut resolving = FxHashSet::default();
         let mut completed = FxHashMap::default();
-        let mut typed_dicts = FxHashSet::default();
-        let mut ordered_types = FxOrderSet::default();
+        let mut typed_dicts = FxOrderSet::default();
+        let mut other_types = FxOrderSet::default();
         if !actual.elements(self.db).iter().all(|element| {
             collect_typed_dicts(
                 self.db,
@@ -2726,7 +2724,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 &mut resolving,
                 &mut completed,
                 &mut typed_dicts,
-                &mut ordered_types,
+                &mut other_types,
             )
         }) {
             return None;
@@ -2735,75 +2733,149 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             return None;
         }
 
-        // Use the read-only `Mapping[str, object]` as the fallback rather than `dict[str, object]`.
-        // The current constraint solver can consider mutable protocol constraints equivalent even
-        // when a `TypedDict` preserves more precise correlations between its keys and values.
-        let spec = &[KnownClass::Str.to_instance(self.db), Type::object()];
-        let mapping = KnownClass::Mapping.to_specialized_instance(self.db, spec);
-        let mapping_when = mapping.when_constraint_set_assignable_to_owned(self.db, formal);
-        let mapping_when = self.constraints.load(self.db, &mapping_when);
-        let mapping_solutions = mapping_when.solutions(self.db, self.constraints, self.inferable);
-        let mut preserved_typed_dict_constraints = FxHashMap::default();
-        let mut gradual_typed_dicts = FxHashSet::default();
-        for element in typed_dicts.iter().copied() {
+        if !other_types.is_empty() {
+            // `SupportsKeysAndGetItem` observes a `TypedDict` through arbitrary string keys.
+            // Implicitly open `TypedDict`s therefore share `Mapping[str, object]`, while explicit
+            // extra items preserve their exposed value type. Other protocols can observe
+            // individual gradual or specialized fields and must retain their original constraints.
+            let Type::ProtocolInstance(protocol) = formal else {
+                return None;
+            };
+            if !protocol.to_nominal_instance().is_some_and(|instance| {
+                instance.class_name(self.db) == "SupportsKeysAndGetItem"
+                    && instance
+                        .class_module_name(self.db)
+                        .is_some_and(|module| module.as_str() == "_typeshed")
+            }) {
+                return None;
+            }
+
+            if !typed_dicts.iter().all(|element| match element {
+                Type::TypedDict(_) => true,
+                Type::Intersection(intersection) => {
+                    intersection.negative(self.db).is_empty()
+                        && intersection.iter_positive(self.db).all(|positive| {
+                            let positive = positive.resolve_type_alias(self.db);
+                            positive.is_typed_dict()
+                                || matches!(positive, Type::NominalInstance(instance)
+                                    if instance.class(self.db).is_known(self.db, KnownClass::Dict)
+                                        && instance.class(self.db).into_generic_alias().is_some_and(
+                                            |alias| alias.specialization(self.db).materialization_kind(self.db)
+                                                == Some(MaterializationKind::Top),
+                                        ))
+                        })
+                }
+                _ => false,
+            }) {
+                return None;
+            }
+
+            let string = KnownClass::Str.to_instance(self.db);
+            let key_type = protocol
+                .to_nominal_instance()
+                .and_then(|instance| instance.class(self.db).into_generic_alias())
+                .and_then(|alias| {
+                    alias
+                        .specialization(self.db)
+                        .types(self.db)
+                        .first()
+                        .copied()
+                });
+            if !other_types.iter().all(|element| {
+                let Some(Type::TypeVar(key_typevar)) = key_type else {
+                    // A fixed protocol key cannot prove that a structural mapping has static keys.
+                    return element.nominal_class(self.db).is_some_and(|class| {
+                        class.iter_mro(self.db).filter_map(ClassBase::into_class).any(
+                            |base| {
+                                (base.is_known(self.db, KnownClass::Dict)
+                                    || base.is_known(self.db, KnownClass::Mapping))
+                                    && base.into_generic_alias().is_some_and(|alias| {
+                                        matches!(alias.specialization(self.db).types(self.db), [key, _]
+                                            if key.resolve_type_alias(self.db) == string)
+                                    })
+                            },
+                        )
+                    });
+                };
+                let when = self.constraints.load(
+                    self.db,
+                    &element.when_constraint_set_assignable_to_owned(self.db, formal),
+                );
+                let Solutions::Constrained(solutions) =
+                    when.solutions(self.db, self.constraints, self.inferable)
+                else {
+                    return false;
+                };
+                solutions.iter().all(|solution| {
+                    solution
+                        .iter()
+                        .find(|binding| binding.bound_typevar == key_typevar)
+                        .is_some_and(|binding| {
+                            binding.solution.resolve_type_alias(self.db) == string
+                        })
+                })
+            }) {
+                return None;
+            }
+        }
+
+        let mut shared_mappings = FxOrderSet::default();
+        if !typed_dicts.into_iter().all(|element| {
+            let value_ty = if other_types.is_empty() {
+                Type::object()
+            } else {
+                match element {
+                    Type::TypedDict(typed_dict) => typed_dict.value_type(self.db),
+                    Type::Intersection(intersection) => {
+                        let Some(typed_dict) =
+                            intersection
+                                .iter_positive(self.db)
+                                .find_map(|positive| match positive.resolve_type_alias(self.db) {
+                                    Type::TypedDict(typed_dict) => Some(typed_dict),
+                                    _ => None,
+                                })
+                        else {
+                            return false;
+                        };
+                        typed_dict.value_type(self.db)
+                    }
+                    _ => return false,
+                }
+            };
+            // Use read-only `Mapping` representatives so collapsing does not introduce mutable
+            // correlations. Explicit extra items determine the observable arbitrary-key values.
+            let mapping = KnownClass::Mapping.to_specialized_instance(
+                self.db,
+                &[KnownClass::Str.to_instance(self.db), value_ty],
+            );
+            let mapping_when = mapping.when_constraint_set_assignable_to_owned(self.db, formal);
+            let mapping_when = self.constraints.load(self.db, &mapping_when);
             let element_when = self.constraints.load(
                 self.db,
                 &element.when_constraint_set_assignable_to_owned(self.db, formal),
             );
-            let equivalent = element_when
+            if !element_when
                 .iff(self.db, self.constraints, mapping_when)
-                .is_always_satisfied(self.db);
-            // Equivalent constraints can differ in their inferred solutions. For
-            // `class TD(TypedDict): value: Any`, replacing `TD` with `Mapping[str, object]` in a
-            // generic `__getitem__(Literal["value"]) -> T` protocol changes `T` from `Any` to
-            // `object`, while an unrelated `Any` field does not affect the protocol constraints.
-            let element_solutions =
-                element_when.solutions(self.db, self.constraints, self.inferable);
-            if !equivalent || element_solutions != mapping_solutions {
-                if let Solutions::Constrained(solutions) = &element_solutions
-                    && solutions.iter().flatten().any(|solution| {
-                        solution.solution.bottom_materialization(self.db)
-                            != solution.solution.top_materialization(self.db)
-                    })
-                {
-                    gradual_typed_dicts.insert(element);
-                }
-                preserved_typed_dict_constraints.insert(element, element_when);
+                .is_always_satisfied(self.db)
+            {
+                return false;
             }
+            shared_mappings.insert(mapping);
+            true
+        }) {
+            return None;
         }
 
-        let mut included_mapping = false;
-        // Concrete bounds must precede gradual evidence so either source spelling retains `Any`.
-        let mut gradual_constraints = Vec::new();
-        let constraints =
-            ordered_types
-                .into_iter()
-                .when_all(self.db, self.constraints, |element| {
-                    if let Some(constraints) = preserved_typed_dict_constraints.get(&element) {
-                        if gradual_typed_dicts.contains(&element) {
-                            gradual_constraints.push(*constraints);
-                            ConstraintSet::from_bool(self.constraints, true)
-                        } else {
-                            *constraints
-                        }
-                    } else if typed_dicts.contains(&element) {
-                        if std::mem::replace(&mut included_mapping, true) {
-                            ConstraintSet::from_bool(self.constraints, true)
-                        } else {
-                            mapping_when
-                        }
-                    } else {
-                        self.constraints.load(
-                            self.db,
-                            &element.when_constraint_set_assignable_to_owned(self.db, formal),
-                        )
-                    }
-                });
-        Some(constraints.and(self.db, self.constraints, || {
-            gradual_constraints
-                .into_iter()
-                .when_all(self.db, self.constraints, |constraints| constraints)
-        }))
+        Some(shared_mappings.into_iter().chain(other_types).when_all(
+            self.db,
+            self.constraints,
+            |element| {
+                self.constraints.load(
+                    self.db,
+                    &element.when_constraint_set_assignable_to_owned(self.db, formal),
+                )
+            },
+        ))
     }
 
     /// Infer type mappings by comparing formal callable signatures against actual callables.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -34,8 +34,8 @@ use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, CallableTypes,
     ClassLiteral, FindLegacyTypeVarsVisitor, IntersectionType, KnownClass, KnownInstanceType,
     MaterializationKind, SubclassOfInner, Type, TypeAliasType, TypeContext, TypeMapping,
-    TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType,
-    binding_type, infer_definition_types, inferred_declaration,
+    TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType, UnionAccumulator,
+    UnionType, binding_type, infer_definition_types, inferred_declaration,
 };
 use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -2664,7 +2664,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             resolving: &mut FxHashSet<Type<'db>>,
             completed: &mut FxHashMap<Type<'db>, bool>,
             typed_dicts: &mut FxHashSet<Type<'db>>,
-            other_types: &mut FxOrderSet<Type<'db>>,
+            ordered_types: &mut FxOrderSet<Option<Type<'db>>>,
         ) -> bool {
             let ty = ty.resolve_type_alias(db);
             if let Some(result) = completed.get(&ty) {
@@ -2674,6 +2674,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             let result = match ty {
                 Type::TypedDict(_) => {
                     typed_dicts.insert(ty);
+                    ordered_types.insert(None);
                     true
                 }
                 Type::Union(union) => {
@@ -2687,7 +2688,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                             resolving,
                             completed,
                             typed_dicts,
-                            other_types,
+                            ordered_types,
                         )
                     });
                     resolving.remove(&ty);
@@ -2702,10 +2703,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     // `Top[dict[Unknown, Unknown]]`. Keep the full intersection so the normal
                     // constraint-equivalence check below remains authoritative.
                     typed_dicts.insert(ty);
+                    ordered_types.insert(None);
                     true
                 }
                 _ => {
-                    other_types.insert(ty);
+                    ordered_types.insert(Some(ty));
                     true
                 }
             };
@@ -2716,7 +2718,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mut resolving = FxHashSet::default();
         let mut completed = FxHashMap::default();
         let mut typed_dicts = FxHashSet::default();
-        let mut other_types = FxOrderSet::default();
+        // `None` keeps the shared TypedDict constraints at their first source position.
+        let mut ordered_types = FxOrderSet::default();
         if !actual.elements(self.db).iter().all(|element| {
             collect_typed_dicts(
                 self.db,
@@ -2724,12 +2727,36 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 &mut resolving,
                 &mut completed,
                 &mut typed_dicts,
-                &mut other_types,
+                &mut ordered_types,
             )
         }) {
             return None;
         }
         if typed_dicts.is_empty() {
+            return None;
+        }
+
+        // Equivalent constraints can still differ in whether their bounds retain gradual evidence.
+        // For `class TD(TypedDict): value: Any`, a `dict[str, Any] | TD` argument passed to a
+        // generic `__getitem__(Literal["value"]) -> T` protocol must infer `T = Any`; replacing
+        // `TD` with `Mapping[str, object]` would instead infer `T = object`.
+        let has_gradual_values = |typed_dict: TypedDictType<'db>| {
+            typed_dict
+                .items(self.db)
+                .values()
+                .any(|field| field.declared_ty.has_dynamic(self.db))
+                || typed_dict
+                    .explicit_extra_items(self.db)
+                    .is_some_and(|extra_items| extra_items.declared_ty.has_dynamic(self.db))
+        };
+        if typed_dicts.iter().any(|element| match element {
+            Type::TypedDict(typed_dict) => has_gradual_values(*typed_dict),
+            Type::Intersection(intersection) => intersection
+                .iter_positive(self.db)
+                .filter_map(|element| element.resolve_type_alias(self.db).as_typed_dict())
+                .any(has_gradual_values),
+            _ => false,
+        }) {
             return None;
         }
 
@@ -2752,16 +2779,18 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             return None;
         }
 
-        Some(mapping_when.and(self.db, self.constraints, || {
-            other_types
+        Some(
+            ordered_types
                 .into_iter()
                 .when_all(self.db, self.constraints, |element| {
-                    self.constraints.load(
-                        self.db,
-                        &element.when_constraint_set_assignable_to_owned(self.db, formal),
-                    )
-                })
-        }))
+                    element.map_or(mapping_when, |element| {
+                        self.constraints.load(
+                            self.db,
+                            &element.when_constraint_set_assignable_to_owned(self.db, formal),
+                        )
+                    })
+                }),
+        )
     }
 
     /// Infer type mappings by comparing formal callable signatures against actual callables.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2651,7 +2651,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
     }
 
-    /// Returns common protocol constraints for a union containing only `TypedDict`s when every
+    /// Returns common protocol constraints for the `TypedDict` members of a union when every such
     /// member has the same constraints as their shared `Mapping[str, object]` fallback.
     fn common_typed_dict_protocol_constraints(
         &self,
@@ -2664,6 +2664,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             resolving: &mut FxHashSet<Type<'db>>,
             completed: &mut FxHashMap<Type<'db>, bool>,
             typed_dicts: &mut FxHashSet<Type<'db>>,
+            other_types: &mut FxOrderSet<Type<'db>>,
         ) -> bool {
             let ty = ty.resolve_type_alias(db);
             if let Some(result) = completed.get(&ty) {
@@ -2680,7 +2681,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         return false;
                     }
                     let result = union.elements(db).iter().all(|element| {
-                        collect_typed_dicts(db, *element, resolving, completed, typed_dicts)
+                        collect_typed_dicts(
+                            db,
+                            *element,
+                            resolving,
+                            completed,
+                            typed_dicts,
+                            other_types,
+                        )
                     });
                     resolving.remove(&ty);
                     result
@@ -2696,7 +2704,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     typed_dicts.insert(ty);
                     true
                 }
-                _ => false,
+                _ => {
+                    other_types.insert(ty);
+                    true
+                }
             };
             completed.insert(ty, result);
             result
@@ -2705,6 +2716,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mut resolving = FxHashSet::default();
         let mut completed = FxHashMap::default();
         let mut typed_dicts = FxHashSet::default();
+        let mut other_types = FxOrderSet::default();
         if !actual.elements(self.db).iter().all(|element| {
             collect_typed_dicts(
                 self.db,
@@ -2712,8 +2724,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 &mut resolving,
                 &mut completed,
                 &mut typed_dicts,
+                &mut other_types,
             )
         }) {
+            return None;
+        }
+        if typed_dicts.is_empty() {
             return None;
         }
 
@@ -2724,18 +2740,28 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mapping = KnownClass::Mapping.to_specialized_instance(self.db, spec);
         let mapping_when = mapping.when_constraint_set_assignable_to_owned(self.db, formal);
         let mapping_when = self.constraints.load(self.db, &mapping_when);
-        typed_dicts
-            .into_iter()
-            .all(|element| {
-                let element_when = self.constraints.load(
-                    self.db,
-                    &element.when_constraint_set_assignable_to_owned(self.db, formal),
-                );
-                element_when
-                    .iff(self.db, self.constraints, mapping_when)
-                    .is_always_satisfied(self.db)
-            })
-            .then_some(mapping_when)
+        if !typed_dicts.into_iter().all(|element| {
+            let element_when = self.constraints.load(
+                self.db,
+                &element.when_constraint_set_assignable_to_owned(self.db, formal),
+            );
+            element_when
+                .iff(self.db, self.constraints, mapping_when)
+                .is_always_satisfied(self.db)
+        }) {
+            return None;
+        }
+
+        Some(mapping_when.and(self.db, self.constraints, || {
+            other_types
+                .into_iter()
+                .when_all(self.db, self.constraints, |element| {
+                    self.constraints.load(
+                        self.db,
+                        &element.when_constraint_set_assignable_to_owned(self.db, formal),
+                    )
+                })
+        }))
     }
 
     /// Infer type mappings by comparing formal callable signatures against actual callables.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2663,7 +2663,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             ty: Type<'db>,
             resolving: &mut FxHashSet<Type<'db>>,
             completed: &mut FxHashMap<Type<'db>, bool>,
-            typed_dicts: &mut FxOrderSet<Type<'db>>,
+            typed_dicts: &mut FxHashSet<Type<'db>>,
             other_types: &mut FxOrderSet<Type<'db>>,
         ) -> bool {
             let ty = ty.resolve_type_alias(db);
@@ -2694,20 +2694,41 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     result
                 }
                 Type::Intersection(intersection)
-                    if intersection
-                        .iter_positive(db)
-                        .any(|element| element.resolve_type_alias(db).is_typed_dict()) =>
+                    if intersection.negative(db).is_empty()
+                        && intersection
+                            .iter_positive(db)
+                            .any(|element| element.resolve_type_alias(db).is_typed_dict())
+                        && intersection.iter_positive(db).all(|element| {
+                            let element = element.resolve_type_alias(db);
+                            element.is_typed_dict()
+                                || element
+                                    == KnownClass::Dict
+                                        .to_instance_unknown(db)
+                                        .top_materialization(db)
+                        }) =>
                 {
                     // `isinstance(value, dict)` narrows a `TypedDict` to an intersection with
-                    // `Top[dict[Unknown, Unknown]]`. Keep the full intersection so the normal
-                    // constraint-equivalence check below remains authoritative.
+                    // `Top[dict[Unknown, Unknown]]`. Other conjuncts may contribute gradual
+                    // constraints that the shared mapping would erase.
                     typed_dicts.insert(ty);
                     true
                 }
-                _ => {
+                Type::NominalInstance(instance)
+                    if matches!(
+                        instance.class(db).known(db),
+                        Some(KnownClass::Dict | KnownClass::Mapping | KnownClass::OrderedDict)
+                    ) && instance
+                        .class(db)
+                        .into_generic_alias()
+                        .is_some_and(|alias| {
+                            matches!(alias.specialization(db).types(db), [key, _]
+                                if key.resolve_type_alias(db) == KnownClass::Str.to_instance(db))
+                        }) =>
+                {
                     other_types.insert(ty);
                     true
                 }
+                _ => false,
             };
             completed.insert(ty, result);
             result
@@ -2715,7 +2736,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
         let mut resolving = FxHashSet::default();
         let mut completed = FxHashMap::default();
-        let mut typed_dicts = FxOrderSet::default();
+        let mut typed_dicts = FxHashSet::default();
         let mut other_types = FxOrderSet::default();
         if !actual.elements(self.db).iter().all(|element| {
             collect_typed_dicts(
@@ -2732,150 +2753,55 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         if typed_dicts.is_empty() {
             return None;
         }
-
-        if !other_types.is_empty() {
-            // `SupportsKeysAndGetItem` observes a `TypedDict` through arbitrary string keys.
-            // Implicitly open `TypedDict`s therefore share `Mapping[str, object]`, while explicit
-            // extra items preserve their exposed value type. Other protocols can observe
-            // individual gradual or specialized fields and must retain their original constraints.
-            let Type::ProtocolInstance(protocol) = formal else {
-                return None;
-            };
-            if !protocol.to_nominal_instance().is_some_and(|instance| {
-                instance.class_name(self.db) == "SupportsKeysAndGetItem"
-                    && instance
-                        .class_module_name(self.db)
-                        .is_some_and(|module| module.as_str() == "_typeshed")
-            }) {
-                return None;
-            }
-
-            if !typed_dicts.iter().all(|element| match element {
-                Type::TypedDict(_) => true,
-                Type::Intersection(intersection) => {
-                    intersection.negative(self.db).is_empty()
-                        && intersection.iter_positive(self.db).all(|positive| {
-                            let positive = positive.resolve_type_alias(self.db);
-                            positive.is_typed_dict()
-                                || matches!(positive, Type::NominalInstance(instance)
-                                    if instance.class(self.db).is_known(self.db, KnownClass::Dict)
-                                        && instance.class(self.db).into_generic_alias().is_some_and(
-                                            |alias| alias.specialization(self.db).materialization_kind(self.db)
-                                                == Some(MaterializationKind::Top),
-                                        ))
-                        })
-                }
-                _ => false,
-            }) {
-                return None;
-            }
-
-            let string = KnownClass::Str.to_instance(self.db);
-            let key_type = protocol
-                .to_nominal_instance()
-                .and_then(|instance| instance.class(self.db).into_generic_alias())
-                .and_then(|alias| {
-                    alias
-                        .specialization(self.db)
-                        .types(self.db)
-                        .first()
-                        .copied()
-                });
-            if !other_types.iter().all(|element| {
-                let Some(Type::TypeVar(key_typevar)) = key_type else {
-                    // A fixed protocol key cannot prove that a structural mapping has static keys.
-                    return element.nominal_class(self.db).is_some_and(|class| {
-                        class.iter_mro(self.db).filter_map(ClassBase::into_class).any(
-                            |base| {
-                                (base.is_known(self.db, KnownClass::Dict)
-                                    || base.is_known(self.db, KnownClass::Mapping))
-                                    && base.into_generic_alias().is_some_and(|alias| {
-                                        matches!(alias.specialization(self.db).types(self.db), [key, _]
-                                            if key.resolve_type_alias(self.db) == string)
-                                    })
-                            },
-                        )
-                    });
-                };
-                let when = self.constraints.load(
-                    self.db,
-                    &element.when_constraint_set_assignable_to_owned(self.db, formal),
-                );
-                let Solutions::Constrained(solutions) =
-                    when.solutions(self.db, self.constraints, self.inferable)
-                else {
-                    return false;
-                };
-                solutions.iter().all(|solution| {
-                    solution
-                        .iter()
-                        .find(|binding| binding.bound_typevar == key_typevar)
-                        .is_some_and(|binding| {
-                            binding.solution.resolve_type_alias(self.db) == string
-                        })
-                })
-            }) {
-                return None;
-            }
+        // Other protocols can observe key-specific or gradual evidence that the shared mapping
+        // fallback erases; restrict mixed unions to the protocol used by dictionary constructors.
+        if !other_types.is_empty()
+            && !matches!(formal, Type::ProtocolInstance(protocol)
+            if protocol.to_nominal_instance().is_some_and(|instance| {
+                instance.class(self.db).is_known(self.db, KnownClass::SupportsKeysAndGetItem)
+            }))
+        {
+            return None;
         }
 
-        let mut shared_mappings = FxOrderSet::default();
+        // Use the read-only `Mapping[str, object]` as the fallback rather than `dict[str, object]`.
+        // The current constraint solver can consider mutable protocol constraints equivalent even
+        // when a `TypedDict` preserves more precise correlations between its keys and values.
+        let spec = &[KnownClass::Str.to_instance(self.db), Type::object()];
+        let mapping = KnownClass::Mapping.to_specialized_instance(self.db, spec);
+        let mapping_when = mapping.when_constraint_set_assignable_to_owned(self.db, formal);
+        let mapping_when = self.constraints.load(self.db, &mapping_when);
+        // Logically equivalent constraints can still infer different solutions, such as `Any`
+        // instead of `object`; preserve the original constraints when gradual evidence differs.
+        let mapping_solutions = (!other_types.is_empty())
+            .then(|| mapping_when.solutions(self.db, self.constraints, self.inferable));
         if !typed_dicts.into_iter().all(|element| {
-            let value_ty = if other_types.is_empty() {
-                Type::object()
-            } else {
-                match element {
-                    Type::TypedDict(typed_dict) => typed_dict.value_type(self.db),
-                    Type::Intersection(intersection) => {
-                        let Some(typed_dict) =
-                            intersection
-                                .iter_positive(self.db)
-                                .find_map(|positive| match positive.resolve_type_alias(self.db) {
-                                    Type::TypedDict(typed_dict) => Some(typed_dict),
-                                    _ => None,
-                                })
-                        else {
-                            return false;
-                        };
-                        typed_dict.value_type(self.db)
-                    }
-                    _ => return false,
-                }
-            };
-            // Use read-only `Mapping` representatives so collapsing does not introduce mutable
-            // correlations. Explicit extra items determine the observable arbitrary-key values.
-            let mapping = KnownClass::Mapping.to_specialized_instance(
-                self.db,
-                &[KnownClass::Str.to_instance(self.db), value_ty],
-            );
-            let mapping_when = mapping.when_constraint_set_assignable_to_owned(self.db, formal);
-            let mapping_when = self.constraints.load(self.db, &mapping_when);
             let element_when = self.constraints.load(
                 self.db,
                 &element.when_constraint_set_assignable_to_owned(self.db, formal),
             );
-            if !element_when
+            element_when
                 .iff(self.db, self.constraints, mapping_when)
                 .is_always_satisfied(self.db)
-            {
-                return false;
-            }
-            shared_mappings.insert(mapping);
-            true
+                && mapping_solutions.as_ref().is_none_or(|solutions| {
+                    &element_when.solutions(self.db, self.constraints, self.inferable) == solutions
+                })
         }) {
             return None;
         }
 
-        Some(shared_mappings.into_iter().chain(other_types).when_all(
-            self.db,
-            self.constraints,
-            |element| {
-                self.constraints.load(
-                    self.db,
-                    &element.when_constraint_set_assignable_to_owned(self.db, formal),
-                )
-            },
-        ))
+        // Reuse one constraint for all equivalent TypedDicts, but retain each mapping arm's
+        // original constraints.
+        Some(mapping_when.and(self.db, self.constraints, || {
+            other_types
+                .into_iter()
+                .when_all(self.db, self.constraints, |element| {
+                    self.constraints.load(
+                        self.db,
+                        &element.when_constraint_set_assignable_to_owned(self.db, formal),
+                    )
+                })
+        }))
     }
 
     /// Infer type mappings by comparing formal callable signatures against actual callables.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -34,8 +34,8 @@ use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, CallableTypes,
     ClassLiteral, FindLegacyTypeVarsVisitor, IntersectionType, KnownClass, KnownInstanceType,
     MaterializationKind, SubclassOfInner, Type, TypeAliasType, TypeContext, TypeMapping,
-    TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType, UnionAccumulator,
-    UnionType, binding_type, infer_definition_types, inferred_declaration,
+    TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType,
+    binding_type, infer_definition_types, inferred_declaration,
 };
 use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -2664,7 +2664,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             resolving: &mut FxHashSet<Type<'db>>,
             completed: &mut FxHashMap<Type<'db>, bool>,
             typed_dicts: &mut FxHashSet<Type<'db>>,
-            ordered_types: &mut FxOrderSet<Option<Type<'db>>>,
+            ordered_types: &mut FxOrderSet<Type<'db>>,
         ) -> bool {
             let ty = ty.resolve_type_alias(db);
             if let Some(result) = completed.get(&ty) {
@@ -2674,7 +2674,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             let result = match ty {
                 Type::TypedDict(_) => {
                     typed_dicts.insert(ty);
-                    ordered_types.insert(None);
+                    ordered_types.insert(ty);
                     true
                 }
                 Type::Union(union) => {
@@ -2703,11 +2703,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     // `Top[dict[Unknown, Unknown]]`. Keep the full intersection so the normal
                     // constraint-equivalence check below remains authoritative.
                     typed_dicts.insert(ty);
-                    ordered_types.insert(None);
+                    ordered_types.insert(ty);
                     true
                 }
                 _ => {
-                    ordered_types.insert(Some(ty));
+                    ordered_types.insert(ty);
                     true
                 }
             };
@@ -2718,7 +2718,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mut resolving = FxHashSet::default();
         let mut completed = FxHashMap::default();
         let mut typed_dicts = FxHashSet::default();
-        // `None` keeps the shared TypedDict constraints at their first source position.
         let mut ordered_types = FxOrderSet::default();
         if !actual.elements(self.db).iter().all(|element| {
             collect_typed_dicts(
@@ -2736,30 +2735,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             return None;
         }
 
-        // Equivalent constraints can still differ in whether their bounds retain gradual evidence.
-        // For `class TD(TypedDict): value: Any`, a `dict[str, Any] | TD` argument passed to a
-        // generic `__getitem__(Literal["value"]) -> T` protocol must infer `T = Any`; replacing
-        // `TD` with `Mapping[str, object]` would instead infer `T = object`.
-        let has_gradual_values = |typed_dict: TypedDictType<'db>| {
-            typed_dict
-                .items(self.db)
-                .values()
-                .any(|field| field.declared_ty.has_dynamic(self.db))
-                || typed_dict
-                    .explicit_extra_items(self.db)
-                    .is_some_and(|extra_items| extra_items.declared_ty.has_dynamic(self.db))
-        };
-        if typed_dicts.iter().any(|element| match element {
-            Type::TypedDict(typed_dict) => has_gradual_values(*typed_dict),
-            Type::Intersection(intersection) => intersection
-                .iter_positive(self.db)
-                .filter_map(|element| element.resolve_type_alias(self.db).as_typed_dict())
-                .any(has_gradual_values),
-            _ => false,
-        }) {
-            return None;
-        }
-
         // Use the read-only `Mapping[str, object]` as the fallback rather than `dict[str, object]`.
         // The current constraint solver can consider mutable protocol constraints equivalent even
         // when a `TypedDict` preserves more precise correlations between its keys and values.
@@ -2767,30 +2742,68 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mapping = KnownClass::Mapping.to_specialized_instance(self.db, spec);
         let mapping_when = mapping.when_constraint_set_assignable_to_owned(self.db, formal);
         let mapping_when = self.constraints.load(self.db, &mapping_when);
-        if !typed_dicts.into_iter().all(|element| {
+        let mapping_solutions = mapping_when.solutions(self.db, self.constraints, self.inferable);
+        let mut preserved_typed_dict_constraints = FxHashMap::default();
+        let mut gradual_typed_dicts = FxHashSet::default();
+        for element in typed_dicts.iter().copied() {
             let element_when = self.constraints.load(
                 self.db,
                 &element.when_constraint_set_assignable_to_owned(self.db, formal),
             );
-            element_when
+            let equivalent = element_when
                 .iff(self.db, self.constraints, mapping_when)
-                .is_always_satisfied(self.db)
-        }) {
-            return None;
+                .is_always_satisfied(self.db);
+            // Equivalent constraints can differ in their inferred solutions. For
+            // `class TD(TypedDict): value: Any`, replacing `TD` with `Mapping[str, object]` in a
+            // generic `__getitem__(Literal["value"]) -> T` protocol changes `T` from `Any` to
+            // `object`, while an unrelated `Any` field does not affect the protocol constraints.
+            let element_solutions =
+                element_when.solutions(self.db, self.constraints, self.inferable);
+            if !equivalent || element_solutions != mapping_solutions {
+                if let Solutions::Constrained(solutions) = &element_solutions
+                    && solutions.iter().flatten().any(|solution| {
+                        solution.solution.bottom_materialization(self.db)
+                            != solution.solution.top_materialization(self.db)
+                    })
+                {
+                    gradual_typed_dicts.insert(element);
+                }
+                preserved_typed_dict_constraints.insert(element, element_when);
+            }
         }
 
-        Some(
+        let mut included_mapping = false;
+        // Concrete bounds must precede gradual evidence so either source spelling retains `Any`.
+        let mut gradual_constraints = Vec::new();
+        let constraints =
             ordered_types
                 .into_iter()
                 .when_all(self.db, self.constraints, |element| {
-                    element.map_or(mapping_when, |element| {
+                    if let Some(constraints) = preserved_typed_dict_constraints.get(&element) {
+                        if gradual_typed_dicts.contains(&element) {
+                            gradual_constraints.push(*constraints);
+                            ConstraintSet::from_bool(self.constraints, true)
+                        } else {
+                            *constraints
+                        }
+                    } else if typed_dicts.contains(&element) {
+                        if std::mem::replace(&mut included_mapping, true) {
+                            ConstraintSet::from_bool(self.constraints, true)
+                        } else {
+                            mapping_when
+                        }
+                    } else {
                         self.constraints.load(
                             self.db,
                             &element.when_constraint_set_assignable_to_owned(self.db, formal),
                         )
-                    })
-                }),
-        )
+                    }
+                });
+        Some(constraints.and(self.db, self.constraints, || {
+            gradual_constraints
+                .into_iter()
+                .when_all(self.db, self.constraints, |constraints| constraints)
+        }))
     }
 
     /// Infer type mappings by comparing formal callable signatures against actual callables.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2774,8 +2774,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mapping_when = self.constraints.load(self.db, &mapping_when);
         // Logically equivalent constraints can still infer different solutions, such as `Any`
         // instead of `object`; preserve the original constraints when gradual evidence differs.
-        let mapping_solutions = (!other_types.is_empty())
-            .then(|| mapping_when.solutions(self.db, self.constraints, self.inferable));
+        let mapping_solutions = mapping_when.solutions(self.db, self.constraints, self.inferable);
         if !typed_dicts.into_iter().all(|element| {
             let element_when = self.constraints.load(
                 self.db,
@@ -2784,9 +2783,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             element_when
                 .iff(self.db, self.constraints, mapping_when)
                 .is_always_satisfied(self.db)
-                && mapping_solutions.as_ref().is_none_or(|solutions| {
-                    &element_when.solutions(self.db, self.constraints, self.inferable) == solutions
-                })
+                && element_when.solutions(self.db, self.constraints, self.inferable)
+                    == mapping_solutions
         }) {
             return None;
         }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2669,6 +2669,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     KnownClass::Dict
                         | KnownClass::Mapping
                         | KnownClass::MutableMapping
+                        | KnownClass::DefaultDict
+                        | KnownClass::ChainMap
                         | KnownClass::OrderedDict
                 )
             ) && instance

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2658,6 +2658,30 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         formal: Type<'db>,
         actual: UnionType<'db>,
     ) -> Option<ConstraintSet<'db, 'c>> {
+        fn is_string_keyed_mapping<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+            let Type::NominalInstance(instance) = ty.resolve_type_alias(db) else {
+                return false;
+            };
+
+            matches!(
+                instance.class(db).known(db),
+                Some(
+                    KnownClass::Dict
+                        | KnownClass::Mapping
+                        | KnownClass::MutableMapping
+                        | KnownClass::OrderedDict
+                )
+            ) && instance
+                .class(db)
+                .into_generic_alias()
+                .is_some_and(|alias| {
+                    matches!(
+                        alias.specialization(db).types(db),
+                        [key, _] if key.resolve_type_alias(db) == KnownClass::Str.to_instance(db)
+                    )
+                })
+        }
+
         fn collect_typed_dicts<'db>(
             db: &'db dyn Db,
             ty: Type<'db>,
@@ -2713,19 +2737,27 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     typed_dicts.insert(ty);
                     true
                 }
-                Type::NominalInstance(instance)
-                    if matches!(
-                        instance.class(db).known(db),
-                        Some(
-                            KnownClass::Dict
-                                | KnownClass::Mapping
-                                | KnownClass::MutableMapping
-                                | KnownClass::OrderedDict
-                        )
-                    ) && let Some(alias) = instance.class(db).into_generic_alias()
-                        && let [key, _] = alias.specialization(db).types(db)
-                        && key.resolve_type_alias(db) == KnownClass::Str.to_instance(db) =>
+                Type::Intersection(intersection)
+                    if intersection.negative(db).is_empty()
+                        && intersection
+                            .iter_positive(db)
+                            .any(|element| is_string_keyed_mapping(db, element))
+                        && intersection.iter_positive(db).all(|element| {
+                            let element = element.resolve_type_alias(db);
+                            is_string_keyed_mapping(db, element)
+                                || element
+                                    == KnownClass::Dict
+                                        .to_instance_unknown(db)
+                                        .top_materialization(db)
+                        }) =>
                 {
+                    // `isinstance(value, dict)` can also narrow a mapping to an intersection with
+                    // `Top[dict[Unknown, Unknown]]`. Retain the full intersection so its original
+                    // key and value constraints are preserved.
+                    other_types.insert(ty);
+                    true
+                }
+                Type::NominalInstance(_) if is_string_keyed_mapping(db, ty) => {
                     other_types.insert(ty);
                     true
                 }


### PR DESCRIPTION
## Summary

Prior to this change, we handled unions of `TypedDict` instances efficiently when inferring the type of `dict(value)`. But adding a single ordinary dictionary to the union disabled that optimization:

```python
class A(TypedDict):
    kind: Literal["a"]

class B(TypedDict):
    kind: Literal["b"]

def copy(value: A | B | dict[str, Any]) -> None:
    dict(value)
```

For sufficiently large unions, combining the protocol constraints for each member became exponential.

In #27096, we tried to replace the constraints for the `TypedDict` members with the shared constraints for `Mapping[str, object]`, then combine the remaining union members separately. This fixes the performance issue, but assumes that constraints that are equivalent for assignability also produce the same inferred solutions.

Turns out that assumption doesn;t hold in general. For example, a `TypedDict` with additional `Any` items must retain that information:

```python
class Extras(TypedDict, extra_items=Any): ...

def copy(value: Extras | dict[str, str]) -> None:
    reveal_type(dict(value))  # dict[str, Any | str]
```

Unconditionally replacing `Extras` with `Mapping[str, object]` would instead infer `dict[str, object]`. Similar problems arise with bounded type variables, custom protocols, and intersections introduced by narrowing.

This PR applies the same optimization, but only when it is safe to reuse the `TypedDict` constraints. We require both equivalent constraints and equivalent inferred solutions, preserve the original constraints for ordinary mapping members, and limit the optimization to the `SupportsKeysAndGetItem` protocol used by dictionary constructors.

We also retain the optimization after `isinstance(value, dict)`:

```python
def copy(value: A | B | dict[str, Any]) -> None:
    if isinstance(value, dict):
        dict(value)
```
