### PR TITLE
Insert a space after the colon in Ruff suppression comments

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -467,7 +467,7 @@ pub struct CheckCommand {
         conflicts_with = "diff",
     )]
     pub add_noqa: Option<String>,
-    /// Enable automatic additions of `ruff:ignore` comments to failing lines.
+    /// Enable automatic additions of `ruff: ignore` comments to failing lines.
     /// Optionally provide a reason to append after the rule names.
     /// Requires preview mode.
     #[arg(

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -2628,9 +2628,9 @@ fn add_ignore() -> Result<()> {
         test_code,
         @"
 
-        def first_square():
-            return [x * x for x in range(20)][0]  # ruff:ignore[unnecessary-iterable-allocation-for-first-element]
-        ",
+    def first_square():
+        return [x * x for x in range(20)][0]  # ruff: ignore[unnecessary-iterable-allocation-for-first-element]
+    ",
     );
 
     Ok(())
@@ -3744,18 +3744,18 @@ def foo():
             ])
             .pass_stdin(source),
         @"
-        success: true
-        exit_code: 0
-        ----- stdout -----
-        # ruff:file-ignore[unused-import]
-        import os
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    # ruff: file-ignore[unused-import]
+    import os
 
-        def foo():
-            value = 1  # ruff:ignore[unused-variable]
+    def foo():
+        value = 1  # ruff: ignore[unused-variable]
 
-        ----- stderr -----
-        Found 4 errors (4 fixed, 0 remaining).
-        ",
+    ----- stderr -----
+    Found 4 errors (4 fixed, 0 remaining).
+    ",
     );
 
     Ok(())

--- a/crates/ruff_linter/resources/mdtest/ruff/noqa-comments.md
+++ b/crates/ruff_linter/resources/mdtest/ruff/noqa-comments.md
@@ -17,17 +17,17 @@ import math
 ```
 
 ```snapshot
-error[RUF105]: `ruff: noqa` comment used instead of `ruff:file-ignore`
+error[RUF105]: `ruff: noqa` comment used instead of `ruff: file-ignore`
  --> src/mdtest_snippet.py:2:1
   |
 2 | # ruff: noqa: F401
   | ^^^^^^^^^^^^^^^^^^
   |
-help: Use `ruff:file-ignore` instead
+help: Use `ruff: file-ignore` instead
   |
 1 | # snapshot: noqa-comments
   - # ruff: noqa: F401
-2 + # ruff:file-ignore[F401]
+2 + # ruff: file-ignore[F401]
 3 | import math
   |
 ```
@@ -45,17 +45,17 @@ for os in []:
 ```
 
 ```snapshot
-error[RUF105]: `ruff: noqa` comment used instead of `ruff:file-ignore`
+error[RUF105]: `ruff: noqa` comment used instead of `ruff: file-ignore`
  --> src/mdtest_snippet.py:2:1
   |
 2 | # ruff: noqa: F401, F402, F403
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-help: Use `ruff:file-ignore` instead
+help: Use `ruff: file-ignore` instead
   |
 1 | # snapshot: noqa-comments
   - # ruff: noqa: F401, F402, F403
-2 + # ruff:file-ignore[F401, F402, F403]
+2 + # ruff: file-ignore[F401, F402, F403]
 3 | import math
   |
 ```
@@ -73,17 +73,17 @@ for os in []:
 ```
 
 ```snapshot
-error[RUF105]: `ruff: noqa` comment used instead of `ruff:file-ignore`
+error[RUF105]: `ruff: noqa` comment used instead of `ruff: file-ignore`
  --> src/mdtest_snippet.py:2:1
   |
 2 | # ruff: noqa: F401, F402, F403 for some reason
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-help: Use `ruff:file-ignore` instead
+help: Use `ruff: file-ignore` instead
   |
 1 | # snapshot: noqa-comments
   - # ruff: noqa: F401, F402, F403 for some reason
