### PR TITLE
Stabilize `--add-ignore`

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -468,8 +468,8 @@ pub struct CheckCommand {
     )]
     pub add_noqa: Option<String>,
     /// Enable automatic additions of `ruff:ignore` comments to failing lines.
-    /// Optionally provide a reason to append after the rule names.
-    /// Requires preview mode.
+    /// Optionally provide a reason to append after the codes.
+    /// In preview, add suppression comments with rule names instead.
     #[arg(
         long,
         value_name = "REASON",

--- a/crates/ruff/src/commands/add_noqa.rs
+++ b/crates/ruff/src/commands/add_noqa.rs
@@ -1,14 +1,13 @@
 use std::path::PathBuf;
 use std::time::Instant;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use log::{debug, error};
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 
 use ruff_linter::SuppressionKind;
 use ruff_linter::linter::add_suppressions_to_path;
-use ruff_linter::preview::is_human_readable_names_enabled;
 use ruff_linter::source_kind::SourceKind;
 use ruff_linter::warn_user_once;
 use ruff_python_ast::{PySourceType, SourceType};
@@ -79,14 +78,6 @@ pub(crate) fn add_noqa(
                 )
             {
                 return Ok(0);
-            }
-            if matches!(suppression_kind, SuppressionKind::Ignore)
-                && !is_human_readable_names_enabled(settings.linter.preview)
-            {
-                bail!(
-                    "`--add-ignore` requires preview mode, but preview is disabled for `{}`",
-                    path.display()
-                );
             }
             let source_kind = match SourceKind::from_path(path, source_type) {
                 Ok(Some(source_kind)) => source_kind,

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -2614,7 +2614,6 @@ fn add_ignore() -> Result<()> {
         fixture
             .check_command()
             .arg("--select=RUF015")
-            .arg("--preview")
             .arg("--add-ignore"),
         @"
         success: true
@@ -2632,37 +2631,10 @@ fn add_ignore() -> Result<()> {
         test_code,
         @"
 
-        def first_square():
-            return [x * x for x in range(20)][0]  # ruff:ignore[unnecessary-iterable-allocation-for-first-element]
-        ",
+    def first_square():
+        return [x * x for x in range(20)][0]  # ruff:ignore[RUF015]
+    ",
     );
-
-    Ok(())
-}
-
-#[test]
-fn add_ignore_requires_preview() -> Result<()> {
-    let fixture = CliTest::new()?;
-    fixture.write_file("noqa.py", "import os\n")?;
-
-    assert_cmd_snapshot!(
-        fixture
-            .check_command()
-            .arg("--select=F401")
-            .arg("--add-ignore"),
-        @"
-        success: false
-        exit_code: 2
-        ----- stdout -----
-
-        ----- stderr -----
-        ruff failed
-          Cause: `--add-ignore` requires preview mode, but preview is disabled for `[TMP]/noqa.py`
-        ",
-    );
-
-    let test_code = fixture.read_file("noqa.py")?;
-    insta::assert_snapshot!(test_code, @"import os");
 
     Ok(())
 }

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -436,6 +436,7 @@ pub fn add_suppressions_to_path(
         reason,
         &suppressions,
         suppression_kind,
+        settings.preview,
     )
 }
 

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -19,8 +19,10 @@ use rustc_hash::FxHashSet;
 use crate::Edit;
 use crate::Locator;
 use crate::fs::relativize_path;
+use crate::preview::is_human_readable_names_enabled;
 use crate::registry::Rule;
 use crate::rule_redirects::get_redirect_target;
+use crate::settings::types::PreviewMode;
 use crate::suppression::{self, Suppressions};
 
 /// Generates an array of edits that matches the length of `diagnostics`.
@@ -39,6 +41,7 @@ pub fn generate_suppression_edits(
     line_ending: LineEnding,
     suppressions: &Suppressions,
     suppression_kind: SuppressionKind,
+    preview: PreviewMode,
 ) -> Vec<Option<Edit>> {
     let file_directives = FileNoqaDirectives::extract(locator, comment_ranges, external, path);
     let exemption = FileExemption::from(&file_directives);
@@ -51,6 +54,7 @@ pub fn generate_suppression_edits(
         noqa_line_for,
         suppressions,
         suppression_kind,
+        preview,
     );
     build_suppression_edits_by_diagnostic(comments, locator, line_ending, None, suppression_kind)
 }
