### PR TITLE
[ty] Don't consider known-instance types, generic aliases or non-singleton special-form types to be single-valued

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -86,27 +86,6 @@ def non_empty_first(flag: bool) -> None:
         reveal_type(value)  # revealed: range
 ```
 
-Empty ranges all compare equal, but non-empty ranges with the same type refinement may contain
-different values:
-
-```py
-empty_left = range(0)
-empty_right = range(1, 1)
-
-if empty_left == empty_right:
-    reveal_type(empty_left)  # revealed: range
-else:
-    reveal_type(empty_left)  # revealed: Never
-
-non_empty_left = range(1)
-non_empty_right = range(2)
-
-if non_empty_left == non_empty_right:
-    reveal_type(non_empty_left)  # revealed: range
-else:
-    reveal_type(non_empty_left)  # revealed: range
-```
-
 ## With shadowed `range`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -1206,6 +1206,101 @@ def narrow_different_equality_implementations(value: FinalObject | FinalInt, oth
         reveal_type(value)  # revealed: FinalObject
 ```
 
+## Sentinels
+
+Sentinels always compare equal to themselves, since they are singletons:
+
+```py
+from typing_extensions import Sentinel
+
+MISSING = Sentinel("MISSING")
+
+reveal_type(MISSING == MISSING)  # revealed: Literal[True]
+```
+
+## Known typing-object equality behavior
+
+Certain typing APIs are heavily special-cased by ty, which makes it tempting to special case
+equality inference for these symbols. This, however, is error-prone: for example, ty currently
+infers the same type for `typing_extensions.Literal` as it does for `typing.Literal`, even though
+these may not be the same runtime object and may not compare equal. There's also no known use case
+for precisely inferring equality comparisons between these objects.
+
+For most special-cased typing APIs, therefore, we simply fallback to the nominal instance that the
+typing symbol is known to be an instance of:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from functools import partial
+from typing import Literal, NamedTuple
+from typing_extensions import NamedTuple as ExtensionsNamedTuple
+from ty_extensions._internal import generic_context
+
+type Alias = int
+
+class GenericClass[T]: ...
+
+reveal_type(Alias == Alias)  # revealed: bool
+reveal_type(generic_context(GenericClass) == generic_context(GenericClass))  # revealed: bool
+reveal_type((int | str) == (int | str))  # revealed: bool
+reveal_type(Literal[1] == Literal[1])  # revealed: bool
+
+def target(value: int) -> int:
+    return value
+
+# The bound `__call__` methods belong to distinct `partial` objects.
+reveal_type(partial(target, 1).__call__ == partial(target, 1).__call__)  # revealed: bool
+
+reveal_type(NamedTuple == ExtensionsNamedTuple)  # revealed: bool
+reveal_type(NamedTuple != ExtensionsNamedTuple)  # revealed: bool
+```
+
+Repeated construction of `dataclasses.Field` and `typing_extensions.deprecated` produces distinct
+objects that will compare unequal, even when their inferred payloads are identical:
+
+```py
+from dataclasses import dataclass, field
+from typing_extensions import deprecated
+
+@dataclass
+class FieldComparisons:
+    # False at runtime!
+    equals: bool = reveal_type(field(default=1) == field(default=1))  # revealed: bool
+    # True at runtime!
+    not_equals: bool = reveal_type(field(default=1) != field(default=1))  # revealed: bool
+
+# False at runtime!
+reveal_type(deprecated("gone") == deprecated("gone"))  # revealed: bool
+# True at runtime!
+reveal_type(deprecated("gone") != deprecated("gone"))  # revealed: bool
+```
+
+Runtime-significant metadata, spelling, and origin can be erased from the types that ty records for
+many of these APIs. Just because ty infers two of these objects as being of the same type does not
+therefore mean that they are equal:
+
+```py
+import builtins
+from collections.abc import Callable as AbcCallable
+from typing import Annotated, Callable, List, Type, TypeAlias
+
+A: TypeAlias = "int"
+B: TypeAlias = "builtins.int"
+
+# The `Annotated[]` metadata is discarded and ignored by ty, so these are inferred
+# as having the same type, but they will compare unequal at runtime
+reveal_type(Annotated[int, "a"] == Annotated[int, "b"])  # revealed: bool
+
+reveal_type(A == B)  # revealed: bool
+reveal_type(Callable[[int], str] == AbcCallable[[int], str])  # revealed: bool
+reveal_type(List[int] == list[int])  # revealed: bool
+reveal_type(Type[int] == type[int])  # revealed: bool
+```
+
 ## Constrained type variables
 
 Equality analysis expands the constraints of a constrained type variable in either operand position.
@@ -1717,7 +1812,7 @@ def _(x: Any, y: Any | str):
 
 def _(x: Any):
     if x != list[Any]:
-        reveal_type(x)  # revealed: Any & ~<class 'list[Any]'>
+        reveal_type(x)  # revealed: Any
 
 def _(x: Any, y: SingleIntEnum):
     if x == y:
@@ -1734,7 +1829,7 @@ def _(x: Any):
     if x == RUNTIME_TYPE_VAR:
         pass
     else:
-        reveal_type(x)  # revealed: Any & ~TypeVar
+        reveal_type(x)  # revealed: Any
 ```
 
 `Any` must stay `Any` when compared with an enum, on either side of the comparison:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -2932,31 +2932,57 @@ def _(value: FinalPatternInt):
             reveal_type(value)  # revealed: FinalPatternInt
 ```
 
-Some precisely modeled objects compare equal to themselves, so an equivalent value pattern is
-exhaustive:
+We don't attempt to precisely model equality behaviour between special-cased typing-API objects. As
+described in `narrow/conditionals/eq.md`, doing so would be possible in some cases, but it would be
+error-prone, and there are few known use cases for doing this.
 
 ```py
