### PR TITLE
[ty] Use Fx hashing for docstring parameter documentation

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -9,11 +9,10 @@
 mod document;
 mod markdown;
 
-use indexmap::IndexMap;
 use ruff_python_trivia::{PythonWhitespace, expand_tabs, leading_indentation};
 use ruff_source_file::UniversalNewlines;
 
-use crate::MarkupKind;
+use crate::{FxIndexMap, MarkupKind};
 
 /// A docstring which hasn't yet been interpreted or rendered
 ///
@@ -48,7 +47,7 @@ impl Docstring {
 
     /// Extract parameter documentation from popular docstring formats.
     /// Returns a map of parameter names to their documentation.
-    pub fn parameter_documentation(&self) -> IndexMap<String, String> {
+    pub fn parameter_documentation(&self) -> FxIndexMap<String, String> {
         let normalized_source = documentation_trim(&self.0);
         document::parameter_documentation(&normalized_source)
     }

--- a/crates/ty_ide/src/docstring/document.rs
+++ b/crates/ty_ide/src/docstring/document.rs
@@ -1,8 +1,8 @@
-use indexmap::IndexMap;
 use ruff_text_size::{TextRange, TextSize};
 use strum_macros::EnumIter;
 
 use self::syntax::{indentation, starts_with_markdown_list_item};
+use crate::FxIndexMap;
 
 pub(super) mod google;
 mod numpy;
@@ -14,7 +14,7 @@ pub(in crate::docstring) mod syntax;
 ///
 /// `normalized_source` must have already undergone PEP-257 trimming and universal newline
 /// normalization.
-pub(super) fn parameter_documentation(normalized_source: &str) -> IndexMap<String, String> {
+pub(super) fn parameter_documentation(normalized_source: &str) -> FxIndexMap<String, String> {
     let mut parameters = google::parameter_documentation(normalized_source);
     parameters.extend(numpy::parameter_documentation(normalized_source));
     parameters.extend(rst::parameter_documentation(normalized_source));

--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -30,7 +30,6 @@
 //!     retries: Number of retries.
 //! ```
 
-use indexmap::IndexMap;
 use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_python_trivia::Cursor;
 use ruff_text_size::{TextRange, TextSize};
@@ -41,12 +40,13 @@ use super::syntax::{
     parsed_lines, split_once_at_top_level_colon, split_trailing_parenthetical,
 };
 use super::{DescriptionBuilder, HeaderKind, SectionKind};
+use crate::FxIndexMap;
 
 /// Returns parameter documentation from recognized Google-style parameter sections.
 ///
 /// `normalized_source` must have already undergone PEP-257 trimming and universal newline
 /// normalization.
-pub(super) fn parameter_documentation(normalized_source: &str) -> IndexMap<String, String> {
+pub(super) fn parameter_documentation(normalized_source: &str) -> FxIndexMap<String, String> {
     let mut parameters = Parameters::default();
     for section in sections(normalized_source) {
         let Section {
@@ -184,7 +184,7 @@ impl<'a> ParameterDisplayName<'a> {
 }
 
 #[derive(Default)]
-struct Parameters(IndexMap<String, String>);
+struct Parameters(FxIndexMap<String, String>);
 
 impl Parameters {
     fn extend_fragments(&mut self, fragments: Vec<BodyFragment>) {
@@ -209,7 +209,7 @@ impl Parameters {
         }
     }
 
-    fn into_inner(self) -> IndexMap<String, String> {
+    fn into_inner(self) -> FxIndexMap<String, String> {
         self.0
     }
 }

--- a/crates/ty_ide/src/docstring/document/numpy.rs
+++ b/crates/ty_ide/src/docstring/document/numpy.rs
@@ -24,7 +24,6 @@
 //!     The arithmetic mean.
 //! ```
 
-use indexmap::IndexMap;
 use ruff_text_size::{TextRange, TextSize};
 
 use super::preformatted::{PreformattedBlockScanner, starts_preformatted_block};
@@ -33,12 +32,13 @@ use super::syntax::{
     split_once_at_top_level_colon, starts_container_block,
 };
 use super::{DescriptionBuilder, HeaderKind, SectionKind};
+use crate::FxIndexMap;
 
 /// Returns parameter documentation from recognized NumPy-style parameter sections.
 ///
 /// `normalized_source` must have already undergone PEP-257 trimming and universal newline
 /// normalization.
-pub(super) fn parameter_documentation(normalized_source: &str) -> IndexMap<String, String> {
+pub(super) fn parameter_documentation(normalized_source: &str) -> FxIndexMap<String, String> {
     let mut parameters = Parameters::default();
 
     for section in sections(normalized_source) {
@@ -56,7 +56,7 @@ pub(super) fn parameter_documentation(normalized_source: &str) -> IndexMap<Strin
 }
 
 #[derive(Default)]
-struct Parameters(IndexMap<String, String>);
+struct Parameters(FxIndexMap<String, String>);
 
 impl Parameters {
     fn extend_fragments(&mut self, fragments: Vec<BodyFragment>) {
@@ -85,7 +85,7 @@ impl Parameters {
         }
     }
 
-    fn into_inner(self) -> IndexMap<String, String> {
+    fn into_inner(self) -> FxIndexMap<String, String> {
         self.0
     }
 }

--- a/crates/ty_ide/src/docstring/document/rst.rs
+++ b/crates/ty_ide/src/docstring/document/rst.rs
@@ -1,12 +1,12 @@
 use std::iter::{Enumerate, Peekable};
 
 use compact_str::{CompactString, ToCompactString};
-use indexmap::IndexMap;
 use ruff_python_trivia::leading_indentation;
 use ruff_source_file::{Line as SourceLine, UniversalNewlineIterator, UniversalNewlines};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use super::preformatted::PreformattedBlockScanner;
+use crate::FxIndexMap;
 
 /// Parses all reST field lists in a docstring.
 fn field_lists(raw: &str) -> Vec<FieldList> {
@@ -35,8 +35,8 @@ pub(in crate::docstring) fn top_level_field_lists(
 ///
 /// `normalized_source` must have already undergone PEP-257 trimming and universal newline
 /// normalization.
-pub(super) fn parameter_documentation(normalized_source: &str) -> IndexMap<String, String> {
-    let mut parameters = IndexMap::new();
+pub(super) fn parameter_documentation(normalized_source: &str) -> FxIndexMap<String, String> {
+    let mut parameters = FxIndexMap::default();
 
     for field_list in top_level_field_lists(normalized_source) {
         for field in field_list.fields {

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -69,10 +69,12 @@ use ruff_db::{
     vendored::VendoredPath,
 };
 use ruff_text_size::{Ranged, TextRange};
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxBuildHasher, FxHashSet};
 use std::ops::{Deref, DerefMut};
 use ty_project::Db;
 use ty_python_semantic::types::{Type, TypeDefinition};
+
+type FxIndexMap<K, V> = indexmap::IndexMap<K, V, FxBuildHasher>;
 
 /// Information associated with a text range.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/crates/ty_ide/src/signature_help.rs
+++ b/crates/ty_ide/src/signature_help.rs
@@ -7,6 +7,7 @@
 //! and overloads.
 
 use crate::Db;
+use crate::FxIndexMap;
 use crate::docstring::Docstring;
 use crate::goto::docstring_for_call_definition;
 use ruff_db::files::File;
@@ -236,7 +237,7 @@ fn create_parameters<'db>(
     let param_docs = if let Some(docstring) = docstring {
         docstring.parameter_documentation()
     } else {
-        indexmap::IndexMap::new()
+        FxIndexMap::default()
     };
 
     parameters


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Following up on [this bit of review feedback](https://github.com/astral-sh/ruff/pull/25924#discussion_r3636552035), this switches the hash map implementation that we use for parameter documentation in hover and signature help responses from `IndexMap` to `FxIndexMap`. This does not change the behaviour of those language server responses.

## Test Plan

This is a refactor that relies on existing test coverage.
<!-- How was it tested? -->
