### PR TITLE
[ty] Narrow tagged unions using identity comparisons

### DIFF
--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -687,24 +687,21 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
             self.add_narrowing_target(comparator, &mut places);
         }
 
-        let can_narrow_attribute_base =
-            matches!(&*expr_compare.ops, [ast::CmpOp::Eq | ast::CmpOp::NotEq]);
-        let can_narrow_subscript_base = matches!(
+        let can_narrow_tagged_union_base = matches!(
             &*expr_compare.ops,
             [ast::CmpOp::Eq | ast::CmpOp::NotEq | ast::CmpOp::Is | ast::CmpOp::IsNot]
         );
 
-        // For subscript expressions on either side, the subscript base can also be narrowed.
-        // (TypedDict and tuple discriminated union narrowing.)
+        // Tagged-union checks can also narrow the base of a subscript or attribute on either side.
         for expr in std::iter::once(&*expr_compare.left).chain(&expr_compare.comparators) {
-            if can_narrow_subscript_base
+            if can_narrow_tagged_union_base
                 && let ast::Expr::Subscript(subscript) = expr.expression_value()
                 && let Some(place_expr) = PlaceExpr::try_from_expr(&subscript.value)
                 && let Some(place) = self.places.place_id((&place_expr).into())
             {
                 places.insert(place);
             }
-            if can_narrow_attribute_base
+            if can_narrow_tagged_union_base
                 && let ast::Expr::Attribute(attribute) = expr
                 && let Some(place_expr) = PlaceExpr::try_from_expr(&attribute.value)
                 && let Some(place) = self.places.place_id((&place_expr).into())

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1430,6 +1430,28 @@ def overwritten_tagged_union(value: A | B | bool):
             reveal_type(value)  # revealed: Literal[True]
         else:
             reveal_type(value)  # revealed: Literal[False]
+
+def overwritten_tagged_union_attribute(value: A | B | str):
+    if isinstance(value, (A, B)):
+        if (value := value.tag) == "a":
+            reveal_type(value)  # revealed: Literal["a"]
+        else:
+            reveal_type(value)  # revealed: Literal["b"]
+
+def tagged_union_rebound_by_comparator(value: A | B | str):
+    if isinstance(value, (A, B)):
+        if value.tag == (value := "a"):
+            reveal_type(value)  # revealed: Literal["a"]
+        else:
+            reveal_type(value)  # revealed: Literal["a"]
+
+def tagged_union_with_unrelated_assignment(value: A | B):
+    if value.tag == (tag := "a"):
+        reveal_type(value)  # revealed: A
+        reveal_type(tag)  # revealed: Literal["a"]
+    else:
+        reveal_type(value)  # revealed: B
+        reveal_type(tag)  # revealed: Literal["a"]
 ```
 
 ## Union with `Any`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -28,6 +28,126 @@ def _(x: A, y: A | None):
     reveal_type(y)  # revealed: A | None
 ```
 
+## Narrowing tagged unions of nominal classes by attribute identity
+
+```py
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal, NewType
+
+@dataclass
+class Foo:
+    tag: Literal[False]
+
+@dataclass
+class Bar:
+    tag: Literal[True]
+
+@dataclass
+class UnknownTag:
+    tag: bool
+
+def boolean_tags(value: Foo | Bar):
+    if value.tag is True:
+        reveal_type(value)  # revealed: Bar
+    else:
+        reveal_type(value)  # revealed: Foo
+
+    if value.tag is not True:
+        reveal_type(value)  # revealed: Foo
+    else:
+        reveal_type(value)  # revealed: Bar
+
+    if True is value.tag:
+        reveal_type(value)  # revealed: Bar
+    else:
+        reveal_type(value)  # revealed: Foo
+
+    if True is not value.tag:
+        reveal_type(value)  # revealed: Foo
+    else:
+        reveal_type(value)  # revealed: Bar
+
+def ambiguous_tag(value: Foo | Bar | UnknownTag):
+    if value.tag is True:
+        reveal_type(value)  # revealed: Bar | UnknownTag
+    else:
+        reveal_type(value)  # revealed: Foo | UnknownTag
+
+def nonsingleton_tag(value: Foo | Bar, tag: bool):
+    if value.tag is tag:
+        reveal_type(value)  # revealed: Foo | Bar
+    else:
+        reveal_type(value)  # revealed: Foo | Bar
+
+def overwritten_tagged_union(value: Foo | Bar | bool):
+    if isinstance(value, (Foo, Bar)):
+        if (value := value.tag) is True:
+            reveal_type(value)  # revealed: Literal[True]
+        else:
+            reveal_type(value)  # revealed: Literal[False]
+
+def tagged_union_rebound_by_comparator(value: Foo | Bar | bool):
+    if isinstance(value, (Foo, Bar)):
+        if value.tag is (value := True):
+            reveal_type(value)  # revealed: Literal[True]
+        else:
+            reveal_type(value)  # revealed: Literal[True]
+
+def tagged_union_with_unrelated_assignment(value: Foo | Bar):
+    if value.tag is (tag := True):
+        reveal_type(value)  # revealed: Bar
+        reveal_type(tag)  # revealed: Literal[True]
+    else:
+        reveal_type(value)  # revealed: Foo
+        reveal_type(tag)  # revealed: Literal[True]
+
+class MissingTag:
+    tag: None
+
+class PresentTag:
+    tag: str
+
+def optional_tags(value: MissingTag | PresentTag):
+    if value.tag is None:
+        reveal_type(value)  # revealed: MissingTag
+    else:
+        reveal_type(value)  # revealed: PresentTag
+
+class Tag(Enum):
+    FOO = 1
+    BAR = 2
+
+class EnumFoo:
+    tag: Literal[Tag.FOO]
+
+class EnumBar:
+    tag: Literal[Tag.BAR]
+
+def enum_tags(value: EnumFoo | EnumBar):
+    if value.tag is Tag.FOO:
+        reveal_type(value)  # revealed: EnumFoo
+    else:
+        reveal_type(value)  # revealed: EnumBar
+
+BoolTag = NewType("BoolTag", bool)
+
+class NewTypeTag:
+    tag: BoolTag
+
+def newtype_tags(value: Foo | Bar | NewTypeTag):
+    if value.tag is True:
+        reveal_type(value)  # revealed: Bar | NewTypeTag
+    else:
+        reveal_type(value)  # revealed: Foo | NewTypeTag
+
+def nonsingleton_newtype_tag(value: Foo | Bar, tag: BoolTag):
+    if value.tag is tag:
+        reveal_type(value)  # revealed: Foo | Bar
+    else:
+        reveal_type(value)  # revealed: Foo | Bar
+```
+
 ## `is` in chained comparisons
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -75,10 +75,56 @@ impl<'db> Type<'db> {
         )
     }
 
-    /// Return `true` if `self` and `other` cannot describe the same runtime object.
-    pub(crate) fn is_disjoint_from_for_identity(self, db: &'db dyn Db, other: Type<'db>) -> bool {
-        self.identity_comparison_type(db)
-            .is_disjoint_from(db, other.identity_comparison_type(db))
+    /// Return whether values of these types always, never, or possibly identify the same object.
+    pub(crate) fn identity_comparison_truthiness(
+        self,
+        db: &'db dyn Db,
+        other: Type<'db>,
+    ) -> Truthiness {
+        let is_singleton_or_intersection_with_singleton = |ty: Type<'db>| {
+            ty.is_singleton(db)
+                || ty
+                    .resolve_type_alias(db)
+                    .as_intersection()
+                    .is_some_and(|intersection| {
+                        intersection
+                            .positive(db)
+                            .iter()
+                            .any(|ty| ty.is_singleton(db))
+                    })
+        };
+
+        // Two occurrences of the same constrained `TypeVar` require separate handling. Although
+        // different specializations can choose different singleton constraints, every occurrence in
+        // one specialization shares the same selected constraint and therefore the same object.
+        if let Type::TypeVar(left) = self.resolve_type_alias(db)
+            && let Type::TypeVar(right) = other.resolve_type_alias(db)
+            && left.is_same_typevar_as(db, right)
+            && is_singleton_or_intersection_with_singleton(Type::TypeVar(left))
+        {
+            return Truthiness::AlwaysTrue;
+        }
+
+        // `NewType` instances are identity functions at runtime, so distinct static types can still
+        // identify the same object. Compare the types of their possible runtime objects instead.
+        let left_identity = self.identity_comparison_type(db);
+        let right_identity = other.identity_comparison_type(db);
+
+        // Non-disjoint singleton types do not necessarily identify the same object: disjointness can
+        // be inconclusive, for example when aliases between enum members cannot be determined.
+        // Require one singleton type to be a subtype of the other before concluding that they are
+        // definitely identical.
+        if left_identity.is_disjoint_from(db, right_identity) {
+            Truthiness::AlwaysFalse
+        } else if is_singleton_or_intersection_with_singleton(left_identity)
+            && is_singleton_or_intersection_with_singleton(right_identity)
+            && (left_identity.is_subtype_of(db, right_identity)
+                || right_identity.is_subtype_of(db, left_identity))
+        {
+            Truthiness::AlwaysTrue
+        } else {
+            Truthiness::Ambiguous
+        }
     }
 }
 