-2 + # ruff:file-ignore[F401, F402, F403] for some reason
+2 + # ruff: file-ignore[F401, F402, F403] for some reason
 3 | import math
   |
 ```
@@ -101,17 +101,17 @@ for os in []:
 ```
 
 ```snapshot
-error[RUF105]: `ruff: noqa` comment used instead of `ruff:file-ignore`
+error[RUF105]: `ruff: noqa` comment used instead of `ruff: file-ignore`
  --> src/mdtest_snippet.py:2:1
   |
 2 | # ruff: noqa: F401, F402, F403 # fmt:skip
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-help: Use `ruff:file-ignore` instead
+help: Use `ruff: file-ignore` instead
   |
 1 | # snapshot: noqa-comments
   - # ruff: noqa: F401, F402, F403 # fmt:skip
-2 + # ruff:file-ignore[F401, F402, F403] # fmt:skip
+2 + # ruff: file-ignore[F401, F402, F403] # fmt:skip
 3 | import math
   |
 ```
@@ -134,17 +134,17 @@ import math  # noqa: F401, UNK001
 ```
 
 ```snapshot
-error[RUF105]: `noqa` comment used instead of `ruff:ignore`
+error[RUF105]: `noqa` comment used instead of `ruff: ignore`
  --> src/mdtest_snippet.py:3:14
   |
 3 | import math  # noqa: F401, UNK001
   |              ^^^^^^^^^^^^^^^^^^^^
   |
-help: Use `ruff:ignore` instead
+help: Use `ruff: ignore` instead
   |
 2 | # snapshot: noqa-comments
   - import math  # noqa: F401, UNK001
-3 + import math  # ruff:ignore[F401, UNK001]
+3 + import math  # ruff: ignore[F401, UNK001]
   |
 ```
 
@@ -166,7 +166,7 @@ import math  # noqa: EXT001, EXT002
 
 However, if only some of the codes are `external`, a diagnostic is emitted without an autofix. In
 this case, the external codes likely need to remain in a `noqa` comment, while the codes known by
-Ruff could potentially move into a `ruff:ignore` comment.
+Ruff could potentially move into a `ruff: ignore` comment.
 
 ```py
 # snapshot: noqa-comments
@@ -174,20 +174,20 @@ import math  # noqa: F401, EXT001
 ```
 
 ```snapshot
-error[RUF105]: `noqa` comment used instead of `ruff:ignore`
+error[RUF105]: `noqa` comment used instead of `ruff: ignore`
  --> src/mdtest_snippet.py:4:14
   |
 4 | import math  # noqa: F401, EXT001
   |              ^^^^^^^^^^^^^^^^^^^^
   |
-help: Use `ruff:ignore` instead
+help: Use `ruff: ignore` instead
 ```
 
 ### Any unmatched code disables the fix
 
 This leaves an unused `noqa` comment to be cleaned up by `RUF100` instead, which can be especially
 important in the case of a standalone `noqa` comment, which has no effect (in almost all cases), but
-could become an effectful own-line `ruff:ignore` comment if `RUF105` applied.
+could become an effectful own-line `ruff: ignore` comment if `RUF105` applied.
 
 ```py
 # snapshot: noqa-comments
@@ -196,13 +196,13 @@ import math
 ```
 
 ```snapshot
-error[RUF105]: `ruff: noqa` comment used instead of `ruff:file-ignore`
+error[RUF105]: `ruff: noqa` comment used instead of `ruff: file-ignore`
  --> src/mdtest_snippet.py:2:1
   |
 2 | # ruff: noqa: F401, F402
   | ^^^^^^^^^^^^^^^^^^^^^^^^
   |
