### PR TITLE
[`ruff`] Add subdiagnostics explaining missing fixes (`RUF105`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/ruff/noqa-comments.md
+++ b/crates/ruff_linter/resources/mdtest/ruff/noqa-comments.md
@@ -335,7 +335,7 @@ error[RUF105]: `ruff: noqa` comment used instead of `ruff: file-ignore`
 2 | # ruff: noqa
   | ^^^^^^^^^^^^
 help: Use `ruff: file-ignore` instead
-info: Automatic fix is unavailable because unused codes are present. Consider enabling `RUF100` to remove them.
+info: Automatic fix is unavailable because `ruff: file-ignore` requires explicit rule codes.
 ```
 
 ## Inline self-suppression

--- a/crates/ruff_linter/resources/mdtest/ruff/noqa-comments.md
+++ b/crates/ruff_linter/resources/mdtest/ruff/noqa-comments.md
@@ -175,6 +175,7 @@ error[RUF105]: `noqa` comment used instead of `ruff: ignore`
 4 | import math  # noqa: F401, EXT001
   |              ^^^^^^^^^^^^^^^^^^^^
 help: Use `ruff: ignore` instead
+info: Automatic fix is unavailable because external codes are present.
 ```
 
 ### Any unmatched code disables the fix
@@ -196,6 +197,7 @@ error[RUF105]: `ruff: noqa` comment used instead of `ruff: file-ignore`
 2 | # ruff: noqa: F401, F402
   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: Use `ruff: file-ignore` instead
+info: Automatic fix is unavailable because unused codes are present. Consider enabling `RUF100` to remove them.
 ```
 
 ### Flake8 comments are ignored
@@ -244,6 +246,7 @@ error[RUF105]: `noqa` comment used instead of `ruff: ignore`
 2 | import os  # noqa: F401, F402
   |            ^^^^^^^^^^^^^^^^^^
 help: Use `ruff: ignore` instead
+info: Automatic fix is unavailable because unused codes are present. Consider enabling `RUF100` to remove them.
 ```
 
 ### Nested pragma comment before the directive
@@ -332,6 +335,7 @@ error[RUF105]: `ruff: noqa` comment used instead of `ruff: file-ignore`
 2 | # ruff: noqa
   | ^^^^^^^^^^^^
 help: Use `ruff: file-ignore` instead
+info: Automatic fix is unavailable because unused codes are present. Consider enabling `RUF100` to remove them.
 ```
 
 ## Inline self-suppression

--- a/crates/ruff_linter/src/rules/ruff/rules/noqa_comments.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/noqa_comments.rs
@@ -132,6 +132,7 @@ pub(crate) fn noqa_comments(
 
     // If some codes are external, return without a fix.
     if has_external_codes {
+        diagnostic.info("Automatic fix is unavailable because external codes are present.");
         return;
     }
 
@@ -145,6 +146,10 @@ pub(crate) fn noqa_comments(
     //
     // by converting it to a valid `ruff: ignore` comment.
     if has_unused_codes {
+        diagnostic.info(
+            "Automatic fix is unavailable because unused codes are present. \
+			 Consider enabling `RUF100` to remove them.",
+        );
         return;
     }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/noqa_comments.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/noqa_comments.rs
@@ -146,10 +146,17 @@ pub(crate) fn noqa_comments(
     //
     // by converting it to a valid `ruff: ignore` comment.
     if has_unused_codes {
-        diagnostic.info(
-            "Automatic fix is unavailable because unused codes are present. \
+        if file_level && matches!(directive, Directive::All(_)) {
+            diagnostic.info(
+                "Automatic fix is unavailable because `ruff: file-ignore` \
+			     requires explicit rule codes.",
+            );
+        } else {
+            diagnostic.info(
+                "Automatic fix is unavailable because unused codes are present. \
 			 Consider enabling `RUF100` to remove them.",
-        );
+            );
+        }
         return;
     }
 


### PR DESCRIPTION
Summary
--

After seeing #27107, I remembered #22565 and thought it might also be worth attaching `info`
subdiagnostics here to explain why the fixes are unavailable. With a little more work we could
include exactly which codes are external or unused, but this seems like enough to nudge users in the
right direction.

I don't feel too strongly about this, just a small fix in case others also think it could help.

Test Plan
--

Updated existing snapshots