@@ -780,6 +784,7 @@ pub(crate) fn add_suppression(
     reason: Option<&str>,
     suppressions: &Suppressions,
     suppression_kind: SuppressionKind,
+    preview: PreviewMode,
 ) -> Result<usize> {
     let (count, output) = add_suppression_inner(
         path,
@@ -792,6 +797,7 @@ pub(crate) fn add_suppression(
         reason,
         suppressions,
         suppression_kind,
+        preview,
     );
 
     fs::write(path, output)?;
@@ -810,6 +816,7 @@ fn add_suppression_inner(
     reason: Option<&str>,
     suppressions: &Suppressions,
     suppression_kind: SuppressionKind,
+    preview: PreviewMode,
 ) -> (usize, String) {
     let mut count = 0;
 
@@ -827,6 +834,7 @@ fn add_suppression_inner(
         noqa_line_for,
         suppressions,
         suppression_kind,
+        preview,
     );
 
     let edits =
@@ -938,6 +946,7 @@ impl Ranged for ExistingDirective<'_> {
     }
 }
 
+#[expect(clippy::too_many_arguments)]
 fn find_suppression_comments<'a>(
     diagnostics: &'a [Diagnostic],
     locator: &'a Locator,
@@ -946,6 +955,7 @@ fn find_suppression_comments<'a>(
     noqa_line_for: &NoqaMapping,
     suppressions: &'a Suppressions,
     suppression_kind: SuppressionKind,
+    preview: PreviewMode,
 ) -> Vec<Option<SuppressionComment<'a>>> {
     // List of suppression comments, ordered to match up with `messages`
     let mut comments_by_line: Vec<Option<SuppressionComment<'a>>> = vec![];
@@ -1023,7 +1033,8 @@ fn find_suppression_comments<'a>(
 
         let identifier = match suppression_kind {
             SuppressionKind::Noqa => code.as_str(),
-            SuppressionKind::Ignore => message.name(),
+            SuppressionKind::Ignore if is_human_readable_names_enabled(preview) => message.name(),
+            SuppressionKind::Ignore => code.as_str(),
         };
 
         comments_by_line.push(Some(SuppressionComment {
@@ -1368,6 +1379,7 @@ mod tests {
     use crate::rules::pycodestyle::rules::{AmbiguousVariableName, UselessSemicolon};
     use crate::rules::pyflakes::rules::UnusedVariable;
     use crate::rules::pyupgrade::rules::PrintfStringFormatting;
+    use crate::settings::types::PreviewMode;
     use crate::settings::{LinterSettings, flags};
     use crate::source_kind::SourceKind;
     use crate::suppression::Suppressions;
@@ -1423,6 +1435,7 @@ mod tests {
             None,
             &suppressions,
             suppression_kind,
+            settings.preview,
         )
     }
 
@@ -3328,6 +3341,7 @@ mod tests {
             None,
             &Suppressions::default(),
             SuppressionKind::Noqa,
+            PreviewMode::Disabled,
         );
         assert_eq!(count, 0);
         assert_eq!(output, format!("{contents}"));
@@ -3354,6 +3368,7 @@ mod tests {
             None,
             &Suppressions::default(),
             SuppressionKind::Noqa,
+            PreviewMode::Disabled,
         );
         assert_eq!(count, 1);
         assert_eq!(output, "x = 1  # noqa: F841\n");
@@ -3387,6 +3402,7 @@ mod tests {
             None,
             &Suppressions::default(),
             SuppressionKind::Noqa,
+            PreviewMode::Disabled,
         );
         assert_eq!(count, 1);
         assert_eq!(output, "x = 1  # noqa: E741, F841\n");
@@ -3420,6 +3436,7 @@ mod tests {
             None,
             &Suppressions::default(),
             SuppressionKind::Noqa,
+            PreviewMode::Disabled,
         );
         assert_eq!(count, 0);
         assert_eq!(output, "x = 1  # noqa");
@@ -3453,6 +3470,7 @@ print(
             LineEnding::Lf,
             &suppressions,
             SuppressionKind::Noqa,
+            PreviewMode::Disabled,
         );
         assert_eq!(
             edits,
@@ -3487,6 +3505,7 @@ bar =
             LineEnding::Lf,
             &suppressions,
             SuppressionKind::Noqa,
+            PreviewMode::Disabled,
         );
         assert_eq!(
             edits,

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -162,6 +162,7 @@ pub(crate) fn check(
         } else {
             SuppressionKind::Noqa
         },
+        settings.linter.preview,
     );
     let context = LspDiagnosticContext {
         source_kind: &source_kind,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -645,8 +645,8 @@ Options:
           Optionally provide a reason to append after the codes
       --add-ignore[=<REASON>]
           Enable automatic additions of `ruff:ignore` comments to failing
-          lines. Optionally provide a reason to append after the rule names.
-          Requires preview mode
+          lines. Optionally provide a reason to append after the codes. In
+          preview, add suppression comments with rule names instead
       --show-files
           See the files Ruff will be run against with the current settings
       --show-settings


### PR DESCRIPTION
Summary
--

This makes sense to accompany `ruff: ignore` comments being stabilized. The preview gate has been pushed down to cover only the names vs codes decision. I'll flag this as a comment, but I wasn't totally sure about the LSP case. I left using `ruff: ignore` in its suppression edits preview-gated for now.

Test Plan
--

Existing tests, dropping one that showed the preview error with `--add-ignore`. I left `--preview` in many of the tests to continue testing the human-readable names but removed it from one.