### PR TITLE
[ty] Make module resolution environment-aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,6 +3157,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_ranged_value",
  "rustc-hash",
+ "salsa",
  "serde",
  "serde_json",
  "tikv-jemallocator",
@@ -4653,7 +4654,6 @@ dependencies = [
  "ruff_text_size",
  "ty_ide",
  "ty_project",
- "ty_python_core",
 ]
 
 [[package]]
@@ -4673,7 +4673,6 @@ dependencies = [
  "ty_ide",
  "ty_module_resolver",
  "ty_project",
- "ty_python_core",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,7 +3157,6 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_ranged_value",
  "rustc-hash",
- "salsa",
  "serde",
  "serde_json",
  "tikv-jemallocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,6 +3163,7 @@ dependencies = [
  "tracing",
  "ty_module_resolver",
  "ty_project",
+ "ty_python_core",
 ]
 
 [[package]]
@@ -4652,6 +4653,7 @@ dependencies = [
  "ruff_text_size",
  "ty_ide",
  "ty_project",
+ "ty_python_core",
 ]
 
 [[package]]
@@ -4671,6 +4673,7 @@ dependencies = [
  "ty_ide",
  "ty_module_resolver",
  "ty_project",
+ "ty_python_core",
  "walkdir",
 ]
 
@@ -4722,6 +4725,7 @@ dependencies = [
  "compact_str",
  "get-size2",
  "insta",
+ "ordermap",
  "regex",
  "regex-syntax",
  "ruff_db",

--- a/crates/ruff/src/commands/analyze_graph.rs
+++ b/crates/ruff/src/commands/analyze_graph.rs
@@ -6,12 +6,13 @@ use indexmap::IndexSet;
 use log::{debug, warn};
 use path_absolutize::CWD;
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
-use ruff_graph::{Direction, ImportMap, ModuleDb, ModuleImports};
+use ruff_graph::{
+    Direction, ImportMap, ModuleDb, ModuleImports, ResolverEnvironment, resolve_search_paths,
+};
 use ruff_linter::package::PackageRoot;
 use ruff_linter::source_kind::SourceKind;
 use ruff_linter::{warn_user, warn_user_once};
 use ruff_python_ast::SourceType;
-use ruff_python_parser::ParseOptions;
 use ruff_workspace::resolver::{ResolvedFile, match_exclusion, project_files_in_path};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::io::Write;
@@ -97,12 +98,14 @@ pub(crate) fn analyze_graph(
     );
 
     let system = OsSystem::default();
-    let db = ModuleDb::from_src_roots(
-        system,
+    let search_paths = resolve_search_paths(
+        &system,
         src_roots.into_iter().collect(),
         args.python
             .and_then(|python| SystemPathBuf::from_path_buf(python).ok()),
     )?;
+    let db = ModuleDb::new(system);
+    search_paths.try_register_static_roots(&db);
 
     let imports = {
         // Create a cache for resolved globs.
@@ -112,6 +115,7 @@ pub(crate) fn analyze_graph(
         let result = Arc::new(Mutex::new(Vec::new()));
         let inner_result = Arc::clone(&result);
         let db = db.clone();
+        let search_paths = &search_paths;
 
         rayon::scope(move |scope| {
             for resolved_file in paths {
@@ -172,14 +176,13 @@ pub(crate) fn analyze_graph(
                         }
                     };
 
-                    let source_code = source_kind.source_code();
+                    let environment = ResolverEnvironment::new(&db, python_version, search_paths);
 
                     // Identify any imports via static analysis.
                     let mut imports = ModuleImports::detect(
                         &db,
-                        source_code,
-                        ParseOptions::from(source_type.expect_python())
-                            .with_target_version(python_version),
+                        environment,
+                        &source_kind,
                         &path,
                         package.as_deref(),
                         string_imports,

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -23,6 +23,7 @@ ruff_python_formatter = { workspace = true, optional = true }
 ruff_python_parser = { workspace = true, optional = true }
 ruff_python_trivia = { workspace = true, optional = true }
 ty_module_resolver = { workspace = true, optional = true }
+ty_python_core = { workspace = true, optional = true }
 ty_project = { workspace = true, optional = true }
 
 anyhow = { workspace = true }
@@ -60,7 +61,7 @@ ruff_instrumented = [
 # Enables the ty instrumented benchmarks
 ty_instrumented = ["criterion", "ty_project", "ruff_python_trivia"]
 # Enables the module-resolution benchmark
-module_resolution = ["divan", "ty_module_resolver", "ty_project"]
+module_resolution = ["divan", "ty_module_resolver", "ty_project", "ty_python_core"]
 codspeed = ["codspeed-criterion-compat"]
 # Enables the ty_walltime benchmarks
 ty_walltime = ["ruff_db/os", "ty_project", "divan"]

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -45,7 +45,6 @@ rayon = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_ranged_value = { workspace = true }
 rustc-hash = { workspace = true }
-salsa = { workspace = true }
 
 [features]
 default = ["module_resolution", "ruff_instrumented", "ty_instrumented", "ty_walltime"]

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -45,6 +45,7 @@ rayon = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_ranged_value = { workspace = true }
 rustc-hash = { workspace = true }
+salsa = { workspace = true }
 
 [features]
 default = ["module_resolution", "ruff_instrumented", "ty_instrumented", "ty_walltime"]

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -114,6 +114,7 @@ ignored = [
     "ruff_python_parser",
     "ruff_python_trivia",
     "ty_module_resolver",
+    "ty_python_core",
     "mimalloc",
     "tikv-jemallocator"
 ]

--- a/crates/ruff_benchmark/benches/module_resolution.rs
+++ b/crates/ruff_benchmark/benches/module_resolution.rs
@@ -5,15 +5,15 @@ use std::hint::black_box;
 
 use divan::{Bencher, bench};
 
-use ruff_db::PythonFile;
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::{SystemPath, SystemPathBuf, TestSystem};
 use ruff_ranged_value::RangedValue;
-use ty_module_resolver::{ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
 use ty_project::metadata::options::{EnvironmentOptions, Options};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::RelativePathBuf;
-use ty_project::{Db as _, ProjectDatabase, ProjectMetadata};
+use ty_project::{ProjectDatabase, ProjectMetadata};
+use ty_python_core::program::Program;
 
 const SEEDED_TARGETS: &[&str] = &["target_0", "target_1", "target_2", "target_3", "target_4"];
 // Exercise stub-overlay discovery followed by normal fallback.
@@ -94,10 +94,13 @@ fn ty_module_resolver<const PATHS: usize>(bencher: Bencher) {
     bencher
         .with_inputs(|| setup_case(PATHS))
         .bench_local_refs(|case| {
-            let importing_file =
-                PythonFile::new(&case.db, case.importing_file, case.db.python_version());
+            let environment = Program::get(&case.db).resolver_environment(&case.db);
             for name in &case.resolves {
-                black_box(resolve_module(&case.db, importing_file, name));
+                black_box(resolve_module(
+                    &case.db,
+                    ImportingFile::File(case.importing_file, environment),
+                    name,
+                ));
             }
         });
 }

--- a/crates/ruff_benchmark/benches/module_resolution.rs
+++ b/crates/ruff_benchmark/benches/module_resolution.rs
@@ -8,7 +8,8 @@ use divan::{Bencher, bench};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::{SystemPath, SystemPathBuf, TestSystem};
 use ruff_ranged_value::RangedValue;
-use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
+use salsa::plumbing::{AsId, FromId, Id};
+use ty_module_resolver::{ImportingFile, ModuleName, ResolverEnvironment, resolve_module};
 use ty_project::metadata::options::{EnvironmentOptions, Options};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::RelativePathBuf;
@@ -38,6 +39,7 @@ const STDLIB_NAMES: &[&str] = &[
 
 struct Case {
     db: ProjectDatabase,
+    resolver_environment: Id,
     importing_file: File,
     resolves: Vec<ModuleName>,
 }
@@ -73,6 +75,7 @@ fn setup_case(n: usize) -> Case {
     });
 
     let db = ProjectDatabase::fallible(metadata, system).unwrap();
+    let resolver_environment = Program::get(&db).resolver_environment(&db).as_id();
     let importing_file = system_path_to_file(&db, &importing_path).unwrap();
 
     let resolves = SEEDED_TARGETS
@@ -84,6 +87,7 @@ fn setup_case(n: usize) -> Case {
 
     Case {
         db,
+        resolver_environment,
         importing_file,
         resolves,
     }
@@ -94,7 +98,7 @@ fn ty_module_resolver<const PATHS: usize>(bencher: Bencher) {
     bencher
         .with_inputs(|| setup_case(PATHS))
         .bench_local_refs(|case| {
-            let environment = Program::get(&case.db).resolver_environment(&case.db);
+            let environment = ResolverEnvironment::from_id(case.resolver_environment);
             for name in &case.resolves {
                 black_box(resolve_module(
                     &case.db,

--- a/crates/ruff_benchmark/benches/module_resolution.rs
+++ b/crates/ruff_benchmark/benches/module_resolution.rs
@@ -73,6 +73,7 @@ fn setup_case(n: usize) -> Case {
     });
 
     let db = ProjectDatabase::fallible(metadata, system).unwrap();
+    // Intern the resolver environment before timing so its initial allocation is not benchmarked.
     let _ = Program::get(&db).resolver_environment(&db);
     let importing_file = system_path_to_file(&db, &importing_path).unwrap();
 

--- a/crates/ruff_benchmark/benches/module_resolution.rs
+++ b/crates/ruff_benchmark/benches/module_resolution.rs
@@ -8,8 +8,7 @@ use divan::{Bencher, bench};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::{SystemPath, SystemPathBuf, TestSystem};
 use ruff_ranged_value::RangedValue;
-use salsa::plumbing::{AsId, FromId, Id};
-use ty_module_resolver::{ImportingFile, ModuleName, ResolverEnvironment, resolve_module};
+use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
 use ty_project::metadata::options::{EnvironmentOptions, Options};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::RelativePathBuf;
@@ -39,7 +38,6 @@ const STDLIB_NAMES: &[&str] = &[
 
 struct Case {
     db: ProjectDatabase,
-    resolver_environment: Id,
     importing_file: File,
     resolves: Vec<ModuleName>,
 }
@@ -75,7 +73,7 @@ fn setup_case(n: usize) -> Case {
     });
 
     let db = ProjectDatabase::fallible(metadata, system).unwrap();
-    let resolver_environment = Program::get(&db).resolver_environment(&db).as_id();
+    let _ = Program::get(&db).resolver_environment(&db);
     let importing_file = system_path_to_file(&db, &importing_path).unwrap();
 
     let resolves = SEEDED_TARGETS
@@ -87,7 +85,6 @@ fn setup_case(n: usize) -> Case {
 
     Case {
         db,
-        resolver_environment,
         importing_file,
         resolves,
     }
@@ -98,7 +95,7 @@ fn ty_module_resolver<const PATHS: usize>(bencher: Bencher) {
     bencher
         .with_inputs(|| setup_case(PATHS))
         .bench_local_refs(|case| {
-            let environment = ResolverEnvironment::from_id(case.resolver_environment);
+            let environment = Program::get(&case.db).resolver_environment(&case.db);
             for name in &case.resolves {
                 black_box(resolve_module(
                     &case.db,

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -30,7 +30,7 @@ pub mod vendored;
 /// This is the key for [`parsed::parsed_module`]. Including the Python version allows the same
 /// file to be parsed for different versions within a single Salsa revision without sharing an
 /// incompatible AST or syntax diagnostics.
-#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
+#[salsa::interned(debug, revisions = usize::MAX, heap_size = ruff_memory_usage::heap_size)]
 pub struct PythonFile<'db> {
     #[returns(copy)]
     pub file: File,

--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -30,7 +30,7 @@ pub mod vendored;
 /// This is the key for [`parsed::parsed_module`]. Including the Python version allows the same
 /// file to be parsed for different versions within a single Salsa revision without sharing an
 /// incompatible AST or syntax diagnostics.
-#[salsa::interned(debug, revisions = usize::MAX, heap_size = ruff_memory_usage::heap_size)]
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
 pub struct PythonFile<'db> {
     #[returns(copy)]
     pub file: File,

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -7,7 +7,8 @@ use ruff_db::Db as SourceDb;
 use ruff_db::files::Files;
 use ruff_db::system::{System, SystemPathBuf};
 use ruff_db::vendored::{VendoredFileSystem, VendoredFileSystemBuilder};
-use ty_module_resolver::{FallibleStrategy, SearchPathSettings, SearchPaths};
+use ruff_python_ast::PythonVersion;
+use ty_module_resolver::{FallibleStrategy, ResolverEnvironment, SearchPathSettings, SearchPaths};
 use ty_site_packages::{PythonEnvironment, SysPrefixPathOrigin};
 
 static EMPTY_VENDORED: std::sync::LazyLock<VendoredFileSystem> = std::sync::LazyLock::new(|| {
@@ -26,6 +27,13 @@ pub struct ModuleDb {
 }
 
 impl ModuleDb {
+    pub(crate) fn resolver_environment(
+        &self,
+        python_version: PythonVersion,
+    ) -> ResolverEnvironment<'_> {
+        ResolverEnvironment::new(self, python_version, self.search_paths.as_ref())
+    }
+
     /// Initialize a [`ModuleDb`] from the given source root.
     pub fn from_src_roots<S>(
         system: S,
@@ -79,11 +87,7 @@ impl SourceDb for ModuleDb {
 }
 
 #[salsa::db]
-impl ty_module_resolver::Db for ModuleDb {
-    fn search_paths(&self) -> &SearchPaths {
-        &self.search_paths
-    }
-}
+impl ty_module_resolver::Db for ModuleDb {}
 
 #[salsa::db]
 impl salsa::Database for ModuleDb {}

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -1,15 +1,13 @@
 use anyhow::{Context, Result};
 use std::panic::RefUnwindSafe;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use zip::CompressionMethod;
 
 use ruff_db::Db as SourceDb;
 use ruff_db::files::Files;
 use ruff_db::system::{System, SystemPathBuf};
 use ruff_db::vendored::{VendoredFileSystem, VendoredFileSystemBuilder};
-use ruff_python_ast::PythonVersion;
-use salsa::plumbing::{AsId, FromId, Id};
-use ty_module_resolver::{FallibleStrategy, ResolverEnvironment, SearchPathSettings, SearchPaths};
+use ty_module_resolver::{FallibleStrategy, SearchPathSettings, SearchPaths};
 use ty_site_packages::{PythonEnvironment, SysPrefixPathOrigin};
 
 static EMPTY_VENDORED: std::sync::LazyLock<VendoredFileSystem> = std::sync::LazyLock::new(|| {
@@ -24,68 +22,42 @@ pub struct ModuleDb {
     storage: salsa::Storage<Self>,
     files: Files,
     system: Arc<dyn System + Send + Sync + RefUnwindSafe>,
-    search_paths: Arc<SearchPaths>,
-    /// All cloned databases share their Salsa storage, so their cached environment IDs remain valid.
-    resolver_environments: Arc<[(PythonVersion, OnceLock<Id>)]>,
 }
 
 impl ModuleDb {
-    pub(crate) fn resolver_environment(
-        &self,
-        python_version: PythonVersion,
-    ) -> ResolverEnvironment<'_> {
-        let Some((_, cached)) = self
-            .resolver_environments
-            .iter()
-            .find(|(version, _)| *version == python_version)
-        else {
-            return ResolverEnvironment::new(self, python_version, self.search_paths.as_ref());
-        };
-
-        let id = *cached.get_or_init(|| {
-            ResolverEnvironment::new(self, python_version, self.search_paths.as_ref()).as_id()
-        });
-        ResolverEnvironment::from_id(id)
-    }
-
-    /// Initialize a [`ModuleDb`] from the given source root.
-    pub fn from_src_roots<S>(
-        system: S,
-        src_roots: Vec<SystemPathBuf>,
-        venv_path: Option<SystemPathBuf>,
-    ) -> Result<Self>
+    /// Initialize a [`ModuleDb`] for the given system.
+    pub fn new<S>(system: S) -> Self
     where
         S: System + 'static + Send + Sync + RefUnwindSafe,
     {
-        let mut search_path_settings = SearchPathSettings::new(src_roots);
-        // TODO: Consider calling `PythonEnvironment::discover` if the `venv_path` is not provided.
-        if let Some(venv_path) = venv_path {
-            let environment =
-                PythonEnvironment::new(venv_path, SysPrefixPathOrigin::PythonCliFlag, &system)?;
-            search_path_settings.site_packages_paths = environment
-                .site_packages_paths(&system)
-                .context("Failed to discover the site-packages directory")?
-                .into_vec();
-        }
-        let search_paths = search_path_settings
-            .to_search_paths(&system, &EMPTY_VENDORED, &FallibleStrategy)
-            .context("Invalid search path settings")?;
-
-        let db = Self {
+        Self {
             storage: salsa::Storage::new(None),
             files: Files::default(),
             system: Arc::new(system),
-            search_paths: Arc::new(search_paths),
-            resolver_environments: PythonVersion::iter()
-                .map(|version| (version, OnceLock::new()))
-                .collect(),
-        };
-
-        // Register the static roots for salsa durability
-        db.search_paths.try_register_static_roots(&db);
-
-        Ok(db)
+        }
     }
+}
+
+/// Resolve module search paths for the given source roots and Python environment.
+pub fn resolve_search_paths(
+    system: &dyn System,
+    src_roots: Vec<SystemPathBuf>,
+    venv_path: Option<SystemPathBuf>,
+) -> Result<SearchPaths> {
+    let mut search_path_settings = SearchPathSettings::new(src_roots);
+    // TODO: Consider calling `PythonEnvironment::discover` if the `venv_path` is not provided.
+    if let Some(venv_path) = venv_path {
+        let environment =
+            PythonEnvironment::new(venv_path, SysPrefixPathOrigin::PythonCliFlag, system)?;
+        search_path_settings.site_packages_paths = environment
+            .site_packages_paths(system)
+            .context("Failed to discover the site-packages directory")?
+            .into_vec();
+    }
+
+    search_path_settings
+        .to_search_paths(system, &EMPTY_VENDORED, &FallibleStrategy)
+        .context("Invalid search path settings")
 }
 
 #[salsa::db]

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use std::panic::RefUnwindSafe;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use zip::CompressionMethod;
 
 use ruff_db::Db as SourceDb;
@@ -8,6 +8,7 @@ use ruff_db::files::Files;
 use ruff_db::system::{System, SystemPathBuf};
 use ruff_db::vendored::{VendoredFileSystem, VendoredFileSystemBuilder};
 use ruff_python_ast::PythonVersion;
+use salsa::plumbing::{AsId, FromId, Id};
 use ty_module_resolver::{FallibleStrategy, ResolverEnvironment, SearchPathSettings, SearchPaths};
 use ty_site_packages::{PythonEnvironment, SysPrefixPathOrigin};
 
@@ -24,6 +25,8 @@ pub struct ModuleDb {
     files: Files,
     system: Arc<dyn System + Send + Sync + RefUnwindSafe>,
     search_paths: Arc<SearchPaths>,
+    /// All cloned databases share their Salsa storage, so their cached environment IDs remain valid.
+    resolver_environments: Arc<[(PythonVersion, OnceLock<Id>)]>,
 }
 
 impl ModuleDb {
@@ -31,7 +34,18 @@ impl ModuleDb {
         &self,
         python_version: PythonVersion,
     ) -> ResolverEnvironment<'_> {
-        ResolverEnvironment::new(self, python_version, self.search_paths.as_ref())
+        let Some((_, cached)) = self
+            .resolver_environments
+            .iter()
+            .find(|(version, _)| *version == python_version)
+        else {
+            return ResolverEnvironment::new(self, python_version, self.search_paths.as_ref());
+        };
+
+        let id = *cached.get_or_init(|| {
+            ResolverEnvironment::new(self, python_version, self.search_paths.as_ref()).as_id()
+        });
+        ResolverEnvironment::from_id(id)
     }
 
     /// Initialize a [`ModuleDb`] from the given source root.
@@ -62,6 +76,9 @@ impl ModuleDb {
             files: Files::default(),
             system: Arc::new(system),
             search_paths: Arc::new(search_paths),
+            resolver_environments: PythonVersion::iter()
+                .map(|version| (version, OnceLock::new()))
+                .collect(),
         };
 
         // Register the static roots for salsa durability

--- a/crates/ruff_graph/src/lib.rs
+++ b/crates/ruff_graph/src/lib.rs
@@ -48,7 +48,8 @@ impl ModuleImports {
 
         // Resolve the imports.
         let mut resolved_imports = ModuleImports::default();
-        let resolver = Resolver::new(db, path, python_version);
+        let environment = db.resolver_environment(python_version);
+        let resolver = Resolver::new(db, path, environment);
         for import in imports {
             for resolved in resolver.resolve(import) {
                 if let Some(path) = resolved.as_system_path() {

--- a/crates/ruff_graph/src/lib.rs
+++ b/crates/ruff_graph/src/lib.rs
@@ -3,11 +3,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::Result;
 
 use ruff_db::system::{SystemPath, SystemPathBuf};
+use ruff_linter::source_kind::SourceKind;
 use ruff_python_ast::helpers::to_module_path;
 use ruff_python_parser::{ParseOptions, parse};
+pub use ty_module_resolver::ResolverEnvironment;
 
 use crate::collector::Collector;
-pub use crate::db::ModuleDb;
+pub use crate::db::{ModuleDb, resolve_search_paths};
 use crate::resolver::Resolver;
 pub use crate::settings::{AnalyzeSettings, Direction, StringImports};
 
@@ -22,18 +24,19 @@ pub struct ModuleImports(BTreeSet<SystemPathBuf>);
 
 impl ModuleImports {
     /// Detect the [`ModuleImports`] for a given Python file.
-    pub fn detect(
-        db: &ModuleDb,
-        source: &str,
-        parse_options: ParseOptions,
+    pub fn detect<'db>(
+        db: &'db ModuleDb,
+        environment: ResolverEnvironment<'db>,
+        source: &SourceKind,
         path: &SystemPath,
         package: Option<&SystemPath>,
         string_imports: StringImports,
         type_checking_imports: bool,
     ) -> Result<Self> {
         // Parse the source code.
-        let python_version = parse_options.target_version();
-        let parsed = parse(source, parse_options)?;
+        let parse_options = ParseOptions::from(source.py_source_type())
+            .with_target_version(environment.python_version(db));
+        let parsed = parse(source.source_code(), parse_options)?;
 
         let module_path =
             package.and_then(|package| to_module_path(package.as_std_path(), path.as_std_path()));
@@ -48,7 +51,6 @@ impl ModuleImports {
 
         // Resolve the imports.
         let mut resolved_imports = ModuleImports::default();
-        let environment = db.resolver_environment(python_version);
         let resolver = Resolver::new(db, path, environment);
         for import in imports {
             for resolved in resolver.resolve(import) {

--- a/crates/ruff_graph/src/resolver.rs
+++ b/crates/ruff_graph/src/resolver.rs
@@ -1,10 +1,8 @@
-use ruff_db::PythonFile;
-use ruff_db::files::{FilePath, system_path_to_file};
+use ruff_db::files::{File, FilePath, system_path_to_file};
 use ruff_db::system::SystemPath;
-use ruff_python_ast::PythonVersion;
 use ty_module_resolver::{
-    ModuleName, resolve_module, resolve_module_confident, resolve_real_module,
-    resolve_real_module_confident,
+    ImportingFile, ModuleName, ResolverEnvironment, resolve_module, resolve_module_confident,
+    resolve_real_module, resolve_real_module_confident,
 };
 
 use crate::ModuleDb;
@@ -13,21 +11,23 @@ use crate::collector::CollectedImport;
 /// Collect all imports for a given Python file.
 pub(crate) struct Resolver<'a> {
     db: &'a ModuleDb,
-    file: Option<PythonFile<'a>>,
-    python_version: PythonVersion,
+    file: Option<File>,
+    environment: ResolverEnvironment<'a>,
 }
 
 impl<'a> Resolver<'a> {
     /// Initialize a [`Resolver`] with a given [`ModuleDb`].
-    pub(crate) fn new(db: &'a ModuleDb, path: &SystemPath, python_version: PythonVersion) -> Self {
+    pub(crate) fn new(
+        db: &'a ModuleDb,
+        path: &SystemPath,
+        environment: ResolverEnvironment<'a>,
+    ) -> Self {
         // If we know the importing file we can potentially resolve more imports
-        let file = system_path_to_file(db, path)
-            .ok()
-            .map(|file| PythonFile::new(db, file, python_version));
+        let file = system_path_to_file(db, path).ok();
         Self {
             db,
             file,
-            python_version,
+            environment,
         }
     }
 
@@ -110,9 +110,13 @@ impl<'a> Resolver<'a> {
     /// Resolves a module name to a module.
     fn resolve_module(&self, module_name: &ModuleName) -> Option<&'a FilePath> {
         let module = if let Some(file) = self.file {
-            resolve_module(self.db, file, module_name)?
+            resolve_module(
+                self.db,
+                ImportingFile::File(file, self.environment),
+                module_name,
+            )?
         } else {
-            resolve_module_confident(self.db, self.python_version, module_name)?
+            resolve_module_confident(self.db, self.environment, module_name)?
         };
         Some(module.file(self.db)?.path(self.db))
     }
@@ -120,9 +124,13 @@ impl<'a> Resolver<'a> {
     /// Resolves a module name to a module (stubs not allowed).
     fn resolve_real_module(&self, module_name: &ModuleName) -> Option<&'a FilePath> {
         let module = if let Some(file) = self.file {
-            resolve_real_module(self.db, file, module_name)?
+            resolve_real_module(
+                self.db,
+                ImportingFile::File(file, self.environment),
+                module_name,
+            )?
         } else {
-            resolve_real_module_confident(self.db, self.python_version, module_name)?
+            resolve_real_module_confident(self.db, self.environment, module_name)?
         };
         Some(module.file(self.db)?.path(self.db))
     }

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -409,17 +409,12 @@ impl MainLoop {
                             }
                         }
                         MainLoopMode::Fix(mode) => {
-                            let python_version = db.python_version();
                             let result = match mode {
-                                FixMode::AddIgnore => suppress_all_diagnostics(
-                                    db,
-                                    python_version,
-                                    result,
-                                    &self.cancellation_token,
-                                ),
+                                FixMode::AddIgnore => {
+                                    suppress_all_diagnostics(db, result, &self.cancellation_token)
+                                }
                                 FixMode::ApplyFixes => fix_all_diagnostics(
                                     db,
-                                    python_version,
                                     result,
                                     Applicability::Safe,
                                     &self.cancellation_token,

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -39,7 +39,7 @@ fn resolve_module_confident<'db>(
 ) -> Option<Module<'db>> {
     ty_module_resolver::resolve_module_confident(
         db,
-        Program::get(db).python_version(db),
+        Program::get(db).resolver_environment(db),
         module_name,
     )
 }

--- a/crates/ty_completion_bench/Cargo.toml
+++ b/crates/ty_completion_bench/Cargo.toml
@@ -16,7 +16,6 @@ ruff_text_size = { workspace = true }
 
 ty_ide = { workspace = true }
 ty_project = { workspace = true }
-ty_python_core = { workspace = true }
 
 anyhow = { workspace = true }
 bstr = { workspace = true }

--- a/crates/ty_completion_bench/Cargo.toml
+++ b/crates/ty_completion_bench/Cargo.toml
@@ -16,6 +16,7 @@ ruff_text_size = { workspace = true }
 
 ty_ide = { workspace = true }
 ty_project = { workspace = true }
+ty_python_core = { workspace = true }
 
 anyhow = { workspace = true }
 bstr = { workspace = true }

--- a/crates/ty_completion_bench/src/main.rs
+++ b/crates/ty_completion_bench/src/main.rs
@@ -17,8 +17,7 @@ use ty_ide::{Completion, CompletionCapabilities};
 use ty_project::metadata::Options;
 use ty_project::metadata::options::EnvironmentOptions;
 use ty_project::metadata::value::RelativePathBuf;
-use ty_project::{ProjectDatabase, ProjectMetadata};
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, ProjectMetadata, SemanticDb as _};
 
 #[derive(Debug, clap::Parser)]
 #[command(
@@ -143,7 +142,7 @@ fn get_completions<'db>(
         db,
         &settings,
         CompletionCapabilities::default(),
-        Program::get(db).program_file(db, file),
+        db.program_file(file),
         offset,
     ))
 }

--- a/crates/ty_completion_bench/src/main.rs
+++ b/crates/ty_completion_bench/src/main.rs
@@ -11,15 +11,14 @@ use std::process::ExitCode;
 use anyhow::{Context, anyhow};
 use clap::Parser;
 
-use ruff_db::PythonFile;
 use ruff_db::files::system_path_to_file;
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
 use ty_ide::{Completion, CompletionCapabilities};
-use ty_project::Db as _;
 use ty_project::metadata::Options;
 use ty_project::metadata::options::EnvironmentOptions;
 use ty_project::metadata::value::RelativePathBuf;
 use ty_project::{ProjectDatabase, ProjectMetadata};
+use ty_python_core::program::Program;
 
 #[derive(Debug, clap::Parser)]
 #[command(
@@ -144,7 +143,7 @@ fn get_completions<'db>(
         db,
         &settings,
         CompletionCapabilities::default(),
-        PythonFile::new(db, file, db.python_version()),
+        Program::get(db).program_file(db, file),
         offset,
     ))
 }

--- a/crates/ty_completion_eval/Cargo.toml
+++ b/crates/ty_completion_eval/Cargo.toml
@@ -17,7 +17,6 @@ ruff_text_size = { workspace = true }
 ty_ide = { workspace = true }
 ty_module_resolver = { workspace = true }
 ty_project = { workspace = true }
-ty_python_core = { workspace = true }
 
 anyhow = { workspace = true }
 bstr = { workspace = true }

--- a/crates/ty_completion_eval/Cargo.toml
+++ b/crates/ty_completion_eval/Cargo.toml
@@ -17,6 +17,7 @@ ruff_text_size = { workspace = true }
 ty_ide = { workspace = true }
 ty_module_resolver = { workspace = true }
 ty_project = { workspace = true }
+ty_python_core = { workspace = true }
 
 anyhow = { workspace = true }
 bstr = { workspace = true }

--- a/crates/ty_completion_eval/src/main.rs
+++ b/crates/ty_completion_eval/src/main.rs
@@ -10,16 +10,15 @@ use anyhow::{Context, anyhow};
 use clap::Parser;
 use regex::bytes::Regex;
 
-use ruff_db::PythonFile;
 use ruff_db::files::system_path_to_file;
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
 use ty_ide::{Completion, CompletionCapabilities};
 use ty_module_resolver::ModuleName;
-use ty_project::Db as _;
 use ty_project::metadata::Options;
 use ty_project::metadata::options::EnvironmentOptions;
 use ty_project::metadata::value::RelativePathBuf;
 use ty_project::{ProjectDatabase, ProjectMetadata};
+use ty_python_core::program::Program;
 
 #[derive(Debug, clap::Parser)]
 #[command(
@@ -332,7 +331,7 @@ impl Task {
             &self.db,
             &self.settings,
             CompletionCapabilities::default(),
-            PythonFile::new(&self.db, file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file),
             offset,
         );
         Ok(completions)

--- a/crates/ty_completion_eval/src/main.rs
+++ b/crates/ty_completion_eval/src/main.rs
@@ -17,8 +17,7 @@ use ty_module_resolver::ModuleName;
 use ty_project::metadata::Options;
 use ty_project::metadata::options::EnvironmentOptions;
 use ty_project::metadata::value::RelativePathBuf;
-use ty_project::{ProjectDatabase, ProjectMetadata};
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, ProjectMetadata, SemanticDb as _};
 
 #[derive(Debug, clap::Parser)]
 #[command(
@@ -331,7 +330,7 @@ impl Task {
             &self.db,
             &self.settings,
             CompletionCapabilities::default(),
-            Program::get(&self.db).program_file(&self.db, file),
+            self.db.program_file(file),
             offset,
         );
         Ok(completions)

--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -2,7 +2,7 @@ use compact_str::CompactString;
 use rayon::prelude::*;
 use ruff_db::files::File;
 use ty_module_resolver::{
-    ImportingFile, Module, ModuleName, ResolverFile, all_modules, resolve_real_shadowable_module,
+    ImportingFile, Module, ModuleName, all_modules, resolve_real_shadowable_module,
 };
 use ty_project::{Db, parallel::ParallelIteratorExt};
 use ty_python_core::ProgramFile;
@@ -18,7 +18,7 @@ use crate::{
 /// by the query.
 pub fn all_symbols<'db>(
     db: &'db dyn Db,
-    importing_from: ResolverFile<'db>,
+    importing_from: ProgramFile<'db>,
     query: &QueryPattern,
 ) -> Vec<AllSymbolInfo<'db>> {
     // If the query is empty, return immediately to avoid expensive file scanning
@@ -30,14 +30,11 @@ pub fn all_symbols<'db>(
     let _span = all_symbols_span.enter();
 
     let typing_extensions = ModuleName::new_static("typing_extensions").unwrap();
-    let resolver_environment = importing_from.environment(db);
+    let program = importing_from.program(db);
+    let resolver_environment = importing_from.resolver_environment(db);
+    let importing_file = ImportingFile::File(importing_from.file(db), resolver_environment);
     let is_typing_extensions_available = importing_from.file(db).is_stub(db)
-        || resolve_real_shadowable_module(
-            db,
-            ImportingFile::ResolverFile(importing_from),
-            &typing_extensions,
-        )
-        .is_some();
+        || resolve_real_shadowable_module(db, importing_file, &typing_extensions).is_some();
 
     let results = all_modules(db, resolver_environment)
         .into_par_iter()
@@ -67,7 +64,7 @@ pub fn all_symbols<'db>(
             let Some(file) = module.file(db) else {
                 return Vec::new();
             };
-            let program_file = ProgramFile::new(db, file, resolver_environment);
+            let program_file = ProgramFile::new(db, file, program);
 
             let symbols_for_file_span = tracing::debug_span!(
                 parent: &all_symbols_span,
@@ -719,7 +716,7 @@ def zqzqzq():
 
         let symbols = all_symbols(
             &test.db,
-            test.program_file(test.cursor.file).resolver_file(&test.db),
+            test.program_file(test.cursor.file),
             &QueryPattern::fuzzy("zqzqzq"),
         );
         let symbol = symbols
@@ -1121,7 +1118,7 @@ def test_helper_xyzxyzxyz():
         fn all_symbols(&self, query: &str) -> String {
             let symbols = all_symbols(
                 &self.db,
-                self.program_file(self.cursor.file).resolver_file(&self.db),
+                self.program_file(self.cursor.file),
                 &QueryPattern::fuzzy(query),
             );
 

--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -1,8 +1,11 @@
 use compact_str::CompactString;
 use rayon::prelude::*;
-use ruff_db::{PythonFile, files::File};
-use ty_module_resolver::{Module, ModuleName, all_modules, resolve_real_shadowable_module};
+use ruff_db::files::File;
+use ty_module_resolver::{
+    ImportingFile, Module, ModuleName, ResolverFile, all_modules, resolve_real_shadowable_module,
+};
 use ty_project::{Db, parallel::ParallelIteratorExt};
+use ty_python_core::ProgramFile;
 
 use crate::{
     SymbolKind,
@@ -15,7 +18,7 @@ use crate::{
 /// by the query.
 pub fn all_symbols<'db>(
     db: &'db dyn Db,
-    importing_from: PythonFile<'db>,
+    importing_from: ResolverFile<'db>,
     query: &QueryPattern,
 ) -> Vec<AllSymbolInfo<'db>> {
     // If the query is empty, return immediately to avoid expensive file scanning
@@ -27,10 +30,16 @@ pub fn all_symbols<'db>(
     let _span = all_symbols_span.enter();
 
     let typing_extensions = ModuleName::new_static("typing_extensions").unwrap();
+    let resolver_environment = importing_from.environment(db);
     let is_typing_extensions_available = importing_from.file(db).is_stub(db)
-        || resolve_real_shadowable_module(db, importing_from, &typing_extensions).is_some();
+        || resolve_real_shadowable_module(
+            db,
+            ImportingFile::ResolverFile(importing_from),
+            &typing_extensions,
+        )
+        .is_some();
 
-    let results = all_modules(db, importing_from.python_version(db))
+    let results = all_modules(db, resolver_environment)
         .into_par_iter()
         .map_with_db(db, |db, module| {
             let name = module.name(db);
@@ -55,10 +64,10 @@ pub fn all_symbols<'db>(
                 return Vec::new();
             }
 
-            let Some(python_file) = module.python_file(db) else {
+            let Some(file) = module.file(db) else {
                 return Vec::new();
             };
-            let file = python_file.file(db);
+            let program_file = ProgramFile::new(db, file, resolver_environment);
 
             let symbols_for_file_span = tracing::debug_span!(
                 parent: &all_symbols_span,
@@ -71,7 +80,7 @@ pub fn all_symbols<'db>(
             if query.is_match_symbol_name(module.name(db)) {
                 symbols.push(AllSymbolInfo::from_module(db, module, file));
             }
-            for (_, symbol) in symbols_for_file_global_only(db, python_file).search(query) {
+            for (_, symbol) in symbols_for_file_global_only(db, program_file).search(query) {
                 // Test functions (starting with `test_`) in third-party
                 // packages are almost never useful to import.
                 if is_non_first_party && symbol.name.starts_with("test_") {
@@ -710,7 +719,7 @@ def zqzqzq():
 
         let symbols = all_symbols(
             &test.db,
-            test.python_file(test.cursor.file),
+            test.program_file(test.cursor.file).resolver_file(&test.db),
             &QueryPattern::fuzzy("zqzqzq"),
         );
         let symbol = symbols
@@ -1112,7 +1121,7 @@ def test_helper_xyzxyzxyz():
         fn all_symbols(&self, query: &str) -> String {
             let symbols = all_symbols(
                 &self.db,
-                self.python_file(self.cursor.file),
+                self.program_file(self.cursor.file).resolver_file(&self.db),
                 &QueryPattern::fuzzy(query),
             );
 

--- a/crates/ty_ide/src/call_hierarchy.rs
+++ b/crates/ty_ide/src/call_hierarchy.rs
@@ -13,7 +13,6 @@ pub(crate) mod outgoing_calls;
 
 use crate::goto::{GotoTarget, find_goto_target};
 use crate::{Db, SymbolKind};
-use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::find_node::CoveringNode;
@@ -21,6 +20,8 @@ use ruff_python_ast::name::Name;
 use ruff_python_ast::token::Tokens;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use ty_module_resolver::ResolverFile;
+use ty_python_core::ProgramFile;
 use ty_python_core::definition::DefinitionKind;
 use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticModel};
 
@@ -33,10 +34,10 @@ use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticMode
 /// cursor on a specific `@overload def` yields just that one.
 pub fn prepare_call_hierarchy(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<Vec<CallHierarchyItem>> {
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let model = SemanticModel::new(db, file);
     let goto_target = find_goto_target(&model, &module, offset)?;
     let definitions = goto_target
@@ -109,7 +110,7 @@ impl CallHierarchyItem {
         Some(CallHierarchyItem {
             name: Name::new(name),
             kind,
-            detail: module_detail(db, def.python_file(db)),
+            detail: module_detail(db, def.program_file(db).resolver_file(db)),
             file: def_file,
             full_range: def.full_range(db, module).range(),
             selection_range: def.focus_range(db, module).range(),
@@ -117,7 +118,7 @@ impl CallHierarchyItem {
     }
 }
 
-fn module_detail(db: &dyn Db, file: PythonFile<'_>) -> Option<String> {
+fn module_detail(db: &dyn Db, file: ResolverFile<'_>) -> Option<String> {
     ty_module_resolver::file_to_module(db, file).map(|module| module.name(db).to_string())
 }
 
@@ -199,7 +200,7 @@ mod tests {
         pub(super) fn prepare_calls(&self) -> Option<Vec<CallHierarchyItem>> {
             prepare_call_hierarchy(
                 &self.db,
-                self.python_file(self.cursor.file),
+                self.program_file(self.cursor.file),
                 self.cursor.offset,
             )
         }

--- a/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
@@ -3,7 +3,6 @@ use crate::goto::{Definitions, GotoTarget, find_goto_target};
 use crate::references::has_any_external_visible_definitions;
 use crate::{CallHierarchyItem, Db, SymbolKind};
 use rayon::prelude::*;
-use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::helpers::is_dunder;
@@ -13,7 +12,9 @@ use ruff_python_ast::visitor::source_order::{SourceOrderVisitor, TraversalSignal
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use rustc_hash::FxHashMap;
+use ty_module_resolver::ResolverFile;
 use ty_project::parallel::{ParallelIteratorExt, minimum_parallel_job_len};
+use ty_python_core::ProgramFile;
 use ty_python_core::scope::{NodeWithScopeKind, ScopeKind};
 use ty_python_semantic::types::ide_support::static_member_type_for_attribute;
 use ty_python_semantic::types::{PropertyAccessorRole, Type};
@@ -29,8 +30,8 @@ const MAX_MIN_FILES_PER_PARALLEL_JOB: usize = 16;
 
 /// Find every place in the project that calls the symbol at `offset`, grouped
 /// by enclosing function/method/class/module.
-pub fn incoming_calls(db: &dyn Db, file: PythonFile<'_>, offset: TextSize) -> Vec<IncomingCall> {
-    let module = parsed_module(db, file).load(db);
+pub fn incoming_calls(db: &dyn Db, file: ProgramFile<'_>, offset: TextSize) -> Vec<IncomingCall> {
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let source_file = file.file(db);
     let model = SemanticModel::new(db, file);
     let Some(goto_target) = find_goto_target(&model, &module, offset) else {
@@ -75,8 +76,8 @@ pub fn incoming_calls(db: &dyn Db, file: PythonFile<'_>, offset: TextSize) -> Ve
     let mut raw = call_sites_for_file(db, file, &target_definitions, target_role, needle);
 
     if is_externally_visible {
+        let resolver_environment = model.program_environment().resolver_environment(db);
         let files = db.project().files(db);
-        let python_version = file.python_version(db);
         let files: Vec<_> = files
             .iter()
             .copied()
@@ -103,7 +104,7 @@ pub fn incoming_calls(db: &dyn Db, file: PythonFile<'_>, offset: TextSize) -> Ve
 
                 call_sites_for_file(
                     db,
-                    PythonFile::new(db, other_file, python_version),
+                    ProgramFile::new(db, other_file, resolver_environment),
                     &target_definitions,
                     target_role,
                     needle,
@@ -170,12 +171,12 @@ struct EnclosingKey {
 /// `target_definitions`.
 fn call_sites_for_file(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     target_definitions: &Definitions<'_>,
     target_role: Option<PropertyAccessorRole>,
     needle: Option<&str>,
 ) -> Vec<RawCallSite> {
-    let parsed = parsed_module(db, file);
+    let parsed = parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
     let model = SemanticModel::new(db, file);
     let mut sites = Vec::new();
@@ -390,8 +391,9 @@ impl<'a> CallSitesFinder<'a, '_> {
     /// method's AST node. Comprehension and annotation scopes have no callable
     /// hierarchy item of their own, so walk outward until reaching one that does.
     fn enclosing_scope_item(&self, scope_node: AnyNodeRef<'_>) -> CallHierarchyItem {
-        let python_file = self.model.python_file();
-        let file = python_file.file(self.db);
+        let program_file = self.model.program_file();
+        let resolver_file = program_file.resolver_file(self.db);
+        let file = program_file.file(self.db);
         let mut ancestors = self.model.ancestor_scopes(scope_node);
         let Some((_, enclosing)) = ancestors.find(|(_, ancestor)| {
             matches!(
@@ -399,11 +401,11 @@ impl<'a> CallSitesFinder<'a, '_> {
                 ScopeKind::Module | ScopeKind::Function | ScopeKind::Class | ScopeKind::Lambda
             )
         }) else {
-            return module_item(self.db, python_file);
+            return module_item(self.db, resolver_file);
         };
 
         match enclosing.node() {
-            NodeWithScopeKind::Module => module_item(self.db, python_file),
+            NodeWithScopeKind::Module => module_item(self.db, resolver_file),
             NodeWithScopeKind::Function(func) => {
                 let func = func.node(self.module);
                 let is_method = ancestors
@@ -422,7 +424,7 @@ impl<'a> CallSitesFinder<'a, '_> {
                     } else {
                         SymbolKind::Function
                     },
-                    detail: module_detail(self.db, python_file),
+                    detail: module_detail(self.db, resolver_file),
                     file,
                     full_range: func.range(),
                     selection_range: func.name.range(),
@@ -433,7 +435,7 @@ impl<'a> CallSitesFinder<'a, '_> {
                 CallHierarchyItem {
                     name: class.name.id.clone(),
                     kind: SymbolKind::Class,
-                    detail: module_detail(self.db, python_file),
+                    detail: module_detail(self.db, resolver_file),
                     file,
                     full_range: class.range(),
                     selection_range: class.name.range(),
@@ -450,13 +452,13 @@ impl<'a> CallSitesFinder<'a, '_> {
                 CallHierarchyItem {
                     name: Name::new_static("(lambda)"),
                     kind: SymbolKind::Function,
-                    detail: module_detail(self.db, python_file),
+                    detail: module_detail(self.db, resolver_file),
                     file,
                     full_range: lambda.range(),
                     selection_range: TextRange::new(lambda.start(), end),
                 }
             }
-            _ => module_item(self.db, python_file),
+            _ => module_item(self.db, resolver_file),
         }
     }
 }
@@ -467,7 +469,7 @@ struct RawCallSite {
 }
 
 /// Build an item for the module-level enclosing scope (no enclosing function).
-fn module_item(db: &dyn Db, file: PythonFile<'_>) -> CallHierarchyItem {
+fn module_item(db: &dyn Db, file: ResolverFile<'_>) -> CallHierarchyItem {
     let name = ty_module_resolver::file_to_module(db, file)
         .map(|module| Name::new(module.name(db).last_component()))
         .unwrap_or_else(|| Name::new_static("<module>"));
@@ -527,7 +529,7 @@ mod tests {
             };
             let calls = incoming_calls(
                 &self.db,
-                self.python_file(target.file),
+                self.program_file(target.file),
                 target.selection_range.start(),
             );
             if calls.is_empty() {
@@ -1147,7 +1149,7 @@ def make() -> C:
         };
         let incoming = incoming_calls(
             &test.db,
-            test.python_file(target.file),
+            test.program_file(target.file),
             target.selection_range.start(),
         );
         // The selection identifies the anonymous callable header.
@@ -1280,7 +1282,7 @@ def make() -> C:
         };
         let incoming = incoming_calls(
             &test.db,
-            test.python_file(target.file),
+            test.program_file(target.file),
             target.selection_range.start(),
         );
         assert_eq!(incoming.len(), 1, "got {incoming:?}");
@@ -1289,7 +1291,7 @@ def make() -> C:
 
         let follow_up_incoming = incoming_calls(
             &test.db,
-            test.python_file(lambda_item.file),
+            test.program_file(lambda_item.file),
             lambda_item.selection_range.start(),
         );
         assert!(
@@ -1299,7 +1301,7 @@ def make() -> C:
 
         let follow_up_outgoing = outgoing_calls(
             &test.db,
-            test.python_file(lambda_item.file),
+            test.program_file(lambda_item.file),
             lambda_item.selection_range.start(),
         );
         assert!(

--- a/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
@@ -76,7 +76,7 @@ pub fn incoming_calls(db: &dyn Db, file: ProgramFile<'_>, offset: TextSize) -> V
     let mut raw = call_sites_for_file(db, file, &target_definitions, target_role, needle);
 
     if is_externally_visible {
-        let resolver_environment = model.program_environment().resolver_environment(db);
+        let program = model.program();
         let files = db.project().files(db);
         let files: Vec<_> = files
             .iter()
@@ -104,7 +104,7 @@ pub fn incoming_calls(db: &dyn Db, file: ProgramFile<'_>, offset: TextSize) -> V
 
                 call_sites_for_file(
                     db,
-                    ProgramFile::new(db, other_file, resolver_environment),
+                    ProgramFile::new(db, other_file, program),
                     &target_definitions,
                     target_role,
                     needle,

--- a/crates/ty_ide/src/call_hierarchy/outgoing_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/outgoing_calls.rs
@@ -3,7 +3,6 @@ use std::collections::hash_map::Entry;
 use crate::call_hierarchy::CalleeLeaf;
 use crate::goto::find_goto_target;
 use crate::{CallHierarchyItem, Db};
-use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::token::Tokens;
@@ -16,6 +15,7 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashMap;
+use ty_python_core::ProgramFile;
 use ty_python_core::definition::DefinitionKind;
 use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 
@@ -30,8 +30,8 @@ use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 /// are reported when the nested callable is expanded separately. Declaration
 /// expressions attached to a nested callable are still included while
 /// traversing the containing item's body.
-pub fn outgoing_calls(db: &dyn Db, file: PythonFile<'_>, offset: TextSize) -> Vec<OutgoingCall> {
-    let module = parsed_module(db, file).load(db);
+pub fn outgoing_calls(db: &dyn Db, file: ProgramFile<'_>, offset: TextSize) -> Vec<OutgoingCall> {
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let model = SemanticModel::new(db, file);
     let Some(goto_target) = find_goto_target(&model, &module, offset) else {
         return Vec::new();
@@ -54,7 +54,7 @@ pub fn outgoing_calls(db: &dyn Db, file: PythonFile<'_>, offset: TextSize) -> Ve
         };
         let parsed = parsed_module(db, def.python_file(db)).load(db);
 
-        let model = SemanticModel::new(db, def.python_file(db));
+        let model = SemanticModel::new(db, def.program_file(db));
         let mut finder = OutgoingCallsFinder {
             db,
             model: &model,
@@ -306,7 +306,7 @@ mod tests {
             };
             let calls = outgoing_calls(
                 &self.db,
-                self.python_file(target.file),
+                self.program_file(target.file),
                 target.selection_range.start(),
             );
             if calls.is_empty() {

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -2,11 +2,11 @@ use crate::completion;
 
 use ruff_db::parsed::parsed_module;
 
-use ruff_db::PythonFile;
 use ruff_diagnostics::Edit;
 use ruff_python_ast::find_node::covering_node;
 use ruff_text_size::TextRange;
 use ty_project::Db;
+use ty_python_core::ProgramFile;
 use ty_python_semantic::lint::LintId;
 use ty_python_semantic::suppress_single;
 use ty_python_semantic::types::{UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
@@ -21,7 +21,7 @@ pub struct QuickFix {
 
 pub fn code_actions(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     diagnostic_range: TextRange,
     diagnostic_id: &str,
 ) -> Vec<QuickFix> {
@@ -44,7 +44,7 @@ pub fn code_actions(
     // Suggest just suppressing the lint (always a valid option, but never ideal)
     actions.push(QuickFix {
         title: format!("Ignore '{}' for this line", lint_id.name()),
-        edits: suppress_single(db, file, lint_id, diagnostic_range).into_edits(),
+        edits: suppress_single(db, file.python_file(db), lint_id, diagnostic_range).into_edits(),
         preferred: false,
     });
 
@@ -53,10 +53,10 @@ pub fn code_actions(
 
 fn unresolved_fixes(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     diagnostic_range: TextRange,
 ) -> Option<impl Iterator<Item = QuickFix>> {
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = parsed_module(db, file.python_file(db)).load(db);
     let node = covering_node(parsed.syntax().into(), diagnostic_range).node();
     let symbol = &node.expr_name()?.id;
     Some(
@@ -77,7 +77,6 @@ mod tests {
 
     use insta::assert_snapshot;
     use ruff_db::{
-        PythonFile,
         diagnostic::{
             Annotation, Diagnostic, DiagnosticFormat, DiagnosticId, DisplayDiagnosticConfig,
             LintName, Span, SubDiagnostic,
@@ -89,6 +88,7 @@ mod tests {
     use ruff_python_trivia::textwrap::dedent;
     use ruff_text_size::{TextRange, TextSize};
     use ty_project::ProjectMetadata;
+    use ty_python_core::ProgramFile;
     use ty_python_semantic::{
         default_lint_registry,
         lint::LintMetadata,
@@ -936,7 +936,11 @@ mod tests {
 
             for mut action in code_actions(
                 &self.db,
-                PythonFile::new(&self.db, self.file, self.db.python_version()),
+                ProgramFile::new(
+                    &self.db,
+                    self.file,
+                    self.db.program_environment().program(&self.db),
+                ),
                 self.diagnostic_range,
                 &lint.name,
             ) {

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -15,7 +15,7 @@ use ruff_python_codegen::Stylist;
 use ruff_python_literal::escape::{Escape, UnicodeEscape};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::{ImportingFile, KnownModule, Module, ModuleName, ResolverFile};
+use ty_module_resolver::{ImportingFile, KnownModule, Module, ModuleName};
 use ty_python_core::ProgramFile;
 use ty_python_semantic::HasType;
 use ty_python_semantic::types::{SpecialFormType, UnionType};
@@ -42,8 +42,7 @@ pub fn completion<'db>(
     let file = file.file(db);
     let source = source_text(db, file);
 
-    let Some(context) = Context::new(db, program_file.resolver_file(db), &parsed, &source, offset)
-    else {
+    let Some(context) = Context::new(db, program_file, &parsed, &source, offset) else {
         return vec![];
     };
     let model = SemanticModel::new(db, program_file);
@@ -789,7 +788,7 @@ impl<'m> Context<'m> {
     /// Create a new context for finding completions.
     fn new(
         db: &'_ dyn Db,
-        file: ResolverFile<'_>,
+        file: ProgramFile<'_>,
         parsed: &'m ParsedModuleRef,
         source: &'m SourceText,
         offset: TextSize,
@@ -803,7 +802,11 @@ impl<'m> Context<'m> {
             ContextKind::Keywords(keywords)
         } else if cursor.is_in_definition_place() {
             return None;
-        } else if let Some(import) = ImportStatement::detect(db, file, &cursor) {
+        } else if let Some(import) = ImportStatement::detect(
+            db,
+            ImportingFile::File(file.file(db), file.resolver_environment(db)),
+            &cursor,
+        ) {
             ContextKind::Import(import)
         } else {
             let target_token = CompletionTargetTokens::find(&cursor)?;
@@ -2296,9 +2299,9 @@ fn add_unimported_completions<'db>(
     let stylist = Stylist::from_tokens(parsed.tokens(), source.as_str());
     let importer = Importer::new(db, &stylist, file, source.as_str(), parsed);
     let members = importer.members_in_scope_at(scoped.node, scoped.node.start());
-    let resolver_file = file.resolver_file(db);
+    let importing_file = ImportingFile::File(source_file, file.resolver_environment(db));
 
-    for symbol in all_symbols(db, resolver_file, &completions.query.pattern) {
+    for symbol in all_symbols(db, file, &completions.query.pattern) {
         if symbol.file() == source_file || symbol.module().is_known(db, KnownModule::Builtins) {
             continue;
         }
@@ -2313,7 +2316,7 @@ fn add_unimported_completions<'db>(
             });
 
         // Don't suggest symbols that are already imported.
-        if members.satisfies(db, resolver_file, &request) {
+        if members.satisfies(db, importing_file, &request) {
             continue;
         }
 
@@ -2578,7 +2581,7 @@ impl<'a> ImportStatement<'a> {
     /// `tokens`.
     fn detect(
         db: &'_ dyn Db,
-        file: ResolverFile<'_>,
+        file: ImportingFile<'_>,
         cursor: &ContextCursor<'a>,
     ) -> Option<ImportStatement<'a>> {
         use TokenKind as TK;
@@ -2944,12 +2947,7 @@ impl<'a> ImportStatement<'a> {
                         let import_keyword_allowed =
                             all_dots || !to_complete_without_leading_dots.contains('.');
                         let parent = if all_dots {
-                            ModuleName::from_import_statement(
-                                db,
-                                ImportingFile::ResolverFile(file),
-                                ast,
-                            )
-                            .ok()?
+                            ModuleName::from_import_statement(db, file, ast).ok()?
                         } else {
                             // We know `to_complete` is not all dots.
                             // But that it starts with a dot.
@@ -2963,13 +2961,7 @@ impl<'a> ImportStatement<'a> {
                             let parent = to_complete_without_leading_dots
                                 .rsplit_once('.')
                                 .map(|(parent, _)| parent);
-                            ModuleName::from_identifier_parts(
-                                db,
-                                ImportingFile::ResolverFile(file),
-                                parent,
-                                ast.level,
-                            )
-                            .ok()?
+                            ModuleName::from_identifier_parts(db, file, parent, ast.level).ok()?
                         };
                         FromImportKind::Relative {
                             parent,

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3,7 +3,6 @@ use std::collections::{BinaryHeap, binary_heap};
 use ty_python_semantic::ProgramEnvironment;
 
 use compact_str::{CompactString, CompactStringExt};
-use ruff_db::PythonFile;
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_db::source::{SourceText, source_text};
 use ruff_diagnostics::Edit;
@@ -16,7 +15,8 @@ use ruff_python_codegen::Stylist;
 use ruff_python_literal::escape::{Escape, UnicodeEscape};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::{KnownModule, Module, ModuleName};
+use ty_module_resolver::{ImportingFile, KnownModule, Module, ModuleName, ResolverFile};
+use ty_python_core::ProgramFile;
 use ty_python_semantic::HasType;
 use ty_python_semantic::types::{SpecialFormType, UnionType};
 use ty_python_semantic::{
@@ -34,18 +34,19 @@ pub fn completion<'db>(
     db: &'db dyn Db,
     settings: &CompletionSettings,
     capabilities: CompletionCapabilities,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     offset: TextSize,
 ) -> Vec<Completion<'db>> {
-    let python_file = file;
-    let parsed = parsed_module(db, file).load(db);
+    let program_file = file;
+    let parsed = parsed_module(db, file.python_file(db)).load(db);
     let file = file.file(db);
     let source = source_text(db, file);
 
-    let Some(context) = Context::new(db, python_file, &parsed, &source, offset) else {
+    let Some(context) = Context::new(db, program_file.resolver_file(db), &parsed, &source, offset)
+    else {
         return vec![];
     };
-    let model = SemanticModel::new(db, python_file);
+    let model = SemanticModel::new(db, program_file);
 
     if !matches!(context.kind, ContextKind::Keywords(_)) && context.cursor.is_in_string() {
         let Some(string_expr) = context.cursor.enclosing_string_literal_expr() else {
@@ -54,7 +55,7 @@ pub fn completion<'db>(
 
         let mut completions = Completions::new(
             db,
-            python_file,
+            program_file,
             CollectionContext::none(),
             UserQuery::fuzzy(None),
         );
@@ -72,7 +73,7 @@ pub fn completion<'db>(
     let query = UserQuery::fuzzy(context.cursor.typed);
     let mut completions = Completions::new(
         db,
-        python_file,
+        program_file,
         context.collection_context(db, &model, settings, capabilities),
         query,
     );
@@ -84,7 +85,7 @@ pub fn completion<'db>(
             }
         }
         ContextKind::Import(ref import) => {
-            import.add_completions(db, python_file, &mut completions);
+            import.add_completions(db, program_file, &mut completions);
         }
         ContextKind::NonImport(ref non_import) => match non_import.target {
             CompletionTargetAst::ObjectDot { expr } => {
@@ -106,7 +107,7 @@ pub fn completion<'db>(
                 add_keyword_completions(db, &env, &mut completions);
                 add_argument_completions(
                     db,
-                    python_file,
+                    program_file,
                     &model,
                     &context.cursor,
                     &mut completions,
@@ -114,7 +115,7 @@ pub fn completion<'db>(
                 if settings.auto_import {
                     add_unimported_completions(
                         db,
-                        python_file,
+                        program_file,
                         &parsed,
                         scoped,
                         |module_name: &ModuleName, symbol: &str| {
@@ -146,7 +147,7 @@ impl CompletionCapabilities {
 /// A collection of completions built up from various sources.
 struct Completions<'db> {
     db: &'db dyn Db,
-    python_file: PythonFile<'db>,
+    program_file: ProgramFile<'db>,
     context: CollectionContext<'db>,
     items: BinaryHeap<CompletionRanker<'db>>,
     /// The query used to match against candidate completions.
@@ -172,13 +173,13 @@ impl<'db> Completions<'db> {
     /// add completions that match it.
     fn new(
         db: &'db dyn Db,
-        python_file: PythonFile<'db>,
+        program_file: ProgramFile<'db>,
         context: CollectionContext<'db>,
         query: UserQuery,
     ) -> Completions<'db> {
         Completions {
             db,
-            python_file,
+            program_file,
             context,
             items: BinaryHeap::new(),
             query,
@@ -274,7 +275,7 @@ impl<'db> Completions<'db> {
             return false;
         }
         let completion =
-            CompletionRanker(builder.build(self.db, self.python_file, &self.context, &self.query));
+            CompletionRanker(builder.build(self.db, self.program_file, &self.context, &self.query));
         if self.items.len() >= Completions::LIMIT {
             // OK because `self.items` is guaranteed to be non-empty here.
             let worst = self.items.peek_mut().unwrap();
@@ -294,7 +295,7 @@ impl<'db> Extend<SemanticCompletion<'db>> for Completions<'db> {
         T: IntoIterator<Item = SemanticCompletion<'db>>,
     {
         let db = self.db;
-        let env = ProgramEnvironment::from_file(self.python_file);
+        let env = ProgramEnvironment::from_file(self.program_file);
         for c in it {
             self.add_semantic(db, &env, c);
         }
@@ -487,7 +488,7 @@ impl<'db> CompletionBuilder<'db> {
     fn build(
         mut self,
         db: &'db dyn Db,
-        python_file: PythonFile<'db>,
+        program_file: ProgramFile<'db>,
         collection_context: &CollectionContext<'db>,
         query: &UserQuery,
     ) -> Completion<'db> {
@@ -501,7 +502,7 @@ impl<'db> CompletionBuilder<'db> {
             // but aren't marked here. That is, false negatives are
             // possible but false positives are not.
             if let Some(exception_ty) = collection_context.exception_ty {
-                let env = ProgramEnvironment::from_file(python_file);
+                let env = ProgramEnvironment::from_file(program_file);
                 self.is_context_specific |= ty.is_assignable_to(db, &env, exception_ty);
             }
             if collection_context.is_in_class_def() {
@@ -788,7 +789,7 @@ impl<'m> Context<'m> {
     /// Create a new context for finding completions.
     fn new(
         db: &'_ dyn Db,
-        file: PythonFile<'_>,
+        file: ResolverFile<'_>,
         parsed: &'m ParsedModuleRef,
         source: &'m SourceText,
         offset: TextSize,
@@ -1964,7 +1965,7 @@ enum Sort {
 /// Detect and add completions for unset arguments.
 fn add_argument_completions<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     model: &SemanticModel<'db>,
     cursor: &ContextCursor<'_>,
     completions: &mut Completions<'db>,
@@ -2052,7 +2053,7 @@ fn add_class_arg_completions<'db>(
 /// set and 2) been defined as positional-only.
 fn add_function_arg_completions<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     cursor: &ContextCursor<'_>,
     completions: &mut Completions<'db>,
 ) {
@@ -2133,7 +2134,7 @@ pub(crate) struct ImportEdit {
 /// Get fixes that would resolve an unresolved reference
 pub(crate) fn unresolved_fixes<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     parsed: &ParsedModuleRef,
     symbol: &str,
     node: AnyNodeRef,
@@ -2276,7 +2277,7 @@ fn add_string_literal_completions<'db>(
 /// when selected into `File`.
 fn add_unimported_completions<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     parsed: &ParsedModuleRef,
     scoped: ScopedTarget<'_>,
     create_import_request: impl for<'a> Fn(&'a ModuleName, &'a str) -> ImportRequest<'a>,
@@ -2295,8 +2296,9 @@ fn add_unimported_completions<'db>(
     let stylist = Stylist::from_tokens(parsed.tokens(), source.as_str());
     let importer = Importer::new(db, &stylist, file, source.as_str(), parsed);
     let members = importer.members_in_scope_at(scoped.node, scoped.node.start());
+    let resolver_file = file.resolver_file(db);
 
-    for symbol in all_symbols(db, file, &completions.query.pattern) {
+    for symbol in all_symbols(db, resolver_file, &completions.query.pattern) {
         if symbol.file() == source_file || symbol.module().is_known(db, KnownModule::Builtins) {
             continue;
         }
@@ -2311,7 +2313,7 @@ fn add_unimported_completions<'db>(
             });
 
         // Don't suggest symbols that are already imported.
-        if members.satisfies(db, file, &request) {
+        if members.satisfies(db, resolver_file, &request) {
             continue;
         }
 
@@ -2576,7 +2578,7 @@ impl<'a> ImportStatement<'a> {
     /// `tokens`.
     fn detect(
         db: &'_ dyn Db,
-        file: PythonFile<'_>,
+        file: ResolverFile<'_>,
         cursor: &ContextCursor<'a>,
     ) -> Option<ImportStatement<'a>> {
         use TokenKind as TK;
@@ -2942,7 +2944,12 @@ impl<'a> ImportStatement<'a> {
                         let import_keyword_allowed =
                             all_dots || !to_complete_without_leading_dots.contains('.');
                         let parent = if all_dots {
-                            ModuleName::from_import_statement(db, file, ast).ok()?
+                            ModuleName::from_import_statement(
+                                db,
+                                ImportingFile::ResolverFile(file),
+                                ast,
+                            )
+                            .ok()?
                         } else {
                             // We know `to_complete` is not all dots.
                             // But that it starts with a dot.
@@ -2956,7 +2963,13 @@ impl<'a> ImportStatement<'a> {
                             let parent = to_complete_without_leading_dots
                                 .rsplit_once('.')
                                 .map(|(parent, _)| parent);
-                            ModuleName::from_identifier_parts(db, file, parent, ast.level).ok()?
+                            ModuleName::from_identifier_parts(
+                                db,
+                                ImportingFile::ResolverFile(file),
+                                parent,
+                                ast.level,
+                            )
+                            .ok()?
                         };
                         FromImportKind::Relative {
                             parent,
@@ -2974,7 +2987,7 @@ impl<'a> ImportStatement<'a> {
     fn add_completions<'db>(
         &self,
         db: &'db dyn Db,
-        file: PythonFile<'db>,
+        file: ProgramFile<'db>,
         completions: &mut Completions<'db>,
     ) {
         let model = SemanticModel::new(db, file);
@@ -3071,7 +3084,7 @@ fn add_import_completions_impl<'db>(
     semantic_completions: impl IntoIterator<Item = SemanticCompletion<'db>>,
     module_dependency_kind: impl Fn(&SemanticCompletion<'db>) -> Option<ModuleDependencyKind>,
 ) {
-    let env = ProgramEnvironment::from_file(completions.python_file);
+    let env = ProgramEnvironment::from_file(completions.program_file);
     for semantic in semantic_completions {
         let module_dependency_kind = module_dependency_kind(&semantic);
         let mut builder = CompletionBuilder::from_semantic_completion(db, &env, semantic);
@@ -10877,7 +10890,7 @@ raise <CURSOR>
                 &self.cursor_test.db,
                 &self.settings,
                 self.capabilities,
-                self.cursor_test.python_file(self.cursor_test.cursor.file),
+                self.cursor_test.program_file(self.cursor_test.cursor.file),
                 self.cursor_test.cursor.offset,
             );
             let filtered = original

--- a/crates/ty_ide/src/doc_highlights.rs
+++ b/crates/ty_ide/src/doc_highlights.rs
@@ -1,18 +1,18 @@
 use crate::goto::find_goto_target;
 use crate::references::{ReferencesMode, references};
 use crate::{Db, ReferenceTarget};
-use ruff_db::PythonFile;
 use ruff_text_size::TextSize;
+use ty_python_core::ProgramFile;
 use ty_python_semantic::SemanticModel;
 
 /// Find all document highlights for a symbol at the given position.
 /// Document highlights are limited to the current file only.
 pub fn document_highlights(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<Vec<ReferenceTarget>> {
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+    let parsed = ruff_db::parsed::parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
     let model = SemanticModel::new(db, file);
 
@@ -36,7 +36,7 @@ mod tests {
         fn document_highlights(&self) -> String {
             let Some(highlight_results) = document_highlights(
                 &self.db,
-                self.python_file(self.cursor.file),
+                self.program_file(self.cursor.file),
                 self.cursor.offset,
             ) else {
                 return "No highlights found".to_string();

--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -1,9 +1,9 @@
 use crate::symbols::{FlatSymbols, symbols_for_file};
-use ruff_db::PythonFile;
 use ty_project::Db;
+use ty_python_core::ProgramFile;
 
 /// Get all document symbols for a file with the given options.
-pub fn document_symbols<'db>(db: &'db dyn Db, file: PythonFile<'db>) -> &'db FlatSymbols {
+pub fn document_symbols<'db>(db: &'db dyn Db, file: ProgramFile<'db>) -> &'db FlatSymbols {
     symbols_for_file(db, file)
 }
 
@@ -405,7 +405,7 @@ def function():
 <CURSOR>",
         );
 
-        let symbols = document_symbols(&test.db, test.python_file(test.cursor.file))
+        let symbols = document_symbols(&test.db, test.program_file(test.cursor.file))
             .iter()
             .map(|(_, symbol)| (symbol.name.into_owned(), symbol.kind))
             .collect::<Vec<_>>();
@@ -442,7 +442,7 @@ lambda_value = lambda: (lambda_local := 1)
 <CURSOR>",
         );
 
-        let names = document_symbols(&test.db, test.python_file(test.cursor.file))
+        let names = document_symbols(&test.db, test.program_file(test.cursor.file))
             .iter()
             .map(|(_, symbol)| symbol.name.into_owned())
             .collect::<Vec<_>>();
@@ -464,7 +464,7 @@ class Example((class_base := Base)):
 <CURSOR>",
         );
 
-        let symbols = document_symbols(&test.db, test.python_file(test.cursor.file))
+        let symbols = document_symbols(&test.db, test.program_file(test.cursor.file))
             .iter()
             .map(|(_, symbol)| (symbol.name.into_owned(), symbol.kind))
             .collect::<Vec<_>>();
@@ -487,7 +487,7 @@ class Example((class_base := Base)):
     impl CursorTest {
         fn document_symbols(&self) -> String {
             let symbols =
-                document_symbols(&self.db, self.python_file(self.cursor.file)).to_hierarchical();
+                document_symbols(&self.db, self.program_file(self.cursor.file)).to_hierarchical();
 
             if symbols.is_empty() {
                 return "No symbols found".to_string();

--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -1,19 +1,19 @@
 use crate::goto::find_goto_target;
 use crate::references::{ReferencesMode, references};
 use crate::{Db, ReferenceTarget};
-use ruff_db::PythonFile;
 use ruff_text_size::TextSize;
+use ty_python_core::ProgramFile;
 use ty_python_semantic::SemanticModel;
 
 /// Find all references to a symbol at the given position.
 /// Search for references across all files in the project.
 pub fn find_references(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
     include_declaration: bool,
 ) -> Option<Vec<ReferenceTarget>> {
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+    let parsed = ruff_db::parsed::parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
     let model = SemanticModel::new(db, file);
 
@@ -48,7 +48,7 @@ mod tests {
         fn references_with_include_declaration(&self, include_declaration: bool) -> String {
             let Some(mut reference_results) = find_references(
                 &self.db,
-                self.python_file(self.cursor.file),
+                self.program_file(self.cursor.file),
                 self.cursor.offset,
                 include_declaration,
             ) else {

--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -2579,7 +2579,11 @@ with open("file.txt") as f:
 
     impl CursorTest {
         fn folding_ranges(&self) -> String {
-            let ranges = folding_ranges(&self.db, self.python_file(self.cursor.file), None);
+            let ranges = folding_ranges(
+                &self.db,
+                self.program_file(self.cursor.file).python_file(&self.db),
+                None,
+            );
 
             if ranges.is_empty() {
                 return "No folding ranges found".to_string();

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -14,6 +14,7 @@ use ruff_python_ast::token::{Token, TokenAt, TokenKind, Tokens};
 use ruff_python_ast::{self as ast, AnyNodeRef, ExprRef};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
+use ty_python_core::ProgramFile;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_semantic::types::Type;
 use ty_python_semantic::types::ide_support::{
@@ -265,7 +266,7 @@ impl<'db> Definitions<'db> {
         let ty_def = ty.definition(db, env)?;
         let resolved = match ty_def {
             ty_python_semantic::types::TypeDefinition::Module(module) => {
-                ResolvedDefinition::Module(module.python_file(db)?)
+                ResolvedDefinition::Module(ProgramFile::new(db, module.file(db)?, env.program(db)))
             }
             ty_python_semantic::types::TypeDefinition::StaticClass(definition)
             | ty_python_semantic::types::TypeDefinition::DynamicClass(definition)
@@ -1451,7 +1452,11 @@ fn definitions_for_module<'db>(
     level: u32,
 ) -> Option<Vec<ResolvedDefinition<'db>>> {
     let module = model.resolve_module(module, level)?;
-    let file = module.python_file(model.db())?;
+    let file = ProgramFile::new(
+        model.db(),
+        module.file(model.db())?,
+        model.program_environment().program(model.db()),
+    );
     Some(vec![ResolvedDefinition::Module(file)])
 }
 

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -1452,11 +1452,7 @@ fn definitions_for_module<'db>(
     level: u32,
 ) -> Option<Vec<ResolvedDefinition<'db>>> {
     let module = model.resolve_module(module, level)?;
-    let file = ProgramFile::new(
-        model.db(),
-        module.file(model.db())?,
-        model.program_environment().program(model.db()),
-    );
+    let file = ProgramFile::new(model.db(), module.file(model.db())?, model.program());
     Some(vec![ResolvedDefinition::Module(file)])
 }
 

--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -1,9 +1,9 @@
 use crate::goto::find_goto_target;
 use crate::{Db, NavigationTargets, RangedValue};
-use ruff_db::PythonFile;
 use ruff_db::files::FileRange;
 use ruff_db::parsed::parsed_module;
 use ruff_text_size::{Ranged, TextSize};
+use ty_python_core::ProgramFile;
 use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 
 /// Navigate to the declaration of a symbol.
@@ -13,10 +13,10 @@ use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 /// is needed because Python doesn't require formal declarations of variables like most languages do.
 pub fn goto_declaration(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<RangedValue<NavigationTargets>> {
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let model = SemanticModel::new(db, file);
     let goto_target = find_goto_target(&model, &module, offset)?;
 
@@ -2768,7 +2768,7 @@ def ab(a: int, *, c: int): ...
             let Some(targets) = salsa::attach(&self.db, || {
                 goto_declaration(
                     &self.db,
-                    self.python_file(self.cursor.file),
+                    self.program_file(self.cursor.file),
                     self.cursor.offset,
                 )
             }) else {

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -1,9 +1,9 @@
 use crate::goto::find_goto_target;
 use crate::{Db, NavigationTargets, RangedValue};
-use ruff_db::PythonFile;
 use ruff_db::files::FileRange;
 use ruff_db::parsed::parsed_module;
 use ruff_text_size::{Ranged, TextSize};
+use ty_python_core::ProgramFile;
 use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 
 /// Navigate to the definition of a symbol.
@@ -14,10 +14,10 @@ use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 /// source file implementations using the `StubMapper`.
 pub fn goto_definition(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<RangedValue<NavigationTargets>> {
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let model = SemanticModel::new(db, file);
     let goto_target = find_goto_target(&model, &module, offset)?;
     let definition_targets = goto_target
@@ -2651,7 +2651,7 @@ class GenericFoo[T](Base):
             let Some(targets) = salsa::attach(&self.db, || {
                 goto_definition(
                     &self.db,
-                    self.python_file(self.cursor.file),
+                    self.program_file(self.cursor.file),
                     self.cursor.offset,
                 )
             }) else {

--- a/crates/ty_ide/src/goto_implementation.rs
+++ b/crates/ty_ide/src/goto_implementation.rs
@@ -58,11 +58,11 @@
 use crate::goto::{Definitions, GotoTarget, find_goto_target};
 use crate::{Db, NavigationTarget, NavigationTargets, RangedValue};
 use rayon::prelude::*;
-use ruff_db::PythonFile;
 use ruff_db::files::{File, FileRange};
 use ruff_db::parsed::parsed_module;
 use ruff_text_size::{Ranged, TextSize};
 use ty_project::parallel::ParallelIteratorExt;
+use ty_python_core::ProgramFile;
 use ty_python_semantic::{
     ImplementationsFinder, ImportAliasResolution, ResolvedDefinition, SemanticModel,
 };
@@ -73,15 +73,15 @@ use ty_python_semantic::{
 /// identified.
 pub fn goto_implementation(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<RangedValue<NavigationTargets>> {
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let model = SemanticModel::new(db, file);
     let goto_target = find_goto_target(&model, &module, offset)?;
     let finder = prepare_implementations_finder_for_goto_target(&model, &goto_target)?;
     let source_file = file.file(db);
-    let python_version = file.python_version(db);
+    let program = file.program(db);
 
     let mut candidate_files: Vec<File> = db
         .project()
@@ -95,7 +95,7 @@ pub fn goto_implementation(
     let batches = candidate_files
         .into_par_iter()
         .map_with_db(db, |db, file| {
-            let file = PythonFile::new(db, file, python_version);
+            let file = ProgramFile::new(db, file, program);
             let definitions = finder.implementations_for_file(db, file);
             definitions_to_implementation_targets(db, definitions)
         })
@@ -838,7 +838,7 @@ mod tests {
         let targets = salsa::attach(&test.db, || {
             goto_implementation(
                 &test.db,
-                test.python_file(test.cursor.file),
+                test.program_file(test.cursor.file),
                 test.cursor.offset,
             )
             .expect("implementation targets")
@@ -2144,7 +2144,7 @@ class MyClass:
             let Some(targets) = salsa::attach(&self.db, || {
                 goto_implementation(
                     &self.db,
-                    self.python_file(self.cursor.file),
+                    self.program_file(self.cursor.file),
                     self.cursor.offset,
                 )
             }) else {

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -1,17 +1,17 @@
 use crate::goto::find_goto_target;
 use crate::{Db, HasNavigationTargets, NavigationTargets, RangedValue};
-use ruff_db::PythonFile;
 use ruff_db::files::FileRange;
 use ruff_db::parsed::parsed_module;
 use ruff_text_size::{Ranged, TextSize};
+use ty_python_core::ProgramFile;
 use ty_python_semantic::SemanticModel;
 
 pub fn goto_type_definition(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<RangedValue<NavigationTargets>> {
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let model = SemanticModel::new(db, file);
     let goto_target = find_goto_target(&model, &module, offset)?;
 
@@ -2055,7 +2055,7 @@ def function():
             let Some(targets) = salsa::attach(&self.db, || {
                 goto_type_definition(
                     &self.db,
-                    self.python_file(self.cursor.file),
+                    self.program_file(self.cursor.file),
                     self.cursor.offset,
                 )
             }) else {

--- a/crates/ty_ide/src/hints.rs
+++ b/crates/ty_ide/src/hints.rs
@@ -1,6 +1,6 @@
-use ruff_db::PythonFile;
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
+use ty_python_core::ProgramFile;
 use ty_python_semantic::types::ide_support::{
     UnreachableKind, unreachable_ranges, unused_bindings,
 };
@@ -40,7 +40,7 @@ impl HintKind {
     }
 }
 
-pub fn hints(db: &dyn Db, file: PythonFile<'_>) -> Vec<Hint> {
+pub fn hints(db: &dyn Db, file: ProgramFile<'_>) -> Vec<Hint> {
     let source_file = file.file(db);
     if !db.should_check_file(source_file) {
         return Vec::new();

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -1,13 +1,13 @@
 use crate::docstring::{Docstring, DocstringFragment};
 use crate::goto::{Definitions, GotoTarget, docstring_for_call_definition, find_goto_target};
 use crate::{Db, MarkupKind, RangedValue};
-use ruff_db::PythonFile;
 use ruff_db::files::FileRange;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextSize};
 use std::fmt;
 use std::fmt::Formatter;
+use ty_python_core::ProgramFile;
 use ty_python_semantic::ProgramEnvironment;
 use ty_python_semantic::types::ide_support::{resolved_call_signature, typed_dict_key_hover};
 use ty_python_semantic::types::{KnownInstanceType, Type, TypeAliasType, TypeVarVariance};
@@ -16,10 +16,10 @@ use ty_python_semantic::{DisplaySettings, SemanticModel, TypeQualifiers};
 
 pub fn hover<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     offset: TextSize,
 ) -> Option<RangedValue<Hover<'db>>> {
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = parsed_module(db, file.python_file(db)).load(db);
     let model = SemanticModel::new(db, file);
     let goto_target = find_goto_target(&model, &parsed, offset)?;
 
@@ -142,7 +142,7 @@ pub fn hover<'db>(
     Some(RangedValue {
         range: FileRange::new(file.file(db), goto_target.range()),
         value: Hover {
-            python_file: file,
+            program_file: file,
             contents,
         },
     })
@@ -224,7 +224,7 @@ fn documentation_for_parameter(docstring: &Docstring, name: &str) -> Option<Docs
 }
 
 pub struct Hover<'db> {
-    python_file: PythonFile<'db>,
+    program_file: ProgramFile<'db>,
     contents: Vec<HoverContent<'db>>,
 }
 
@@ -271,7 +271,7 @@ impl fmt::Display for DisplayHover<'_, '_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let db = self.db;
         let mut first = true;
-        let env = ProgramEnvironment::from_file(self.hover.python_file);
+        let env = ProgramEnvironment::from_file(self.hover.program_file);
         for content in &self.hover.contents {
             if !first {
                 self.kind.horizontal_line().fmt(f)?;
@@ -6900,7 +6900,7 @@ type U<CURSOR> = MyType
 
             let Some(hover) = hover(
                 &self.db,
-                self.python_file(self.cursor.file),
+                self.program_file(self.cursor.file),
                 self.cursor.offset,
             ) else {
                 return "Hover provided no content".to_string();

--- a/crates/ty_ide/src/importer.rs
+++ b/crates/ty_ide/src/importer.rs
@@ -29,7 +29,7 @@ use ruff_python_ast::visitor::source_order::{SourceOrderVisitor, TraversalSignal
 use ruff_python_codegen::Stylist;
 use ruff_python_importer::Insertion;
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use ty_module_resolver::{ImportingFile, ModuleName, ResolverFile};
+use ty_module_resolver::{ImportingFile, ModuleName};
 use ty_project::Db;
 use ty_python_core::ProgramFile;
 use ty_python_core::definition::DefinitionKind;
@@ -146,9 +146,13 @@ impl<'a> Importer<'a> {
         request: ImportRequest<'_>,
         members: &MembersInScope,
     ) -> ImportAction {
-        let request = request.avoid_conflicts(self.db, self.file.resolver_file(self.db), members);
+        let importing_file = ImportingFile::File(
+            self.file.file(self.db),
+            self.file.resolver_environment(self.db),
+        );
+        let request = request.avoid_conflicts(self.db, importing_file, members);
         let mut symbol_text: Box<str> = request.member.unwrap_or(request.module).into();
-        let Some(response) = self.find(&request, members.at) else {
+        let Some(response) = self.find(importing_file, &request, members.at) else {
             let insertion = if let Some(future) = self.find_last_future_import(members.at) {
                 Insertion::end_of_statement(future.stmt, self.source, self.stylist)
             } else {
@@ -223,6 +227,7 @@ impl<'a> Importer<'a> {
     /// satisfies the request.
     fn find<'importer>(
         &'importer self,
+        importing_file: ImportingFile<'_>,
         request: &ImportRequest<'_>,
         available_at: TextSize,
     ) -> Option<ImportResponse<'importer, 'a>> {
@@ -248,9 +253,7 @@ impl<'a> Importer<'a> {
                 return choice;
             }
 
-            if let Some(response) =
-                import.satisfies(self.db, self.file.resolver_file(self.db), request)
-            {
+            if let Some(response) = import.satisfies(self.db, importing_file, request) {
                 let partial = matches!(response.kind, ImportResponseKind::Partial { .. });
 
                 // The LSP doesn't support edits across cell boundaries.
@@ -375,7 +378,7 @@ impl<'ast> MembersInScope<'ast> {
     pub(crate) fn satisfies(
         &self,
         db: &dyn Db,
-        importing_file: ResolverFile<'_>,
+        importing_file: ImportingFile<'_>,
         request: &ImportRequest<'_>,
     ) -> bool {
         let symbol_text = request.member.unwrap_or(request.module);
@@ -411,7 +414,7 @@ impl<'ast> MemberInScope<'ast> {
     fn satisfies_anywhere(
         &self,
         db: &dyn Db,
-        importing_file: ResolverFile<'_>,
+        importing_file: ImportingFile<'_>,
         request: &ImportRequest<'_>,
     ) -> bool {
         let MemberImportKind::Imported(ref ast_import) = self.kind else {
@@ -483,7 +486,7 @@ impl<'ast> AstImport<'ast> {
     fn satisfies<'importer>(
         &'importer self,
         db: &'_ dyn Db,
-        importing_file: ResolverFile<'_>,
+        importing_file: ImportingFile<'_>,
         request: &ImportRequest<'_>,
     ) -> Option<ImportResponse<'importer, 'ast>> {
         self.kind
@@ -514,7 +517,7 @@ impl<'ast> AstImportKind<'ast> {
     fn satisfies<'importer>(
         &'importer self,
         db: &'_ dyn Db,
-        importing_file: ResolverFile<'_>,
+        importing_file: ImportingFile<'_>,
         request: &ImportRequest<'_>,
     ) -> Option<ImportResponseKind<'ast>> {
         match *self {
@@ -544,12 +547,7 @@ impl<'ast> AstImportKind<'ast> {
                     return None;
                 }
 
-                let module = ModuleName::from_import_statement(
-                    db,
-                    ImportingFile::ResolverFile(importing_file),
-                    ast,
-                )
-                .ok()?;
+                let module = ModuleName::from_import_statement(db, importing_file, ast).ok()?;
                 if module.as_str() != request.module {
                     return None;
                 }
@@ -646,7 +644,7 @@ impl<'a> ImportRequest<'a> {
     fn avoid_conflicts(
         self,
         db: &dyn Db,
-        importing_file: ResolverFile<'_>,
+        importing_file: ImportingFile<'_>,
         members: &MembersInScope,
     ) -> Self {
         let Some(member) = self.member else {

--- a/crates/ty_ide/src/importer.rs
+++ b/crates/ty_ide/src/importer.rs
@@ -20,7 +20,6 @@ use rustc_hash::FxHashMap;
 
 use ruff_db::parsed::ParsedModuleRef;
 
-use ruff_db::PythonFile;
 use ruff_db::source::source_text;
 use ruff_diagnostics::Edit;
 use ruff_python_ast as ast;
@@ -30,8 +29,9 @@ use ruff_python_ast::visitor::source_order::{SourceOrderVisitor, TraversalSignal
 use ruff_python_codegen::Stylist;
 use ruff_python_importer::Insertion;
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use ty_module_resolver::ModuleName;
+use ty_module_resolver::{ImportingFile, ModuleName, ResolverFile};
 use ty_project::Db;
+use ty_python_core::ProgramFile;
 use ty_python_core::definition::DefinitionKind;
 use ty_python_semantic::types::Type;
 use ty_python_semantic::{MemberDefinition, SemanticModel};
@@ -41,7 +41,7 @@ pub(crate) struct Importer<'a> {
     db: &'a dyn Db,
     /// The file corresponding to the module that
     /// we want to insert an import statement into.
-    file: PythonFile<'a>,
+    file: ProgramFile<'a>,
     /// The parsed module ref.
     parsed: &'a ParsedModuleRef,
     /// The tokens representing the Python AST.
@@ -74,7 +74,7 @@ impl<'a> Importer<'a> {
     pub(crate) fn new(
         db: &'a dyn Db,
         stylist: &'a Stylist<'a>,
-        file: PythonFile<'a>,
+        file: ProgramFile<'a>,
         source: &'a str,
         parsed: &'a ParsedModuleRef,
     ) -> Self {
@@ -146,7 +146,7 @@ impl<'a> Importer<'a> {
         request: ImportRequest<'_>,
         members: &MembersInScope,
     ) -> ImportAction {
-        let request = request.avoid_conflicts(self.db, self.file, members);
+        let request = request.avoid_conflicts(self.db, self.file.resolver_file(self.db), members);
         let mut symbol_text: Box<str> = request.member.unwrap_or(request.module).into();
         let Some(response) = self.find(&request, members.at) else {
             let insertion = if let Some(future) = self.find_last_future_import(members.at) {
@@ -248,7 +248,9 @@ impl<'a> Importer<'a> {
                 return choice;
             }
 
-            if let Some(response) = import.satisfies(self.db, self.file, request) {
+            if let Some(response) =
+                import.satisfies(self.db, self.file.resolver_file(self.db), request)
+            {
                 let partial = matches!(response.kind, ImportResponseKind::Partial { .. });
 
                 // The LSP doesn't support edits across cell boundaries.
@@ -331,7 +333,7 @@ pub struct MembersInScope<'ast> {
 impl<'ast> MembersInScope<'ast> {
     fn new(
         db: &'ast dyn Db,
-        file: PythonFile<'ast>,
+        file: ProgramFile<'ast>,
         parsed: &'ast ParsedModuleRef,
         node: ast::AnyNodeRef<'_>,
         at: TextSize,
@@ -373,7 +375,7 @@ impl<'ast> MembersInScope<'ast> {
     pub(crate) fn satisfies(
         &self,
         db: &dyn Db,
-        importing_file: PythonFile<'_>,
+        importing_file: ResolverFile<'_>,
         request: &ImportRequest<'_>,
     ) -> bool {
         let symbol_text = request.member.unwrap_or(request.module);
@@ -409,7 +411,7 @@ impl<'ast> MemberInScope<'ast> {
     fn satisfies_anywhere(
         &self,
         db: &dyn Db,
-        importing_file: PythonFile<'_>,
+        importing_file: ResolverFile<'_>,
         request: &ImportRequest<'_>,
     ) -> bool {
         let MemberImportKind::Imported(ref ast_import) = self.kind else {
@@ -481,7 +483,7 @@ impl<'ast> AstImport<'ast> {
     fn satisfies<'importer>(
         &'importer self,
         db: &'_ dyn Db,
-        importing_file: PythonFile<'_>,
+        importing_file: ResolverFile<'_>,
         request: &ImportRequest<'_>,
     ) -> Option<ImportResponse<'importer, 'ast>> {
         self.kind
@@ -512,7 +514,7 @@ impl<'ast> AstImportKind<'ast> {
     fn satisfies<'importer>(
         &'importer self,
         db: &'_ dyn Db,
-        importing_file: PythonFile<'_>,
+        importing_file: ResolverFile<'_>,
         request: &ImportRequest<'_>,
     ) -> Option<ImportResponseKind<'ast>> {
         match *self {
@@ -542,7 +544,12 @@ impl<'ast> AstImportKind<'ast> {
                     return None;
                 }
 
-                let module = ModuleName::from_import_statement(db, importing_file, ast).ok()?;
+                let module = ModuleName::from_import_statement(
+                    db,
+                    ImportingFile::ResolverFile(importing_file),
+                    ast,
+                )
+                .ok()?;
                 if module.as_str() != request.module {
                     return None;
                 }
@@ -639,7 +646,7 @@ impl<'a> ImportRequest<'a> {
     fn avoid_conflicts(
         self,
         db: &dyn Db,
-        importing_file: PythonFile<'_>,
+        importing_file: ResolverFile<'_>,
         members: &MembersInScope,
     ) -> Self {
         let Some(member) = self.member else {
@@ -979,7 +986,11 @@ mod tests {
             Importer::new(
                 &self.db,
                 &self.cursor.stylist,
-                PythonFile::new(&self.db, self.cursor.file, self.db.python_version()),
+                ProgramFile::new(
+                    &self.db,
+                    self.cursor.file,
+                    self.db.program_environment().program(&self.db),
+                ),
                 self.cursor.source.as_str(),
                 &self.cursor.parsed,
             )

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -5,7 +5,6 @@ use rustc_hash::FxHashMap;
 
 use crate::importer::{ImportAction, ImportRequest, Importer, MembersInScope};
 use crate::{Db, HasNavigationTargets, NavigationTarget};
-use ruff_db::PythonFile;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_python_ast::visitor::source_order::{self, SourceOrderVisitor, TraversalSignal};
@@ -13,6 +12,7 @@ use ruff_python_ast::{AnyNodeRef, ArgOrKeyword, Expr, ExprUnaryOp, Stmt, UnaryOp
 use ruff_python_codegen::Stylist;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use ty_module_resolver::file_to_module;
+use ty_python_core::ProgramFile;
 use ty_python_semantic::types::ide_support::inlay_hint_call_argument_details;
 use ty_python_semantic::types::{Type, TypeDetail};
 use ty_python_semantic::{HasType, SemanticModel};
@@ -103,7 +103,8 @@ impl InlayHint {
                             .as_deref()
                             .unwrap_or(&details.label[start..end]);
 
-                        let module = file_to_module(db, definition.python_file(db))?;
+                        let file = definition.program_file(db);
+                        let module = file_to_module(db, file.resolver_file(db))?;
 
                         if should_skip_import(db, module, *ty) {
                             return None;
@@ -291,11 +292,11 @@ pub struct InlayHintTextEdit {
 
 pub fn inlay_hints(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     range: TextRange,
     settings: &InlayHintSettings,
 ) -> Vec<InlayHint> {
-    let ast = parsed_module(db, file).load(db);
+    let ast = parsed_module(db, file.python_file(db)).load(db);
     let source_file = file.file(db);
 
     let source = source_text(db, source_file);
@@ -348,7 +349,7 @@ impl Default for InlayHintSettings {
 
 struct InlayHintImportContext<'a, 'db> {
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     importer: &'a Importer<'db>,
     dynamic_imports: &'a mut FxHashMap<DynamicallyImportedMember, ImportAction>,
 }
@@ -370,7 +371,7 @@ struct InlayHintVisitor<'a, 'db> {
 impl<'a, 'db> InlayHintVisitor<'a, 'db> {
     fn new(
         db: &'db dyn Db,
-        file: PythonFile<'db>,
+        file: ProgramFile<'db>,
         importer: Importer<'db>,
         range: TextRange,
         settings: &'a InlayHintSettings,
@@ -399,7 +400,7 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
 
         let context = InlayHintImportContext {
             db: self.db,
-            file: self.model.python_file(),
+            file: self.model.program_file(),
             importer: &self.importer,
             dynamic_imports: &mut self.dynamic_imports,
         };
@@ -882,7 +883,11 @@ mod tests {
         fn inlay_hints_with_settings(&mut self, settings: &InlayHintSettings) -> String {
             let hints = inlay_hints(
                 &self.db,
-                PythonFile::new(&self.db, self.file, self.db.python_version()),
+                ProgramFile::new(
+                    &self.db,
+                    self.file,
+                    self.db.program_environment().program(&self.db),
+                ),
                 self.range,
                 settings,
             );

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -403,7 +403,6 @@ mod tests {
     use insta::internals::SettingsBindDropGuard;
 
     use ruff_db::Db;
-    use ruff_db::PythonFile;
     use ruff_db::diagnostic::{
         Annotation, Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig, UnifiedFile,
     };
@@ -417,6 +416,7 @@ mod tests {
     use ruff_text_size::TextSize;
     use ty_module_resolver::SearchPathSettings;
     use ty_project::{Db as _, ProjectMetadata};
+    use ty_python_core::ProgramFile;
     use ty_python_core::platform::PythonPlatform;
     use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
     use ty_python_semantic::PythonVersionWithSource;
@@ -440,8 +440,8 @@ mod tests {
             CursorTestBuilder::default()
         }
 
-        pub(super) fn python_file(&self, file: File) -> PythonFile<'_> {
-            PythonFile::new(&self.db, file, self.db.python_version())
+        pub(super) fn program_file(&self, file: File) -> ProgramFile<'_> {
+            Program::get(&self.db).program_file(&self.db, file)
         }
 
         pub(super) fn write_file(
@@ -568,9 +568,11 @@ mod tests {
                     db.project().open_file(&mut db, file);
 
                     let source = source_text(&db, file);
-                    let parsed =
-                        parsed_module(&db, PythonFile::new(&db, file, db.python_version()))
-                            .load(&db);
+                    let parsed = parsed_module(
+                        &db,
+                        Program::get(&db).program_file(&db, file).python_file(&db),
+                    )
+                    .load(&db);
                     let stylist =
                         Stylist::from_tokens(parsed.tokens(), source.as_str()).into_owned();
                     cursor = Some(Cursor {
@@ -722,9 +724,11 @@ mod tests {
                     db.project().open_file(&mut db, file);
 
                     let source = source_text(&db, file);
-                    let parsed =
-                        parsed_module(&db, PythonFile::new(&db, file, db.python_version()))
-                            .load(&db);
+                    let parsed = parsed_module(
+                        &db,
+                        Program::get(&db).program_file(&db, file).python_file(&db),
+                    )
+                    .load(&db);
                     let stylist =
                         Stylist::from_tokens(parsed.tokens(), source.as_str()).into_owned();
                     cursor = Some(Cursor {

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -415,7 +415,7 @@ mod tests {
     use ruff_python_trivia::textwrap::dedent;
     use ruff_text_size::TextSize;
     use ty_module_resolver::SearchPathSettings;
-    use ty_project::{Db as _, ProjectMetadata};
+    use ty_project::{Db as _, ProjectMetadata, SemanticDb as _};
     use ty_python_core::ProgramFile;
     use ty_python_core::platform::PythonPlatform;
     use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
@@ -441,7 +441,7 @@ mod tests {
         }
 
         pub(super) fn program_file(&self, file: File) -> ProgramFile<'_> {
-            Program::get(&self.db).program_file(&self.db, file)
+            self.db.program_file(file)
         }
 
         pub(super) fn write_file(
@@ -568,11 +568,8 @@ mod tests {
                     db.project().open_file(&mut db, file);
 
                     let source = source_text(&db, file);
-                    let parsed = parsed_module(
-                        &db,
-                        Program::get(&db).program_file(&db, file).python_file(&db),
-                    )
-                    .load(&db);
+                    let parsed =
+                        parsed_module(&db, db.program_file(file).python_file(&db)).load(&db);
                     let stylist =
                         Stylist::from_tokens(parsed.tokens(), source.as_str()).into_owned();
                     cursor = Some(Cursor {
@@ -724,11 +721,8 @@ mod tests {
                     db.project().open_file(&mut db, file);
 
                     let source = source_text(&db, file);
-                    let parsed = parsed_module(
-                        &db,
-                        Program::get(&db).program_file(&db, file).python_file(&db),
-                    )
-                    .load(&db);
+                    let parsed =
+                        parsed_module(&db, db.program_file(file).python_file(&db)).load(&db);
                     let stylist =
                         Stylist::from_tokens(parsed.tokens(), source.as_str()).into_owned();
                     cursor = Some(Cursor {

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -13,7 +13,6 @@
 use crate::goto::{Definitions, GotoTarget};
 use crate::{Db, ReferenceKind, ReferenceTarget};
 use rayon::prelude::*;
-use ruff_db::PythonFile;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::find_node::{CoveringNode, covering_node};
 use ruff_python_ast::token::Tokens;
@@ -23,6 +22,7 @@ use ruff_python_ast::{
 };
 use ruff_text_size::Ranged;
 use ty_project::parallel::{ParallelIteratorExt, minimum_parallel_job_len};
+use ty_python_core::ProgramFile;
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::scope::{FileScopeId, NodeWithScopeKind, ScopeKind};
 use ty_python_semantic::{
@@ -87,7 +87,7 @@ impl ReferencesMode {
 /// Search for references across all files in the project.
 pub(crate) fn references(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     goto_target: &GotoTarget,
     mode: ReferencesMode,
 ) -> Option<Vec<ReferenceTarget>> {
@@ -118,8 +118,8 @@ pub(crate) fn references(
     let is_parameter = parameter_owner_is_externally_visible(db, &target_definitions);
 
     if search_across_files && (is_parameter || is_externally_visible_symbol) {
+        let resolver_environment = model.program_environment().resolver_environment(db);
         let files = db.project().files(db);
-        let python_version = file.python_version(db);
         let files: Vec<_> = files
             .iter()
             .copied()
@@ -135,7 +135,7 @@ pub(crate) fn references(
                     return Vec::new();
                 }
 
-                let other_file = PythonFile::new(db, other_file, python_version);
+                let other_file = ProgramFile::new(db, other_file, resolver_environment);
 
                 if is_externally_visible_symbol {
                     references_for_file(db, other_file, &target_definitions, &target_text, mode)
@@ -164,7 +164,7 @@ pub(crate) fn references(
 
 fn references_for_keyword_arguments_in_file(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     target_definitions: &Definitions<'_>,
     target_text: &str,
     mode: ReferencesMode,
@@ -176,7 +176,7 @@ fn references_for_keyword_arguments_in_file(
         "keyword-label cross-file scan should not run in DocumentHighlights mode"
     );
 
-    let parsed = parsed_module(db, file);
+    let parsed = parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
     let model = SemanticModel::new(db, file);
     let mut references = Vec::new();
@@ -225,12 +225,12 @@ fn is_slots_assignment(node: AnyNodeRef<'_>, value: AnyNodeRef<'_>) -> bool {
 /// The behavior depends on the provided mode.
 fn references_for_file(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     target_definitions: &Definitions<'_>,
     target_text: &str,
     mode: ReferencesMode,
 ) -> Vec<ReferenceTarget> {
-    let parsed = parsed_module(db, file);
+    let parsed = parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
     let model = SemanticModel::new(db, file);
     let mut references = Vec::new();
@@ -261,7 +261,7 @@ pub(crate) fn has_any_external_visible_definitions(
             ScopeKind::Comprehension => {
                 matches!(definition.kind(db), DefinitionKind::NamedExpression(_))
                     && definition.place(db).as_symbol().is_some_and(|symbol_id| {
-                        ty_python_core::semantic_index(db, definition.python_file(db))
+                        ty_python_core::semantic_index(db, definition.program_file(db))
                             .symbol_resolves_to_global_scope(symbol_id, definition.file_scope(db))
                     })
             }
@@ -707,7 +707,7 @@ impl<'a> LocalReferencesFinder<'a> {
         let file = self.model.file();
         let class_range = class.range();
         let module = ruff_db::parsed::parsed_module(db, self.model.python_file()).load(db);
-        let index = ty_python_core::semantic_index(db, self.model.python_file());
+        let index = ty_python_core::semantic_index(db, self.model.program_file());
 
         // The nearest class scope lexically enclosing `scope`, if any. `ancestor_scopes` skips
         // class scopes for name resolution, so we walk the lexical parents directly to stop at the
@@ -808,7 +808,7 @@ mod tests {
     use crate::tests::{CursorTest, cursor_test};
 
     fn cursor_target_is_externally_visible(test: &CursorTest) -> bool {
-        let model = SemanticModel::new(&test.db, test.python_file(test.cursor.file));
+        let model = SemanticModel::new(&test.db, test.program_file(test.cursor.file));
         let goto_target =
             find_goto_target(&model, &test.cursor.parsed, test.cursor.offset).unwrap();
         let definitions = goto_target

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -118,7 +118,7 @@ pub(crate) fn references(
     let is_parameter = parameter_owner_is_externally_visible(db, &target_definitions);
 
     if search_across_files && (is_parameter || is_externally_visible_symbol) {
-        let resolver_environment = model.program_environment().resolver_environment(db);
+        let program = model.program();
         let files = db.project().files(db);
         let files: Vec<_> = files
             .iter()
@@ -135,7 +135,7 @@ pub(crate) fn references(
                     return Vec::new();
                 }
 
-                let other_file = ProgramFile::new(db, other_file, resolver_environment);
+                let other_file = ProgramFile::new(db, other_file, program);
 
                 if is_externally_visible_symbol {
                     references_for_file(db, other_file, &target_definitions, &target_text, mode)

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -1,18 +1,18 @@
 use crate::goto::find_goto_target;
 use crate::references::{ReferencesMode, references};
 use crate::{Db, ReferenceTarget};
-use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ruff_text_size::{Ranged, TextSize};
+use ty_python_core::ProgramFile;
 use ty_python_semantic::SemanticModel;
 
 /// Returns the range of the symbol if it can be renamed, None if not.
 pub fn can_rename(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<ruff_text_size::TextRange> {
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+    let parsed = ruff_db::parsed::parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
     let source_file = file.file(db);
     let model = SemanticModel::new(db, file);
@@ -56,11 +56,11 @@ pub fn can_rename(
 /// Returns all locations that need to be updated with the new name.
 pub fn rename(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
     new_name: &str,
 ) -> Option<Vec<ReferenceTarget>> {
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+    let parsed = ruff_db::parsed::parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
     let model = SemanticModel::new(db, file);
 
@@ -108,7 +108,7 @@ mod tests {
             let Some(range) = salsa::attach(&self.db, || {
                 can_rename(
                     &self.db,
-                    self.python_file(self.cursor.file),
+                    self.program_file(self.cursor.file),
                     self.cursor.offset,
                 )
             }) else {
@@ -122,13 +122,13 @@ mod tests {
             let rename_results = salsa::attach(&self.db, || {
                 can_rename(
                     &self.db,
-                    self.python_file(self.cursor.file),
+                    self.program_file(self.cursor.file),
                     self.cursor.offset,
                 )?;
 
                 rename(
                     &self.db,
-                    self.python_file(self.cursor.file),
+                    self.program_file(self.cursor.file),
                     self.cursor.offset,
                     new_name,
                 )

--- a/crates/ty_ide/src/selection_range.rs
+++ b/crates/ty_ide/src/selection_range.rs
@@ -437,7 +437,7 @@ b"123a𝐁<CURSOR>c"
         fn selection_range(&self) -> String {
             let ranges = selection_range(
                 &self.db,
-                self.python_file(self.cursor.file),
+                self.program_file(self.cursor.file).python_file(&self.db),
                 self.cursor.offset,
             );
 

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -28,7 +28,6 @@
 
 use crate::Db;
 use bitflags::bitflags;
-use ruff_db::PythonFile;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::visitor::source_order::{
     SourceOrderVisitor, TraversalSignal, walk_arguments, walk_expr,
@@ -40,6 +39,7 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use std::ops::Deref;
+use ty_python_core::ProgramFile;
 use ty_python_core::definition::{Definition, DefinitionKind, ParameterDefinitionNodeKind};
 use ty_python_semantic::{
     HasType, ImportAliasResolution, ResolvedDefinition, SemanticModel, definitions_for_attribute,
@@ -185,10 +185,10 @@ impl Deref for SemanticTokens {
 /// Pass None to get tokens for the entire file.
 pub fn semantic_tokens(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     range: Option<TextRange>,
 ) -> SemanticTokens {
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = parsed_module(db, file.python_file(db)).load(db);
     let model = SemanticModel::new(db, file);
 
     let mut visitor = SemanticTokenVisitor::new(&model, range);
@@ -303,7 +303,7 @@ impl<'db> SemanticTokenVisitor<'db> {
     ) -> Option<(SemanticTokenType, SemanticTokenModifier)> {
         let mut modifiers = SemanticTokenModifier::empty();
         let db = self.model.db();
-        let model = SemanticModel::new(db, definition.python_file(db));
+        let model = SemanticModel::new(db, definition.program_file(db));
 
         if model.is_type_alias_definition(definition) {
             return Some((SemanticTokenType::Class, modifiers));
@@ -4723,7 +4723,11 @@ from pathlib import Missing as Alias
         fn highlight_file(&self) -> SemanticTokens {
             semantic_tokens(
                 &self.db,
-                PythonFile::new(&self.db, self.file, self.db.python_version()),
+                ProgramFile::new(
+                    &self.db,
+                    self.file,
+                    self.db.program_environment().program(&self.db),
+                ),
                 None,
             )
         }
@@ -4732,7 +4736,11 @@ from pathlib import Missing as Alias
         fn highlight_range(&self, range: TextRange) -> SemanticTokens {
             semantic_tokens(
                 &self.db,
-                PythonFile::new(&self.db, self.file, self.db.python_version()),
+                ProgramFile::new(
+                    &self.db,
+                    self.file,
+                    self.db.program_environment().program(&self.db),
+                ),
                 Some(range),
             )
         }

--- a/crates/ty_ide/src/signature_help.rs
+++ b/crates/ty_ide/src/signature_help.rs
@@ -10,12 +10,12 @@ use crate::Db;
 use crate::FxIndexMap;
 use crate::docstring::Docstring;
 use crate::goto::docstring_for_call_definition;
-use ruff_db::PythonFile;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::find_node::covering_node;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextSize};
+use ty_python_core::ProgramFile;
 use ty_python_semantic::SemanticModel;
 use ty_python_semantic::types::Type;
 use ty_python_semantic::types::ide_support::{
@@ -76,10 +76,10 @@ pub struct SignatureHelpInfo<'db> {
 /// Signature help information for function calls at the given position
 pub fn signature_help<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     offset: TextSize,
 ) -> Option<SignatureHelpInfo<'db>> {
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = parsed_module(db, file.python_file(db)).load(db);
 
     // Get the call expression at the given position.
     let (call_expr, current_arg_index) = get_call_expr(&parsed, offset)?;
@@ -1464,7 +1464,7 @@ def ab(a: int, *, c: int):
         fn signature_help(&self) -> Option<SignatureHelpInfo<'_>> {
             crate::signature_help::signature_help(
                 &self.db,
-                self.python_file(self.cursor.file),
+                self.program_file(self.cursor.file),
                 self.cursor.offset,
             )
         }

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -8,15 +8,15 @@ use regex::Regex;
 
 use ruff_db::parsed::parsed_module;
 
-use ruff_db::PythonFile;
 use ruff_index::{IndexVec, newtype_index};
 use ruff_python_ast as ast;
 use ruff_python_ast::name::{Name, UnqualifiedName};
 use ruff_python_ast::visitor::source_order::{self, SourceOrderVisitor};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
-use ty_module_resolver::{ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, ModuleName, ResolverFile, resolve_module};
 use ty_project::Db;
+use ty_python_core::ProgramFile;
 
 use crate::completion::CompletionKind;
 
@@ -392,11 +392,11 @@ impl SymbolKind {
 /// The flattened list includes parent/child information and can be
 /// converted into a hierarchical collection of symbols.
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn symbols_for_file(db: &dyn Db, file: PythonFile<'_>) -> FlatSymbols {
-    let parsed = parsed_module(db, file);
+pub(crate) fn symbols_for_file(db: &dyn Db, file: ProgramFile<'_>) -> FlatSymbols {
+    let parsed = parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
 
-    let mut visitor = SymbolVisitor::tree(db, file);
+    let mut visitor = SymbolVisitor::tree(db, file.resolver_file(db));
     visitor.visit_body(&module.syntax().body);
     visitor.into_flat_symbols()
 }
@@ -411,12 +411,12 @@ pub(crate) fn symbols_for_file(db: &dyn Db, file: PythonFile<'_>) -> FlatSymbols
     cycle_initial=|_, _, _| FlatSymbols::default(),
     heap_size=ruff_memory_usage::heap_size,
 )]
-pub(crate) fn symbols_for_file_global_only(db: &dyn Db, file: PythonFile<'_>) -> FlatSymbols {
+pub(crate) fn symbols_for_file_global_only(db: &dyn Db, file: ProgramFile<'_>) -> FlatSymbols {
     let source_file = file.file(db);
-    let parsed = parsed_module(db, file);
+    let parsed = parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
 
-    let mut visitor = SymbolVisitor::globals(db, file);
+    let mut visitor = SymbolVisitor::globals(db, file.resolver_file(db));
     visitor.visit_body(&module.syntax().body);
 
     if source_file
@@ -455,11 +455,13 @@ impl ImportedFrom {
 
     fn import_from(
         db: &dyn Db,
-        importing_file: PythonFile<'_>,
+        importing_file: ResolverFile<'_>,
         ast: &ast::StmtImportFrom,
         kind: ImportKind,
     ) -> Option<ImportedFrom> {
-        let module_name = ModuleName::from_import_statement(db, importing_file, ast).ok()?;
+        let module_name =
+            ModuleName::from_import_statement(db, ImportingFile::ResolverFile(importing_file), ast)
+                .ok()?;
         Some(ImportedFrom { module_name, kind })
     }
 
@@ -596,16 +598,24 @@ impl<'db> Imports<'db> {
     fn get_module_symbols(
         &self,
         db: &'db dyn Db,
-        importing_file: PythonFile<'db>,
+        importing_file: ResolverFile<'db>,
         name: &ModuleName,
     ) -> Option<&'db FlatSymbols> {
-        let module_name = match self.module_names.get(name.as_str())? {
+        let module_kind = self.module_names.get(name.as_str())?;
+        let module_name = match module_kind {
             ImportModuleKind::Definitive(name) | ImportModuleKind::Possible(name) => {
                 name.to_module_name(db, importing_file)?
             }
         };
-        let module = resolve_module(db, importing_file, &module_name)?;
-        Some(symbols_for_file_global_only(db, module.python_file(db)?))
+        let module = resolve_module(
+            db,
+            ImportingFile::ResolverFile(importing_file),
+            &module_name,
+        )?;
+        Some(symbols_for_file_global_only(
+            db,
+            ProgramFile::new(db, module.file(db)?, importing_file.environment(db)),
+        ))
     }
 }
 
@@ -657,13 +667,17 @@ impl<'db> ImportModuleName<'db> {
     fn to_module_name(
         self,
         db: &'db dyn Db,
-        importing_file: PythonFile<'db>,
+        importing_file: ResolverFile<'db>,
     ) -> Option<ModuleName> {
         match self {
             ImportModuleName::Import(name) => ModuleName::new(name),
             ImportModuleName::ImportFrom { parent, child } => {
-                let mut module_name =
-                    ModuleName::from_import_statement(db, importing_file, parent).ok()?;
+                let mut module_name = ModuleName::from_import_statement(
+                    db,
+                    ImportingFile::ResolverFile(importing_file),
+                    parent,
+                )
+                .ok()?;
                 let child_module_name = ModuleName::new(child)?;
                 module_name.extend(&child_module_name);
                 Some(module_name)
@@ -694,7 +708,7 @@ impl Ranged for AstImport<'_> {
 #[expect(clippy::struct_excessive_bools)]
 struct SymbolVisitor<'db> {
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ResolverFile<'db>,
     symbols: IndexVec<SymbolId, SymbolTree>,
     symbol_stack: Vec<SymbolId>,
     /// Track if we're currently inside a function at any point.
@@ -732,7 +746,7 @@ struct SymbolVisitor<'db> {
 }
 
 impl<'db> SymbolVisitor<'db> {
-    fn tree(db: &'db dyn Db, file: PythonFile<'db>) -> Self {
+    fn tree(db: &'db dyn Db, file: ResolverFile<'db>) -> Self {
         Self {
             db,
             file,
@@ -750,7 +764,7 @@ impl<'db> SymbolVisitor<'db> {
         }
     }
 
-    fn globals(db: &'db dyn Db, file: PythonFile<'db>) -> Self {
+    fn globals(db: &'db dyn Db, file: ResolverFile<'db>) -> Self {
         Self {
             exports_only: true,
             ..Self::tree(db, file)
@@ -1133,12 +1147,25 @@ impl<'db> SymbolVisitor<'db> {
         &self,
         import_from: &ast::StmtImportFrom,
     ) -> Option<&'db FlatSymbols> {
-        let module_name =
-            ModuleName::from_import_statement(self.db, self.file, import_from).ok()?;
-        let module = resolve_module(self.db, self.file, &module_name)?;
+        let resolver_file = self.file;
+        let module_name = ModuleName::from_import_statement(
+            self.db,
+            ImportingFile::ResolverFile(resolver_file),
+            import_from,
+        )
+        .ok()?;
+        let module = resolve_module(
+            self.db,
+            ImportingFile::ResolverFile(resolver_file),
+            &module_name,
+        )?;
         Some(symbols_for_file_global_only(
             self.db,
-            module.python_file(self.db)?,
+            ProgramFile::new(
+                self.db,
+                module.file(self.db)?,
+                self.file.environment(self.db),
+            ),
         ))
     }
 
@@ -1599,12 +1626,12 @@ mod tests {
     use insta::internals::SettingsBindDropGuard;
 
     use ruff_db::Db;
-    use ruff_db::PythonFile;
     use ruff_db::files::{FileRootKind, system_path_to_file};
     use ruff_db::system::{DbWithWritableSystem, SystemPath, SystemPathBuf};
     use ruff_python_ast::PythonVersion;
     use ruff_python_trivia::textwrap::dedent;
     use ty_project::{ProjectMetadata, TestDb};
+    use ty_python_core::ProgramFile;
 
     use super::symbols_for_file_global_only;
 
@@ -3165,7 +3192,11 @@ class C: ...
             let file = system_path_to_file(&self.db, path.as_ref()).unwrap();
             symbols_for_file_global_only(
                 &self.db,
-                PythonFile::new(&self.db, file, self.db.python_version()),
+                ProgramFile::new(
+                    &self.db,
+                    file,
+                    self.db.program_environment().program(&self.db),
+                ),
             )
         }
 

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -14,7 +14,7 @@ use ruff_python_ast::name::{Name, UnqualifiedName};
 use ruff_python_ast::visitor::source_order::{self, SourceOrderVisitor};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
-use ty_module_resolver::{ImportingFile, ModuleName, ResolverFile, resolve_module};
+use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
 use ty_project::Db;
 use ty_python_core::ProgramFile;
 
@@ -396,7 +396,7 @@ pub(crate) fn symbols_for_file(db: &dyn Db, file: ProgramFile<'_>) -> FlatSymbol
     let parsed = parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
 
-    let mut visitor = SymbolVisitor::tree(db, file.resolver_file(db));
+    let mut visitor = SymbolVisitor::tree(db, file);
     visitor.visit_body(&module.syntax().body);
     visitor.into_flat_symbols()
 }
@@ -416,7 +416,7 @@ pub(crate) fn symbols_for_file_global_only(db: &dyn Db, file: ProgramFile<'_>) -
     let parsed = parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
 
-    let mut visitor = SymbolVisitor::globals(db, file.resolver_file(db));
+    let mut visitor = SymbolVisitor::globals(db, file);
     visitor.visit_body(&module.syntax().body);
 
     if source_file
@@ -455,13 +455,11 @@ impl ImportedFrom {
 
     fn import_from(
         db: &dyn Db,
-        importing_file: ResolverFile<'_>,
+        importing_file: ImportingFile<'_>,
         ast: &ast::StmtImportFrom,
         kind: ImportKind,
     ) -> Option<ImportedFrom> {
-        let module_name =
-            ModuleName::from_import_statement(db, ImportingFile::ResolverFile(importing_file), ast)
-                .ok()?;
+        let module_name = ModuleName::from_import_statement(db, importing_file, ast).ok()?;
         Some(ImportedFrom { module_name, kind })
     }
 
@@ -598,23 +596,21 @@ impl<'db> Imports<'db> {
     fn get_module_symbols(
         &self,
         db: &'db dyn Db,
-        importing_file: ResolverFile<'db>,
+        program_file: ProgramFile<'db>,
         name: &ModuleName,
     ) -> Option<&'db FlatSymbols> {
         let module_kind = self.module_names.get(name.as_str())?;
+        let importing_file =
+            ImportingFile::File(program_file.file(db), program_file.resolver_environment(db));
         let module_name = match module_kind {
             ImportModuleKind::Definitive(name) | ImportModuleKind::Possible(name) => {
                 name.to_module_name(db, importing_file)?
             }
         };
-        let module = resolve_module(
-            db,
-            ImportingFile::ResolverFile(importing_file),
-            &module_name,
-        )?;
+        let module = resolve_module(db, importing_file, &module_name)?;
         Some(symbols_for_file_global_only(
             db,
-            ProgramFile::new(db, module.file(db)?, importing_file.environment(db)),
+            ProgramFile::new(db, module.file(db)?, program_file.program(db)),
         ))
     }
 }
@@ -667,17 +663,13 @@ impl<'db> ImportModuleName<'db> {
     fn to_module_name(
         self,
         db: &'db dyn Db,
-        importing_file: ResolverFile<'db>,
+        importing_file: ImportingFile<'db>,
     ) -> Option<ModuleName> {
         match self {
             ImportModuleName::Import(name) => ModuleName::new(name),
             ImportModuleName::ImportFrom { parent, child } => {
-                let mut module_name = ModuleName::from_import_statement(
-                    db,
-                    ImportingFile::ResolverFile(importing_file),
-                    parent,
-                )
-                .ok()?;
+                let mut module_name =
+                    ModuleName::from_import_statement(db, importing_file, parent).ok()?;
                 let child_module_name = ModuleName::new(child)?;
                 module_name.extend(&child_module_name);
                 Some(module_name)
@@ -708,7 +700,7 @@ impl Ranged for AstImport<'_> {
 #[expect(clippy::struct_excessive_bools)]
 struct SymbolVisitor<'db> {
     db: &'db dyn Db,
-    file: ResolverFile<'db>,
+    file: ProgramFile<'db>,
     symbols: IndexVec<SymbolId, SymbolTree>,
     symbol_stack: Vec<SymbolId>,
     /// Track if we're currently inside a function at any point.
@@ -746,7 +738,7 @@ struct SymbolVisitor<'db> {
 }
 
 impl<'db> SymbolVisitor<'db> {
-    fn tree(db: &'db dyn Db, file: ResolverFile<'db>) -> Self {
+    fn tree(db: &'db dyn Db, file: ProgramFile<'db>) -> Self {
         Self {
             db,
             file,
@@ -764,7 +756,7 @@ impl<'db> SymbolVisitor<'db> {
         }
     }
 
-    fn globals(db: &'db dyn Db, file: ResolverFile<'db>) -> Self {
+    fn globals(db: &'db dyn Db, file: ProgramFile<'db>) -> Self {
         Self {
             exports_only: true,
             ..Self::tree(db, file)
@@ -920,9 +912,15 @@ impl<'db> SymbolVisitor<'db> {
         let full_range = import.range();
         let Some(imported_from) = (match import {
             AstImport::Import(_) => ImportedFrom::import(alias, import_kind),
-            AstImport::ImportFrom(ast) => {
-                ImportedFrom::import_from(self.db, self.file, ast, import_kind)
-            }
+            AstImport::ImportFrom(ast) => ImportedFrom::import_from(
+                self.db,
+                ImportingFile::File(
+                    self.file.file(self.db),
+                    self.file.resolver_environment(self.db),
+                ),
+                ast,
+                import_kind,
+            ),
         }) else {
             tracing::debug!(
                 "Dropping imported symbol {name} since its module name could not be discovered",
@@ -1087,6 +1085,10 @@ impl<'db> SymbolVisitor<'db> {
             .iter()
             .find(|alias| &alias.name == "*")
             .map(Ranged::range);
+        let importing_file = ImportingFile::File(
+            self.file.file(self.db),
+            self.file.resolver_environment(self.db),
+        );
         self.symbols
             .extend(symbols.symbols.iter().filter_map(|symbol| {
                 // If there's no `__all__`, then names with an underscore
@@ -1102,7 +1104,7 @@ impl<'db> SymbolVisitor<'db> {
                 }
                 let Some(imported_from) = ImportedFrom::import_from(
                     self.db,
-                    self.file,
+                    importing_file,
                     import_from,
                     ImportKind::Wildcard,
                 ) else {
@@ -1147,25 +1149,16 @@ impl<'db> SymbolVisitor<'db> {
         &self,
         import_from: &ast::StmtImportFrom,
     ) -> Option<&'db FlatSymbols> {
-        let resolver_file = self.file;
-        let module_name = ModuleName::from_import_statement(
-            self.db,
-            ImportingFile::ResolverFile(resolver_file),
-            import_from,
-        )
-        .ok()?;
-        let module = resolve_module(
-            self.db,
-            ImportingFile::ResolverFile(resolver_file),
-            &module_name,
-        )?;
+        let importing_file = ImportingFile::File(
+            self.file.file(self.db),
+            self.file.resolver_environment(self.db),
+        );
+        let module_name =
+            ModuleName::from_import_statement(self.db, importing_file, import_from).ok()?;
+        let module = resolve_module(self.db, importing_file, &module_name)?;
         Some(symbols_for_file_global_only(
             self.db,
-            ProgramFile::new(
-                self.db,
-                module.file(self.db)?,
-                self.file.environment(self.db),
-            ),
+            ProgramFile::new(self.db, module.file(self.db)?, self.file.program(self.db)),
         ))
     }
 

--- a/crates/ty_ide/src/type_hierarchy.rs
+++ b/crates/ty_ide/src/type_hierarchy.rs
@@ -1,12 +1,12 @@
 use crate::Db;
 use crate::goto::find_goto_target;
 use rayon::prelude::*;
-use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_text_size::{TextRange, TextSize};
 use ty_project::parallel::ParallelIteratorExt;
+use ty_python_core::ProgramFile;
 use ty_python_semantic::TypeHierarchyClass;
 use ty_python_semantic::types::Type;
 use ty_python_semantic::{ProgramEnvironment, SemanticModel};
@@ -31,10 +31,10 @@ pub struct TypeHierarchyItem {
 /// Returns `None` if the position is not on a class definition or class reference.
 pub fn prepare_type_hierarchy(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<TypeHierarchyItem> {
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let model = SemanticModel::new(db, file);
     let goto_target = find_goto_target(&model, &module, offset)?;
     let ty = goto_target.inferred_type(&model)?;
@@ -47,7 +47,7 @@ pub fn prepare_type_hierarchy(
 /// Get the supertypes (base classes) of a type hierarchy item.
 pub fn type_hierarchy_supertypes(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Vec<TypeHierarchyItem> {
     let Some(ty) = resolve_type_at(db, file, offset) else {
@@ -65,14 +65,14 @@ pub fn type_hierarchy_supertypes(
 /// This scans all available modules and can be expensive in large projects.
 pub fn type_hierarchy_subtypes(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Vec<TypeHierarchyItem> {
     let Some(ty) = resolve_type_at(db, file, offset) else {
         return vec![];
     };
 
-    ty_module_resolver::all_modules(db, file.python_version(db))
+    ty_module_resolver::all_modules(db, file.resolver_environment(db))
         .into_par_iter()
         .map_with_db(db, |db, module| {
             let env = ProgramEnvironment::from_file(file);
@@ -91,10 +91,10 @@ pub fn type_hierarchy_subtypes(
 /// not be inferred, `None` is returned.
 fn resolve_type_at<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     offset: TextSize,
 ) -> Option<Type<'db>> {
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let model = SemanticModel::new(db, file);
 
     let goto_target = find_goto_target(&model, &module, offset)?;
@@ -733,7 +733,7 @@ Public = _Internal
         fn prepare(&self) -> Option<TypeHierarchyItem> {
             prepare_type_hierarchy(
                 &self.db,
-                self.python_file(self.cursor.file),
+                self.program_file(self.cursor.file),
                 self.cursor.offset,
             )
         }
@@ -744,7 +744,7 @@ Public = _Internal
             };
             type_hierarchy_supertypes(
                 &self.db,
-                self.python_file(item.file),
+                self.program_file(item.file),
                 item.selection_range.start(),
             )
         }
@@ -755,7 +755,7 @@ Public = _Internal
             };
             type_hierarchy_subtypes(
                 &self.db,
-                self.python_file(item.file),
+                self.program_file(item.file),
                 item.selection_range.start(),
             )
         }

--- a/crates/ty_ide/src/workspace_symbols.rs
+++ b/crates/ty_ide/src/workspace_symbols.rs
@@ -1,8 +1,8 @@
 use crate::symbols::{QueryPattern, SymbolInfo, symbols_for_file};
 use rayon::prelude::*;
-use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ty_project::{Db, parallel::ParallelIteratorExt};
+use ty_python_core::program::Program;
 
 /// Get all workspace symbols matching the query string.
 /// Returns symbols from all files in the workspace, filtered by the query.
@@ -31,7 +31,7 @@ pub fn workspace_symbols(db: &dyn Db, query: &str) -> Vec<WorkspaceSymbolInfo> {
             );
             let _entered = symbols_for_file_span.entered();
 
-            symbols_for_file(db, PythonFile::new(db, file, db.python_version()))
+            symbols_for_file(db, Program::get(db).program_file(db, file))
                 .search(&query)
                 .map(|(_, symbol)| WorkspaceSymbolInfo {
                     symbol: symbol.to_owned(),

--- a/crates/ty_ide/src/workspace_symbols.rs
+++ b/crates/ty_ide/src/workspace_symbols.rs
@@ -2,7 +2,6 @@ use crate::symbols::{QueryPattern, SymbolInfo, symbols_for_file};
 use rayon::prelude::*;
 use ruff_db::files::File;
 use ty_project::{Db, parallel::ParallelIteratorExt};
-use ty_python_core::program::Program;
 
 /// Get all workspace symbols matching the query string.
 /// Returns symbols from all files in the workspace, filtered by the query.
@@ -31,7 +30,7 @@ pub fn workspace_symbols(db: &dyn Db, query: &str) -> Vec<WorkspaceSymbolInfo> {
             );
             let _entered = symbols_for_file_span.entered();
 
-            symbols_for_file(db, Program::get(db).program_file(db, file))
+            symbols_for_file(db, db.program_file(file))
                 .search(&query)
                 .map(|(_, symbol)| WorkspaceSymbolInfo {
                     symbol: symbol.to_owned(),

--- a/crates/ty_module_resolver/Cargo.toml
+++ b/crates/ty_module_resolver/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 compact_str = { workspace = true }
 get-size2 = { workspace = true }
+ordermap = { workspace = true }
 regex = { workspace = true }
 regex-syntax = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/ty_module_resolver/src/db.rs
+++ b/crates/ty_module_resolver/src/db.rs
@@ -1,12 +1,7 @@
 use ruff_db::Db as SourceDb;
 
-use crate::resolve::SearchPaths;
-
 #[salsa::db]
-pub trait Db: SourceDb {
-    /// Returns the search paths for module resolution.
-    fn search_paths(&self) -> &SearchPaths;
-}
+pub trait Db: SourceDb {}
 
 #[cfg(test)]
 pub(crate) mod tests {
@@ -19,7 +14,7 @@ pub(crate) mod tests {
     use ruff_python_ast::PythonVersion;
 
     use super::Db;
-    use crate::resolve::SearchPaths;
+    use crate::{ResolverEnvironment, resolve::SearchPaths};
 
     type Events = Arc<Mutex<Vec<salsa::Event>>>;
 
@@ -66,13 +61,17 @@ pub(crate) mod tests {
             self
         }
 
-        pub(crate) fn python_version(&self) -> PythonVersion {
-            self.python_version
-        }
-
         pub(crate) fn set_search_paths(&mut self, search_paths: SearchPaths) {
             search_paths.try_register_static_roots(self);
             self.search_paths = Arc::new(search_paths);
+        }
+
+        pub(crate) fn search_paths(&self) -> &SearchPaths {
+            &self.search_paths
+        }
+
+        pub(crate) fn resolver_environment(&self) -> ResolverEnvironment<'_> {
+            ResolverEnvironment::new(self, self.python_version, self.search_paths.as_ref())
         }
 
         /// Takes the salsa events.
@@ -113,11 +112,7 @@ pub(crate) mod tests {
     }
 
     #[salsa::db]
-    impl Db for TestDb {
-        fn search_paths(&self) -> &SearchPaths {
-            &self.search_paths
-        }
-    }
+    impl Db for TestDb {}
 
     #[salsa::db]
     impl salsa::Database for TestDb {}

--- a/crates/ty_module_resolver/src/environment.rs
+++ b/crates/ty_module_resolver/src/environment.rs
@@ -1,0 +1,66 @@
+use std::fmt;
+
+use ruff_db::files::File;
+use ruff_python_ast::PythonVersion;
+
+use crate::{Db, ModuleResolveMode, SearchPaths, search_paths};
+
+/// The Python version and search paths used to resolve modules.
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
+pub struct ResolverEnvironment<'db> {
+    #[returns(copy)]
+    pub python_version: PythonVersion,
+
+    #[returns(ref)]
+    pub search_paths: SearchPaths,
+}
+
+impl get_size2::GetSize for ResolverEnvironment<'_> {}
+
+impl<'db> ResolverEnvironment<'db> {
+    pub fn display_search_paths(
+        self,
+        db: &'db dyn Db,
+        mode: ModuleResolveMode,
+    ) -> DisplaySearchPaths<'db> {
+        DisplaySearchPaths {
+            db,
+            resolver_environment: self,
+            mode,
+        }
+    }
+}
+
+pub struct DisplaySearchPaths<'db> {
+    db: &'db dyn Db,
+    resolver_environment: ResolverEnvironment<'db>,
+    mode: ModuleResolveMode,
+}
+
+impl fmt::Display for DisplaySearchPaths<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut paths = search_paths(self.db, self.resolver_environment, self.mode).peekable();
+
+        if paths.peek().is_none() {
+            return f.write_str("[]");
+        }
+
+        writeln!(f, "[")?;
+        for path in paths {
+            writeln!(f, "  {path},")?;
+        }
+        f.write_str("]")
+    }
+}
+
+/// A physical file interpreted in one module-resolution environment.
+#[salsa::interned(debug, revisions = usize::MAX, heap_size = ruff_memory_usage::heap_size)]
+pub struct ResolverFile<'db> {
+    #[returns(copy)]
+    pub file: File,
+
+    #[returns(copy)]
+    pub environment: ResolverEnvironment<'db>,
+}
+
+impl get_size2::GetSize for ResolverFile<'_> {}

--- a/crates/ty_module_resolver/src/environment.rs
+++ b/crates/ty_module_resolver/src/environment.rs
@@ -53,7 +53,41 @@ impl fmt::Display for DisplaySearchPaths<'_> {
     }
 }
 
-/// A physical file interpreted in one module-resolution environment.
+/// A file interpreted within a particular module-resolution environment.
+///
+/// The same file can resolve imports differently depending on the Python version and search paths
+/// used to interpret it.
+///
+/// For example, consider a file containing:
+///
+/// ```python
+/// from zipfile._path import Path
+/// ```
+///
+/// Typeshed makes `zipfile._path` available only on Python 3.12 and newer:
+///
+/// ```text
+/// resolve_module(ResolverFile(shared.py, Python 3.11), "zipfile._path")
+///     -> unresolved
+///
+/// resolve_module(ResolverFile(shared.py, Python 3.12), "zipfile._path")
+///     -> zipfile/_path/__init__.pyi
+/// ```
+///
+/// Search paths can also change which file an import resolves to, even when the Python version is
+/// identical:
+///
+/// ```text
+/// resolve_module(ResolverFile(shared.py, project environment), "dependency")
+///     -> .venv/lib/dependency.py
+///
+/// resolve_module(ResolverFile(shared.py, script environment), "dependency")
+///     -> .script-venv/lib/dependency.py
+/// ```
+///
+/// Including the resolver environment in the file's identity keeps these resolution results
+/// separate. Projects and scripts with equivalent resolver environments can still share resolution
+/// results.
 #[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
 pub struct ResolverFile<'db> {
     #[returns(copy)]

--- a/crates/ty_module_resolver/src/environment.rs
+++ b/crates/ty_module_resolver/src/environment.rs
@@ -54,7 +54,7 @@ impl fmt::Display for DisplaySearchPaths<'_> {
 }
 
 /// A physical file interpreted in one module-resolution environment.
-#[salsa::interned(debug, revisions = usize::MAX, heap_size = ruff_memory_usage::heap_size)]
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
 pub struct ResolverFile<'db> {
     #[returns(copy)]
     pub file: File,

--- a/crates/ty_module_resolver/src/lib.rs
+++ b/crates/ty_module_resolver/src/lib.rs
@@ -1,11 +1,14 @@
+use std::hash::BuildHasherDefault;
 use std::iter::FusedIterator;
 
 use ruff_db::system::SystemPath;
+use rustc_hash::FxHasher;
 
 pub use db::Db;
+pub use environment::{ResolverEnvironment, ResolverFile};
 pub use module::KnownModule;
 pub use module::Module;
-pub use module_name::{ModuleName, ModuleNameResolutionError};
+pub use module_name::{ImportingFile, ModuleName, ModuleNameResolutionError};
 pub use path::{SearchPath, SearchPathError};
 pub use resolve::{
     SearchPaths, file_to_module, resolve_module, resolve_module_confident, resolve_real_module,
@@ -20,6 +23,7 @@ pub use module_glob::{ModuleGlobError, ModuleGlobSet, ModuleGlobSetBuilder, Modu
 pub use resolve::{ModuleResolveMode, SearchPathIterator, search_paths};
 
 mod db;
+mod environment;
 mod list;
 mod module;
 mod module_glob;
@@ -30,15 +34,20 @@ mod settings;
 mod strategy;
 mod typeshed;
 
+type FxOrderMap<K, V> = ordermap::map::OrderMap<K, V, BuildHasherDefault<FxHasher>>;
+
 #[cfg(test)]
 mod testing;
 
 /// Returns an iterator over all search paths pointing to a system path
-pub fn system_module_search_paths(db: &dyn Db) -> SystemModuleSearchPathsIter<'_> {
+pub fn system_module_search_paths<'db>(
+    db: &'db dyn Db,
+    resolver_environment: ResolverEnvironment<'db>,
+) -> SystemModuleSearchPathsIter<'db> {
     SystemModuleSearchPathsIter {
         // Always run in `Typing` mode because we want to include as much as possible
         // and we don't care about the "real" stdlib
-        inner: search_paths(db, ModuleResolveMode::Typing),
+        inner: search_paths(db, resolver_environment, ModuleResolveMode::Typing),
     }
 }
 

--- a/crates/ty_module_resolver/src/list.rs
+++ b/crates/ty_module_resolver/src/list.rs
@@ -1,10 +1,9 @@
 use std::borrow::Cow;
 use std::collections::btree_map::{BTreeMap, Entry};
 
-use ruff_db::PythonFile;
 use ruff_db::files::directory_listing;
-use ruff_python_ast::PythonVersion;
 
+use crate::ResolverEnvironment;
 use crate::db::Db;
 use crate::module::{Module, ModuleKind};
 use crate::module_name::ModuleName;
@@ -12,8 +11,11 @@ use crate::path::{ModulePath, SearchPath, SystemOrVendoredPathRef};
 use crate::resolve::{ModuleResolveMode, ResolverContext, resolve_file_module, search_paths};
 
 /// List all available modules, including all sub-modules, sorted in lexicographic order.
-pub fn all_modules(db: &dyn Db, python_version: PythonVersion) -> Vec<Module<'_>> {
-    let mut modules = list_modules(db, python_version).to_vec();
+pub fn all_modules<'db>(
+    db: &'db dyn Db,
+    resolver_environment: ResolverEnvironment<'db>,
+) -> Vec<Module<'db>> {
+    let mut modules = list_modules(db, resolver_environment).to_vec();
     let mut stack = modules.clone();
     while let Some(module) = stack.pop() {
         for &submodule in module.all_submodules(db) {
@@ -26,27 +28,23 @@ pub fn all_modules(db: &dyn Db, python_version: PythonVersion) -> Vec<Module<'_>
 }
 
 /// List all available top-level modules.
-pub fn list_modules(db: &dyn Db, python_version: PythonVersion) -> &[Module<'_>] {
-    list_modules_impl(db, PythonVersionIngredient::new(db, python_version))
-}
-
-#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
-struct PythonVersionIngredient<'db> {
-    #[returns(copy)]
-    python_version: PythonVersion,
+pub fn list_modules<'db>(
+    db: &'db dyn Db,
+    resolver_environment: ResolverEnvironment<'db>,
+) -> &'db [Module<'db>] {
+    list_modules_impl(db, resolver_environment)
 }
 
 #[salsa::tracked(returns(deref))]
 fn list_modules_impl<'db>(
     db: &'db dyn Db,
-    version: PythonVersionIngredient<'db>,
+    resolver_environment: ResolverEnvironment<'db>,
 ) -> Box<[Module<'db>]> {
-    let python_version = version.python_version(db);
     let mut modules: BTreeMap<&ModuleName, ListedModule<'_>> = BTreeMap::new();
-    for search_path in search_paths(db, ModuleResolveMode::Typing) {
+    for search_path in search_paths(db, resolver_environment, ModuleResolveMode::Typing) {
         for &new in list_modules_in(
             db,
-            SearchPathIngredient::new(db, search_path.clone(), python_version),
+            SearchPathIngredient::new(db, resolver_environment, search_path.clone()),
         ) {
             match modules.entry(new.module(db).name(db)) {
                 Entry::Vacant(entry) => {
@@ -83,10 +81,10 @@ fn list_modules_impl<'db>(
 
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 struct SearchPathIngredient<'db> {
+    #[returns(copy)]
+    resolver_environment: ResolverEnvironment<'db>,
     #[returns(ref)]
     path: SearchPath,
-    #[returns(copy)]
-    python_version: PythonVersion,
 }
 
 /// List all available top-level modules in the given `SearchPath`.
@@ -97,7 +95,7 @@ fn list_modules_in<'db>(
 ) -> Vec<ListedModule<'db>> {
     let path = search_path.path(db);
     tracing::debug!("Listing modules in search path '{}'", path);
-    let mut lister = Lister::new(db, path, search_path.python_version(db));
+    let mut lister = Lister::new(db, search_path.resolver_environment(db), path);
     match path.as_path() {
         SystemOrVendoredPathRef::System(system_search_path) => {
             let Ok(listing) = directory_listing(db, system_search_path) else {
@@ -138,7 +136,7 @@ impl get_size2::GetSize for ListedModule<'_> {}
 struct Lister<'db> {
     db: &'db dyn Db,
     search_path: &'db SearchPath,
-    python_version: PythonVersion,
+    resolver_environment: ResolverEnvironment<'db>,
     modules: BTreeMap<&'db ModuleName, ListedModule<'db>>,
 }
 
@@ -147,13 +145,13 @@ impl<'db> Lister<'db> {
     /// of file paths.
     fn new(
         db: &'db dyn Db,
+        resolver_environment: ResolverEnvironment<'db>,
         search_path: &'db SearchPath,
-        python_version: PythonVersion,
     ) -> Lister<'db> {
         Lister {
             db,
             search_path,
-            python_version,
+            resolver_environment,
             modules: BTreeMap::new(),
         }
     }
@@ -205,10 +203,11 @@ impl<'db> Lister<'db> {
                         &module_path,
                         Module::file_module(
                             self.db,
+                            file,
+                            self.resolver_environment,
                             Cow::Owned(module_name),
                             ModuleKind::Package,
                             self.search_path.clone(),
-                            PythonFile::new(self.db, file, self.python_version),
                         ),
                     );
                     return;
@@ -251,8 +250,8 @@ impl<'db> Lister<'db> {
                         &module_path,
                         Module::namespace_package(
                             self.db,
+                            self.resolver_environment,
                             Cow::Owned(module_name),
-                            self.python_version,
                         ),
                     );
                 }
@@ -281,10 +280,11 @@ impl<'db> Lister<'db> {
             &module_path,
             Module::file_module(
                 self.db,
+                file,
+                self.resolver_environment,
                 Cow::Owned(module_name),
                 ModuleKind::Module,
                 self.search_path.clone(),
-                PythonFile::new(self.db, file, self.python_version),
             ),
         );
     }
@@ -347,14 +347,17 @@ impl<'db> Lister<'db> {
 
     /// Returns true if the given module name cannot be shadowable.
     fn is_non_shadowable(&self, name: &ModuleName) -> bool {
-        ModuleResolveMode::Typing.is_non_shadowable(self.python_version.minor, name.as_str())
+        ModuleResolveMode::Typing.is_non_shadowable(
+            self.resolver_environment.python_version(self.db).minor,
+            name.as_str(),
+        )
     }
 
     /// Constructs a resolver context for use with some APIs that require it.
     fn context(&self) -> ResolverContext<'db> {
         ResolverContext {
             db: self.db,
-            python_version: self.python_version,
+            resolver_environment: self.resolver_environment,
             // We don't currently support listing modules
             // in a "no stubs allowed" mode.
             mode: ModuleResolveMode::Typing,
@@ -432,7 +435,7 @@ mod tests {
     use crate::testing::{FileSpec, MockedTypeshed, TestCase, TestCaseBuilder};
 
     fn list_modules(db: &TestDb) -> &[Module<'_>] {
-        super::list_modules(db, db.python_version())
+        super::list_modules(db, db.resolver_environment())
     }
 
     struct ModuleDebugSnapshot<'db> {
@@ -449,14 +452,11 @@ mod tests {
                 Module::File(module) => {
                     // For snapshots, just normalize all paths to using
                     // Unix slashes for simplicity.
-                    let path_components =
-                        match module.python_file(self.db).file(self.db).path(self.db) {
-                            FilePath::System(path) => path.components(),
-                            FilePath::Vendored(path) => path.components(),
-                            FilePath::SystemVirtual(path) => {
-                                Utf8Path::new(path.as_str()).components()
-                            }
-                        };
+                    let path_components = match module.file(self.db).path(self.db) {
+                        FilePath::System(path) => path.components(),
+                        FilePath::Vendored(path) => path.components(),
+                        FilePath::SystemVirtual(path) => Utf8Path::new(path.as_str()).components(),
+                    };
                     let nice_path = path_components
                         // Avoid including a root component, since that
                         // results in a platform dependent separator.
@@ -1465,7 +1465,11 @@ not_a_directory
         assert_function_query_was_not_run(
             &db,
             dynamic_resolution_paths,
-            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::Typing),
+            ModuleResolveModeIngredient::new(
+                &db,
+                db.resolver_environment(),
+                ModuleResolveMode::Typing,
+            ),
             &events,
         );
     }

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::fmt::Formatter;
 use std::str::FromStr;
 
-use ruff_db::PythonFile;
 use ruff_db::files::{File, directory_listing, system_path_to_file, vendored_path_to_file};
 use ruff_db::system::SystemPath;
 use ruff_db::vendored::VendoredPath;
@@ -10,9 +9,9 @@ use ruff_python_ast::PythonVersion;
 use salsa::Database;
 use salsa::plumbing::AsId;
 
-use crate::Db;
 use crate::module_name::ModuleName;
 use crate::path::{SearchPath, SystemOrVendoredPathRef};
+use crate::{Db, ResolverEnvironment};
 
 /// Representation of a Python module.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, salsa::Supertype, salsa::SalsaValue)]
@@ -28,22 +27,39 @@ impl get_size2::GetSize for Module<'_> {}
 impl<'db> Module<'db> {
     pub(crate) fn file_module(
         db: &'db dyn Db,
+        file: File,
+        resolver_environment: ResolverEnvironment<'db>,
         name: Cow<'_, ModuleName>,
         kind: ModuleKind,
         search_path: SearchPath,
-        file: PythonFile<'db>,
     ) -> Self {
         let known = KnownModule::try_from_search_path_and_name(&search_path, &name);
 
-        Self::File(FileModule::new(db, name, kind, search_path, file, known))
+        Self::File(FileModule::new(
+            db,
+            name,
+            kind,
+            search_path,
+            file,
+            resolver_environment,
+            known,
+        ))
     }
 
     pub(crate) fn namespace_package(
         db: &'db dyn Db,
+        resolver_environment: ResolverEnvironment<'db>,
         name: Cow<'_, ModuleName>,
-        python_version: PythonVersion,
     ) -> Self {
-        Self::Namespace(NamespacePackage::new(db, name, python_version))
+        Self::Namespace(NamespacePackage::new(db, resolver_environment, name))
+    }
+
+    /// The resolver environment used to resolve this module.
+    pub fn resolver_environment(self, db: &'db dyn Database) -> ResolverEnvironment<'db> {
+        match self {
+            Module::File(module) => module.resolver_environment(db),
+            Module::Namespace(module) => module.resolver_environment(db),
+        }
     }
 
     /// The absolute name of the module (e.g. `foo.bar`)
@@ -59,27 +75,14 @@ impl<'db> Module<'db> {
     /// This is `None` for namespace packages.
     pub fn file(self, db: &'db dyn Database) -> Option<File> {
         match self {
-            Module::File(module) => Some(module.python_file(db).file(db)),
-            Module::Namespace(_) => None,
-        }
-    }
-
-    /// The versioned file used to parse this module.
-    ///
-    /// This is `None` for namespace packages.
-    pub fn python_file(self, db: &'db dyn Database) -> Option<PythonFile<'db>> {
-        match self {
-            Module::File(module) => Some(module.python_file(db)),
+            Module::File(module) => Some(module.file(db)),
             Module::Namespace(_) => None,
         }
     }
 
     /// The Python version used to resolve this module.
     pub fn python_version(self, db: &'db dyn Database) -> PythonVersion {
-        match self {
-            Module::File(module) => module.python_file(db).python_version(db),
-            Module::Namespace(module) => module.python_version(db),
-        }
+        self.resolver_environment(db).python_version(db)
     }
 
     /// Is this a module that we special-case somehow? If so, which one?
@@ -187,14 +190,14 @@ fn all_submodule_names_for_package<'db>(
         return None;
     }
 
-    let python_file = module.python_file(db);
-    let path = SystemOrVendoredPathRef::try_from_file(db, python_file.file(db))?;
+    let path = SystemOrVendoredPathRef::try_from_file(db, module.file(db))?;
     debug_assert!(
         matches!(path.file_name(), Some("__init__.py" | "__init__.pyi")),
         "expected package file `{:?}` to be `__init__.py` or `__init__.pyi`",
         path.file_name(),
     );
 
+    let resolver_environment = module.resolver_environment(db);
     Some(match path.parent()? {
         SystemOrVendoredPathRef::System(parent_directory) => {
             directory_listing(db, parent_directory)
@@ -230,10 +233,11 @@ fn all_submodule_names_for_package<'db>(
                     };
                     Some(Module::file_module(
                         db,
+                        file,
+                        resolver_environment,
                         Cow::Owned(name),
                         kind,
                         module.search_path(db).clone(),
-                        PythonFile::new(db, file, python_file.python_version(db)),
                     ))
                 })
                 .collect()
@@ -267,10 +271,11 @@ fn all_submodule_names_for_package<'db>(
                 };
                 Some(Module::file_module(
                     db,
+                    file,
+                    resolver_environment,
                     Cow::Owned(name),
                     kind,
                     module.search_path(db).clone(),
-                    PythonFile::new(db, file, python_file.python_version(db)),
                 ))
             })
             .collect(),
@@ -287,7 +292,9 @@ pub struct FileModule<'db> {
     #[returns(ref)]
     pub(super) search_path: SearchPath,
     #[returns(copy)]
-    pub(super) python_file: PythonFile<'db>,
+    pub(super) file: File,
+    #[returns(copy)]
+    pub(super) resolver_environment: ResolverEnvironment<'db>,
     #[returns(copy)]
     pub(super) known: Option<KnownModule>,
 }
@@ -298,10 +305,10 @@ pub struct FileModule<'db> {
 /// multiple possible paths and they have no corresponding code file.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct NamespacePackage<'db> {
+    #[returns(copy)]
+    pub(super) resolver_environment: ResolverEnvironment<'db>,
     #[returns(ref)]
     pub(super) name: ModuleName,
-    #[returns(copy)]
-    pub(super) python_version: PythonVersion,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]

--- a/crates/ty_module_resolver/src/module_name.rs
+++ b/crates/ty_module_resolver/src/module_name.rs
@@ -4,12 +4,13 @@ use std::ops::Deref;
 
 use compact_str::{CompactString, ToCompactString};
 
-use ruff_db::PythonFile;
+use ruff_db::files::File;
 use ruff_python_ast as ast;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::db::Db;
 use crate::resolve::file_to_module;
+use crate::{ResolverEnvironment, ResolverFile};
 
 /// A module name, e.g. `foo.bar`.
 ///
@@ -305,13 +306,12 @@ impl ModuleName {
     /// Extracts a module name from the AST of a `from <module> import ...`
     /// statement.
     ///
-    /// `importing_file` must be the [`PythonFile`] that contains the import
-    /// statement.
+    /// `importing_file` must be the file that contains the import statement.
     ///
     /// This handles relative import statements.
     pub fn from_import_statement<'db>(
         db: &'db dyn Db,
-        importing_file: PythonFile<'db>,
+        importing_file: ImportingFile<'db>,
         node: &'db ast::StmtImportFrom,
     ) -> Result<Self, ModuleNameResolutionError> {
         let ast::StmtImportFrom {
@@ -328,12 +328,12 @@ impl ModuleName {
     /// Computes the absolute module name from the LHS components of `from LHS import RHS`
     pub fn from_identifier_parts<'db>(
         db: &'db dyn Db,
-        importing_file: PythonFile<'db>,
+        importing_file: ImportingFile<'db>,
         module: Option<&str>,
         level: u32,
     ) -> Result<Self, ModuleNameResolutionError> {
         if let Some(level) = NonZeroU32::new(level) {
-            relative_module_name(db, importing_file, module, level)
+            relative_module_name(db, importing_file.resolver_file(db), module, level)
         } else {
             module
                 .and_then(Self::new)
@@ -346,7 +346,7 @@ impl ModuleName {
     /// i.e. this resolves `.`
     pub fn package_for_file<'db>(
         db: &'db dyn Db,
-        importing_file: PythonFile<'db>,
+        importing_file: ImportingFile<'db>,
     ) -> Result<Self, ModuleNameResolutionError> {
         Self::from_identifier_parts(db, importing_file, None, 1)
     }
@@ -468,6 +468,38 @@ impl std::fmt::Display for ModuleName {
     }
 }
 
+/// The file containing an import statement, with either an existing resolver key or its parts.
+#[derive(Clone, Copy)]
+pub enum ImportingFile<'db> {
+    ResolverFile(ResolverFile<'db>),
+    File(File, ResolverEnvironment<'db>),
+}
+
+impl<'db> ImportingFile<'db> {
+    pub fn file(self, db: &dyn Db) -> File {
+        match self {
+            Self::ResolverFile(file) => file.file(db),
+            Self::File(file, _) => file,
+        }
+    }
+
+    pub fn resolver_environment(self, db: &'db dyn Db) -> ResolverEnvironment<'db> {
+        match self {
+            Self::ResolverFile(file) => file.environment(db),
+            Self::File(_, resolver_environment) => resolver_environment,
+        }
+    }
+
+    pub fn resolver_file(self, db: &'db dyn Db) -> ResolverFile<'db> {
+        match self {
+            Self::ResolverFile(file) => file,
+            Self::File(file, resolver_environment) => {
+                ResolverFile::new(db, file, resolver_environment)
+            }
+        }
+    }
+}
+
 /// Given a `from .foo import bar` relative import, resolve the relative module
 /// we're importing `bar` from into an absolute [`ModuleName`]
 /// using the name of the module we're currently analyzing.
@@ -480,7 +512,7 @@ impl std::fmt::Display for ModuleName {
 ///   - `from ..foo.bar import baz` => `tail == "foo.bar"`
 fn relative_module_name<'db>(
     db: &'db dyn Db,
-    importing_file: PythonFile<'db>,
+    importing_file: ResolverFile<'db>,
     tail: Option<&str>,
     level: NonZeroU32,
 ) -> Result<ModuleName, ModuleNameResolutionError> {

--- a/crates/ty_module_resolver/src/module_name.rs
+++ b/crates/ty_module_resolver/src/module_name.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 use compact_str::{CompactString, ToCompactString};
 
 use ruff_db::files::File;
-use ruff_python_ast as ast;
+use ruff_python_ast::{self as ast, PythonVersion};
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::db::Db;
@@ -488,6 +488,10 @@ impl<'db> ImportingFile<'db> {
             Self::ResolverFile(file) => file.environment(db),
             Self::File(_, resolver_environment) => resolver_environment,
         }
+    }
+
+    pub fn python_version(self, db: &'db dyn Db) -> PythonVersion {
+        self.resolver_environment(db).python_version(db)
     }
 
     pub fn resolver_file(self, db: &'db dyn Db) -> ResolverFile<'db> {

--- a/crates/ty_module_resolver/src/module_name.rs
+++ b/crates/ty_module_resolver/src/module_name.rs
@@ -468,10 +468,34 @@ impl std::fmt::Display for ModuleName {
     }
 }
 
-/// The file containing an import statement, with either an existing resolver key or its parts.
+/// The file from which an import is resolved.
+///
+/// Most absolute imports only need the resolver environment. Creating a [`ResolverFile`] for each
+/// such import would unnecessarily intern the file and environment together, even though that
+/// combined identity is never used:
+///
+/// ```text
+/// resolve_module(ImportingFile::File(shared.py, environment), "dependency")
+///     -> resolve using environment; no ResolverFile needed
+/// ```
+///
+/// Relative imports, on the other hand, need the importing file's module identity and therefore
+/// require a [`ResolverFile`]:
+///
+/// ```text
+/// from .dependency import value
+///     -> importing_file.resolver_file(db)
+///     -> ResolverFile(shared.py, environment)
+/// ```
+///
+/// [`ImportingFile::File`] defers interning until such a code path actually calls
+/// [`ImportingFile::resolver_file`]. Callers that already have an interned resolver file can pass
+/// [`ImportingFile::ResolverFile`] to reuse it directly.
 #[derive(Clone, Copy)]
 pub enum ImportingFile<'db> {
+    /// An already-interned resolver key that can be reused without materialization.
     ResolverFile(ResolverFile<'db>),
+    /// An importing file and resolver environment whose combined key is materialized lazily.
     File(File, ResolverEnvironment<'db>),
 }
 
@@ -494,6 +518,7 @@ impl<'db> ImportingFile<'db> {
         self.resolver_environment(db).python_version(db)
     }
 
+    /// Returns the existing resolver key or materializes one when required.
     pub fn resolver_file(self, db: &'db dyn Db) -> ResolverFile<'db> {
         match self {
             Self::ResolverFile(file) => file,

--- a/crates/ty_module_resolver/src/path.rs
+++ b/crates/ty_module_resolver/src/path.rs
@@ -13,7 +13,7 @@ use ruff_db::vendored::{VendoredPath, VendoredPathBuf};
 use crate::Db;
 use crate::module_name::ModuleName;
 use crate::resolve::{PyTyped, ResolverContext};
-use crate::typeshed::{TypeshedVersionsQueryResult, typeshed_versions};
+use crate::typeshed::TypeshedVersionsQueryResult;
 
 /// A path that points to a Python module.
 ///
@@ -428,13 +428,14 @@ fn query_stdlib_version(
     let Some(module_name) = stdlib_path_to_module_name(relative_path) else {
         return TypeshedVersionsQueryResult::DoesNotExist;
     };
-    let ResolverContext {
-        db,
-        python_version,
-        mode: _,
-    } = context;
-
-    typeshed_versions(*db).query_module(&module_name, *python_version)
+    context
+        .resolver_environment
+        .search_paths(context.db)
+        .typeshed_versions()
+        .query_module(
+            &module_name,
+            context.resolver_environment.python_version(context.db),
+        )
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -894,6 +895,7 @@ mod tests {
     use ruff_db::Db;
     use ruff_python_ast::PythonVersion;
 
+    use crate::ResolverEnvironment;
     use crate::db::tests::TestDb;
     use crate::resolve::ModuleResolveMode;
     use crate::testing::{FileSpec, MockedTypeshed, TestCase, TestCaseBuilder};
@@ -1160,7 +1162,11 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY38, db.search_paths()),
+            ModuleResolveMode::Typing,
+        );
 
         let asyncio_regular_package = stdlib_path.join("asyncio");
         assert!(asyncio_regular_package.is_directory(&resolver));
@@ -1190,7 +1196,11 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY38, db.search_paths()),
+            ModuleResolveMode::Typing,
+        );
 
         let xml_namespace_package = stdlib_path.join("xml");
         assert!(xml_namespace_package.is_directory(&resolver));
@@ -1212,7 +1222,11 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY38, db.search_paths()),
+            ModuleResolveMode::Typing,
+        );
 
         let functools_module = stdlib_path.join("functools.pyi");
         assert!(functools_module.to_file(&resolver).is_some());
@@ -1228,7 +1242,11 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY38, db.search_paths()),
+            ModuleResolveMode::Typing,
+        );
 
         let collections_regular_package = stdlib_path.join("collections");
         assert_eq!(collections_regular_package.to_file(&resolver), None);
@@ -1244,7 +1262,11 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY38, db.search_paths()),
+            ModuleResolveMode::Typing,
+        );
 
         let importlib_namespace_package = stdlib_path.join("importlib");
         assert_eq!(importlib_namespace_package.to_file(&resolver), None);
@@ -1265,7 +1287,11 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY38, db.search_paths()),
+            ModuleResolveMode::Typing,
+        );
 
         let non_existent = stdlib_path.join("doesnt_even_exist");
         assert_eq!(non_existent.to_file(&resolver), None);
@@ -1293,7 +1319,11 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY39, ModuleResolveMode::Typing);
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY39, db.search_paths()),
+            ModuleResolveMode::Typing,
+        );
 
         // Since we've set the target version to Py39,
         // `collections` should now exist as a directory, according to VERSIONS...
@@ -1324,7 +1354,11 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY39, ModuleResolveMode::Typing);
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY39, db.search_paths()),
+            ModuleResolveMode::Typing,
+        );
 
         // The `importlib` directory now also exists
         let importlib_namespace_package = stdlib_path.join("importlib");
@@ -1348,7 +1382,11 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY39, ModuleResolveMode::Typing);
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY39, db.search_paths()),
+            ModuleResolveMode::Typing,
+        );
 
         // The `xml` package no longer exists on py39:
         let xml_namespace_package = stdlib_path.join("xml");

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -32,7 +32,6 @@ specifies ty's implementation of Python's import resolution algorithm.
 */
 
 use std::borrow::Cow;
-use std::fmt;
 use std::iter::FusedIterator;
 
 use rustc_hash::{FxBuildHasher, FxHashSet};
@@ -43,29 +42,30 @@ use ruff_db::source::source_text;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_python_ast::{
-    self as ast, PySourceType, PythonVersion,
+    self as ast, PySourceType,
     visitor::{Visitor, walk_body},
 };
 
 use crate::db::Db;
 use crate::module::{Module, ModuleKind};
-use crate::module_name::ModuleName;
+use crate::module_name::{ImportingFile, ModuleName};
 use crate::path::{ModulePath, SearchPath, SystemOrVendoredPathRef};
 use crate::strategy::MisconfigurationStrategy;
 use crate::typeshed::{TypeshedVersions, vendored_typeshed_versions};
-use crate::{SearchPathSettings, SearchPathSettingsError};
+use crate::{ResolverEnvironment, ResolverFile, SearchPathSettings, SearchPathSettingsError};
 
 /// Resolves a module name to a module.
 pub fn resolve_module<'db>(
     db: &'db dyn Db,
-    importing_file: PythonFile<'db>,
+    importing_file: ImportingFile<'db>,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
+    let resolver_environment = importing_file.resolver_environment(db);
     let interned_name = ModuleNameIngredient::new(
         db,
         module_name,
         ModuleResolveMode::Typing,
-        importing_file.python_version(db),
+        resolver_environment,
     );
 
     resolve_module_query(db, interned_name)
@@ -78,11 +78,15 @@ pub fn resolve_module<'db>(
 /// we don't have a well-defined importing file.
 pub fn resolve_module_confident<'db>(
     db: &'db dyn Db,
-    python_version: PythonVersion,
+    resolver_environment: ResolverEnvironment<'db>,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
-    let interned_name =
-        ModuleNameIngredient::new(db, module_name, ModuleResolveMode::Typing, python_version);
+    let interned_name = ModuleNameIngredient::new(
+        db,
+        module_name,
+        ModuleResolveMode::Typing,
+        resolver_environment,
+    );
 
     resolve_module_query(db, interned_name)
 }
@@ -90,14 +94,15 @@ pub fn resolve_module_confident<'db>(
 /// Resolves a module name to a module (stubs not allowed).
 pub fn resolve_real_module<'db>(
     db: &'db dyn Db,
-    importing_file: PythonFile<'db>,
+    importing_file: ImportingFile<'db>,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
+    let resolver_environment = importing_file.resolver_environment(db);
     let interned_name = ModuleNameIngredient::new(
         db,
         module_name,
         ModuleResolveMode::Runtime,
-        importing_file.python_version(db),
+        resolver_environment,
     );
 
     resolve_module_query(db, interned_name)
@@ -110,11 +115,15 @@ pub fn resolve_real_module<'db>(
 /// we don't have a well-defined importing file.
 pub fn resolve_real_module_confident<'db>(
     db: &'db dyn Db,
-    python_version: PythonVersion,
+    resolver_environment: ResolverEnvironment<'db>,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
-    let interned_name =
-        ModuleNameIngredient::new(db, module_name, ModuleResolveMode::Runtime, python_version);
+    let interned_name = ModuleNameIngredient::new(
+        db,
+        module_name,
+        ModuleResolveMode::Runtime,
+        resolver_environment,
+    );
 
     resolve_module_query(db, interned_name)
 }
@@ -132,14 +141,15 @@ pub fn resolve_real_module_confident<'db>(
 /// are involved in an import cycle with `builtins`.
 pub fn resolve_real_shadowable_module<'db>(
     db: &'db dyn Db,
-    importing_file: PythonFile<'db>,
+    importing_file: ImportingFile<'db>,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
+    let resolver_environment = importing_file.resolver_environment(db);
     let interned_name = ModuleNameIngredient::new(
         db,
         module_name,
         ModuleResolveMode::RuntimeSomeShadowingAllowed,
-        importing_file.python_version(db),
+        resolver_environment,
     );
 
     resolve_module_query(db, interned_name)
@@ -174,6 +184,8 @@ pub enum ModuleResolveMode {
 #[salsa::interned(heap_size=ruff_memory_usage::heap_size)]
 #[derive(Debug)]
 pub(crate) struct ModuleResolveModeIngredient<'db> {
+    #[returns(copy)]
+    resolver_environment: ResolverEnvironment<'db>,
     #[returns(copy)]
     mode: ModuleResolveMode,
 }
@@ -228,10 +240,10 @@ fn resolve_module_query<'db>(
 ) -> Option<Module<'db>> {
     let name = module_name.name(db);
     let mode = module_name.mode(db);
-    let python_version = module_name.python_version(db);
+    let resolver_environment = module_name.resolver_environment(db);
     let _span = tracing::trace_span!("resolve_module", %name).entered();
 
-    let Some(resolved) = resolve_name(db, name, mode, python_version) else {
+    let Some(resolved) = resolve_name(db, resolver_environment, name, mode) else {
         tracing::debug!("Module `{name}` not found in search paths");
         return None;
     };
@@ -239,7 +251,7 @@ fn resolve_module_query<'db>(
     resolved
         .into_iter()
         .next()
-        .map(|candidate| candidate.into_module(db, name, python_version))
+        .map(|candidate| candidate.into_module(db, resolver_environment, name))
 }
 
 /// Like `resolve_module_query` but for cases where it failed to resolve the module
@@ -262,10 +274,11 @@ fn desperately_resolve_module<'db>(
 ) -> Option<Module<'db>> {
     let name = module_name.name(db);
     let mode = module_name.mode(db);
-    let python_version = module_name.python_version(db);
+    let resolver_environment = module_name.resolver_environment(db);
     let _span = tracing::trace_span!("desperately_resolve_module", %name).entered();
 
-    let Some(resolved) = desperately_resolve_name(db, importing_file, name, mode, python_version)
+    let Some(resolved) =
+        desperately_resolve_name(db, importing_file, resolver_environment, name, mode)
     else {
         let mode = match mode {
             ModuleResolveMode::Typing => "typing mode",
@@ -281,7 +294,7 @@ fn desperately_resolve_module<'db>(
     resolved
         .into_iter()
         .next()
-        .map(|candidate| candidate.into_module(db, name, python_version))
+        .map(|candidate| candidate.into_module(db, resolver_environment, name))
 }
 
 /// Resolves the module for the given path.
@@ -290,8 +303,8 @@ fn desperately_resolve_module<'db>(
 #[allow(unused)]
 pub(crate) fn path_to_module<'db>(
     db: &'db dyn Db,
+    resolver_environment: ResolverEnvironment<'db>,
     path: &FilePath,
-    python_version: PythonVersion,
 ) -> Option<Module<'db>> {
     // It's not entirely clear on first sight why this method calls `file_to_module` instead of
     // it being the other way round, considering that the first thing that `file_to_module` does
@@ -302,7 +315,7 @@ pub(crate) fn path_to_module<'db>(
     // `VfsFile` is. So what we do here is to retrieve the `path`'s `VfsFile` so that we can make
     // use of Salsa's caching and invalidation.
     let file = path.to_file(db)?;
-    file_to_module(db, PythonFile::new(db, file, python_version))
+    file_to_module(db, ResolverFile::new(db, file, resolver_environment))
 }
 
 /// Resolves the module for the file with the given id.
@@ -314,25 +327,35 @@ pub(crate) fn path_to_module<'db>(
 /// This intuition is particularly useful for understanding why it's correct that we pass
 /// the file itself as `importing_file` to various subroutines.
 #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
-pub fn file_to_module<'db>(db: &'db dyn Db, file: PythonFile<'db>) -> Option<Module<'db>> {
-    let source_file = file.file(db);
-    let _span = tracing::trace_span!("file_to_module", file=?source_file).entered();
+pub fn file_to_module<'db>(
+    db: &'db dyn Db,
+    resolver_file: ResolverFile<'db>,
+) -> Option<Module<'db>> {
+    let resolver_environment = resolver_file.environment(db);
+    let file = resolver_file.file(db);
+    let _span = tracing::trace_span!("file_to_module", ?file).entered();
 
-    let path = SystemOrVendoredPathRef::try_from_file(db, source_file)?;
+    let path = SystemOrVendoredPathRef::try_from_file(db, file)?;
 
-    file_to_module_impl(db, file, path, search_paths(db, ModuleResolveMode::Typing)).or_else(|| {
+    file_to_module_impl(
+        db,
+        resolver_file,
+        path,
+        search_paths(db, resolver_environment, ModuleResolveMode::Typing),
+    )
+    .or_else(|| {
         file_to_module_impl(
             db,
-            file,
+            resolver_file,
             path,
-            relative_desperate_search_paths(db, source_file).iter(),
+            relative_desperate_search_paths(db, resolver_file).iter(),
         )
     })
 }
 
 fn file_to_module_impl<'db, 'a>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    resolver_file: ResolverFile<'db>,
     path: SystemOrVendoredPathRef<'a>,
     mut search_paths: impl Iterator<Item = &'a SearchPath>,
 ) -> Option<Module<'db>> {
@@ -348,20 +371,21 @@ fn file_to_module_impl<'db, 'a>(
     // If it doesn't, then that means that multiple modules have the same name in different
     // root paths, but that the module corresponding to `path` is in a lower priority search path,
     // in which case we ignore it.
-    let module = resolve_module(db, file, &module_name)?;
+    let module = resolve_module(db, ImportingFile::ResolverFile(resolver_file), &module_name)?;
     let module_file = module.file(db)?;
 
-    let source_file = file.file(db);
-    let file_path = source_file.path(db);
+    let file: File = resolver_file.file(db);
+    let file_path = file.path(db);
     if file_path == module_file.path(db) {
         return Some(module);
-    } else if source_file.source_type(db) == PySourceType::Python
+    } else if file.source_type(db) == PySourceType::Python
         && module_file.source_type(db) == PySourceType::Stub
     {
         // If a .py and .pyi are both defined, the .pyi will be the one returned by `resolve_module().file`,
         // which would make us erroneously believe the `.py` is *not* also this module (breaking things
         // like relative imports). So here we try `resolve_real_module().file` to cover both cases.
-        let module = resolve_real_module(db, file, &module_name)?;
+        let module =
+            resolve_real_module(db, ImportingFile::ResolverFile(resolver_file), &module_name)?;
         let module_file = module.file(db)?;
         if file_path == module_file.path(db) {
             return Some(module);
@@ -377,8 +401,14 @@ fn file_to_module_impl<'db, 'a>(
     None
 }
 
-pub fn search_paths(db: &dyn Db, resolve_mode: ModuleResolveMode) -> SearchPathIterator<'_> {
-    db.search_paths().iter(db, resolve_mode)
+pub fn search_paths<'db>(
+    db: &'db dyn Db,
+    resolver_environment: ResolverEnvironment<'db>,
+    resolve_mode: ModuleResolveMode,
+) -> SearchPathIterator<'db> {
+    resolver_environment
+        .search_paths(db)
+        .iter(db, resolver_environment, resolve_mode)
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -467,8 +497,14 @@ impl StubPackageIndex {
 /// Returns an index of search paths that may contain a top-level stub package, preserving their
 /// resolution order relative to stdlib.
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
-fn stub_package_index(db: &dyn Db) -> StubPackageIndex {
-    StubPackageIndex::from_search_paths(db, search_paths(db, ModuleResolveMode::Typing))
+fn stub_package_index(
+    db: &dyn Db,
+    resolver_environment: ResolverEnvironment<'_>,
+) -> StubPackageIndex {
+    StubPackageIndex::from_search_paths(
+        db,
+        search_paths(db, resolver_environment, ModuleResolveMode::Typing),
+    )
 }
 
 fn search_path_may_contain_stub_package(db: &dyn Db, search_path: &SearchPath) -> bool {
@@ -490,21 +526,26 @@ fn search_path_may_contain_stub_package(db: &dyn Db, search_path: &SearchPath) -
 ///
 /// We exclude `__init__.py(i)` dirs to avoid truncating packages.
 #[salsa::tracked(returns(as_deref), heap_size=ruff_memory_usage::heap_size)]
-fn absolute_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<Box<[SearchPath]>> {
+fn absolute_desperate_search_paths(
+    db: &dyn Db,
+    importing_file: ResolverFile<'_>,
+) -> Option<Box<[SearchPath]>> {
+    let resolver_environment = importing_file.environment(db);
+    let importing_file = importing_file.file(db);
     let system = db.system();
     let importing_path = importing_file.path(db).as_system_path()?;
 
     // Only allow this if the importing_file is under the first-party search path
-    let (base_path, rel_path) =
-        search_paths(db, ModuleResolveMode::Typing).find_map(|search_path| {
-            if !search_path.is_first_party() {
-                return None;
-            }
-            Some((
-                search_path.as_system_path()?,
-                search_path.relativize_system_path_only(importing_path)?,
-            ))
-        })?;
+    let (base_path, rel_path) = search_paths(db, resolver_environment, ModuleResolveMode::Typing)
+        .find_map(|search_path| {
+        if !search_path.is_first_party() {
+            return None;
+        }
+        Some((
+            search_path.as_system_path()?,
+            search_path.relativize_system_path_only(importing_path)?,
+        ))
+    })?;
 
     // Only allow searching up to the first-party path's root
     let mut search_paths = Vec::new();
@@ -554,21 +595,26 @@ fn absolute_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<
 /// chaotic things. In particular, all files under a given pyproject.toml will currently
 /// agree on this being their desperate search-path, which is really nice.
 #[salsa::tracked(returns(clone), heap_size=ruff_memory_usage::heap_size)]
-fn relative_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<SearchPath> {
+fn relative_desperate_search_paths(
+    db: &dyn Db,
+    importing_file: ResolverFile<'_>,
+) -> Option<SearchPath> {
+    let resolver_environment = importing_file.environment(db);
+    let importing_file = importing_file.file(db);
     let system = db.system();
     let importing_path = importing_file.path(db).as_system_path()?;
 
     // Only allow this if the importing_file is under the first-party search path
-    let (base_path, rel_path) =
-        search_paths(db, ModuleResolveMode::Typing).find_map(|search_path| {
-            if !search_path.is_first_party() {
-                return None;
-            }
-            Some((
-                search_path.as_system_path()?,
-                search_path.relativize_system_path_only(importing_path)?,
-            ))
-        })?;
+    let (base_path, rel_path) = search_paths(db, resolver_environment, ModuleResolveMode::Typing)
+        .find_map(|search_path| {
+        if !search_path.is_first_party() {
+            return None;
+        }
+        Some((
+            search_path.as_system_path()?,
+            search_path.relativize_system_path_only(importing_path)?,
+        ))
+    })?;
 
     // Only allow searching up to the first-party path's root
     for rel_dir in rel_path.ancestors() {
@@ -587,7 +633,7 @@ fn relative_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<
 
     None
 }
-#[derive(Clone, Debug, PartialEq, Eq, get_size2::GetSize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub struct SearchPaths {
     /// Search paths that have been statically determined purely from reading
     /// ty's configuration settings. These shouldn't ever change unless the
@@ -815,14 +861,19 @@ impl SearchPaths {
         }
     }
 
-    fn iter<'a>(&'a self, db: &'a dyn Db, mode: ModuleResolveMode) -> SearchPathIterator<'a> {
+    pub(super) fn iter<'a>(
+        &'a self,
+        db: &'a dyn Db,
+        resolver_environment: ResolverEnvironment<'a>,
+        mode: ModuleResolveMode,
+    ) -> SearchPathIterator<'a> {
         let stdlib_path = self.stdlib(mode);
         SearchPathIterator {
             db,
             static_paths: self.static_paths.iter(),
             stdlib_path,
             dynamic_paths: None,
-            mode: ModuleResolveModeIngredient::new(db, mode),
+            mode: ModuleResolveModeIngredient::new(db, resolver_environment, mode),
         }
     }
 
@@ -835,18 +886,6 @@ impl SearchPaths {
         }
     }
 
-    pub fn display<'a>(
-        &'a self,
-        db: &'a dyn Db,
-        mode: ModuleResolveMode,
-    ) -> DisplaySearchPaths<'a> {
-        DisplaySearchPaths {
-            search_paths: self,
-            db,
-            mode,
-        }
-    }
-
     pub fn custom_stdlib(&self) -> Option<&SystemPath> {
         self.stdlib_path
             .as_ref()
@@ -855,28 +894,6 @@ impl SearchPaths {
 
     pub fn typeshed_versions(&self) -> &TypeshedVersions {
         &self.typeshed_versions
-    }
-}
-
-pub struct DisplaySearchPaths<'a> {
-    search_paths: &'a SearchPaths,
-    db: &'a dyn Db,
-    mode: ModuleResolveMode,
-}
-
-impl fmt::Display for DisplaySearchPaths<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut paths = self.search_paths.iter(self.db, self.mode).peekable();
-
-        if paths.peek().is_none() {
-            return f.write_str("[]");
-        }
-
-        writeln!(f, "[")?;
-        for path in paths {
-            writeln!(f, "  {path},")?;
-        }
-        f.write_str("]")
     }
 }
 
@@ -901,7 +918,7 @@ pub(crate) fn dynamic_resolution_paths<'db>(
         site_packages,
         typeshed_versions: _,
         real_stdlib_path,
-    } = db.search_paths();
+    } = mode.resolver_environment(db).search_paths(db);
 
     let mut dynamic_paths = Vec::new();
 
@@ -1070,7 +1087,7 @@ impl<'db> Iterator for SearchPathIterator<'db> {
 
 impl FusedIterator for SearchPathIterator<'_> {}
 
-/// A thin wrapper around a module name, resolution mode, and Python version to make them a Salsa
+/// A thin wrapper around a module name, resolution mode, and resolver environment to make them a Salsa
 /// ingredient.
 ///
 /// This is needed because Salsa requires that all query arguments are salsa ingredients.
@@ -1081,23 +1098,25 @@ struct ModuleNameIngredient<'db> {
     #[returns(copy)]
     pub(super) mode: ModuleResolveMode,
     #[returns(copy)]
-    pub(super) python_version: PythonVersion,
+    pub(super) resolver_environment: ResolverEnvironment<'db>,
 }
 
 /// Given a module name and a list of search paths in which to lookup modules,
 /// attempt to resolve the module name
-fn resolve_name(
-    db: &dyn Db,
+fn resolve_name<'db>(
+    db: &'db dyn Db,
+    resolver_environment: ResolverEnvironment<'db>,
     name: &ModuleName,
     mode: ModuleResolveMode,
-    python_version: PythonVersion,
 ) -> Option<ResolvedNames> {
-    let resolver = NameResolver::new(db, name, mode, python_version);
+    let resolver = NameResolver::new(db, resolver_environment, name, mode);
 
     match mode {
-        ModuleResolveMode::Typing => resolver.resolve_typing(stub_package_index(db)),
+        ModuleResolveMode::Typing => {
+            resolver.resolve_typing(stub_package_index(db, resolver_environment))
+        }
         ModuleResolveMode::Runtime | ModuleResolveMode::RuntimeSomeShadowingAllowed => {
-            resolver.resolve_runtime(search_paths(db, mode))
+            resolver.resolve_runtime(search_paths(db, resolver_environment, mode))
         }
     }
 }
@@ -1106,15 +1125,16 @@ fn resolve_name(
 /// and we are now Getting Desperate and willing to try the ancestor directories of
 /// the `importing_file` as potential temporary search paths that are private
 /// to this import.
-fn desperately_resolve_name(
-    db: &dyn Db,
+fn desperately_resolve_name<'db>(
+    db: &'db dyn Db,
     importing_file: File,
+    resolver_environment: ResolverEnvironment<'db>,
     name: &ModuleName,
     mode: ModuleResolveMode,
-    python_version: PythonVersion,
 ) -> Option<ResolvedNames> {
+    let importing_file = ResolverFile::new(db, importing_file, resolver_environment);
     let search_paths = absolute_desperate_search_paths(db, importing_file).unwrap_or_default();
-    let resolver = NameResolver::new(db, name, mode, python_version);
+    let resolver = NameResolver::new(db, resolver_environment, name, mode);
 
     match mode {
         ModuleResolveMode::Typing => resolver.resolve_desperate_typing(search_paths),
@@ -1201,13 +1221,13 @@ impl ModuleResolutionCandidate {
     fn into_module<'db>(
         self,
         db: &'db dyn Db,
+        resolver_environment: ResolverEnvironment<'db>,
         name: &ModuleName,
-        python_version: PythonVersion,
     ) -> Module<'db> {
         match self.module {
             ResolvedModule::NamespacePackage => {
                 tracing::trace!("Resolve namespace package `{name}`");
-                Module::namespace_package(db, Cow::Borrowed(name), python_version)
+                Module::namespace_package(db, resolver_environment, Cow::Borrowed(name))
             }
             ResolvedModule::LegacyNamespacePackage(file) => {
                 // legacy namespace packages behave like regular packages
@@ -1218,10 +1238,11 @@ impl ModuleResolutionCandidate {
                 );
                 Module::file_module(
                     db,
+                    file,
+                    resolver_environment,
                     Cow::Borrowed(name),
                     ModuleKind::Package,
                     self.path.into_search_path(),
-                    PythonFile::new(db, file, python_version),
                 )
             }
             ResolvedModule::RegularPackage(file) => {
@@ -1231,20 +1252,22 @@ impl ModuleResolutionCandidate {
                 );
                 Module::file_module(
                     db,
+                    file,
+                    resolver_environment,
                     Cow::Borrowed(name),
                     ModuleKind::Package,
                     self.path.into_search_path(),
-                    PythonFile::new(db, file, python_version),
                 )
             }
             ResolvedModule::Module(file) => {
                 tracing::trace!("Resolved module `{name}` to `{path}`", path = file.path(db));
                 Module::file_module(
                     db,
+                    file,
+                    resolver_environment,
                     Cow::Borrowed(name),
                     ModuleKind::Module,
                     self.path.into_search_path(),
-                    PythonFile::new(db, file, python_version),
                 )
             }
         }
@@ -1286,12 +1309,13 @@ struct NameResolver<'db, 'name> {
 impl<'db, 'name> NameResolver<'db, 'name> {
     fn new(
         db: &'db dyn Db,
+        resolver_environment: ResolverEnvironment<'db>,
         name: &'name ModuleName,
         mode: ModuleResolveMode,
-        python_version: PythonVersion,
     ) -> Self {
+        let python_version = resolver_environment.python_version(db);
         Self {
-            context: ResolverContext::new(db, python_version, mode),
+            context: ResolverContext::new(db, resolver_environment, mode),
             name,
             is_non_shadowable: mode.is_non_shadowable(python_version.minor, name.as_str()),
         }
@@ -1303,11 +1327,18 @@ impl<'db, 'name> NameResolver<'db, 'name> {
     /// a fallback when no stub provides the requested module. A stub overlay may use runtime
     /// packages as parents, but its final module must come from a stub file.
     fn resolve_typing(&self, stub_packages: &StubPackageIndex) -> Option<ResolvedNames> {
-        let search_paths = self.context.db.search_paths();
+        let search_paths = self
+            .context
+            .resolver_environment
+            .search_paths(self.context.db);
 
         if self.name.components().nth(1).is_none() {
             let candidates = self.discover_roots(
-                search_paths.iter(self.context.db, ModuleResolveMode::Typing),
+                search_paths.iter(
+                    self.context.db,
+                    self.context.resolver_environment,
+                    ModuleResolveMode::Typing,
+                ),
                 stub_packages.all(),
             );
             return self.resolve_remaining(candidates, ComponentFileFilter::ByMode);
@@ -1319,7 +1350,11 @@ impl<'db, 'name> NameResolver<'db, 'name> {
         let (overlay_stub_packages, remaining_stub_packages) = stub_packages.split_overlay();
         let mut candidates = self.discover_roots(
             search_paths
-                .iter(self.context.db, ModuleResolveMode::Typing)
+                .iter(
+                    self.context.db,
+                    self.context.resolver_environment,
+                    ModuleResolveMode::Typing,
+                )
                 .take_while(|search_path| search_path.is_extra()),
             overlay_stub_packages,
         );
@@ -1331,7 +1366,11 @@ impl<'db, 'name> NameResolver<'db, 'name> {
 
         let remaining_candidates = self.discover_roots(
             search_paths
-                .iter(self.context.db, ModuleResolveMode::Typing)
+                .iter(
+                    self.context.db,
+                    self.context.resolver_environment,
+                    ModuleResolveMode::Typing,
+                )
                 .skip_while(|search_path| search_path.is_extra()),
             remaining_stub_packages,
         );
@@ -1738,7 +1777,11 @@ fn is_legacy_namespace_package(
     // but hey, this is better than nothing!
     let parsed = ruff_db::parsed::parsed_module(
         context.db,
-        ruff_db::PythonFile::new(context.db, init, context.python_version),
+        PythonFile::new(
+            context.db,
+            init,
+            context.resolver_environment.python_version(context.db),
+        ),
     );
     let mut visitor = LegacyNamespacePackageVisitor::default();
     visitor.visit_body(parsed.load(context.db).suite());
@@ -1774,19 +1817,19 @@ impl PyTyped {
 
 pub(super) struct ResolverContext<'db> {
     pub(super) db: &'db dyn Db,
-    pub(super) python_version: PythonVersion,
+    pub(super) resolver_environment: ResolverEnvironment<'db>,
     pub(super) mode: ModuleResolveMode,
 }
 
 impl<'db> ResolverContext<'db> {
     pub(super) fn new(
         db: &'db dyn Db,
-        python_version: PythonVersion,
+        resolver_environment: ResolverEnvironment<'db>,
         mode: ModuleResolveMode,
     ) -> Self {
         Self {
             db,
-            python_version,
+            resolver_environment,
             mode,
         }
     }
@@ -2017,18 +2060,18 @@ mod tests {
         db: &'db TestDb,
         module_name: &ModuleName,
     ) -> Option<Module<'db>> {
-        super::resolve_module_confident(db, db.python_version(), module_name)
+        super::resolve_module_confident(db, db.resolver_environment(), module_name)
     }
 
     fn resolve_real_module_confident<'db>(
         db: &'db TestDb,
         module_name: &ModuleName,
     ) -> Option<Module<'db>> {
-        super::resolve_real_module_confident(db, db.python_version(), module_name)
+        super::resolve_real_module_confident(db, db.resolver_environment(), module_name)
     }
 
     fn path_to_module<'db>(db: &'db TestDb, path: &FilePath) -> Option<Module<'db>> {
-        super::path_to_module(db, path, db.python_version())
+        super::path_to_module(db, db.resolver_environment(), path)
     }
 
     #[test]
@@ -2102,10 +2145,13 @@ mod tests {
             ])
             .build();
         let importing_file = system_path_to_file(&db, src.join("nested/main.py")).unwrap();
-        let importing_file = PythonFile::new(&db, importing_file, db.python_version());
 
-        let foo =
-            resolve_module(&db, importing_file, &ModuleName::new_static("foo").unwrap()).unwrap();
+        let foo = resolve_module(
+            &db,
+            ImportingFile::File(importing_file, db.resolver_environment()),
+            &ModuleName::new_static("foo").unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             foo.file(&db).unwrap().path(&db),
             &src.join("nested/foo-stubs/__init__.pyi")
@@ -2303,7 +2349,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_module_uses_importing_file_python_version() {
+    fn resolve_module_uses_resolver_environment_python_version() {
         const TYPESHED: MockedTypeshed = MockedTypeshed {
             stdlib_files: &[("_sha256.pyi", ""), ("py312_only.pyi", "")],
             versions: "_sha256: 3.11-\npy312_only: 3.12-",
@@ -2321,12 +2367,13 @@ mod tests {
             .with_python_version(PythonVersion::PY311)
             .build();
         let importing_file = system_path_to_file(&db, src.join("main.py")).unwrap();
-        let py311 = PythonFile::new(&db, importing_file, PythonVersion::PY311);
-        let py312 = PythonFile::new(&db, importing_file, PythonVersion::PY312);
-
+        let py311 = ResolverEnvironment::new(&db, PythonVersion::PY311, db.search_paths());
+        let py312 = ResolverEnvironment::new(&db, PythonVersion::PY312, db.search_paths());
         let sha256 = ModuleName::new_static("_sha256").unwrap();
-        let py311_module = resolve_module(&db, py311, &sha256).unwrap();
-        let py312_module = resolve_module(&db, py312, &sha256).unwrap();
+        let py311_module =
+            resolve_module(&db, ImportingFile::File(importing_file, py311), &sha256).unwrap();
+        let py312_module =
+            resolve_module(&db, ImportingFile::File(importing_file, py312), &sha256).unwrap();
         assert_eq!(
             py311_module.file(&db).unwrap().path(&db),
             &stdlib.join("_sha256.pyi")
@@ -2339,8 +2386,10 @@ mod tests {
         assert_eq!(py312_module.python_version(&db), PythonVersion::PY312);
 
         let namespace = ModuleName::new_static("namespace").unwrap();
-        let py311_namespace = resolve_module(&db, py311, &namespace).unwrap();
-        let py312_namespace = resolve_module(&db, py312, &namespace).unwrap();
+        let py311_namespace =
+            resolve_module(&db, ImportingFile::File(importing_file, py311), &namespace).unwrap();
+        let py312_namespace =
+            resolve_module(&db, ImportingFile::File(importing_file, py312), &namespace).unwrap();
         assert!(matches!(py311_namespace, Module::Namespace(_)));
         assert!(matches!(py312_namespace, Module::Namespace(_)));
         assert_eq!(py311_namespace.python_version(&db), PythonVersion::PY311);
@@ -2348,14 +2397,54 @@ mod tests {
         assert_ne!(py311_namespace, py312_namespace);
 
         let py312_only = ModuleName::new_static("py312_only").unwrap();
-        assert!(resolve_module(&db, py311, &py312_only).is_none());
+        assert!(
+            resolve_module(&db, ImportingFile::File(importing_file, py311), &py312_only).is_none()
+        );
         assert_eq!(
-            resolve_module(&db, py312, &py312_only)
+            resolve_module(&db, ImportingFile::File(importing_file, py312), &py312_only)
                 .and_then(|module| module.file(&db))
                 .unwrap()
                 .path(&db),
             &stdlib.join("py312_only.pyi")
         );
+    }
+
+    #[test]
+    fn resolve_module_uses_resolver_environment_search_paths() {
+        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[("main.py", ""), ("shared.py", "from_src = True")])
+            .with_vendored_typeshed()
+            .build();
+        db.write_file("/alternate/shared.py", "from_alternate = True")
+            .unwrap();
+
+        let alternate_paths = SearchPathSettings {
+            src_roots: vec![SystemPathBuf::from("/alternate")],
+            ..SearchPathSettings::empty()
+        }
+        .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
+        .unwrap();
+        alternate_paths.try_register_static_roots(&db);
+
+        let primary = db.resolver_environment();
+        let alternate = ResolverEnvironment::new(&db, PythonVersion::default(), &alternate_paths);
+        let importing_file = system_path_to_file(&db, src.join("main.py")).unwrap();
+        let name = ModuleName::new_static("shared").unwrap();
+
+        let primary_module =
+            resolve_module(&db, ImportingFile::File(importing_file, primary), &name).unwrap();
+        let alternate_module =
+            resolve_module(&db, ImportingFile::File(importing_file, alternate), &name).unwrap();
+
+        assert_eq!(
+            primary_module.file(&db).unwrap().path(&db),
+            &src.join("shared.py")
+        );
+        assert_eq!(
+            alternate_module.file(&db).unwrap().path(&db),
+            &SystemPathBuf::from("/alternate/shared.py")
+        );
+        assert_ne!(primary_module, alternate_module);
     }
 
     #[test]
@@ -2894,7 +2983,7 @@ mod tests {
                 &db,
                 functools_module_name,
                 ModuleResolveMode::Typing,
-                db.python_version(),
+                db.resolver_environment(),
             ),
             &events,
         );
@@ -3153,7 +3242,11 @@ not_a_directory
         assert_function_query_was_not_run(
             &db,
             dynamic_resolution_paths,
-            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::Typing),
+            ModuleResolveModeIngredient::new(
+                &db,
+                db.resolver_environment(),
+                ModuleResolveMode::Typing,
+            ),
             &events,
         );
     }
@@ -3172,7 +3265,11 @@ not_a_directory
 
         dynamic_resolution_paths(
             &db,
-            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::Typing),
+            ModuleResolveModeIngredient::new(
+                &db,
+                db.resolver_environment(),
+                ModuleResolveMode::Typing,
+            ),
         );
         db.clear_salsa_events();
 
@@ -3180,14 +3277,22 @@ not_a_directory
             .unwrap();
         dynamic_resolution_paths(
             &db,
-            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::Typing),
+            ModuleResolveModeIngredient::new(
+                &db,
+                db.resolver_environment(),
+                ModuleResolveMode::Typing,
+            ),
         );
 
         let events = db.take_salsa_events();
         assert_function_query_was_not_run(
             &db,
             dynamic_resolution_paths,
-            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::Typing),
+            ModuleResolveModeIngredient::new(
+                &db,
+                db.resolver_environment(),
+                ModuleResolveMode::Typing,
+            ),
             &events,
         );
     }
@@ -3284,7 +3389,8 @@ not_a_directory
             .with_site_packages_files(&[("_foo.pth", "/src")])
             .build();
 
-        let search_paths: Vec<&SearchPath> = search_paths(&db, ModuleResolveMode::Typing).collect();
+        let search_paths: Vec<&SearchPath> =
+            search_paths(&db, db.resolver_environment(), ModuleResolveMode::Typing).collect();
 
         assert!(search_paths.contains(
             &&SearchPath::first_party(db.system(), SystemPathBuf::from("/src")).unwrap()
@@ -3432,7 +3538,7 @@ not_a_directory
         let foo_module_file = File::new(&db, FilePath::from(installed_foo_module));
         let module = file_to_module(
             &db,
-            PythonFile::new(&db, foo_module_file, db.python_version()),
+            ResolverFile::new(&db, foo_module_file, db.resolver_environment()),
         )
         .unwrap();
         assert_eq!(module.search_path(&db).unwrap(), &site_packages);

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -406,9 +406,15 @@ pub fn search_paths<'db>(
     resolver_environment: ResolverEnvironment<'db>,
     resolve_mode: ModuleResolveMode,
 ) -> SearchPathIterator<'db> {
-    resolver_environment
-        .search_paths(db)
-        .iter(db, resolver_environment, resolve_mode)
+    let search_paths = resolver_environment.search_paths(db);
+
+    SearchPathIterator {
+        db,
+        static_paths: search_paths.static_paths.iter(),
+        stdlib_path: search_paths.stdlib(resolve_mode),
+        dynamic_paths: None,
+        mode: ModuleResolveModeIngredient::new(db, resolver_environment, resolve_mode),
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -858,22 +864,6 @@ impl SearchPaths {
                     files.try_add_root(db, system_path, FileRootKind::SearchPath);
                 }
             }
-        }
-    }
-
-    pub(super) fn iter<'a>(
-        &'a self,
-        db: &'a dyn Db,
-        resolver_environment: ResolverEnvironment<'a>,
-        mode: ModuleResolveMode,
-    ) -> SearchPathIterator<'a> {
-        let stdlib_path = self.stdlib(mode);
-        SearchPathIterator {
-            db,
-            static_paths: self.static_paths.iter(),
-            stdlib_path,
-            dynamic_paths: None,
-            mode: ModuleResolveModeIngredient::new(db, resolver_environment, mode),
         }
     }
 
@@ -1327,14 +1317,9 @@ impl<'db, 'name> NameResolver<'db, 'name> {
     /// a fallback when no stub provides the requested module. A stub overlay may use runtime
     /// packages as parents, but its final module must come from a stub file.
     fn resolve_typing(&self, stub_packages: &StubPackageIndex) -> Option<ResolvedNames> {
-        let search_paths = self
-            .context
-            .resolver_environment
-            .search_paths(self.context.db);
-
         if self.name.components().nth(1).is_none() {
             let candidates = self.discover_roots(
-                search_paths.iter(
+                search_paths(
                     self.context.db,
                     self.context.resolver_environment,
                     ModuleResolveMode::Typing,
@@ -1349,13 +1334,12 @@ impl<'db, 'name> NameResolver<'db, 'name> {
         // normal fallback so that each extra path is probed only once.
         let (overlay_stub_packages, remaining_stub_packages) = stub_packages.split_overlay();
         let mut candidates = self.discover_roots(
-            search_paths
-                .iter(
-                    self.context.db,
-                    self.context.resolver_environment,
-                    ModuleResolveMode::Typing,
-                )
-                .take_while(|search_path| search_path.is_extra()),
+            search_paths(
+                self.context.db,
+                self.context.resolver_environment,
+                ModuleResolveMode::Typing,
+            )
+            .take_while(|search_path| search_path.is_extra()),
             overlay_stub_packages,
         );
         if let Some(resolved) =
@@ -1365,13 +1349,12 @@ impl<'db, 'name> NameResolver<'db, 'name> {
         }
 
         let remaining_candidates = self.discover_roots(
-            search_paths
-                .iter(
-                    self.context.db,
-                    self.context.resolver_environment,
-                    ModuleResolveMode::Typing,
-                )
-                .skip_while(|search_path| search_path.is_extra()),
+            search_paths(
+                self.context.db,
+                self.context.resolver_environment,
+                ModuleResolveMode::Typing,
+            )
+            .skip_while(|search_path| search_path.is_extra()),
             remaining_stub_packages,
         );
         candidates.extend(remaining_candidates);

--- a/crates/ty_module_resolver/src/typeshed.rs
+++ b/crates/ty_module_resolver/src/typeshed.rs
@@ -6,9 +6,8 @@ use std::str::FromStr;
 
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_python_ast::{PythonVersion, PythonVersionDeserializationError};
-use rustc_hash::FxHashMap;
 
-use crate::db::Db;
+use crate::FxOrderMap;
 use crate::module_name::ModuleName;
 
 pub(crate) fn vendored_typeshed_versions(vendored: &VendoredFileSystem) -> TypeshedVersions {
@@ -18,10 +17,6 @@ pub(crate) fn vendored_typeshed_versions(vendored: &VendoredFileSystem) -> Types
             .expect("The vendored typeshed stubs should contain a VERSIONS file"),
     )
     .expect("The VERSIONS file in the vendored typeshed stubs should be well-formed")
-}
-
-pub(crate) fn typeshed_versions(db: &dyn Db) -> &TypeshedVersions {
-    db.search_paths().typeshed_versions()
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -71,8 +66,8 @@ pub enum TypeshedVersionsParseErrorKind {
     VersionParseError(#[from] PythonVersionDeserializationError),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, get_size2::GetSize)]
-pub struct TypeshedVersions(FxHashMap<ModuleName, PyVersionRange>);
+#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize)]
+pub struct TypeshedVersions(FxOrderMap<ModuleName, PyVersionRange>);
 
 impl TypeshedVersions {
     #[must_use]
@@ -164,7 +159,7 @@ impl FromStr for TypeshedVersions {
     type Err = TypeshedVersionsParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut map = FxHashMap::default();
+        let mut map = FxOrderMap::default();
 
         for (line_index, line) in s.lines().enumerate() {
             // humans expect line numbers to be 1-indexed

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -15,7 +15,6 @@ use ruff_db::system::System;
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_python_ast::PythonVersion;
 use salsa::{Database, Event, Setter};
-use ty_module_resolver::SearchPaths;
 use ty_python_core::program::{
     FallibleStrategy, MisconfigurationStrategy, Program, UseDefaultStrategy,
 };
@@ -538,11 +537,7 @@ impl SalsaMemoryDump {
 }
 
 #[salsa::db]
-impl ty_module_resolver::Db for ProjectDatabase {
-    fn search_paths(&self) -> &SearchPaths {
-        Program::get(self).search_paths(self)
-    }
-}
+impl ty_module_resolver::Db for ProjectDatabase {}
 
 #[salsa::db]
 impl SemanticDb for ProjectDatabase {
@@ -737,7 +732,7 @@ pub(crate) mod testing {
         }
 
         pub fn program_environment(&self) -> ProgramEnvironment<'_> {
-            ProgramEnvironment::from_program(self.python_version())
+            ProgramEnvironment::from_program(Program::get(self).resolver_environment(self))
         }
 
         /// Takes the salsa events.
@@ -774,11 +769,7 @@ pub(crate) mod testing {
     }
 
     #[salsa::db]
-    impl ty_module_resolver::Db for TestDb {
-        fn search_paths(&self) -> &ty_module_resolver::SearchPaths {
-            Program::get(self).search_paths(self)
-        }
-    }
+    impl ty_module_resolver::Db for TestDb {}
 
     #[salsa::db]
     impl ty_python_core::Db for TestDb {
@@ -844,8 +835,9 @@ mod tests {
     use ruff_db::files::FileRootKind;
     use ruff_db::system::{SystemPathBuf, TestSystem};
     use ty_module_resolver::list_modules;
+    use ty_python_core::program::Program;
 
-    use crate::{Db as _, ProjectDatabase, ProjectMetadata};
+    use crate::{ProjectDatabase, ProjectMetadata};
 
     #[test]
     fn frozen_inputs_support_a_one_shot_check() -> anyhow::Result<()> {
@@ -889,7 +881,7 @@ mod tests {
         let metadata = ProjectMetadata::discover(&project, &system)?;
         let db = ProjectDatabase::fallible(metadata, system)?;
 
-        let modules = list_modules(&db, db.python_version());
+        let modules = list_modules(&db, Program::get(&db).resolver_environment(&db));
         assert!(
             modules
                 .iter()

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -15,6 +15,7 @@ use ruff_db::system::System;
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_python_ast::PythonVersion;
 use salsa::{Database, Event, Setter};
+use ty_python_core::ProgramFile;
 use ty_python_core::program::{
     FallibleStrategy, MisconfigurationStrategy, Program, UseDefaultStrategy,
 };
@@ -545,6 +546,10 @@ impl SemanticDb for ProjectDatabase {
         ProjectDatabase::check_file(self, file)
     }
 
+    fn program_file(&self, file: File) -> ProgramFile<'_> {
+        Program::get(self).program_file(self, file)
+    }
+
     fn rule_selection(&self, file: File) -> &RuleSelection {
         let settings = file_settings(self, file);
         settings.rules(self)
@@ -645,6 +650,7 @@ pub(crate) mod testing {
     use ruff_db::vendored::VendoredFileSystem;
     use ruff_python_ast::PythonVersion;
     use ty_module_resolver::SearchPathSettings;
+    use ty_python_core::ProgramFile;
     use ty_python_core::platform::PythonPlatform;
     use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
     use ty_python_semantic::lint::{LintRegistry, RuleSelection};
@@ -783,6 +789,10 @@ pub(crate) mod testing {
         #[inline]
         fn check_file(&self, file: File) -> Vec<Diagnostic> {
             crate::check_file(self, file)
+        }
+
+        fn program_file(&self, file: File) -> ProgramFile<'_> {
+            Program::get(self).program_file(self, file)
         }
 
         fn rule_selection(&self, _file: ruff_db::files::File) -> &RuleSelection {

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -14,7 +14,6 @@ use files::{Index, Indexed, IndexedFiles};
 use metadata::settings::Settings;
 pub use metadata::{ProjectMetadata, ProjectMetadataError};
 use rayon::prelude::*;
-use ruff_db::PythonFile;
 use ruff_db::diagnostic::{
     Diagnostic, DiagnosticId, Severity, SubDiagnostic, SubDiagnosticSeverity,
 };
@@ -28,6 +27,8 @@ use std::collections::{BTreeSet, hash_set};
 use std::iter::FusedIterator;
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 use std::sync::Arc;
+use ty_python_core::ProgramFile;
+use ty_python_core::program::Program;
 pub use ty_python_semantic::Db as SemanticDb;
 use ty_python_semantic::lint::RuleSelection;
 
@@ -394,15 +395,16 @@ impl Project {
                 let check_file_span =
                     tracing::debug_span!(parent: &project_span, "check_file", ?file);
                 let _entered = check_file_span.entered();
-                let python_file = PythonFile::new(db, file, db.python_version());
+                let program_file = Program::get(db).program_file(db, file);
 
-                match check_file_impl(db, python_file) {
+                match check_file_impl(db, program_file) {
                     Ok(diagnostics) => {
                         reporter.report_checked_file(db, file, diagnostics);
 
                         // This is outside `check_file_impl` to avoid that opening or closing
                         // a file invalidates the `check_file_impl` query of every file!
                         if !open_files.contains(&file) {
+                            let python_file = program_file.python_file(db);
                             // The module has already been parsed by `check_file_impl`.
                             // We only retrieve it here so that we can call `clear` on it.
                             let parsed = parsed_module(db, python_file);
@@ -660,7 +662,7 @@ fn check_file(db: &dyn Db, file: File) -> Vec<Diagnostic> {
         return Vec::new();
     }
 
-    check_file_impl(db, PythonFile::new(db, file, db.python_version()))
+    check_file_impl(db, Program::get(db).program_file(db, file))
         .map(<[Diagnostic]>::to_vec)
         .unwrap_or_else(|diagnostic| vec![diagnostic.clone()])
 }
@@ -744,7 +746,7 @@ pub enum ProjectReloadResult {
 #[salsa::tracked(returns(as_deref), heap_size=ruff_memory_usage::heap_size)]
 pub(crate) fn check_file_impl(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
 ) -> Result<Box<[Diagnostic]>, Diagnostic> {
     let source_file = file.file(db);
     {
@@ -894,11 +896,11 @@ mod tests {
     use crate::db::Db as _;
     use crate::db::testing::TestDb;
     use crate::{IncludeResult, ProjectMetadata};
-    use ruff_db::PythonFile;
     use ruff_db::files::system_path_to_file;
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
+    use ty_python_core::program::Program;
     use ty_python_semantic::types::check_types;
 
     #[test]
@@ -917,7 +919,7 @@ mod tests {
 
         assert_eq!(source_text(&db, file).as_str(), "");
         assert_eq!(
-            check_file_impl(&db, PythonFile::new(&db, file, db.python_version()))
+            check_file_impl(&db, Program::get(&db).program_file(&db, file))
                 .as_ref()
                 .unwrap_err()
                 .headline_message()
@@ -929,7 +931,7 @@ mod tests {
         assert_function_query_was_not_run(
             &db,
             check_types,
-            PythonFile::new(&db, file, db.python_version()),
+            Program::get(&db).program_file(&db, file),
             &events,
         );
 
@@ -939,7 +941,7 @@ mod tests {
 
         assert_eq!(source_text(&db, file).as_str(), "");
         assert_eq!(
-            check_file_impl(&db, PythonFile::new(&db, file, db.python_version()))
+            check_file_impl(&db, Program::get(&db).program_file(&db, file))
                 .as_ref()
                 .unwrap()
                 .iter()

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -28,7 +28,6 @@ use std::iter::FusedIterator;
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 use std::sync::Arc;
 use ty_python_core::ProgramFile;
-use ty_python_core::program::Program;
 pub use ty_python_semantic::Db as SemanticDb;
 use ty_python_semantic::lint::RuleSelection;
 
@@ -395,7 +394,7 @@ impl Project {
                 let check_file_span =
                     tracing::debug_span!(parent: &project_span, "check_file", ?file);
                 let _entered = check_file_span.entered();
-                let program_file = Program::get(db).program_file(db, file);
+                let program_file = db.program_file(file);
 
                 match check_file_impl(db, program_file) {
                     Ok(diagnostics) => {
@@ -662,7 +661,7 @@ fn check_file(db: &dyn Db, file: File) -> Vec<Diagnostic> {
         return Vec::new();
     }
 
-    check_file_impl(db, Program::get(db).program_file(db, file))
+    check_file_impl(db, db.program_file(file))
         .map(<[Diagnostic]>::to_vec)
         .unwrap_or_else(|diagnostic| vec![diagnostic.clone()])
 }
@@ -900,7 +899,7 @@ mod tests {
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
-    use ty_python_core::program::Program;
+    use ty_python_semantic::Db as _;
     use ty_python_semantic::types::check_types;
 
     #[test]
@@ -919,7 +918,7 @@ mod tests {
 
         assert_eq!(source_text(&db, file).as_str(), "");
         assert_eq!(
-            check_file_impl(&db, Program::get(&db).program_file(&db, file))
+            check_file_impl(&db, db.program_file(file))
                 .as_ref()
                 .unwrap_err()
                 .headline_message()
@@ -928,12 +927,7 @@ mod tests {
         );
 
         let events = db.take_salsa_events();
-        assert_function_query_was_not_run(
-            &db,
-            check_types,
-            Program::get(&db).program_file(&db, file),
-            &events,
-        );
+        assert_function_query_was_not_run(&db, check_types, db.program_file(file), &events);
 
         // The user now creates a new file with an empty text. The source text
         // content returned by `source_text` remains unchanged, but the diagnostics should get updated.
@@ -941,7 +935,7 @@ mod tests {
 
         assert_eq!(source_text(&db, file).as_str(), "");
         assert_eq!(
-            check_file_impl(&db, Program::get(&db).program_file(&db, file))
+            check_file_impl(&db, db.program_file(file))
                 .as_ref()
                 .unwrap()
                 .iter()

--- a/crates/ty_project/src/watch/project_watcher.rs
+++ b/crates/ty_project/src/watch/project_watcher.rs
@@ -6,6 +6,7 @@ use tracing::info;
 use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_db::system::{SystemPath, SystemPathBuf};
 use ty_module_resolver::system_module_search_paths;
+use ty_python_core::program::Program;
 
 use crate::db::{Db, ProjectDatabase};
 use crate::watch::Watcher;
@@ -40,7 +41,8 @@ impl ProjectWatcher {
     }
 
     pub fn update(&mut self, db: &ProjectDatabase) {
-        let search_paths: Vec<_> = system_module_search_paths(db).collect();
+        let environment = Program::get(db).resolver_environment(db);
+        let search_paths: Vec<_> = system_module_search_paths(db, environment).collect();
         let project_path = db.project().root(db);
 
         let new_cache_key = Self::compute_cache_key(project_path, &search_paths);

--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -1,11 +1,11 @@
 use rustc_hash::FxHashMap;
 
-use ruff_db::PythonFile;
 use ruff_index::{IndexVec, newtype_index};
 use ruff_python_ast as ast;
 use ruff_python_ast::ExprRef;
 
 use crate::Db;
+use crate::ProgramFile;
 use crate::frozen::FrozenMap;
 use crate::scope::FileScopeId;
 use crate::semantic_index;
@@ -55,7 +55,7 @@ impl AstIds {
     }
 }
 
-fn ast_ids<'db>(db: &'db dyn Db, file: PythonFile<'db>) -> &'db AstIds {
+fn ast_ids<'db>(db: &'db dyn Db, file: ProgramFile<'db>) -> &'db AstIds {
     semantic_index(db, file).ast_ids()
 }
 
@@ -66,46 +66,46 @@ pub struct ScopedUseId;
 
 pub trait HasScopedUseId {
     /// Returns the ID that uniquely identifies the use in its scope.
-    fn scoped_use_id(&self, db: &dyn Db, file: PythonFile<'_>) -> ScopedUseId;
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId;
 }
 
 impl HasScopedUseId for ast::Identifier {
-    fn scoped_use_id(&self, db: &dyn Db, file: PythonFile<'_>) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let ast_ids = ast_ids(db, file);
         ast_ids.use_id(self)
     }
 }
 
 impl HasScopedUseId for ast::ExprName {
-    fn scoped_use_id(&self, db: &dyn Db, file: PythonFile<'_>) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let expression_ref = ExprRef::from(self);
         expression_ref.scoped_use_id(db, file)
     }
 }
 
 impl HasScopedUseId for ast::ExprAttribute {
-    fn scoped_use_id(&self, db: &dyn Db, file: PythonFile<'_>) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let expression_ref = ExprRef::from(self);
         expression_ref.scoped_use_id(db, file)
     }
 }
 
 impl HasScopedUseId for ast::ExprSubscript {
-    fn scoped_use_id(&self, db: &dyn Db, file: PythonFile<'_>) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let expression_ref = ExprRef::from(self);
         expression_ref.scoped_use_id(db, file)
     }
 }
 
 impl HasScopedUseId for ast::Keyword {
-    fn scoped_use_id(&self, db: &dyn Db, file: PythonFile<'_>) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let ast_ids = ast_ids(db, file);
         ast_ids.use_id(self)
     }
 }
 
 impl HasScopedUseId for ast::ExprRef<'_> {
-    fn scoped_use_id(&self, db: &dyn Db, file: PythonFile<'_>) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let ast_ids = ast_ids(db, file);
         ast_ids.use_id(*self)
     }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -8,7 +8,6 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use ruff_db::parsed::ParsedModuleRef;
 
-use ruff_db::PythonFile;
 use ruff_db::source::{SourceText, source_text};
 use ruff_index::IndexVec;
 use ruff_python_ast::name::Name;
@@ -20,9 +19,10 @@ use ruff_python_parser::semantic_errors::{
 };
 use ruff_text_size::{Ranged, TextRange};
 use smallvec::SmallVec;
-use ty_module_resolver::{ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, ModuleName, ResolverEnvironment, resolve_module};
 
 use crate::HasTrackedScope;
+use crate::ProgramFile;
 use crate::ast_ids::node_key::ExpressionNodeKey;
 use crate::ast_ids::{AstIdsBuilder, ScopedUseId};
 use crate::ast_node_ref::AstNodeRef;
@@ -229,7 +229,7 @@ impl ConditionFlowSnapshot {
 pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     // Builder state
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     source_type: PySourceType,
     module: &'ast ParsedModuleRef,
     scope_stack: Vec<ScopeInfo<'ast>>,
@@ -253,7 +253,7 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     in_type_checking_block: bool,
 
     // Used for checking semantic syntax errors
-    python_version: PythonVersion,
+    resolver_environment: ResolverEnvironment<'db>,
     source_text: OnceCell<SourceText>,
     semantic_checker: SemanticSyntaxChecker,
     in_try: bool,
@@ -302,7 +302,7 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
 impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     pub(super) fn new(
         db: &'db dyn Db,
-        file: PythonFile<'db>,
+        file: ProgramFile<'db>,
         module_ref: &'ast ParsedModuleRef,
     ) -> Self {
         let mut builder = Self {
@@ -344,7 +344,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
             enclosing_snapshots: FxHashMap::default(),
 
-            python_version: file.python_version(db),
+            resolver_environment: file.resolver_environment(db),
             source_text: OnceCell::new(),
             semantic_checker: SemanticSyntaxChecker::default(),
             in_try: false,
@@ -977,7 +977,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                                     symbol.name().to_string(),
                                 ),
                                 range: declaration.range,
-                                python_version: self.python_version,
+                                python_version: self.python_version(),
                             });
                         }
                         // This `nonlocal` is resolved.
@@ -1040,7 +1040,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         self.report_semantic_error(SemanticSyntaxError {
                             kind: SemanticSyntaxErrorKind::NonlocalWithoutBinding(name.to_string()),
                             range: declaration.range,
-                            python_version: self.python_version,
+                            python_version: self.python_version(),
                         });
                     }
                 }
@@ -3166,14 +3166,18 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // in one function is visible in another function.
                 let mut is_self_import = false;
                 let source_file = self.file.file(self.db);
+                let resolver_environment = self.resolver_environment;
                 if source_file.is_package(self.db)
                     && let Ok(module_name) = ModuleName::from_identifier_parts(
                         self.db,
-                        self.file,
+                        ImportingFile::File(source_file, resolver_environment),
                         node.module.as_deref(),
                         node.level,
                     )
-                    && let Ok(thispackage) = ModuleName::package_for_file(self.db, self.file)
+                    && let Ok(thispackage) = ModuleName::package_for_file(
+                        self.db,
+                        ImportingFile::File(source_file, resolver_environment),
+                    )
                 {
                     // Record whether this is equivalent to `from . import ...`
                     is_self_import = module_name == thispackage;
@@ -3246,19 +3250,27 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             continue;
                         }
 
-                        let Ok(module_name) =
-                            ModuleName::from_import_statement(self.db, self.file, node)
-                        else {
+                        let Ok(module_name) = ModuleName::from_import_statement(
+                            self.db,
+                            ImportingFile::File(source_file, resolver_environment),
+                            node,
+                        ) else {
                             continue;
                         };
 
-                        let Some(module) = resolve_module(self.db, self.file, &module_name) else {
+                        let Some(module) = resolve_module(
+                            self.db,
+                            ImportingFile::File(source_file, resolver_environment),
+                            &module_name,
+                        ) else {
                             continue;
                         };
 
-                        let Some(referenced_parse_file) = module.python_file(self.db) else {
+                        let Some(referenced_file) = module.file(self.db) else {
                             continue;
                         };
+                        let referenced_program_file =
+                            ProgramFile::new(self.db, referenced_file, resolver_environment);
                         // In order to understand the reachability of definitions created by a `*` import,
                         // we need to know the reachability of the global-scope definitions in the
                         // `referenced_module` the symbols imported from. Much like predicates for `if`
@@ -3273,14 +3285,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         // ```
                         //
                         // For more details, see the doc-comment on `StarImportPlaceholderPredicate`.
-                        for export in exported_names(self.db, referenced_parse_file) {
+                        for export in exported_names(self.db, referenced_program_file) {
                             let symbol_id = self.add_symbol(export.clone());
                             let node_ref = StarImportDefinitionNodeRef { node, symbol_id };
                             let star_import = StarImportPlaceholderPredicate::new(
                                 self.db,
                                 self.file,
                                 symbol_id,
-                                referenced_parse_file,
+                                referenced_program_file,
                             );
 
                             let star_import_predicate = self.add_predicate(star_import.into());
@@ -3461,7 +3473,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         self.report_semantic_error(SemanticSyntaxError {
                             kind: SemanticSyntaxErrorKind::AnnotatedGlobal(name.id.as_str().into()),
                             range: name.range,
-                            python_version: self.python_version,
+                            python_version: self.python_version(),
                         });
                     }
                     // Check whether the variable has been declared nonlocal.
@@ -3471,7 +3483,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                                 name.id.as_str().into(),
                             ),
                             range: name.range,
-                            python_version: self.python_version,
+                            python_version: self.python_version(),
                         });
                     }
                 }
@@ -4230,7 +4242,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                                 start: name.range.start(),
                             },
                             range: name.range,
-                            python_version: self.python_version,
+                            python_version: self.python_version(),
                         });
                     }
                     // Check whether the variable has also been declared nonlocal.
@@ -4238,7 +4250,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         self.report_semantic_error(SemanticSyntaxError {
                             kind: SemanticSyntaxErrorKind::NonlocalAndGlobal(name.to_string()),
                             range: name.range,
-                            python_version: self.python_version,
+                            python_version: self.python_version(),
                         });
                         // Never mark a symbol both global and nonlocal, even in this error case.
                         continue;
@@ -4283,7 +4295,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                                 start: name.range.start(),
                             },
                             range: name.range,
-                            python_version: self.python_version,
+                            python_version: self.python_version(),
                         });
                     }
                     // Check whether the variable has also been declared global.
@@ -4291,7 +4303,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         self.report_semantic_error(SemanticSyntaxError {
                             kind: SemanticSyntaxErrorKind::NonlocalAndGlobal(name.to_string()),
                             range: name.range,
-                            python_version: self.python_version,
+                            python_version: self.python_version(),
                         });
                         // Never mark a symbol both global and nonlocal, even in this error case.
                         continue;
@@ -5003,7 +5015,7 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_, '_> {
     }
 
     fn python_version(&self) -> PythonVersion {
-        self.python_version
+        self.resolver_environment.python_version(self.db)
     }
 
     fn source(&self) -> &str {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3270,7 +3270,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             continue;
                         };
                         let referenced_program_file =
-                            ProgramFile::new(self.db, referenced_file, resolver_environment);
+                            ProgramFile::new(self.db, referenced_file, self.file.program(self.db));
                         // In order to understand the reachability of definitions created by a `*` import,
                         // we need to know the reachability of the global-scope definitions in the
                         // `referenced_module` the symbols imported from. Much like predicates for `if`

--- a/crates/ty_python_core/src/db.rs
+++ b/crates/ty_python_core/src/db.rs
@@ -21,9 +21,7 @@ pub(crate) mod tests {
     };
     use ruff_db::vendored::VendoredFileSystem;
     use ruff_python_ast::PythonVersion;
-    use ty_module_resolver::{
-        Db as ModuleResolverDb, FallibleStrategy, SearchPathSettings, SearchPaths,
-    };
+    use ty_module_resolver::{Db as ModuleResolverDb, FallibleStrategy, SearchPathSettings};
     use ty_site_packages::{PythonVersionSource, PythonVersionWithSource};
 
     use crate::platform::PythonPlatform;
@@ -93,11 +91,7 @@ pub(crate) mod tests {
     }
 
     #[salsa::db]
-    impl ModuleResolverDb for TestDb {
-        fn search_paths(&self) -> &SearchPaths {
-            Program::get(self).search_paths(self)
-        }
-    }
+    impl ModuleResolverDb for TestDb {}
 
     #[salsa::db]
     impl salsa::Database for TestDb {}

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -11,6 +11,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 use smallvec::SmallVec;
 
 use crate::LoopHeaderId;
+use crate::ProgramFile;
 use crate::ast_node_ref::AstNodeRef;
 use crate::member::ScopedMemberId;
 use crate::node_key::NodeKey;
@@ -88,7 +89,11 @@ impl<'db> Definition<'db> {
         self.scope_id(db).python_file(db)
     }
 
-    pub fn program(self, db: &'db dyn Db) -> Program {
+    pub fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
+        self.scope_id(db).program_file(db)
+    }
+
+    pub fn program(self, db: &'db dyn Db) -> Program<'db> {
         self.scope_id(db).program(db)
     }
 

--- a/crates/ty_python_core/src/expression.rs
+++ b/crates/ty_python_core/src/expression.rs
@@ -1,7 +1,7 @@
-use crate::Program;
 use crate::ast_node_ref::AstNodeRef;
 use crate::db::Db;
 use crate::scope::ScopeId;
+use crate::{Program, ProgramFile};
 use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ruff_python_ast as ast;
@@ -80,7 +80,11 @@ impl<'db> Expression<'db> {
         self.scope_id(db).python_file(db)
     }
 
-    pub fn program(self, db: &'db dyn Db) -> Program {
+    pub fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
+        self.scope_id(db).program_file(db)
+    }
+
+    pub fn program(self, db: &'db dyn Db) -> Program<'db> {
         self.scope_id(db).program(db)
     }
 }

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 
 use ruff_db::parsed::parsed_module;
 
-use ruff_db::PythonFile;
 use ruff_index::{FrozenIndexVec, IndexSlice};
 use ruff_python_ast::NodeIndex;
 use ruff_python_parser::semantic_errors::SemanticSyntaxError;
@@ -16,11 +15,11 @@ use ruff_text_size::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::plumbing::AsId;
 use smallvec::SmallVec;
-use ty_module_resolver::ModuleName;
+use ty_module_resolver::{ModuleName, ResolverEnvironment};
 
 // FIXME: Replace this temporary alias once semantic query keys can use the environment-bearing
 // `Program` Salsa ingredient directly.
-pub type Program = ast::PythonVersion;
+pub type Program<'db> = ResolverEnvironment<'db>;
 
 use crate::frozen::{FrozenMap, FrozenSet};
 use crate::place::ScopedPlaceId;
@@ -66,15 +65,17 @@ pub mod unpack;
 mod use_def;
 pub use db::Db;
 pub mod program;
+pub mod program_file;
+pub use program_file::ProgramFile;
 
 /// Returns the semantic index for `file`.
 ///
 /// Prefer using [`symbol_table`] when working with symbols from a single scope.
 #[salsa::tracked(returns(ref), no_eq, heap_size=ruff_memory_usage::heap_size)]
-pub fn semantic_index<'db>(db: &'db dyn Db, file: PythonFile<'db>) -> SemanticIndex<'db> {
+pub fn semantic_index<'db>(db: &'db dyn Db, file: ProgramFile<'db>) -> SemanticIndex<'db> {
     let _span = tracing::trace_span!("semantic_index", ?file).entered();
 
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, file.python_file(db)).load(db);
 
     SemanticIndexBuilder::new(db, file, &module).build()
 }
@@ -86,9 +87,9 @@ pub fn semantic_index<'db>(db: &'db dyn Db, file: PythonFile<'db>) -> SemanticIn
 /// is unchanged.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
 pub fn place_table<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<PlaceTable> {
-    let python_file = scope.python_file(db);
-    let _span = tracing::trace_span!("place_table", scope=?scope.as_id(), ?python_file).entered();
-    let index = semantic_index(db, python_file);
+    let program_file = scope.program_file(db);
+    let _span = tracing::trace_span!("place_table", scope=?scope.as_id(), ?program_file).entered();
+    let index = semantic_index(db, program_file);
     Arc::clone(&index.place_tables[scope.file_scope_id(db)])
 }
 
@@ -99,9 +100,9 @@ pub fn place_table<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<PlaceTable>
 /// is unchanged.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
 pub fn use_def_map<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<UseDefMap<'db>> {
-    let python_file = scope.python_file(db);
-    let _span = tracing::trace_span!("use_def_map", scope=?scope.as_id(), ?python_file).entered();
-    let index = semantic_index(db, python_file);
+    let program_file = scope.program_file(db);
+    let _span = tracing::trace_span!("use_def_map", scope=?scope.as_id(), ?program_file).entered();
+    let index = semantic_index(db, program_file);
     Arc::clone(&index.use_def_maps[scope.file_scope_id(db)])
 }
 
@@ -176,7 +177,7 @@ pub fn attribute_scopes<'db>(
     db: &'db dyn Db,
     class_body_scope: ScopeId<'db>,
 ) -> impl Iterator<Item = FileScopeId> + 'db {
-    let index = semantic_index(db, class_body_scope.python_file(db));
+    let index = semantic_index(db, class_body_scope.program_file(db));
     let class_scope_id = class_body_scope.file_scope_id(db);
     ChildrenIter::new(&index.scopes, class_scope_id)
         .filter_map(move |(child_scope_id, scope)| {
@@ -225,7 +226,7 @@ pub fn attribute_scopes<'db>(
 
 /// Returns the module global scope of `file`.
 #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
-pub fn global_scope<'db>(db: &'db dyn Db, file: PythonFile<'db>) -> ScopeId<'db> {
+pub fn global_scope<'db>(db: &'db dyn Db, file: ProgramFile<'db>) -> ScopeId<'db> {
     let _span = tracing::trace_span!("global_scope", ?file).entered();
 
     FileScopeId::global().to_scope_id(db, file)
@@ -1124,8 +1125,8 @@ mod tests {
         TestCase { db, file }
     }
 
-    fn python_file(db: &TestDb, file: File) -> PythonFile<'_> {
-        PythonFile::new(db, file, Program::get(db).python_version(db))
+    fn program_file(db: &TestDb, file: File) -> ProgramFile<'_> {
+        Program::get(db).program_file(db, file)
     }
 
     fn names(table: &PlaceTable) -> Vec<String> {
@@ -1138,7 +1139,7 @@ mod tests {
     #[test]
     fn empty() {
         let TestCase { db, file } = test_case("");
-        let global_table = place_table(&db, global_scope(&db, python_file(&db, file)));
+        let global_table = place_table(&db, global_scope(&db, program_file(&db, file)));
 
         let global_names = names(global_table);
 
@@ -1148,7 +1149,7 @@ mod tests {
     #[test]
     fn simple() {
         let TestCase { db, file } = test_case("x");
-        let global_table = place_table(&db, global_scope(&db, python_file(&db, file)));
+        let global_table = place_table(&db, global_scope(&db, program_file(&db, file)));
 
         assert_eq!(names(global_table), vec!["x"]);
     }
@@ -1156,7 +1157,7 @@ mod tests {
     #[test]
     fn annotation_only() {
         let TestCase { db, file } = test_case("x: int");
-        let scope = global_scope(&db, python_file(&db, file));
+        let scope = global_scope(&db, program_file(&db, file));
         let global_table = place_table(&db, scope);
 
         assert_eq!(names(global_table), vec!["int", "x"]);
@@ -1174,7 +1175,7 @@ mod tests {
     #[test]
     fn import() {
         let TestCase { db, file } = test_case("import foo");
-        let scope = global_scope(&db, python_file(&db, file));
+        let scope = global_scope(&db, program_file(&db, file));
         let global_table = place_table(&db, scope);
 
         assert_eq!(names(global_table), vec!["foo"]);
@@ -1188,7 +1189,7 @@ mod tests {
     #[test]
     fn import_sub() {
         let TestCase { db, file } = test_case("import foo.bar");
-        let global_table = place_table(&db, global_scope(&db, python_file(&db, file)));
+        let global_table = place_table(&db, global_scope(&db, program_file(&db, file)));
 
         assert_eq!(names(global_table), vec!["foo"]);
     }
@@ -1196,7 +1197,7 @@ mod tests {
     #[test]
     fn import_as() {
         let TestCase { db, file } = test_case("import foo.bar as baz");
-        let global_table = place_table(&db, global_scope(&db, python_file(&db, file)));
+        let global_table = place_table(&db, global_scope(&db, program_file(&db, file)));
 
         assert_eq!(names(global_table), vec!["baz"]);
     }
@@ -1204,7 +1205,7 @@ mod tests {
     #[test]
     fn import_from() {
         let TestCase { db, file } = test_case("from bar import foo");
-        let scope = global_scope(&db, python_file(&db, file));
+        let scope = global_scope(&db, program_file(&db, file));
         let global_table = place_table(&db, scope);
 
         assert_eq!(names(global_table), vec!["foo"]);
@@ -1225,7 +1226,7 @@ mod tests {
     #[test]
     fn assign() {
         let TestCase { db, file } = test_case("x = foo");
-        let scope = global_scope(&db, python_file(&db, file));
+        let scope = global_scope(&db, program_file(&db, file));
         let global_table = place_table(&db, scope);
 
         assert_eq!(names(global_table), vec!["foo", "x"]);
@@ -1245,7 +1246,7 @@ mod tests {
     #[test]
     fn augmented_assignment() {
         let TestCase { db, file } = test_case("x += 1");
-        let scope = global_scope(&db, python_file(&db, file));
+        let scope = global_scope(&db, program_file(&db, file));
         let global_table = place_table(&db, scope);
 
         assert_eq!(names(global_table), vec!["x"]);
@@ -1270,12 +1271,12 @@ class C:
 y = 2
 ",
         );
-        let global_table = place_table(&db, global_scope(&db, python_file(&db, file)));
+        let global_table = place_table(&db, global_scope(&db, program_file(&db, file)));
 
         assert_eq!(names(global_table), vec!["C", "y"]);
 
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
-        let index = semantic_index(&db, python_file(&db, file));
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
+        let index = semantic_index(&db, program_file(&db, file));
 
         let [(class_scope_id, class_scope)] = index
             .child_scopes(FileScopeId::global())
@@ -1286,7 +1287,7 @@ y = 2
         assert_eq!(class_scope.kind(), ScopeKind::Class);
         assert_eq!(
             class_scope_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "C"
         );
@@ -1310,8 +1311,8 @@ def func():
 y = 2
 ",
         );
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
-        let index = semantic_index(&db, python_file(&db, file));
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
+        let index = semantic_index(&db, program_file(&db, file));
         let global_table = index.place_table(FileScopeId::global());
 
         assert_eq!(names(global_table), vec!["func", "y"]);
@@ -1325,7 +1326,7 @@ y = 2
         assert_eq!(function_scope.kind(), ScopeKind::Function);
         assert_eq!(
             function_scope_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "func"
         );
@@ -1349,8 +1350,8 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
 ",
         );
 
-        let index = semantic_index(&db, python_file(&db, file));
-        let global_table = place_table(&db, global_scope(&db, python_file(&db, file)));
+        let index = semantic_index(&db, program_file(&db, file));
+        let global_table = place_table(&db, global_scope(&db, program_file(&db, file)));
 
         assert_eq!(names(global_table), vec!["str", "int", "f"]);
 
@@ -1394,8 +1395,8 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
     fn lambda_parameter_symbols() {
         let TestCase { db, file } = test_case("lambda a, b, c=1, *args, d=2, **kwargs: None");
 
-        let index = semantic_index(&db, python_file(&db, file));
-        let global_table = place_table(&db, global_scope(&db, python_file(&db, file)));
+        let index = semantic_index(&db, program_file(&db, file));
+        let global_table = place_table(&db, global_scope(&db, program_file(&db, file)));
 
         assert!(names(global_table).is_empty());
 
@@ -1460,8 +1461,8 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
 ",
         );
 
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
-        let index = semantic_index(&db, python_file(&db, file));
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
+        let index = semantic_index(&db, program_file(&db, file));
         let global_table = index.place_table(FileScopeId::global());
 
         assert_eq!(names(global_table), vec!["iter1"]);
@@ -1476,7 +1477,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
         assert_eq!(comprehension_scope.kind(), ScopeKind::Comprehension);
         assert_eq!(
             comprehension_scope_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "<listcomp>"
         );
@@ -1511,7 +1512,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
 ",
         );
 
-        let index = semantic_index(&db, python_file(&db, file));
+        let index = semantic_index(&db, program_file(&db, file));
         let [(comprehension_scope_id, _)] = index
             .child_scopes(FileScopeId::global())
             .collect::<Vec<_>>()[..]
@@ -1521,7 +1522,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
 
         let use_def = index.use_def_map(comprehension_scope_id);
 
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
         let syntax = module.syntax();
         let element = syntax.body[0]
             .as_expr_stmt()
@@ -1532,7 +1533,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             .elt
             .as_name_expr()
             .unwrap();
-        let element_use_id = element.scoped_use_id(&db, python_file(&db, file));
+        let element_use_id = element.scoped_use_id(&db, program_file(&db, file));
 
         let binding = use_def.first_binding_at_use(element_use_id).unwrap();
         let DefinitionKind::Comprehension(comprehension) = binding.kind(&db) else {
@@ -1556,8 +1557,8 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
 ",
         );
 
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
-        let index = semantic_index(&db, python_file(&db, file));
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
+        let index = semantic_index(&db, program_file(&db, file));
         let global_table = index.place_table(FileScopeId::global());
 
         assert_eq!(names(global_table), vec!["iter1"]);
@@ -1572,7 +1573,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
         assert_eq!(comprehension_scope.kind(), ScopeKind::Comprehension);
         assert_eq!(
             comprehension_scope_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "<listcomp>"
         );
@@ -1591,7 +1592,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
         assert_eq!(inner_comprehension_scope.kind(), ScopeKind::Comprehension);
         assert_eq!(
             inner_comprehension_scope_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "<setcomp>"
         );
@@ -1610,7 +1611,7 @@ with item1 as x, item2 as y:
 ",
         );
 
-        let index = semantic_index(&db, python_file(&db, file));
+        let index = semantic_index(&db, program_file(&db, file));
         let global_table = index.place_table(FileScopeId::global());
 
         assert_eq!(names(global_table), vec!["item1", "x", "item2", "y"]);
@@ -1633,7 +1634,7 @@ with context() as (x, y):
 ",
         );
 
-        let index = semantic_index(&db, python_file(&db, file));
+        let index = semantic_index(&db, program_file(&db, file));
         let global_table = index.place_table(FileScopeId::global());
 
         assert_eq!(names(global_table), vec!["context", "x", "y"]);
@@ -1657,8 +1658,8 @@ def func():
     y = 2
 ",
         );
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
-        let index = semantic_index(&db, python_file(&db, file));
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
+        let index = semantic_index(&db, program_file(&db, file));
         let global_table = index.place_table(FileScopeId::global());
 
         assert_eq!(names(global_table), vec!["func"]);
@@ -1676,14 +1677,14 @@ def func():
 
         assert_eq!(
             func_scope1_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "func"
         );
         assert_eq!(func_scope_2.kind(), ScopeKind::Function);
         assert_eq!(
             func_scope2_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "func"
         );
@@ -1709,8 +1710,8 @@ def func[T]():
 ",
         );
 
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
-        let index = semantic_index(&db, python_file(&db, file));
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
+        let index = semantic_index(&db, program_file(&db, file));
         let global_table = index.place_table(FileScopeId::global());
 
         assert_eq!(names(global_table), vec!["func"]);
@@ -1725,7 +1726,7 @@ def func[T]():
         assert_eq!(ann_scope.kind(), ScopeKind::TypeParams);
         assert_eq!(
             ann_scope_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "func"
         );
@@ -1740,7 +1741,7 @@ def func[T]():
         assert_eq!(func_scope.kind(), ScopeKind::Function);
         assert_eq!(
             func_scope_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "func"
         );
@@ -1757,8 +1758,8 @@ class C[T]:
 ",
         );
 
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
-        let index = semantic_index(&db, python_file(&db, file));
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
+        let index = semantic_index(&db, program_file(&db, file));
         let global_table = index.place_table(FileScopeId::global());
 
         assert_eq!(names(global_table), vec!["C"]);
@@ -1773,7 +1774,7 @@ class C[T]:
         assert_eq!(ann_scope.kind(), ScopeKind::TypeParams);
         assert_eq!(
             ann_scope_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "C"
         );
@@ -1795,7 +1796,7 @@ class C[T]:
         assert_eq!(class_scope.kind(), ScopeKind::Class);
         assert_eq!(
             class_scope_id
-                .to_scope_id(&db, python_file(&db, file))
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "C"
         );
@@ -1805,8 +1806,8 @@ class C[T]:
     #[test]
     fn reachability_trivial() {
         let TestCase { db, file } = test_case("x = 1; x");
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
-        let scope = global_scope(&db, python_file(&db, file));
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
+        let scope = global_scope(&db, program_file(&db, file));
         let ast = module.syntax();
         let ast::Stmt::Expr(ast::StmtExpr {
             value: x_use_expr, ..
@@ -1817,7 +1818,7 @@ class C[T]:
         let ast::Expr::Name(x_use_expr_name) = x_use_expr.as_ref() else {
             panic!("expected a Name");
         };
-        let x_use_id = x_use_expr_name.scoped_use_id(&db, python_file(&db, file));
+        let x_use_id = x_use_expr_name.scoped_use_id(&db, program_file(&db, file));
         let use_def = use_def_map(&db, scope);
         let binding = use_def.first_binding_at_use(x_use_id).unwrap();
         let DefinitionKind::Assignment(assignment) = binding.kind(&db) else {
@@ -1837,8 +1838,8 @@ class C[T]:
     fn expression_scope() {
         let TestCase { db, file } = test_case("x = 1;\ndef test():\n  y = 4");
 
-        let index = semantic_index(&db, python_file(&db, file));
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
+        let index = semantic_index(&db, program_file(&db, file));
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
         let ast = module.syntax();
 
         let x_stmt = ast.body[0].as_assign_stmt().unwrap();
@@ -1866,10 +1867,7 @@ class C[T]:
                 .into_iter()
                 .map(|(scope_id, _)| {
                     scope_id
-                        .to_scope_id(
-                            db,
-                            PythonFile::new(db, file, Program::get(db).python_version(db)),
-                        )
+                        .to_scope_id(db, Program::get(db).program_file(db, file))
                         .name(db, module)
                 })
                 .collect()
@@ -1888,8 +1886,8 @@ def x():
     pass",
         );
 
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
-        let index = semantic_index(&db, python_file(&db, file));
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
+        let index = semantic_index(&db, program_file(&db, file));
 
         let descendants = index.descendent_scopes(FileScopeId::global());
         assert_eq!(
@@ -1935,7 +1933,7 @@ match subject:
 ",
         );
 
-        let global_scope_id = global_scope(&db, python_file(&db, file));
+        let global_scope_id = global_scope(&db, program_file(&db, file));
         let global_table = place_table(&db, global_scope_id);
 
         assert!(global_table.symbol_by_name("Foo").unwrap().is_used());
@@ -1967,7 +1965,7 @@ match 1:
 ",
         );
 
-        let global_scope_id = global_scope(&db, python_file(&db, file));
+        let global_scope_id = global_scope(&db, program_file(&db, file));
         let global_table = place_table(&db, global_scope_id);
 
         assert_eq!(names(global_table), vec!["first", "second"]);
@@ -1984,7 +1982,7 @@ match 1:
     #[test]
     fn for_loops_single_assignment() {
         let TestCase { db, file } = test_case("for x in a: pass");
-        let scope = global_scope(&db, python_file(&db, file));
+        let scope = global_scope(&db, program_file(&db, file));
         let global_table = place_table(&db, scope);
 
         assert_eq!(&names(global_table), &["a", "x"]);
@@ -2000,7 +1998,7 @@ match 1:
     #[test]
     fn for_loops_simple_unpacking() {
         let TestCase { db, file } = test_case("for (x, y) in a: pass");
-        let scope = global_scope(&db, python_file(&db, file));
+        let scope = global_scope(&db, program_file(&db, file));
         let global_table = place_table(&db, scope);
 
         assert_eq!(&names(global_table), &["a", "x", "y"]);
@@ -2020,7 +2018,7 @@ match 1:
     #[test]
     fn for_loops_complex_unpacking() {
         let TestCase { db, file } = test_case("for [((a,) b), (c, d)] in e: pass");
-        let scope = global_scope(&db, python_file(&db, file));
+        let scope = global_scope(&db, program_file(&db, file));
         let global_table = place_table(&db, scope);
 
         assert_eq!(&names(global_table), &["e", "a", "b", "c", "d"]);

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -13,6 +13,7 @@ use ruff_db::files::File;
 use ruff_index::{FrozenIndexVec, Idx, IndexVec};
 use ruff_python_ast::{Singleton, name::Name};
 
+use crate::ProgramFile;
 use crate::ast_ids::ExpressionNodeKey;
 use crate::db::Db;
 use crate::expression::Expression;
@@ -233,7 +234,7 @@ pub enum PatternPredicateKind<'db> {
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct PatternPredicate<'db> {
     #[returns(copy)]
-    pub python_file: PythonFile<'db>,
+    pub program_file: ProgramFile<'db>,
 
     #[returns(copy)]
     pub file_scope: FileScopeId,
@@ -257,14 +258,18 @@ impl get_size2::GetSize for PatternPredicate<'_> {}
 
 impl<'db> PatternPredicate<'db> {
     pub fn file(self, db: &'db dyn Db) -> File {
-        self.python_file(db).file(db)
+        self.program_file(db).file(db)
+    }
+
+    pub fn python_file(self, db: &'db dyn Db) -> PythonFile<'db> {
+        self.program_file(db).python_file(db)
     }
 
     pub fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
-        self.file_scope(db).to_scope_id(db, self.python_file(db))
+        self.file_scope(db).to_scope_id(db, self.program_file(db))
     }
 
-    pub fn program(self, db: &'db dyn Db) -> Program {
+    pub fn program(self, db: &'db dyn Db) -> Program<'db> {
         self.scope(db).program(db)
     }
 }
@@ -312,7 +317,7 @@ impl<'db> PatternPredicate<'db> {
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct StarImportPlaceholderPredicate<'db> {
     #[returns(copy)]
-    pub importing_parse_file: PythonFile<'db>,
+    pub importing_file: ProgramFile<'db>,
 
     /// Each symbol imported by a `*` import has a separate predicate associated with it:
     /// this field identifies which symbol that is.
@@ -327,7 +332,7 @@ pub struct StarImportPlaceholderPredicate<'db> {
     pub symbol_id: ScopedSymbolId,
 
     #[returns(copy)]
-    pub referenced_parse_file: PythonFile<'db>,
+    pub referenced_file: ProgramFile<'db>,
 }
 
 // The Salsa heap is tracked separately.
@@ -337,7 +342,7 @@ impl<'db> StarImportPlaceholderPredicate<'db> {
     pub fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
         // See doc-comment above [`StarImportPlaceholderPredicate::symbol_id`]:
         // valid `*`-import definitions can only take place in the global scope.
-        global_scope(db, self.importing_parse_file(db))
+        global_scope(db, self.importing_file(db))
     }
 }
 

--- a/crates/ty_python_core/src/program.rs
+++ b/crates/ty_python_core/src/program.rs
@@ -56,7 +56,6 @@ impl Program {
     }
 
     /// Returns the module-resolution environment for this program.
-    #[salsa::tracked(returns(copy))]
     pub fn resolver_environment(self, db: &dyn Db) -> ResolverEnvironment<'_> {
         ResolverEnvironment::new(db, self.python_version(db), self.search_paths(db))
     }

--- a/crates/ty_python_core/src/program.rs
+++ b/crates/ty_python_core/src/program.rs
@@ -1,11 +1,14 @@
 use crate::{Db, platform::PythonPlatform};
 
+use ruff_db::files::File;
 use ruff_db::system::SystemPath;
 use ruff_python_ast::PythonVersion;
 use salsa::Durability;
 use salsa::Setter;
-use ty_module_resolver::SearchPaths;
+use ty_module_resolver::{ResolverEnvironment, SearchPaths};
 use ty_site_packages::PythonVersionWithSource;
+
+use crate::ProgramFile;
 
 // Re-export the misconfiguration strategy types from ty_module_resolver.
 pub use ty_module_resolver::{FallibleStrategy, MisconfigurationStrategy, UseDefaultStrategy};
@@ -22,6 +25,7 @@ pub struct Program {
     pub search_paths: SearchPaths,
 }
 
+#[salsa::tracked]
 impl Program {
     pub fn init_or_update(db: &mut dyn Db, settings: ProgramSettings) -> Self {
         match Self::try_get(db) {
@@ -49,6 +53,16 @@ impl Program {
 
     pub fn python_version(self, db: &dyn Db) -> PythonVersion {
         self.python_version_with_source(db).version
+    }
+
+    /// Returns the module-resolution environment for this program.
+    #[salsa::tracked(returns(copy))]
+    pub fn resolver_environment(self, db: &dyn Db) -> ResolverEnvironment<'_> {
+        ResolverEnvironment::new(db, self.python_version(db), self.search_paths(db))
+    }
+
+    pub fn program_file(self, db: &dyn Db, file: File) -> ProgramFile<'_> {
+        ProgramFile::new(db, file, self.resolver_environment(db))
     }
 
     pub fn update_from_settings(self, db: &mut dyn Db, settings: ProgramSettings) {

--- a/crates/ty_python_core/src/program_file.rs
+++ b/crates/ty_python_core/src/program_file.rs
@@ -1,0 +1,55 @@
+use ruff_db::PythonFile;
+use ruff_db::files::File;
+use ruff_python_ast::PythonVersion;
+use ty_module_resolver::{ResolverEnvironment, ResolverFile};
+
+use crate::{Db, Program};
+
+/// A physical file interpreted in one module-resolution environment.
+#[salsa::interned(
+    debug,
+    constructor = new_internal,
+    revisions = usize::MAX,
+    heap_size = ruff_memory_usage::heap_size
+)]
+pub struct ProgramFile<'db> {
+    /// The cached parser key for `file` and the environment's Python version.
+    #[returns(copy)]
+    pub python_file: PythonFile<'db>,
+
+    #[returns(copy)]
+    pub resolver_environment: ResolverEnvironment<'db>,
+}
+
+impl get_size2::GetSize for ProgramFile<'_> {}
+
+impl<'db> ProgramFile<'db> {
+    pub fn new(
+        db: &'db dyn Db,
+        file: File,
+        resolver_environment: ResolverEnvironment<'db>,
+    ) -> Self {
+        let python_file = PythonFile::new(db, file, resolver_environment.python_version(db));
+        Self::new_internal(db, python_file, resolver_environment)
+    }
+
+    /// Returns the physical file represented by this program file.
+    pub fn file(self, db: &'db dyn Db) -> File {
+        self.python_file(db).file(db)
+    }
+
+    /// Returns the resolver key for this file.
+    pub fn resolver_file(self, db: &'db dyn Db) -> ResolverFile<'db> {
+        ResolverFile::new(db, self.file(db), self.resolver_environment(db))
+    }
+
+    /// Returns the program associated with this file.
+    pub fn program(self, db: &'db dyn Db) -> Program<'db> {
+        self.resolver_environment(db)
+    }
+
+    /// Returns the Python version associated with this file's resolver environment.
+    pub fn python_version(self, db: &'db dyn Db) -> PythonVersion {
+        self.resolver_environment(db).python_version(db)
+    }
+}

--- a/crates/ty_python_core/src/program_file.rs
+++ b/crates/ty_python_core/src/program_file.rs
@@ -5,7 +5,49 @@ use ty_module_resolver::{ResolverEnvironment, ResolverFile};
 
 use crate::{Db, Program};
 
-/// A physical file interpreted in one program.
+/// A file interpreted within a particular Python program.
+///
+/// The same file can participate in multiple programs, each with different Python versions, search
+/// paths, or other settings that affect type inference.
+///
+/// For example:
+///
+/// ```text
+/// project/
+/// ├── app.py         # Project program: Python 3.11
+/// ├── generate.py    # Script program:  Python 3.12
+/// └── shared.py      # Imported by both
+/// ```
+///
+/// In `shared.py`, version-dependent code can produce different types:
+///
+/// ```python
+/// import sys
+///
+/// if sys.version_info >= (3, 12):
+///     value = 1
+/// else:
+///     value = "one"
+/// ```
+///
+/// The two interpretations therefore need separate semantic identities:
+///
+/// ```text
+/// ProgramFile(shared.py, project program) -> value: str
+/// ProgramFile(shared.py, script program)  -> value: int
+/// ```
+///
+/// Semantic queries, such as `semantic_index`, use `ProgramFile` to avoid sharing results between
+/// incompatible programs. Lower-level operations use narrower identities where possible:
+///
+/// ```text
+/// program_file.python_file(db)   -> File + Python version
+/// program_file.resolver_file(db) -> File + resolver environment
+/// ```
+///
+/// This allows programs with the same Python version to share parsed syntax, and programs with
+/// equivalent resolver environments to share module resolution, while keeping type inference
+/// isolated.
 #[salsa::interned(
     debug,
     constructor = new_internal,

--- a/crates/ty_python_core/src/program_file.rs
+++ b/crates/ty_python_core/src/program_file.rs
@@ -9,7 +9,6 @@ use crate::{Db, Program};
 #[salsa::interned(
     debug,
     constructor = new_internal,
-    revisions = usize::MAX,
     heap_size = ruff_memory_usage::heap_size
 )]
 pub struct ProgramFile<'db> {

--- a/crates/ty_python_core/src/program_file.rs
+++ b/crates/ty_python_core/src/program_file.rs
@@ -5,7 +5,7 @@ use ty_module_resolver::{ResolverEnvironment, ResolverFile};
 
 use crate::{Db, Program};
 
-/// A physical file interpreted in one module-resolution environment.
+/// A physical file interpreted in one program.
 #[salsa::interned(
     debug,
     constructor = new_internal,

--- a/crates/ty_python_core/src/re_exports.rs
+++ b/crates/ty_python_core/src/re_exports.rs
@@ -22,24 +22,23 @@
 
 use ruff_db::parsed::parsed_module;
 
-use ruff_db::PythonFile;
 use ruff_python_ast::{
     self as ast,
     name::Name,
     visitor::{Visitor, walk_expr, walk_pattern, walk_stmt},
 };
 use rustc_hash::FxHashMap;
-use ty_module_resolver::{ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
 
-use crate::Db;
+use crate::{Db, ProgramFile};
 
 #[salsa::tracked(
     returns(deref),
     cycle_initial=|_, _, _| Box::default(),
     heap_size=ruff_memory_usage::heap_size)
 ]
-pub(super) fn exported_names(db: &dyn Db, file: PythonFile<'_>) -> Box<[Name]> {
-    let module = parsed_module(db, file).load(db);
+pub(super) fn exported_names(db: &dyn Db, file: ProgramFile<'_>) -> Box<[Name]> {
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let mut finder = ExportFinder::new(db, file);
     finder.visit_body(module.suite());
 
@@ -53,17 +52,17 @@ pub(super) fn exported_names(db: &dyn Db, file: PythonFile<'_>) -> Box<[Name]> {
 
 struct ExportFinder<'db> {
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    program_file: ProgramFile<'db>,
     visiting_stub_file: bool,
     exports: FxHashMap<&'db Name, PossibleExportKind>,
     dunder_all: DunderAll,
 }
 
 impl<'db> ExportFinder<'db> {
-    fn new(db: &'db dyn Db, file: PythonFile<'db>) -> Self {
+    fn new(db: &'db dyn Db, file: ProgramFile<'db>) -> Self {
         Self {
             db,
-            file,
+            program_file: file,
             visiting_stub_file: file.file(db).is_stub(db),
             exports: FxHashMap::default(),
             dunder_all: DunderAll::NotPresent,
@@ -250,20 +249,35 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
                     if &name.name.id == "*" {
                         if !found_star {
                             found_star = true;
-                            for export in
-                                ModuleName::from_import_statement(self.db, self.file, node)
-                                    .ok()
-                                    .and_then(|module_name| {
-                                        resolve_module(self.db, self.file, &module_name)
+                            let db = self.db;
+                            let program_file = self.program_file;
+                            let file = program_file.file(db);
+                            let resolver_environment = program_file.resolver_environment(db);
+                            for export in ModuleName::from_import_statement(
+                                db,
+                                ImportingFile::File(file, resolver_environment),
+                                node,
+                            )
+                            .ok()
+                            .and_then(|module_name| {
+                                resolve_module(
+                                    db,
+                                    ImportingFile::File(file, resolver_environment),
+                                    &module_name,
+                                )
+                            })
+                            .iter()
+                            .flat_map(|module| {
+                                module
+                                    .file(db)
+                                    .map(|file| {
+                                        exported_names(
+                                            db,
+                                            ProgramFile::new(db, file, resolver_environment),
+                                        )
                                     })
-                                    .iter()
-                                    .flat_map(|module| {
-                                        module
-                                            .python_file(self.db)
-                                            .map(|file| exported_names(self.db, file))
-                                            .unwrap_or_default()
-                                    })
-                            {
+                                    .unwrap_or_default()
+                            }) {
                                 self.possibly_add_export(export, PossibleExportKind::Normal);
                             }
                         }

--- a/crates/ty_python_core/src/re_exports.rs
+++ b/crates/ty_python_core/src/re_exports.rs
@@ -273,7 +273,7 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
                                     .map(|file| {
                                         exported_names(
                                             db,
-                                            ProgramFile::new(db, file, resolver_environment),
+                                            ProgramFile::new(db, file, program_file.program(db)),
                                         )
                                     })
                                     .unwrap_or_default()

--- a/crates/ty_python_core/src/scope.rs
+++ b/crates/ty_python_core/src/scope.rs
@@ -5,7 +5,7 @@ use ruff_index::newtype_index;
 use ruff_python_ast::{self as ast, NodeIndex};
 
 use crate::{
-    Db, Program, SemanticIndex, ast_node_ref::AstNodeRef, definition::Definition,
+    Db, Program, ProgramFile, SemanticIndex, ast_node_ref::AstNodeRef, definition::Definition,
     node_key::NodeKey, semantic_index,
 };
 
@@ -13,7 +13,7 @@ use crate::{
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct ScopeId<'db> {
     #[returns(copy)]
-    pub python_file: PythonFile<'db>,
+    pub program_file: ProgramFile<'db>,
 
     #[returns(copy)]
     pub file_scope_id: FileScopeId,
@@ -24,11 +24,15 @@ impl get_size2::GetSize for ScopeId<'_> {}
 
 impl<'db> ScopeId<'db> {
     pub fn file(self, db: &dyn Db) -> File {
-        self.python_file(db).file(db)
+        self.program_file(db).file(db)
     }
 
-    pub fn program(self, db: &dyn Db) -> Program {
-        self.python_file(db).python_version(db)
+    pub fn python_file(self, db: &'db dyn Db) -> PythonFile<'db> {
+        self.program_file(db).python_file(db)
+    }
+
+    pub fn program(self, db: &'db dyn Db) -> Program<'db> {
+        self.program_file(db).resolver_environment(db)
     }
 
     pub fn is_annotation(self, db: &'db dyn Db) -> bool {
@@ -52,12 +56,12 @@ impl<'db> ScopeId<'db> {
     }
 
     pub fn scope(self, db: &'db dyn Db) -> &'db Scope {
-        semantic_index(db, self.python_file(db)).scope(self.file_scope_id(db))
+        semantic_index(db, self.program_file(db)).scope(self.file_scope_id(db))
     }
 
     /// Returns the class definition for the enclosing class if this scope is a method body.
     pub fn class_definition_of_method(self, db: &'db dyn Db) -> Option<Definition<'db>> {
-        semantic_index(db, self.python_file(db)).class_definition_of_method(self.file_scope_id(db))
+        semantic_index(db, self.program_file(db)).class_definition_of_method(self.file_scope_id(db))
     }
 
     pub fn is_method_scope(self, db: &'db dyn Db) -> bool {
@@ -105,7 +109,7 @@ impl FileScopeId {
         self == FileScopeId::global()
     }
 
-    pub fn to_scope_id<'db>(self, db: &'db dyn Db, file: PythonFile<'db>) -> ScopeId<'db> {
+    pub fn to_scope_id<'db>(self, db: &'db dyn Db, file: ProgramFile<'db>) -> ScopeId<'db> {
         let index = semantic_index(db, file);
         index.scope_ids_by_scope[self]
     }

--- a/crates/ty_python_core/src/scope.rs
+++ b/crates/ty_python_core/src/scope.rs
@@ -32,7 +32,7 @@ impl<'db> ScopeId<'db> {
     }
 
     pub fn program(self, db: &'db dyn Db) -> Program<'db> {
-        self.program_file(db).resolver_environment(db)
+        self.program_file(db).program(db)
     }
 
     pub fn is_annotation(self, db: &'db dyn Db) -> bool {

--- a/crates/ty_python_core/src/statement.rs
+++ b/crates/ty_python_core/src/statement.rs
@@ -1,10 +1,10 @@
-use crate::Program;
 use crate::ast_node_ref::AstNodeRef;
 use crate::db::Db;
 use crate::definition::Definition;
 use crate::expression::Expression;
 use crate::node_key::NodeKey;
 use crate::scope::{FileScopeId, ScopeId};
+use crate::{Program, ProgramFile};
 use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ruff_python_ast as ast;
@@ -40,7 +40,7 @@ pub enum Statement<'db> {
 pub struct StatementInner<'db> {
     /// The file in which the statement occurs.
     #[returns(copy)]
-    pub python_file: PythonFile<'db>,
+    pub program_file: ProgramFile<'db>,
 
     /// The scope in which the statement occurs.
     #[returns(copy)]
@@ -58,14 +58,18 @@ impl get_size2::GetSize for StatementInner<'_> {}
 
 impl<'db> StatementInner<'db> {
     pub fn file(self, db: &'db dyn Db) -> File {
-        self.python_file(db).file(db)
+        self.program_file(db).file(db)
+    }
+
+    pub fn python_file(self, db: &'db dyn Db) -> PythonFile<'db> {
+        self.program_file(db).python_file(db)
     }
 
     pub fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
-        self.file_scope(db).to_scope_id(db, self.python_file(db))
+        self.file_scope(db).to_scope_id(db, self.program_file(db))
     }
 
-    pub fn program(self, db: &'db dyn Db) -> Program {
+    pub fn program(self, db: &'db dyn Db) -> Program<'db> {
         self.scope(db).program(db)
     }
 }

--- a/crates/ty_python_core/src/unpack.rs
+++ b/crates/ty_python_core/src/unpack.rs
@@ -7,6 +7,7 @@ use ruff_text_size::{Ranged, TextRange};
 
 use crate::Db;
 use crate::EvaluationMode;
+use crate::ProgramFile;
 use crate::ast_node_ref::AstNodeRef;
 use crate::expression::Expression;
 use crate::scope::{FileScopeId, ScopeId};
@@ -32,7 +33,7 @@ use crate::scope::{FileScopeId, ScopeId};
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct Unpack<'db> {
     #[returns(copy)]
-    pub python_file: PythonFile<'db>,
+    pub program_file: ProgramFile<'db>,
 
     #[returns(copy)]
     pub(crate) value_file_scope: FileScopeId,
@@ -58,7 +59,11 @@ impl get_size2::GetSize for Unpack<'_> {}
 
 impl<'db> Unpack<'db> {
     pub fn file(self, db: &'db dyn Db) -> File {
-        self.python_file(db).file(db)
+        self.program_file(db).file(db)
+    }
+
+    pub fn python_file(self, db: &'db dyn Db) -> PythonFile<'db> {
+        self.program_file(db).python_file(db)
     }
 
     pub fn target<'ast>(self, db: &'db dyn Db, parsed: &'ast ParsedModuleRef) -> &'ast ast::Expr {
@@ -68,10 +73,10 @@ impl<'db> Unpack<'db> {
     /// Returns the scope where the unpack target expression belongs to.
     pub fn target_scope(self, db: &'db dyn Db) -> ScopeId<'db> {
         self.target_file_scope(db)
-            .to_scope_id(db, self.python_file(db))
+            .to_scope_id(db, self.program_file(db))
     }
 
-    pub fn program(self, db: &'db dyn Db) -> Program {
+    pub fn program(self, db: &'db dyn Db) -> Program<'db> {
         self.target_scope(db).program(db)
     }
 

--- a/crates/ty_python_semantic/src/db.rs
+++ b/crates/ty_python_semantic/src/db.rs
@@ -2,12 +2,15 @@ use crate::AnalysisSettings;
 use crate::lint::{LintRegistry, RuleSelection};
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::File;
-use ty_python_core::Db as PythonCoreDb;
+use ty_python_core::{Db as PythonCoreDb, ProgramFile};
 
 /// Database giving access to semantic information about a Python program.
 #[salsa::db]
 pub trait Db: PythonCoreDb {
     fn check_file(&self, file: File) -> Vec<Diagnostic>;
+
+    /// Returns the program file for `file`.
+    fn program_file(&self, file: File) -> ProgramFile<'_>;
 
     /// Resolves the rule selection for a given file.
     fn rule_selection(&self, file: File) -> &RuleSelection;
@@ -155,7 +158,11 @@ pub(crate) mod tests {
                 return Vec::new();
             }
 
-            check_file_unwrap(self, Program::get(self).program_file(self, file))
+            check_file_unwrap(self, self.program_file(file))
+        }
+
+        fn program_file(&self, file: File) -> ProgramFile<'_> {
+            Program::get(self).program_file(self, file)
         }
 
         fn rule_selection(&self, _file: File) -> &RuleSelection {

--- a/crates/ty_python_semantic/src/db.rs
+++ b/crates/ty_python_semantic/src/db.rs
@@ -37,14 +37,14 @@ pub(crate) mod tests {
     use ty_python_core::platform::PythonPlatform;
 
     use crate::{ProgramEnvironment, check_file_unwrap, default_lint_registry};
+    use ruff_db::Db as SourceDb;
     use ruff_db::files::Files;
     use ruff_db::system::{
         DbWithTestSystem, DbWithWritableSystem as _, System, SystemPath, SystemPathBuf, TestSystem,
     };
     use ruff_db::vendored::VendoredFileSystem;
-    use ruff_db::{Db as SourceDb, PythonFile};
     use ruff_python_ast::PythonVersion;
-    use ty_module_resolver::{Db as ModuleResolverDb, SearchPathSettings, SearchPaths};
+    use ty_module_resolver::{Db as ModuleResolverDb, SearchPathSettings};
     use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
     use ty_site_packages::{PythonVersionSource, PythonVersionWithSource};
 
@@ -90,7 +90,7 @@ pub(crate) mod tests {
         }
 
         pub(crate) fn program_environment(&self) -> ProgramEnvironment<'_> {
-            ProgramEnvironment::from_program(self.python_version())
+            ProgramEnvironment::from_program(Program::get(self).resolver_environment(self))
         }
 
         /// Marks `file` as open in the editor.
@@ -155,7 +155,7 @@ pub(crate) mod tests {
                 return Vec::new();
             }
 
-            check_file_unwrap(self, PythonFile::new(self, file, self.python_version()))
+            check_file_unwrap(self, Program::get(self).program_file(self, file))
         }
 
         fn rule_selection(&self, _file: File) -> &RuleSelection {
@@ -184,11 +184,7 @@ pub(crate) mod tests {
     }
 
     #[salsa::db]
-    impl ModuleResolverDb for TestDb {
-        fn search_paths(&self) -> &SearchPaths {
-            Program::get(self).search_paths(self)
-        }
-    }
+    impl ModuleResolverDb for TestDb {}
 
     #[salsa::db]
     impl salsa::Database for TestDb {}

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -1,23 +1,22 @@
-use ruff_db::PythonFile;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{self as ast};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::{ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
 
 use crate::types::{Type, TypeContext, infer_expression_types};
 use crate::{Db, ProgramEnvironment};
-use ty_python_core::{SemanticIndex, Truthiness, semantic_index};
+use ty_python_core::{ProgramFile, SemanticIndex, Truthiness, semantic_index};
 
 /// Returns a set of names in the `__all__` variable for `file`, [`None`] if it is not defined or
 /// if it contains invalid elements.
 #[salsa::tracked(returns(as_ref), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn dunder_all_names(db: &dyn Db, file: PythonFile<'_>) -> Option<FxHashSet<Name>> {
+pub(crate) fn dunder_all_names(db: &dyn Db, file: ProgramFile<'_>) -> Option<FxHashSet<Name>> {
     let source_file = file.file(db);
     let _span = tracing::trace_span!("dunder_all_names", file=?source_file.path(db)).entered();
 
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let index = semantic_index(db, file);
     let mut collector = DunderAllNamesCollector::new(db, file, index);
     collector.visit_body(module.suite());
@@ -28,7 +27,7 @@ pub(crate) fn dunder_all_names(db: &dyn Db, file: PythonFile<'_>) -> Option<FxHa
 struct DunderAllNamesCollector<'db> {
     db: &'db dyn Db,
     env: ProgramEnvironment<'db>,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
 
     /// The semantic index for the module.
     index: &'db SemanticIndex<'db>,
@@ -45,7 +44,7 @@ struct DunderAllNamesCollector<'db> {
 }
 
 impl<'db> DunderAllNamesCollector<'db> {
-    fn new(db: &'db dyn Db, file: PythonFile<'db>, index: &'db SemanticIndex<'db>) -> Self {
+    fn new(db: &'db dyn Db, file: ProgramFile<'db>, index: &'db SemanticIndex<'db>) -> Self {
         Self {
             db,
             env: ProgramEnvironment::from_file(file),
@@ -94,7 +93,8 @@ impl<'db> DunderAllNamesCollector<'db> {
                 };
                 let Some(module_dunder_all_names) = module_literal
                     .module(db)
-                    .python_file(db)
+                    .file(db)
+                    .map(|file| ProgramFile::new(db, file, self.env.program(db)))
                     .and_then(|file| dunder_all_names(db, file))
                 else {
                     // The module either does not have a `__all__` variable or it is invalid.
@@ -163,9 +163,14 @@ impl<'db> DunderAllNamesCollector<'db> {
     ) -> Option<&'db FxHashSet<Name>> {
         let db = self.db;
 
-        let module_name = ModuleName::from_import_statement(db, self.file, import_from).ok()?;
-        let module = resolve_module(db, self.file, &module_name)?;
-        dunder_all_names(db, module.python_file(db)?)
+        let importing_file = ImportingFile::File(self.file.file(db), self.env.program(db));
+        let module_name =
+            ModuleName::from_import_statement(db, importing_file, import_from).ok()?;
+        let module = resolve_module(db, importing_file, &module_name)?;
+        dunder_all_names(
+            db,
+            ProgramFile::new(db, module.file(db)?, self.env.program(db)),
+        )
     }
 
     /// Infer the type of a standalone expression.

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -163,7 +163,8 @@ impl<'db> DunderAllNamesCollector<'db> {
     ) -> Option<&'db FxHashSet<Name>> {
         let db = self.db;
 
-        let importing_file = ImportingFile::File(self.file.file(db), self.env.program(db));
+        let importing_file =
+            ImportingFile::File(self.file.file(db), self.env.resolver_environment(db));
         let module_name =
             ModuleName::from_import_statement(db, importing_file, import_from).ok()?;
         let module = resolve_module(db, importing_file, &module_name)?;

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -11,7 +11,6 @@ use ruff_db::{
     source::source_text,
 };
 use ruff_diagnostics::{Applicability, Edit, Fix, IsolationLevel, SourceMap};
-use ruff_python_ast::PythonVersion;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::Setter as _;
@@ -39,13 +38,11 @@ pub struct FixAllResults {
 /// If the `db`'s system isn't [writable](WritableSystem).
 pub fn suppress_all_diagnostics(
     db: &mut dyn Db,
-    python_version: PythonVersion,
     diagnostics: Vec<Diagnostic>,
     cancellation_token: &CancellationToken,
 ) -> Result<FixAllResults, Canceled> {
     fix_all(
         db,
-        python_version,
         diagnostics,
         FixMode::Suppress,
         cancellation_token,
@@ -61,14 +58,12 @@ pub fn suppress_all_diagnostics(
 /// If the `db`'s system isn't [writable](WritableSystem).
 pub fn fix_all_diagnostics(
     db: &mut dyn Db,
-    python_version: PythonVersion,
     diagnostics: Vec<Diagnostic>,
     applicability: Applicability,
     cancellation_token: &CancellationToken,
 ) -> Result<FixAllResults, Canceled> {
     fix_all(
         db,
-        python_version,
         diagnostics,
         FixMode::ApplyFixes(applicability),
         cancellation_token,
@@ -83,7 +78,6 @@ const MAX_ITERATIONS: usize = 10;
 /// `check_file` is a separate parameter so that tests can easily mock out a file's diagnostics.
 fn fix_all<F>(
     db: &mut dyn Db,
-    python_version: PythonVersion,
     mut diagnostics: Vec<Diagnostic>,
     fix_mode: FixMode,
     cancellation_token: &CancellationToken,
@@ -135,7 +129,7 @@ where
             continue;
         };
 
-        let python_file = PythonFile::new(db, file, python_version);
+        let python_file = db.program_file(file).python_file(db);
         let parsed = parsed_module(db, python_file);
         if parsed.load(db).has_syntax_errors() {
             tracing::warn!("Skipping file `{path}` with syntax errors");
@@ -184,7 +178,6 @@ where
         // This is done outside the above loop so that it can run in parallel.
         let check_results = recheck_files(
             &*db,
-            python_version,
             unstaged_fixes,
             fix_mode,
             cancellation_token,
@@ -757,7 +750,6 @@ enum CheckResult<'a> {
 
 fn recheck_files<'a, F>(
     db: &dyn Db,
-    python_version: PythonVersion,
     changes: Vec<(QueuedFile<'a>, usize)>,
     fix_mode: FixMode,
     cancellation_token: &CancellationToken,
@@ -783,7 +775,7 @@ where
 
                     let db = &*db;
 
-                    let python_file = PythonFile::new(db, file.file, python_version);
+                    let python_file = db.program_file(file.file).python_file(db);
                     let parsed = parsed_module(db, python_file);
                     let parsed = parsed.load(db);
 
@@ -814,7 +806,6 @@ where
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
-    use ruff_db::PythonFile;
     use ruff_db::cancellation::CancellationTokenSource;
     use ruff_db::diagnostic::{
         Annotation, Diagnostic, DiagnosticId, DisplayDiagnosticConfig, DisplayDiagnostics,
@@ -1725,12 +1716,10 @@ class B(A):
         };
 
         let initial_diagnostics = check_file(&db, file);
-        let python_version = db.python_version();
 
         let cancellation_token_source = CancellationTokenSource::new();
         let fixes = fix_all(
             &mut db,
-            python_version,
             initial_diagnostics,
             FixMode::ApplyFixes(Applicability::Safe),
             &cancellation_token_source.token(),
@@ -1804,12 +1793,10 @@ class B(A):
         };
 
         let initial_diagnostics = check_file(&db, file);
-        let python_version = db.python_version();
 
         let cancellation_token_source = CancellationTokenSource::new();
         let fixes = fix_all(
             &mut db,
-            python_version,
             initial_diagnostics,
             FixMode::ApplyFixes(Applicability::Safe),
             &cancellation_token_source.token(),
@@ -1881,10 +1868,8 @@ class B(A):
             create_diagnostics(file)
         };
 
-        let python_version = db.python_version();
         let result = fix_all(
             &mut db,
-            python_version,
             initial_diagnostics,
             FixMode::ApplyFixes(Applicability::Safe),
             &cancellation_token_source.token(),
@@ -1983,12 +1968,10 @@ class B(A):
         };
 
         let initial_diagnostics = check_file(&db, file);
-        let python_version = db.python_version();
 
         let cancellation_token_source = CancellationTokenSource::new();
         let fixes = fix_all(
             &mut db,
-            python_version,
             initial_diagnostics,
             FixMode::ApplyFixes(Applicability::Safe),
             &cancellation_token_source.token(),
@@ -2020,8 +2003,7 @@ class B(A):
 
         let file = system_path_to_file(&db, "test.py").unwrap();
 
-        let python_version = db.python_version();
-        let parsed_before = parsed_module(&db, PythonFile::new(&db, file, python_version));
+        let parsed_before = parsed_module(&db, db.program_file(file).python_file(&db));
         let had_syntax_errors = parsed_before.load(&db).has_syntax_errors();
 
         let diagnostics = db.check_file(file);
@@ -2036,13 +2018,9 @@ class B(A):
             .cloned()
             .collect();
         let cancellation_token_source = CancellationTokenSource::new();
-        let fixes = suppress_all_diagnostics(
-            &mut db,
-            python_version,
-            diagnostics,
-            &cancellation_token_source.token(),
-        )
-        .expect("operation never gets cancelled");
+        let fixes =
+            suppress_all_diagnostics(&mut db, diagnostics, &cancellation_token_source.token())
+                .expect("operation never gets cancelled");
 
         if had_syntax_errors {
             assert_eq!(fixes.count, 0);
@@ -2076,7 +2054,7 @@ class B(A):
 
         let fixed = source_text(&db, file);
 
-        let parsed = parsed_module(&db, PythonFile::new(&db, file, python_version));
+        let parsed = parsed_module(&db, db.program_file(file).python_file(&db));
         let parsed = parsed.load(&db);
 
         let diagnostics_after_applying_fixes = db.check_file(file);

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -29,6 +29,7 @@ pub(crate) use suppression::{
 };
 use ty_module_resolver::ModuleGlobSet;
 pub use ty_python_core::Program;
+use ty_python_core::ProgramFile;
 use ty_python_core::definition::docstring_from_body;
 use ty_python_core::platform::PythonPlatform;
 use ty_python_core::scope::ScopeId;
@@ -130,7 +131,7 @@ pub(crate) fn attribute_assignments<'db, 's>(
     class_body_scope: ScopeId<'db>,
     name: &'s str,
 ) -> impl Iterator<Item = (BindingWithConstraintsIterator<'db, 'db>, FileScopeId)> + use<'s, 'db> {
-    let index = semantic_index(db, class_body_scope.python_file(db));
+    let index = semantic_index(db, class_body_scope.program_file(db));
 
     attribute_scopes(db, class_body_scope).filter_map(|function_scope_id| {
         let place_table = index.place_table(function_scope_id);
@@ -150,7 +151,7 @@ pub(crate) fn attribute_declarations<'db, 's>(
     class_body_scope: ScopeId<'db>,
     name: &'s str,
 ) -> impl Iterator<Item = (DeclarationsIterator<'db, 'db>, FileScopeId)> + use<'s, 'db> {
-    let index = semantic_index(db, class_body_scope.python_file(db));
+    let index = semantic_index(db, class_body_scope.program_file(db));
 
     attribute_scopes(db, class_body_scope).filter_map(|function_scope_id| {
         let place_table = index.place_table(function_scope_id);
@@ -170,13 +171,13 @@ pub(crate) fn module_docstring(db: &dyn Db, file: PythonFile<'_>) -> Option<Stri
         .map(|docstring_expr| docstring_expr.value.to_str().to_owned())
 }
 
-pub fn check_file_unwrap(db: &dyn Db, file: PythonFile<'_>) -> Vec<Diagnostic> {
+pub fn check_file_unwrap(db: &dyn Db, file: ProgramFile<'_>) -> Vec<Diagnostic> {
     check_file(db, file)
         .map(<[ruff_db::diagnostic::Diagnostic]>::into_vec)
         .unwrap_or_else(|error| vec![error])
 }
 
-pub fn check_file(db: &dyn Db, file: PythonFile<'_>) -> Result<Box<[Diagnostic]>, Diagnostic> {
+pub fn check_file(db: &dyn Db, file: ProgramFile<'_>) -> Result<Box<[Diagnostic]>, Diagnostic> {
     let source_file = file.file(db);
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
 
@@ -191,7 +192,7 @@ pub fn check_file(db: &dyn Db, file: PythonFile<'_>) -> Result<Box<[Diagnostic]>
         .to_diagnostic());
     }
 
-    let parsed = parsed_module(db, file);
+    let parsed = parsed_module(db, file.python_file(db));
 
     let parsed_ref = parsed.load(db);
     diagnostics.extend(

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -713,7 +713,7 @@ pub(crate) fn known_module_symbol<'db>(
     known_module: KnownModule,
     symbol: &str,
 ) -> PlaceAndQualifiers<'db> {
-    resolve_module_confident(db, env.program(db), &known_module.name())
+    resolve_module_confident(db, env.resolver_environment(db), &known_module.name())
         .and_then(|module| {
             let file = ProgramFile::new(db, module.file(db)?, env.program(db));
             Some(imported_symbol(db, env, Some(file), symbol, None))

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1,6 +1,5 @@
 use crate::ProgramEnvironment;
 use itertools::Either;
-use ruff_db::PythonFile;
 use ruff_index::IndexSlice;
 use ruff_python_ast::PythonVersion;
 use ty_module_resolver::{
@@ -28,8 +27,8 @@ use ty_python_core::reachability_constraints::{
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{
     BindingWithConstraints, BindingWithConstraintsIterator, BoundnessAnalysis,
-    DeclarationWithConstraint, DeclarationsIterator, Truthiness, global_scope, place_table,
-    use_def_map,
+    DeclarationWithConstraint, DeclarationsIterator, ProgramFile, Truthiness, global_scope,
+    place_table, use_def_map,
 };
 
 pub(crate) use implicit_globals::{
@@ -487,7 +486,7 @@ pub(crate) fn symbol<'db>(
 /// Use [`imported_symbol`] to perform the lookup as seen from outside the file (e.g. via imports).
 pub(crate) fn explicit_global_symbol<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
     symbol_impl(
@@ -509,7 +508,7 @@ pub(crate) fn explicit_global_symbol<'db>(
 #[allow(unused)]
 pub(crate) fn global_symbol<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
     let env = ProgramEnvironment::from_file(file);
@@ -527,12 +526,12 @@ pub(crate) fn global_symbol<'db>(
 pub(crate) fn imported_symbol<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
-    file: Option<PythonFile<'db>>,
+    file: Option<ProgramFile<'db>>,
     name: &str,
     requires_explicit_reexport: Option<RequiresExplicitReExport>,
 ) -> PlaceAndQualifiers<'db> {
     if let Some(file) = file {
-        debug_assert_eq!(file.python_version(db), env.python_version(db));
+        debug_assert_eq!(file.program(db), env.program(db));
     }
 
     // If it's not found in the global scope, check if it's present as an instance on
@@ -664,10 +663,10 @@ fn builtins_symbol_impl<'db>(
     symbol: &str,
     visibility: BuiltinVisibility,
 ) -> Option<(ScopeId<'db>, PlaceAndQualifiers<'db>)> {
-    let python_version = env.python_version(db);
+    let program = env.program(db);
     let resolver = |module: Module<'db>| {
-        let python_file = module.python_file(db)?;
-        let scope = global_scope(db, python_file);
+        let file = ProgramFile::new(db, module.file(db)?, program);
+        let scope = global_scope(db, file);
         let found_symbol = symbol_impl(
             db,
             scope,
@@ -679,7 +678,7 @@ fn builtins_symbol_impl<'db>(
             // We're looking up in the builtins namespace and not the module, so we should
             // do the normal lookup in `types.ModuleType` and not the special one as in
             // `imported_symbol`.
-            module_type_implicit_global_symbol(db, python_file, symbol)
+            module_type_implicit_global_symbol(db, file, symbol)
         });
         found_symbol.ignore_possibly_undefined()?;
 
@@ -696,13 +695,12 @@ fn builtins_symbol_impl<'db>(
     // If this symbol is not present in project-level builtins, search in the default ones.
     resolve_module_confident(
         db,
-        python_version,
+        program,
         &ModuleName::new_static("__builtins__").unwrap(),
     )
     .and_then(&resolver)
     .or_else(|| {
-        resolve_module_confident(db, python_version, &KnownModule::Builtins.name())
-            .and_then(resolver)
+        resolve_module_confident(db, program, &KnownModule::Builtins.name()).and_then(resolver)
     })
 }
 
@@ -715,9 +713,9 @@ pub(crate) fn known_module_symbol<'db>(
     known_module: KnownModule,
     symbol: &str,
 ) -> PlaceAndQualifiers<'db> {
-    resolve_module_confident(db, env.python_version(db), &known_module.name())
+    resolve_module_confident(db, env.program(db), &known_module.name())
         .and_then(|module| {
-            let file = module.python_file(db)?;
+            let file = ProgramFile::new(db, module.file(db)?, env.program(db));
             Some(imported_symbol(db, env, Some(file), symbol, None))
         })
         .unwrap_or_default()
@@ -766,8 +764,12 @@ fn core_module_scope<'db>(
     env: &ProgramEnvironment<'db>,
     core_module: KnownModule,
 ) -> Option<ScopeId<'db>> {
-    let module = resolve_module_confident(db, env.python_version(db), &core_module.name())?;
-    Some(global_scope(db, module.python_file(db)?))
+    let program = env.program(db);
+    let module = resolve_module_confident(db, program, &core_module.name())?;
+    Some(global_scope(
+        db,
+        ProgramFile::new(db, module.file(db)?, program),
+    ))
 }
 
 /// Infer the combined type from an iterator of bindings, and return it
@@ -1412,7 +1414,7 @@ fn symbol_impl<'db>(
     let _span = tracing::trace_span!("symbol", ?name).entered();
 
     let is_known_module = |known_module| {
-        file_to_module(db, scope.python_file(db))
+        file_to_module(db, scope.program_file(db).resolver_file(db))
             .is_some_and(|module| module.is_known(db, known_module))
     };
 
@@ -2120,7 +2122,7 @@ fn is_reexported(db: &dyn Db, definition: Definition<'_>) -> bool {
     // At this point, the definition should either be an `import` or `from ... import` statement.
     // This is because the default value of `is_reexported` is `true` for any other kind of
     // definition.
-    let Some(all_names) = dunder_all_names(db, definition.python_file(db)) else {
+    let Some(all_names) = dunder_all_names(db, definition.program_file(db)) else {
         return false;
     };
     let table = place_table(db, definition.scope(db));
@@ -2130,7 +2132,6 @@ fn is_reexported(db: &dyn Db, definition: Definition<'_>) -> bool {
 }
 
 pub(crate) mod implicit_globals {
-    use ruff_db::PythonFile;
     use ruff_db::parsed::parsed_module;
     use ruff_python_ast as ast;
     use ruff_python_ast::name::Name;
@@ -2146,7 +2147,7 @@ pub(crate) mod implicit_globals {
     use ty_python_core::definition::{DefinitionKind, DefinitionState};
     use ty_python_core::scope::{NodeWithScopeRef, ScopeId};
     use ty_python_core::symbol::Symbol;
-    use ty_python_core::{place_table, semantic_index, use_def_map};
+    use ty_python_core::{ProgramFile, place_table, semantic_index, use_def_map};
 
     use super::{DefinedPlace, Place, core_module_scope, is_reexported, place_from_declarations};
 
@@ -2159,15 +2160,15 @@ pub(crate) mod implicit_globals {
         module_scope: ScopeId<'db>,
         name: &str,
     ) -> Option<ScopeId<'db>> {
-        let python_file = module_scope.python_file(db);
-        let file = python_file.file(db);
+        let program_file = module_scope.program_file(db);
+        let file = program_file.file(db);
         if !file.path(db).is_vendored_path() {
             return None;
         }
         let symbol_id = place_table(db, module_scope).symbol_id(name)?;
         let use_def = use_def_map(db, module_scope);
-        let module = parsed_module(db, python_file).load(db);
-        let index = semantic_index(db, python_file);
+        let module = parsed_module(db, program_file.python_file(db)).load(db);
+        let index = semantic_index(db, program_file);
         let mut body_scope = None;
 
         for binding in use_def.end_of_scope_symbol_bindings(symbol_id) {
@@ -2187,7 +2188,7 @@ pub(crate) mod implicit_globals {
             };
             let class_scope = index
                 .node_scope(NodeWithScopeRef::Class(class.node(&module)))
-                .to_scope_id(db, python_file);
+                .to_scope_id(db, program_file);
             if body_scope.is_some_and(|body_scope| body_scope != class_scope) {
                 return None;
             }
@@ -2202,15 +2203,14 @@ pub(crate) mod implicit_globals {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<ScopeId<'db>> {
-        module_type_body_scope_inner(db, env.program(db), ())
+        module_type_body_scope_inner(db, env.program(db))
     }
 
     #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
-    fn module_type_body_scope_inner(
-        db: &dyn Db,
-        program: Program,
-        _: (), // FIXME: Remove once `Program` is a Salsa-interned struct.
-    ) -> Option<ScopeId<'_>> {
+    fn module_type_body_scope_inner<'db>(
+        db: &'db dyn Db,
+        program: Program<'db>,
+    ) -> Option<ScopeId<'db>> {
         let env = ProgramEnvironment::from_program(program);
         let module_scope = core_module_scope(db, &env, KnownModule::Types)?;
         try_vendored_class_scope(db, module_scope, "ModuleType").or_else(|| {
@@ -2262,7 +2262,7 @@ pub(crate) mod implicit_globals {
     /// global scope if they're being imported **from a different file**.
     pub(crate) fn module_type_implicit_global_symbol<'db>(
         db: &'db dyn Db,
-        file: PythonFile<'db>,
+        file: ProgramFile<'db>,
         name: &str,
     ) -> PlaceAndQualifiers<'db> {
         let env = ProgramEnvironment::from_file(file);
@@ -2275,7 +2275,7 @@ pub(crate) mod implicit_globals {
             // We special-case `__doc__` because a module with a literal docstring has `__doc__`
             // set to that string at runtime. We only narrow when a docstring is present: `__doc__`
             // may be set dynamically, so we fall back to the typeshed's `str | None`.
-            "__doc__" if module_docstring(db, file).is_some() => {
+            "__doc__" if module_docstring(db, file.python_file(db)).is_some() => {
                 // Docstrings are stripped in `-OO` optimized mode, but here we assume that the
                 // existence of an actual docstring AND the usage of `__doc__` is reason enough to
                 // believe that it will exist at runtime.
@@ -2384,18 +2384,17 @@ pub(crate) mod implicit_globals {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> &'db [ast::name::Name] {
-        module_type_symbols_inner(db, env.program(db), ())
+        module_type_symbols_inner(db, env.program(db))
     }
 
     #[salsa::tracked(
         returns(deref),
-        cycle_initial=|_, _, _, ()| smallvec::SmallVec::default(),
+        cycle_initial=|_, _, _| smallvec::SmallVec::default(),
         heap_size=ruff_memory_usage::heap_size
     )]
-    fn module_type_symbols_inner(
-        db: &dyn Db,
-        program: Program,
-        _: (), // FIXME: Remove once `Program` is a Salsa-interned struct.
+    fn module_type_symbols_inner<'db>(
+        db: &'db dyn Db,
+        program: Program<'db>,
     ) -> smallvec::SmallVec<[ast::name::Name; 8]> {
         let env = ProgramEnvironment::from_program(program);
         let Some(module_type_scope) = module_type_body_scope(db, &env) else {
@@ -2413,7 +2412,7 @@ pub(crate) mod implicit_globals {
     /// for the current module, not `str | None`).
     pub(crate) fn all_implicit_module_globals<'db>(
         db: &'db dyn Db,
-        file: PythonFile<'db>,
+        file: ProgramFile<'db>,
     ) -> impl Iterator<Item = (Name, Type<'db>)> + 'db {
         // Special-cased implicit globals that are not in `module_type_symbols`
         let special_cased = ["__builtins__", "__debug__", "__warningregistry__"]

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -765,7 +765,7 @@ fn core_module_scope<'db>(
     core_module: KnownModule,
 ) -> Option<ScopeId<'db>> {
     let program = env.program(db);
-    let module = resolve_module_confident(db, program, &core_module.name())?;
+    let module = resolve_module_confident(db, env.resolver_environment(db), &core_module.name())?;
     Some(global_scope(
         db,
         ProgramFile::new(db, module.file(db)?, program),

--- a/crates/ty_python_semantic/src/pull_types.rs
+++ b/crates/ty_python_semantic/src/pull_types.rs
@@ -4,15 +4,16 @@
 //! (Mdtest uses the `pull_types` function via the `ty_test` crate.)
 
 use crate::{Db, HasType, SemanticModel};
-use ruff_db::{PythonFile, parsed::parsed_module};
+use ruff_db::parsed::parsed_module;
 use ruff_python_ast::{
     self as ast, visitor::source_order, visitor::source_order::SourceOrderVisitor,
 };
+use ty_python_core::ProgramFile;
 
-pub fn pull_types(db: &dyn Db, file: PythonFile<'_>) {
+pub fn pull_types(db: &dyn Db, file: ProgramFile<'_>) {
     let mut visitor = PullTypesVisitor::new(db, file);
 
-    let ast = parsed_module(db, file).load(db);
+    let ast = parsed_module(db, file.python_file(db)).load(db);
 
     visitor.visit_body(ast.suite());
 }
@@ -22,7 +23,7 @@ struct PullTypesVisitor<'db> {
 }
 
 impl<'db> PullTypesVisitor<'db> {
-    fn new(db: &'db dyn Db, file: PythonFile<'db>) -> Self {
+    fn new(db: &'db dyn Db, file: ProgramFile<'db>) -> Self {
         Self {
             model: SemanticModel::new(db, file),
         }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -281,7 +281,7 @@ fn type_narrowed_by_pattern<'db>(
     predicate: PatternPredicate<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
-    let env = ProgramEnvironment::from_file(predicate.python_file(db));
+    let env = ProgramEnvironment::from_file(predicate.program_file(db));
     pattern_binding_fallthrough_type(db, &env, predicate.kind(db), subject_ty)
 }
 
@@ -1538,8 +1538,8 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
         PredicateNode::StarImportPlaceholder(star_import) => {
             let place_table = place_table(db, star_import.scope(db));
             let symbol = place_table.symbol(star_import.symbol_id(db));
-            let python_file = star_import.referenced_parse_file(db);
-            let requires_explicit_reexport = match dunder_all_names(db, python_file) {
+            let program_file = star_import.referenced_file(db);
+            let requires_explicit_reexport = match dunder_all_names(db, program_file) {
                 Some(all_names) => {
                     if all_names.contains(symbol.name()) {
                         Some(RequiresExplicitReExport::No)
@@ -1547,7 +1547,7 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
                         tracing::trace!(
                             "Symbol `{}` (via star import) not found in `__all__` of `{}`",
                             symbol.name(),
-                            python_file.file(db).path(db)
+                            program_file.file(db).path(db)
                         );
                         return Truthiness::AlwaysFalse;
                     }
@@ -1558,7 +1558,7 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
             match imported_symbol(
                 db,
                 env,
-                Some(python_file),
+                Some(program_file),
                 symbol.name(),
                 requires_explicit_reexport,
             )
@@ -1790,9 +1790,9 @@ impl<'db> DeclarationsIteratorExtension<'db> for DeclarationsIterator<'_, 'db> {
 mod tests {
     use super::*;
     use crate::db::tests::setup_db;
-    use ruff_db::PythonFile;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::DbWithWritableSystem as _;
+    use ty_python_core::ProgramFile;
     use ty_python_core::narrowing_constraints::InteriorNode;
     use ty_python_core::predicate::Predicates;
     use ty_python_core::semantic_index;
@@ -1826,8 +1826,8 @@ class TargetB:
         db.write_files([("/src/a.py", a.as_str()), ("/src/b.py", b.as_str())])?;
 
         let file = system_path_to_file(&db, "/src/a.py").unwrap();
-        let python_file = PythonFile::new(&db, file, db.python_version());
-        let index = semantic_index(&db, python_file);
+        let program_file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let index = semantic_index(&db, program_file);
         let class_scope = index
             .child_scopes(FileScopeId::global())
             .find(|(_, scope)| scope.node().as_class().is_some())
@@ -1838,7 +1838,7 @@ class TargetB:
             .find(|(_, scope)| scope.node().as_function().is_some())
             .unwrap()
             .0
-            .to_scope_id(&db, python_file);
+            .to_scope_id(&db, program_file);
 
         // Enter the range directly so it becomes the cycle head when inferring `other.target`
         // reaches the other module and then re-enters this scope.
@@ -1860,13 +1860,13 @@ class TargetB:
 
         let file = system_path_to_file(&db, "/src/test.py").unwrap();
         let function_scope = {
-            let python_file = PythonFile::new(&db, file, db.python_version());
-            let index = semantic_index(&db, python_file);
+            let program_file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+            let index = semantic_index(&db, program_file);
             index.child_scopes(FileScopeId::global()).next().unwrap().0
         };
         {
-            let python_file = PythonFile::new(&db, file, db.python_version());
-            let scope = function_scope.to_scope_id(&db, python_file);
+            let program_file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+            let scope = function_scope.to_scope_id(&db, program_file);
             let use_def = use_def_map(&db, scope);
             assert!(
                 evaluate_reachability_constraint(&db, scope, use_def.end_of_scope_reachability(),)
@@ -1879,8 +1879,8 @@ class TargetB:
             "from typing import NoReturn\ndef callback() -> NoReturn: ...",
         )?;
 
-        let python_file = PythonFile::new(&db, file, db.python_version());
-        let scope = function_scope.to_scope_id(&db, python_file);
+        let program_file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let scope = function_scope.to_scope_id(&db, program_file);
         let use_def = use_def_map(&db, scope);
         assert!(
             evaluate_reachability_constraint(&db, scope, use_def.end_of_scope_reachability(),)
@@ -1908,7 +1908,9 @@ class TargetB:
                 )?;
 
                 let file = system_path_to_file(&db, "/src/test.py").unwrap();
-                let index = semantic_index(&db, PythonFile::new(&db, file, db.python_version()));
+                let program_file =
+                    ProgramFile::new(&db, file, db.program_environment().program(&db));
+                let index = semantic_index(&db, program_file);
                 let function_scope = index.child_scopes(FileScopeId::global()).next().unwrap().0;
                 let use_def = index.use_def_map(function_scope);
                 let predicate = use_def

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -23,12 +23,12 @@ use crate::types::{
     CycleDetector, ProgramEnvironment, SpecialFormType, Type, TypeQualifiers, binding_type,
     infer_complete_scope_types, inferred_declaration,
 };
-use ty_python_core::ProgramFile;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place_table;
 use ty_python_core::scope::{FileScopeId, Scope};
 use ty_python_core::semantic_index;
 use ty_python_core::symbol::Symbol;
+use ty_python_core::{Program, ProgramFile};
 
 /// The primary interface the LSP should use for querying semantic information about a [`File`].
 ///
@@ -72,6 +72,10 @@ impl<'db> SemanticModel<'db> {
 
     pub fn program_file(&self) -> ProgramFile<'db> {
         self.file
+    }
+
+    pub fn program(&self) -> Program<'db> {
+        self.file.program(self.db)
     }
 
     pub fn program_environment(&self) -> ProgramEnvironment<'db> {
@@ -131,8 +135,10 @@ impl<'db> SemanticModel<'db> {
 
     /// Resolve the given import made in this file to a Module
     pub fn resolve_module(&self, module: Option<&str>, level: u32) -> Option<Module<'db>> {
-        let importing_file =
-            ImportingFile::File(self.file(), self.program_environment().program(self.db));
+        let importing_file = ImportingFile::File(
+            self.file(),
+            self.program_environment().resolver_environment(self.db),
+        );
         let module_name =
             ModuleName::from_identifier_parts(self.db, importing_file, module, level).ok()?;
         resolve_module(self.db, importing_file, &module_name)
@@ -142,7 +148,7 @@ impl<'db> SemanticModel<'db> {
     pub fn import_completions(&self) -> Vec<Completion<'db>> {
         let typing_extensions = ModuleName::new_static("typing_extensions").unwrap();
         let file = self.file();
-        let resolver_environment = self.program_environment().program(self.db);
+        let resolver_environment = self.program_environment().resolver_environment(self.db);
         let is_typing_extensions_available = file.is_stub(self.db)
             || resolve_real_shadowable_module(
                 self.db,
@@ -172,7 +178,10 @@ impl<'db> SemanticModel<'db> {
     pub fn from_import_completions(&self, import: &ast::StmtImportFrom) -> Vec<Completion<'db>> {
         let module_name = match ModuleName::from_import_statement(
             self.db,
-            ImportingFile::File(self.file(), self.program_environment().program(self.db)),
+            ImportingFile::File(
+                self.file(),
+                self.program_environment().resolver_environment(self.db),
+            ),
             import,
         ) {
             Ok(module_name) => module_name,
@@ -195,7 +204,10 @@ impl<'db> SemanticModel<'db> {
     ) -> Vec<Completion<'db>> {
         let Some(module) = resolve_module(
             self.db,
-            ImportingFile::File(self.file(), self.program_environment().program(self.db)),
+            ImportingFile::File(
+                self.file(),
+                self.program_environment().resolver_environment(self.db),
+            ),
             module_name,
         ) else {
             tracing::debug!("Could not resolve module from `{module_name:?}`");
@@ -210,7 +222,10 @@ impl<'db> SemanticModel<'db> {
         let db = self.db;
         let Some(module) = resolve_module(
             self.db,
-            ImportingFile::File(self.file(), self.program_environment().program(self.db)),
+            ImportingFile::File(
+                self.file(),
+                self.program_environment().resolver_environment(self.db),
+            ),
             module_name,
         ) else {
             tracing::debug!("Could not resolve module from `{module_name:?}`");

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -11,7 +11,8 @@ use ruff_source_file::LineIndex;
 use ruff_text_size::Ranged;
 use rustc_hash::FxHashMap;
 use ty_module_resolver::{
-    KnownModule, Module, ModuleName, list_modules, resolve_module, resolve_real_shadowable_module,
+    ImportingFile, KnownModule, Module, ModuleName, list_modules, resolve_module,
+    resolve_real_shadowable_module,
 };
 
 use crate::Db;
@@ -22,6 +23,7 @@ use crate::types::{
     CycleDetector, ProgramEnvironment, SpecialFormType, Type, TypeQualifiers, binding_type,
     infer_complete_scope_types, inferred_declaration,
 };
+use ty_python_core::ProgramFile;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place_table;
 use ty_python_core::scope::{FileScopeId, Scope};
@@ -41,14 +43,14 @@ use ty_python_core::symbol::Symbol;
 /// methods will automatically handle using the string literal's AST node when necessary.
 pub struct SemanticModel<'db> {
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     /// If `Some` then this `SemanticModel` is for analyzing the sub-AST of a string annotation.
     /// This expression will be used as a witness to the scope/location we're analyzing.
     in_string_annotation_expr: Option<Box<Expr>>,
 }
 
 impl<'db> SemanticModel<'db> {
-    pub fn new(db: &'db dyn Db, file: PythonFile<'db>) -> Self {
+    pub fn new(db: &'db dyn Db, file: ProgramFile<'db>) -> Self {
         Self {
             db,
             file,
@@ -65,11 +67,15 @@ impl<'db> SemanticModel<'db> {
     }
 
     pub fn python_file(&self) -> PythonFile<'db> {
+        self.file.python_file(self.db)
+    }
+
+    pub fn program_file(&self) -> ProgramFile<'db> {
         self.file
     }
 
     pub fn program_environment(&self) -> ProgramEnvironment<'db> {
-        ProgramEnvironment::from_file(self.python_file())
+        ProgramEnvironment::from_file(self.program_file())
     }
 
     pub fn file_path(&self) -> &FilePath {
@@ -91,8 +97,8 @@ impl<'db> SemanticModel<'db> {
     ) -> FxHashMap<Name, MemberDefinition<'db>> {
         let db = self.db;
         let mut members = FxHashMap::default();
-        let python_file = self.python_file();
-        let index = semantic_index(self.db, python_file);
+        let program_file = self.program_file();
+        let index = semantic_index(self.db, program_file);
         let Some(file_scope) = self.scope(node) else {
             return members;
         };
@@ -102,7 +108,8 @@ impl<'db> SemanticModel<'db> {
             .into_iter()
             .rev()
         {
-            for memberdef in all_reachable_members(db, file_scope.to_scope_id(self.db, python_file))
+            for memberdef in
+                all_reachable_members(db, file_scope.to_scope_id(self.db, program_file))
             {
                 members.insert(
                     memberdef.member.name,
@@ -119,24 +126,31 @@ impl<'db> SemanticModel<'db> {
     /// Resolve the given import made in this file to a Type
     pub fn resolve_module_type(&self, module: Option<&str>, level: u32) -> Option<Type<'db>> {
         let module = self.resolve_module(module, level)?;
-        Some(Type::module_literal(self.db, self.python_file(), module))
+        Some(Type::module_literal(self.db, self.program_file(), module))
     }
 
     /// Resolve the given import made in this file to a Module
     pub fn resolve_module(&self, module: Option<&str>, level: u32) -> Option<Module<'db>> {
+        let importing_file =
+            ImportingFile::File(self.file(), self.program_environment().program(self.db));
         let module_name =
-            ModuleName::from_identifier_parts(self.db, self.python_file(), module, level).ok()?;
-        resolve_module(self.db, self.python_file(), &module_name)
+            ModuleName::from_identifier_parts(self.db, importing_file, module, level).ok()?;
+        resolve_module(self.db, importing_file, &module_name)
     }
 
     /// Returns completions for symbols available in a `import <CURSOR>` context.
     pub fn import_completions(&self) -> Vec<Completion<'db>> {
         let typing_extensions = ModuleName::new_static("typing_extensions").unwrap();
         let file = self.file();
+        let resolver_environment = self.program_environment().program(self.db);
         let is_typing_extensions_available = file.is_stub(self.db)
-            || resolve_real_shadowable_module(self.db, self.python_file(), &typing_extensions)
-                .is_some();
-        list_modules(self.db, self.python_file().python_version(self.db))
+            || resolve_real_shadowable_module(
+                self.db,
+                ImportingFile::File(file, resolver_environment),
+                &typing_extensions,
+            )
+            .is_some();
+        list_modules(self.db, resolver_environment)
             .iter()
             .copied()
             .filter(|module| {
@@ -144,7 +158,7 @@ impl<'db> SemanticModel<'db> {
             })
             .map(|module| {
                 let builtin = module.is_known(self.db, KnownModule::Builtins);
-                let ty = Type::module_literal(self.db, self.python_file(), module);
+                let ty = Type::module_literal(self.db, self.program_file(), module);
                 Completion {
                     name: CompactString::new(module.name(self.db).as_str()),
                     ty: Some(ty),
@@ -158,7 +172,7 @@ impl<'db> SemanticModel<'db> {
     pub fn from_import_completions(&self, import: &ast::StmtImportFrom) -> Vec<Completion<'db>> {
         let module_name = match ModuleName::from_import_statement(
             self.db,
-            self.python_file(),
+            ImportingFile::File(self.file(), self.program_environment().program(self.db)),
             import,
         ) {
             Ok(module_name) => module_name,
@@ -179,7 +193,11 @@ impl<'db> SemanticModel<'db> {
         &self,
         module_name: &ModuleName,
     ) -> Vec<Completion<'db>> {
-        let Some(module) = resolve_module(self.db, self.python_file(), module_name) else {
+        let Some(module) = resolve_module(
+            self.db,
+            ImportingFile::File(self.file(), self.program_environment().program(self.db)),
+            module_name,
+        ) else {
             tracing::debug!("Could not resolve module from `{module_name:?}`");
             return vec![];
         };
@@ -190,11 +208,15 @@ impl<'db> SemanticModel<'db> {
     /// it were imported by this model's `File`.
     fn module_completions(&self, module_name: &ModuleName) -> Vec<Completion<'db>> {
         let db = self.db;
-        let Some(module) = resolve_module(self.db, self.python_file(), module_name) else {
+        let Some(module) = resolve_module(
+            self.db,
+            ImportingFile::File(self.file(), self.program_environment().program(self.db)),
+            module_name,
+        ) else {
             tracing::debug!("Could not resolve module from `{module_name:?}`");
             return vec![];
         };
-        let ty = Type::module_literal(self.db, self.python_file(), module);
+        let ty = Type::module_literal(self.db, self.program_file(), module);
         let builtin = module.is_known(self.db, KnownModule::Builtins);
 
         let mut completions = vec![];
@@ -219,7 +241,7 @@ impl<'db> SemanticModel<'db> {
 
         let mut completions = vec![];
         for submodule in module.all_submodules(self.db) {
-            let ty = Type::module_literal(self.db, self.python_file(), *submodule);
+            let ty = Type::module_literal(self.db, self.program_file(), *submodule);
             let base = submodule.name(self.db).last_component();
             completions.push(Completion {
                 name: CompactString::new(base),
@@ -254,15 +276,15 @@ impl<'db> SemanticModel<'db> {
     /// scope of this model's `File` are returned.
     pub fn scoped_completions(&self, node: ast::AnyNodeRef<'_>) -> Vec<Completion<'db>> {
         let db = self.db;
-        let python_file = self.python_file();
-        let index = semantic_index(self.db, python_file);
+        let program_file = self.program_file();
+        let index = semantic_index(self.db, program_file);
         let Some(file_scope) = self.scope(node) else {
             return vec![];
         };
         let mut completions = vec![];
         for (file_scope, _) in index.ancestor_scopes(file_scope) {
             completions.extend(
-                all_reachable_members(db, file_scope.to_scope_id(self.db, python_file)).map(
+                all_reachable_members(db, file_scope.to_scope_id(self.db, program_file)).map(
                     |memberdef| Completion {
                         name: CompactString::new(memberdef.member.name),
                         ty: Some(memberdef.member.ty),
@@ -286,7 +308,9 @@ impl<'db> SemanticModel<'db> {
 
         // Project-level builtins take precedence over the standard builtins.
         let project_builtins = ModuleName::new_static("__builtins__").unwrap();
-        if resolve_module(self.db, self.file, &project_builtins).is_some() {
+        let importing_file =
+            ImportingFile::File(self.file(), self.file.resolver_environment(self.db));
+        if resolve_module(self.db, importing_file, &project_builtins).is_some() {
             completions.extend(self.module_completions(&project_builtins).into_iter().map(
                 |mut completion| {
                     completion.builtin = true;
@@ -309,7 +333,7 @@ impl<'db> SemanticModel<'db> {
     /// Returns `true` if the given class definition's name was previously
     /// bound in the same scope (i.e., the class definition is a re-assignment).
     pub fn is_class_name_reassigned(&self, class_def: &ast::StmtClassDef) -> bool {
-        let index = semantic_index(self.db, self.python_file());
+        let index = semantic_index(self.db, self.program_file());
         let definition = index.expect_single_definition(class_def);
         let scope = definition.scope(self.db);
         let table = place_table(self.db, scope);
@@ -319,7 +343,7 @@ impl<'db> SemanticModel<'db> {
 
     /// Returns the scope in which `node` is defined (handles string annotations).
     pub fn scope(&self, node: ast::AnyNodeRef<'_>) -> Option<FileScopeId> {
-        let index = semantic_index(self.db, self.python_file());
+        let index = semantic_index(self.db, self.program_file());
         match self.node_in_ast(node) {
             ast::AnyNodeRef::Identifier(identifier) => index.try_expression_scope_id(identifier),
 
@@ -373,7 +397,7 @@ impl<'db> SemanticModel<'db> {
         &self,
         node: ast::AnyNodeRef<'_>,
     ) -> impl Iterator<Item = (FileScopeId, &Scope)> + '_ {
-        let index = semantic_index(self.db, self.python_file());
+        let index = semantic_index(self.db, self.program_file());
         self.scope(node)
             .into_iter()
             .flat_map(move |scope| index.ancestor_scopes(scope))
@@ -391,8 +415,8 @@ impl<'db> SemanticModel<'db> {
         &self,
         covering_node: &CoveringNode<'_>,
     ) -> Option<Definition<'db>> {
-        let index = semantic_index(self.db, self.python_file());
-        let parsed = parsed_module(self.db, self.file).load(self.db);
+        let index = semantic_index(self.db, self.program_file());
+        let parsed = parsed_module(self.db, self.python_file()).load(self.db);
         let target_range = covering_node.node().range();
 
         for node in covering_node.ancestors() {
@@ -462,11 +486,11 @@ impl<'db> SemanticModel<'db> {
     ) -> Option<(Parsed<ModExpression>, Self)> {
         // Ask the inference engine whether this is actually a string annotation
         let expr = ExprRef::StringLiteral(string_expr);
-        let index = semantic_index(self.db, self.python_file());
+        let index = semantic_index(self.db, self.program_file());
         // When looking up scopes, use the expr in the top-level AST
         // (we might be trying to enter a sub-sub-AST, so this isn't silly)
         let file_scope = index.expression_scope_id(&self.expr_ref_in_ast(expr));
-        let scope = file_scope.to_scope_id(self.db, self.python_file());
+        let scope = file_scope.to_scope_id(self.db, self.program_file());
         // When querying whether the expr is a string annotation, we do however use the actual expr
         // (the inference engine should record this information even for sub-nodes)
         if !infer_complete_scope_types(self.db, scope).is_string_annotation(expr) {
@@ -507,7 +531,7 @@ impl<'db> SemanticModel<'db> {
             DefinitionKind::TypeAlias(_) => true,
             DefinitionKind::AnnotatedAssignment(assignment) => {
                 let parsed = parsed_module(self.db, definition.python_file(self.db));
-                let model = Self::new(self.db, definition.python_file(self.db));
+                let model = Self::new(self.db, definition.program_file(self.db));
                 model.is_type_alias_annotation(assignment.annotation(&parsed.load(self.db)))
             }
             _ => false,
@@ -619,9 +643,9 @@ impl<'db> SemanticModel<'db> {
         string_expr: &ast::ExprStringLiteral,
     ) -> Option<Type<'db>> {
         let expr = ast::ExprRef::from(string_expr);
-        let index = semantic_index(self.db, self.python_file());
+        let index = semantic_index(self.db, self.program_file());
         let file_scope = index.try_expression_scope_id(&self.expr_ref_in_ast(expr))?;
-        let scope = file_scope.to_scope_id(self.db, self.python_file());
+        let scope = file_scope.to_scope_id(self.db, self.program_file());
 
         infer_complete_scope_types(self.db, scope).try_expected_type(expr)
     }
@@ -720,7 +744,7 @@ pub(crate) trait HasOptionalDefinition {
 
 impl HasType for ast::ExprRef<'_> {
     fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Option<Type<'db>> {
-        let file = model.python_file();
+        let file = model.program_file();
         let index = semantic_index(model.db, file);
         // TODO(#1637): semantic tokens is making this crash even with
         // `try_expr_ref_in_ast` guarding this, for now just use `try_expression_scope_id`.
@@ -824,7 +848,7 @@ macro_rules! impl_binding_has_ty_def {
         impl HasDefinition for $ty {
             #[inline]
             fn definition<'db>(&self, model: &SemanticModel<'db>) -> Definition<'db> {
-                let index = semantic_index(model.db, model.python_file());
+                let index = semantic_index(model.db, model.program_file());
                 index.expect_single_definition(self)
             }
         }
@@ -853,7 +877,7 @@ impl HasType for ast::Alias {
         if &self.name == "*" {
             return Some(Type::Never);
         }
-        let index = semantic_index(model.db, model.python_file());
+        let index = semantic_index(model.db, model.program_file());
         Some(binding_type(
             model.db(),
             index.expect_single_definition(self),
@@ -865,7 +889,7 @@ impl HasOptionalDefinition for ast::ExceptHandlerExceptHandler {
     fn optional_definition<'db>(&self, model: &SemanticModel<'db>) -> Option<Definition<'db>> {
         self.name.as_ref()?;
 
-        let index = semantic_index(model.db, model.python_file());
+        let index = semantic_index(model.db, model.program_file());
         Some(index.expect_single_definition(self))
     }
 }
@@ -881,9 +905,9 @@ impl HasType for ast::ExceptHandlerExceptHandler {
 mod tests {
     use crate::db::tests::TestDbBuilder;
     use crate::{HasType, SemanticModel};
-    use ruff_db::PythonFile;
     use ruff_db::files::system_path_to_file;
     use ruff_db::parsed::parsed_module;
+    use ty_python_core::ProgramFile;
 
     #[test]
     fn function_type() -> anyhow::Result<()> {
@@ -893,8 +917,8 @@ mod tests {
 
         let foo = system_path_to_file(&db, "/src/foo.py").unwrap();
 
-        let foo = PythonFile::new(&db, foo, db.python_version());
-        let ast = parsed_module(&db, foo).load(&db);
+        let foo = ProgramFile::new(&db, foo, db.program_environment().program(&db));
+        let ast = parsed_module(&db, foo.python_file(&db)).load(&db);
 
         let function = ast.suite()[0].as_function_def_stmt().unwrap();
         let model = SemanticModel::new(&db, foo);
@@ -913,8 +937,8 @@ mod tests {
 
         let foo = system_path_to_file(&db, "/src/foo.py").unwrap();
 
-        let foo = PythonFile::new(&db, foo, db.python_version());
-        let ast = parsed_module(&db, foo).load(&db);
+        let foo = ProgramFile::new(&db, foo, db.program_environment().program(&db));
+        let ast = parsed_module(&db, foo.python_file(&db)).load(&db);
 
         let class = ast.suite()[0].as_class_def_stmt().unwrap();
         let model = SemanticModel::new(&db, foo);
@@ -934,8 +958,8 @@ mod tests {
 
         let bar = system_path_to_file(&db, "/src/bar.py").unwrap();
 
-        let bar = PythonFile::new(&db, bar, db.python_version());
-        let ast = parsed_module(&db, bar).load(&db);
+        let bar = ProgramFile::new(&db, bar, db.program_environment().program(&db));
+        let ast = parsed_module(&db, bar.python_file(&db)).load(&db);
 
         let import = ast.suite()[0].as_import_from_stmt().unwrap();
         let alias = &import.names[0];

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -9282,7 +9282,10 @@ impl<'db> ModuleLiteralType<'db> {
         absolute_submodule_name.extend(&relative_submodule_name);
         let submodule = resolve_module(
             db,
-            ImportingFile::File(importing_file.file(db), importing_file.program(db)),
+            ImportingFile::File(
+                importing_file.file(db),
+                importing_file.resolver_environment(db),
+            ),
             &absolute_submodule_name,
         )?;
         Some(Type::module_literal(db, importing_file, submodule))

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -14,14 +14,13 @@ use call::{CallDunderError, CallError, CallErrorKind};
 use context::InferContext;
 pub use context::ProgramEnvironment;
 use ruff_db::Instant;
-use ruff_db::PythonFile;
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span};
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use smallvec::smallvec_inline;
-use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, KnownModule, Module, ModuleName, resolve_module};
 
 pub(crate) use self::callable::UpcastPolicy;
 pub use self::cyclic::CycleDetector;
@@ -114,7 +113,7 @@ pub(crate) use special_form::TypedDictModule;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{Truthiness, place_table, semantic_index, use_def_map};
+use ty_python_core::{ProgramFile, Truthiness, place_table, semantic_index, use_def_map};
 
 mod attribute_write;
 mod bool;
@@ -173,7 +172,7 @@ mod definition;
 mod property_tests;
 mod subscript;
 
-pub fn check_types(db: &dyn Db, file: PythonFile<'_>) -> Vec<Diagnostic> {
+pub fn check_types(db: &dyn Db, file: ProgramFile<'_>) -> Vec<Diagnostic> {
     let source_file = file.file(db);
     let _span = tracing::trace_span!("check_types", ?source_file).entered();
     tracing::debug!("Checking file '{path}'", path = source_file.path(db));
@@ -204,7 +203,7 @@ pub fn check_types(db: &dyn Db, file: PythonFile<'_>) -> Vec<Diagnostic> {
             .map(|error| Diagnostic::invalid_syntax(source_file, error, error)),
     );
 
-    let diagnostics = check_suppressions(db, file, diagnostics);
+    let diagnostics = check_suppressions(db, file.python_file(db), diagnostics);
 
     let elapsed = start.elapsed();
     if elapsed >= Duration::from_millis(100) {
@@ -237,7 +236,7 @@ pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) ->
 /// ```
 #[salsa::tracked(returns(copy))]
 pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db>) -> bool {
-    let file = definition.python_file(db);
+    let file = definition.program_file(db);
     let inference = infer_definition_types(db, definition);
     let ty = inference.binding_type(definition);
 
@@ -250,7 +249,7 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
         return false;
     }
 
-    let parsed = parsed_module(db, file);
+    let parsed = parsed_module(db, file.python_file(db));
     let module = parsed.load(db);
 
     // Definitions inside an `if TYPE_CHECKING` block are never available at runtime.
@@ -337,7 +336,7 @@ fn definition_expression_type<'db>(
     definition: Definition<'db>,
     expression: &ast::Expr,
 ) -> Type<'db> {
-    let file = definition.python_file(db);
+    let file = definition.program_file(db);
     let index = semantic_index(db, file);
     let file_scope = index.expression_scope_id(expression);
     let scope = file_scope.to_scope_id(db, file);
@@ -364,7 +363,7 @@ fn definition_expression_annotation<'db>(
     definition: Definition<'db>,
     expression: &ast::Expr,
 ) -> TypeAndQualifiers<'db> {
-    let file = definition.python_file(db);
+    let file = definition.program_file(db);
     let index = semantic_index(db, file);
     let file_scope = index.expression_scope_id(expression);
     let scope = file_scope.to_scope_id(db, file);
@@ -638,7 +637,7 @@ impl Default for MemberLookupPolicy {
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 struct MemberLookupKey<'db> {
     #[returns(copy)]
-    program: Program,
+    program: Program<'db>,
     #[returns(copy)]
     ty: Type<'db>,
     #[returns(ref)]
@@ -1192,7 +1191,7 @@ impl<T> InstanceProjection<T> {
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 struct TypePair<'db> {
     #[returns(copy)]
-    program: Program,
+    program: Program<'db>,
     #[returns(copy)]
     first: Type<'db>,
     #[returns(copy)]
@@ -1694,7 +1693,7 @@ impl<'db> Type<'db> {
     fn cached_materialization(
         self,
         db: &'db dyn Db,
-        program: Program,
+        program: Program<'db>,
         materialization_kind: MaterializationKind,
     ) -> Type<'db> {
         let env = &ProgramEnvironment::from_program(program);
@@ -1894,7 +1893,7 @@ impl<'db> Type<'db> {
 
     pub(crate) fn module_literal(
         db: &'db dyn Db,
-        importing_file: PythonFile<'db>,
+        importing_file: ProgramFile<'db>,
         submodule: Module<'db>,
     ) -> Self {
         Self::ModuleLiteral(ModuleLiteralType::new(
@@ -2873,7 +2872,7 @@ impl<'db> Type<'db> {
         #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
         fn lookup_dunder_new_inner<'db>(
             db: &'db dyn Db,
-            program: Program,
+            program: Program<'db>,
             ty: Type<'db>,
         ) -> Option<PlaceAndQualifiers<'db>> {
             let env = &ProgramEnvironment::from_program(program);
@@ -3463,7 +3462,7 @@ impl<'db> Type<'db> {
         #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
         fn try_call_dunder_get_inner<'db>(
             db: &'db dyn Db,
-            program: Program,
+            program: Program<'db>,
             ty: Type<'db>,
             instance: Option<Type<'db>>,
             owner: Type<'db>,
@@ -3798,7 +3797,11 @@ impl<'db> Type<'db> {
         cycle_initial=|_, _, _, _| true,
         heap_size=ruff_memory_usage::heap_size
     )]
-    fn is_definitely_non_data_descriptor_impl(self, db: &'db dyn Db, program: Program) -> bool {
+    fn is_definitely_non_data_descriptor_impl(
+        self,
+        db: &'db dyn Db,
+        program: Program<'db>,
+    ) -> bool {
         let env = &ProgramEnvironment::from_program(program);
         match self {
             Type::Dynamic(_) | Type::Divergent(_) | Type::TypeVar(_) => false,
@@ -3826,7 +3829,7 @@ impl<'db> Type<'db> {
     fn is_data_descriptor_impl(
         self,
         db: &'db dyn Db,
-        program: Program,
+        program: Program<'db>,
         any_of_union: bool,
     ) -> bool {
         let env = &ProgramEnvironment::from_program(program);
@@ -6562,7 +6565,7 @@ impl<'db> Type<'db> {
                             fallback_type: Type::unknown(),
                         });
                     }
-                    let index = semantic_index(db, scope_id.python_file(db));
+                    let index = semantic_index(db, scope_id.program_file(db));
                     Ok(bind_typevar(
                         db,
                         index,
@@ -7647,7 +7650,7 @@ impl<'db> Type<'db> {
         },
         heap_size=ruff_memory_usage::heap_size
     )]
-    fn expand_eagerly_(self, db: &'db dyn Db, program: Program) -> Type<'db> {
+    fn expand_eagerly_(self, db: &'db dyn Db, program: Program<'db>) -> Type<'db> {
         let env = &ProgramEnvironment::from_program(program);
         self.apply_type_mapping(
             db,
@@ -9058,7 +9061,7 @@ impl<'db> InvalidTypeExpression<'db> {
             && function_body_scope
                 .scope(db)
                 .parent()
-                .map(|parent| parent.to_scope_id(db, function_body_scope.python_file(db)))
+                .map(|parent| parent.to_scope_id(db, function_body_scope.program_file(db)))
                 == builtins_module_scope(db, env)
         {
             diagnostic.set_primary_annotation_message("Did you mean `collections.abc.Callable`?");
@@ -9198,14 +9201,14 @@ pub struct ModuleLiteralType<'db> {
     /// the same underlying single-file module are understood by ty as being equivalent types
     /// in all situations.
     #[returns(copy)]
-    _importing_file: Option<PythonFile<'db>>,
+    _importing_file: Option<ProgramFile<'db>>,
 }
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for ModuleLiteralType<'_> {}
 
 impl<'db> ModuleLiteralType<'db> {
-    fn importing_file(self, db: &'db dyn Db) -> Option<PythonFile<'db>> {
+    fn importing_file(self, db: &'db dyn Db) -> Option<ProgramFile<'db>> {
         debug_assert_eq!(
             self._importing_file(db).is_some(),
             self.module(db).kind(db).is_package()
@@ -9277,7 +9280,11 @@ impl<'db> ModuleLiteralType<'db> {
         let relative_submodule_name = ModuleName::new(name)?;
         let mut absolute_submodule_name = self.module(db).name(db).clone();
         absolute_submodule_name.extend(&relative_submodule_name);
-        let submodule = resolve_module(db, importing_file, &absolute_submodule_name)?;
+        let submodule = resolve_module(
+            db,
+            ImportingFile::File(importing_file.file(db), importing_file.program(db)),
+            &absolute_submodule_name,
+        )?;
         Some(Type::module_literal(db, importing_file, submodule))
     }
 
@@ -9290,7 +9297,10 @@ impl<'db> ModuleLiteralType<'db> {
         // For module literals, we want to try calling the module's own `__getattr__` function
         // if it exists. First, we need to look up the `__getattr__` function in the module's scope.
         let module = self.module(db);
-        if let Some(file) = module.python_file(db) {
+        if let Some(file) = module
+            .file(db)
+            .map(|file| ProgramFile::new(db, file, env.program(db)))
+        {
             let getattr_symbol = imported_symbol(db, env, Some(file), "__getattr__", None);
             // If we found a __getattr__ function, try to call it with the name argument
             if let Place::Defined(place) = getattr_symbol.place
@@ -9345,7 +9355,10 @@ impl<'db> ModuleLiteralType<'db> {
             return Place::bound(submodule).into();
         }
 
-        let place_and_qualifiers = imported_symbol(db, env, module.python_file(db), name, None);
+        let file = module
+            .file(db)
+            .map(|file| ProgramFile::new(db, file, env.program(db)));
+        let place_and_qualifiers = imported_symbol(db, env, file, name, None);
 
         // If the normal lookup failed, try to call the module's `__getattr__` function
         if place_and_qualifiers.place.is_undefined() {

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -161,7 +161,7 @@ impl<'db> Type<'db> {
         #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
         fn try_call_bin_op_return_type_impl<'db>(
             db: &'db dyn Db,
-            program: Program,
+            program: Program<'db>,
             left_ty: Type<'db>,
             op: ast::Operator,
             right_ty: Type<'db>,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -76,7 +76,7 @@ use crate::types::{
 use crate::{DisplaySettings, FxOrderSet};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
 use ruff_python_ast::{self as ast, AnyNodeRef, ArgOrKeyword, PythonVersion};
-use ty_python_core::semantic_index;
+use ty_python_core::{ProgramFile, semantic_index};
 
 pub(crate) use self::constructor::ConstructorCallableKind;
 
@@ -2305,7 +2305,8 @@ impl<'db> Bindings<'db> {
                                     Type::ModuleLiteral(module_literal) => {
                                         let all_names = module_literal
                                             .module(db)
-                                            .python_file(db)
+                                            .file(db)
+                                            .map(|file| ProgramFile::new(db, file, env.program(db)))
                                             .map(|file| dunder_all_names(db, file))
                                             .unwrap_or_default();
                                         match all_names {
@@ -7658,7 +7659,7 @@ impl<'db> CallableDescription<'db> {
             db: &'db dyn Db,
             function: FunctionType<'db>,
         ) -> Cow<'db, str> {
-            let semantic_index = semantic_index(db, function.python_file(db));
+            let semantic_index = semantic_index(db, function.program_file(db));
             let enclosing_scope = semantic_index.scope(function.definition(db).file_scope(db));
             if let Some(class_node) = enclosing_scope.node().as_class()
                 && let Some(class) =

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -52,7 +52,6 @@ use crate::{
     },
     types::{MetaclassCandidate, TypeDefinition, UnionType},
 };
-use ruff_db::PythonFile;
 use ruff_db::diagnostic::Span;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
@@ -61,7 +60,7 @@ use ruff_python_ast::{self as ast, NodeIndex};
 use ruff_text_size::{Ranged, TextRange};
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{place_table, use_def_map};
+use ty_python_core::{ProgramFile, place_table, use_def_map};
 
 mod dynamic_literal;
 mod enum_literal;
@@ -495,7 +494,7 @@ impl<'db> GenericAlias<'db> {
         typevar: BoundTypeVarIdentity<'db>,
     ) -> TypeVarVariance {
         let origin = self.origin(db);
-        let env = ProgramEnvironment::from_file(origin.python_file(db));
+        let env = ProgramEnvironment::from_file(origin.program_file(db));
 
         let specialization = self.specialization(db);
 
@@ -783,13 +782,13 @@ impl<'db> ClassLiteral<'db> {
         }
     }
 
-    pub(crate) fn python_file(self, db: &'db dyn Db) -> PythonFile<'db> {
+    pub(crate) fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
         match self {
-            Self::Static(class) => class.python_file(db),
-            Self::Dynamic(class) => class.scope(db).python_file(db),
-            Self::DynamicNamedTuple(class) => class.scope(db).python_file(db),
-            Self::DynamicTypedDict(class) => class.scope(db).python_file(db),
-            Self::DynamicEnum(enum_lit) => enum_lit.scope(db).python_file(db),
+            Self::Static(class) => class.program_file(db),
+            Self::Dynamic(class) => class.scope(db).program_file(db),
+            Self::DynamicNamedTuple(class) => class.scope(db).program_file(db),
+            Self::DynamicTypedDict(class) => class.scope(db).program_file(db),
+            Self::DynamicEnum(enum_lit) => enum_lit.scope(db).program_file(db),
         }
     }
 
@@ -1384,7 +1383,7 @@ impl<'db> ClassType<'db> {
         }
 
         let mut abstract_methods: FxIndexMap<Name, _> = FxIndexMap::default();
-        let env = &ProgramEnvironment::from_file(self.class_literal(db).python_file(db));
+        let env = &ProgramEnvironment::from_file(self.class_literal(db).program_file(db));
 
         // Iterate through the MRO in reverse order,
         // skipping `object` (we know it doesn't define any abstract methods)
@@ -2203,7 +2202,7 @@ impl<'db> ClassType<'db> {
         db: &'db dyn Db,
         receiver: Type<'db>,
     ) -> CallableTypes<'db> {
-        let env = &ProgramEnvironment::from_file(self.class_literal(db).python_file(db));
+        let env = &ProgramEnvironment::from_file(self.class_literal(db).program_file(db));
         // TODO: This mimics a lot of the logic in Type::try_call_from_constructor. Can we
         // consolidate the two? Can we invoke a class by upcasting the class into a Callable, and
         // then relying on the call binding machinery to Just Work™?
@@ -2986,7 +2985,7 @@ impl<'db> QualifiedClassName<'db> {
                 let body_scope = class.body_scope(self.db);
                 // Skip the class body scope itself.
                 (
-                    body_scope.python_file(self.db),
+                    body_scope.program_file(self.db),
                     body_scope.file_scope_id(self.db),
                     1,
                 )
@@ -2994,20 +2993,20 @@ impl<'db> QualifiedClassName<'db> {
             ClassLiteral::Dynamic(class) => {
                 // Dynamic classes don't have a body scope; start from the enclosing scope.
                 let scope = class.scope(self.db);
-                (scope.python_file(self.db), scope.file_scope_id(self.db), 0)
+                (scope.program_file(self.db), scope.file_scope_id(self.db), 0)
             }
             ClassLiteral::DynamicNamedTuple(namedtuple) => {
                 // Dynamic namedtuples don't have a body scope; start from the enclosing scope.
                 let scope = namedtuple.scope(self.db);
-                (scope.python_file(self.db), scope.file_scope_id(self.db), 0)
+                (scope.program_file(self.db), scope.file_scope_id(self.db), 0)
             }
             ClassLiteral::DynamicTypedDict(typeddict) => {
                 let scope = typeddict.scope(self.db);
-                (scope.python_file(self.db), scope.file_scope_id(self.db), 0)
+                (scope.program_file(self.db), scope.file_scope_id(self.db), 0)
             }
             ClassLiteral::DynamicEnum(enum_lit) => {
                 let scope = enum_lit.scope(self.db);
-                (scope.python_file(self.db), scope.file_scope_id(self.db), 0)
+                (scope.program_file(self.db), scope.file_scope_id(self.db), 0)
             }
         };
 

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -202,8 +202,9 @@ impl<'db> DynamicClassLiteral<'db> {
             db: &'db dyn Db,
             definition: Definition<'db>,
         ) -> Box<[Type<'db>]> {
-            let python_file = definition.python_file(db);
-            let env = ProgramEnvironment::from_file(python_file);
+            let program_file = definition.program_file(db);
+            let python_file = program_file.python_file(db);
+            let env = ProgramEnvironment::from_file(program_file);
             let module = parsed_module(db, python_file).load(db);
 
             let value = definition

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1646,16 +1646,8 @@ impl KnownClass {
             "SupportsIndex" => &[Self::SupportsIndex],
             "Enum" => &[Self::Enum],
             "EnumMeta" => &[Self::EnumType],
-            "EnumType"
-                if file.resolver_environment(db).python_version(db) >= PythonVersion::PY311 =>
-            {
-                &[Self::EnumType]
-            }
-            "StrEnum"
-                if file.resolver_environment(db).python_version(db) >= PythonVersion::PY311 =>
-            {
-                &[Self::StrEnum]
-            }
+            "EnumType" if file.python_version(db) >= PythonVersion::PY311 => &[Self::EnumType],
+            "StrEnum" if file.python_version(db) >= PythonVersion::PY311 => &[Self::StrEnum],
             "IntEnum" => &[Self::IntEnum],
             "Flag" => &[Self::Flag],
             "IntFlag" => &[Self::IntFlag],
@@ -1690,7 +1682,7 @@ impl KnownClass {
         };
 
         let module = file_to_module(db, file.resolver_file(db))?.known(db)?;
-        let python_version = file.resolver_environment(db).python_version(db);
+        let python_version = file.python_version(db);
         candidates
             .iter()
             .copied()

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1691,7 +1691,6 @@ impl KnownClass {
 
         let module = file_to_module(db, file.resolver_file(db))?.known(db)?;
         let python_version = file.resolver_environment(db).python_version(db);
-
         candidates
             .iter()
             .copied()

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -13,7 +13,6 @@ use crate::{
         known_instance::DeprecatedInstance,
     },
 };
-use ruff_db::PythonFile;
 use ruff_python_ast as ast;
 use ruff_python_ast::PythonVersion;
 use rustc_hash::FxHashSet;
@@ -21,7 +20,7 @@ use std::{
     borrow::Cow,
     sync::{LazyLock, Mutex},
 };
-use ty_module_resolver::{KnownModule, file_to_module};
+use ty_module_resolver::{ImportingFile, KnownModule, file_to_module};
 use ty_python_core::{SemanticIndex, Truthiness, scope::NodeWithScopeKind};
 
 /// Non-exhaustive enumeration of known classes (e.g. `builtins.int`, `typing.Any`, ...) to allow
@@ -1569,7 +1568,7 @@ impl KnownClass {
 
     pub(crate) fn try_from_file_and_name(
         db: &dyn Db,
-        file: PythonFile<'_>,
+        file: ImportingFile<'_>,
         class_name: &str,
     ) -> Option<Self> {
         // We assert that this match is exhaustive over the right-hand side in the unit test
@@ -1647,8 +1646,16 @@ impl KnownClass {
             "SupportsIndex" => &[Self::SupportsIndex],
             "Enum" => &[Self::Enum],
             "EnumMeta" => &[Self::EnumType],
-            "EnumType" if file.python_version(db) >= PythonVersion::PY311 => &[Self::EnumType],
-            "StrEnum" if file.python_version(db) >= PythonVersion::PY311 => &[Self::StrEnum],
+            "EnumType"
+                if file.resolver_environment(db).python_version(db) >= PythonVersion::PY311 =>
+            {
+                &[Self::EnumType]
+            }
+            "StrEnum"
+                if file.resolver_environment(db).python_version(db) >= PythonVersion::PY311 =>
+            {
+                &[Self::StrEnum]
+            }
             "IntEnum" => &[Self::IntEnum],
             "Flag" => &[Self::Flag],
             "IntFlag" => &[Self::IntFlag],
@@ -1682,8 +1689,8 @@ impl KnownClass {
             _ => return None,
         };
 
-        let module = file_to_module(db, file)?.known(db)?;
-        let python_version = file.python_version(db);
+        let module = file_to_module(db, file.resolver_file(db))?.known(db)?;
+        let python_version = file.resolver_environment(db).python_version(db);
 
         candidates
             .iter()
@@ -1967,7 +1974,7 @@ struct KnownClassArgument {
     class: KnownClass,
 
     #[returns(copy)]
-    program: Program,
+    program: Program<'db>,
 }
 
 /// Enumeration of ways in which looking up a [`KnownClass`] in its canonical module could fail.
@@ -2076,6 +2083,7 @@ mod tests {
                 source: PythonVersionSource::default(),
             });
         let python_version = db.python_version();
+        let program = db.program_environment().program(&db);
         for class in KnownClass::iter() {
             if class.canonical_module(python_version).is_third_party() {
                 continue;
@@ -2083,7 +2091,7 @@ mod tests {
             let class_name = class.name(python_version);
             let class_module = resolve_module_confident(
                 &db,
-                python_version,
+                program,
                 &class.canonical_module(python_version).name(),
             )
             .unwrap();
@@ -2091,7 +2099,7 @@ mod tests {
             assert_eq!(
                 KnownClass::try_from_file_and_name(
                     &db,
-                    class_module.python_file(&db).unwrap(),
+                    ImportingFile::File(class_module.file(&db).unwrap(), program),
                     class_name
                 ),
                 Some(class),

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -2074,7 +2074,7 @@ mod tests {
                 source: PythonVersionSource::default(),
             });
         let python_version = db.python_version();
-        let program = db.program_environment().program(&db);
+        let resolver_environment = db.program_environment().resolver_environment(&db);
         for class in KnownClass::iter() {
             if class.canonical_module(python_version).is_third_party() {
                 continue;
@@ -2082,7 +2082,7 @@ mod tests {
             let class_name = class.name(python_version);
             let class_module = resolve_module_confident(
                 &db,
-                program,
+                resolver_environment,
                 &class.canonical_module(python_version).name(),
             )
             .unwrap();
@@ -2090,7 +2090,7 @@ mod tests {
             assert_eq!(
                 KnownClass::try_from_file_and_name(
                     &db,
-                    ImportingFile::File(class_module.file(&db).unwrap(), program),
+                    ImportingFile::File(class_module.file(&db).unwrap(), resolver_environment),
                     class_name
                 ),
                 Some(class),

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -62,7 +62,7 @@ use crate::{
 };
 use crate::{attribute_assignments, attribute_declarations};
 use ty_python_core::{
-    attribute_scopes,
+    ProgramFile, attribute_scopes,
     definition::{Definition, DefinitionKind, DefinitionState, TargetKind},
     place_table,
     scope::{Scope, ScopeId},
@@ -404,11 +404,12 @@ impl<'db> StaticClassLiteral<'db> {
     )]
     fn pep695_generic_context_inner(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
         let scope = self.body_scope(db);
-        let python_file = scope.python_file(db);
+        let program_file = scope.program_file(db);
+        let python_file = program_file.python_file(db);
         let parsed = parsed_module(db, python_file).load(db);
         let class_def_node = scope.node(db).expect_class().node(&parsed);
         class_def_node.type_params.as_ref().map(|type_params| {
-            let index = semantic_index(db, python_file);
+            let index = semantic_index(db, program_file);
             let definition = index.expect_single_definition(class_def_node);
             GenericContext::from_type_params(db, index, definition, type_params)
         })
@@ -522,6 +523,10 @@ impl<'db> StaticClassLiteral<'db> {
         self.body_scope(db).python_file(db)
     }
 
+    pub(crate) fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
+        self.body_scope(db).program_file(db)
+    }
+
     /// Return the original [`ast::StmtClassDef`] node associated with this class
     ///
     /// ## Note
@@ -533,7 +538,7 @@ impl<'db> StaticClassLiteral<'db> {
 
     pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         let body_scope = self.body_scope(db);
-        let index = semantic_index(db, body_scope.python_file(db));
+        let index = semantic_index(db, body_scope.program_file(db));
         index.expect_single_definition(body_scope.node(db).expect_class())
     }
 
@@ -625,12 +630,13 @@ impl<'db> StaticClassLiteral<'db> {
                 class.name(db)
             );
 
-            let python_file = class.python_file(db);
+            let program_file = class.program_file(db);
+            let python_file = program_file.python_file(db);
             let module = parsed_module(db, python_file).load(db);
             let class_stmt = class.node(db, &module);
 
             let class_definition =
-                semantic_index(db, python_file).expect_single_definition(class_stmt);
+                semantic_index(db, program_file).expect_single_definition(class_stmt);
             expanded_class_base_entries(db, class.known(db), class_stmt, class_definition)
                 .into_iter()
                 .map(ExpandedClassBaseEntry::ty)
@@ -716,7 +722,8 @@ impl<'db> StaticClassLiteral<'db> {
     fn decorators_inner(self, db: &'db dyn Db) -> Box<[Type<'db>]> {
         tracing::trace!("StaticClassLiteral::decorators: {}", self.name(db));
 
-        let python_file = self.python_file(db);
+        let program_file = self.program_file(db);
+        let python_file = program_file.python_file(db);
         let module = parsed_module(db, python_file).load(db);
 
         let class_stmt = self.node(db, &module);
@@ -725,7 +732,7 @@ impl<'db> StaticClassLiteral<'db> {
         }
 
         let class_definition =
-            semantic_index(db, self.python_file(db)).expect_single_definition(class_stmt);
+            semantic_index(db, self.program_file(db)).expect_single_definition(class_stmt);
 
         class_stmt
             .decorator_list
@@ -749,10 +756,12 @@ impl<'db> StaticClassLiteral<'db> {
     /// Iterate through the decorators on this class, returning the index of the first one
     /// that is either `@dataclass` or `@dataclass(...)`.
     pub(crate) fn find_dataclass_decorator_position(self, db: &'db dyn Db) -> Option<usize> {
-        let python_file = self.python_file(db);
+        let program_file = self.program_file(db);
+        let python_file = program_file.python_file(db);
         let module = parsed_module(db, python_file).load(db);
         let class_stmt = self.node(db, &module);
-        let class_definition = semantic_index(db, python_file).expect_single_definition(class_stmt);
+        let class_definition =
+            semantic_index(db, program_file).expect_single_definition(class_stmt);
 
         class_stmt.decorator_list.iter().position(|decorator| {
             let decorator_callable = decorator
@@ -1073,8 +1082,9 @@ impl<'db> StaticClassLiteral<'db> {
             db: &'db dyn Db,
             class: StaticClassLiteral<'db>,
         ) -> Result<(Type<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>> {
-            let python_file = class.python_file(db);
-            let env = ProgramEnvironment::from_file(python_file);
+            let program_file = class.program_file(db);
+            let python_file = program_file.python_file(db);
+            let env = ProgramEnvironment::from_file(program_file);
             tracing::trace!("StaticClassLiteral::try_metaclass: {}", class.name(db));
 
             // Identify the class's own metaclass (or take the first base class's metaclass).
@@ -2777,8 +2787,9 @@ impl<'db> StaticClassLiteral<'db> {
         let class_body_scope = attribute.class_body_scope(db);
         let name = attribute.name(db).as_str();
         let target_method_decorator = attribute.target_method_decorator(db);
-        let python_file = class_body_scope.python_file(db);
-        let env = &ProgramEnvironment::from_file(python_file);
+        let program_file = class_body_scope.program_file(db);
+        let python_file = program_file.python_file(db);
+        let env = &ProgramEnvironment::from_file(program_file);
 
         // If we do not see any declarations of an attribute, neither in the class body nor in
         // any method, we build a union of the raw types inferred from all bindings of that
@@ -2790,7 +2801,7 @@ impl<'db> StaticClassLiteral<'db> {
         let mut provenance = Provenance::Unknown;
 
         let module = parsed_module(db, python_file).load(db);
-        let index = semantic_index(db, python_file);
+        let index = semantic_index(db, program_file);
         let class_map = use_def_map(db, class_body_scope);
         let class_table = place_table(db, class_body_scope);
         let is_valid_scope = |method_scope: &Scope| {
@@ -3594,10 +3605,10 @@ impl<'db> StaticClassLiteral<'db> {
             return TypeVarVariance::Bivariant;
         }
         let class_body_scope = self.body_scope(db);
-        let python_file = class_body_scope.python_file(db);
+        let program_file = class_body_scope.program_file(db);
         let python_version = env.python_version(db);
 
-        let index = semantic_index(db, python_file);
+        let index = semantic_index(db, program_file);
 
         let explicit_bases_variances = self
             .explicit_bases(db)
@@ -3792,7 +3803,7 @@ impl get_size2::GetSize for ImplicitAttributeName<'_> {}
 
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
 fn implicit_attribute_names<'db>(db: &'db dyn Db, class_body_scope: ScopeId<'db>) -> Box<[Name]> {
-    let index = semantic_index(db, class_body_scope.python_file(db));
+    let index = semantic_index(db, class_body_scope.program_file(db));
     let mut names = Vec::new();
 
     for function_scope_id in attribute_scopes(db, class_body_scope) {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3897,7 +3897,7 @@ impl<'db> Type<'db> {
         )]
         fn assignable_solutions_impl<'db>(
             db: &'db dyn Db,
-            program: Program,
+            program: Program<'db>,
             source: Type<'db>,
             target: Type<'db>,
             inferable: TypeVarSet<'db>,

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -25,9 +25,10 @@ use crate::{
     lint::{LintId, LintMetadata},
     suppression::suppressions,
 };
+use ty_module_resolver::ResolverEnvironment;
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::semantic_index;
+use ty_python_core::{ProgramFile, semantic_index};
 
 /// The lazily resolved program used by a semantic operation.
 #[derive(Clone)]
@@ -37,8 +38,8 @@ pub struct ProgramEnvironment<'db> {
 }
 
 impl<'db> ProgramEnvironment<'db> {
-    /// Creates an environment that lazily obtains its Python version from `file`.
-    pub fn from_file(file: PythonFile<'db>) -> Self {
+    /// Creates an environment that lazily obtains its program from `file`.
+    pub fn from_file(file: ProgramFile<'db>) -> Self {
         Self {
             environment: Cell::new(ProgramSource::File(file.as_id())),
             lifetime: PhantomData,
@@ -62,22 +63,23 @@ impl<'db> ProgramEnvironment<'db> {
     }
 
     /// Creates an environment with an already-established program.
-    pub const fn from_program(program: Program) -> Self {
+    pub fn from_program(program: Program<'db>) -> Self {
         Self {
-            environment: Cell::new(ProgramSource::Program(program)),
+            environment: Cell::new(ProgramSource::Program(program.as_id())),
             lifetime: PhantomData,
         }
     }
 
     /// Returns the program used by this operation.
-    pub fn program(&self, db: &'db dyn Db) -> Program {
+    #[inline]
+    pub fn program(&self, db: &'db dyn Db) -> Program<'db> {
         let program = match self.environment.get() {
-            ProgramSource::Program(program) => return program,
+            ProgramSource::Program(id) => return ResolverEnvironment::from_id(id),
             ProgramSource::File(file) => {
                 cold_path();
                 // The source handle and database share `'db`; re-wrapping the stored ingredient
                 // ID immediately before the read restores the original database lifetime.
-                PythonFile::from_id(file).python_version(db)
+                ProgramFile::from_id(file).program(db)
             }
             ProgramSource::Definition(definition) => {
                 cold_path();
@@ -93,23 +95,30 @@ impl<'db> ProgramEnvironment<'db> {
             }
         };
 
-        self.environment.set(ProgramSource::Program(program));
+        self.environment
+            .set(ProgramSource::Program(program.as_id()));
         program
     }
 
     /// Returns the Python version used by this operation.
     #[inline]
     pub fn python_version(&self, db: &'db dyn Db) -> PythonVersion {
+        self.program(db).python_version(db)
+    }
+
+    /// Returns the resolver environment used by this operation.
+    #[inline]
+    pub fn resolver_environment(&self, db: &'db dyn Db) -> ResolverEnvironment<'db> {
         self.program(db)
     }
 }
 
 #[derive(Clone, Copy)]
 enum ProgramSource {
-    Program(Program),
-    // Salsa interned handles are thin `Id` wrappers, so converting between `PythonFile` and `Id`
+    Program(Id),
+    // Salsa interned handles are thin `Id` wrappers, so converting between `ProgramFile` and `Id`
     // is an inlined representation change with no database lookup. Keeping the lifetime-bearing
-    // `PythonFile` out of the `Cell` preserves covariance in `'db`; replacing this variant after
+    // `ProgramFile` out of the `Cell` preserves covariance in `'db`; replacing this variant after
     // the first read avoids repeated Salsa ingredient reads in hot, recursive type operations.
     File(Id),
     Definition(Id),
@@ -133,7 +142,7 @@ pub(crate) struct InferContext<'db, 'ast> {
     program_environment: &'ast ProgramEnvironment<'db>,
     scope: ScopeId<'db>,
     file: File,
-    python_file: PythonFile<'db>,
+    program_file: ProgramFile<'db>,
     module: &'ast ParsedModuleRef,
     diagnostics: std::cell::RefCell<TypeCheckDiagnostics>,
     diagnostics_suppressed: bool,
@@ -148,11 +157,12 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         program_environment: &'ast ProgramEnvironment<'db>,
         scope: ScopeId<'db>,
         file: File,
-        python_file: PythonFile<'db>,
+        program_file: ProgramFile<'db>,
         module: &'ast ParsedModuleRef,
     ) -> Self {
-        debug_assert_eq!(scope.python_file(db), python_file);
-        debug_assert_eq!(python_file.file(db), file);
+        debug_assert_eq!(scope.program_file(db), program_file);
+        debug_assert_eq!(program_file.file(db), file);
+        debug_assert_eq!(program_environment.program(db), scope.program(db));
 
         Self {
             db,
@@ -160,7 +170,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
             scope,
             module,
             file,
-            python_file,
+            program_file,
             diagnostics: std::cell::RefCell::new(TypeCheckDiagnostics::default()),
             diagnostics_suppressed: false,
             inference_flags: InferenceFlags::empty(),
@@ -176,7 +186,11 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
     }
 
     pub(crate) fn python_file(&self) -> PythonFile<'db> {
-        self.python_file
+        self.program_file.python_file(self.db())
+    }
+
+    pub(crate) fn program_file(&self) -> ProgramFile<'db> {
+        self.program_file
     }
 
     #[inline]
@@ -302,7 +316,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
 
         // Accessing the semantic index here is fine because
         // the index belongs to the same file as for which we emit the diagnostic.
-        let index = semantic_index(self.db(), self.python_file);
+        let index = semantic_index(self.db(), self.program_file);
 
         let scope_id = self.scope.file_scope_id(self.db());
 
@@ -330,7 +344,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
     /// specific statement or expression containing this range is reachable.
     fn is_range_reachable(&self, range: TextRange) -> bool {
         let db = self.db;
-        let index = semantic_index(self.db(), self.python_file);
+        let index = semantic_index(self.db(), self.program_file);
         let scope_id = self.scope.file_scope_id(self.db());
         is_range_reachable(db, index, scope_id, range)
     }
@@ -366,7 +380,7 @@ impl fmt::Debug for InferContext<'_, '_> {
             .field("db", &"<dyn Db>")
             .field("scope", &self.scope)
             .field("file", &self.file)
-            .field("python_file", &self.python_file)
+            .field("program_file", &self.program_file)
             .field("diagnostics", &self.diagnostics)
             .field("diagnostics_suppressed", &self.diagnostics_suppressed)
             .field("inference_flags", &self.inference_flags)

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -690,11 +690,11 @@ mod tests {
     use crate::db::tests::setup_db;
     use crate::place::global_symbol;
     use crate::types::Type;
-    use ruff_db::PythonFile;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::DbWithWritableSystem;
     use std::cell::Cell;
     use std::hash::{Hash, Hasher};
+    use ty_python_core::ProgramFile;
 
     struct TestVisit;
 
@@ -765,7 +765,7 @@ mod tests {
         name: &str,
     ) -> Type<'db> {
         let file = system_path_to_file(db, "/src/a.py").unwrap();
-        let file = PythonFile::new(db, file, env.python_version(db));
+        let file = ProgramFile::new(db, file, env.program(db));
         global_symbol(db, file, name)
             .place
             .expect_type()

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -171,7 +171,7 @@ impl<'db> FieldMetadata<'db> {
         // using `StrictInt = Annotated[int, Strict()]`. Since we don't retain the `Annotated`
         // metadata, we need to follow the alias back to its definition and parse the metadata
         // from there.
-        let model = SemanticModel::new(db, definition.python_file(db));
+        let model = SemanticModel::new(db, definition.program_file(db));
         let Some(alias_definition) = definitions_for_name(
             &model,
             name.id.as_str(),
@@ -1189,7 +1189,7 @@ fn instance_symbol<'db>(
     ty: Type<'db>,
 ) -> Option<(KnownModule, &'db str, StaticClassLiteral<'db>)> {
     let class = ty.nominal_class(db, env)?.class_literal(db).as_static()?;
-    let module = file_to_module(db, class.python_file(db))?.known(db)?;
+    let module = file_to_module(db, class.program_file(db).resolver_file(db))?.known(db)?;
     Some((module, class.name(db).as_str(), class))
 }
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -50,7 +50,7 @@ use std::fmt::{self, Formatter};
 use ty_module_resolver::{KnownModule, Module, ModuleName, file_to_module};
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place::{PlaceTable, ScopedPlaceId};
-use ty_python_core::{global_scope, place_table, use_def_map};
+use ty_python_core::{ProgramFile, global_scope, place_table, use_def_map};
 
 const RUNTIME_CHECKABLE_DOCS_URL: &str =
     "https://docs.python.org/3/library/typing.html#typing.runtime_checkable";
@@ -1477,8 +1477,8 @@ pub(super) fn note_numbers_module_not_supported<'db>(
         let file = target_instance
             .class(db, env)
             .class_literal(db)
-            .python_file(db);
-        if let Some(module) = file_to_module(db, file)
+            .program_file(db);
+        if let Some(module) = file_to_module(db, file.resolver_file(db))
             && module.is_known(db, KnownModule::Numbers)
         {
             let is_numeric = value_ty.is_subtype_of(
@@ -4736,6 +4736,7 @@ pub(super) fn hint_if_stdlib_submodule_exists_on_other_versions(
 /// misconfigured their Python version.
 pub(super) fn hint_if_stdlib_attribute_exists_on_other_versions(
     db: &dyn Db,
+    env: &ProgramEnvironment<'_>,
     mut diagnostic: LintDiagnosticGuard,
     value_type: Type,
     attr: &str,
@@ -4748,7 +4749,7 @@ pub(super) fn hint_if_stdlib_attribute_exists_on_other_versions(
         return;
     };
     let module = module_ty.module(db);
-    let Some(file) = module.python_file(db) else {
+    let Some(file) = module.file(db) else {
         return;
     };
     let Some(search_path) = module.search_path(db) else {
@@ -4761,7 +4762,8 @@ pub(super) fn hint_if_stdlib_attribute_exists_on_other_versions(
     // We populate place_table entries for stdlib items across all known versions and platforms,
     // so if this lookup succeeds then we know that this lookup *could* succeed with possible
     // configuration changes.
-    let symbol_table = place_table(db, global_scope(db, file));
+    let program_file = ProgramFile::new(db, file, env.program(db));
+    let symbol_table = place_table(db, global_scope(db, program_file));
     let Some(symbol) = symbol_table.symbol_by_name(attr) else {
         return;
     };

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -7,7 +7,6 @@ use std::collections::hash_map::Entry;
 use std::fmt::{self, Display, Formatter, Write};
 use std::rc::Rc;
 
-use ruff_db::PythonFile;
 use ruff_db::files::FilePath;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::{line_index, source_text};
@@ -38,6 +37,7 @@ use crate::types::{
     SpecialFormType, StringLiteralType, SubclassOfInner, SubclassOfType, Type, TypeAliasType,
     TypeGuardLike, TypedDictModule, TypedDictType, UnionType, WrapperDescriptorKind, visitor,
 };
+use ty_python_core::ProgramFile;
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::{FileScopeId, ScopeKind};
 use ty_python_core::semantic_index;
@@ -742,11 +742,11 @@ fn fmt_file_location<'db>(
 /// A vector of path components in order (e.g., `["module", "OuterClass", "InnerClass"]`)
 pub(super) fn qualified_name_components_from_scope(
     db: &dyn Db,
-    file: PythonFile<'_>,
+    file: ProgramFile<'_>,
     file_scope_id: FileScopeId,
     skip_count: usize,
 ) -> Vec<String> {
-    let module_ast = parsed_module(db, file).load(db);
+    let module_ast = parsed_module(db, file.python_file(db)).load(db);
     let index = semantic_index(db, file);
 
     let mut name_parts = vec![];
@@ -772,7 +772,7 @@ pub(super) fn qualified_name_components_from_scope(
         }
     }
 
-    if let Some(module) = file_to_module(db, file) {
+    if let Some(module) = file_to_module(db, file.resolver_file(db)) {
         let module_name = module.name(db);
         name_parts.push(module_name.as_str().to_string());
     }

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -332,7 +332,7 @@ fn enum_class_literal<'db>(
     db: &'db dyn Db,
     class: ClassLiteral<'db>,
 ) -> Option<EnumClassLiteral<'db>> {
-    let env = ProgramEnvironment::from_file(class.python_file(db));
+    let env = ProgramEnvironment::from_file(class.program_file(db));
     let metadata = enum_metadata(db, class)?;
     let members = metadata
         .members
@@ -1056,7 +1056,7 @@ pub(crate) fn enum_metadata<'db>(
         return None;
     }
 
-    let env = ProgramEnvironment::from_file(class.python_file(db));
+    let env = ProgramEnvironment::from_file(class.program_file(db));
 
     if !is_enum_class_by_inheritance(db, &env, class) {
         return None;

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -1108,7 +1108,7 @@ fn enum_class_key_profile<'db>(
     enum_class: EnumClassLiteral<'db>,
     operator: ComparisonOperator,
 ) -> EnumClassKeyProfile<'db> {
-    let env = ProgramEnvironment::from_file(enum_class.class_literal(db).python_file(db));
+    let env = ProgramEnvironment::from_file(enum_class.class_literal(db).program_file(db));
     let semantics = KnownComparisonSemantics::of_instance(
         db,
         &env,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2907,8 +2907,10 @@ impl KnownFunction {
                 let Some(module_name) = ModuleName::new(module_name) else {
                     return;
                 };
-                let importing_file =
-                    ImportingFile::File(context.file(), context.program_environment().program(db));
+                let importing_file = ImportingFile::File(
+                    context.file(),
+                    context.program_environment().resolver_environment(db),
+                );
                 let Some(module) = resolve_module(db, importing_file, &module_name) else {
                     return;
                 };

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -63,7 +63,7 @@ use ruff_python_ast::find_node::covering_node;
 use ruff_python_ast::{self as ast, OperatorPrecedence, ParameterWithDefault};
 use ruff_text_size::Ranged;
 use salsa::plumbing::AsId;
-use ty_module_resolver::{KnownModule, ModuleName, file_to_module, resolve_module};
+use ty_module_resolver::{ImportingFile, KnownModule, ModuleName, file_to_module, resolve_module};
 
 use crate::place::{DefinedPlace, Definedness, Place, place_from_bindings};
 use crate::types::call::{Binding, CallArguments};
@@ -101,7 +101,7 @@ use crate::{Db, FxOrderSet, ProgramEnvironment};
 use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{FileScopeId, SemanticIndex, semantic_index};
+use ty_python_core::{FileScopeId, ProgramFile, SemanticIndex, semantic_index};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct RecursiveTypeNormalizationKey {
@@ -336,6 +336,10 @@ impl<'db> OverloadLiteral<'db> {
         self.body_scope(db).python_file(db)
     }
 
+    pub(crate) fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
+        self.body_scope(db).program_file(db)
+    }
+
     pub(crate) fn has_known_decorator(self, db: &dyn Db, decorator: FunctionDecorators) -> bool {
         self.decorators(db).contains(decorator)
     }
@@ -441,7 +445,7 @@ impl<'db> OverloadLiteral<'db> {
     /// over-invalidation.
     fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         let body_scope = self.body_scope(db);
-        let index = semantic_index(db, body_scope.python_file(db));
+        let index = semantic_index(db, body_scope.program_file(db));
         index.expect_single_definition(body_scope.node(db).expect_function())
     }
 
@@ -453,14 +457,14 @@ impl<'db> OverloadLiteral<'db> {
         let scope = self.definition(db).scope(db);
         let module = parsed_module(db, self.python_file(db)).load(db);
         let use_def =
-            semantic_index(db, scope.python_file(db)).use_def_map(scope.file_scope_id(db));
+            semantic_index(db, scope.program_file(db)).use_def_map(scope.file_scope_id(db));
         let use_id = self
             .body_scope(db)
             .node(db)
             .expect_function()
             .node(&module)
             .name
-            .scoped_use_id(db, self.python_file(db));
+            .scoped_use_id(db, self.program_file(db));
 
         let env = ProgramEnvironment::from_scope(scope);
         let Place::Defined(DefinedPlace {
@@ -513,16 +517,17 @@ impl<'db> OverloadLiteral<'db> {
     /// over-invalidation.
     pub(crate) fn signature(self, db: &'db dyn Db) -> Signature<'db> {
         let scope = self.body_scope(db);
-        let python_file = self.python_file(db);
+        let program_file = self.program_file(db);
+        let python_file = program_file.python_file(db);
         let mut signature = self.raw_signature(db, ReturnCallableTypeVarScope::Public);
         let module = parsed_module(db, python_file).load(db);
         let function_node = scope.node(db).expect_function().node(&module);
-        let index = semantic_index(db, python_file);
+        let index = semantic_index(db, program_file);
         let file_scope_id = scope.file_scope_id(db);
         let is_generator = file_scope_id.is_generator_function(index);
 
         if function_node.is_async && !is_generator {
-            let env = ProgramEnvironment::from_file(python_file);
+            let env = ProgramEnvironment::from_file(program_file);
             signature = signature.wrap_coroutine_return_type(db, &env);
         }
 
@@ -615,11 +620,12 @@ impl<'db> OverloadLiteral<'db> {
 
         let env = &ProgramEnvironment::from_scope(self.body_scope(db));
         let scope = self.body_scope(db);
-        let python_file = self.python_file(db);
+        let program_file = self.program_file(db);
+        let python_file = program_file.python_file(db);
         let module = parsed_module(db, python_file).load(db);
         let function_stmt_node = scope.node(db).expect_function().node(&module);
         let definition = self.definition(db);
-        let index = semantic_index(db, python_file);
+        let index = semantic_index(db, program_file);
         let pep695_ctx = function_stmt_node.type_params.as_ref().map(|type_params| {
             GenericContext::from_type_params(db, index, definition, type_params)
         });
@@ -685,7 +691,7 @@ impl<'db> OverloadLiteral<'db> {
             if method_has_explicit_self || class_is_generic || class_is_fallback {
                 let scope_id = definition.scope(db);
                 let typevar_binding_context = Some(definition);
-                let index = semantic_index(db, scope_id.python_file(db));
+                let index = semantic_index(db, scope_id.program_file(db));
                 let class = nearest_enclosing_class(db, index, scope_id).unwrap();
 
                 let typing_self = typing_self(db, scope_id, typevar_binding_context, class.into())
@@ -1016,8 +1022,9 @@ impl<'db> FunctionLiteral<'db> {
             implementation: OverloadLiteral<'db>,
         ) -> FunctionBodyKind {
             let definition = implementation.definition(db);
-            let python_file = definition.python_file(db);
-            let env = ProgramEnvironment::from_file(python_file);
+            let program_file = definition.program_file(db);
+            let python_file = program_file.python_file(db);
+            let env = ProgramEnvironment::from_file(program_file);
             let file = python_file.file(db);
             let module = parsed_module(db, python_file).load(db);
             let node = implementation.node(db, file, &module);
@@ -1341,6 +1348,10 @@ impl<'db> FunctionType<'db> {
 
     pub(crate) fn python_file(self, db: &'db dyn Db) -> PythonFile<'db> {
         self.literal(db).last_definition.python_file(db)
+    }
+
+    pub(crate) fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
+        self.literal(db).last_definition.program_file(db)
     }
 
     /// Returns the AST node for this function.
@@ -2376,7 +2387,9 @@ impl KnownFunction {
 
         let candidate = Self::from_str(name).ok()?;
         candidate
-            .check_module(file_to_module(db, definition.python_file(db))?.known(db)?)
+            .check_module(
+                file_to_module(db, definition.program_file(db).resolver_file(db))?.known(db)?,
+            )
             .then_some(candidate)
     }
 
@@ -2894,11 +2907,13 @@ impl KnownFunction {
                 let Some(module_name) = ModuleName::new(module_name) else {
                     return;
                 };
-                let Some(module) = resolve_module(db, context.python_file(), &module_name) else {
+                let importing_file =
+                    ImportingFile::File(context.file(), context.program_environment().program(db));
+                let Some(module) = resolve_module(db, importing_file, &module_name) else {
                     return;
                 };
 
-                overload.set_return_type(Type::module_literal(db, context.python_file(), module));
+                overload.set_return_type(Type::module_literal(db, context.program_file(), module));
             }
 
             KnownFunction::TotalOrdering => {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -256,7 +256,7 @@ pub(crate) fn typing_self<'db>(
     class: ClassLiteral<'db>,
 ) -> Option<BoundTypeVarInstance<'db>> {
     let env = ProgramEnvironment::from_scope(scope_id);
-    let index = semantic_index(db, scope_id.python_file(db));
+    let index = semantic_index(db, scope_id.program_file(db));
 
     let identity = TypeVarIdentity::new(
         db,
@@ -344,7 +344,7 @@ pub(crate) fn typing_self<'db>(
 #[salsa::interned(debug, constructor=new_internal, heap_size=ruff_memory_usage::heap_size)]
 pub struct GenericContext<'db> {
     #[returns(copy)]
-    pub(crate) program: Program,
+    pub(crate) program: Program<'db>,
 
     #[returns(ref)]
     variables_inner: FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>,
@@ -437,7 +437,7 @@ impl<'db> GenericContext<'db> {
 
     fn from_typevar_instances_in_program(
         db: &'db dyn Db,
-        program: Program,
+        program: Program<'db>,
         type_params: impl IntoIterator<Item = BoundTypeVarInstance<'db>>,
     ) -> Self {
         Self::new_internal(

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1281,7 +1281,7 @@ pub fn definitions_for_imported_symbol<'db>(
     resolve_definition::resolve_from_import_definitions(
         model.db(),
         &env,
-        ImportingFile::File(model.file(), env.program(model.db())),
+        ImportingFile::File(model.file(), env.resolver_environment(model.db())),
         import_node,
         symbol_name,
         &mut visited,
@@ -2270,7 +2270,8 @@ mod resolve_definition {
                 };
 
                 // Resolve the module to its file
-                let importing_file = ImportingFile::File(file.file(db), env.program(db));
+                let importing_file =
+                    ImportingFile::File(file.file(db), env.resolver_environment(db));
                 let Some(resolved_module) = resolve_module(db, importing_file, &module_name) else {
                     return Vec::new(); // Module not found, return empty list
                 };
@@ -2302,7 +2303,7 @@ mod resolve_definition {
                 resolve_from_import_definitions(
                     db,
                     env,
-                    ImportingFile::File(file.file(db), env.program(db)),
+                    ImportingFile::File(file.file(db), env.resolver_environment(db)),
                     import_node,
                     &alias.name,
                     visited,
@@ -2321,7 +2322,7 @@ mod resolve_definition {
                     resolve_from_import_definitions(
                         db,
                         env,
-                        ImportingFile::File(file.file(db), env.program(db)),
+                        ImportingFile::File(file.file(db), env.resolver_environment(db)),
                         import_node,
                         symbol_name,
                         visited,

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -15,16 +15,15 @@ use crate::types::{
 };
 use crate::{Db, DisplaySettings, HasDefinition, HasType, ProgramEnvironment, SemanticModel};
 use itertools::Either;
-use ruff_db::PythonFile;
 use ruff_db::files::FileRange;
 use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_python_ast::{self as ast, AnyNodeRef, name::Name};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
-use ty_module_resolver::Module;
+use ty_module_resolver::{ImportingFile, Module, ResolverFile};
 use ty_python_core::definition::{Definition, DefinitionKind, NestedBindingExecution};
-use ty_python_core::{attribute_scopes, global_scope, semantic_index, use_def_map};
+use ty_python_core::{ProgramFile, attribute_scopes, global_scope, semantic_index, use_def_map};
 
 mod unreachable_code;
 #[path = "ide_support/unused_bindings.rs"]
@@ -64,7 +63,8 @@ pub fn definitions_for_name<'db>(
     alias_resolution: ImportAliasResolution,
 ) -> Vec<ResolvedDefinition<'db>> {
     let db = model.db();
-    let file = model.python_file();
+    let env = model.program_environment();
+    let file = model.program_file();
     let index = semantic_index(db, file);
 
     // Get the scope for this name expression
@@ -165,12 +165,11 @@ pub fn definitions_for_name<'db>(
     let mut resolved_definitions = Vec::new();
 
     for definition in &all_definitions {
-        let resolved = resolve_definition(db, *definition, Some(name_str), alias_resolution);
+        let resolved = resolve_definition(db, &env, *definition, Some(name_str), alias_resolution);
         resolved_definitions.extend(resolved);
     }
 
     // If we didn't find any definitions in scopes, fallback to builtins
-    let env = model.program_environment();
     if resolved_definitions.is_empty()
         && let Some(builtins_scope) = implicit_builtins_symbol_scope(db, &env, name_str)
     {
@@ -209,6 +208,7 @@ pub fn definitions_for_name<'db>(
             .flat_map(|def| {
                 resolve_definition(
                     db,
+                    &env,
                     def,
                     Some(name_str),
                     ImportAliasResolution::ResolveAliases,
@@ -275,11 +275,16 @@ pub fn definitions_for_attribute<'db>(
     for ty in expanded_tys {
         // Handle modules
         if let Type::ModuleLiteral(module_literal) = ty {
-            if let Some(module_file) = module_literal.module(db).python_file(db) {
+            if let Some(module_file) = module_literal
+                .module(db)
+                .file(db)
+                .map(|file| ProgramFile::new(db, file, model.program_environment().program(db)))
+            {
                 let module_scope = global_scope(db, module_file);
                 for def in find_symbol_in_scope(db, module_scope, name_str) {
                     resolved.extend(resolve_definition(
                         db,
+                        &env,
                         def,
                         Some(name_str),
                         ImportAliasResolution::ResolveAliases,
@@ -437,7 +442,7 @@ impl<'db> ImplementationsFinder<'db> {
     pub fn implementations_for_file<'scan>(
         &'scan self,
         db: &'scan dyn Db,
-        file: PythonFile<'scan>,
+        file: ProgramFile<'scan>,
     ) -> Vec<ResolvedDefinition<'scan>>
     where
         'db: 'scan,
@@ -524,7 +529,7 @@ impl<'db> ImplementationsFinder<'db> {
             .and_then(Type::as_property_instance)
             .and_then(|property| property.accessor_role(db, function_definition));
         let class_node = containing_scope.node(db).as_class()?;
-        let class_definition = semantic_index(db, containing_scope.python_file(db))
+        let class_definition = semantic_index(db, containing_scope.program_file(db))
             .expect_single_definition(class_node);
         let class_ty = binding_type(db, class_definition);
         let root = extract_class_literal(db, &env, class_ty)?;
@@ -637,7 +642,7 @@ impl<'db> ImplementationsFinder<'db> {
 /// Finds subclasses of `roots` defined in `file`.
 fn class_implementations_for_file<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     roots: &FxHashSet<ClassLiteral<'db>>,
 ) -> Vec<ResolvedDefinition<'db>> {
     if !contains_identifier(&source_text(db, file.file(db)), "class") {
@@ -680,6 +685,7 @@ fn definitions_for_attribute_in_class_hierarchy<'db>(
     attribute_name: &str,
 ) -> Vec<ResolvedDefinition<'db>> {
     let db = model.db();
+    let env = model.program_environment();
     let mut resolved = Vec::new();
     'scopes: for ancestor in class_literal
         .iter_mro(db)
@@ -694,6 +700,7 @@ fn definitions_for_attribute_in_class_hierarchy<'db>(
             let use_def = use_def_map(db, class_scope);
             let resolved_in_scope = resolve_reachable_definitions(
                 db,
+                &env,
                 attribute_name,
                 use_def
                     .reachable_symbol_declarations(place_id)
@@ -711,7 +718,7 @@ fn definitions_for_attribute_in_class_hierarchy<'db>(
         }
 
         // Look for instance attributes in method scopes (e.g., self.x = 1)
-        let index = semantic_index(db, class_scope.python_file(db));
+        let index = semantic_index(db, class_scope.program_file(db));
 
         for function_scope_id in attribute_scopes(db, class_scope) {
             if let Some(place_id) = index
@@ -721,6 +728,7 @@ fn definitions_for_attribute_in_class_hierarchy<'db>(
                 let use_def = index.use_def_map(function_scope_id);
                 let resolved_in_scope = resolve_reachable_definitions(
                     db,
+                    &env,
                     attribute_name,
                     use_def
                         .reachable_member_declarations(place_id)
@@ -745,7 +753,7 @@ fn definitions_for_attribute_in_class_hierarchy<'db>(
 /// Finds member implementations contributed by subclasses of `roots` defined in `file`.
 fn member_implementations_for_file<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
     roots: &FxHashSet<ClassLiteral<'db>>,
     member_name: &str,
     accessor_role: Option<PropertyAccessorRole>,
@@ -877,7 +885,7 @@ fn own_member_definitions<'db>(
         }
     }
 
-    let file = class_scope.python_file(db);
+    let file = class_scope.program_file(db);
     let index = semantic_index(db, file);
     let mut instance_definitions = Vec::new();
     for function_scope_id in attribute_scopes(db, class_scope) {
@@ -1073,7 +1081,7 @@ fn user_visible_definitions<'db>(
 
         match definition.kind(db) {
             DefinitionKind::NestedBindings(nested) => {
-                let index = semantic_index(db, definition.python_file(db));
+                let index = semantic_index(db, definition.program_file(db));
                 let sources = nested
                     .visible_binding_sources(index, definition.file_scope(db))
                     .flatten()
@@ -1110,8 +1118,8 @@ fn is_reachable_implementation_definition<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> bool {
-    let file = definition.python_file(db);
-    let parsed = parsed_module(db, file).load(db);
+    let file = definition.program_file(db);
+    let parsed = parsed_module(db, file.python_file(db)).load(db);
     is_range_reachable(
         db,
         semantic_index(db, file),
@@ -1152,6 +1160,7 @@ fn is_ascii_identifier_continue(byte: u8) -> bool {
 
 fn resolve_reachable_definitions<'db>(
     db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
     symbol_name: &str,
     definitions: impl IntoIterator<Item = Definition<'db>>,
 ) -> Vec<ResolvedDefinition<'db>> {
@@ -1160,6 +1169,7 @@ fn resolve_reachable_definitions<'db>(
         .flat_map(|definition| {
             resolve_definition(
                 db,
+                env,
                 definition,
                 Some(symbol_name),
                 ImportAliasResolution::ResolveAliases,
@@ -1267,9 +1277,11 @@ pub fn definitions_for_imported_symbol<'db>(
     alias_resolution: ImportAliasResolution,
 ) -> Vec<ResolvedDefinition<'db>> {
     let mut visited = FxHashSet::default();
+    let env = model.program_environment();
     resolve_definition::resolve_from_import_definitions(
         model.db(),
-        model.python_file(),
+        &env,
+        ImportingFile::File(model.file(), env.program(model.db())),
         import_node,
         symbol_name,
         &mut visited,
@@ -2056,7 +2068,6 @@ mod resolve_definition {
     }
 
     use indexmap::IndexSet;
-    use ruff_db::PythonFile;
     use ruff_db::files::{FileRange, vendored_path_to_file};
     use ruff_db::parsed::{ParsedModuleRef, parsed_module};
     use ruff_db::system::SystemPath;
@@ -2066,14 +2077,17 @@ mod resolve_definition {
     use ruff_text_size::TextRange;
     use rustc_hash::FxHashSet;
     use tracing::trace;
-    use ty_module_resolver::{ModuleName, file_to_module, resolve_module, resolve_real_module};
+    use ty_module_resolver::{
+        ImportingFile, ModuleName, file_to_module, resolve_module, resolve_real_module,
+    };
 
     use crate::Db;
+    use crate::ProgramEnvironment;
     use crate::module_docstring;
     use crate::types::binding_type;
     use ty_python_core::definition::{Definition, DefinitionCategory, DefinitionKind};
     use ty_python_core::scope::{NodeWithScopeKind, ScopeId};
-    use ty_python_core::{global_scope, place_table, semantic_index, use_def_map};
+    use ty_python_core::{ProgramFile, global_scope, place_table, semantic_index, use_def_map};
 
     /// Represents the result of resolving an import to either a specific definition or
     /// a specific range within a file.
@@ -2085,7 +2099,7 @@ mod resolve_definition {
         /// The import resolved to a specific definition within a module
         Definition(Definition<'db>),
         /// The import resolved to an entire module
-        Module(PythonFile<'db>),
+        Module(ProgramFile<'db>),
         /// The import resolved to a file with a specific range
         FileWithRange(FileRange),
     }
@@ -2126,9 +2140,9 @@ mod resolve_definition {
             }
         }
 
-        fn python_file(&self, db: &'db dyn Db) -> Option<PythonFile<'db>> {
+        fn program_file(&self, db: &'db dyn Db) -> Option<ProgramFile<'db>> {
             match *self {
-                ResolvedDefinition::Definition(definition) => Some(definition.python_file(db)),
+                ResolvedDefinition::Definition(definition) => Some(definition.program_file(db)),
                 ResolvedDefinition::Module(file) => Some(file),
                 ResolvedDefinition::FileWithRange(_) => None,
             }
@@ -2137,7 +2151,7 @@ mod resolve_definition {
         pub fn docstring(&self, db: &'db dyn Db) -> Option<String> {
             match self {
                 ResolvedDefinition::Definition(definition) => definition.docstring(db),
-                ResolvedDefinition::Module(file) => module_docstring(db, *file),
+                ResolvedDefinition::Module(file) => module_docstring(db, file.python_file(db)),
                 ResolvedDefinition::FileWithRange(_) => None,
             }
         }
@@ -2198,6 +2212,7 @@ mod resolve_definition {
     /// Always returns at least the original definition as a fallback if resolution fails.
     pub(crate) fn resolve_definition<'db>(
         db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
         definition: Definition<'db>,
         symbol_name: Option<&str>,
         alias_resolution: ImportAliasResolution,
@@ -2205,6 +2220,7 @@ mod resolve_definition {
         let mut visited = FxHashSet::default();
         let resolved = resolve_definition_recursive(
             db,
+            env,
             definition,
             &mut visited,
             symbol_name,
@@ -2222,6 +2238,7 @@ mod resolve_definition {
     /// Helper function to resolve import definitions recursively.
     fn resolve_definition_recursive<'db>(
         db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
         definition: Definition<'db>,
         visited: &mut FxHashSet<Definition<'db>>,
         symbol_name: Option<&str>,
@@ -2237,8 +2254,8 @@ mod resolve_definition {
 
         match kind {
             DefinitionKind::Import(import_def) => {
-                let file = definition.python_file(db);
-                let module = parsed_module(db, file).load(db);
+                let file = definition.program_file(db);
+                let module = parsed_module(db, file.python_file(db)).load(db);
                 let alias = import_def.alias(&module);
 
                 if alias.asname.is_some()
@@ -2253,13 +2270,15 @@ mod resolve_definition {
                 };
 
                 // Resolve the module to its file
-                let Some(resolved_module) = resolve_module(db, file, &module_name) else {
+                let importing_file = ImportingFile::File(file.file(db), env.program(db));
+                let Some(resolved_module) = resolve_module(db, importing_file, &module_name) else {
                     return Vec::new(); // Module not found, return empty list
                 };
 
-                let Some(module_file) = resolved_module.python_file(db) else {
+                let Some(module_file) = resolved_module.file(db) else {
                     return Vec::new(); // No file for module, return empty list
                 };
+                let module_file = ProgramFile::new(db, module_file, env.program(db));
 
                 // For simple imports like "import os", we want to navigate to the module itself.
                 // Return the module file directly instead of trying to find definitions within it.
@@ -2267,8 +2286,8 @@ mod resolve_definition {
             }
 
             DefinitionKind::ImportFrom(import_from_def) => {
-                let file = definition.python_file(db);
-                let module = parsed_module(db, file).load(db);
+                let file = definition.program_file(db);
+                let module = parsed_module(db, file.python_file(db)).load(db);
                 let import_node = import_from_def.import(&module);
                 let alias = import_from_def.alias(&module);
 
@@ -2282,7 +2301,8 @@ mod resolve_definition {
                 // (alias.name), not the local alias (symbol_name)
                 resolve_from_import_definitions(
                     db,
-                    file,
+                    env,
+                    ImportingFile::File(file.file(db), env.program(db)),
                     import_node,
                     &alias.name,
                     visited,
@@ -2292,15 +2312,16 @@ mod resolve_definition {
 
             // For star imports, try to resolve to the specific symbol being accessed
             DefinitionKind::StarImport(star_import_def) => {
-                let file = definition.python_file(db);
-                let module = parsed_module(db, file).load(db);
+                let file = definition.program_file(db);
+                let module = parsed_module(db, file.python_file(db)).load(db);
                 let import_node = star_import_def.import(&module);
 
                 // If we have a symbol name, use the helper to resolve it in the target module
                 if let Some(symbol_name) = symbol_name {
                     resolve_from_import_definitions(
                         db,
-                        file,
+                        env,
+                        ImportingFile::File(file.file(db), env.program(db)),
                         import_node,
                         symbol_name,
                         visited,
@@ -2320,7 +2341,8 @@ mod resolve_definition {
     /// Helper function to resolve import definitions for `ImportFrom` and `StarImport` cases.
     pub(crate) fn resolve_from_import_definitions<'db>(
         db: &'db dyn Db,
-        file: PythonFile<'db>,
+        env: &ProgramEnvironment<'db>,
+        importing_file: ImportingFile<'db>,
         import_node: &ast::StmtImportFrom,
         symbol_name: &str,
         visited: &mut FxHashSet<Definition<'db>>,
@@ -2331,7 +2353,7 @@ mod resolve_definition {
                 if let Some(asname) = &alias.asname {
                     if asname.as_str() == symbol_name {
                         return vec![ResolvedDefinition::FileWithRange(FileRange::new(
-                            file.file(db),
+                            importing_file.file(db),
                             asname.range,
                         ))];
                     }
@@ -2340,22 +2362,26 @@ mod resolve_definition {
         }
 
         // Resolve the module being imported from (handles both relative and absolute imports)
-        let Some(module_name) = ModuleName::from_import_statement(db, file, import_node).ok()
+        let Some(module_name) =
+            ModuleName::from_import_statement(db, importing_file, import_node).ok()
         else {
             return Vec::new();
         };
-        let Some(resolved_module) = resolve_module(db, file, &module_name) else {
+        let Some(resolved_module) = resolve_module(db, importing_file, &module_name) else {
             return Vec::new();
         };
 
         // Resolve the target module file
-        let module_file = resolved_module.python_file(db);
+        let module_file = resolved_module
+            .file(db)
+            .map(|file| ProgramFile::new(db, file, env.program(db)));
 
         let Some(module_file) = module_file else {
             // No file means this is a namespace package, try to import the submodule
             return Vec::from_iter(resolve_from_import_submodule_definitions(
                 db,
-                file,
+                env,
+                importing_file,
                 symbol_name,
                 module_name,
             ));
@@ -2368,8 +2394,14 @@ mod resolve_definition {
         // Recursively resolve any import definitions found in the target module
         let mut resolved_definitions = Vec::new();
         for def in definitions_in_module {
-            let resolved =
-                resolve_definition_recursive(db, def, visited, Some(symbol_name), alias_resolution);
+            let resolved = resolve_definition_recursive(
+                db,
+                env,
+                def,
+                visited,
+                Some(symbol_name),
+                alias_resolution,
+            );
             resolved_definitions.extend(resolved);
         }
 
@@ -2382,7 +2414,8 @@ mod resolve_definition {
             // `child` has no binding in `pkg/__init__.py`.
             Vec::from_iter(resolve_from_import_submodule_definitions(
                 db,
-                file,
+                env,
+                importing_file,
                 symbol_name,
                 module_name,
             ))
@@ -2394,15 +2427,16 @@ mod resolve_definition {
     // Helper to resolve `from x.y import z` assuming `x.y.z` is a module.
     fn resolve_from_import_submodule_definitions<'db>(
         db: &'db dyn Db,
-        file: PythonFile<'db>,
+        env: &ProgramEnvironment<'db>,
+        importing_file: ImportingFile<'db>,
         symbol_name: &str,
         module_name: ModuleName,
     ) -> Option<ResolvedDefinition<'db>> {
         let submodule_name = ModuleName::new(symbol_name)?;
         let mut full_submodule_name = module_name;
         full_submodule_name.extend(&submodule_name);
-        let module = resolve_module(db, file, &full_submodule_name)?;
-        let file = module.python_file(db)?;
+        let module = resolve_module(db, importing_file, &full_submodule_name)?;
+        let file = ProgramFile::new(db, module.file(db)?, env.program(db));
 
         Some(ResolvedDefinition::Module(file))
     }
@@ -2449,13 +2483,14 @@ mod resolve_definition {
         def: &ResolvedDefinition<'db>,
         cached_vendored_typeshed: Option<&SystemPath>,
     ) -> Option<Vec<ResolvedDefinition<'db>>> {
-        let Some(stub_parse_file) = def.python_file(db) else {
+        let Some(stub_program_file) = def.program_file(db) else {
             trace!("Found arbitrary FileWithRange while stub mapping, giving up");
             return None;
         };
+        let env = ProgramEnvironment::from_file(stub_program_file);
 
         // If the file isn't a stub, this is presumably the real definition
-        let stub_file = stub_parse_file.file(db);
+        let stub_file = stub_program_file.file(db);
         trace!("Stub mapping definition in: {}", stub_file.path(db));
         if !stub_file.is_stub(db) {
             trace!("File isn't a stub, no stub mapping to do");
@@ -2472,7 +2507,7 @@ mod resolve_definition {
         // we're in typeshed to successfully stub-map to the Real Stdlib. So here we attempt
         // to do just that. The resulting file must not be used for anything other than
         // this module lookup, as the `ResolvedDefinition` we're handling isn't for that file.
-        let mut stub_file_for_module_lookup = stub_parse_file;
+        let mut stub_file_for_module_lookup = stub_program_file;
         if let Some(vendored_typeshed) = cached_vendored_typeshed
             && let Some(stub_path) = stub_file.path(db).as_system_path()
             && let Ok(rel_path) = stub_path.strip_prefix(vendored_typeshed)
@@ -2483,12 +2518,12 @@ mod resolve_definition {
                 "Stub is cached vendored typeshed: {}",
                 typeshed_file.path(db)
             );
-            stub_file_for_module_lookup =
-                PythonFile::new(db, typeshed_file, stub_parse_file.python_version(db));
+            stub_file_for_module_lookup = ProgramFile::new(db, typeshed_file, env.program(db));
         }
 
         // It's definitely a stub, so now rerun module resolution but with stubs disabled.
-        let stub_module = file_to_module(db, stub_file_for_module_lookup)?;
+        let resolver_file = stub_file_for_module_lookup.resolver_file(db);
+        let stub_module = file_to_module(db, resolver_file)?;
         trace!("Found stub module: {}", stub_module.name(db));
         // We need to pass an importing file to `resolve_real_module` which is a bit odd
         // here because there isn't really an importing file. However this `resolve_real_module`
@@ -2502,10 +2537,13 @@ mod resolve_definition {
         if is_builtin_module(stub_module.python_version(db).minor, stub_module.name(db)) {
             return None;
         }
-        let real_module =
-            resolve_real_module(db, stub_file_for_module_lookup, stub_module.name(db))?;
+        let real_module = resolve_real_module(
+            db,
+            ImportingFile::ResolverFile(resolver_file),
+            stub_module.name(db),
+        )?;
         trace!("Found real module: {}", real_module.name(db));
-        let real_parse_file = real_module.python_file(db)?;
+        let real_parse_file = ProgramFile::new(db, real_module.file(db)?, env.program(db));
         let real_file = real_parse_file.file(db);
         trace!("Found real file: {}", real_file.path(db));
 
@@ -2539,7 +2577,7 @@ mod resolve_definition {
                 path.push(leaf);
 
                 // Get the ancestors of the path (all the definitions we're nested under)
-                let index = semantic_index(db, definition.python_file(db));
+                let index = semantic_index(db, definition.program_file(db));
                 for (_scope_id, scope) in index.ancestor_scopes(definition.file_scope(db)) {
                     let node = scope.node();
                     let component = definition_path_component_for_node(&stub_ref, node)
@@ -2592,6 +2630,7 @@ mod resolve_definition {
                             .flat_map(|definition| {
                                 resolve_definition(
                                     db,
+                                    &env,
                                     definition,
                                     Some(component),
                                     ImportAliasResolution::ResolveAliases,
@@ -2717,7 +2756,7 @@ pub struct TypeHierarchyClass<'db> {
     /// The name of the class.
     pub name: Name,
     /// The file containing the class definition.
-    pub file: PythonFile<'db>,
+    pub file: ResolverFile<'db>,
     /// The range covering the full class definition header.
     pub full_range: TextRange,
     /// The range of the class name (for selection/focus).
@@ -2789,7 +2828,7 @@ pub fn type_hierarchy_subtypes<'db>(
     let Some(target_class) = extract_class_literal(db, env, ty) else {
         return vec![];
     };
-    direct_subtypes(db, target_class, modules)
+    direct_subtypes(db, env, target_class, modules)
         .into_iter()
         .map(|class_literal| class_literal_to_hierarchy_info(db, class_literal))
         .collect()
@@ -2806,6 +2845,7 @@ pub fn type_hierarchy_subtypes<'db>(
 /// For `Animal`, this returns `Dog`, but not `LoudDog`.
 fn direct_subtypes<'db>(
     db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
     target_class: ClassLiteral<'db>,
     modules: &[Module<'db>],
 ) -> Vec<ClassLiteral<'db>> {
@@ -2814,10 +2854,9 @@ fn direct_subtypes<'db>(
     let mut subtypes = vec![];
 
     for &module in modules {
-        let Some(python_file) = module.python_file(db) else {
+        let Some(file) = module.file(db) else {
             continue;
         };
-        let file = python_file.file(db);
 
         // Note that this will always consider namespace
         // packages to be "not firsty party." This isn't
@@ -2847,8 +2886,9 @@ fn direct_subtypes<'db>(
             continue;
         }
 
-        let file_env = ProgramEnvironment::from_file(python_file);
-        for class_ty in reachable_class_literals_in_file(db, python_file) {
+        let program_file = ProgramFile::new(db, file, env.program(db));
+        let file_env = ProgramEnvironment::from_file(program_file);
+        for class_ty in reachable_class_literals_in_file(db, program_file) {
             let bases = class_ty.explicit_bases(db);
             let is_subtype = if target_is_object
                 && bases.is_empty()
@@ -2872,11 +2912,11 @@ fn direct_subtypes<'db>(
 /// Enumerates the reachable class definitions in `file`.
 fn reachable_class_literals_in_file<'db>(
     db: &'db dyn Db,
-    file: PythonFile<'db>,
+    file: ProgramFile<'db>,
 ) -> Vec<ClassLiteral<'db>> {
     let env = ProgramEnvironment::from_file(file);
     let index = semantic_index(db, file);
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = parsed_module(db, file.python_file(db)).load(db);
     let mut classes = Vec::new();
 
     for scope_id in index.scope_ids() {
@@ -2945,7 +2985,7 @@ fn class_literal_to_hierarchy_info<'db>(
     class_literal: ClassLiteral<'db>,
 ) -> TypeHierarchyClass<'db> {
     let name = class_literal.name(db).clone();
-    let file = class_literal.python_file(db);
+    let file = class_literal.program_file(db).resolver_file(db);
 
     let (full_range, selection_range) = match class_literal {
         ClassLiteral::Static(static_class) => {
@@ -3076,9 +3116,9 @@ mod tests {
     use super::{CallArgumentForm, call_argument_forms, contains_identifier};
     use crate::SemanticModel;
     use crate::db::tests::TestDbBuilder;
-    use ruff_db::PythonFile;
     use ruff_db::files::system_path_to_file;
     use ruff_db::parsed::parsed_module;
+    use ty_python_core::ProgramFile;
 
     #[test]
     fn source_candidate_prefilters_use_identifier_boundaries() {
@@ -3105,8 +3145,8 @@ cast(val="", typ=int)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let file = PythonFile::new(&db, file, db.python_version());
-        let parsed = parsed_module(&db, file).load(&db);
+        let file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let parsed = parsed_module(&db, file.python_file(&db)).load(&db);
         let call = parsed
             .suite()
             .last()
@@ -3146,8 +3186,8 @@ f(y="", x=1)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let file = PythonFile::new(&db, file, db.python_version());
-        let parsed = parsed_module(&db, file).load(&db);
+        let file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let parsed = parsed_module(&db, file.python_file(&db)).load(&db);
         let call = parsed
             .suite()
             .last()
@@ -3183,8 +3223,8 @@ f(val="", typ=int)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let file = PythonFile::new(&db, file, db.python_version());
-        let parsed = parsed_module(&db, file).load(&db);
+        let file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let parsed = parsed_module(&db, file.python_file(&db)).load(&db);
         let call = parsed
             .suite()
             .last()
@@ -3221,8 +3261,8 @@ f("", int)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let file = PythonFile::new(&db, file, db.python_version());
-        let parsed = parsed_module(&db, file).load(&db);
+        let file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let parsed = parsed_module(&db, file.python_file(&db)).load(&db);
         let call = parsed
             .suite()
             .last()
@@ -3262,8 +3302,8 @@ f(int, x)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let file = PythonFile::new(&db, file, db.python_version());
-        let parsed = parsed_module(&db, file).load(&db);
+        let file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let parsed = parsed_module(&db, file.python_file(&db)).load(&db);
         let call = parsed
             .suite()
             .last()
@@ -3307,8 +3347,8 @@ TypeAliasType("Alias", int)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let file = PythonFile::new(&db, file, db.python_version());
-        let parsed = parsed_module(&db, file).load(&db);
+        let file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let parsed = parsed_module(&db, file.python_file(&db)).load(&db);
         let calls: Vec<_> = parsed
             .suite()
             .iter()
@@ -3353,8 +3393,8 @@ cast(*args)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let file = PythonFile::new(&db, file, db.python_version());
-        let parsed = parsed_module(&db, file).load(&db);
+        let file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let parsed = parsed_module(&db, file.python_file(&db)).load(&db);
         let call = parsed
             .suite()
             .last()

--- a/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
@@ -2,8 +2,8 @@ use crate::Db;
 use crate::reachability::is_reachable;
 use get_size2::GetSize;
 use itertools::Itertools;
-use ruff_db::PythonFile;
 use ruff_text_size::TextRange;
+use ty_python_core::ProgramFile;
 use ty_python_core::reachability_constraints::ScopedReachabilityConstraintId;
 use ty_python_core::semantic_index;
 
@@ -45,7 +45,7 @@ pub enum UnreachableKind {
 /// `ALWAYS_FALSE` constraints are classified as unconditional; all others are
 /// unreachable only under the current analysis.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-pub fn unreachable_ranges(db: &dyn Db, file: PythonFile<'_>) -> Box<[UnreachableRange]> {
+pub fn unreachable_ranges(db: &dyn Db, file: ProgramFile<'_>) -> Box<[UnreachableRange]> {
     let index = semantic_index(db, file);
     let mut unreachable = Vec::new();
     for scope_id in index.scope_ids() {
@@ -94,13 +94,13 @@ mod tests {
     use super::{UnreachableKind, unreachable_ranges};
     use crate::db::tests::{TestDb, TestDbBuilder};
     use insta::assert_snapshot;
-    use ruff_db::PythonFile;
     use ruff_db::diagnostic::{
         Annotation, Diagnostic, DiagnosticId, DisplayDiagnosticConfig, DisplayDiagnostics, Severity,
     };
     use ruff_db::files::{FileRange, system_path_to_file};
     use ruff_python_ast::PythonVersion;
     use ruff_python_trivia::textwrap::dedent;
+    use ty_python_core::ProgramFile;
     use ty_python_core::platform::PythonPlatform;
 
     const TEST_PATH: &str = "/src/main.py";
@@ -147,23 +147,26 @@ mod tests {
 
     fn render_unreachable_diagnostics(db: &TestDb, path: &str) -> String {
         let file = system_path_to_file(db, path).unwrap();
-        let diagnostics = unreachable_ranges(db, PythonFile::new(db, file, db.python_version()))
-            .iter()
-            .map(|range| {
-                let mut diagnostic = Diagnostic::new(
-                    DiagnosticId::lint("unreachable-code"),
-                    Severity::Info,
-                    match range.kind {
-                        UnreachableKind::Unconditional => "Code is always unreachable",
-                        UnreachableKind::CurrentAnalysis => "Code is unreachable",
-                    },
-                );
-                diagnostic.annotate(Annotation::primary(
-                    FileRange::new(file, range.range).into(),
-                ));
-                diagnostic
-            })
-            .collect::<Vec<_>>();
+        let diagnostics = unreachable_ranges(
+            db,
+            ProgramFile::new(db, file, db.program_environment().program(db)),
+        )
+        .iter()
+        .map(|range| {
+            let mut diagnostic = Diagnostic::new(
+                DiagnosticId::lint("unreachable-code"),
+                Severity::Info,
+                match range.kind {
+                    UnreachableKind::Unconditional => "Code is always unreachable",
+                    UnreachableKind::CurrentAnalysis => "Code is unreachable",
+                },
+            );
+            diagnostic.annotate(Annotation::primary(
+                FileRange::new(file, range.range).into(),
+            ));
+            diagnostic
+        })
+        .collect::<Vec<_>>();
 
         DisplayDiagnostics::new(
             db,

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -3,7 +3,6 @@ use crate::reachability::is_reachable;
 use crate::types::function::FunctionDecorators;
 use crate::types::infer::function_known_decorator_flags;
 use get_size2::GetSize;
-use ruff_db::PythonFile;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
@@ -11,7 +10,7 @@ use rustc_hash::FxHashSet;
 use ty_python_core::definition::{DefinitionCategory, DefinitionKind, DefinitionState};
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::{FileScopeId, ScopeKind};
-use ty_python_core::{SemanticIndex, semantic_index};
+use ty_python_core::{ProgramFile, SemanticIndex, semantic_index};
 
 /// Returns `true` for definition kinds that create user-facing bindings we consider for
 /// unused-binding diagnostics.
@@ -103,9 +102,9 @@ pub struct UnusedBinding {
 /// without broader reference analysis. Bare local annotations (`x: int`) are also
 /// reported, but only if the symbol is neither bound nor used elsewhere in the scope.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-pub fn unused_bindings(db: &dyn Db, file: PythonFile<'_>) -> Box<[UnusedBinding]> {
+pub fn unused_bindings(db: &dyn Db, file: ProgramFile<'_>) -> Box<[UnusedBinding]> {
     let source_file = file.file(db);
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = parsed_module(db, file.python_file(db)).load(db);
     let is_stub_file = source_file.is_stub(db);
     let index = semantic_index(db, file);
     let mut unused = Vec::new();
@@ -234,11 +233,11 @@ pub fn unused_bindings(db: &dyn Db, file: PythonFile<'_>) -> Box<[UnusedBinding]
 mod tests {
     use super::{UnusedBinding, unused_bindings};
     use crate::db::tests::TestDbBuilder;
-    use ruff_db::PythonFile;
     use ruff_db::files::system_path_to_file;
     use ruff_python_ast::name::Name;
     use ruff_python_trivia::textwrap::dedent;
     use ruff_text_size::{TextRange, TextSize};
+    use ty_python_core::ProgramFile;
 
     fn collect_unused_bindings_in_file(
         path: &str,
@@ -246,8 +245,8 @@ mod tests {
     ) -> anyhow::Result<Vec<UnusedBinding>> {
         let db = TestDbBuilder::new().with_file(path, source).build()?;
         let file = system_path_to_file(&db, path).unwrap();
-        let mut bindings =
-            unused_bindings(&db, PythonFile::new(&db, file, db.python_version())).to_vec();
+        let program = db.program_environment().program(&db);
+        let mut bindings = unused_bindings(&db, ProgramFile::new(&db, file, program)).to_vec();
         bindings.sort_unstable_by_key(|binding| (binding.range.start(), binding.range.end()));
         Ok(bindings)
     }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -135,7 +135,8 @@ pub(crate) fn infer_definition_types<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> DefinitionInference<'db> {
-    let python_file = definition.python_file(db);
+    let program_file = definition.program_file(db);
+    let python_file = program_file.python_file(db);
     let module = parsed_module(db, python_file).load(db);
     let _span = tracing::trace_span!(
         "infer_definition_types",
@@ -144,16 +145,16 @@ pub(crate) fn infer_definition_types<'db>(
     )
     .entered();
 
-    let index = semantic_index(db, python_file);
+    let index = semantic_index(db, program_file);
 
-    let env = ProgramEnvironment::from_file(python_file);
+    let env = ProgramEnvironment::from_file(program_file);
 
     TypeInferenceBuilder::new(
         db,
         &env,
         InferenceRegion::Definition(definition),
         python_file.file(db),
-        python_file,
+        program_file,
         index,
         &module,
     )
@@ -196,18 +197,19 @@ pub(crate) fn function_known_decorators<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> FunctionDecoratorInference<'db> {
-    let python_file = definition.python_file(db);
+    let program_file = definition.program_file(db);
+    let python_file = program_file.python_file(db);
     let module = parsed_module(db, python_file).load(db);
-    let index = semantic_index(db, python_file);
+    let index = semantic_index(db, program_file);
 
-    let env = ProgramEnvironment::from_file(python_file);
+    let env = ProgramEnvironment::from_file(program_file);
 
     TypeInferenceBuilder::new(
         db,
         &env,
         InferenceRegion::FunctionDecorators(definition),
         python_file.file(db),
-        python_file,
+        program_file,
         index,
         &module,
     )
@@ -284,7 +286,8 @@ pub(crate) fn infer_deferred_types<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> DefinitionInference<'db> {
-    let python_file = definition.python_file(db);
+    let program_file = definition.program_file(db);
+    let python_file = program_file.python_file(db);
     let module = parsed_module(db, python_file).load(db);
     let _span = tracing::trace_span!(
         "infer_deferred_types",
@@ -294,16 +297,16 @@ pub(crate) fn infer_deferred_types<'db>(
     )
     .entered();
 
-    let index = semantic_index(db, python_file);
+    let index = semantic_index(db, program_file);
 
-    let env = ProgramEnvironment::from_file(python_file);
+    let env = ProgramEnvironment::from_file(program_file);
 
     TypeInferenceBuilder::new(
         db,
         &env,
         InferenceRegion::Deferred(definition),
         python_file.file(db),
-        python_file,
+        program_file,
         index,
         &module,
     )
@@ -323,13 +326,13 @@ pub(crate) fn infer_complete_scope_types<'db>(
     // Scopes that may require type context are inferred during the inference of
     // their outer scope.
     if scope.accepts_type_context(db) {
-        let python_file = scope.python_file(db);
-        let index = semantic_index(db, python_file);
+        let program_file = scope.program_file(db);
+        let index = semantic_index(db, program_file);
 
         if let Some(parent_scope) = index.parent_scope_id(scope.file_scope_id(db)) {
             // Note that nested lambdas or comprehensions may require recursing until we reach
             // an outer scope that is independent of any type context.
-            return infer_complete_scope_types(db, parent_scope.to_scope_id(db, python_file));
+            return infer_complete_scope_types(db, parent_scope.to_scope_id(db, program_file));
         }
     }
 
@@ -367,7 +370,8 @@ pub(crate) fn infer_scope_types_impl<'db>(
     input: InferScope<'db>,
 ) -> ScopeInference<'db> {
     let (scope, tcx) = input.into_inner(db);
-    let python_file = scope.python_file(db);
+    let program_file = scope.program_file(db);
+    let python_file = program_file.python_file(db);
     let _span =
         tracing::trace_span!("infer_scope_types", scope=?scope.as_id(), ?python_file).entered();
 
@@ -375,16 +379,16 @@ pub(crate) fn infer_scope_types_impl<'db>(
 
     // Using the index here is fine because the code below depends on the AST anyway.
     // The isolation of the query is by the return inferred types.
-    let index = semantic_index(db, python_file);
+    let index = semantic_index(db, program_file);
 
-    let env = ProgramEnvironment::from_file(python_file);
+    let env = ProgramEnvironment::from_file(program_file);
 
     TypeInferenceBuilder::new(
         db,
         &env,
         InferenceRegion::Scope(scope, tcx),
         python_file.file(db),
-        python_file,
+        program_file,
         index,
         &module,
     )
@@ -419,7 +423,8 @@ pub(super) fn infer_expression_types_impl<'db>(
 ) -> ExpressionInference<'db> {
     let (expression, tcx) = input.into_inner(db);
 
-    let python_file = expression.python_file(db);
+    let program_file = expression.program_file(db);
+    let python_file = program_file.python_file(db);
     let module = parsed_module(db, python_file).load(db);
     let _span = tracing::trace_span!(
         "infer_expression_types",
@@ -429,16 +434,16 @@ pub(super) fn infer_expression_types_impl<'db>(
     )
     .entered();
 
-    let index = semantic_index(db, python_file);
+    let index = semantic_index(db, program_file);
 
-    let env = ProgramEnvironment::from_file(python_file);
+    let env = ProgramEnvironment::from_file(program_file);
 
     TypeInferenceBuilder::new(
         db,
         &env,
         InferenceRegion::Expression(expression, tcx),
         python_file.file(db),
-        python_file,
+        program_file,
         index,
         &module,
     )
@@ -530,7 +535,7 @@ pub(super) fn infer_statement_types<'db>(
         StatementInferenceInner::cycle_initial(statement.scope(db), Type::divergent(id))
     },
     cycle_fn=|db, cycle, previous: &StatementInferenceInner<'db>, inference: StatementInferenceInner<'db>, statement: StatementInner<'db>| {
-        let env = ProgramEnvironment::from_file(statement.python_file(db));
+        let env = ProgramEnvironment::from_file(statement.program_file(db));
         inference.cycle_normalized(db, &env, previous, cycle)
     },
     heap_size=ruff_memory_usage::heap_size
@@ -539,7 +544,8 @@ fn infer_statement_types_impl<'db>(
     db: &'db dyn Db,
     statement: StatementInner<'db>,
 ) -> StatementInferenceInner<'db> {
-    let python_file = statement.python_file(db);
+    let program_file = statement.program_file(db);
+    let python_file = program_file.python_file(db);
     let module = parsed_module(db, python_file).load(db);
     let _span = tracing::trace_span!(
         "infer_statement_types",
@@ -549,16 +555,16 @@ fn infer_statement_types_impl<'db>(
     )
     .entered();
 
-    let index = semantic_index(db, python_file);
+    let index = semantic_index(db, program_file);
 
-    let env = ProgramEnvironment::from_file(python_file);
+    let env = ProgramEnvironment::from_file(program_file);
 
     TypeInferenceBuilder::new(
         db,
         &env,
         InferenceRegion::Statement(statement),
         python_file.file(db),
-        python_file,
+        program_file,
         index,
         &module,
     )
@@ -723,13 +729,14 @@ impl<'db> From<Type<'db>> for TypeContext<'db> {
     returns(ref),
     cycle_initial=|_, id, _| UnpackResult::cycle_initial(Type::divergent(id)),
     cycle_fn=|db, cycle, previous: &UnpackResult<'db>, result: UnpackResult<'db>, unpack: Unpack<'db>| {
-        let env = ProgramEnvironment::from_file(unpack.python_file(db));
+        let env = ProgramEnvironment::from_file(unpack.program_file(db));
         result.cycle_normalized(db, &env, previous, cycle)
     },
     heap_size=ruff_memory_usage::heap_size
 )]
 pub(super) fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> UnpackResult<'db> {
-    let python_file = unpack.python_file(db);
+    let program_file = unpack.program_file(db);
+    let python_file = program_file.python_file(db);
     let module = parsed_module(db, python_file).load(db);
     let _span = tracing::trace_span!(
         "infer_unpack_types",
@@ -738,8 +745,8 @@ pub(super) fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> U
     )
     .entered();
 
-    let env = ProgramEnvironment::from_file(python_file);
-    let mut unpacker = Unpacker::new(db, &env, unpack.target_scope(db), python_file, &module);
+    let env = ProgramEnvironment::from_file(program_file);
+    let mut unpacker = Unpacker::new(db, &env, unpack.target_scope(db), program_file, &module);
     unpacker.unpack(unpack.target(db, &module), unpack.value(db));
     unpacker.finish()
 }
@@ -1369,7 +1376,8 @@ impl<'db> DefinitionInference<'db> {
         // Eagerly store more precise types for collection literals to avoid an extra
         // cycle iteration, i.e., by inferring `list[Divergent]` instead of `Divergent`.
         if let DefinitionKind::Assignment(assignment) = definition.kind(db) {
-            let python_file = definition.python_file(db);
+            let program_file = definition.program_file(db);
+            let python_file = program_file.python_file(db);
             let module = parsed_module(db, python_file).load(db);
             let known_collection = match assignment.value(&module) {
                 ast::Expr::Set(_) => Some(KnownClass::Set),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 
 use compact_str::CompactString;
 use itertools::Itertools;
-use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
@@ -20,7 +19,7 @@ use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use strum::IntoEnumIterator;
-use ty_module_resolver::{ModuleName, resolve_module};
+use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
 use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
@@ -138,8 +137,8 @@ use ty_python_core::predicate::PatternPredicate;
 use ty_python_core::scope::{FileScopeId, NodeWithScopeKind, NodeWithScopeRef, ScopeId, ScopeKind};
 use ty_python_core::symbol::{ScopedSymbolId, Symbol};
 use ty_python_core::{
-    ApplicableConstraints, EnclosingSnapshotResult, EvaluationMode, SemanticIndex, Truthiness,
-    unpack::UnpackPosition,
+    ApplicableConstraints, EnclosingSnapshotResult, EvaluationMode, ProgramFile, SemanticIndex,
+    Truthiness, unpack::UnpackPosition,
 };
 use ty_python_core::{ExpressionNodeKey, Statement};
 
@@ -465,13 +464,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         env: &'ast ProgramEnvironment<'db>,
         region: InferenceRegion<'db>,
         file: File,
-        python_file: PythonFile<'db>,
+        program_file: ProgramFile<'db>,
         index: &'db SemanticIndex<'db>,
         module: &'ast ParsedModuleRef,
     ) -> Self {
         let scope = region.scope(db);
         Self {
-            context: InferContext::new(db, env, scope, file, python_file, module),
+            context: InferContext::new(db, env, scope, file, program_file, module),
             index,
             region,
             scope,
@@ -776,8 +775,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.context.file()
     }
 
-    fn python_file(&self) -> PythonFile<'db> {
-        self.context.python_file()
+    fn program_file(&self) -> ProgramFile<'db> {
+        self.context.program_file()
     }
 
     #[inline]
@@ -985,7 +984,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// already in progress for that scope (further up the stack).
     fn file_expression_type(&self, expression: &ast::Expr) -> Type<'db> {
         let file_scope = self.index.expression_scope_id(expression);
-        let expr_scope = file_scope.to_scope_id(self.db(), self.python_file());
+        let expr_scope = file_scope.to_scope_id(self.db(), self.program_file());
         match self.region {
             InferenceRegion::Scope(scope, _) if scope == expr_scope => {
                 self.expression_type(expression)
@@ -997,7 +996,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Get metadata for a type expression from any scope in the same file.
     fn file_type_expression_flags(&self, expression: &ast::Expr) -> TypeExpressionFlags {
         let file_scope = self.index.expression_scope_id(expression);
-        let expr_scope = file_scope.to_scope_id(self.db(), self.python_file());
+        let expr_scope = file_scope.to_scope_id(self.db(), self.program_file());
         match self.region {
             InferenceRegion::Scope(scope, _) if scope == expr_scope => {
                 self.type_expression_flags(expression)
@@ -1641,7 +1640,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let PlaceExprRef::Symbol(symbol) = &place
                 && scope.is_global()
             {
-                module_type_implicit_global_symbol(db, self.python_file(), symbol.name())
+                module_type_implicit_global_symbol(db, self.program_file(), symbol.name())
             } else {
                 Place::Undefined.into()
             }
@@ -1702,7 +1701,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .map(|symbol| {
                             module_type_implicit_global_symbol(
                                 db,
-                                self.python_file(),
+                                self.program_file(),
                                 symbol.name(),
                             )
                         })
@@ -2079,7 +2078,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let rhs_scope = self
             .index
             .node_scope(NodeWithScopeRef::TypeAlias(type_alias))
-            .to_scope_id(self.db(), self.python_file());
+            .to_scope_id(self.db(), self.program_file());
 
         let type_alias_ty =
             Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
@@ -3413,7 +3412,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         if let Some(special_form) = target.as_name_expr().and_then(|name| {
-            SpecialFormType::try_from_file_and_name(self.db(), self.python_file(), &name.id)
+            let db = self.db();
+            let importing_file =
+                ImportingFile::File(self.file(), self.program_environment().program(db));
+            SpecialFormType::try_from_file_and_name(db, importing_file, &name.id)
         }) {
             target_ty = Type::SpecialForm(special_form);
         }
@@ -4457,7 +4459,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let Some(name_expr) = target.as_name_expr()
             && let Some(special_form) = SpecialFormType::try_from_file_and_name(
                 self.db(),
-                self.python_file(),
+                ImportingFile::File(self.file(), self.program_environment().program(self.db())),
                 &name_expr.id,
             )
         {
@@ -5063,7 +5065,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     continue;
                 }
             }
-            if !module_type_implicit_global_symbol(self.db(), self.python_file(), name)
+            if !module_type_implicit_global_symbol(self.db(), self.program_file(), name)
                 .place
                 .is_undefined()
             {
@@ -5088,8 +5090,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn module_type_from_name(&self, module_name: &ModuleName) -> Option<Type<'db>> {
-        resolve_module(self.db(), self.python_file(), module_name)
-            .map(|module| Type::module_literal(self.db(), self.python_file(), module))
+        let db = self.db();
+        let importing_file =
+            ImportingFile::File(self.file(), self.program_environment().program(db));
+        resolve_module(db, importing_file, module_name)
+            .map(|module| Type::module_literal(self.db(), self.program_file(), module))
     }
 
     fn infer_decorator(&mut self, decorator: &ast::Decorator) -> Type<'db> {
@@ -7714,7 +7719,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let evaluation_mode =
             EvaluationMode::from_is_async(scope_id.is_async_comprehension(self.index));
         let yield_tcx = self.generator_yield_type_context(tcx, evaluation_mode);
-        let scope = scope_id.to_scope_id(self.db(), self.python_file());
+        let scope = scope_id.to_scope_id(self.db(), self.program_file());
         let inference = infer_scope_types(self.db(), scope, yield_tcx);
         self.extend_scope(inference);
         let yield_type = self.comprehension_element_type(elt, inference);
@@ -7794,7 +7799,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         else {
             return Type::unknown();
         };
-        let scope = scope_id.to_scope_id(self.db(), self.python_file());
+        let scope = scope_id.to_scope_id(self.db(), self.program_file());
         let inference = infer_scope_types(self.db(), scope, tcx);
         self.extend_scope(inference);
 
@@ -7835,7 +7840,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         else {
             return Type::unknown();
         };
-        let scope = scope_id.to_scope_id(self.db(), self.python_file());
+        let scope = scope_id.to_scope_id(self.db(), self.program_file());
         let inference = infer_scope_types(self.db(), scope, tcx);
         self.extend_scope(inference);
 
@@ -7877,7 +7882,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         else {
             return Type::unknown();
         };
-        let scope = scope_id.to_scope_id(self.db(), self.python_file());
+        let scope = scope_id.to_scope_id(self.db(), self.program_file());
         let inference = infer_scope_types(self.db(), scope, tcx);
         self.extend_scope(inference);
 
@@ -8333,7 +8338,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
 
-        let scope = scope_id.to_scope_id(self.db(), self.python_file());
+        let scope = scope_id.to_scope_id(self.db(), self.program_file());
 
         // If we have a direct `Callable` type context, we can infer the body with the annotated
         // return type as type context.
@@ -8402,7 +8407,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Collect the types of each distinct key.
         let mut elements: Vec<(&str, Type<'db>)> = Vec::new();
-        for bindings in use_def.multi_bindings_at_use(keyword.scoped_use_id(db, self.python_file()))
+        for bindings in
+            use_def.multi_bindings_at_use(keyword.scoped_use_id(db, self.program_file()))
         {
             let place = place_from_bindings_with_reachability_cache(
                 db,
@@ -9621,7 +9627,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Check the "implicit globals" such as `__doc__`, `__file__`, `__name__`, etc.
             // These are looked up as attributes on `types.ModuleType`.
             .or_fall_back_to(db, env, || {
-                module_type_implicit_global_symbol(db, self.python_file(), symbol_name).map_type(
+                module_type_implicit_global_symbol(db, self.program_file(), symbol_name).map_type(
                     |ty| {
                         self.narrow_place_with_applicable_constraints(
                             PlaceExprRef::from(&expr),
@@ -9723,7 +9729,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return (place, None);
             }
 
-            let use_id = expr_ref.scoped_use_id(db, self.python_file());
+            let use_id = expr_ref.scoped_use_id(db, self.program_file());
             let place = place_from_bindings_with_reachability_cache(
                 db,
                 env,
@@ -9813,7 +9819,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Place::Undefined.into();
         };
 
-        explicit_global_symbol(self.db(), self.python_file(), symbol_name).map_type(|ty| {
+        explicit_global_symbol(self.db(), self.program_file(), symbol_name).map_type(|ty| {
             self.narrow_place_with_applicable_constraints(place_expr, ty, constraint_keys)
         })
     }
@@ -10067,7 +10073,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // We've reached the defining scope of the variable. Infer its public type.
                 debug_assert!(enclosing_place.is_bound() || enclosing_place.is_declared());
                 let enclosing_scope_id =
-                    enclosing_scope_file_id.to_scope_id(db, self.python_file());
+                    enclosing_scope_file_id.to_scope_id(db, self.program_file());
                 return eagerly_resolved_place.unwrap_or_else(|| {
                     place_by_id(
                         self.db(),
@@ -10359,8 +10365,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         {
                             let mut maybe_submodule_name = module_name.clone();
                             maybe_submodule_name.extend(&relative_submodule);
-                            if resolve_module(db, self.python_file(), &maybe_submodule_name)
-                                .is_some()
+                            if resolve_module(
+                                db,
+                                ImportingFile::File(
+                                    self.file(),
+                                    self.program_environment().program(db),
+                                ),
+                                &maybe_submodule_name,
+                            )
+                            .is_some()
                             {
                                 if let Some(builder) = self
                                     .context
@@ -10488,6 +10501,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     } else {
                         hint_if_stdlib_attribute_exists_on_other_versions(
                             db,
+                            env,
                             diagnostic,
                             value_type,
                             attr_name,
@@ -11542,7 +11556,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.program_environment(),
             region,
             self.file(),
-            self.python_file(),
+            self.program_file(),
             index,
             self.module(),
         );

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3413,8 +3413,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Some(special_form) = target.as_name_expr().and_then(|name| {
             let db = self.db();
-            let importing_file =
-                ImportingFile::File(self.file(), self.program_environment().program(db));
+            let importing_file = ImportingFile::File(
+                self.file(),
+                self.program_environment().resolver_environment(db),
+            );
             SpecialFormType::try_from_file_and_name(db, importing_file, &name.id)
         }) {
             target_ty = Type::SpecialForm(special_form);
@@ -4459,7 +4461,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let Some(name_expr) = target.as_name_expr()
             && let Some(special_form) = SpecialFormType::try_from_file_and_name(
                 self.db(),
-                ImportingFile::File(self.file(), self.program_environment().program(self.db())),
+                ImportingFile::File(
+                    self.file(),
+                    self.program_environment().resolver_environment(self.db()),
+                ),
                 &name_expr.id,
             )
         {
@@ -5091,8 +5096,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn module_type_from_name(&self, module_name: &ModuleName) -> Option<Type<'db>> {
         let db = self.db();
-        let importing_file =
-            ImportingFile::File(self.file(), self.program_environment().program(db));
+        let importing_file = ImportingFile::File(
+            self.file(),
+            self.program_environment().resolver_environment(db),
+        );
         resolve_module(db, importing_file, module_name)
             .map(|module| Type::module_literal(self.db(), self.program_file(), module))
     }
@@ -10369,7 +10376,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 db,
                                 ImportingFile::File(
                                     self.file(),
-                                    self.program_environment().program(db),
+                                    self.program_environment().resolver_environment(db),
                                 ),
                                 &maybe_submodule_name,
                             )

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -110,7 +110,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .to_scope_id(db, self.program_file());
 
         let file = self.program_file();
-        let importing_file = ImportingFile::File(file.file(db), env.program(db));
+        let importing_file = ImportingFile::File(file.file(db), env.resolver_environment(db));
         let maybe_known_class = KnownClass::try_from_file_and_name(db, importing_file, name);
 
         let known_module = || {

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -15,7 +15,7 @@ use crate::types::{
     special_form::TypeQualifier,
 };
 use ruff_python_ast::{self as ast, helpers::any_over_expr};
-use ty_module_resolver::{KnownModule, file_to_module};
+use ty_module_resolver::{ImportingFile, KnownModule, file_to_module};
 use ty_python_core::{definition::Definition, scope::NodeWithScopeRef};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
@@ -107,12 +107,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let body_scope = self
             .index
             .node_scope(NodeWithScopeRef::Class(class_node))
-            .to_scope_id(db, self.python_file());
+            .to_scope_id(db, self.program_file());
 
-        let maybe_known_class = KnownClass::try_from_file_and_name(db, self.python_file(), name);
+        let file = self.program_file();
+        let importing_file = ImportingFile::File(file.file(db), env.program(db));
+        let maybe_known_class = KnownClass::try_from_file_and_name(db, importing_file, name);
 
-        let known_module =
-            || file_to_module(db, self.python_file()).and_then(|module| module.known(db));
+        let known_module = || {
+            file_to_module(db, importing_file.resolver_file(db)).and_then(|module| module.known(db))
+        };
         let in_typing_module = || {
             matches!(
                 known_module(),

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -63,7 +63,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             let class_body_scope = class_literal.body_scope(db);
             let class_scope_id = class_body_scope.file_scope_id(db);
-            let class_index = semantic_index(db, class_body_scope.python_file(db));
+            let class_index = semantic_index(db, class_body_scope.program_file(db));
             let place_table = class_index.place_table(class_scope_id);
             let Some(symbol_id) = place_table.symbol_id(attribute) else {
                 continue;
@@ -257,7 +257,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         if let Some((class_literal, _)) = class_ty.static_class_literal(db) {
             let class_body_scope = class_literal.body_scope(db);
             let class_scope_id = class_body_scope.file_scope_id(db);
-            let class_index = semantic_index(db, class_body_scope.python_file(db));
+            let class_index = semantic_index(db, class_body_scope.program_file(db));
             let pt = class_index.place_table(class_scope_id);
 
             if let Some(symbol) = pt.symbol_by_name(attribute)

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -80,7 +80,7 @@ impl<'db> ExpectedReturnType<'db> {
             }
         }
 
-        let env = ProgramEnvironment::from_file(function.python_file(db));
+        let env = ProgramEnvironment::from_file(function.program_file(db));
         let public = normalize(
             db,
             &env,
@@ -417,7 +417,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let body_scope = self
             .index
             .node_scope(NodeWithScopeRef::Function(function))
-            .to_scope_id(db, self.python_file());
+            .to_scope_id(db, self.program_file());
 
         let overload_literal = OverloadLiteral::new(
             db,
@@ -601,7 +601,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let type_params_scope = self
                     .index
                     .node_scope(NodeWithScopeRef::FunctionTypeParameters(function))
-                    .to_scope_id(db, self.python_file());
+                    .to_scope_id(db, self.program_file());
                 let type_params_inference =
                     infer_scope_types(self.db(), type_params_scope, TypeContext::default());
 
@@ -1016,7 +1016,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> Option<Type<'db>> {
         let env = self.program_environment();
         let db = self.db();
-        let file = self.python_file();
+        let file = self.program_file();
 
         let function_scope_id = self.scope();
         let function_scope = function_scope_id.scope(db);

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -97,8 +97,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
         } else {
-            let importing_file =
-                ImportingFile::File(self.file(), self.program_environment().program(db));
+            let importing_file = ImportingFile::File(
+                self.file(),
+                self.program_environment().resolver_environment(db),
+            );
             if let Some(better_level) = (0..level).rev().find(|reduced_level| {
                 let Ok(module_name) =
                     ModuleName::from_identifier_parts(db, importing_file, module, *reduced_level)
@@ -126,7 +128,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let verbose = db.verbose();
         let search_paths = search_paths(
             db,
-            self.program_environment().program(db),
+            self.program_environment().resolver_environment(db),
             ModuleResolveMode::Typing,
         );
 
@@ -275,8 +277,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             format_import_from_module(*level, module),
             self.file().path(db),
         );
-        let importing_file =
-            ImportingFile::File(self.file(), self.program_environment().program(db));
+        let importing_file = ImportingFile::File(
+            self.file(),
+            self.program_environment().resolver_environment(db),
+        );
         let module_name = ModuleName::from_import_statement(db, importing_file, import_from);
 
         let module_name = match module_name {
@@ -319,8 +323,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) {
         let db = self.db();
 
-        let importing_file =
-            ImportingFile::File(self.file(), self.program_environment().program(db));
+        let importing_file = ImportingFile::File(
+            self.file(),
+            self.program_environment().resolver_environment(db),
+        );
         let Ok(module_name) = ModuleName::from_import_statement(db, importing_file, import_from)
         else {
             self.add_unknown_declaration_with_binding(alias.into(), definition);
@@ -545,8 +551,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         definition: Definition<'db>,
     ) {
         let db = self.db();
-        let importing_file =
-            ImportingFile::File(self.file(), self.program_environment().program(db));
+        let importing_file = ImportingFile::File(
+            self.file(),
+            self.program_environment().resolver_environment(db),
+        );
 
         // Get this package's absolute module name by resolving `.`, and make sure it exists
         let Ok(thispackage_name) = ModuleName::package_for_file(db, importing_file) else {

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -1,7 +1,8 @@
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange};
 use ty_module_resolver::{
-    ModuleName, ModuleNameResolutionError, ModuleResolveMode, resolve_module, search_paths,
+    ImportingFile, ModuleName, ModuleNameResolutionError, ModuleResolveMode, resolve_module,
+    search_paths,
 };
 
 use crate::{
@@ -69,8 +70,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if level == 0 {
             if let Some(module_name) = module_name {
-                let program = ty_python_core::program::Program::get(db);
-                let typeshed_versions = program.search_paths(db).typeshed_versions();
+                let resolver_environment = self.program_environment().program(db);
+                let typeshed_versions = resolver_environment.search_paths(db).typeshed_versions();
 
                 // Loop over ancestors in case we have info on the parent module but not submodule
                 for module_name in module_name.ancestors() {
@@ -96,16 +97,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
         } else {
+            let importing_file =
+                ImportingFile::File(self.file(), self.program_environment().program(db));
             if let Some(better_level) = (0..level).rev().find(|reduced_level| {
-                let Ok(module_name) = ModuleName::from_identifier_parts(
-                    db,
-                    self.python_file(),
-                    module,
-                    *reduced_level,
-                ) else {
+                let Ok(module_name) =
+                    ModuleName::from_identifier_parts(db, importing_file, module, *reduced_level)
+                else {
                     return false;
                 };
-                resolve_module(db, self.python_file(), &module_name).is_some()
+                resolve_module(db, importing_file, &module_name).is_some()
             }) {
                 diagnostic
                     .help("The module can be resolved if the number of leading dots is reduced");
@@ -124,7 +124,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Add search paths information to the diagnostic
         // Use the same search paths function that is used in actual module resolution
         let verbose = db.verbose();
-        let search_paths = search_paths(db, ModuleResolveMode::Typing);
+        let search_paths = search_paths(
+            db,
+            self.program_environment().program(db),
+            ModuleResolveMode::Typing,
+        );
 
         diagnostic.info(format_args!(
             "Searched in the following paths during module resolution:"
@@ -271,7 +275,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             format_import_from_module(*level, module),
             self.file().path(db),
         );
-        let module_name = ModuleName::from_import_statement(db, self.python_file(), import_from);
+        let importing_file =
+            ImportingFile::File(self.file(), self.program_environment().program(db));
+        let module_name = ModuleName::from_import_statement(db, importing_file, import_from);
 
         let module_name = match module_name {
             Ok(module_name) => module_name,
@@ -300,7 +306,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        if resolve_module(db, self.python_file(), &module_name).is_none() {
+        if resolve_module(db, importing_file, &module_name).is_none() {
             self.report_unresolved_import(module_ref.range(), *level, module, Some(&module_name));
         }
     }
@@ -313,8 +319,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) {
         let db = self.db();
 
-        let Ok(module_name) =
-            ModuleName::from_import_statement(db, self.python_file(), import_from)
+        let importing_file =
+            ImportingFile::File(self.file(), self.program_environment().program(db));
+        let Ok(module_name) = ModuleName::from_import_statement(db, importing_file, import_from)
         else {
             self.add_unknown_declaration_with_binding(alias.into(), definition);
             return;
@@ -334,7 +341,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         }
 
-        let Some(module) = resolve_module(db, self.python_file(), &module_name) else {
+        let Some(module) = resolve_module(db, importing_file, &module_name) else {
             self.add_unknown_declaration_with_binding(alias.into(), definition);
             return;
         };
@@ -342,7 +349,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let module_literal = ModuleLiteralType::new(
             db,
             module,
-            module.kind(db).is_package().then_some(self.python_file()),
+            module.kind(db).is_package().then_some(self.program_file()),
         );
         let module_ty = Type::ModuleLiteral(module_literal);
 
@@ -510,6 +517,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if !submodule_hint_added {
             hint_if_stdlib_attribute_exists_on_other_versions(
                 db,
+                self.program_environment(),
                 diagnostic,
                 module_ty,
                 name,
@@ -537,15 +545,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         definition: Definition<'db>,
     ) {
         let db = self.db();
+        let importing_file =
+            ImportingFile::File(self.file(), self.program_environment().program(db));
 
         // Get this package's absolute module name by resolving `.`, and make sure it exists
-        let Ok(thispackage_name) = ModuleName::package_for_file(db, self.python_file()) else {
+        let Ok(thispackage_name) = ModuleName::package_for_file(db, importing_file) else {
             self.add_binding(import_from.into(), definition)
                 .insert(self, Type::unknown());
             return;
         };
 
-        let Some(module) = resolve_module(db, self.python_file(), &thispackage_name) else {
+        let Some(module) = resolve_module(db, importing_file, &thispackage_name) else {
             self.add_binding(import_from.into(), definition)
                 .insert(self, Type::unknown());
             return;
@@ -557,7 +567,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // First we normalize to `whatever.thispackage.x.y`
         let Some(final_part) = ModuleName::from_identifier_parts(
             db,
-            self.python_file(),
+            importing_file,
             import_from.module.as_deref(),
             import_from.level,
         )

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1172,7 +1172,7 @@ fn check_class_namespace_against_metaclass_members<'db>(
         .filter_map(|class| class.static_class_literal(db).map(|(literal, _)| literal))
     {
         let body_scope = metaclass.body_scope(db);
-        let metaclass_index = semantic_index(db, body_scope.python_file(db));
+        let metaclass_index = semantic_index(db, body_scope.program_file(db));
         let body_scope_id = body_scope.file_scope_id(db);
         let metaclass_table = metaclass_index.place_table(body_scope_id);
         let metaclass_use_def = metaclass_index.use_def_map(body_scope_id);

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -235,10 +235,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // updating all of the subscript logic below to use custom callables for all of the _other_
                 // special cases, too.
                 if class.is_tuple(db) {
-                    return tuple_generic_alias(
-                        self.program_environment(),
-                        self.infer_tuple_type_expression(subscript),
-                    );
+                    return tuple_generic_alias(env, self.infer_tuple_type_expression(subscript));
                 } else if class.is_known(db, KnownClass::Type) {
                     let argument_ty = self.infer_type_expression(slice);
                     return Type::KnownInstance(KnownInstanceType::TypeGenericAlias(
@@ -269,10 +266,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             Type::SpecialForm(special_form) => match special_form {
                 SpecialFormType::Tuple => {
-                    return tuple_generic_alias(
-                        self.program_environment(),
-                        self.infer_tuple_type_expression(subscript),
-                    );
+                    return tuple_generic_alias(env, self.infer_tuple_type_expression(subscript));
                 }
                 SpecialFormType::Literal => match self.infer_literal_parameter_type(slice) {
                     Ok(result) => {

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -235,7 +235,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // updating all of the subscript logic below to use custom callables for all of the _other_
                 // special cases, too.
                 if class.is_tuple(db) {
-                    return tuple_generic_alias(env, self.infer_tuple_type_expression(subscript));
+                    return tuple_generic_alias(
+                        self.program_environment(),
+                        self.infer_tuple_type_expression(subscript),
+                    );
                 } else if class.is_known(db, KnownClass::Type) {
                     let argument_ty = self.infer_type_expression(slice);
                     return Type::KnownInstance(KnownInstanceType::TypeGenericAlias(
@@ -266,7 +269,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             Type::SpecialForm(special_form) => match special_form {
                 SpecialFormType::Tuple => {
-                    return tuple_generic_alias(env, self.infer_tuple_type_expression(subscript));
+                    return tuple_generic_alias(
+                        self.program_environment(),
+                        self.infer_tuple_type_expression(subscript),
+                    );
                 }
                 SpecialFormType::Literal => match self.infer_literal_parameter_type(slice) {
                     Ok(result) => {
@@ -2054,7 +2060,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     instance.class(db, env).static_class_literal(db)
                                 })
                                 .and_then(|(class_literal, _)| {
-                                    file_to_module(db, class_literal.python_file(db))
+                                    let file = class_literal.program_file(db);
+                                    file_to_module(db, file.resolver_file(db))
                                 })
                                 .and_then(|module| module.search_path(db))
                                 .is_some_and(ty_module_resolver::SearchPath::is_first_party)

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -3,24 +3,25 @@ use crate::db::tests::{TestDb, TestDbBuilder, setup_db};
 use crate::place::symbol;
 use crate::place::{ConsideredDefinitions, Place, PlaceAndQualifiers};
 use crate::types::{KnownClass, KnownInstanceType, check_types};
-use ruff_db::PythonFile;
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::DbWithWritableSystem as _;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
 use ruff_python_ast::PythonVersion;
+use ty_module_resolver::ResolverEnvironment;
 use ty_python_core::definition::Definition;
+use ty_python_core::program::Program as ProjectProgram;
 use ty_python_core::scope::FileScopeId;
-use ty_python_core::{global_scope, place_table, semantic_index, use_def_map};
+use ty_python_core::{ProgramFile, global_scope, place_table, semantic_index, use_def_map};
 
 use super::*;
 
-fn python_file(db: &TestDb, file: File) -> PythonFile<'_> {
-    PythonFile::new(db, file, db.python_version())
+fn program_file(db: &TestDb, file: File) -> ProgramFile<'_> {
+    ProgramFile::new(db, file, db.program_environment().program(db))
 }
 
 fn global_symbol<'db>(db: &'db TestDb, file: File, name: &str) -> PlaceAndQualifiers<'db> {
-    crate::place::global_symbol(db, python_file(db, file), name)
+    crate::place::global_symbol(db, program_file(db, file), name)
 }
 
 #[track_caller]
@@ -31,8 +32,8 @@ fn get_symbol<'db>(
     symbol_name: &str,
 ) -> Place<'db> {
     let file = system_path_to_file(db, file_name).expect("file to exist");
-    let file = python_file(db, file);
-    let module = parsed_module(db, file).load(db);
+    let file = program_file(db, file);
+    let module = parsed_module(db, file.python_file(db)).load(db);
     let index = semantic_index(db, file);
     let mut file_scope_id = FileScopeId::global();
     let mut scope = file_scope_id.to_scope_id(db, file);
@@ -61,7 +62,7 @@ fn assert_diagnostic_messages(diagnostics: &[Diagnostic], expected: &[&str]) {
 #[track_caller]
 fn assert_file_diagnostics(db: &TestDb, filename: &str, expected: &[&str]) {
     let file = system_path_to_file(db, filename).unwrap();
-    let diagnostics = check_types(db, python_file(db, file));
+    let diagnostics = check_types(db, program_file(db, file));
 
     assert_diagnostic_messages(&diagnostics, expected);
 }
@@ -69,7 +70,7 @@ fn assert_file_diagnostics(db: &TestDb, filename: &str, expected: &[&str]) {
 #[track_caller]
 fn assert_revealed_type(db: &TestDb, filename: &str, expected: &str) {
     let file = system_path_to_file(db, filename).unwrap();
-    let diagnostics = check_types(db, python_file(db, file));
+    let diagnostics = check_types(db, program_file(db, file));
     assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
 
     let diagnostic = &diagnostics[0];
@@ -110,8 +111,17 @@ fn same_file_at_different_python_versions() -> anyhow::Result<()> {
     db.write_dedented("src/py312_dependency.py", "value: int = 312")?;
 
     let file = system_path_to_file(&db, "src/main.py").expect("file to exist");
-    let py311 = PythonFile::new(&db, file, PythonVersion::PY311);
-    let py312 = PythonFile::new(&db, file, PythonVersion::PY312);
+    let search_paths = ProjectProgram::get(&db).search_paths(&db);
+    let py311 = ProgramFile::new(
+        &db,
+        file,
+        ResolverEnvironment::new(&db, PythonVersion::PY311, search_paths),
+    );
+    let py312 = ProgramFile::new(
+        &db,
+        file,
+        ResolverEnvironment::new(&db, PythonVersion::PY312, search_paths),
+    );
 
     let check = |file, expected_type, expect_invalid_syntax, expect_unresolved_import| {
         let diagnostics = crate::check_file_unwrap(&db, file);
@@ -169,7 +179,7 @@ fn expected_types_are_collected_only_for_open_files() -> anyhow::Result<()> {
             db.open_file(file);
         }
 
-        let module = parsed_module(&db, python_file(&db, file)).load(&db);
+        let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
         let assignment = module.syntax().body[1]
             .as_ann_assign_stmt()
             .expect("annotated assignment");
@@ -179,7 +189,7 @@ fn expected_types_are_collected_only_for_open_files() -> anyhow::Result<()> {
             .expect("annotated assignment to have a value")
             .as_string_literal_expr()
             .expect("string literal value");
-        let scope = global_scope(&db, python_file(&db, file));
+        let scope = global_scope(&db, program_file(&db, file));
 
         Ok(infer_complete_scope_types(&db, scope)
             .try_expected_type(ruff_python_ast::ExprRef::from(string_expr))
@@ -209,12 +219,12 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
     )?;
 
     let file = system_path_to_file(&db, "/src/definitions.py").unwrap();
-    let module = parsed_module(&db, python_file(&db, file)).load(&db);
+    let module = parsed_module(&db, program_file(&db, file).python_file(&db)).load(&db);
     let first_assignment = module.syntax().body[0].as_assign_stmt().unwrap();
     let second_assignment = module.syntax().body[1].as_assign_stmt().unwrap();
-    let first = semantic_index(&db, python_file(&db, file))
+    let first = semantic_index(&db, program_file(&db, file))
         .expect_single_definition(first_assignment.targets[0].as_name_expr().unwrap());
-    let second = semantic_index(&db, python_file(&db, file))
+    let second = semantic_index(&db, program_file(&db, file))
         .expect_single_definition(second_assignment.targets[0].as_name_expr().unwrap());
 
     let owner_type = Type::unknown();
@@ -666,7 +676,7 @@ class Form(Ui):
 // Incremental inference tests
 #[track_caller]
 fn first_public_binding<'db>(db: &'db TestDb, file: File, name: &str) -> Definition<'db> {
-    let scope = global_scope(db, python_file(db, file));
+    let scope = global_scope(db, program_file(db, file));
     use_def_map(db, scope)
         .end_of_scope_symbol_bindings(place_table(db, scope).symbol_id(name).unwrap())
         .find_map(|b| b.binding.definition())
@@ -792,12 +802,12 @@ fn dependency_unrelated_symbol() -> anyhow::Result<()> {
 fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
     fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
         let file_main = system_path_to_file(db, "/src/main.py").unwrap();
-        let ast = parsed_module(db, python_file(db, file_main)).load(db);
+        let ast = parsed_module(db, program_file(db, file_main).python_file(db)).load(db);
         // Get the second statement in `main.py` (x = …) and extract the expression
         // node on the right-hand side:
         let x_rhs_node = &ast.syntax().body[1].as_assign_stmt().unwrap().value;
 
-        let index = semantic_index(db, python_file(db, file_main));
+        let index = semantic_index(db, program_file(db, file_main));
         index.expression(x_rhs_node.as_ref())
     }
 
@@ -890,12 +900,12 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
 fn dependency_own_instance_member() -> anyhow::Result<()> {
     fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
         let file_main = system_path_to_file(db, "/src/main.py").unwrap();
-        let ast = parsed_module(db, python_file(db, file_main)).load(db);
+        let ast = parsed_module(db, program_file(db, file_main).python_file(db)).load(db);
         // Get the second statement in `main.py` (x = …) and extract the expression
         // node on the right-hand side:
         let x_rhs_node = &ast.syntax().body[1].as_assign_stmt().unwrap().value;
 
-        let index = semantic_index(db, python_file(db, file_main));
+        let index = semantic_index(db, program_file(db, file_main));
         index.expression(x_rhs_node.as_ref())
     }
 
@@ -992,12 +1002,12 @@ fn dependency_own_instance_member() -> anyhow::Result<()> {
 fn dependency_implicit_class_member() -> anyhow::Result<()> {
     fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
         let file_main = system_path_to_file(db, "/src/main.py").unwrap();
-        let ast = parsed_module(db, python_file(db, file_main)).load(db);
+        let ast = parsed_module(db, program_file(db, file_main).python_file(db)).load(db);
         // Get the third statement in `main.py` (x = …) and extract the expression
         // node on the right-hand side:
         let x_rhs_node = &ast.syntax().body[2].as_assign_stmt().unwrap().value;
 
-        let index = semantic_index(db, python_file(db, file_main));
+        let index = semantic_index(db, program_file(db, file_main));
         index.expression(x_rhs_node.as_ref())
     }
 
@@ -1129,9 +1139,9 @@ fn call_type_doesnt_rerun_when_only_callee_changed() -> anyhow::Result<()> {
     );
     let events = db.take_salsa_events();
 
-    let module = parsed_module(&db, python_file(&db, bar)).load(&db);
+    let module = parsed_module(&db, program_file(&db, bar).python_file(&db)).load(&db);
     let call = &*module.syntax().body[1].as_assign_stmt().unwrap().value;
-    let foo_call = semantic_index(&db, python_file(&db, bar)).expression(call);
+    let foo_call = semantic_index(&db, program_file(&db, bar)).expression(call);
 
     assert_function_query_was_run(
         &db,
@@ -1160,9 +1170,9 @@ fn call_type_doesnt_rerun_when_only_callee_changed() -> anyhow::Result<()> {
     );
     let events = db.take_salsa_events();
 
-    let module = parsed_module(&db, python_file(&db, bar)).load(&db);
+    let module = parsed_module(&db, program_file(&db, bar).python_file(&db)).load(&db);
     let call = &*module.syntax().body[1].as_assign_stmt().unwrap().value;
-    let foo_call = semantic_index(&db, python_file(&db, bar)).expression(call);
+    let foo_call = semantic_index(&db, program_file(&db, bar)).expression(call);
 
     assert_function_query_was_not_run(
         &db,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -263,7 +263,7 @@ impl<'db> NominalInstanceType<'db> {
         env: &ProgramEnvironment<'db>,
     ) -> Option<&'db ModuleName> {
         let class = self.class(db, env).class_literal(db);
-        file_to_module(db, class.python_file(db)).map(|module| module.name(db))
+        file_to_module(db, class.program_file(db).resolver_file(db)).map(|module| module.name(db))
     }
 
     pub(super) fn class(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> ClassType<'db> {
@@ -845,7 +845,7 @@ fn non_recursive_protocol_interface<'db>(
         }
     }
 
-    let env = ProgramEnvironment::from_file(protocol.class_literal(db).python_file(db));
+    let env = ProgramEnvironment::from_file(protocol.class_literal(db).program_file(db));
     interface.filter_members(db, |member| {
         let visitor = ProtocolReferenceFinder {
             env: &env,

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -23,8 +23,8 @@ use crate::{
     },
 };
 use ty_python_core::{
-    attribute_scopes, definition::Definition, global_scope, place_table, scope::ScopeId,
-    semantic_index, use_def_map,
+    ProgramFile, attribute_scopes, definition::Definition, global_scope, place_table,
+    scope::ScopeId, semantic_index, use_def_map,
 };
 
 /// Iterate over all declarations and bindings that exist at the end
@@ -423,18 +423,19 @@ impl<'db> AllMembers<'db> {
 
                 self.extend_with_type(db, env, KnownClass::ModuleType.to_instance(db, env));
 
-                let Some(python_file) = module.python_file(db) else {
+                let Some(file) = module.file(db) else {
                     return;
                 };
+                let program_file = ProgramFile::new(db, file, env.program(db));
 
-                let module_scope = global_scope(db, python_file);
+                let module_scope = global_scope(db, program_file);
                 let use_def_map = use_def_map(db, module_scope);
                 let place_table = place_table(db, module_scope);
 
                 for (symbol_id, _) in use_def_map.all_end_of_scope_symbol_declarations() {
                     let symbol_name = place_table.symbol(symbol_id).name();
                     let Place::Defined(defined) =
-                        imported_symbol(db, env, Some(python_file), symbol_name, None).place
+                        imported_symbol(db, env, Some(program_file), symbol_name, None).place
                     else {
                         continue;
                     };
@@ -443,7 +444,7 @@ impl<'db> AllMembers<'db> {
                         && !exists_at_runtime(db, definition)
                         // Source-module completions retain `@type_check_only` symbols and rank them
                         // lower.
-                        && (python_file.file(db).is_stub(db) || !defined.ty.is_type_check_only(db))
+                        && (file.is_stub(db) || !defined.ty.is_type_check_only(db))
                         // The decorator itself is typing-only, but users must still be able to
                         // import it when defining typing-only classes and functions.
                         && !matches!(
@@ -550,8 +551,8 @@ impl<'db> AllMembers<'db> {
         class_literal: StaticClassLiteral<'db>,
     ) {
         let class_body_scope = class_literal.body_scope(db);
-        let python_file = class_body_scope.python_file(db);
-        let index = semantic_index(db, python_file);
+        let program_file = class_body_scope.program_file(db);
+        let index = semantic_index(db, program_file);
         for function_scope_id in attribute_scopes(db, class_body_scope) {
             for place_expr in index.place_table(function_scope_id).members() {
                 let Some(name) = place_expr.as_instance_attribute() else {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -119,8 +119,9 @@ fn all_narrowing_constraints_for_pattern<'db>(
     db: &'db dyn Db,
     pattern: PatternPredicate<'db>,
 ) -> Option<FrozenNarrowingConstraints<'db>> {
-    let python_file = pattern.python_file(db);
-    let env = ProgramEnvironment::from_file(python_file);
+    let program_file = pattern.program_file(db);
+    let python_file = program_file.python_file(db);
+    let env = ProgramEnvironment::from_file(program_file);
     let module = parsed_module(db, python_file).load(db);
     NarrowingConstraintsBuilder::new(db, &env, &module, PredicateNode::Pattern(pattern), true)
         .finish()
@@ -135,8 +136,9 @@ fn all_narrowing_constraints_for_expression<'db>(
     db: &'db dyn Db,
     expression: Expression<'db>,
 ) -> ExpressionNarrowingConstraints<'db> {
-    let python_file = expression.python_file(db);
-    let env = ProgramEnvironment::from_file(python_file);
+    let program_file = expression.program_file(db);
+    let python_file = program_file.python_file(db);
+    let env = ProgramEnvironment::from_file(program_file);
     let module = parsed_module(db, python_file).load(db);
     let predicate = PredicateNode::Expression(expression);
     ExpressionNarrowingConstraints {
@@ -150,8 +152,9 @@ fn all_negative_narrowing_constraints_for_pattern<'db>(
     db: &'db dyn Db,
     pattern: PatternPredicate<'db>,
 ) -> Option<FrozenNarrowingConstraints<'db>> {
-    let python_file = pattern.python_file(db);
-    let env = ProgramEnvironment::from_file(python_file);
+    let program_file = pattern.program_file(db);
+    let python_file = program_file.python_file(db);
+    let env = ProgramEnvironment::from_file(program_file);
     let module = parsed_module(db, python_file).load(db);
     NarrowingConstraintsBuilder::new(db, &env, &module, PredicateNode::Pattern(pattern), false)
         .finish()
@@ -163,8 +166,9 @@ fn all_narrowing_constraints_for_subject_element_pattern<'db>(
     pattern: PatternPredicate<'db>,
     target: ExpressionNodeKey,
 ) -> Option<FrozenNarrowingConstraints<'db>> {
-    let python_file = pattern.python_file(db);
-    let env = ProgramEnvironment::from_file(python_file);
+    let program_file = pattern.program_file(db);
+    let python_file = program_file.python_file(db);
+    let env = ProgramEnvironment::from_file(program_file);
     let module = parsed_module(db, python_file).load(db);
     NarrowingConstraintsBuilder::new(
         db,
@@ -1164,7 +1168,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         let db = self.db;
         match expression_node {
             ast::Expr::Name(_) => {
-                let index = semantic_index(db, expression.python_file(db));
+                let index = semantic_index(db, expression.program_file(db));
                 let constraints = self.evaluate_simple_expr(expression_node, is_positive);
                 if let Some(alias_predicate) = index.narrowing_alias_predicate(expression_node) {
                     let aliased_constraints =

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -66,8 +66,9 @@ impl<'db> NewType<'db> {
         // in assignments, but invalid definitions still get here, and also `NewType` might show up
         // in places that aren't definitions at all. Fall back to `object` in all error cases.
         let definition = self.definition(db);
-        let python_file = definition.python_file(db);
-        let env = ProgramEnvironment::from_file(python_file);
+        let program_file = definition.program_file(db);
+        let python_file = program_file.python_file(db);
+        let env = ProgramEnvironment::from_file(program_file);
         let object_fallback = NewTypeBase::ClassType(ClassType::object(db, &env));
         let module = parsed_module(db, python_file).load(db);
         let DefinitionKind::Assignment(assignment) = definition.kind(db) else {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -1126,7 +1126,7 @@ fn effective_superclass_variable_kind<'db>(
     superclass: ClassType<'db>,
     name: Name,
 ) -> Option<VariableKind> {
-    let env = &ProgramEnvironment::from_file(superclass.class_literal(db).python_file(db));
+    let env = &ProgramEnvironment::from_file(superclass.class_literal(db).program_file(db));
     let inherited_variable_kind = || {
         superclass
             .iter_mro(db)

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -1,5 +1,4 @@
 use crate::Db;
-use crate::ProgramEnvironment;
 use crate::place::{DefinedPlace, Place, builtins_symbol, global_symbol, known_module_symbol};
 use crate::types::enums::is_single_member_enum;
 use crate::types::known_instance::KnownInstanceType;
@@ -9,13 +8,13 @@ use crate::types::{
     IntersectionType, KnownClass, MaterializationKind, Parameter, Parameters, Signature,
     SpecialFormType, SubclassOfType, Type, UnionType,
 };
+use crate::{Program, ProgramEnvironment};
 use quickcheck::{Arbitrary, Gen};
-use ruff_db::PythonFile;
 use ruff_db::files::system_path_to_file;
-use ruff_python_ast::PythonVersion;
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
 use ty_module_resolver::KnownModule;
+use ty_python_core::ProgramFile;
 
 /// A test representation of a type that can be transformed unambiguously into a real Type,
 /// given a db.
@@ -142,11 +141,11 @@ enum ParamKind {
 #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
 fn create_bound_method<'db>(
     db: &'db dyn Db,
-    python_version: PythonVersion,
+    program: Program<'db>,
     function: Type<'db>,
     builtins_class: Type<'db>,
 ) -> Type<'db> {
-    let env = ProgramEnvironment::from_program(python_version);
+    let env = ProgramEnvironment::from_program(program);
     Type::BoundMethod(BoundMethodType::new(
         db,
         function.expect_function_literal(),
@@ -265,7 +264,7 @@ impl Ty {
                 let builtins_class = builtins_symbol(db, env, class).place.expect_type();
                 let function = builtins_class.member(db, env, method).place.expect_type();
 
-                create_bound_method(db, env.python_version(db), function, builtins_class)
+                create_bound_method(db, env.program(db), function, builtins_class)
             }
             Ty::Callable { params, returns } => Type::single_callable(
                 db,
@@ -301,7 +300,7 @@ fn divergent<'db>(
 fn newtype_instance<'db>(db: &'db dyn Db, env: &ProgramEnvironment<'db>, name: &str) -> Type<'db> {
     let file = system_path_to_file(db, super::setup::PROPERTY_TEST_MODULE_PATH)
         .expect("Property-test module must exist");
-    let file = PythonFile::new(db, file, env.python_version(db));
+    let file = ProgramFile::new(db, file, env.program(db));
     let Place::Defined(DefinedPlace { ty, .. }) = global_symbol(db, file, name).place else {
         panic!(
             "Expected a global symbol for `{name}` in the property test module, but it was not found"

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -138,32 +138,19 @@ enum ParamKind {
     KeywordVariadic,
 }
 
+#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
 fn create_bound_method<'db>(
     db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
+    program: Program<'db>,
     function: Type<'db>,
     builtins_class: Type<'db>,
 ) -> Type<'db> {
-    #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
-    fn create_bound_method_inner<'db>(
-        db: &'db dyn Db,
-        program: Program<'db>,
-        function: Type<'db>,
-        builtins_class: Type<'db>,
-    ) -> Type<'db> {
-        let env = ProgramEnvironment::from_program(program);
-        Type::BoundMethod(BoundMethodType::new(
-            db,
-            function.expect_function_literal(),
-            builtins_class.to_instance_approximation(db, &env).unwrap(),
-        ))
-    }
-
-    debug_assert_eq!(
-        env.program(db),
-        function.expect_function_literal().program(db)
-    );
-    create_bound_method_inner(db, env.program(db), function, builtins_class)
+    let env = ProgramEnvironment::from_program(program);
+    Type::BoundMethod(BoundMethodType::new(
+        db,
+        function.expect_function_literal(),
+        builtins_class.to_instance_approximation(db, &env).unwrap(),
+    ))
 }
 
 impl Ty {
@@ -277,7 +264,7 @@ impl Ty {
                 let builtins_class = builtins_symbol(db, env, class).place.expect_type();
                 let function = builtins_class.member(db, env, method).place.expect_type();
 
-                create_bound_method(db, env, function, builtins_class)
+                create_bound_method(db, env.program(db), function, builtins_class)
             }
             Ty::Callable { params, returns } => Type::single_callable(
                 db,

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -138,19 +138,32 @@ enum ParamKind {
     KeywordVariadic,
 }
 
-#[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
 fn create_bound_method<'db>(
     db: &'db dyn Db,
-    program: Program<'db>,
+    env: &ProgramEnvironment<'db>,
     function: Type<'db>,
     builtins_class: Type<'db>,
 ) -> Type<'db> {
-    let env = ProgramEnvironment::from_program(program);
-    Type::BoundMethod(BoundMethodType::new(
-        db,
-        function.expect_function_literal(),
-        builtins_class.to_instance_approximation(db, &env).unwrap(),
-    ))
+    #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+    fn create_bound_method_inner<'db>(
+        db: &'db dyn Db,
+        program: Program<'db>,
+        function: Type<'db>,
+        builtins_class: Type<'db>,
+    ) -> Type<'db> {
+        let env = ProgramEnvironment::from_program(program);
+        Type::BoundMethod(BoundMethodType::new(
+            db,
+            function.expect_function_literal(),
+            builtins_class.to_instance_approximation(db, &env).unwrap(),
+        ))
+    }
+
+    debug_assert_eq!(
+        env.program(db),
+        function.expect_function_literal().program(db)
+    );
+    create_bound_method_inner(db, env.program(db), function, builtins_class)
 }
 
 impl Ty {
@@ -264,7 +277,7 @@ impl Ty {
                 let builtins_class = builtins_symbol(db, env, class).place.expect_type();
                 let function = builtins_class.member(db, env, method).place.expect_type();
 
-                create_bound_method(db, env.program(db), function, builtins_class)
+                create_bound_method(db, env, function, builtins_class)
             }
             Ty::Callable { params, returns } => Type::single_callable(
                 db,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -330,7 +330,7 @@ impl<'db> From<ProtocolClass<'db>> for Type<'db> {
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub(super) struct ProtocolInterface<'db> {
     #[returns(copy)]
-    pub(super) program: Program,
+    pub(super) program: Program<'db>,
 
     #[returns(ref)]
     inner: BTreeMap<Name, ProtocolMemberData<'db>>,
@@ -3493,7 +3493,7 @@ fn cached_protocol_interface<'db>(
     db: &'db dyn Db,
     class: ClassType<'db>,
 ) -> ProtocolInterface<'db> {
-    let env = ProgramEnvironment::from_file(class.class_literal(db).python_file(db));
+    let env = ProgramEnvironment::from_file(class.class_literal(db).program_file(db));
     let mut members = BTreeMap::default();
 
     ProtocolClass(class).for_each_member_candidate(db, &env, |name, candidate, specialization| {
@@ -3555,7 +3555,7 @@ fn protocol_interface_cycle_initial<'db>(
 ) -> ProtocolInterface<'db> {
     ProtocolInterface::empty(
         db,
-        &ProgramEnvironment::from_file(class.class_literal(db).python_file(db)),
+        &ProgramEnvironment::from_file(class.class_literal(db).program_file(db)),
     )
 }
 
@@ -3567,7 +3567,7 @@ fn proto_interface_cycle_recover<'db>(
     value: ProtocolInterface<'db>,
     class: ClassType<'db>,
 ) -> ProtocolInterface<'db> {
-    let env = ProgramEnvironment::from_file(class.class_literal(db).python_file(db));
+    let env = ProgramEnvironment::from_file(class.class_literal(db).program_file(db));
     value.cycle_normalized(db, &env, *previous, cycle)
 }
 
@@ -3580,7 +3580,7 @@ fn proto_interface_cycle_recover<'db>(
 #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
 fn protocol_bind_self<'db>(
     db: &'db dyn Db,
-    program: Program,
+    program: Program<'db>,
     callable: CallableType<'db>,
     self_type: Option<Type<'db>>,
 ) -> CallableType<'db> {
@@ -3596,7 +3596,7 @@ fn protocol_bind_self<'db>(
 )]
 fn protocol_apply_self_with_receiver<'db>(
     db: &'db dyn Db,
-    program: Program,
+    program: Program<'db>,
     callable: CallableType<'db>,
     receiver_type: Type<'db>,
     self_type: Type<'db>,

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -2005,9 +2005,9 @@ mod tests {
     use crate::types::type_alias::TypeAliasType;
     use crate::types::{KnownClass, KnownInstanceType, Truthiness};
 
-    use ruff_db::PythonFile;
     use ruff_db::system::DbWithWritableSystem as _;
     use ty_module_resolver::KnownModule;
+    use ty_python_core::ProgramFile;
 
     #[test]
     fn build_union_no_elements() {
@@ -2203,7 +2203,7 @@ mod tests {
         let env = db.program_environment();
 
         let module = ruff_db::files::system_path_to_file(&db, "/src/a.py").unwrap();
-        let module = PythonFile::new(&db, module, db.python_version());
+        let module = ProgramFile::new(&db, module, db.program_environment().program(&db));
         let alias_ty = global_symbol(&db, module, "Alias").place.expect_type();
         let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias))) =
             alias_ty

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -74,7 +74,7 @@ fn function_signature_expression_type<'db>(
     definition: Definition<'db>,
     expression: &ast::Expr,
 ) -> Type<'db> {
-    let file = definition.python_file(db);
+    let file = definition.program_file(db);
     let index = semantic_index(db, file);
     let file_scope = index.expression_scope_id(expression);
     let scope = file_scope.to_scope_id(db, file);
@@ -92,7 +92,7 @@ fn function_signature_type_expression_flags<'db>(
     definition: Definition<'db>,
     expression: &ast::Expr,
 ) -> TypeExpressionFlags {
-    let file = definition.python_file(db);
+    let file = definition.program_file(db);
     let index = semantic_index(db, file);
     let file_scope = index.expression_scope_id(expression);
     let scope = file_scope.to_scope_id(db, file);
@@ -5337,7 +5337,7 @@ impl<'db> Parameter<'db> {
         parameter: &ast::Parameter,
         kind: ParameterKind<'db>,
     ) -> Self {
-        let index = semantic_index(db, function_definition.python_file(db));
+        let index = semantic_index(db, function_definition.program_file(db));
         let definition = Some(index.expect_single_definition(parameter));
 
         let (annotated_type, inferred_annotation, annotation_flags, has_starred_annotation) =
@@ -5668,13 +5668,13 @@ mod tests {
     use crate::db::tests::{TestDb, setup_db};
     use crate::place::global_symbol;
     use crate::types::{FunctionType, KnownClass, LiteralValueType};
-    use ruff_db::PythonFile;
     use ruff_db::system::DbWithWritableSystem as _;
+    use ty_python_core::ProgramFile;
 
     #[track_caller]
     fn get_function_f<'db>(db: &'db TestDb, file: &'static str) -> FunctionType<'db> {
         let module = ruff_db::files::system_path_to_file(db, file).unwrap();
-        let module = PythonFile::new(db, module, db.python_version());
+        let module = ProgramFile::new(db, module, db.program_environment().program(db));
         global_symbol(db, module, "f")
             .place
             .expect_type()

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -830,7 +830,8 @@ impl SpecialFormType {
         self.definition_modules()
             .iter()
             .find_map(|module| {
-                let module = resolve_module_confident(db, env.program(db), &module.name())?;
+                let module =
+                    resolve_module_confident(db, env.resolver_environment(db), &module.name())?;
                 let file = ProgramFile::new(db, module.file(db)?, env.program(db));
                 let scope = FileScopeId::global().to_scope_id(db, file);
                 let symbol_id = place_table(db, scope).symbol_id(self.name())?;

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -11,11 +11,10 @@ use crate::types::{
     generics::typing_self,
     infer::{function_known_decorator_flags, nearest_enclosing_class},
 };
-use ruff_db::PythonFile;
 use strum_macros::EnumString;
-use ty_module_resolver::{KnownModule, file_to_module, resolve_module_confident};
+use ty_module_resolver::{ImportingFile, KnownModule, file_to_module, resolve_module_confident};
 use ty_python_core::{
-    FileScopeId,
+    FileScopeId, ProgramFile,
     definition::{Definition, DefinitionKind},
     place::ScopedPlaceId,
     place_table,
@@ -294,16 +293,18 @@ impl SpecialFormType {
 
     pub(super) fn try_from_file_and_name(
         db: &dyn Db,
-        file: PythonFile<'_>,
+        file: ImportingFile<'_>,
         symbol_name: &str,
     ) -> Option<Self> {
-        Self::candidates_from_name(symbol_name)
+        let candidates = Self::candidates_from_name(symbol_name);
+        if candidates.is_empty() {
+            return None;
+        }
+
+        let known_module = file_to_module(db, file.resolver_file(db))?.known(db)?;
+        candidates
             .iter()
-            .find(|candidate| {
-                file_to_module(db, file)
-                    .and_then(|module| module.known(db))
-                    .is_some_and(|known_module| candidate.check_module(known_module))
-            })
+            .find(|candidate| candidate.check_module(known_module))
             .copied()
     }
 
@@ -829,8 +830,8 @@ impl SpecialFormType {
         self.definition_modules()
             .iter()
             .find_map(|module| {
-                let file = resolve_module_confident(db, env.python_version(db), &module.name())?
-                    .python_file(db)?;
+                let module = resolve_module_confident(db, env.program(db), &module.name())?;
+                let file = ProgramFile::new(db, module.file(db)?, env.program(db));
                 let scope = FileScopeId::global().to_scope_id(db, file);
                 let symbol_id = place_table(db, scope).symbol_id(self.name())?;
 
@@ -886,8 +887,8 @@ impl SpecialFormType {
                     return Err(InvalidTypeExpression::TypingSelfInTypeAlias);
                 }
 
-                let python_file = scope_id.python_file(db);
-                let index = semantic_index(db, python_file);
+                let program_file = scope_id.program_file(db);
+                let index = semantic_index(db, program_file);
                 let Some(class) = nearest_enclosing_class(db, index, scope_id) else {
                     return Err(InvalidTypeExpression::InvalidType(
                         Type::SpecialForm(self),

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -4,11 +4,11 @@ use crate::ProgramEnvironment;
 use crate::db::tests::{TestDbBuilder, setup_db};
 use crate::place::{typing_extensions_symbol, typing_symbol};
 use crate::types::type_alias::PEP695TypeAliasType;
-use ruff_db::PythonFile;
 use ruff_db::system::DbWithWritableSystem as _;
 use ruff_python_ast as ast;
 use ruff_python_ast::PythonVersion;
 use test_case::test_case;
+use ty_python_core::ProgramFile;
 
 /// Explicitly test for Python version <3.13 and >=3.13, to ensure that
 /// the fallback to `typing_extensions` is working correctly.
@@ -75,7 +75,7 @@ fn oscillating_generic_alias_cycle_recover<'db>(
     current: Type<'db>,
 ) -> Type<'db> {
     let env = ProgramEnvironment::from_program(
-        ty_python_core::program::Program::get(db).python_version(db),
+        ty_python_core::program::Program::get(db).resolver_environment(db),
     );
     current.cycle_normalized(db, &env, *previous, cycle)
 }
@@ -87,7 +87,7 @@ fn oscillating_generic_alias_cycle_recover<'db>(
 )]
 fn oscillating_generic_alias(db: &dyn Db) -> Type<'_> {
     let env = ProgramEnvironment::from_program(
-        ty_python_core::program::Program::get(db).python_version(db),
+        ty_python_core::program::Program::get(db).resolver_environment(db),
     );
     let previous = oscillating_generic_alias(db);
     let argument = if let Type::GenericAlias(alias) = previous
@@ -454,7 +454,7 @@ fn type_alias_variance() {
 
     fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> PEP695TypeAliasType<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
-        let module = PythonFile::new(db, module, db.python_version());
+        let module = ProgramFile::new(db, module, db.program_environment().program(db));
         let ty = global_symbol(db, module, name).place.expect_type();
         let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
             type_alias,
@@ -709,7 +709,7 @@ fn eager_expansion() {
 
     fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> Type<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
-        let module = PythonFile::new(db, module, db.python_version());
+        let module = ProgramFile::new(db, module, db.program_environment().program(db));
         let ty = global_symbol(db, module, name).place.expect_type();
         let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
             type_alias,

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -131,7 +131,7 @@ impl TupleLength {
 #[salsa::interned(debug, constructor=new_internal, heap_size=ruff_memory_usage::heap_size)]
 pub struct TupleType<'db> {
     #[returns(copy)]
-    pub(crate) program: Program,
+    pub(crate) program: Program<'db>,
 
     #[returns(ref)]
     pub(crate) tuple: TupleSpec<'db>,

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -51,7 +51,7 @@ impl<'db> PEP695TypeAliasType<'db> {
     fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         let scope = self.rhs_scope(db);
         let type_alias_stmt_node = scope.node(db).expect_type_alias();
-        semantic_index(db, scope.python_file(db)).expect_single_definition(type_alias_stmt_node)
+        semantic_index(db, scope.program_file(db)).expect_single_definition(type_alias_stmt_node)
     }
 
     /// The RHS type of a PEP-695 style type alias with specialization applied.
@@ -77,7 +77,8 @@ impl<'db> PEP695TypeAliasType<'db> {
     )]
     pub(super) fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
         let scope = self.rhs_scope(db);
-        let python_file = scope.python_file(db);
+        let program_file = scope.program_file(db);
+        let python_file = program_file.python_file(db);
         let module = parsed_module(db, python_file).load(db);
         let type_alias_stmt_node = scope.node(db).expect_type_alias();
         let definition = self.definition(db);
@@ -113,7 +114,8 @@ impl<'db> PEP695TypeAliasType<'db> {
     #[salsa::tracked(returns(copy), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
         let scope = self.rhs_scope(db);
-        let python_file = scope.python_file(db);
+        let program_file = scope.program_file(db);
+        let python_file = program_file.python_file(db);
         let parsed = parsed_module(db, python_file).load(db);
         let type_alias_stmt_node = scope.node(db).expect_type_alias();
 
@@ -122,7 +124,7 @@ impl<'db> PEP695TypeAliasType<'db> {
             .type_params
             .as_ref()
             .map(|type_params| {
-                let index = semantic_index(db, python_file);
+                let index = semantic_index(db, program_file);
                 let definition = index.expect_single_definition(type_alias_stmt_node);
                 GenericContext::from_type_params(db, index, definition, type_params)
             })
@@ -219,9 +221,9 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
     #[salsa::tracked(returns(copy), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
         let definition = self.definition(db);
-        let file = definition.python_file(db);
+        let file = definition.program_file(db);
         let env = ProgramEnvironment::from_file(file);
-        let module = parsed_module(db, file).load(db);
+        let module = parsed_module(db, file.python_file(db)).load(db);
         let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
             return None;
         };
@@ -475,7 +477,7 @@ impl<'db> QualifiedTypeAliasName<'db> {
     /// would return `["a", "b", "C"]`.
     pub(crate) fn components_excluding_self(&self) -> Vec<String> {
         let definition = self.type_alias.definition(self.db);
-        let file = definition.python_file(self.db);
+        let file = definition.program_file(self.db);
         let file_scope_id = definition.file_scope(self.db);
 
         // Type aliases are defined directly in their enclosing scope (no body scope like classes),

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -259,8 +259,9 @@ impl<'db> TypedDictType<'db> {
                 }
             };
 
-            let python_file = static_class.python_file(db);
-            let env = ProgramEnvironment::from_file(python_file);
+            let program_file = static_class.program_file(db);
+            let python_file = program_file.python_file(db);
+            let env = ProgramEnvironment::from_file(program_file);
             let module = parsed_module(db, python_file).load(db);
             let class_definition = static_class.definition(db);
             let class_stmt = class_definition
@@ -1297,8 +1298,9 @@ pub(super) fn deferred_functional_typed_dict_schema<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> TypedDictSchema<'db> {
-    let python_file = definition.python_file(db);
-    let env = ProgramEnvironment::from_file(python_file);
+    let program_file = definition.program_file(db);
+    let python_file = program_file.python_file(db);
+    let env = ProgramEnvironment::from_file(program_file);
     let module = parsed_module(db, python_file).load(db);
     let node = definition
         .kind(db)
@@ -1361,8 +1363,9 @@ pub(super) fn deferred_functional_typed_dict_openness<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> TypedDictOpenness<'db> {
-    let python_file = definition.python_file(db);
-    let env = ProgramEnvironment::from_file(python_file);
+    let program_file = definition.program_file(db);
+    let python_file = program_file.python_file(db);
+    let env = ProgramEnvironment::from_file(program_file);
     let module = parsed_module(db, python_file).load(db);
     let node = definition
         .kind(db)

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -540,7 +540,8 @@ impl<'db> TypeVarInstance<'db> {
     )]
     fn lazy_bound_unchecked(self, db: &'db dyn Db) -> Option<Type<'db>> {
         let definition = self.definition(db)?;
-        let python_file = definition.python_file(db);
+        let program_file = definition.program_file(db);
+        let python_file = program_file.python_file(db);
         let module = parsed_module(db, python_file).load(db);
         let ty = match definition.kind(db) {
             // PEP 695 typevar
@@ -580,8 +581,9 @@ impl<'db> TypeVarInstance<'db> {
     )]
     fn lazy_constraints_unchecked(self, db: &'db dyn Db) -> Option<TypeVarConstraints<'db>> {
         let definition = self.definition(db)?;
-        let python_file = definition.python_file(db);
-        let env = ProgramEnvironment::from_file(python_file);
+        let program_file = definition.program_file(db);
+        let python_file = program_file.python_file(db);
+        let env = ProgramEnvironment::from_file(program_file);
         let module = parsed_module(db, python_file).load(db);
         let constraints = match definition.kind(db) {
             // PEP 695 typevar
@@ -684,7 +686,8 @@ impl<'db> TypeVarInstance<'db> {
         }
 
         let definition = self.definition(db)?;
-        let python_file = definition.python_file(db);
+        let program_file = definition.program_file(db);
+        let python_file = program_file.python_file(db);
         let module = parsed_module(db, python_file).load(db);
         let ty = match definition.kind(db) {
             // PEP 695 typevar
@@ -758,7 +761,7 @@ impl<'db> TypeVarInstance<'db> {
             return None;
         }
         let typevar_definition = self.definition(db)?;
-        let index = semantic_index(db, typevar_definition.python_file(db));
+        let index = semantic_index(db, typevar_definition.program_file(db));
         let (_, child) = index
             .child_scopes(typevar_definition.file_scope(db))
             .next()?;
@@ -1532,11 +1535,11 @@ fn lazy_bound_cycle_recover<'db>(
 ) -> Option<Type<'db>> {
     // Normalize the bounds/constraints to ensure cycle convergence.
     let current = current?;
-    let python_file = typevar
+    let program_file = typevar
         .definition(db)
         .expect("a lazy TypeVar bound must have a source definition")
-        .python_file(db);
-    let env = ProgramEnvironment::from_file(python_file);
+        .program_file(db);
+    let env = ProgramEnvironment::from_file(program_file);
     Some(match previous {
         Some(prev) => current.cycle_normalized(db, &env, *prev, cycle),
         None => current.recursive_type_normalized(db, &env, cycle),
@@ -1554,11 +1557,11 @@ fn lazy_constraints_cycle_recover<'db>(
 ) -> Option<TypeVarConstraints<'db>> {
     // Normalize the bounds/constraints to ensure cycle convergence.
     let current = current?;
-    let python_file = typevar
+    let program_file = typevar
         .definition(db)
         .expect("lazy TypeVar constraints must have a source definition")
-        .python_file(db);
-    let env = ProgramEnvironment::from_file(python_file);
+        .program_file(db);
+    let env = ProgramEnvironment::from_file(program_file);
     Some(match previous {
         Some(prev) => current.cycle_normalized(db, &env, *prev, cycle),
         None => current.recursive_type_normalized(db, &env, cycle),
@@ -1575,11 +1578,11 @@ fn lazy_default_cycle_recover<'db>(
 ) -> Option<Type<'db>> {
     // Normalize the default to ensure cycle convergence.
     let current = current?;
-    let python_file = typevar
+    let program_file = typevar
         .definition(db)
         .expect("a lazy TypeVar default must have a source definition")
-        .python_file(db);
-    let env = ProgramEnvironment::from_file(python_file);
+        .program_file(db);
+    let env = ProgramEnvironment::from_file(program_file);
     Some(match previous_default {
         Some(prev) => current.cycle_normalized(db, &env, *prev, cycle),
         None => current.recursive_type_normalized(db, &env, cycle),
@@ -1594,7 +1597,7 @@ pub enum BindingContext<'db> {
     /// The typevar is synthesized internally, and is not associated with a particular definition
     /// in the source, but is still bound and eligible for specialization inference. Its program
     /// identifies the environment that cannot otherwise be recovered from a source definition.
-    Synthetic(Program),
+    Synthetic(Program<'db>),
 }
 
 impl<'db> From<Definition<'db>> for BindingContext<'db> {
@@ -1611,7 +1614,7 @@ impl<'db> BindingContext<'db> {
         }
     }
 
-    pub(crate) fn program(self, db: &'db dyn Db) -> Program {
+    pub(crate) fn program(self, db: &'db dyn Db) -> Program<'db> {
         match self {
             Self::Definition(definition) => definition.program(db),
             Self::Synthetic(program) => program,
@@ -1828,12 +1831,12 @@ fn bound_typevar_default_type_cycle_recover<'db>(
     bound_typevar: BoundTypeVarInstance<'db>,
 ) -> Option<Type<'db>> {
     let default = default?;
-    let python_file = bound_typevar
+    let program_file = bound_typevar
         .typevar(db)
         .definition(db)
         .expect("a bound TypeVar with a default must have a source definition")
-        .python_file(db);
-    let env = ProgramEnvironment::from_file(python_file);
+        .program_file(db);
+    let env = ProgramEnvironment::from_file(program_file);
     Some(match previous_default {
         Some(previous) => default.cycle_normalized(db, &env, *previous, cycle),
         None => default.recursive_type_normalized(db, &env, cycle),

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -3,7 +3,6 @@ use std::borrow::Cow;
 
 use ruff_db::parsed::ParsedModuleRef;
 
-use ruff_db::PythonFile;
 use rustc_hash::FxHashMap;
 
 use ruff_python_ast::visitor::{self, Visitor};
@@ -14,6 +13,7 @@ use crate::types::infer::{ExpressionInference, FrozenMap};
 use crate::types::tuple::{ResizeTupleError, TupleLength, TupleSpec, TupleUnpacker};
 use crate::types::{Type, TypeCheckDiagnostics, TypeContext, infer_expression_types};
 use ty_python_core::ExpressionNodeKey;
+use ty_python_core::ProgramFile;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::unpack::{UnpackKind, UnpackValue};
 
@@ -43,7 +43,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
         db: &'db dyn Db,
         env: &'ast ProgramEnvironment<'db>,
         target_scope: ScopeId<'db>,
-        python_file: PythonFile<'db>,
+        program_file: ProgramFile<'db>,
         module: &'ast ParsedModuleRef,
     ) -> Self {
         Self {
@@ -51,8 +51,8 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
                 db,
                 env,
                 target_scope,
-                python_file.file(db),
-                python_file,
+                program_file.file(db),
+                program_file,
                 module,
             ),
             targets: FxHashMap::default(),

--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -12,12 +12,12 @@ use ty_python_core::platform::PythonPlatform;
 use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 use ty_python_semantic::pull_types::pull_types;
-use ty_python_semantic::{AnalysisSettings, check_file_unwrap, default_lint_registry};
+use ty_python_semantic::{AnalysisSettings, Db as _, check_file_unwrap, default_lint_registry};
 use ty_site_packages::{PythonVersionSource, PythonVersionWithSource};
 
 use ruff_db::diagnostic::Diagnostic;
 use test_case::test_case;
-use ty_python_core::Db as _;
+use ty_python_core::{Db as _, ProgramFile};
 
 fn get_cargo_workspace_root() -> anyhow::Result<&'static SystemPath> {
     SystemPath::new(env!("CARGO_MANIFEST_DIR"))
@@ -112,7 +112,7 @@ fn run_corpus_tests(pattern: &str) -> anyhow::Result<()> {
             let file = system_path_to_file(&db, path).unwrap();
 
             if let Err(err) = std::panic::catch_unwind(|| {
-                pull_types(&db, Program::get(&db).program_file(&db, file));
+                pull_types(&db, db.program_file(file));
             }) {
                 println!("Check failed for {relative_path:?}.");
                 std::panic::resume_unwind(err);
@@ -220,10 +220,14 @@ impl ty_python_core::Db for CorpusDb {
 impl ty_python_semantic::Db for CorpusDb {
     fn check_file(&self, file: File) -> Vec<Diagnostic> {
         if self.should_check_file(file) {
-            check_file_unwrap(self, Program::get(self).program_file(self, file))
+            check_file_unwrap(self, self.program_file(file))
         } else {
             Vec::new()
         }
+    }
+
+    fn program_file(&self, file: File) -> ProgramFile<'_> {
+        Program::get(self).program_file(self, file)
     }
 
     fn rule_selection(&self, _file: File) -> &RuleSelection {

--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
+use ruff_db::Db;
 use ruff_db::files::{File, Files, system_path_to_file};
 use ruff_db::system::{DbWithTestSystem, System, SystemPath, SystemPathBuf, TestSystem};
 use ruff_db::vendored::VendoredFileSystem;
-use ruff_db::{Db, PythonFile};
 use ruff_python_ast::PythonVersion;
 
 use ty_module_resolver::SearchPathSettings;
@@ -112,7 +112,7 @@ fn run_corpus_tests(pattern: &str) -> anyhow::Result<()> {
             let file = system_path_to_file(&db, path).unwrap();
 
             if let Err(err) = std::panic::catch_unwind(|| {
-                pull_types(&db, PythonFile::new(&db, file, db.python_version()));
+                pull_types(&db, Program::get(&db).program_file(&db, file));
             }) {
                 println!("Check failed for {relative_path:?}.");
                 std::panic::resume_unwind(err);
@@ -179,10 +179,6 @@ impl CorpusDb {
 
         db
     }
-
-    fn python_version(&self) -> PythonVersion {
-        Program::get(self).python_version(self)
-    }
 }
 
 impl DbWithTestSystem for CorpusDb {
@@ -211,11 +207,7 @@ impl ruff_db::Db for CorpusDb {
 }
 
 #[salsa::db]
-impl ty_module_resolver::Db for CorpusDb {
-    fn search_paths(&self) -> &ty_module_resolver::SearchPaths {
-        Program::get(self).search_paths(self)
-    }
-}
+impl ty_module_resolver::Db for CorpusDb {}
 
 #[salsa::db]
 impl ty_python_core::Db for CorpusDb {
@@ -228,7 +220,7 @@ impl ty_python_core::Db for CorpusDb {
 impl ty_python_semantic::Db for CorpusDb {
     fn check_file(&self, file: File) -> Vec<Diagnostic> {
         if self.should_check_file(file) {
-            check_file_unwrap(self, PythonFile::new(self, file, self.python_version()))
+            check_file_unwrap(self, Program::get(self).program_file(self, file))
         } else {
             Vec::new()
         }

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -12,7 +12,6 @@ use ruff_text_size::Ranged;
 use rustc_hash::{FxHashMap, FxHashSet};
 use ty_ide::{Hint, hints};
 
-use ruff_db::PythonFile;
 use ruff_db::diagnostic::{
     Annotation, DisplayDiagnosticConfig, HyperlinkMode, Severity, SubDiagnostic,
 };
@@ -21,6 +20,7 @@ use ruff_db::source::source_text;
 use ruff_db::system::SystemPathBuf;
 use serde::{Deserialize, Serialize};
 use ty_project::{Db as _, ProjectDatabase};
+use ty_python_core::program::Program;
 
 use crate::capabilities::ResolvedClientCapabilities;
 use crate::document::{FileRangeExt, ToRangeExt};
@@ -402,7 +402,7 @@ pub(super) fn compute_diagnostics(
     };
 
     let diagnostics = db.check_file(file);
-    let unnecessary_hints = hints(db, PythonFile::new(db, file, db.python_version()));
+    let unnecessary_hints = hints(db, Program::get(db).program_file(db, file));
 
     Some(Diagnostics {
         items: diagnostics,

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -19,8 +19,7 @@ use ruff_db::files::{File, FileRange};
 use ruff_db::source::source_text;
 use ruff_db::system::SystemPathBuf;
 use serde::{Deserialize, Serialize};
-use ty_project::{Db as _, ProjectDatabase};
-use ty_python_core::program::Program;
+use ty_project::{Db as _, ProjectDatabase, SemanticDb as _};
 
 use crate::capabilities::ResolvedClientCapabilities;
 use crate::document::{FileRangeExt, ToRangeExt};
@@ -402,7 +401,7 @@ pub(super) fn compute_diagnostics(
     };
 
     let diagnostics = db.check_file(file);
-    let unnecessary_hints = hints(db, Program::get(db).program_file(db, file));
+    let unnecessary_hints = hints(db, db.program_file(file));
 
     Some(Diagnostics {
         items: diagnostics,

--- a/crates/ty_server/src/server/api/requests/call_hierarchy_incoming_calls.rs
+++ b/crates/ty_server/src/server/api/requests/call_hierarchy_incoming_calls.rs
@@ -1,7 +1,6 @@
 use lsp_types::CallHierarchyIncomingCallsRequest;
 use lsp_types::{CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams};
-use ruff_db::PythonFile;
-use ty_project::Db as _;
+use ty_python_core::program::Program;
 
 use crate::document::{ToRangeExt as _, resolve_file_uri_range};
 use crate::server::api::requests::prepare_call_hierarchy::convert_to_lsp_item;
@@ -42,8 +41,7 @@ impl BackgroundRequestHandler for CallHierarchyIncomingCallsRequestHandler {
                 continue;
             };
 
-            for call in
-                ty_ide::incoming_calls(db, PythonFile::new(db, file, db.python_version()), offset)
+            for call in ty_ide::incoming_calls(db, Program::get(db).program_file(db, file), offset)
             {
                 // `from_ranges` are byte offsets into `call.from.file` (the caller),
                 // NOT into `file` (the prepared/queried symbol). Capture the caller

--- a/crates/ty_server/src/server/api/requests/call_hierarchy_incoming_calls.rs
+++ b/crates/ty_server/src/server/api/requests/call_hierarchy_incoming_calls.rs
@@ -1,6 +1,6 @@
 use lsp_types::CallHierarchyIncomingCallsRequest;
 use lsp_types::{CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams};
-use ty_python_core::program::Program;
+use ty_project::SemanticDb as _;
 
 use crate::document::{ToRangeExt as _, resolve_file_uri_range};
 use crate::server::api::requests::prepare_call_hierarchy::convert_to_lsp_item;
@@ -41,8 +41,7 @@ impl BackgroundRequestHandler for CallHierarchyIncomingCallsRequestHandler {
                 continue;
             };
 
-            for call in ty_ide::incoming_calls(db, Program::get(db).program_file(db, file), offset)
-            {
+            for call in ty_ide::incoming_calls(db, db.program_file(file), offset) {
                 // `from_ranges` are byte offsets into `call.from.file` (the caller),
                 // NOT into `file` (the prepared/queried symbol). Capture the caller
                 // file before moving `call.from` into `convert_to_lsp_item`.

--- a/crates/ty_server/src/server/api/requests/call_hierarchy_outgoing_calls.rs
+++ b/crates/ty_server/src/server/api/requests/call_hierarchy_outgoing_calls.rs
@@ -1,6 +1,6 @@
 use lsp_types::CallHierarchyOutgoingCallsRequest;
 use lsp_types::{CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams};
-use ty_python_core::program::Program;
+use ty_project::SemanticDb as _;
 
 use crate::document::{ToRangeExt as _, resolve_file_uri_range};
 use crate::server::api::requests::prepare_call_hierarchy::convert_to_lsp_item;
@@ -41,8 +41,7 @@ impl BackgroundRequestHandler for CallHierarchyOutgoingCallsRequestHandler {
                 continue;
             };
 
-            for call in ty_ide::outgoing_calls(db, Program::get(db).program_file(db, file), offset)
-            {
+            for call in ty_ide::outgoing_calls(db, db.program_file(file), offset) {
                 let Some(to) = convert_to_lsp_item(db, call.to, encoding) else {
                     continue;
                 };

--- a/crates/ty_server/src/server/api/requests/call_hierarchy_outgoing_calls.rs
+++ b/crates/ty_server/src/server/api/requests/call_hierarchy_outgoing_calls.rs
@@ -1,7 +1,6 @@
 use lsp_types::CallHierarchyOutgoingCallsRequest;
 use lsp_types::{CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams};
-use ruff_db::PythonFile;
-use ty_project::Db as _;
+use ty_python_core::program::Program;
 
 use crate::document::{ToRangeExt as _, resolve_file_uri_range};
 use crate::server::api::requests::prepare_call_hierarchy::convert_to_lsp_item;
@@ -42,8 +41,7 @@ impl BackgroundRequestHandler for CallHierarchyOutgoingCallsRequestHandler {
                 continue;
             };
 
-            for call in
-                ty_ide::outgoing_calls(db, PythonFile::new(db, file, db.python_version()), offset)
+            for call in ty_ide::outgoing_calls(db, Program::get(db).program_file(db, file), offset)
             {
                 let Some(to) = convert_to_lsp_item(db, call.to, encoding) else {
                     continue;

--- a/crates/ty_server/src/server/api/requests/code_action.rs
+++ b/crates/ty_server/src/server/api/requests/code_action.rs
@@ -2,13 +2,12 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 use lsp_types::{self as types, Code, CodeActionRequest, CodeActionResponse, TextEdit, Uri};
-use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ruff_diagnostics::Edit;
 use ruff_text_size::Ranged;
 use ty_ide::code_actions;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 use types::CodeActionKind;
 
 use crate::db::Db;
@@ -43,7 +42,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
         let Some(file) = snapshot.to_notebook_or_file(db) else {
             return Ok(None);
         };
-        let python_file = PythonFile::new(db, file, db.python_version());
+        let python_file = Program::get(db).program_file(db, file);
         let mut actions = Vec::new();
 
         for mut diagnostic in diagnostics.into_iter().filter(|diagnostic| {

--- a/crates/ty_server/src/server/api/requests/code_action.rs
+++ b/crates/ty_server/src/server/api/requests/code_action.rs
@@ -6,8 +6,7 @@ use ruff_db::files::File;
 use ruff_diagnostics::Edit;
 use ruff_text_size::Ranged;
 use ty_ide::code_actions;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 use types::CodeActionKind;
 
 use crate::db::Db;
@@ -42,7 +41,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
         let Some(file) = snapshot.to_notebook_or_file(db) else {
             return Ok(None);
         };
-        let python_file = Program::get(db).program_file(db, file);
+        let python_file = db.program_file(file);
         let mut actions = Vec::new();
 
         for mut diagnostic in diagnostics.into_iter().filter(|diagnostic| {

--- a/crates/ty_server/src/server/api/requests/code_action.rs
+++ b/crates/ty_server/src/server/api/requests/code_action.rs
@@ -41,7 +41,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
         let Some(file) = snapshot.to_notebook_or_file(db) else {
             return Ok(None);
         };
-        let python_file = db.program_file(file);
+        let program_file = db.program_file(file);
         let mut actions = Vec::new();
 
         for mut diagnostic in diagnostics.into_iter().filter(|diagnostic| {
@@ -100,7 +100,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
             if let Some(diagnostic_id) = diagnostic_id
                 && let Some(range) = diagnostic.range.to_text_range(db, file, uri, encoding)
             {
-                for action in code_actions(db, python_file, range, &diagnostic_id) {
+                for action in code_actions(db, program_file, range, &diagnostic_id) {
                     actions.push(CodeActionResponse::CodeAction(lsp_types::CodeAction {
                         title: action.title,
                         kind: Some(CodeActionKind::QuickFix),

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -6,15 +6,14 @@ use lsp_types::{
     CompletionParams, CompletionRequest, CompletionResponse, Documentation, InsertTextFormat,
     TextEdit, Uri,
 };
-use ruff_db::PythonFile;
 use ruff_source_file::OneIndexed;
 use ruff_text_size::Ranged;
 use ty_ide::{
     CompletionCapabilities, CompletionCommand, CompletionInsertTextFormat, CompletionKind,
     completion,
 };
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 use ty_python_semantic::ProgramEnvironment;
 
 use crate::capabilities::ResolvedClientCapabilities;
@@ -64,14 +63,14 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
             return Ok(None);
         };
         let client_capabilities = snapshot.resolved_client_capabilities();
-        let python_file = PythonFile::new(db, file, db.python_version());
-        let env = ProgramEnvironment::from_file(python_file);
+        let program_file = Program::get(db).program_file(db, file);
+        let env = ProgramEnvironment::from_file(program_file);
         let completions = completion(
             db,
             snapshot.workspace_settings().completions(),
             CompletionCapabilities::default()
                 .snippets(client_capabilities.supports_completion_item_snippets()),
-            python_file,
+            program_file,
             offset,
         );
         if completions.is_empty() {

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -12,8 +12,7 @@ use ty_ide::{
     CompletionCapabilities, CompletionCommand, CompletionInsertTextFormat, CompletionKind,
     completion,
 };
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 use ty_python_semantic::ProgramEnvironment;
 
 use crate::capabilities::ResolvedClientCapabilities;
@@ -63,7 +62,7 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
             return Ok(None);
         };
         let client_capabilities = snapshot.resolved_client_capabilities();
-        let program_file = Program::get(db).program_file(db, file);
+        let program_file = db.program_file(file);
         let env = ProgramEnvironment::from_file(program_file);
         let completions = completion(
             db,

--- a/crates/ty_server/src/server/api/requests/doc_highlights.rs
+++ b/crates/ty_server/src/server/api/requests/doc_highlights.rs
@@ -3,8 +3,7 @@ use std::borrow::Cow;
 use lsp_types::DocumentHighlightRequest;
 use lsp_types::{DocumentHighlight, DocumentHighlightKind, DocumentHighlightParams, Uri};
 use ty_ide::{ReferenceKind, document_highlights};
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::{PositionExt, ToRangeExt};
 use crate::server::api::traits::{
@@ -50,9 +49,7 @@ impl BackgroundDocumentRequestHandler for DocumentHighlightRequestHandler {
             return Ok(None);
         };
 
-        let Some(highlights_result) =
-            document_highlights(db, Program::get(db).program_file(db, file), offset)
-        else {
+        let Some(highlights_result) = document_highlights(db, db.program_file(file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/doc_highlights.rs
+++ b/crates/ty_server/src/server/api/requests/doc_highlights.rs
@@ -2,10 +2,9 @@ use std::borrow::Cow;
 
 use lsp_types::DocumentHighlightRequest;
 use lsp_types::{DocumentHighlight, DocumentHighlightKind, DocumentHighlightParams, Uri};
-use ruff_db::PythonFile;
 use ty_ide::{ReferenceKind, document_highlights};
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::{PositionExt, ToRangeExt};
 use crate::server::api::traits::{
@@ -52,7 +51,7 @@ impl BackgroundDocumentRequestHandler for DocumentHighlightRequestHandler {
         };
 
         let Some(highlights_result) =
-            document_highlights(db, PythonFile::new(db, file, db.python_version()), offset)
+            document_highlights(db, Program::get(db).program_file(db, file), offset)
         else {
             return Ok(None);
         };

--- a/crates/ty_server/src/server/api/requests/document_symbols.rs
+++ b/crates/ty_server/src/server/api/requests/document_symbols.rs
@@ -4,8 +4,7 @@ use lsp_types::DocumentSymbolRequest;
 use lsp_types::{DocumentSymbol, DocumentSymbolParams, Uri};
 use ruff_db::files::File;
 use ty_ide::{HierarchicalSymbols, SymbolId, SymbolInfo, document_symbols};
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::Db;
 use crate::document::{PositionEncoding, ToRangeExt};
@@ -49,7 +48,7 @@ impl BackgroundDocumentRequestHandler for DocumentSymbolRequestHandler {
             .resolved_client_capabilities()
             .supports_hierarchical_document_symbols();
 
-        let symbols = document_symbols(db, Program::get(db).program_file(db, file));
+        let symbols = document_symbols(db, db.program_file(file));
         if symbols.is_empty() {
             return Ok(None);
         }

--- a/crates/ty_server/src/server/api/requests/document_symbols.rs
+++ b/crates/ty_server/src/server/api/requests/document_symbols.rs
@@ -2,11 +2,10 @@ use std::borrow::Cow;
 
 use lsp_types::DocumentSymbolRequest;
 use lsp_types::{DocumentSymbol, DocumentSymbolParams, Uri};
-use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ty_ide::{HierarchicalSymbols, SymbolId, SymbolInfo, document_symbols};
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::Db;
 use crate::document::{PositionEncoding, ToRangeExt};
@@ -50,7 +49,7 @@ impl BackgroundDocumentRequestHandler for DocumentSymbolRequestHandler {
             .resolved_client_capabilities()
             .supports_hierarchical_document_symbols();
 
-        let symbols = document_symbols(db, PythonFile::new(db, file, db.python_version()));
+        let symbols = document_symbols(db, Program::get(db).program_file(db, file));
         if symbols.is_empty() {
             return Ok(None);
         }

--- a/crates/ty_server/src/server/api/requests/execute_command.rs
+++ b/crates/ty_server/src/server/api/requests/execute_command.rs
@@ -84,8 +84,8 @@ fn debug_information(session: &Session) -> crate::Result<String> {
             writer,
             "  search-paths: {:#}",
             program
-                .search_paths(db)
-                .display(db, ModuleResolveMode::Typing)
+                .resolver_environment(db)
+                .display_search_paths(db, ModuleResolveMode::Typing)
         )?;
 
         writeln!(buffer, "Settings: {:#?}", db.project().settings(db))?;

--- a/crates/ty_server/src/server/api/requests/folding_range.rs
+++ b/crates/ty_server/src/server/api/requests/folding_range.rs
@@ -5,8 +5,7 @@ use lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams, Uri};
 use ruff_db::source::source_text;
 use ruff_text_size::TextRange;
 use ty_ide::folding_ranges;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::db::Db;
 use crate::document::ToRangeExt;
@@ -57,33 +56,29 @@ impl BackgroundDocumentRequestHandler for FoldingRangeRequestHandler {
             cell_range = cell_index.and_then(|index| notebook.cell_range(index));
         }
 
-        let results: Vec<_> = folding_ranges(
-            db,
-            Program::get(db).program_file(db, file).python_file(db),
-            cell_range,
-        )
-        .into_iter()
-        .filter_map(|folding_range| {
-            let lsp_range = folding_range
-                .range
-                .to_lsp_range(db, file, snapshot.encoding())?;
+        let results: Vec<_> = folding_ranges(db, db.program_file(file).python_file(db), cell_range)
+            .into_iter()
+            .filter_map(|folding_range| {
+                let lsp_range = folding_range
+                    .range
+                    .to_lsp_range(db, file, snapshot.encoding())?;
 
-            let kind = folding_range.kind.map(|k| match k {
-                ty_ide::FoldingRangeKind::Comment => FoldingRangeKind::Comment,
-                ty_ide::FoldingRangeKind::Imports => FoldingRangeKind::Imports,
-                ty_ide::FoldingRangeKind::Region => FoldingRangeKind::Region,
-            });
+                let kind = folding_range.kind.map(|k| match k {
+                    ty_ide::FoldingRangeKind::Comment => FoldingRangeKind::Comment,
+                    ty_ide::FoldingRangeKind::Imports => FoldingRangeKind::Imports,
+                    ty_ide::FoldingRangeKind::Region => FoldingRangeKind::Region,
+                });
 
-            Some(FoldingRange {
-                start_line: lsp_range.local_range().start.line,
-                start_character: Some(lsp_range.local_range().start.character),
-                end_line: lsp_range.local_range().end.line,
-                end_character: Some(lsp_range.local_range().end.character),
-                kind,
-                collapsed_text: None,
+                Some(FoldingRange {
+                    start_line: lsp_range.local_range().start.line,
+                    start_character: Some(lsp_range.local_range().start.character),
+                    end_line: lsp_range.local_range().end.line,
+                    end_character: Some(lsp_range.local_range().end.character),
+                    kind,
+                    collapsed_text: None,
+                })
             })
-        })
-        .collect();
+            .collect();
 
         if results.is_empty() {
             Ok(None)

--- a/crates/ty_server/src/server/api/requests/folding_range.rs
+++ b/crates/ty_server/src/server/api/requests/folding_range.rs
@@ -2,12 +2,11 @@ use std::borrow::Cow;
 
 use lsp_types::FoldingRangeRequest;
 use lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams, Uri};
-use ruff_db::PythonFile;
 use ruff_db::source::source_text;
 use ruff_text_size::TextRange;
 use ty_ide::folding_ranges;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::db::Db;
 use crate::document::ToRangeExt;
@@ -60,7 +59,7 @@ impl BackgroundDocumentRequestHandler for FoldingRangeRequestHandler {
 
         let results: Vec<_> = folding_ranges(
             db,
-            PythonFile::new(db, file, db.python_version()),
+            Program::get(db).program_file(db, file).python_file(db),
             cell_range,
         )
         .into_iter()

--- a/crates/ty_server/src/server/api/requests/goto_declaration.rs
+++ b/crates/ty_server/src/server/api/requests/goto_declaration.rs
@@ -1,10 +1,9 @@
 use std::borrow::Cow;
 
 use lsp_types::{DeclarationParams, DeclarationRequest, DeclarationResponse, Uri};
-use ruff_db::PythonFile;
 use ty_ide::goto_declaration;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -50,8 +49,7 @@ impl BackgroundDocumentRequestHandler for GotoDeclarationRequestHandler {
             return Ok(None);
         };
 
-        let Some(ranged) =
-            goto_declaration(db, PythonFile::new(db, file, db.python_version()), offset)
+        let Some(ranged) = goto_declaration(db, Program::get(db).program_file(db, file), offset)
         else {
             return Ok(None);
         };

--- a/crates/ty_server/src/server/api/requests/goto_declaration.rs
+++ b/crates/ty_server/src/server/api/requests/goto_declaration.rs
@@ -2,8 +2,7 @@ use std::borrow::Cow;
 
 use lsp_types::{DeclarationParams, DeclarationRequest, DeclarationResponse, Uri};
 use ty_ide::goto_declaration;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -49,8 +48,7 @@ impl BackgroundDocumentRequestHandler for GotoDeclarationRequestHandler {
             return Ok(None);
         };
 
-        let Some(ranged) = goto_declaration(db, Program::get(db).program_file(db, file), offset)
-        else {
+        let Some(ranged) = goto_declaration(db, db.program_file(file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/goto_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_definition.rs
@@ -3,8 +3,7 @@ use std::borrow::Cow;
 use lsp_types::DefinitionRequest;
 use lsp_types::{DefinitionParams, DefinitionResponse, Uri};
 use ty_ide::goto_definition;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -50,8 +49,7 @@ impl BackgroundDocumentRequestHandler for GotoDefinitionRequestHandler {
             return Ok(None);
         };
 
-        let Some(ranged) = goto_definition(db, Program::get(db).program_file(db, file), offset)
-        else {
+        let Some(ranged) = goto_definition(db, db.program_file(file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/goto_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_definition.rs
@@ -2,10 +2,9 @@ use std::borrow::Cow;
 
 use lsp_types::DefinitionRequest;
 use lsp_types::{DefinitionParams, DefinitionResponse, Uri};
-use ruff_db::PythonFile;
 use ty_ide::goto_definition;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -51,8 +50,7 @@ impl BackgroundDocumentRequestHandler for GotoDefinitionRequestHandler {
             return Ok(None);
         };
 
-        let Some(ranged) =
-            goto_definition(db, PythonFile::new(db, file, db.python_version()), offset)
+        let Some(ranged) = goto_definition(db, Program::get(db).program_file(db, file), offset)
         else {
             return Ok(None);
         };

--- a/crates/ty_server/src/server/api/requests/goto_implementation.rs
+++ b/crates/ty_server/src/server/api/requests/goto_implementation.rs
@@ -2,8 +2,7 @@ use std::borrow::Cow;
 
 use lsp_types::{ImplementationParams, ImplementationRequest, ImplementationResponse, Uri};
 use ty_ide::goto_implementation;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -49,8 +48,7 @@ impl BackgroundDocumentRequestHandler for GotoImplementationRequestHandler {
             return Ok(None);
         };
 
-        let Some(ranged) = goto_implementation(db, Program::get(db).program_file(db, file), offset)
-        else {
+        let Some(ranged) = goto_implementation(db, db.program_file(file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/goto_implementation.rs
+++ b/crates/ty_server/src/server/api/requests/goto_implementation.rs
@@ -1,10 +1,9 @@
 use std::borrow::Cow;
 
 use lsp_types::{ImplementationParams, ImplementationRequest, ImplementationResponse, Uri};
-use ruff_db::PythonFile;
 use ty_ide::goto_implementation;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -50,8 +49,7 @@ impl BackgroundDocumentRequestHandler for GotoImplementationRequestHandler {
             return Ok(None);
         };
 
-        let Some(ranged) =
-            goto_implementation(db, PythonFile::new(db, file, db.python_version()), offset)
+        let Some(ranged) = goto_implementation(db, Program::get(db).program_file(db, file), offset)
         else {
             return Ok(None);
         };

--- a/crates/ty_server/src/server/api/requests/goto_type_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_type_definition.rs
@@ -3,8 +3,7 @@ use std::borrow::Cow;
 use lsp_types::{TypeDefinitionParams, TypeDefinitionRequest};
 use lsp_types::{TypeDefinitionResponse, Uri};
 use ty_ide::goto_type_definition;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -50,9 +49,7 @@ impl BackgroundDocumentRequestHandler for GotoTypeDefinitionRequestHandler {
             return Ok(None);
         };
 
-        let Some(ranged) =
-            goto_type_definition(db, Program::get(db).program_file(db, file), offset)
-        else {
+        let Some(ranged) = goto_type_definition(db, db.program_file(file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/goto_type_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_type_definition.rs
@@ -2,10 +2,9 @@ use std::borrow::Cow;
 
 use lsp_types::{TypeDefinitionParams, TypeDefinitionRequest};
 use lsp_types::{TypeDefinitionResponse, Uri};
-use ruff_db::PythonFile;
 use ty_ide::goto_type_definition;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -52,7 +51,7 @@ impl BackgroundDocumentRequestHandler for GotoTypeDefinitionRequestHandler {
         };
 
         let Some(ranged) =
-            goto_type_definition(db, PythonFile::new(db, file, db.python_version()), offset)
+            goto_type_definition(db, Program::get(db).program_file(db, file), offset)
         else {
             return Ok(None);
         };

--- a/crates/ty_server/src/server/api/requests/hover.rs
+++ b/crates/ty_server/src/server/api/requests/hover.rs
@@ -9,8 +9,7 @@ use crate::session::client::Client;
 use lsp_types::HoverRequest;
 use lsp_types::{HoverParams, MarkupContent, Uri};
 use ty_ide::{MarkupKind, hover};
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 pub(crate) struct HoverRequestHandler;
 
@@ -49,7 +48,7 @@ impl BackgroundDocumentRequestHandler for HoverRequestHandler {
             return Ok(None);
         };
 
-        let Some(range_info) = hover(db, Program::get(db).program_file(db, file), offset) else {
+        let Some(range_info) = hover(db, db.program_file(file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/hover.rs
+++ b/crates/ty_server/src/server/api/requests/hover.rs
@@ -8,10 +8,9 @@ use crate::session::DocumentSnapshot;
 use crate::session::client::Client;
 use lsp_types::HoverRequest;
 use lsp_types::{HoverParams, MarkupContent, Uri};
-use ruff_db::PythonFile;
 use ty_ide::{MarkupKind, hover};
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 pub(crate) struct HoverRequestHandler;
 
@@ -50,8 +49,7 @@ impl BackgroundDocumentRequestHandler for HoverRequestHandler {
             return Ok(None);
         };
 
-        let Some(range_info) = hover(db, PythonFile::new(db, file, db.python_version()), offset)
-        else {
+        let Some(range_info) = hover(db, Program::get(db).program_file(db, file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -3,11 +3,10 @@ use std::time::Instant;
 
 use lsp_types::InlayHintRequest;
 use lsp_types::{InlayHintParams, Uri};
-use ruff_db::PythonFile;
 use ruff_db::files::File;
 use ty_ide::{InlayHintKind, InlayHintLabel, InlayHintTextEdit, inlay_hints};
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::PositionEncoding;
 use crate::document::{RangeExt, TextSizeExt, ToLink};
@@ -55,7 +54,7 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
 
         let inlay_hints = inlay_hints(
             db,
-            PythonFile::new(db, file, db.python_version()),
+            Program::get(db).program_file(db, file),
             range,
             workspace_settings.inlay_hints(),
         );

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -5,8 +5,7 @@ use lsp_types::InlayHintRequest;
 use lsp_types::{InlayHintParams, Uri};
 use ruff_db::files::File;
 use ty_ide::{InlayHintKind, InlayHintLabel, InlayHintTextEdit, inlay_hints};
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::PositionEncoding;
 use crate::document::{RangeExt, TextSizeExt, ToLink};
@@ -54,7 +53,7 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
 
         let inlay_hints = inlay_hints(
             db,
-            Program::get(db).program_file(db, file),
+            db.program_file(file),
             range,
             workspace_settings.inlay_hints(),
         );

--- a/crates/ty_server/src/server/api/requests/prepare_call_hierarchy.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_call_hierarchy.rs
@@ -2,9 +2,8 @@ use std::borrow::Cow;
 
 use lsp_types::CallHierarchyPrepareRequest;
 use lsp_types::{CallHierarchyItem, CallHierarchyPrepareParams, Uri};
-use ruff_db::PythonFile;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::PositionEncoding;
 use crate::document::{PositionExt, ToRangeExt as _};
@@ -59,11 +58,9 @@ impl BackgroundDocumentRequestHandler for PrepareCallHierarchyRequestHandler {
             return Ok(None);
         };
 
-        let Some(items) = ty_ide::prepare_call_hierarchy(
-            db,
-            PythonFile::new(db, file, db.python_version()),
-            offset,
-        ) else {
+        let Some(items) =
+            ty_ide::prepare_call_hierarchy(db, Program::get(db).program_file(db, file), offset)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/prepare_call_hierarchy.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_call_hierarchy.rs
@@ -2,8 +2,7 @@ use std::borrow::Cow;
 
 use lsp_types::CallHierarchyPrepareRequest;
 use lsp_types::{CallHierarchyItem, CallHierarchyPrepareParams, Uri};
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::PositionEncoding;
 use crate::document::{PositionExt, ToRangeExt as _};
@@ -58,9 +57,7 @@ impl BackgroundDocumentRequestHandler for PrepareCallHierarchyRequestHandler {
             return Ok(None);
         };
 
-        let Some(items) =
-            ty_ide::prepare_call_hierarchy(db, Program::get(db).program_file(db, file), offset)
-        else {
+        let Some(items) = ty_ide::prepare_call_hierarchy(db, db.program_file(file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/prepare_rename.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_rename.rs
@@ -1,10 +1,9 @@
 use std::borrow::Cow;
 
 use lsp_types::{PrepareRenameParams, PrepareRenameRequest, PrepareRenameResult, Uri};
-use ruff_db::PythonFile;
 use ty_ide::can_rename;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::{PositionExt, ToRangeExt};
 use crate::server::api::traits::{
@@ -50,8 +49,7 @@ impl BackgroundDocumentRequestHandler for PrepareRenameRequestHandler {
             return Ok(None);
         };
 
-        let Some(range) = can_rename(db, PythonFile::new(db, file, db.python_version()), offset)
-        else {
+        let Some(range) = can_rename(db, Program::get(db).program_file(db, file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/prepare_rename.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_rename.rs
@@ -2,8 +2,7 @@ use std::borrow::Cow;
 
 use lsp_types::{PrepareRenameParams, PrepareRenameRequest, PrepareRenameResult, Uri};
 use ty_ide::can_rename;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::{PositionExt, ToRangeExt};
 use crate::server::api::traits::{
@@ -49,7 +48,7 @@ impl BackgroundDocumentRequestHandler for PrepareRenameRequestHandler {
             return Ok(None);
         };
 
-        let Some(range) = can_rename(db, Program::get(db).program_file(db, file), offset) else {
+        let Some(range) = can_rename(db, db.program_file(file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/prepare_type_hierarchy.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_type_hierarchy.rs
@@ -2,9 +2,8 @@ use std::borrow::Cow;
 
 use lsp_types::TypeHierarchyPrepareRequest;
 use lsp_types::{TypeHierarchyItem, TypeHierarchyPrepareParams, Uri};
-use ruff_db::PythonFile;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::PositionExt;
 use crate::server::api::traits::{
@@ -60,11 +59,9 @@ impl BackgroundDocumentRequestHandler for PrepareTypeHierarchyRequestHandler {
             return Ok(None);
         };
 
-        let Some(item) = ty_ide::prepare_type_hierarchy(
-            db,
-            PythonFile::new(db, file, db.python_version()),
-            offset,
-        ) else {
+        let Some(item) =
+            ty_ide::prepare_type_hierarchy(db, Program::get(db).program_file(db, file), offset)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/prepare_type_hierarchy.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_type_hierarchy.rs
@@ -2,8 +2,7 @@ use std::borrow::Cow;
 
 use lsp_types::TypeHierarchyPrepareRequest;
 use lsp_types::{TypeHierarchyItem, TypeHierarchyPrepareParams, Uri};
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::PositionExt;
 use crate::server::api::traits::{
@@ -59,9 +58,7 @@ impl BackgroundDocumentRequestHandler for PrepareTypeHierarchyRequestHandler {
             return Ok(None);
         };
 
-        let Some(item) =
-            ty_ide::prepare_type_hierarchy(db, Program::get(db).program_file(db, file), offset)
-        else {
+        let Some(item) = ty_ide::prepare_type_hierarchy(db, db.program_file(file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/references.rs
+++ b/crates/ty_server/src/server/api/requests/references.rs
@@ -2,10 +2,9 @@ use std::borrow::Cow;
 
 use lsp_types::ReferencesRequest;
 use lsp_types::{Location, ReferenceParams, Uri};
-use ruff_db::PythonFile;
 use ty_ide::find_references;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -55,7 +54,7 @@ impl BackgroundDocumentRequestHandler for ReferencesRequestHandler {
 
         let Some(references_result) = find_references(
             db,
-            PythonFile::new(db, file, db.python_version()),
+            Program::get(db).program_file(db, file),
             offset,
             include_declaration,
         ) else {

--- a/crates/ty_server/src/server/api/requests/references.rs
+++ b/crates/ty_server/src/server/api/requests/references.rs
@@ -3,8 +3,7 @@ use std::borrow::Cow;
 use lsp_types::ReferencesRequest;
 use lsp_types::{Location, ReferenceParams, Uri};
 use ty_ide::find_references;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -52,12 +51,9 @@ impl BackgroundDocumentRequestHandler for ReferencesRequestHandler {
 
         let include_declaration = params.context.include_declaration;
 
-        let Some(references_result) = find_references(
-            db,
-            Program::get(db).program_file(db, file),
-            offset,
-            include_declaration,
-        ) else {
+        let Some(references_result) =
+            find_references(db, db.program_file(file), offset, include_declaration)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/rename.rs
+++ b/crates/ty_server/src/server/api/requests/rename.rs
@@ -4,8 +4,7 @@ use std::collections::HashMap;
 use lsp_types::RenameRequest;
 use lsp_types::{RenameParams, TextEdit, Uri, WorkspaceEdit};
 use ty_ide::rename;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -51,12 +50,8 @@ impl BackgroundDocumentRequestHandler for RenameRequestHandler {
             return Ok(None);
         };
 
-        let Some(rename_results) = rename(
-            db,
-            Program::get(db).program_file(db, file),
-            offset,
-            &params.new_name,
-        ) else {
+        let Some(rename_results) = rename(db, db.program_file(file), offset, &params.new_name)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/rename.rs
+++ b/crates/ty_server/src/server/api/requests/rename.rs
@@ -3,10 +3,9 @@ use std::collections::HashMap;
 
 use lsp_types::RenameRequest;
 use lsp_types::{RenameParams, TextEdit, Uri, WorkspaceEdit};
-use ruff_db::PythonFile;
 use ty_ide::rename;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::{PositionExt, ToLink};
 use crate::server::api::traits::{
@@ -54,7 +53,7 @@ impl BackgroundDocumentRequestHandler for RenameRequestHandler {
 
         let Some(rename_results) = rename(
             db,
-            PythonFile::new(db, file, db.python_version()),
+            Program::get(db).program_file(db, file),
             offset,
             &params.new_name,
         ) else {

--- a/crates/ty_server/src/server/api/requests/selection_range.rs
+++ b/crates/ty_server/src/server/api/requests/selection_range.rs
@@ -5,8 +5,8 @@ use lsp_types::{
 };
 use ruff_db::PythonFile;
 use ty_ide::selection_range;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::{PositionExt, ToRangeExt};
 use crate::server::api::traits::{
@@ -42,7 +42,7 @@ impl BackgroundDocumentRequestHandler for SelectionRangeRequestHandler {
         let Some(file) = snapshot.to_notebook_or_file(db) else {
             return Ok(None);
         };
-        let python_file = PythonFile::new(db, file, db.python_version());
+        let python_file = PythonFile::new(db, file, Program::get(db).python_version(db));
 
         let mut results = Vec::new();
 

--- a/crates/ty_server/src/server/api/requests/selection_range.rs
+++ b/crates/ty_server/src/server/api/requests/selection_range.rs
@@ -3,10 +3,8 @@ use std::borrow::Cow;
 use lsp_types::{
     SelectionRange as LspSelectionRange, SelectionRangeParams, SelectionRangeRequest, Uri,
 };
-use ruff_db::PythonFile;
 use ty_ide::selection_range;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::{PositionExt, ToRangeExt};
 use crate::server::api::traits::{
@@ -42,7 +40,7 @@ impl BackgroundDocumentRequestHandler for SelectionRangeRequestHandler {
         let Some(file) = snapshot.to_notebook_or_file(db) else {
             return Ok(None);
         };
-        let python_file = PythonFile::new(db, file, Program::get(db).python_version(db));
+        let python_file = db.program_file(file).python_file(db);
 
         let mut results = Vec::new();
 

--- a/crates/ty_server/src/server/api/requests/signature_help.rs
+++ b/crates/ty_server/src/server/api/requests/signature_help.rs
@@ -12,8 +12,7 @@ use lsp_types::{
     SignatureHelpParams, SignatureInformation, Uri,
 };
 use ty_ide::signature_help;
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 pub(crate) struct SignatureHelpRequestHandler;
 
@@ -55,9 +54,7 @@ impl BackgroundDocumentRequestHandler for SignatureHelpRequestHandler {
         // Extract signature help capabilities from the client
         let resolved_capabilities = snapshot.resolved_client_capabilities();
 
-        let Some(signature_help_info) =
-            signature_help(db, Program::get(db).program_file(db, file), offset)
-        else {
+        let Some(signature_help_info) = signature_help(db, db.program_file(file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/signature_help.rs
+++ b/crates/ty_server/src/server/api/requests/signature_help.rs
@@ -11,10 +11,9 @@ use lsp_types::{
     Documentation, ParameterInformation, ParameterInformationLabel, SignatureHelp,
     SignatureHelpParams, SignatureInformation, Uri,
 };
-use ruff_db::PythonFile;
 use ty_ide::signature_help;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 pub(crate) struct SignatureHelpRequestHandler;
 
@@ -57,7 +56,7 @@ impl BackgroundDocumentRequestHandler for SignatureHelpRequestHandler {
         let resolved_capabilities = snapshot.resolved_client_capabilities();
 
         let Some(signature_help_info) =
-            signature_help(db, PythonFile::new(db, file, db.python_version()), offset)
+            signature_help(db, Program::get(db).program_file(db, file), offset)
         else {
             return Ok(None);
         };

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -17,8 +17,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use ty_ide::{Hint, hints};
-use ty_project::{ProgressReporter, ProjectDatabase};
-use ty_python_core::program::Program;
+use ty_project::{ProgressReporter, ProjectDatabase, SemanticDb as _};
 
 use crate::PositionEncoding;
 use crate::capabilities::ResolvedClientCapabilities;
@@ -240,7 +239,7 @@ impl ProgressReporter for WorkspaceDiagnosticsProgressReporter<'_> {
     }
 
     fn report_checked_file(&self, db: &ProjectDatabase, file: File, diagnostics: &[Diagnostic]) {
-        let unnecessary_hints = hints(db, Program::get(db).program_file(db, file));
+        let unnecessary_hints = hints(db, db.program_file(file));
 
         // Another thread might have panicked at this point because of a salsa cancellation which
         // poisoned the result. If the response is poisoned, just don't report and wait for our thread
@@ -288,7 +287,7 @@ impl ProgressReporter for WorkspaceDiagnosticsProgressReporter<'_> {
         let response = &mut self.state.get_mut().unwrap().response;
 
         for (file, diagnostics) in by_file {
-            let unnecessary_hints = hints(db, Program::get(db).program_file(db, file));
+            let unnecessary_hints = hints(db, db.program_file(file));
             response.write_diagnostics_for_file(db, file, &diagnostics, &unnecessary_hints);
         }
         response.maybe_flush();

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -10,7 +10,6 @@ use lsp_types::{
     WorkspaceDiagnosticReportPartialResult, WorkspaceDocumentDiagnosticReport,
     WorkspaceFullDocumentDiagnosticReport, WorkspaceUnchangedDocumentDiagnosticReport,
 };
-use ruff_db::PythonFile;
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::File;
 use ruff_db::source::source_text;
@@ -18,8 +17,8 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use ty_ide::{Hint, hints};
-use ty_project::Db as _;
 use ty_project::{ProgressReporter, ProjectDatabase};
+use ty_python_core::program::Program;
 
 use crate::PositionEncoding;
 use crate::capabilities::ResolvedClientCapabilities;
@@ -241,7 +240,7 @@ impl ProgressReporter for WorkspaceDiagnosticsProgressReporter<'_> {
     }
 
     fn report_checked_file(&self, db: &ProjectDatabase, file: File, diagnostics: &[Diagnostic]) {
-        let unnecessary_hints = hints(db, PythonFile::new(db, file, db.python_version()));
+        let unnecessary_hints = hints(db, Program::get(db).program_file(db, file));
 
         // Another thread might have panicked at this point because of a salsa cancellation which
         // poisoned the result. If the response is poisoned, just don't report and wait for our thread
@@ -289,7 +288,7 @@ impl ProgressReporter for WorkspaceDiagnosticsProgressReporter<'_> {
         let response = &mut self.state.get_mut().unwrap().response;
 
         for (file, diagnostics) in by_file {
-            let unnecessary_hints = hints(db, PythonFile::new(db, file, db.python_version()));
+            let unnecessary_hints = hints(db, Program::get(db).program_file(db, file));
             response.write_diagnostics_for_file(db, file, &diagnostics, &unnecessary_hints);
         }
         response.maybe_flush();

--- a/crates/ty_server/src/server/api/semantic_tokens.rs
+++ b/crates/ty_server/src/server/api/semantic_tokens.rs
@@ -3,8 +3,7 @@ use ruff_db::source::{line_index, source_text};
 use ruff_source_file::OneIndexed;
 use ruff_text_size::{Ranged, TextRange};
 use ty_ide::{SemanticTokenModifier, SemanticTokenType, semantic_tokens};
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::document::{PositionEncoding, ToRangeExt};
 
@@ -19,7 +18,7 @@ pub(crate) fn generate_semantic_tokens(
 ) -> Vec<SemanticToken> {
     let source = source_text(db, file);
     let line_index = line_index(db, file);
-    let semantic_token_data = semantic_tokens(db, Program::get(db).program_file(db, file), range);
+    let semantic_token_data = semantic_tokens(db, db.program_file(file), range);
 
     let mut encoder = Encoder {
         tokens: Vec::with_capacity(semantic_token_data.len()),

--- a/crates/ty_server/src/server/api/semantic_tokens.rs
+++ b/crates/ty_server/src/server/api/semantic_tokens.rs
@@ -1,11 +1,10 @@
 use lsp_types::SemanticToken;
-use ruff_db::PythonFile;
 use ruff_db::source::{line_index, source_text};
 use ruff_source_file::OneIndexed;
 use ruff_text_size::{Ranged, TextRange};
 use ty_ide::{SemanticTokenModifier, SemanticTokenType, semantic_tokens};
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::document::{PositionEncoding, ToRangeExt};
 
@@ -20,8 +19,7 @@ pub(crate) fn generate_semantic_tokens(
 ) -> Vec<SemanticToken> {
     let source = source_text(db, file);
     let line_index = line_index(db, file);
-    let semantic_token_data =
-        semantic_tokens(db, PythonFile::new(db, file, db.python_version()), range);
+    let semantic_token_data = semantic_tokens(db, Program::get(db).program_file(db, file), range);
 
     let mut encoder = Encoder {
         tokens: Vec::with_capacity(semantic_token_data.len()),

--- a/crates/ty_server/src/server/api/type_hierarchy.rs
+++ b/crates/ty_server/src/server/api/type_hierarchy.rs
@@ -1,7 +1,6 @@
 use lsp_types::{SymbolKind, TypeHierarchyItem};
-use ruff_db::PythonFile;
-use ty_project::Db as _;
 use ty_project::ProjectDatabase;
+use ty_python_core::program::Program;
 
 use crate::PositionEncoding;
 use crate::document::{ToRangeExt, resolve_file_uri_range};
@@ -35,7 +34,7 @@ pub(crate) fn hierarchy_handler(
         ) else {
             continue;
         };
-        let file = PythonFile::new(db, file, db.python_version());
+        let file = Program::get(db).program_file(db, file);
         let hierarchy_types = match hierarchy_kind {
             TypeHierarchyKind::Subtypes => ty_ide::type_hierarchy_subtypes(db, file, offset),
             TypeHierarchyKind::Supertypes => ty_ide::type_hierarchy_supertypes(db, file, offset),

--- a/crates/ty_server/src/server/api/type_hierarchy.rs
+++ b/crates/ty_server/src/server/api/type_hierarchy.rs
@@ -1,6 +1,5 @@
 use lsp_types::{SymbolKind, TypeHierarchyItem};
-use ty_project::ProjectDatabase;
-use ty_python_core::program::Program;
+use ty_project::{ProjectDatabase, SemanticDb as _};
 
 use crate::PositionEncoding;
 use crate::document::{ToRangeExt, resolve_file_uri_range};
@@ -34,7 +33,7 @@ pub(crate) fn hierarchy_handler(
         ) else {
             continue;
         };
-        let file = Program::get(db).program_file(db, file);
+        let file = db.program_file(file);
         let hierarchy_types = match hierarchy_kind {
             TypeHierarchyKind::Subtypes => ty_ide::type_hierarchy_subtypes(db, file, offset),
             TypeHierarchyKind::Supertypes => ty_ide::type_hierarchy_supertypes(db, file, offset),

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -27,7 +27,7 @@ use ty_project::watch::{ChangeEvent, CreatedKind};
 use ty_project::{ChangeResult, Db as _, ProjectDatabase, ProjectMetadata};
 
 use index::DocumentError;
-use ty_python_core::program::UseDefaultStrategy;
+use ty_python_core::program::{Program, UseDefaultStrategy};
 
 pub(crate) use self::options::InitializationOptions;
 pub use self::options::{ClientOptions, DiagnosticMode, GlobalOptions, WorkspaceOptions};
@@ -1087,7 +1087,11 @@ impl Session {
             let paths = self
                 .project_dbs()
                 .flat_map(|db| {
-                    ty_module_resolver::system_module_search_paths(db).map(move |path| (db, path))
+                    ty_module_resolver::system_module_search_paths(
+                        db,
+                        Program::get(db).resolver_environment(db),
+                    )
+                    .map(move |path| (db, path))
                 })
                 .filter(|(db, path)| !path.starts_with(db.project().root(*db)))
                 .map(|(_, path)| path)

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -188,8 +188,6 @@ Memory report:
 =======SALSA QUERIES=======
 `dynamic_resolution_paths -> alloc::vec::Vec<ty_module_resolver::path::SearchPath>`
     metadata=[X.XXMB]   fields=[X.XXMB]   count=1
-`Program::resolver_environment_ -> ty_module_resolver::environment::ResolverEnvironment<'_>`
-    metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 =======SALSA SUMMARY=======
 TOTAL MEMORY USAGE: [X.XXMB]
     struct metadata = [X.XXMB]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -181,11 +181,14 @@ Settings: Settings {
 Memory report:
 =======SALSA STRUCTS=======
 `Program`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
+`ResolverEnvironment`                              metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `Project`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `FileRoot`                                         metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `ModuleResolveModeIngredient`                      metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 =======SALSA QUERIES=======
 `dynamic_resolution_paths -> alloc::vec::Vec<ty_module_resolver::path::SearchPath>`
+    metadata=[X.XXMB]   fields=[X.XXMB]   count=1
+`Program::resolver_environment_ -> ty_module_resolver::environment::ResolverEnvironment<'_>`
     metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 =======SALSA SUMMARY=======
 TOTAL MEMORY USAGE: [X.XXMB]

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -1,5 +1,6 @@
 use crate::config::{Analysis, Rules, ScriptOptions};
 use camino::{Utf8Component, Utf8PathBuf};
+use ruff_db::Db as SourceDb;
 use ruff_db::diagnostic::{Diagnostic, Severity};
 use ruff_db::files::{File, Files};
 use ruff_db::source::source_text;
@@ -8,13 +9,12 @@ use ruff_db::system::{
     WritableSystem,
 };
 use ruff_db::vendored::VendoredFileSystem;
-use ruff_db::{Db as SourceDb, PythonFile};
 use ruff_notebook::{Notebook, NotebookError};
 use salsa::Setter as _;
 use std::borrow::Cow;
 use std::sync::Arc;
 use tempfile::TempDir;
-use ty_module_resolver::{ModuleGlobSetBuilder, SearchPaths};
+use ty_module_resolver::ModuleGlobSetBuilder;
 use ty_python_core::Db as _;
 use ty_python_core::program::Program;
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
@@ -48,10 +48,6 @@ impl Db {
 
         db.settings = Some(Settings::new(&db));
         db
-    }
-
-    pub(crate) fn python_version(&self) -> ruff_python_ast::PythonVersion {
-        Program::get(self).python_version(self)
     }
 
     fn settings(&self) -> Settings {
@@ -117,11 +113,7 @@ impl SourceDb for Db {
 }
 
 #[salsa::db]
-impl ty_module_resolver::Db for Db {
-    fn search_paths(&self) -> &SearchPaths {
-        Program::get(self).search_paths(self)
-    }
-}
+impl ty_module_resolver::Db for Db {}
 
 #[salsa::db]
 impl ty_python_core::Db for Db {
@@ -137,7 +129,7 @@ impl SemanticDb for Db {
             return Vec::new();
         }
 
-        check_file_unwrap(self, PythonFile::new(self, file, self.python_version()))
+        check_file_unwrap(self, Program::get(self).program_file(self, file))
     }
 
     fn rule_selection(&self, file: File) -> &RuleSelection {

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -15,8 +15,8 @@ use std::borrow::Cow;
 use std::sync::Arc;
 use tempfile::TempDir;
 use ty_module_resolver::ModuleGlobSetBuilder;
-use ty_python_core::Db as _;
 use ty_python_core::program::Program;
+use ty_python_core::{Db as _, ProgramFile};
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 use ty_python_semantic::{
     AnalysisSettings, Db as SemanticDb, check_file_unwrap, default_lint_registry,
@@ -129,7 +129,11 @@ impl SemanticDb for Db {
             return Vec::new();
         }
 
-        check_file_unwrap(self, Program::get(self).program_file(self, file))
+        check_file_unwrap(self, self.program_file(file))
+    }
+
+    fn program_file(&self, file: File) -> ProgramFile<'_> {
+        Program::get(self).program_file(self, file)
     }
 
     fn rule_selection(&self, file: File) -> &RuleSelection {

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -25,7 +25,7 @@ use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
 use ty_python_semantic::pull_types::pull_types;
 use ty_python_semantic::types::UNDEFINED_REVEAL;
 use ty_python_semantic::{
-    PythonEnvironment, PythonVersionSource, PythonVersionWithSource, SysPrefixPathOrigin,
+    Db as _, PythonEnvironment, PythonVersionSource, PythonVersionWithSource, SysPrefixPathOrigin,
     fix_all_diagnostics,
 };
 
@@ -361,10 +361,8 @@ fn run_test(
 
             all_diagnostics.extend(diagnostics);
 
-            let pull_types_result = attempt_test(
-                |file| pull_types(db, Program::get(db).program_file(db, file)),
-                test_file,
-            );
+            let pull_types_result =
+                attempt_test(|file| pull_types(db, db.program_file(file)), test_file);
             match pull_types_result {
                 Ok(()) => {}
                 Err(failures) => {

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -7,12 +7,12 @@ use mdtest::parser::{self};
 use mdtest::{
     Failures, FileFailures, MarkdownEdit, OutputFormat, TestFile, TestOutcome, attempt_test,
 };
+use ruff_db::Db;
 use ruff_db::cancellation::CancellationTokenSource;
 use ruff_db::diagnostic::DiagnosticId;
 use ruff_db::files::{FileRootKind, system_path_to_file};
 use ruff_db::system::{DbWithWritableSystem as _, SystemPath, SystemPathBuf};
 use ruff_db::testing::{setup_logging, setup_logging_with_filter};
-use ruff_db::{Db, PythonFile};
 use ruff_diagnostics::Applicability;
 use ruff_python_ast::PythonVersion;
 use ruff_source_file::OneIndexed;
@@ -362,7 +362,7 @@ fn run_test(
             all_diagnostics.extend(diagnostics);
 
             let pull_types_result = attempt_test(
-                |file| pull_types(db, PythonFile::new(db, file, python_version)),
+                |file| pull_types(db, Program::get(db).program_file(db, file)),
                 test_file,
             );
             match pull_types_result {
@@ -496,12 +496,12 @@ struct ModuleInconsistency<'db> {
 /// `list_module`.
 fn run_module_resolution_consistency_test(db: &db::Db) -> Result<(), Vec<ModuleInconsistency<'_>>> {
     let mut errs = vec![];
-    let python_version = db.python_version();
-    for from_list in list_modules(db, python_version).iter().copied() {
+    let environment = Program::get(db).resolver_environment(db);
+    for from_list in list_modules(db, environment).iter().copied() {
         // TODO: For now list_modules does not partake in desperate module resolution so
         // only compare against confident module resolution.
         errs.push(
-            match resolve_module_confident(db, python_version, from_list.name(db)) {
+            match resolve_module_confident(db, environment, from_list.name(db)) {
                 None => ModuleInconsistency {
                     db,
                     from_list,

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -423,7 +423,6 @@ fn run_test(
         let token_source = CancellationTokenSource::new();
         let result = fix_all_diagnostics(
             db,
-            python_version,
             all_diagnostics,
             Applicability::Unsafe,
             &token_source.token(),

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -27,7 +27,7 @@ use ty_ide::{NavigationTarget, NavigationTargets, hints, signature_help};
 use ty_project::metadata::options::Options;
 use ty_project::watch::{ChangeEvent, ChangedKind, CreatedKind, DeletedKind};
 use ty_project::{CheckMode, ProjectMetadata};
-use ty_project::{Db, ProjectDatabase};
+use ty_project::{Db, ProjectDatabase, SemanticDb as _};
 use ty_python_core::program::{FallibleStrategy, Program};
 use ty_python_semantic::ProgramEnvironment;
 use wasm_bindgen::prelude::*;
@@ -277,13 +277,10 @@ impl Workspace {
 
     #[wasm_bindgen(js_name = "hints")]
     pub fn hints(&self, file_id: &FileHandle) -> Result<Vec<Hint>, Error> {
-        Ok(hints(
-            &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
-        )
-        .into_iter()
-        .map(|hint| Hint::from_ide_hint(&self.db, file_id.file, self.position_encoding, &hint))
-        .collect())
+        Ok(hints(&self.db, self.db.program_file(file_id.file))
+            .into_iter()
+            .map(|hint| Hint::from_ide_hint(&self.db, file_id.file, self.position_encoding, &hint))
+            .collect())
     }
 
     /// Checks all open files
@@ -337,11 +334,9 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(targets) = goto_type_definition(
-            &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
-            offset,
-        ) else {
+        let Some(targets) =
+            goto_type_definition(&self.db, self.db.program_file(file_id.file), offset)
+        else {
             return Ok(Vec::new());
         };
 
@@ -365,11 +360,8 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(targets) = goto_declaration(
-            &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
-            offset,
-        ) else {
+        let Some(targets) = goto_declaration(&self.db, self.db.program_file(file_id.file), offset)
+        else {
             return Ok(Vec::new());
         };
 
@@ -393,11 +385,8 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(targets) = goto_definition(
-            &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
-            offset,
-        ) else {
+        let Some(targets) = goto_definition(&self.db, self.db.program_file(file_id.file), offset)
+        else {
             return Ok(Vec::new());
         };
 
@@ -421,12 +410,9 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(targets) = find_references(
-            &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
-            offset,
-            true,
-        ) else {
+        let Some(targets) =
+            find_references(&self.db, self.db.program_file(file_id.file), offset, true)
+        else {
             return Ok(Vec::new());
         };
 
@@ -465,11 +451,7 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(range) = can_rename(
-            &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
-            offset,
-        ) else {
+        let Some(range) = can_rename(&self.db, self.db.program_file(file_id.file), offset) else {
             return Ok(None);
         };
 
@@ -492,7 +474,7 @@ impl Workspace {
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
-        let program_file = Program::get(&self.db).program_file(&self.db, file_id.file);
+        let program_file = self.db.program_file(file_id.file);
 
         if can_rename(&self.db, program_file, offset).is_none() {
             return Ok(Vec::new());
@@ -523,11 +505,7 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(range_info) = hover(
-            &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
-            offset,
-        ) else {
+        let Some(range_info) = hover(&self.db, self.db.program_file(file_id.file), offset) else {
             return Ok(None);
         };
 
@@ -558,7 +536,7 @@ impl Workspace {
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
         let settings = ty_ide::CompletionSettings::default();
-        let program_file = Program::get(&self.db).program_file(&self.db, file_id.file);
+        let program_file = self.db.program_file(file_id.file);
         let env = ProgramEnvironment::from_file(program_file);
         let completions = ty_ide::completion(
             &self.db,
@@ -608,7 +586,7 @@ impl Workspace {
 
         let result = inlay_hints(
             &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
+            self.db.program_file(file_id.file),
             range.to_text_range(&index, &source, self.position_encoding)?,
             // TODO: Provide a way to configure this
             &InlayHintSettings {
@@ -665,11 +643,8 @@ impl Workspace {
         let index = line_index(&self.db, file_id.file);
         let source = source_text(&self.db, file_id.file);
 
-        let semantic_token = ty_ide::semantic_tokens(
-            &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
-            None,
-        );
+        let semantic_token =
+            ty_ide::semantic_tokens(&self.db, self.db.program_file(file_id.file), None);
 
         let result = semantic_token
             .iter()
@@ -694,7 +669,7 @@ impl Workspace {
 
         let semantic_token = ty_ide::semantic_tokens(
             &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
+            self.db.program_file(file_id.file),
             Some(range.to_text_range(&index, &source, self.position_encoding)?),
         );
 
@@ -731,7 +706,7 @@ impl Workspace {
             actions.extend(
                 ty_ide::code_actions(
                     &self.db,
-                    Program::get(&self.db).program_file(&self.db, file_id.file),
+                    self.db.program_file(file_id.file),
                     range,
                     diagnostic.inner.id().as_str(),
                 )
@@ -766,11 +741,9 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(signature_help_info) = signature_help(
-            &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
-            offset,
-        ) else {
+        let Some(signature_help_info) =
+            signature_help(&self.db, self.db.program_file(file_id.file), offset)
+        else {
             return Ok(None);
         };
 
@@ -817,11 +790,9 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(targets) = document_highlights(
-            &self.db,
-            Program::get(&self.db).program_file(&self.db, file_id.file),
-            offset,
-        ) else {
+        let Some(targets) =
+            document_highlights(&self.db, self.db.program_file(file_id.file), offset)
+        else {
             return Ok(Vec::new());
         };
 

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -279,7 +279,7 @@ impl Workspace {
     pub fn hints(&self, file_id: &FileHandle) -> Result<Vec<Hint>, Error> {
         Ok(hints(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
         )
         .into_iter()
         .map(|hint| Hint::from_ide_hint(&self.db, file_id.file, self.position_encoding, &hint))
@@ -339,7 +339,7 @@ impl Workspace {
 
         let Some(targets) = goto_type_definition(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             offset,
         ) else {
             return Ok(Vec::new());
@@ -367,7 +367,7 @@ impl Workspace {
 
         let Some(targets) = goto_declaration(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             offset,
         ) else {
             return Ok(Vec::new());
@@ -395,7 +395,7 @@ impl Workspace {
 
         let Some(targets) = goto_definition(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             offset,
         ) else {
             return Ok(Vec::new());
@@ -423,7 +423,7 @@ impl Workspace {
 
         let Some(targets) = find_references(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             offset,
             true,
         ) else {
@@ -467,7 +467,7 @@ impl Workspace {
 
         let Some(range) = can_rename(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             offset,
         ) else {
             return Ok(None);
@@ -492,13 +492,13 @@ impl Workspace {
         let index = line_index(&self.db, file_id.file);
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
-        let python_file = PythonFile::new(&self.db, file_id.file, self.db.python_version());
+        let program_file = Program::get(&self.db).program_file(&self.db, file_id.file);
 
-        if can_rename(&self.db, python_file, offset).is_none() {
+        if can_rename(&self.db, program_file, offset).is_none() {
             return Ok(Vec::new());
         }
 
-        let Some(rename_results) = rename(&self.db, python_file, offset, new_name) else {
+        let Some(rename_results) = rename(&self.db, program_file, offset, new_name) else {
             return Ok(Vec::new());
         };
 
@@ -525,7 +525,7 @@ impl Workspace {
 
         let Some(range_info) = hover(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             offset,
         ) else {
             return Ok(None);
@@ -558,13 +558,13 @@ impl Workspace {
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
         let settings = ty_ide::CompletionSettings::default();
-        let python_file = PythonFile::new(&self.db, file_id.file, self.db.python_version());
-        let env = ProgramEnvironment::from_file(python_file);
+        let program_file = Program::get(&self.db).program_file(&self.db, file_id.file);
+        let env = ProgramEnvironment::from_file(program_file);
         let completions = ty_ide::completion(
             &self.db,
             &settings,
             CompletionCapabilities::default(),
-            python_file,
+            program_file,
             offset,
         );
 
@@ -608,7 +608,7 @@ impl Workspace {
 
         let result = inlay_hints(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             range.to_text_range(&index, &source, self.position_encoding)?,
             // TODO: Provide a way to configure this
             &InlayHintSettings {
@@ -667,7 +667,7 @@ impl Workspace {
 
         let semantic_token = ty_ide::semantic_tokens(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             None,
         );
 
@@ -694,7 +694,7 @@ impl Workspace {
 
         let semantic_token = ty_ide::semantic_tokens(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             Some(range.to_text_range(&index, &source, self.position_encoding)?),
         );
 
@@ -731,7 +731,7 @@ impl Workspace {
             actions.extend(
                 ty_ide::code_actions(
                     &self.db,
-                    PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+                    Program::get(&self.db).program_file(&self.db, file_id.file),
                     range,
                     diagnostic.inner.id().as_str(),
                 )
@@ -768,7 +768,7 @@ impl Workspace {
 
         let Some(signature_help_info) = signature_help(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             offset,
         ) else {
             return Ok(None);
@@ -819,7 +819,7 @@ impl Workspace {
 
         let Some(targets) = document_highlights(
             &self.db,
-            PythonFile::new(&self.db, file_id.file, self.db.python_version()),
+            Program::get(&self.db).program_file(&self.db, file_id.file),
             offset,
         ) else {
             return Ok(Vec::new());

--- a/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
+++ b/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
@@ -8,19 +8,17 @@ use std::sync::{Arc, Mutex, OnceLock};
 use libfuzzer_sys::{Corpus, fuzz_target};
 
 use ruff_db::Db as SourceDb;
-use ruff_db::PythonFile;
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{File, Files, system_path_to_file};
 use ruff_db::system::{
     DbWithTestSystem, DbWithWritableSystem as _, System, SystemPathBuf, TestSystem,
 };
 use ruff_db::vendored::VendoredFileSystem;
-use ruff_python_ast::PythonVersion;
 use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
 use ty_module_resolver::{Db as ModuleResolverDb, SearchPathSettings};
-use ty_python_core::Db as _;
 use ty_python_core::platform::PythonPlatform;
 use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
+use ty_python_core::{Db as _, ProgramFile};
 use ty_python_semantic::lint::LintRegistry;
 use ty_python_semantic::types::check_types;
 use ty_python_semantic::{
@@ -57,10 +55,6 @@ impl TestDb {
             analysis_settings: AnalysisSettings::default().into(),
         }
     }
-
-    fn python_version(&self) -> PythonVersion {
-        Program::get(self).python_version(self)
-    }
 }
 
 #[salsa::db]
@@ -89,11 +83,7 @@ impl DbWithTestSystem for TestDb {
 }
 
 #[salsa::db]
-impl ModuleResolverDb for TestDb {
-    fn search_paths(&self) -> &ty_module_resolver::SearchPaths {
-        Program::get(self).search_paths(self)
-    }
-}
+impl ModuleResolverDb for TestDb {}
 
 #[salsa::db]
 impl ty_python_core::Db for TestDb {
@@ -106,11 +96,14 @@ impl ty_python_core::Db for TestDb {
 impl SemanticDb for TestDb {
     fn check_file(&self, file: File) -> Vec<Diagnostic> {
         if self.should_check_file(file) {
-            let python_file = PythonFile::new(self, file, self.python_version());
-            ty_python_semantic::check_file_unwrap(self, python_file)
+            ty_python_semantic::check_file_unwrap(self, self.program_file(file))
         } else {
             Vec::new()
         }
+    }
+
+    fn program_file(&self, file: File) -> ProgramFile<'_> {
+        Program::get(self).program_file(self, file)
     }
 
     fn rule_selection(&self, _file: File) -> &RuleSelection {
@@ -183,7 +176,7 @@ fn do_fuzz(case: &[u8]) -> Corpus {
     for path in &["/src/a.py", "/src/a.pyi"] {
         db.write_file(path, code).unwrap();
         let file = system_path_to_file(&*db, path).unwrap();
-        check_types(&*db, PythonFile::new(&*db, file, db.python_version()));
+        check_types(&*db, db.program_file(file));
         db.memory_file_system().remove_file(path).unwrap();
         file.sync(&mut *db);
     }


### PR DESCRIPTION
## Summary

This PR continues the refactor to make type inference and module resolution support scripts that may have different settings than the main project. 

This PR introduces:

* `ResolverEnvironment(SearchPaths, PythonVersion)`: Uniquely identifies the settings used to resolve a module
* `ResolverFile(File, ResolverEnvironment)`: A file with its `ResolverEnvironment`. Used for desperate module resolution and `module_to_file` (and all other places where the operation doesn't depend on type-inference specific settings).


This PR also `ProgramFile` and updates the `Program` alias to point to `ResolverEnvironment`. These changes are in preparation to reduce the diff of the third PR (we don't want to rewrite all `python_file` call sites to `resolver_file` to then rename them to `program_file`). 

## Memory regression

This PR changes `Program` from `PythonVersion` (u16) to `ResolverEnvironment` (u64). This increases the size of interned structs and interned query arguments that contain `Program`. Memory usage is still lower than before we made db `Program` aware (the base PR reduced memory usage by about 1%).

## Test Plan

Testing: Ran workspace checks, resolver/core/semantic/IDE tests, and repository hooks, including cross-version inference coverage.