### PR TITLE
Offer both `ruff: ignore` and `noqa` actions

### DIFF
--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -25,8 +25,8 @@ use crate::rule_redirects::get_redirect_target;
 use crate::settings::types::PreviewMode;
 use crate::suppression::{self, Suppressions};
 
-/// Generates an array of edits that matches the length of `diagnostics`.
-/// Each potential edit in the array is paired, in order, with the associated diagnostic.
+/// Generates arrays of `ruff: ignore` and `noqa` edits that match the length of `diagnostics`.
+/// Each potential edit is paired, in order, with the associated diagnostic.
 /// Each edit will add a suppression comment to the appropriate line in the source to hide
 /// the diagnostic. These edits may conflict with each other and should not be applied
 /// simultaneously.
@@ -40,23 +40,48 @@ pub fn generate_suppression_edits(
     noqa_line_for: &NoqaMapping,
     line_ending: LineEnding,
     suppressions: &Suppressions,
-    suppression_kind: SuppressionKind,
     preview: PreviewMode,
-) -> Vec<Option<Edit>> {
+) -> (Vec<Option<Edit>>, Vec<Option<Edit>>) {
     let file_directives = FileNoqaDirectives::extract(locator, comment_ranges, external, path);
     let exemption = FileExemption::from(&file_directives);
     let directives = NoqaDirectives::from_commented_ranges(comment_ranges, path, locator);
-    let comments = find_suppression_comments(
+    let ignore_comments = find_suppression_comments(
         diagnostics,
         locator,
         &exemption,
         &directives,
         noqa_line_for,
         suppressions,
-        suppression_kind,
+        SuppressionKind::Ignore,
         preview,
     );
-    build_suppression_edits_by_diagnostic(comments, locator, line_ending, None, suppression_kind)
+    let noqa_comments = find_suppression_comments(
+        diagnostics,
+        locator,
+        &exemption,
+        &directives,
+        noqa_line_for,
+        suppressions,
+        SuppressionKind::Noqa,
+        preview,
+    );
+
+    (
+        build_suppression_edits_by_diagnostic(
+            ignore_comments,
+            locator,
+            line_ending,
+            None,
+            SuppressionKind::Ignore,
+        ),
+        build_suppression_edits_by_diagnostic(
+            noqa_comments,
+            locator,
+            line_ending,
+            None,
+            SuppressionKind::Noqa,
+        ),
+    )
 }
 
 /// A directive to ignore a set of rules either for a given line of Python source code or an entire file (e.g.,
@@ -3460,7 +3485,7 @@ print(
             .into_diagnostic(TextRange::new(12.into(), 79.into()), &source_file)];
         let comment_ranges = CommentRanges::default();
         let suppressions = Suppressions::default();
-        let edits = generate_suppression_edits(
+        let (_, edits) = generate_suppression_edits(
             path,
             &messages,
             &Locator::new(source),
@@ -3469,7 +3494,6 @@ print(
             &noqa_line_for,
             LineEnding::Lf,
             &suppressions,
-            SuppressionKind::Noqa,
             PreviewMode::Disabled,
         );
         assert_eq!(
@@ -3495,7 +3519,7 @@ bar =
         let noqa_line_for = NoqaMapping::default();
         let comment_ranges = CommentRanges::default();
         let suppressions = Suppressions::default();
-        let edits = generate_suppression_edits(
+        let (_, edits) = generate_suppression_edits(
             path,
             &messages,
             &Locator::new(source),
@@ -3504,7 +3528,6 @@ bar =
             &noqa_line_for,
             LineEnding::Lf,
             &suppressions,
-            SuppressionKind::Noqa,
             PreviewMode::Disabled,
         );
         assert_eq!(

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -45,12 +45,14 @@ pub(crate) struct AssociatedDiagnosticData {
     pub(crate) edits: Vec<lsp_types::TextEdit>,
     /// The identifier displayed for the diagnostic.
     pub(crate) code: String,
-    /// Possible edit to add a suppression comment which will disable this diagnostic.
+    /// Possible edit to add a `ruff:ignore` comment which will disable this diagnostic.
+    pub(crate) ignore_edit: Option<lsp_types::TextEdit>,
+    /// Possible edit to add a `noqa` comment which will disable this diagnostic.
     pub(crate) noqa_edit: Option<lsp_types::TextEdit>,
 }
 
 /// Describes a fix for `fixed_diagnostic` that may have quick fix
-/// edits available, `noqa` comment edits, or both.
+/// edits available, suppression comment edits, or both.
 #[derive(Clone, Debug)]
 pub(crate) struct DiagnosticFix {
     /// The original diagnostic to be fixed
@@ -62,7 +64,9 @@ pub(crate) struct DiagnosticFix {
     /// Edits to fix the diagnostic. If this is empty, a fix
     /// does not exist.
     pub(crate) edits: Vec<lsp_types::TextEdit>,
-    /// Possible edit to add a suppression comment which will disable this diagnostic.
+    /// Possible edit to add a `ruff:ignore` comment which will disable this diagnostic.
+    pub(crate) ignore_edit: Option<lsp_types::TextEdit>,
+    /// Possible edit to add a `noqa` comment which will disable this diagnostic.
     pub(crate) noqa_edit: Option<lsp_types::TextEdit>,
 }
 
@@ -101,7 +105,8 @@ pub(crate) fn check(
 
     let CheckResult {
         diagnostics,
-        suppression_edits,
+        ignore_edits,
+        noqa_edits,
         document,
     } = result;
     let document_uri = query.make_key().into_uri();
@@ -131,13 +136,15 @@ pub(crate) fn check(
             .or_default();
     }
 
-    let mut suppression_edits = suppression_edits.into_iter();
+    let mut ignore_edits = ignore_edits.into_iter();
+    let mut noqa_edits = noqa_edits.into_iter();
     let lsp_diagnostics = diagnostics.into_iter().filter_map(|message| {
-        let suppression_edit = suppression_edits.next().flatten();
+        let ignore_edit = ignore_edits.next().flatten();
+        let noqa_edit = noqa_edits.next().flatten();
         if message.is_invalid_syntax() && !show_syntax_errors {
             None
         } else {
-            Some(to_lsp_diagnostic(&message, suppression_edit, &context))
+            Some(to_lsp_diagnostic(&message, ignore_edit, noqa_edit, &context))
         }
     });
 
@@ -225,7 +232,7 @@ fn check_python(
         &suppressions,
     );
 
-    let suppression_edits = generate_suppression_edits(
+    let ignore_edits = generate_suppression_edits(
         &document_path,
         &diagnostics,
         &locator,
@@ -234,20 +241,27 @@ fn check_python(
         &directives.noqa_line_for,
         stylist.line_ending(),
         &suppressions,
-        if is_human_readable_names_enabled(settings.linter.preview)
-            && !settings.output_prefer_rule_codes
-        {
-            SuppressionKind::Ignore
-        } else {
-            SuppressionKind::Noqa
-        },
+        SuppressionKind::Ignore,
+        settings.linter.preview,
+    );
+    let noqa_edits = generate_suppression_edits(
+        &document_path,
+        &diagnostics,
+        &locator,
+        indexer.comment_ranges(),
+        &settings.linter.external,
+        &directives.noqa_line_for,
+        stylist.line_ending(),
+        &suppressions,
+        SuppressionKind::Noqa,
         settings.linter.preview,
     );
     let index = locator.to_index().clone();
 
     CheckResult {
         diagnostics,
-        suppression_edits,
+        ignore_edits,
+        noqa_edits,
         document: CheckedDocument::Python {
             source: source_kind,
             index,
@@ -279,7 +293,8 @@ fn check_toml<'a>(
 
     CheckResult {
         diagnostics,
-        suppression_edits: Vec::new(),
+        ignore_edits: Vec::new(),
+        noqa_edits: Vec::new(),
         document: CheckedDocument::Toml(document),
     }
 }
@@ -304,6 +319,7 @@ pub(crate) fn fixes_for_diagnostics(
                 fixed_diagnostic,
                 code: associated_data.code,
                 title: associated_data.title,
+                ignore_edit: associated_data.ignore_edit,
                 noqa_edit: associated_data.noqa_edit,
                 edits: associated_data.edits,
             }))
@@ -345,7 +361,8 @@ impl CheckedDocument<'_> {
 
 struct CheckResult<'a> {
     diagnostics: Vec<Diagnostic>,
-    suppression_edits: Vec<Option<Edit>>,
+    ignore_edits: Vec<Option<Edit>>,
+    noqa_edits: Vec<Option<Edit>>,
     document: CheckedDocument<'a>,
 }
 
@@ -365,6 +382,7 @@ struct LspDiagnosticContext<'a> {
 /// If the source kind is a text document, the cell index will always be `0`.
 fn to_lsp_diagnostic(
     diagnostic: &Diagnostic,
+    ignore_edit: Option<Edit>,
     noqa_edit: Option<Edit>,
     context: &LspDiagnosticContext,
 ) -> (usize, lsp_types::Diagnostic) {
@@ -396,7 +414,7 @@ fn to_lsp_diagnostic(
         )
     };
 
-    let data = (fix.is_some() || noqa_edit.is_some())
+    let data = (fix.is_some() || ignore_edit.is_some() || noqa_edit.is_some())
         .then(|| {
             let edits = fix
                 .into_iter()
@@ -406,13 +424,14 @@ fn to_lsp_diagnostic(
                     new_text: edit.content().unwrap_or_default().to_string(),
                 })
                 .collect();
-            let noqa_edit = noqa_edit.map(|noqa_edit| lsp_types::TextEdit {
-                range: diagnostic_edit_range(noqa_edit.range(), context),
-                new_text: noqa_edit.into_content().unwrap_or_default().into_string(),
-            });
+            let suppression_edit = |edit: Edit| lsp_types::TextEdit {
+                range: diagnostic_edit_range(edit.range(), context),
+                new_text: edit.into_content().unwrap_or_default().into_string(),
+            };
             serde_json::to_value(AssociatedDiagnosticData {
                 title: suggestion.unwrap_or(name).to_string(),
-                noqa_edit,
+                ignore_edit: ignore_edit.map(suppression_edit),
+                noqa_edit: noqa_edit.map(suppression_edit),
                 edits,
                 code: code.clone(),
             })
@@ -666,7 +685,7 @@ mod tests {
             supports_related_information: true,
             settings: &settings,
         };
-        let (_, lsp_diagnostic) = to_lsp_diagnostic(&diagnostic, None, &context);
+        let (_, lsp_diagnostic) = to_lsp_diagnostic(&diagnostic, None, None, &context);
 
         assert_eq!(
             lsp_diagnostic.message,

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -17,7 +17,7 @@ use crate::{
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic};
 use ruff_diagnostics::{Applicability, Edit, Fix};
 use ruff_linter::{
-    Locator, SuppressionKind,
+    Locator,
     directives::{Flags, extract_directives},
     generate_suppression_edits,
     linter::{check_path, parse_unchecked_source},
@@ -144,7 +144,12 @@ pub(crate) fn check(
         if message.is_invalid_syntax() && !show_syntax_errors {
             None
         } else {
-            Some(to_lsp_diagnostic(&message, ignore_edit, noqa_edit, &context))
+            Some(to_lsp_diagnostic(
+                &message,
+                ignore_edit,
+                noqa_edit,
+                &context,
+            ))
         }
     });
 
@@ -232,7 +237,7 @@ fn check_python(
         &suppressions,
     );
 
-    let ignore_edits = generate_suppression_edits(
+    let (ignore_edits, noqa_edits) = generate_suppression_edits(
         &document_path,
         &diagnostics,
         &locator,
@@ -241,19 +246,6 @@ fn check_python(
         &directives.noqa_line_for,
         stylist.line_ending(),
         &suppressions,
-        SuppressionKind::Ignore,
-        settings.linter.preview,
-    );
-    let noqa_edits = generate_suppression_edits(
-        &document_path,
-        &diagnostics,
-        &locator,
-        indexer.comment_ranges(),
-        &settings.linter.external,
-        &directives.noqa_line_for,
-        stylist.line_ending(),
-        &suppressions,
-        SuppressionKind::Noqa,
         settings.linter.preview,
     );
     let index = locator.to_index().clone();

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -75,7 +75,7 @@ impl super::BackgroundDocumentRequestHandler for CodeActions {
             && snapshot.client_settings().noqa_comments()
             && supported_code_actions.contains(&SupportedCodeAction::QuickFix)
         {
-            response.extend(noqa_comments(&snapshot, &fixes));
+            response.extend(suppression_comments(&snapshot, &fixes));
         }
 
         if snapshot.client_settings().fix_all() {
@@ -158,11 +158,20 @@ fn quick_fix(
         .collect()
 }
 
-fn noqa_comments(snapshot: &DocumentSnapshot, fixes: &[DiagnosticFix]) -> Vec<CodeActionResponse> {
+fn suppression_comments(
+    snapshot: &DocumentSnapshot,
+    fixes: &[DiagnosticFix],
+) -> Vec<CodeActionResponse> {
     fixes
         .iter()
-        .filter_map(|fix| {
-            let edit = fix.noqa_edit.clone()?;
+        .flat_map(|fix| {
+            [
+                ("ruff:ignore", fix, fix.ignore_edit.as_ref()),
+                ("noqa", fix, fix.noqa_edit.as_ref()),
+            ]
+        })
+        .filter_map(|(kind, fix, edit)| {
+            let edit = edit?.clone();
 
             let mut tracker = WorkspaceEditTracker::new(snapshot.resolved_client_capabilities());
 
@@ -175,7 +184,10 @@ fn noqa_comments(snapshot: &DocumentSnapshot, fixes: &[DiagnosticFix]) -> Vec<Co
                 .ok()?;
 
             Some(CodeActionResponse::CodeAction(types::CodeAction {
-                title: format!("{DIAGNOSTIC_NAME} ({}): Disable for this line", fix.code),
+                title: format!(
+                    "{DIAGNOSTIC_NAME} ({}): Disable for this line ({kind})",
+                    fix.code
+                ),
                 kind: Some(types::CodeActionKind::QuickFix),
                 edit: Some(tracker.into_workspace_edit()),
                 diagnostics: Some(vec![fix.fixed_diagnostic.clone()]),

--- a/crates/ruff_server/tests/e2e/code_action.rs
+++ b/crates/ruff_server/tests/e2e/code_action.rs
@@ -225,7 +225,8 @@ preview = true
         .collect();
 
     assert!(titles.contains(&"Ruff (unused-import): Remove unused import: `os`"));
-    assert!(titles.contains(&"Ruff (unused-import): Disable for this line"));
+    assert!(titles.contains(&"Ruff (unused-import): Disable for this line (ruff:ignore)"));
+    assert!(titles.contains(&"Ruff (unused-import): Disable for this line (noqa)"));
 
     Ok(())
 }

--- a/crates/ruff_server/tests/e2e/diagnostics.rs
+++ b/crates/ruff_server/tests/e2e/diagnostics.rs
@@ -57,8 +57,21 @@ fn uses_human_readable_names_in_preview() -> Result<()> {
                 }
               }
             ],
-            "noqa_edit": {
+            "ignore_edit": {
               "newText": "  # ruff: ignore[unused-import]\n",
+              "range": {
+                "end": {
+                  "character": 0,
+                  "line": 1
+                },
+                "start": {
+                  "character": 9,
+                  "line": 0
+                }
+              }
+            },
+            "noqa_edit": {
+              "newText": "  # noqa: F401\n",
               "range": {
                 "end": {
                   "character": 0,
@@ -138,6 +151,7 @@ extend-select = ["F401"]
                 }
               }
             ],
+            "ignore_edit": null,
             "noqa_edit": null,
             "title": "Replace rule code with `unused-import`"
           }

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
@@ -40,6 +40,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[I002]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: I002\n",
           "range": {
@@ -78,6 +91,19 @@ expression: diagnostics
       "data": {
         "code": "RUF900",
         "edits": [],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF900]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF900\n",
           "range": {
@@ -130,6 +156,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF901]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF901\n",
           "range": {
@@ -182,6 +221,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF902]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF902\n",
           "range": {
@@ -220,6 +272,19 @@ expression: diagnostics
       "data": {
         "code": "RUF903",
         "edits": [],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF903]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF903\n",
           "range": {
@@ -258,6 +323,19 @@ expression: diagnostics
       "data": {
         "code": "RUF950",
         "edits": [],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF950]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF950\n",
           "range": {
@@ -313,6 +391,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[I001]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 23,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: I001\n",
           "range": {
@@ -367,6 +458,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[E703]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 6
+            },
+            "start": {
+              "character": 30,
+              "line": 5
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -423,6 +527,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[E703]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 4
+            },
+            "start": {
+              "character": 23,
+              "line": 3
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -475,6 +592,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[E703]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 9
+            },
+            "start": {
+              "character": 23,
+              "line": 8
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -527,6 +657,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[F541]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 8
+            },
+            "start": {
+              "character": 25,
+              "line": 7
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: F541\n",
           "range": {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
@@ -40,6 +40,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[I002]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: I002\n",
           "range": {
@@ -78,6 +91,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
       "data": {
         "code": "RUF900",
         "edits": [],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF900]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF900\n",
           "range": {
@@ -130,6 +156,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF901]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF901\n",
           "range": {
@@ -182,6 +221,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF902]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF902\n",
           "range": {
@@ -220,6 +272,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
       "data": {
         "code": "RUF903",
         "edits": [],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF903]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF903\n",
           "range": {
@@ -258,6 +323,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
       "data": {
         "code": "RUF950",
         "edits": [],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF950]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF950\n",
           "range": {
@@ -313,6 +391,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[I001]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 23,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: I001\n",
           "range": {
@@ -367,6 +458,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[E703]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 6
+            },
+            "start": {
+              "character": 30,
+              "line": 5
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -423,6 +527,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[E703]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 4
+            },
+            "start": {
+              "character": 23,
+              "line": 3
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -475,6 +592,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[E703]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 9
+            },
+            "start": {
+              "character": 23,
+              "line": 8
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -527,6 +657,19 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[F541]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 8
+            },
+            "start": {
+              "character": 25,
+              "line": 7
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: F541\n",
           "range": {

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
@@ -40,6 +40,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[I002]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: I002\n",
           "range": {
@@ -78,6 +91,19 @@ expression: diagnostics
       "data": {
         "code": "RUF900",
         "edits": [],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF900]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF900\n",
           "range": {
@@ -130,6 +156,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF901]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF901\n",
           "range": {
@@ -182,6 +221,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF902]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF902\n",
           "range": {
@@ -220,6 +272,19 @@ expression: diagnostics
       "data": {
         "code": "RUF903",
         "edits": [],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF903]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF903\n",
           "range": {
@@ -258,6 +323,19 @@ expression: diagnostics
       "data": {
         "code": "RUF950",
         "edits": [],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[RUF950]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 71,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: RUF950\n",
           "range": {
@@ -313,6 +391,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[I001]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 1
+            },
+            "start": {
+              "character": 23,
+              "line": 0
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: I001\n",
           "range": {
@@ -367,6 +458,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[E703]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 6
+            },
+            "start": {
+              "character": 30,
+              "line": 5
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -423,6 +527,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[E703]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 4
+            },
+            "start": {
+              "character": 23,
+              "line": 3
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -475,6 +592,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[E703]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 9
+            },
+            "start": {
+              "character": 23,
+              "line": 8
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: E703\n",
           "range": {
@@ -527,6 +657,19 @@ expression: diagnostics
             }
           }
         ],
+        "ignore_edit": {
+          "newText": "  # ruff: ignore[F541]\n",
+          "range": {
+            "end": {
+              "character": 0,
+              "line": 8
+            },
+            "start": {
+              "character": 25,
+              "line": 7
+            }
+          }
+        },
         "noqa_edit": {
           "newText": "  # noqa: F541\n",
           "range": {

--- a/crates/ruff_server/tests/e2e/workspace.rs
+++ b/crates/ruff_server/tests/e2e/workspace.rs
@@ -81,6 +81,19 @@ ignore = ["F401"]
                 }
               }
             ],
+            "ignore_edit": {
+              "newText": "  # ruff: ignore[F401]\n",
+              "range": {
+                "end": {
+                  "character": 0,
+                  "line": 1
+                },
+                "start": {
+                  "character": 9,
+                  "line": 0
+                }
+              }
+            },
             "noqa_edit": {
               "newText": "  # noqa: F401\n",
               "range": {


### PR DESCRIPTION
Summary
--

This follows up on [#27125 (review)](https://github.com/astral-sh/ruff/pull/27125#pullrequestreview-4764316522) to offer both comment types as code actions in the LSP.

Test Plan
--

Existing tests with updated snapshots/assertions