-help: Use `ruff:file-ignore` instead
+help: Use `ruff: file-ignore` instead
 ```
 
 ### Flake8 comments are ignored
@@ -222,17 +222,17 @@ import math  # noqa: F401
 ```
 
 ```snapshot
-error[RUF105]: `noqa` comment used instead of `ruff:ignore`
+error[RUF105]: `noqa` comment used instead of `ruff: ignore`
  --> src/mdtest_snippet.py:2:14
   |
 2 | import math  # noqa: F401
   |              ^^^^^^^^^^^^
   |
-help: Use `ruff:ignore` instead
+help: Use `ruff: ignore` instead
   |
 1 | # snapshot: noqa-comments
   - import math  # noqa: F401
-2 + import math  # ruff:ignore[F401]
+2 + import math  # ruff: ignore[F401]
   |
 ```
 
@@ -246,13 +246,13 @@ import os  # noqa: F401, F402
 ```
 
 ```snapshot
-error[RUF105]: `noqa` comment used instead of `ruff:ignore`
+error[RUF105]: `noqa` comment used instead of `ruff: ignore`
  --> src/mdtest_snippet.py:2:12
   |
 2 | import os  # noqa: F401, F402
   |            ^^^^^^^^^^^^^^^^^^
   |
-help: Use `ruff:ignore` instead
+help: Use `ruff: ignore` instead
 ```
 
 ### Nested pragma comment before the directive
@@ -263,17 +263,17 @@ import math  # fmt:skip # noqa: F401
 ```
 
 ```snapshot
-error[RUF105]: `noqa` comment used instead of `ruff:ignore`
+error[RUF105]: `noqa` comment used instead of `ruff: ignore`
  --> src/mdtest_snippet.py:2:25
   |
 2 | import math  # fmt:skip # noqa: F401
   |                         ^^^^^^^^^^^^
   |
-help: Use `ruff:ignore` instead
+help: Use `ruff: ignore` instead
   |
 1 | # snapshot: noqa-comments
   - import math  # fmt:skip # noqa: F401
-2 + import math  # fmt:skip # ruff:ignore[F401]
+2 + import math  # fmt:skip # ruff: ignore[F401]
   |
 ```
 
@@ -290,17 +290,17 @@ import math  # noqa
 ```
 
 ```snapshot
-error[RUF105]: `noqa` comment used instead of `ruff:ignore`
+error[RUF105]: `noqa` comment used instead of `ruff: ignore`
  --> src/mdtest_snippet.py:2:14
   |
 2 | import math  # noqa
   |              ^^^^^^
   |
-help: Use `ruff:ignore` instead
+help: Use `ruff: ignore` instead
   |
 1 | # snapshot: noqa-comments
   - import math  # noqa
-2 + import math  # ruff:ignore[F401]
+2 + import math  # ruff: ignore[F401]
 3 | # snapshot: noqa-comments
   |
 ```
@@ -313,17 +313,17 @@ import foo, bar  # noqa
 ```
 
 ```snapshot
-error[RUF105]: `noqa` comment used instead of `ruff:ignore`
+error[RUF105]: `noqa` comment used instead of `ruff: ignore`
  --> src/mdtest_snippet.py:4:18
   |
 4 | import foo, bar  # noqa
   |                  ^^^^^^
   |
-help: Use `ruff:ignore` instead
+help: Use `ruff: ignore` instead
   |
 3 | # snapshot: noqa-comments
   - import foo, bar  # noqa
-4 + import foo, bar  # ruff:ignore[F401]
+4 + import foo, bar  # ruff: ignore[F401]
   |
 ```
 
@@ -338,13 +338,13 @@ import math
 ```
 
 ```snapshot
-error[RUF105]: `ruff: noqa` comment used instead of `ruff:file-ignore`
+error[RUF105]: `ruff: noqa` comment used instead of `ruff: file-ignore`
  --> src/mdtest_snippet.py:2:1
   |
 2 | # ruff: noqa
   | ^^^^^^^^^^^^
   |
-help: Use `ruff:file-ignore` instead
+help: Use `ruff: file-ignore` instead
 ```
 
 ## Inline self-suppression
@@ -368,7 +368,7 @@ But a suppression for `RUF100` should not prevent the rule from firing:
 import math  # noqa: RUF100, F401
 ```
 
