### PR TITLE
[ty] Change `--add-ignore` to add space after the colon for `ty: ignore`

### DIFF
--- a/crates/ty/tests/cli/fixes.rs
+++ b/crates/ty/tests/cli/fixes.rs
@@ -138,7 +138,7 @@ fn add_ignore_unfixable() -> anyhow::Result<()> {
     info[revealed-type]: Revealed type
      --> different_violations.py:6:13
       |
-    6 | reveal_type(x)  # ty:ignore[undefined-reveal]
+    6 | reveal_type(x)  # ty: ignore[undefined-reveal]
       |             ^ `Unknown`
       |
 

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -106,7 +106,7 @@ mod tests {
           |
           |
           - b = a / 10
-        1 + b = a / 10  # ty:ignore[unresolved-reference]
+        1 + b = a / 10  # ty: ignore[unresolved-reference]
           |
         ");
     }
@@ -124,7 +124,7 @@ mod tests {
           |
           |
           - b = a / 10  # fmt: off
-        1 + b = a / 10  # fmt: off  # ty:ignore[unresolved-reference]
+        1 + b = a / 10  # fmt: off  # ty: ignore[unresolved-reference]
           |
         ");
     }
@@ -343,7 +343,7 @@ mod tests {
           |
         1 |
           - b = a / 0  # type:ignore[mypy-code]
-        2 + b = a / 0  # type:ignore[mypy-code]  # ty:ignore[unresolved-reference]
+        2 + b = a / 0  # type:ignore[mypy-code]  # ty: ignore[unresolved-reference]
           |
         ");
     }
@@ -368,7 +368,7 @@ mod tests {
           |
         3 |
           - b = a / 0
-        4 + b = a / 0  # ty:ignore[unresolved-reference]
+        4 + b = a / 0  # ty: ignore[unresolved-reference]
           |
         ");
     }
@@ -437,7 +437,7 @@ mod tests {
           |
         1 |
           - b = a / 0  # ty:ignore[division-by-zero] some explanation
-        2 + b = a / 0  # ty:ignore[division-by-zero] some explanation  # ty:ignore[unresolved-reference]
+        2 + b = a / 0  # ty:ignore[division-by-zero] some explanation  # ty: ignore[unresolved-reference]
           |
         ");
     }
@@ -553,7 +553,7 @@ mod tests {
           |
         4 |     more text
           - """
-        5 + """  # ty:ignore[unresolved-reference]
+        5 + """  # ty: ignore[unresolved-reference]
           |
         "#);
     }
@@ -581,7 +581,7 @@ mod tests {
           |
         3 |     {
           -     a
-        4 +     a  # ty:ignore[unresolved-reference]
+        4 +     a  # ty: ignore[unresolved-reference]
         5 |     }
           |
         ");
@@ -607,7 +607,7 @@ mod tests {
           |
         3 |     more text
           - """
-        4 + """  # ty:ignore[unresolved-reference]
+        4 + """  # ty: ignore[unresolved-reference]
           |
         "#);
     }
@@ -631,7 +631,7 @@ mod tests {
           |
         2 | b = a \
           - + "test"
-        3 + + "test"  # ty:ignore[unresolved-reference]
+        3 + + "test"  # ty: ignore[unresolved-reference]
           |
         "#);
     }
@@ -658,7 +658,7 @@ mod tests {
           |
         4 |         + ddd  \
           -
-        5 +   # ty:ignore[unresolved-reference]
+        5 +   # ty: ignore[unresolved-reference]
         6 |     ] # test
           |
         ");
@@ -694,7 +694,7 @@ mod tests {
           |
         1 |
           - reveal_type(1)
-        2 + reveal_type(1)  # ty:ignore[undefined-reveal]
+        2 + reveal_type(1)  # ty: ignore[undefined-reveal]
           |
         ");
     }
@@ -730,7 +730,7 @@ mod tests {
           |
         1 |
           - @deprecated("do not use")
-        2 + @deprecated("do not use")  # ty:ignore[unresolved-reference]
+        2 + @deprecated("do not use")  # ty: ignore[unresolved-reference]
         3 | def my_func(): ...
           |
         "#);
@@ -783,7 +783,7 @@ mod tests {
           |
         3 |
           - @deprecated("do not use")
-        4 + @deprecated("do not use")  # ty:ignore[unresolved-reference]
+        4 + @deprecated("do not use")  # ty: ignore[unresolved-reference]
         5 | def my_func(): ...
           |
         "#);
@@ -820,7 +820,7 @@ mod tests {
           |
         1 |
           - ExecutionLoader
-        2 + ExecutionLoader  # ty:ignore[unresolved-reference]
+        2 + ExecutionLoader  # ty: ignore[unresolved-reference]
           |
         ");
     }
@@ -860,7 +860,7 @@ mod tests {
           |
         2 | import importlib
           - ExecutionLoader
-        3 + ExecutionLoader  # ty:ignore[unresolved-reference]
+        3 + ExecutionLoader  # ty: ignore[unresolved-reference]
           |
         ");
     }
@@ -910,7 +910,7 @@ mod tests {
           |
         2 | import importlib.abc
           - ExecutionLoader
-        3 + ExecutionLoader  # ty:ignore[unresolved-reference]
+        3 + ExecutionLoader  # ty: ignore[unresolved-reference]
           |
         ");
     }

--- a/crates/ty_ide/src/snapshots/ty_ide__code_action__tests__add_ignore_trailing_whitespace.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__code_action__tests__add_ignore_trailing_whitespace.snap
@@ -10,5 +10,5 @@ info[code-action]: Ignore 'unresolved-reference' for this line
   |
   |
   - b = a / 10  
-1 + b = a / 10  # ty:ignore[unresolved-reference]
+1 + b = a / 10  # ty: ignore[unresolved-reference]
   |

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -447,7 +447,7 @@ struct ApplicableFix {
     /// Gets fixed to:
     ///
     /// ```py
-    /// enumerate(0, "1")  # ty:ignore[invalid-argument-type]
+    /// enumerate(0, "1")  # ty: ignore[invalid-argument-type]
     /// ```
     ///
     /// In which case `fixed_diagnostics` is 2.
@@ -832,7 +832,7 @@ mod tests {
         ## Fixed source
 
         ```py
-        a = b + 10  # ty:ignore[unresolved-reference]
+        a = b + 10  # ty: ignore[unresolved-reference]
         ```
         ");
     }
@@ -849,7 +849,7 @@ mod tests {
         ## Fixed source
 
         ```py
-        a = b + 10 + c  # ty:ignore[unresolved-reference]
+        a = b + 10 + c  # ty: ignore[unresolved-reference]
         ```
         ");
     }
@@ -868,7 +868,7 @@ mod tests {
 
         ```py
         import sys
-        a = b + 10 + sys.veeersion  # ty:ignore[unresolved-attribute, unresolved-reference]
+        a = b + 10 + sys.veeersion  # ty: ignore[unresolved-attribute, unresolved-reference]
         ```
         ");
     }
@@ -967,8 +967,8 @@ mod tests {
 
         test(
             a = 10,
-            c = "unknown"  # ty:ignore[unknown-argument]
-        )  # ty:ignore[missing-argument]
+            c = "unknown"  # ty: ignore[unknown-argument]
+        )  # ty: ignore[missing-argument]
         ```
         "#);
     }
@@ -1013,8 +1013,8 @@ mod tests {
 
         def f() -> None:
             diag = get_data()
-            diag["home_assistant"]["entities"] = sorted(  # ty:ignore[invalid-assignment]
-                diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]  # ty:ignore[invalid-argument-type, not-subscriptable]
+            diag["home_assistant"]["entities"] = sorted(  # ty: ignore[invalid-assignment]
+                diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]  # ty: ignore[invalid-argument-type, not-subscriptable]
             )
         ```
         "#);
@@ -1056,8 +1056,8 @@ mod tests {
 
         def f() -> None:
             diag = get_data()
-            diag["home_assistant"]["entities"] = sorted(  # ty:ignore[invalid-assignment]
-                diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]  # ty:ignore[invalid-argument-type, not-subscriptable]
+            diag["home_assistant"]["entities"] = sorted(  # ty: ignore[invalid-assignment]
+                diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]  # ty: ignore[invalid-argument-type, not-subscriptable]
             ); missing  # ty: ignore[unresolved-reference]
         ```
         "#
@@ -1094,7 +1094,7 @@ class B(A):
             def test(
                 self,
                 b: str
-            ) -> A.b:  # ty:ignore[invalid-method-override, unresolved-attribute]
+            ) -> A.b:  # ty: ignore[invalid-method-override, unresolved-attribute]
                 pass
         ```
         "#);
@@ -1130,7 +1130,7 @@ class B(A):
             def test(  # ty:ignore[unresolved-reference, invalid-method-override]
                 self,
                 b: str
-            ) -> A.b:  # ty:ignore[unresolved-attribute]
+            ) -> A.b:  # ty: ignore[unresolved-attribute]
                 pass
         ```
 
@@ -1179,7 +1179,7 @@ class B(A):
         ## Fixed source
 
         ```py
-        value = missing  # ty: ignore[] tracked by [123]  # ty:ignore[unresolved-reference]
+        value = missing  # ty: ignore[] tracked by [123]  # ty: ignore[unresolved-reference]
         ```
 
         ## Diagnostics after applying fixes
@@ -1187,7 +1187,7 @@ class B(A):
         warning[unused-ignore-comment]: Unused `ty: ignore` without a code
          --> test.py:1:18
           |
-        1 | value = missing  # ty: ignore[] tracked by [123]  # ty:ignore[unresolved-reference]
+        1 | value = missing  # ty: ignore[] tracked by [123]  # ty: ignore[unresolved-reference]
           |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           |
         help: Remove the unused suppression comment

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -69,7 +69,7 @@ pub fn suppress_all(
     //
     // This is important because a suppression inserted at the end of a narrower range
     // can result in a start-line suppression for a wider range. In the example above,
-    // inserting a `ty:ignore` after `sorted(` suppresses the diagnostic with the narrower range
+    // inserting a `ty: ignore` after `sorted(` suppresses the diagnostic with the narrower range
     // but also the diagnostic with the wider range (because the suppression is on its start line).
     ids_with_suppression_range.sort_unstable_by_key(|(_, _, range)| (range.start(), range.end()));
 
@@ -242,7 +242,7 @@ fn add_end_of_line_suppression(source: &str, codes: &[LintName], line_end: TextS
     let trailing_whitespace_len = up_to_line_end.text_len() - up_to_first_content.text_len();
 
     let insertion = format!(
-        "  # ty:ignore[{codes}]",
+        "  # ty: ignore[{codes}]",
         codes = Codes(SuppressionKind::Ty, codes)
     );
 

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_attribute_access_on_unimported.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_attribute_access_on_unimported.snap
@@ -87,7 +87,7 @@ expression: code_actions
                 "character": 24
               }
             },
-            "newText": "  # ty:ignore[unresolved-reference]"
+            "newText": "  # ty: ignore[unresolved-reference]"
           }
         ]
       }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_existing_import_undefined_decorator.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_existing_import_undefined_decorator.snap
@@ -132,7 +132,7 @@ expression: code_actions
                 "character": 28
               }
             },
-            "newText": "  # ty:ignore[unresolved-reference]"
+            "newText": "  # ty: ignore[unresolved-reference]"
           }
         ]
       }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_invalid_string_annotations.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_invalid_string_annotations.snap
@@ -42,7 +42,7 @@ expression: code_actions
                 "character": 12
               }
             },
-            "newText": "  # ty:ignore[unresolved-reference]"
+            "newText": "  # ty: ignore[unresolved-reference]"
           }
         ]
       }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_possible_missing_submodule_attribute.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_possible_missing_submodule_attribute.snap
@@ -42,7 +42,7 @@ expression: code_actions
                 "character": 11
               }
             },
-            "newText": "  # ty:ignore[possibly-missing-submodule]"
+            "newText": "  # ty: ignore[possibly-missing-submodule]"
           }
         ]
       }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_decorator.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_decorator.snap
@@ -87,7 +87,7 @@ expression: code_actions
                 "character": 28
               }
             },
-            "newText": "  # ty:ignore[unresolved-reference]"
+            "newText": "  # ty: ignore[unresolved-reference]"
           }
         ]
       }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_reference_multi.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_undefined_reference_multi.snap
@@ -87,7 +87,7 @@ expression: code_actions
                 "character": 17
               }
             },
-            "newText": "  # ty:ignore[unresolved-reference]"
+            "newText": "  # ty: ignore[unresolved-reference]"
           }
         ]
       }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_with_full_diagnostic_output_link.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_with_full_diagnostic_output_link.snap
@@ -87,7 +87,7 @@ expression: code_actions
                 "character": 17
               }
             },
-            "newText": "  # ty:ignore[unresolved-reference]"
+            "newText": "  # ty: ignore[unresolved-reference]"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Almost all python tooling use `# pragma:<space>`, except Ruff and ty. Funnily enough, most our documentation uses `ty: ignore` and not `ty:ignore`. 


This PR changes `--add-ignore` (and the editor fix) to insert `ty: ignore` instead of `ty:ignore`

Related to #27114.