@@ -222,69 +268,10 @@ pub(super) fn infer_binary_type_comparison<'db>(
 
     let op = match op {
         ast::CmpOp::Is | ast::CmpOp::IsNot => {
-            let is_positive = op == ast::CmpOp::Is;
-
-            let is_singleton_or_intersection_with_singleton = |ty: Type<'db>| {
-                ty.is_singleton(db)
-                    || ty
-                        .resolve_type_alias(db)
-                        .as_intersection()
-                        .is_some_and(|intersection| {
-                            intersection
-                                .positive(db)
-                                .iter()
-                                .any(|ty| ty.is_singleton(db))
-                        })
-            };
-
-            // Keep two occurrences of the same `TypeVar` symbolic. Replacing them with their bounds or
-            // constraints would lose their shared specialization: a `TypeVar` constrained to `None` and
-            // `EllipsisType` chooses the same singleton for both operands, not independent alternatives.
-            if let Type::TypeVar(left) = left.resolve_type_alias(db)
-                && let Type::TypeVar(right) = right.resolve_type_alias(db)
-                && left.is_same_typevar_as(db, right)
-                && is_singleton_or_intersection_with_singleton(Type::TypeVar(left))
-            {
-                return Ok(Type::bool_literal(is_positive));
-            }
-
-            // `NewType` is an identity function at runtime, so distinct NewTypes can still contain the
-            // same object:
-            //
-            // UserId = NewType("UserId", int)
-            // OrderId = NewType("OrderId", int)
-            // UserId(1) is OrderId(1)  # true, even though the two NewTypes are disjoint types!
-            //
-            // Widen both operands to the types of their possible runtime objects before using the
-            // ordinary comparison logic.
-            let left_identity = left.identity_comparison_type(db);
-            let right_identity = right.identity_comparison_type(db);
-
-            // If the identity types are disjoint, the operands cannot refer to the same
-            // runtime object.
-            //
-            // Otherwise, knowing that both types are non-disjoint singletons is still not enough
-            // to establish that they refer to the *same* singleton: `is_disjoint_from` can return
-            // false when disjointness cannot be proven. For example, two enum-literal types will
-            // always both be singletons, but if their aliases are unknown, we cannot tell whether
-            // they denote the same member or distinct members (one might be an alias to the other).
-            //
-            // We therefore require one singleton type to be a subtype of the other before inferring
-            // definite identity. Either direction suffices, which also handles cases like
-            // `None` and `Unknown & None`.
-            let result = if left_identity.is_disjoint_from(db, right_identity) {
-                Type::bool_literal(!is_positive)
-            } else if is_singleton_or_intersection_with_singleton(left_identity)
-                && is_singleton_or_intersection_with_singleton(right_identity)
-                && (left_identity.is_subtype_of(db, right_identity)
-                    || right_identity.is_subtype_of(db, left_identity))
-            {
-                Type::bool_literal(is_positive)
-            } else {
-                KnownClass::Bool.to_instance(db)
-            };
-
-            return Ok(result);
+            let truthiness = left
+                .identity_comparison_truthiness(db, right)
+                .negate_if(op == ast::CmpOp::IsNot);
+            return Ok(Type::from_truthiness(db, truthiness));
         }
         ast::CmpOp::Eq => NonIdentityOperator::Rich(RichCompareOperator::Eq),
         ast::CmpOp::NotEq => NonIdentityOperator::Rich(RichCompareOperator::Ne),

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1044,6 +1044,12 @@ fn necessary_sequence_pattern_type<'db>(
     }
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum NominalAttributeComparison {
+    Equality,
+    Identity,
+}
+
 struct NarrowingConstraintsBuilder<'db, 'ast> {
     db: &'db dyn Db,
     module: &'ast ParsedModuleRef,
@@ -3081,7 +3087,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 let add_runtime_overlap = |builder: UnionBuilder<'db>, element: Type<'db>| {
                     let overlaps_only_at_runtime = |rhs_element| {
                         element.is_disjoint_from(self.db, rhs_element)
-                            && !element.is_disjoint_from_for_identity(self.db, rhs_element)
+                            && element
+                                .identity_comparison_truthiness(self.db, rhs_element)
+                                .may_be_true()
                     };
                     let has_runtime_only_overlap = match rhs_resolved {
                         Type::Union(union) => union
@@ -3274,30 +3282,15 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .as_int_literal()
             && let Ok(index) = i32::try_from(index)
             && let rhs_ty = inference.expression_type(&comparators[0])
-            && let rhs_identity_ty = rhs_ty.identity_comparison_type(self.db)
-            && let rhs_identity_is_singleton = rhs_identity_ty.is_singleton(self.db)
-            && let rhs_is_correlated_singleton = (!rhs_identity_is_singleton
-                && matches!(rhs_ty.resolve_type_alias(self.db), Type::TypeVar(_))
-                && rhs_ty.is_singleton(self.db))
-            && (is_positive_check || rhs_is_correlated_singleton || rhs_identity_is_singleton)
         {
             let filtered = union.filter(self.db, |elem| {
                 elem.tuple_instance_spec(self.db)
                     .and_then(|spec| spec.py_index(self.db, index).ok())
                     .is_none_or(|el_ty| {
-                        if is_positive_check {
-                            // `is X` context: keep tuples where element could be X
-                            !el_ty.is_disjoint_from_for_identity(self.db, rhs_ty)
-                        } else if rhs_is_correlated_singleton {
-                            // Preserve the shared specialization instead of excluding every
-                            // constraint in the projected union.
-                            !el_ty.is_subtype_of(self.db, rhs_ty)
-                        } else {
-                            // `is not X` context: keep tuples where element is not always X
-                            !el_ty
-                                .identity_comparison_type(self.db)
-                                .is_subtype_of(self.db, rhs_identity_ty)
-                        }
+                        el_ty
+                            .identity_comparison_truthiness(self.db, rhs_ty)
+                            .negate_if(!is_positive_check)
+                            .may_be_true()
                     })
             });
             if filtered != Type::Union(union) {
@@ -3401,6 +3394,19 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             if let ast::Expr::Subscript(subscript) = comparators[0].expression_value() {
                 narrow_subscript(subscript, inference.expression_type(&**left));
             }
+        }
+
+        if let [
+            operator @ (ast::CmpOp::Eq | ast::CmpOp::NotEq | ast::CmpOp::Is | ast::CmpOp::IsNot),
+        ] = &**ops
+        {
+            let comparison = if matches!(operator, ast::CmpOp::Is | ast::CmpOp::IsNot) {
+                NominalAttributeComparison::Identity
+            } else {
+                NominalAttributeComparison::Equality
+            };
+            let is_positive_comparison =
+                is_positive == matches!(operator, ast::CmpOp::Eq | ast::CmpOp::Is);
 
             let mut narrow_attribute = |attribute: &ast::ExprAttribute, other_type: Type<'db>| {
                 let value_type = inference.expression_type(&*attribute.value);
@@ -3410,13 +3416,19 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     &attribute.value,
                     attribute.attr.id(),
                     other_type,
-                    is_equality,
+                    comparison,
+                    is_positive_comparison,
                 ) {
                     insert_narrowing_constraint(&mut constraints, place, constraint);
                 }
             };
 
-            if let ast::Expr::Attribute(attribute) = &**left {
+            if let ast::Expr::Attribute(attribute) = &**left
+                && comparators[0].as_named_expr().is_none_or(|named| {
+                    PlaceExpr::try_from_expr(&named.target)
+                        != PlaceExpr::try_from_expr(&attribute.value)
+                })
+            {
                 narrow_attribute(attribute, inference.expression_type(&comparators[0]));
             }
 
@@ -4037,6 +4049,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 &attribute.value,
                 attribute.attr.id(),
                 value_ty,
+                NominalAttributeComparison::Equality,
                 is_positive,
             ) {
                 constraints.insert(place, constraint);
@@ -4294,22 +4307,32 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         attribute_value_expr: &ast::Expr,
         attribute_name: &str,
         rhs_type: Type<'db>,
-        is_equality: bool,
+        comparison: NominalAttributeComparison,
+        is_positive: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         let Type::Union(union) = attribute_value_type.resolve_type_alias(self.db) else {
             return None;
         };
-        if !is_supported_tag_literal(rhs_type) {
+
+        if comparison == NominalAttributeComparison::Equality && !is_supported_tag_literal(rhs_type)
+        {
             return None;
         }
 
         let narrowed = union.filter(self.db, |element| {
             nominal_attribute_type(self.db, *element, attribute_name).is_none_or(|attribute_type| {
-                if is_equality {
-                    !is_supported_tag_literal(attribute_type)
-                        || !attribute_type.is_disjoint_from(self.db, rhs_type)
-                } else {
-                    !attribute_type.is_subtype_of(self.db, rhs_type)
+                match (comparison, is_positive) {
+                    (NominalAttributeComparison::Equality, true) => {
+                        !is_supported_tag_literal(attribute_type)
+                            || !attribute_type.is_disjoint_from(self.db, rhs_type)
+                    }
+                    (NominalAttributeComparison::Equality, false) => {
+                        !attribute_type.is_subtype_of(self.db, rhs_type)
+                    }
+                    (NominalAttributeComparison::Identity, is_positive) => attribute_type
+                        .identity_comparison_truthiness(self.db, rhs_type)
+                        .negate_if(!is_positive)
+                        .may_be_true(),
                 }
             })
         });


### PR DESCRIPTION
(Stacked on top of https://github.com/astral-sh/ruff/pull/27126)

## Summary

- Narrow nominal tagged unions when discriminator attributes are compared with `is` or `is not`, including reversed comparisons, boolean and enum literals, `None`, and `NewType` runtime identities.
- Share identity-comparison truthiness between inference and narrowing while preserving singleton guarantees and constrained-`TypeVar` correlation.
- Avoid stale narrowing when an assignment expression directly rebinds the tagged-union value.

N.B. Codex kept pointing out unrelated walrus narrowing bugs when I asked it to review this branch. But when I challenged it on this it conceded that these were all pre-existing bugs on `main`. I think it only started flagging them because this PR refactors our identity narrowing for tagged unions so that they use a shared helper, so it thought everything to do with identity narrowing for tagged unions was in scope.