-## Suppression with `ruff:ignore`
+## Suppression with `ruff: ignore`
 
 ```toml
 [lint]

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -763,7 +763,7 @@ impl Error for LexicalError {}
 pub enum SuppressionKind {
     /// A `noqa` comment
     Noqa,
-    /// A `ruff:ignore` comment
+    /// A `ruff: ignore` comment
     Ignore,
 }
 
@@ -1060,7 +1060,7 @@ impl SuppressionEdit<'_> {
         }
         match self.suppression_kind {
             SuppressionKind::Noqa => write!(writer, "# noqa: ").unwrap(),
-            SuppressionKind::Ignore => write!(writer, "# ruff:ignore[").unwrap(),
+            SuppressionKind::Ignore => write!(writer, "# ruff: ignore[").unwrap(),
         }
         push_codes(
             writer,
@@ -1107,7 +1107,7 @@ fn generate_suppression_edit<'a>(
             (edit_range, blank_line) = suppression_edit_range(locator, line_range, codes.start());
             existing_codes.extend(codes.iter().map(Code::as_str));
         }
-        // Add additional rule names to an existing `ruff:ignore` comment.
+        // Add additional rule names to an existing `ruff: ignore` comment.
         (Some(ExistingDirective::Ignore(comment)), SuppressionKind::Ignore) => {
             (edit_range, blank_line) = suppression_edit_range(locator, line_range, comment.start());
             existing_codes.extend(comment.codes_as_str(locator.contents()));
@@ -3132,7 +3132,7 @@ mod tests {
         ## Fixed source
 
         ```py
-        def unused(x):  # noqa: ANN001, ARG001, D103  # ruff:ignore[missing-return-type-undocumented-public-function]
+        def unused(x):  # noqa: ANN001, ARG001, D103  # ruff: ignore[missing-return-type-undocumented-public-function]
             pass
         ```
         "
@@ -3182,7 +3182,7 @@ mod tests {
         ## Fixed source
 
         ```py
-        import math  # noqa: F401  # ruff:ignore[noqa-comments]
+        import math  # noqa: F401  # ruff: ignore[noqa-comments]
 
         ```
         "
@@ -3213,7 +3213,7 @@ mod tests {
         ## Fixed source
 
         ```py
-        def unused(x):  # ruff:ignore[ANN001, ARG001, D103, missing-return-type-undocumented-public-function]
+        def unused(x):  # ruff: ignore[ANN001, ARG001, D103, missing-return-type-undocumented-public-function]
             pass
         ```
         "
@@ -3243,7 +3243,7 @@ mod tests {
         ## Fixed source
 
         ```py
-        def unused(x):  # ruff:ignore[missing-return-type-undocumented-public-function, missing-type-function-argument, undocumented-public-function]
+        def unused(x):  # ruff: ignore[missing-return-type-undocumented-public-function, missing-type-function-argument, undocumented-public-function]
             pass
         ```
         "
@@ -3269,7 +3269,7 @@ mod tests {
         ## Fixed source
 
         ```py
-        import z  # ruff:ignore[unsorted-imports]
+        import z  # ruff: ignore[unsorted-imports]
         import c
         import a
         ```
@@ -3301,7 +3301,7 @@ mod tests {
         ## Fixed source
 
         ```py
-        # ruff:ignore[ANN001, missing-return-type-undocumented-public-function]
+        # ruff: ignore[ANN001, missing-return-type-undocumented-public-function]
         def public(x):
             """Return x."""
             return x