+from functools import partial
 from types import FunctionType
-from typing import NewType, TypeVar
+from typing import List, Literal, NewType, Optional, TypeVar
+from typing_extensions import Literal as ExtensionsLiteral
 
 T = TypeVar("T")
 UserId = NewType("UserId", int)
 
 class ReflexivePatternValues:
     LIST_INT = list[int]
+    LEGACY_LIST_INT = List[int]
+    EXTENSIONS_LITERAL = ExtensionsLiteral
+    OPTIONAL = Optional
     TYPE_VAR = T
     NEW_TYPE = UserId
 
+# error: [invalid-return-type]
 def generic_alias_value_pattern() -> int:
     match list[int]:
         case ReflexivePatternValues.LIST_INT:
             return 1
 
+# error: [invalid-return-type]
+def cross_origin_generic_alias_value_pattern() -> int:
+    match list[int]:
+        case ReflexivePatternValues.LEGACY_LIST_INT:
+            return 1
+
+# error: [invalid-return-type]
+def cross_origin_special_form_value_pattern() -> int:
+    match Literal:
+        case ReflexivePatternValues.EXTENSIONS_LITERAL:
+            return 1
+
+def singleton_special_form_value_pattern() -> int:
+    match Optional:
+        case ReflexivePatternValues.OPTIONAL:
+            return 1
+
+# error: [invalid-return-type]
 def type_var_value_pattern() -> int:
     match T:
         case ReflexivePatternValues.TYPE_VAR:
             return 1
 
+# error: [invalid-return-type]
 def new_type_value_pattern() -> int:
     match UserId:
         case ReflexivePatternValues.NEW_TYPE:
@@ -2972,13 +2998,6 @@ def bound_method_value_pattern() -> int:
     match helper.__get__:
         case helper.__get__:
             return 1
-```
-
-Two calls that construct equivalent objects need not produce equal values. For example, separate
-`partial` objects do not compare equal, so this match is not exhaustive:
-
-```py
-from functools import partial
 
 def target(value: int) -> int:
     return value

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_single_valued.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_single_valued.md
@@ -48,7 +48,6 @@ static_assert(not is_single_valued(Callable[[int, str], None]))
 
 static_assert(not is_single_valued(TypeAliasType))
 static_assert(not is_single_valued(UnionType))
