### PR TITLE
[ty] Simplify script metadata query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,7 +4789,6 @@ dependencies = [
  "get-size2",
  "globset",
  "insta",
- "memchr",
  "notify",
  "ordermap",
  "parking_lot",

--- a/crates/ruff_python_ast/src/script.rs
+++ b/crates/ruff_python_ast/src/script.rs
@@ -57,27 +57,16 @@ impl ScriptTag {
         // Identify the opening pragma.
         let index = FINDER.find(contents)?;
 
-        Self::parse_at(contents, index)
-    }
-
-    /// Extracts a `script` metadata block known to start at `index`.
-    ///
-    /// Returns `None` if `index` does not point to an exact opening pragma at the start of a line.
-    pub fn parse_at(contents: &[u8], index: usize) -> Option<Self> {
-        let (prelude, contents) = contents.split_at_checked(index)?;
-
         // The opening pragma must be the first line, or immediately preceded by a newline.
-        if prelude
-            .last()
-            .is_some_and(|byte| !matches!(*byte, b'\r' | b'\n'))
-        {
+        if !(index == 0 || matches!(contents[index - 1], b'\r' | b'\n')) {
             return None;
         }
 
         // Extract the preceding content.
-        let prelude = std::str::from_utf8(prelude).ok()?;
+        let prelude = std::str::from_utf8(&contents[..index]).ok()?;
 
         // Decode as UTF-8.
+        let contents = &contents[index..];
         let contents = std::str::from_utf8(contents).ok()?;
 
         let mut lines = contents.lines();

--- a/crates/ruff_python_ast/src/script.rs
+++ b/crates/ruff_python_ast/src/script.rs
@@ -54,9 +54,12 @@ impl ScriptTag {
     ///
     /// See: <https://peps.python.org/pep-0723/>
     pub fn parse(contents: &[u8]) -> Option<Self> {
-        // Identify the opening pragma.
-        let index = FINDER.find(contents)?;
+        FINDER
+            .find_iter(contents)
+            .find_map(|index| Self::parse_at(contents, index))
+    }
 
+    fn parse_at(contents: &[u8], index: usize) -> Option<Self> {
         // The opening pragma must be the first line, or immediately preceded by a newline.
         if !(index == 0 || matches!(contents[index - 1], b'\r' | b'\n')) {
             return None;

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -40,7 +40,6 @@ compact_str = { workspace = true, features = ["serde"] }
 crossbeam = { workspace = true }
 get-size2 = { workspace = true, features = ["ordermap", "parking_lot"] }
 globset = { workspace = true }
-memchr = { workspace = true }
 notify = { workspace = true }
 ordermap = { workspace = true, features = ["serde"] }
 parking_lot = { workspace = true }

--- a/crates/ty_project/src/metadata/script.rs
+++ b/crates/ty_project/src/metadata/script.rs
@@ -1,27 +1,15 @@
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
-use memchr::memmem::Finder;
 use ruff_db::Db;
 use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_db::system::SystemPathBuf;
 use ruff_python_ast::script::ScriptTag;
-use ruff_python_ast::token::TokenKind;
 use ruff_ranged_value::ValueSource;
-use ruff_text_size::Ranged;
 
 use crate::metadata::pyproject::PyProject;
 
-const SCRIPT_TAG: &str = "# /// script";
-static SCRIPT_TAG_FINDER: LazyLock<Finder<'static>> =
-    LazyLock::new(|| Finder::new(SCRIPT_TAG.as_bytes()));
-
 /// Returns the PEP 723 metadata embedded in `file`.
-///
-/// The byte search keeps the overwhelmingly common non-script path cheap. Parsing is only
-/// necessary after finding a possible opening tag at the start of a line, where the token stream
-/// disambiguates an actual comment from the same text inside a string literal.
 #[salsa::tracked(returns(ref))]
 pub(crate) fn script_metadata(db: &dyn Db, file: File) -> Option<Box<PyProject>> {
     let path = file.path(db);
@@ -34,26 +22,7 @@ pub(crate) fn script_metadata(db: &dyn Db, file: File) -> Option<Box<PyProject>>
         return None;
     }
 
-    let source_bytes = source.as_bytes();
-    let mut candidates = SCRIPT_TAG_FINDER
-        .find_iter(source_bytes)
-        .filter(|&offset| offset == 0 || matches!(source_bytes[offset - 1], b'\r' | b'\n'));
-    let first_candidate = candidates.next()?;
-
-    let parsed = parsed_module(db, file).load(db);
-    let tokens = parsed.tokens();
-    let tag = std::iter::once(first_candidate)
-        .chain(candidates)
-        .filter(|&offset| {
-            let Ok(index) = tokens.binary_search_by_key(&offset, |token| token.start().to_usize())
-            else {
-                return false;
-            };
-            let token = &tokens[index];
-
-            token.kind() == TokenKind::Comment && &source[token.range()] == SCRIPT_TAG
-        })
-        .find_map(|opening| ScriptTag::parse_at(source_bytes, opening))?;
+    let tag = ScriptTag::parse(source.as_bytes())?;
     let value_source = ValueSource::File(Arc::new(SystemPathBuf::from(path.as_str())));
 
     PyProject::from_toml_str_without_spans(tag.metadata(), value_source)

--- a/crates/ty_python_semantic/resources/mdtest/scripts.md
+++ b/crates/ty_python_semantic/resources/mdtest/scripts.md
@@ -126,3 +126,44 @@ print(missing)
 # error: [unresolved-reference]
 print(missing)
 ```
+
+# Valid blocks after invalid opening tags
+
+Invalid opening tags do not prevent a later valid metadata block from being recognized.
+
+```py
+value = 1  # /// script
+# [tool.ty.rules]
+# unresolved-reference = "error"
+# ///
+
+# /// script invalid
+# [tool.ty.rules]
+# unresolved-reference = "error"
+# ///
+
+# /// script
+# [tool.ty.rules]
+# unresolved-reference = "ignore"
+# ///
+
+print(missing)
+```
+
+# Valid blocks after unclosed blocks
+
+An earlier unclosed block does not prevent a later valid metadata block from being recognized.
+
+```py
+# /// script
+# [tool.ty.rules]
+# unresolved-reference = "error"
+value = 1
+
+# /// script
+# [tool.ty.rules]
+# unresolved-reference = "ignore"
+# ///
+
+print(missing)
+```


### PR DESCRIPTION
## Summary

I can already hear you all laughing :) 

This removes the tokens check from ty's script metadata handling in preparation for https://github.com/astral-sh/ruff/pull/26856

With https://github.com/astral-sh/ruff/pull/26856, there's no obvious choice for the Python version. Arguably, there was probably not an obvious choice before. And parsing the file with Python 3.14 (latest) feels wasteful, if the script specifies Python 3.12, and needs to be parsed again. 

I think the proper solution here would be to use our lexer instead of the parser. But we currently don't expose our lexer. That's why I decided, for now, to follow uv's (and many other tools) lead to make this a string based search.

## Test Plan

Testing: Existing CLI and semantic script coverage and repository hooks pass.