--- a/crates/ruff_linter/src/rules/ruff/rules/noqa_comments.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/noqa_comments.rs
@@ -11,11 +11,11 @@ use crate::{
 
 /// ## What it does
 ///
-/// Checks for the use of `noqa` comments instead of Ruff-specific `ruff:ignore` comments.
+/// Checks for the use of `noqa` comments instead of Ruff-specific `ruff: ignore` comments.
 ///
 /// ## Why is this bad?
 ///
-/// `ruff:ignore` comments allow the use of rule names instead of codes and can be used in more
+/// `ruff: ignore` comments allow the use of rule names instead of codes and can be used in more
 /// places than `noqa` comments.
 ///
 /// Note that this is an opinionated, stylistic rule. `noqa` comments may be needed for backwards
@@ -30,13 +30,13 @@ use crate::{
 ///
 /// Use instead:
 /// ```python
-/// import os  # ruff:ignore[F401]
+/// import os  # ruff: ignore[F401]
 /// ```
 ///
 /// Or if you prefer the own-line form:
 ///
 /// ```python
-/// # ruff:ignore[unused-import]
+/// # ruff: ignore[unused-import]
 /// import os
 /// ```
 ///
@@ -56,7 +56,7 @@ use crate::{
 ///
 /// This rule avoids offering a fix if any of the rule codes in a `noqa` comment are unused. See
 /// `unused-noqa` for a rule that will remove these and allow the remaining codes to be moved into a
-/// `ruff:ignore` comment.
+/// `ruff: ignore` comment.
 #[derive(ViolationMetadata)]
 #[violation_metadata(preview_since = "0.15.22")]
 pub(crate) struct NoqaComments {
@@ -69,17 +69,17 @@ impl Violation for NoqaComments {
     #[derive_message_formats]
     fn message(&self) -> String {
         if !self.file_level {
-            "`noqa` comment used instead of `ruff:ignore`".to_string()
+            "`noqa` comment used instead of `ruff: ignore`".to_string()
         } else {
-            "`ruff: noqa` comment used instead of `ruff:file-ignore`".to_string()
+            "`ruff: noqa` comment used instead of `ruff: file-ignore`".to_string()
         }
     }
 
     fn fix_title(&self) -> Option<String> {
         Some(if self.file_level {
-            "Use `ruff:file-ignore` instead".to_string()
+            "Use `ruff: file-ignore` instead".to_string()
         } else {
-            "Use `ruff:ignore` instead".to_string()
+            "Use `ruff: ignore` instead".to_string()
         })
     }
 }
@@ -143,14 +143,14 @@ pub(crate) fn noqa_comments(
     // import math
     // ```
     //
-    // by converting it to a valid `ruff:ignore` comment.
+    // by converting it to a valid `ruff: ignore` comment.
     if has_unused_codes {
         return;
     }
 
     let edit = Edit::range_replacement(
         format!(
-            "# ruff:{action}[{codes}]",
+            "# ruff: {action}[{codes}]",
             action = if file_level { "file-ignore" } else { "ignore" },
         ),
         codes.range,

--- a/crates/ruff_linter/src/rules/ruff/rules/rule_codes_in_suppression_comments.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/rule_codes_in_suppression_comments.rs
@@ -11,18 +11,18 @@ use crate::AlwaysFixableViolation;
 /// Human-readable rule names are easier to understand than rule codes. Using names also avoids
 /// requiring readers to look up the meaning of each code.
 ///
-/// This rule applies to `ruff:ignore`, `ruff:file-ignore`, `ruff:disable`, and `ruff:enable`
+/// This rule applies to `ruff: ignore`, `ruff: file-ignore`, `ruff: disable`, and `ruff: enable`
 /// comments.
 ///
 /// ## Example
 ///
 /// ```python
-/// import os  # ruff:ignore[F401]
+/// import os  # ruff: ignore[F401]
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// import os  # ruff:ignore[unused-import]
+/// import os  # ruff: ignore[unused-import]
 /// ```
 #[derive(ViolationMetadata)]
 #[violation_metadata(preview_since = "0.15.22")]

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -32,13 +32,13 @@ use crate::{Locator, Violation, warn_user_once};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 enum SuppressionAction {
-    /// # ruff:file-ignore[...] file level suppression
+    /// # ruff: file-ignore[...] file level suppression
     FileIgnore,
-    /// # ruff:disable[...] start of a block suppression
+    /// # ruff: disable[...] start of a block suppression
     Disable,
-    /// # ruff:enable[...] end of a block suppression
+    /// # ruff: enable[...] end of a block suppression
     Enable,
-    /// # ruff:ignore[...] ignore a single line or multi-line statement
+    /// # ruff: ignore[...] ignore a single line or multi-line statement
     Ignore,
 }
 
@@ -49,8 +49,8 @@ pub(crate) struct SuppressionComment {
     /// For example:
     ///
     /// ```py
-    /// import math  # start # ruff:ignore[F401] reason # end
-    ///                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    /// import math  # start # ruff: ignore[F401] reason # end
+    ///                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     /// ```
     range: TextRange,
 
@@ -59,8 +59,8 @@ pub(crate) struct SuppressionComment {
     /// For example:
     ///
     /// ```py
-    /// import math  # start # ruff:ignore[F401] reason # end
-    ///              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    /// import math  # start # ruff: ignore[F401] reason # end
+    ///              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     /// ```
     token_range: TextRange,
 
@@ -136,7 +136,7 @@ impl Suppression {
         &self.comments.first().codes
     }
 
-    /// Returns whether or not the suppression is a standalone `ruff:ignore` comment.
+    /// Returns whether or not the suppression is a standalone `ruff: ignore` comment.
     fn is_ignore(&self) -> bool {
         matches!(
             self.comments,
@@ -149,7 +149,7 @@ impl Suppression {
 
     /// Returns whether the suppression's range applies to a diagnostic.
     ///
-    /// `ruff:ignore` comments only need to contain the start of the diagnostic range (or its
+    /// `ruff: ignore` comments only need to contain the start of the diagnostic range (or its
     /// parent), while range suppression comments must contain the entire diagnostic range.
     fn applies_to_diagnostic(&self, range: TextRange, parent: Option<TextSize>) -> bool {
         if self.is_ignore() {
@@ -177,9 +177,9 @@ impl Suppression {
 
 #[derive(Debug)]
 pub(crate) enum SuppressionComments {
-    /// A #ruff:ignore comment, or #ruff:disable without a matching #ruff:enable
+    /// A # ruff: ignore comment, or # ruff: disable without a matching # ruff: enable
     Single(SuppressionComment),
-    /// A matching pair of #ruff:disable and #ruff:enable comments.
+    /// A matching pair of # ruff: disable and # ruff: enable comments.
     DisableEnable(SuppressionComment, SuppressionComment),
 }
 
@@ -309,28 +309,28 @@ impl Suppressions {
     /// the subscript expression:
     ///
     /// ```py
-    /// # ruff:disable[RUF015]
+    /// # ruff: disable[RUF015]
     /// value = [
     ///     *range(10)
     /// ][0]
-    /// # ruff:enable[RUF015]
+    /// # ruff: enable[RUF015]
     /// ```
     ///
     /// is suppressed, but
     ///
     /// ```py
-    /// # ruff:disable[RUF015]
+    /// # ruff: disable[RUF015]
     /// value = [
-    /// # ruff:enable[RUF015]
+    /// # ruff: enable[RUF015]
     ///     *range(10)
     /// ][0]
     /// ```
     ///
-    /// is not. For `ruff:ignore`, this rule is augmented to check whether the diagnostic's start
+    /// is not. For `ruff: ignore`, this rule is augmented to check whether the diagnostic's start
     /// offset is contained instead, meaning that this _will_ be suppressed:
     ///
     /// ```python
-    /// suppressed = [  # ruff:ignore[RUF015]
+    /// suppressed = [  # ruff: ignore[RUF015]
     ///     *range(10)
     /// ][0]
     /// ```
@@ -861,7 +861,7 @@ impl<'a> SuppressionsBuilder<'a> {
         }
     }
 
-    /// Handles a single-comment suppression like `ruff:ignore` or `ruff:file-ignore` and returns
+    /// Handles a single-comment suppression like `ruff: ignore` or `ruff: file-ignore` and returns
     /// `true` if such a comment was found.
     fn register_standalone_suppression(
         &mut self,
@@ -1021,7 +1021,7 @@ impl<'a> SuppressionsBuilder<'a> {
     /// ```py
     ///
     /// # V--- from here
-    /// # ruff:ignore[code]
+    /// # ruff: ignore[code]
     /// foo = [
     ///     1,
     ///     2,
@@ -1029,7 +1029,7 @@ impl<'a> SuppressionsBuilder<'a> {
     /// # ^--- to here
     ///
     /// # V--- from here
-    /// # ruff:ignore[code]
+    /// # ruff: ignore[code]
     /// def foo(
     ///     arg1,
     ///     arg2,
@@ -1047,7 +1047,7 @@ impl<'a> SuppressionsBuilder<'a> {
     ///
     /// foo = [
     ///     # V--- from here
-    ///     # ruff:ignore[code]
+    ///     # ruff: ignore[code]
     ///     1,
     ///     # ^--- to here
     ///     2,
@@ -1112,13 +1112,13 @@ impl<'a> SuppressionsBuilder<'a> {
     ///
     /// ```py
     /// # V-- from here
-    /// foo = 1  # ruff:ignore[code]
-    /// # to here -----------------^
+    /// foo = 1  # ruff: ignore[code]
+    /// # to here ------------------^
     ///
     /// foo = [
     ///     # V--- from here
-    ///     1,  # ruff:ignore[code]
-    ///     # to here ------------^
+    ///     1,  # ruff: ignore[code]
+    ///     # to here -------------^
     /// ]
     /// ```
     ///
@@ -1130,8 +1130,8 @@ impl<'a> SuppressionsBuilder<'a> {
     /// # V--- from here
     /// value = """
     ///     some text
-    /// """  # ruff:ignore[code]
-    /// # to here -------------^
+    /// """  # ruff: ignore[code]
+    /// # to here --------------^
     ///
     /// ```
     ///

--- a/crates/ruff_server/tests/e2e/diagnostics.rs
+++ b/crates/ruff_server/tests/e2e/diagnostics.rs
@@ -58,7 +58,7 @@ fn uses_human_readable_names_in_preview() -> Result<()> {
               }
             ],
             "noqa_edit": {
-              "newText": "  # ruff:ignore[unused-import]\n",
+              "newText": "  # ruff: ignore[unused-import]\n",
               "range": {
                 "end": {
                   "character": 0,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -648,7 +648,7 @@ Options:
           Enable automatic additions of `noqa` directives to failing lines.
           Optionally provide a reason to append after the codes
       --add-ignore[=<REASON>]
-          Enable automatic additions of `ruff:ignore` comments to failing
+          Enable automatic additions of `ruff: ignore` comments to failing
           lines. Optionally provide a reason to append after the rule names.
           Requires preview mode
       --show-files

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -541,7 +541,7 @@ lines, run Ruff with `--add-noqa`:
 $ ruff check /path/to/file.py --add-noqa
 ```
 
-The `--add-noqa` flag adds `noqa` directives with rule codes. To add `ruff:ignore` comments with
+The `--add-noqa` flag adds `noqa` directives with rule codes. To add `ruff: ignore` comments with
 human-readable rule names instead, use `--add-ignore` with preview mode enabled.
 
 ### isort action comments

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -361,7 +361,7 @@ index 71fca60c8d..e92d839f1b 100644
 +from typing import Iterable  # noqa: UP035
 ```
 
-To add `# ruff:ignore[...]` comments with human-readable rule names instead, use the
+To add `# ruff: ignore[...]` comments with human-readable rule names instead, use the
 `--add-ignore` flag with preview mode enabled.
 
 ## Integrations


### PR DESCRIPTION
## Summary
Insert a space after the colon in `ruff: ignore` and `ruff: file-ignore` colon, following the precedence of most Python tooling.

Fixes #27114.

## Test Plan

Testing: Updated the affected snapshots and ran the focused linter, CLI, Markdown, and server tests.
