### PR TITLE
[ty] Render structured type alternatives as separate code spans

### DIFF
--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -521,22 +521,24 @@ pub(super) fn split_once_at_top_level_colon(line: &str) -> Option<(&str, &str)> 
     None
 }
 
+/// Tracks bracket nesting while scanning docstring syntax.
 #[derive(Default)]
-struct BracketNesting {
+pub(in crate::docstring) struct BracketNesting {
     parentheses: usize,
     square: usize,
     curly: usize,
 }
 
 impl BracketNesting {
-    fn is_top_level(&self) -> bool {
+    /// Returns whether the current position is outside all bracket groups.
+    pub(in crate::docstring) fn is_top_level(&self) -> bool {
         self.parentheses == 0 && self.square == 0 && self.curly == 0
     }
 
     /// Updates the nesting depth while tolerating unmatched closing brackets.
     ///
     /// For example, `'('` increments the parenthesis depth and a later `')'` decrements it.
-    fn update(&mut self, character: char) {
+    pub(in crate::docstring) fn update(&mut self, character: char) {
         match character {
             '(' => self.parentheses += 1,
             ')' => self.parentheses = self.parentheses.saturating_sub(1),
@@ -553,7 +555,7 @@ impl BracketNesting {
 ///
 /// For example, after the opening quote in `"value" trailing` has been consumed, a cursor over
 /// `value" trailing` with `quote` set to `'"'` advances to ` trailing`.
-pub(super) fn consume_quoted_string(cursor: &mut Cursor<'_>, quote: char) {
+pub(in crate::docstring) fn consume_quoted_string(cursor: &mut Cursor<'_>, quote: char) {
     while let Some(character) = cursor.bump() {
         if character == '\\' {
             cursor.bump();

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use ruff_python_trivia::Cursor;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use strum::IntoEnumIterator;
 
@@ -7,8 +8,8 @@ use super::general;
 use crate::docstring::document::SectionKind;
 use crate::docstring::document::preformatted::MarkdownFence;
 use crate::docstring::document::syntax::{
-    InlineMarkupScanner, InlineMarkupToken, is_wrapped_in_markdown_code_span,
-    starts_with_markdown_list_item,
+    BracketNesting, InlineMarkupScanner, InlineMarkupToken, consume_quoted_string,
+    is_wrapped_in_markdown_code_span, starts_with_markdown_list_item,
 };
 
 mod google;
@@ -383,7 +384,98 @@ fn render_type_code_span_into(output: &mut String, ty: &str) {
     }
 
     let normalized = normalize_embedded_type_markup(&normalized);
-    render_code_span_into(output, normalized.as_ref());
+    render_type_alternatives_into(output, normalized.as_ref());
+}
+
+/// Renders top-level type alternatives as separate code spans.
+///
+/// For example, `"Unit, str, or None, optional"` becomes
+/// ``"`Unit`, `str`, or `None, optional`"``.
+fn render_type_alternatives_into(output: &mut String, ty: &str) {
+    let mut nesting = BracketNesting::default();
+    let mut cursor = Cursor::new(ty);
+    let mut start = 0usize;
+
+    while let Some(character) = cursor.bump() {
+        let separator_start = cursor.offset().to_usize() - character.len_utf8();
+        match character {
+            quote @ ('\'' | '"') => {
+                consume_quoted_string(&mut cursor, quote);
+                continue;
+            }
+            _ => nesting.update(character),
+        }
+        if !nesting.is_top_level() {
+            continue;
+        }
+
+        let remainder = &ty[separator_start..];
+        let separator_end = if let Some(remainder) = remainder
+            .strip_prefix(" or ")
+            .or_else(|| remainder.strip_prefix(" | "))
+        {
+            if remainder.trim().is_empty() {
+                continue;
+            }
+            ty.len() - remainder.len()
+        } else if let Some(remainder) = remainder.strip_prefix(',') {
+            let remainder = remainder.trim_start();
+            if remainder.is_empty()
+                || remainder.starts_with(['(', '['])
+                || starts_with_type_qualifier(remainder)
+            {
+                continue;
+            }
+            let remainder = remainder.strip_prefix("or ").unwrap_or(remainder);
+            if remainder.trim().is_empty() {
+                continue;
+            }
+            ty.len() - remainder.len()
+        } else {
+            continue;
+        };
+        if ty[start..separator_start].trim().is_empty() {
+            continue;
+        }
+
+        render_code_span_into(output, ty[start..separator_start].trim());
+        output.push_str(&ty[separator_start..separator_end]);
+        cursor.skip_bytes(separator_end - cursor.offset().to_usize());
+        start = separator_end;
+    }
+
+    render_code_span_into(output, ty[start..].trim());
+}
+
+/// Returns whether a comma introduces a type qualifier rather than another alternative.
+fn starts_with_type_qualifier(text: &str) -> bool {
+    let qualifier = text
+        .split(|character: char| {
+            character.is_whitespace() || matches!(character, ',' | '=' | ':' | '(')
+        })
+        .next()
+        .unwrap_or_default();
+
+    [
+        "optional",
+        "default",
+        "keyword-only",
+        "required",
+        "deprecated",
+        "shape",
+        "dtype",
+        "with",
+        "same",
+        "compatible",
+        "length",
+        "ndim",
+        "1d",
+        "2d",
+        "1-D",
+        "2-D",
+    ]
+    .iter()
+    .any(|candidate| qualifier.eq_ignore_ascii_case(candidate))
 }
 
 /// Removes embedded markup before wrapping the normalize type label in a code span.
@@ -549,7 +641,9 @@ mod tests {
     use insta::{Settings, assert_snapshot};
     use ruff_text_size::{TextRange, TextSize};
 
-    use super::{Section, SectionItem, SectionKind, render_sections_into};
+    use super::{
+        Section, SectionItem, SectionKind, render_sections_into, render_type_code_span_into,
+    };
 
     #[test]
     fn sections_render_in_canonical_order() {
@@ -722,7 +816,7 @@ mod tests {
         **arrowstyle**: `str (default='-|>')`<HB>
         Arrow style.
 
-        **model**: `str or pkg.Model`<HB>
+        **model**: `str` or `pkg.Model`<HB>
         Model type.
         ");
     }
@@ -773,7 +867,7 @@ mod tests {
 
         assert_snapshot!(render_markdown(&section), @"
         ## Parameters
-        **colormap**: `str or Colormap or matplotlib.colors or Index`<HB>
+        **colormap**: `str` or `Colormap` or `matplotlib.colors` or `Index`<HB>
         Color mapping.
 
         **model**: `Model`<HB>
@@ -782,7 +876,7 @@ mod tests {
         **extension**: `.py`<HB>
         File extension.
 
-        **config**: `str or .env or .Figure or .lines.Line2D`<HB>
+        **config**: `str` or `.env` or `.Figure` or `.lines.Line2D`<HB>
         Configuration source.
 
         **line**: `lines.line`<HB>
@@ -791,6 +885,42 @@ mod tests {
         **model**: `Model`<HB>
         Named model.
         ");
+    }
+
+    #[test]
+    fn renders_type_alternatives_separately() {
+        for (ty, expected) in [
+            (
+                ":class:`~astropy.units.UnitBase`, str, `~astropy.units.PhysicalType`, or tuple",
+                "`UnitBase`, `str`, `PhysicalType`, or `tuple`",
+            ),
+            (
+                "Sequence[int] | None, default=None",
+                "`Sequence[int]` | `None, default=None`",
+            ),
+            (
+                "str, Path, list[str, Path], optional",
+                "`str`, `Path`, `list[str, Path], optional`",
+            ),
+            (
+                "ndarray of dtype (int or float), optional",
+                "`ndarray of dtype (int or float), optional`",
+            ),
+            ("Literal['a or b'] or None", "`Literal['a or b']` or `None`"),
+            (
+                "array, shape(n, 2, 2), optional",
+                "`array, shape(n, 2, 2), optional`",
+            ),
+            (
+                "{0 or 'index', 1 or 'columns'}, default 0",
+                "`{0 or 'index', 1 or 'columns'}, default 0`",
+            ),
+            ("``str | None``", "``str | None``"),
+        ] {
+            let mut rendered = String::new();
+            render_type_code_span_into(&mut rendered, ty);
+            assert_eq!(rendered, expected, "{ty:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This renders each top-level alternative in a structured docstring type label as a separate code span. The outcome is that separators such as `or`, `|`, and `,` render as prose while each type remains formatted as code, improving readability across all structured docstring formats.

The type splitting that we've implemented performs the following operations:

1. Splits alternatives separated by `or`, `|`, or commas.
2. Keeps qualifiers such as `optional` and `default=None` with the type they describe.
3. Preserves separators inside brackets and quoted strings.

Types that are already complete Markdown code spans continue to pass through unchanged.

The table below shows how parameter docstrings render before and after this change:

| Category / real-world example | Before | After |
| :--- | :--- | :--- |
| [Comma-separated type alternatives](https://github.com/astropy/astropy/blob/9f445d4e2c5be492295165727f8a668d6e182e4f/astropy/units/quantity.py#L388) | **unit_shape_dtype**: `UnitBase, str, PhysicalType, or tuple` | **unit_shape_dtype**: `UnitBase`, `str`, `PhysicalType`, or `tuple` |
| [Type alternative with a qualifier](https://github.com/shap/shap/blob/c7315f1022a9dcb0267035e0825a93fb058c5e71/shap/plots/_violin.py#L90) | **cmap**: `str or Colormap, optional` | **cmap**: `str` or `Colormap, optional` |
| Python union and default | **value**: `Sequence[int] \| None, default=None` | **value**: `Sequence[int]` \| `None, default=None` |

## Test Plan

<!-- How was it tested? -->