-static_assert(is_single_valued(TypeOf[list[int]]))
 
 class A:
     def method(self): ...

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2484,15 +2484,7 @@ impl<'db> Type<'db> {
             | Type::WrapperDescriptor(..)
             | Type::ClassLiteral(..)
             | Type::ModuleLiteral(..) => true,
-            Type::SpecialForm(special_form) => {
-                // Nearly all `SpecialForm` types are singletons, but if a symbol could validly
-                // originate from either `typing` or `typing_extensions` then this is not guaranteed.
-                // E.g. `typing.TypeGuard` is equivalent to `typing_extensions.TypeGuard`, so both are treated
-                // as inhabiting the type `SpecialFormType::TypeGuard` in our model, but they are actually
-                // distinct symbols at different memory addresses at runtime.
-                !(special_form.check_module(KnownModule::Typing)
-                    && special_form.check_module(KnownModule::TypingExtensions))
-            }
+            Type::SpecialForm(special_form) => special_form.is_guaranteed_singleton(),
             Type::KnownInstance(KnownInstanceType::Sentinel(_)) => true,
             Type::KnownInstance(_) => false,
             Type::Callable(_) => {
@@ -2543,22 +2535,22 @@ impl<'db> Type<'db> {
     /// Return true if this type is non-empty and all inhabitants of this type compare equal.
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         match self {
-            // All empty ranges compare equal, but non-empty ranges can contain different values.
-            Type::KnownInstance(KnownInstanceType::Range { is_non_empty }) => !is_non_empty,
+            Type::KnownInstance(KnownInstanceType::Sentinel(_)) => true,
+            Type::SpecialForm(special_form) => special_form.is_guaranteed_singleton(),
 
-            // Each `partial()` call creates a distinct object at runtime.
-            Type::KnownInstance(
-                KnownInstanceType::FunctoolsPartial(_) | KnownInstanceType::FunctoolsPartialCall(_),
-            ) => false,
+            // It's tempting to add extensive special casing here, but it would be very error-prone,
+            // and there's no known use case. For example, `Annotated[int, ""]` does not compare
+            // equal to `Annotated[int, "fooo"]` (but for us they have identical types); `list[int]`
+            // does not compare equal to `typing.List[int]` (but for us they have identical types);
+            // `typing.Literal` will not necessarily be the same object as `typing_extensions.Literal`
+            // even on Python versions where typeshed says they are the same symbol; etc. etc.
+            Type::KnownInstance(_) | Type::GenericAlias(_) => false,
 
             Type::FunctionLiteral(..)
             | Type::WrapperDescriptor(_)
             | Type::KnownBoundMethod(_)
             | Type::ModuleLiteral(..)
-            | Type::ClassLiteral(..)
-            | Type::GenericAlias(..)
-            | Type::SpecialForm(..)
-            | Type::KnownInstance(..) => true,
+            | Type::ClassLiteral(..) => true,
 
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Enum(..) => !self.overrides_equality(db),

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -677,11 +677,6 @@ fn evaluate_structural_comparison<'db>(
         (Type::ModuleLiteral(left_module), Type::ModuleLiteral(right_module)) => {
             operator.result_from_equality(left_module.module(db) == right_module.module(db))
         }
-        (Type::GenericAlias(left_alias), Type::GenericAlias(right_alias))
-            if left_alias == right_alias =>
-        {
-            operator.result_from_equality(true)
-        }
         (Type::WrapperDescriptor(left_descriptor), Type::WrapperDescriptor(right_descriptor))
             if left_descriptor == right_descriptor =>
         {
@@ -1624,7 +1619,8 @@ fn has_known_identity_comparison_semantics<'db>(
     operator: ComparisonOperator,
 ) -> bool {
     match ty {
-        Type::FunctionLiteral(_) | Type::ModuleLiteral(_) | Type::SpecialForm(_) => true,
+        Type::FunctionLiteral(_) | Type::ModuleLiteral(_) => true,
+        Type::SpecialForm(special_form) => special_form.is_guaranteed_singleton(),
         Type::ClassLiteral(class) => {
             KnownComparisonSemantics::of_instance(db, class.metaclass_instance_type(db), operator)
                 == Some(KnownComparisonSemantics::Object)

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -234,6 +234,18 @@ impl SpecialFormType {
         self.class().to_instance(db)
     }
 
+    /// Return `true` if this special form is guaranteed to be a singleton at runtime.
+    ///
+    /// Nearly all `SpecialForm` types are singletons, but if a symbol could validly
+    /// originate from either `typing` or `typing_extensions` then this is not guaranteed.
+    /// E.g. `typing.TypeGuard` is equivalent to `typing_extensions.TypeGuard`, so both are treated
+    /// as inhabiting the type `SpecialFormType::TypeGuard` in our model, but they are actually
+    /// distinct symbols at different memory addresses at runtime.
+    pub(super) const fn is_guaranteed_singleton(self) -> bool {
+        !(self.check_module(KnownModule::Typing)
+            && self.check_module(KnownModule::TypingExtensions))
+    }
+
     /// Return the type denoted by this retained special-form value when it is valid without
     /// parameters or a surrounding inference scope.
     pub(crate) fn type_form_argument(self, db: &dyn Db) -> Option<Type<'_>> {
@@ -517,7 +529,7 @@ impl SpecialFormType {
     ///
     /// Most variants can only exist in one module, which is the same as `self.class().canonical_module(db)`.
     /// Some variants could validly be defined in either `typing` or `typing_extensions`, however.
-    pub(super) fn check_module(self, module: KnownModule) -> bool {
+    pub(super) const fn check_module(self, module: KnownModule) -> bool {
         match self {
             Self::TypeQualifier(qualifier) => qualifier.check_module(module),
             Self::LegacyStdlibAlias(_)


### PR DESCRIPTION
## Summary

Stop assuming that special-cased typing objects and generic aliases compare equal whenever they share the same internal type representation.

Distinct objects that compare unequal at runtime can often have identical representations in ty's model. Examples include `list[int]` and `typing.List[int]`, `Annotated` aliases with different metadata, and special forms from `typing` and `typing_extensions`.

Treat these objects conservatively during equality narrowing and pattern matching, while preserving precise behavior for sentinels and special forms guaranteed to be singletons. Remove unnecessary special-casing for empty ranges.

As well as fixing several bugs and simplifying our implementation, this also makes it easier to remove the troublesome `Type::is_single_valued()` API altogether in a followup PR.

## Test Plan

mdtests updated