### PR TITLE
[ty] Clarify diagnostic message naming

### DIFF
--- a/crates/mdtest/src/matcher.rs
+++ b/crates/mdtest/src/matcher.rs
@@ -462,7 +462,7 @@ fn match_reveal_type_diagnostic(
             return false;
         }
 
-        let primary_message = diagnostic.primary_message();
+        let headline_message = diagnostic.headline_message();
         let Some(primary_annotation) =
             (diagnostic.primary_annotation()).and_then(|a| a.get_message())
         else {
@@ -473,7 +473,7 @@ fn match_reveal_type_diagnostic(
 
         // reveal_type, reveal_protocol_interface
         if matches!(
-            primary_message,
+            headline_message,
             "Revealed type" | "Revealed protocol interface"
         ) && expected_reveal_type_message.is_none_or(|expected_reveal_type_message| {
             primary_annotation == expected_reveal_type_message
@@ -483,7 +483,7 @@ fn match_reveal_type_diagnostic(
 
         // reveal_when_assignable_to, reveal_when_subtype_of, reveal_mro
         if matches!(
-            primary_message,
+            headline_message,
             "Assignability holds" | "Subtyping holds" | "Revealed MRO"
         ) && expected_reveal_type
             .is_none_or(|expected_reveal_type| primary_annotation == expected_reveal_type)

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -212,7 +212,7 @@ fn assert_diagnostics(db: &dyn Db, diagnostics: &[Diagnostic], expected: &[KeyDi
                     .primary_span()
                     .and_then(|span| span.range())
                     .map(Range::<usize>::from),
-                diagnostic.primary_message(),
+                diagnostic.headline_message(),
                 diagnostic.severity(),
             )
         })

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -155,8 +155,8 @@ impl Diagnostic {
     ///
     /// An "info" diagnostic is useful when contextualizing or otherwise
     /// helpful information can be added to help end users understand the
-    /// main diagnostic message better. For example, if a the main diagnostic
-    /// message is about a function call being invalid, a useful "info"
+    /// headline message better. For example, if the headline message is about
+    /// a function call being invalid, a useful "info"
     /// sub-diagnostic could show the function definition (or only the relevant
     /// parts of it).
     ///
@@ -203,18 +203,17 @@ impl Diagnostic {
         self.inner.id
     }
 
-    /// Returns the primary message for this diagnostic.
+    /// Returns the headline message for this diagnostic.
     ///
     /// A diagnostic always has a message, but it may be empty.
-    pub fn primary_message(&self) -> &str {
+    pub fn headline_message(&self) -> &str {
         self.inner.message.as_str()
     }
 
-    /// Introspects this diagnostic and returns what kind of "primary" message
-    /// it contains for concise formatting.
+    /// Introspects this diagnostic and returns its message for concise formatting.
     ///
     /// When we concisely format diagnostics, we likely want to not only
-    /// include the primary diagnostic message but also the message attached
+    /// include the headline message but also the message attached
     /// to the primary annotation. In particular, the primary annotation often
     /// contains *essential* information or context for understanding the
     /// diagnostic.
@@ -242,7 +241,7 @@ impl Diagnostic {
     /// Set a custom message for the concise formatting of this diagnostic.
     ///
     /// This overrides the default behavior of generating a concise message
-    /// from the main diagnostic message and the primary annotation.
+    /// from the headline message and the primary annotation.
     pub fn set_concise_message(&mut self, message: impl IntoDiagnosticMessage) {
         Arc::make_mut(&mut self.inner).custom_concise_message =
             Some(message.into_diagnostic_message());
@@ -702,18 +701,17 @@ impl SubDiagnostic {
         self.primary_annotation().map(Annotation::get_span)
     }
 
-    /// Returns the primary message for this sub-diagnostic.
+    /// Returns the headline message for this sub-diagnostic.
     ///
     /// A sub-diagnostic always has a message, but it may be empty.
-    pub fn primary_message(&self) -> &str {
+    pub fn headline_message(&self) -> &str {
         self.inner.message.as_str()
     }
 
-    /// Introspects this diagnostic and returns what kind of "primary" message
-    /// it contains for concise formatting.
+    /// Introspects this sub-diagnostic and returns its message for concise formatting.
     ///
     /// When we concisely format diagnostics, we likely want to not only
-    /// include the primary diagnostic message but also the message attached
+    /// include the headline message but also the message attached
     /// to the primary annotation. In particular, the primary annotation often
     /// contains *essential* information or context for understanding the
     /// diagnostic.
@@ -722,7 +720,7 @@ impl SubDiagnostic {
     /// cases, just converting it to a string (or printing it) will do what
     /// you want.
     pub fn concise_message(&self) -> ConciseMessage<'_> {
-        let main = self.primary_message();
+        let main = self.headline_message();
         let annotation = self
             .primary_annotation()
             .and_then(|ann| ann.get_message())
@@ -1633,10 +1631,10 @@ pub enum DiagnosticFormat {
 
 /// A representation of the kinds of messages inside a diagnostic.
 pub enum ConciseMessage<'a> {
-    /// A diagnostic contains a non-empty main message and an empty
+    /// A diagnostic contains a non-empty headline message and an empty
     /// primary annotation message.
     MainDiagnostic(&'a str),
-    /// A diagnostic contains a non-empty main message and a non-empty
+    /// A diagnostic contains a non-empty headline message and a non-empty
     /// primary annotation message.
     Both { main: &'a str, annotation: &'a str },
     /// A custom concise message has been provided.

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -2561,7 +2561,7 @@ watermelon
         assert_eq!(
             diagnostics
                 .iter()
-                .map(Diagnostic::primary_message)
+                .map(Diagnostic::headline_message)
                 .collect::<Vec<_>>(),
             ["checking main.py", "checking mod.py"]
         );

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -3645,7 +3645,7 @@ impl DiagnosticGuard<'_, '_> {
     ///
     /// Callers can add additional primary or secondary annotations via the
     /// `DerefMut` trait implementation to a `Diagnostic`.
-    pub(crate) fn set_primary_message(&mut self, message: impl IntoDiagnosticMessage) {
+    pub(crate) fn set_primary_annotation_message(&mut self, message: impl IntoDiagnosticMessage) {
         // N.B. It is normally bad juju to define `self` methods
         // on types that implement `Deref`. Instead, it's idiomatic
         // to do `fn foo(this: &mut LintDiagnosticGuard)`, which in

--- a/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -282,7 +282,7 @@ pub(crate) fn redefined_while_unused(checker: &Checker, scope_id: ScopeId, scope
                 info.shadowed,
             );
 
-            diagnostic.set_primary_message(format_args!("`{name}` redefined here"));
+            diagnostic.set_primary_annotation_message(format_args!("`{name}` redefined here"));
 
             if let Some(range) = info.binding.parent_range(checker.semantic()) {
                 diagnostic.set_parent(range.start());

--- a/crates/ruff_linter/src/rules/ruff/rules/duplicate_entry_in_dunder_all.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/duplicate_entry_in_dunder_all.rs
@@ -163,7 +163,7 @@ fn duplicate_entry_in_dunder_all(checker: &Checker, target: &ast::Expr, value: &
                 previous_expr,
             );
 
-            diagnostic.set_primary_message(format_args!("`{name}` duplicated here"));
+            diagnostic.set_primary_annotation_message(format_args!("`{name}` duplicated here"));
 
             diagnostic.try_set_fix(|| {
                 edits::remove_member(elts, index, source).map(|edit| {

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -376,9 +376,9 @@ fn to_lsp_diagnostic(
             .primary_annotation()
             .and_then(Annotation::get_message)
         {
-            format!("{}: {annotation_message}", diagnostic.primary_message())
+            format!("{}: {annotation_message}", diagnostic.headline_message())
         } else {
-            diagnostic.primary_message().to_string()
+            diagnostic.headline_message().to_string()
         }
     } else {
         diagnostic.concise_message().to_string()

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -1395,11 +1395,11 @@ print(sys.last_exc, os.getegid())
 
     assert_eq!(diagnostics.len(), 2);
     assert_eq!(
-        diagnostics[0].primary_message(),
+        diagnostics[0].headline_message(),
         "Module `sys` has no member `last_exc`"
     );
     assert_eq!(
-        diagnostics[1].primary_message(),
+        diagnostics[1].headline_message(),
         "Module `os` has no member `getegid`"
     );
 
@@ -1453,7 +1453,7 @@ fn reloading_options_updates_inferred_python_version_diagnostics_when_metadata_i
 
     assert_eq!(diagnostics.len(), 1);
     assert_eq!(
-        diagnostics[0].primary_message(),
+        diagnostics[0].headline_message(),
         format!(
             "Ignoring unsupported inferred Python version `3.{unsupported_minor}`; ty will use Python {} instead.",
             PythonVersion::latest_ty()

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -910,7 +910,7 @@ mod tests {
             check_file_impl(&db, file)
                 .as_ref()
                 .unwrap_err()
-                .primary_message()
+                .headline_message()
                 .to_string(),
             "Failed to read file: No such file or directory".to_string()
         );
@@ -928,7 +928,7 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .iter()
-                .map(|diagnostic| diagnostic.primary_message().to_string())
+                .map(|diagnostic| diagnostic.headline_message().to_string())
                 .collect::<Vec<_>>(),
             vec![] as Vec<String>
         );

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1736,12 +1736,12 @@ class B(A):
 
         assert_eq!(diagnostic.id(), LINT_ID);
         assert_eq!(
-            diagnostic.primary_message(),
+            diagnostic.headline_message(),
             "Variable `a` should be named `b`."
         );
 
         assert_eq!(convergence_diagnostic.id(), DiagnosticId::InternalError);
-        assert_snapshot!(convergence_diagnostic.primary_message(), @"Fixes failed to converge after 10 iterations.");
+        assert_snapshot!(convergence_diagnostic.headline_message(), @"Fixes failed to converge after 10 iterations.");
 
         // It should keep the source text from the last allowed fix iteration.
         assert_eq!(&*source_text(&db, file), "a = 10");
@@ -1813,12 +1813,12 @@ class B(A):
 
         assert_eq!(diagnostic.id(), LINT_ID);
         assert_eq!(
-            diagnostic.primary_message(),
+            diagnostic.headline_message(),
             "Variable `b` should be named `c`."
         );
 
         assert_eq!(syntax_error.id(), DiagnosticId::InternalError);
-        assert_snapshot!(syntax_error.primary_message(), @"Applying fixes introduced a syntax error. Reverting changes.");
+        assert_snapshot!(syntax_error.headline_message(), @"Applying fixes introduced a syntax error. Reverting changes.");
 
         // It should revert the source to the last known error free version.
         assert_eq!(&*source_text(&db, file), "b = 10");

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -8560,7 +8560,7 @@ impl<'db> InvalidTypeExpression<'db> {
             {
                 return;
             }
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Did you mean to use the module's member \
                 `{module_name_final_part}.{module_name_final_part}`?"
             ));
@@ -8586,7 +8586,7 @@ impl<'db> InvalidTypeExpression<'db> {
                 .map(|parent| parent.to_scope_id(db, function_body_scope.file(db)))
                 == builtins_module_scope(db)
         {
-            diagnostic.set_primary_message("Did you mean `collections.abc.Callable`?");
+            diagnostic.set_primary_annotation_message("Did you mean `collections.abc.Callable`?");
         } else if matches!(self, InvalidTypeExpression::InvalidBareParamSpec(_)) {
             diagnostic.info("A bare ParamSpec is only valid:");
             diagnostic.info(" - as the first argument to `Callable`");

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -128,7 +128,7 @@ impl<'db> BoundSuperError<'db> {
                         _ => {
                             let mut diagnostic =
                                 builder.into_diagnostic("Argument is not a valid class");
-                            diagnostic.set_primary_message(format_args!(
+                            diagnostic.set_primary_annotation_message(format_args!(
                                 "Argument has type `{}`",
                                 pivot_class.display(context.db())
                             ));

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -80,7 +80,7 @@ use ty_python_core::semantic_index;
 
 pub(crate) use self::constructor::ConstructorCallableKind;
 
-/// Overrides the lint and top-level message for a call diagnostic emitted from an implicit call.
+/// Overrides the lint and headline message for a call diagnostic emitted from an implicit call.
 ///
 /// The original call-error message is retained on the primary annotation, while `info` explains
 /// why the call happened. `argument_ranges` maps synthetic call arguments back to source ranges.
@@ -7697,12 +7697,12 @@ impl<'db> BindingError<'db> {
                     provenance,
                     InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
                 ) {
-                    diag.set_primary_message(format_args!(
+                    diag.set_primary_annotation_message(format_args!(
                         "Possible extra items in unpacked open `TypedDict` have type \
                          `{provided_ty_display}`, expected `{expected_ty_display}`"
                     ));
                 } else {
-                    diag.set_primary_message(format_args!(
+                    diag.set_primary_annotation_message(format_args!(
                         "Expected `{expected_ty_display}`, found `{provided_ty_display}`"
                     ));
                 }
@@ -7801,7 +7801,7 @@ impl<'db> BindingError<'db> {
                 let mut diag = builder.into_diagnostic(
                     "Argument expression after ** must be a mapping with `str` key type",
                 );
-                diag.set_primary_message(format_args!("Found `{provided_ty_display}`"));
+                diag.set_primary_annotation_message(format_args!("Found `{provided_ty_display}`"));
 
                 if let Some(compound_diag) = compound_diag {
                     compound_diag.add_context(context.db(), &mut diag);
@@ -7993,7 +7993,7 @@ impl<'db> BindingError<'db> {
                     SpecializationError::MismatchedBound { bound_typevar, .. } => {
                         let typevar = bound_typevar.typevar(context.db());
                         let typevar_name = typevar.name(context.db());
-                        diag.set_primary_message(format_args!(
+                        diag.set_primary_annotation_message(format_args!(
                             "Argument type `{argument_ty_display}` does not \
                                 satisfy upper bound `{}` of type variable `{typevar_name}`",
                             typevar
@@ -8007,7 +8007,7 @@ impl<'db> BindingError<'db> {
                     SpecializationError::MismatchedConstraint { bound_typevar, .. } => {
                         let typevar = bound_typevar.typevar(context.db());
                         let typevar_name = typevar.name(context.db());
-                        diag.set_primary_message(format_args!(
+                        diag.set_primary_annotation_message(format_args!(
                             "Argument type `{argument_ty_display}` does not \
                                 satisfy constraints ({}) of type variable `{typevar_name}`",
                             typevar

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -129,7 +129,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
     /// The severity of the diagnostic returned is automatically determined
     /// by the given lint and configuration. The message given to
     /// `LintDiagnosticGuardBuilder::to_diagnostic` is used to construct the
-    /// initial diagnostic and should be considered the "top-level message" of
+    /// initial diagnostic and should be considered the "headline message" of
     /// the diagnostic. (i.e., If nothing else about the diagnostic is seen,
     /// aside from its identifier, the message is probably the thing you'd pick
     /// to show.)
@@ -139,7 +139,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
     /// typing context. (That means the range given _must_ be valid for the
     /// `File` currently being type checked.) This primary annotation does
     /// not have a message attached to it, but callers can attach one via
-    /// `LintDiagnosticGuard::set_primary_message`.
+    /// `LintDiagnosticGuard::set_primary_annotation_message`.
     ///
     /// After using the builder to make a guard, once the guard is dropped, the
     /// diagnostic is added to the context, unless there is something in the
@@ -263,7 +263,7 @@ impl fmt::Debug for InferContext<'_, '_> {
 ///
 /// * On `Drop`, the underlying diagnostic is added to the typing context.
 /// * Some convenience methods for mutating the underlying `Diagnostic`
-///   in lint context. For example, `LintDiagnosticGuard::set_primary_message`
+///   in lint context. For example, `LintDiagnosticGuard::set_primary_annotation_message`
 ///   will attach a message to the primary span on the diagnostic.
 pub(super) struct LintDiagnosticGuard<'db, 'ctx> {
     /// The typing context.
@@ -289,7 +289,7 @@ impl LintDiagnosticGuard<'_, '_> {
     ///
     /// Callers can add additional primary or secondary annotations via the
     /// `DerefMut` trait implementation to a `Diagnostic`.
-    pub(super) fn set_primary_message(&mut self, message: impl IntoDiagnosticMessage) {
+    pub(super) fn set_primary_annotation_message(&mut self, message: impl IntoDiagnosticMessage) {
         // N.B. It is normally bad juju to define `self` methods
         // on types that implement `Deref`. Instead, it's idiomatic
         // to do `fn foo(this: &mut LintDiagnosticGuard)`, which in
@@ -506,7 +506,7 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
     /// the ID and severity derived from the `LintMetadata` used to create
     /// this builder. The diagnostic also includes a primary annotation
     /// without a message. To add a message to this primary annotation, use
-    /// `LintDiagnosticGuard::set_primary_message`.
+    /// `LintDiagnosticGuard::set_primary_annotation_message`.
     ///
     /// The diagnostic can be further mutated on the guard via its `DerefMut`
     /// impl to `Diagnostic`.
@@ -516,9 +516,9 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
         self,
         message: impl std::fmt::Display,
     ) -> LintDiagnosticGuard<'db, 'ctx> {
-        // This is why `LintDiagnosticGuard::set_primary_message` exists.
+        // This is why `LintDiagnosticGuard::set_primary_annotation_message` exists.
         // We add the primary annotation here (because it's required). Without a message
-        // override, its optional message can be added later via `set_primary_message`.
+        // override, its optional message can be added later via `set_primary_annotation_message`.
         let primary_span = Span::from(self.ctx.file()).with_range(self.primary_range);
         let mut diag = if let Some((message_override, info)) = self.message_override {
             let mut diag = Diagnostic::new(
@@ -543,7 +543,7 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
         }
     }
 
-    /// Replace the top-level message and add an info sub-diagnostic while retaining the original
+    /// Replace the headline message and add an info sub-diagnostic while retaining the original
     /// message on the primary annotation.
     pub(super) fn with_message_override(mut self, message: String, info: &str) -> Self {
         self.message_override = Some((message, info.to_string()));

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1290,11 +1290,11 @@ pub(crate) fn report_mismatched_type_name<'db>(
             "The name passed to `{constructor}` must match the variable it is assigned to"
         ));
         if let Some(actual_name) = actual_name {
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Expected \"{expected_name}\", got \"{actual_name}\""
             ));
         } else {
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Expected \"{expected_name}\", got variable of type `{}`",
                 actual_name_ty.display(context.db())
             ));
@@ -1663,7 +1663,7 @@ pub(super) fn report_invalid_assignment<'db>(
             }
         }
 
-        diag.set_primary_message(format_args!(
+        diag.set_primary_annotation_message(format_args!(
             "Incompatible value of type `{}`",
             value_ty.display(context.db()),
         ));
@@ -1672,7 +1672,7 @@ pub(super) fn report_invalid_assignment<'db>(
         error_context.attach_to(context.db(), &mut diag);
 
         // Overwrite the concise message to avoid showing the value type twice
-        let message = diag.primary_message().to_string();
+        let message = diag.headline_message().to_string();
         diag.set_concise_message(message);
     }
 
@@ -1736,7 +1736,7 @@ pub(super) fn report_bad_dunder_set_call<'db>(
             diagnostic.annotate(Annotation::secondary(Span::from(file_range)).message(
                 format_args!("Property `{object_type}.{attribute}` defined here with no setter"),
             ));
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Attempted assignment to `{object_type}.{attribute}` here"
             ));
         }
@@ -1790,7 +1790,7 @@ pub(super) fn report_bad_dunder_delete_call<'db>(
             diagnostic.annotate(Annotation::secondary(Span::from(file_range)).message(
                 format_args!("Property `{object_type}.{attribute}` defined here with no deleter"),
             ));
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Attempted deletion of `{object_type}.{attribute}` here"
             ));
         }
@@ -1846,7 +1846,7 @@ pub(super) fn report_invalid_return_type(
     let return_type_span = context.span(return_type_range);
 
     let mut diag = builder.into_diagnostic("Return type does not match returned value");
-    diag.set_primary_message(format_args!(
+    diag.set_primary_annotation_message(format_args!(
         "expected `{expected_ty}`, found `{actual_ty}`",
         expected_ty = expected_ty.display_with(context.db(), settings.clone()),
         actual_ty = actual_ty.display_with(context.db(), settings.clone()),
@@ -1874,7 +1874,7 @@ pub(super) fn report_invalid_generator_function_return_type(
 
     let mut diag = builder.into_diagnostic("Return type does not match returned value");
     let inferred_ty = inferred_return.display(context.db());
-    diag.set_primary_message(format_args!(
+    diag.set_primary_annotation_message(format_args!(
         "expected `{expected_ty}`, found `{inferred_ty}`",
         expected_ty = expected_ty.display(context.db()),
     ));
@@ -1947,7 +1947,7 @@ pub(super) fn report_invalid_generator_yield_type(
             format!("generator with send type `{actual_display}`, expected `{expected_display}`")
         }
     };
-    diag.set_primary_message(primary);
+    diag.set_primary_annotation_message(primary);
 
     if let Some(return_type_span) = return_type_span {
         diag.annotate(Annotation::secondary(return_type_span).message(format!(
@@ -2123,7 +2123,7 @@ pub(super) fn report_invalid_exception_caught(context: &InferContext, node: &ast
     let mut diagnostic = if ty.is_notimplemented(context.db()) {
         let mut diag =
             builder.into_diagnostic("Cannot catch `NotImplemented` in an exception handler");
-        diag.set_primary_message("Did you mean `NotImplementedError`?");
+        diag.set_primary_annotation_message("Did you mean `NotImplementedError`?");
         diag
     } else {
         let mut diag = builder.into_diagnostic(format_args!(
@@ -2134,7 +2134,7 @@ pub(super) fn report_invalid_exception_caught(context: &InferContext, node: &ast
                 "object"
             },
         ));
-        diag.set_primary_message(format_args!(
+        diag.set_primary_annotation_message(format_args!(
             "Object has type `{}`",
             ty.display(context.db())
         ));
@@ -2156,14 +2156,14 @@ pub(crate) fn report_invalid_exception_raised(
     };
     if raise_type.is_notimplemented(context.db()) {
         let mut diagnostic = builder.into_diagnostic(format_args!("Cannot raise `NotImplemented`"));
-        diagnostic.set_primary_message("Did you mean `NotImplementedError`?");
+        diagnostic.set_primary_annotation_message("Did you mean `NotImplementedError`?");
         diagnostic.info("Can only raise an instance or subclass of `BaseException`");
     } else {
         let mut diagnostic = builder.into_diagnostic(format_args!(
             "Cannot raise object of type `{}`",
             raise_type.display(context.db())
         ));
-        diagnostic.set_primary_message("Not an instance or subclass of `BaseException`");
+        diagnostic.set_primary_annotation_message("Not an instance or subclass of `BaseException`");
     }
 }
 
@@ -2175,7 +2175,7 @@ pub(crate) fn report_invalid_exception_cause(context: &InferContext, node: &ast:
         let mut diag = builder.into_diagnostic(format_args!(
             "Cannot use `NotImplemented` as an exception cause",
         ));
-        diag.set_primary_message("Did you mean `NotImplementedError`?");
+        diag.set_primary_annotation_message("Did you mean `NotImplementedError`?");
         diag
     } else {
         builder.into_diagnostic(format_args!(
@@ -2206,7 +2206,7 @@ pub(crate) fn report_instance_layout_conflict(
     let mut diagnostic = builder
         .into_diagnostic("Class will raise `TypeError` at runtime due to incompatible bases");
 
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "Bases {} cannot be combined in multiple inheritance",
         disjoint_bases.describe_problematic_class_bases(db)
     ));
@@ -2436,7 +2436,7 @@ pub(crate) fn report_bad_argument_to_get_protocol_members(
     };
     let db = context.db();
     let mut diagnostic = builder.into_diagnostic("Invalid argument to `get_protocol_members`");
-    diagnostic.set_primary_message("This call will raise `TypeError` at runtime");
+    diagnostic.set_primary_annotation_message("This call will raise `TypeError` at runtime");
     diagnostic.info("Only protocol classes can be passed to `get_protocol_members`");
 
     let mut class_def_diagnostic = SubDiagnostic::new(
@@ -2471,8 +2471,9 @@ pub(crate) fn report_bad_argument_to_protocol_interface(
     };
     let db = context.db();
     let mut diagnostic = builder.into_diagnostic("Invalid argument to `reveal_protocol_interface`");
-    diagnostic
-        .set_primary_message("Only protocol classes can be passed to `reveal_protocol_interface`");
+    diagnostic.set_primary_annotation_message(
+        "Only protocol classes can be passed to `reveal_protocol_interface`",
+    );
 
     if let Some(class) = param_type.to_class_type(context.db()) {
         let mut class_def_diagnostic = SubDiagnostic::new(
@@ -2521,7 +2522,7 @@ pub(crate) fn report_invalid_class_match_pattern<T: Ranged>(
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "`{class_display}` cannot be used in a class pattern because it is not a type"
     ));
-    diagnostic.set_primary_message("This will raise `TypeError` at runtime");
+    diagnostic.set_primary_annotation_message("This will raise `TypeError` at runtime");
 }
 
 pub(crate) fn report_too_many_positional_patterns_for_class_pattern<T: Ranged>(
@@ -2581,7 +2582,7 @@ pub(crate) fn report_runtime_check_against_non_runtime_checkable_protocol(
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Class `{class_name}` cannot be used as the second argument to `{function_name}`",
     ));
-    diagnostic.set_primary_message("This call will raise `TypeError` at runtime");
+    diagnostic.set_primary_annotation_message("This call will raise `TypeError` at runtime");
     add_non_runtime_checkable_protocol_context(db, &mut diagnostic, protocol);
     diagnostic.info(format_args!(
         "A protocol class can only be used in `{function_name}` checks if it is decorated \
@@ -2608,7 +2609,7 @@ pub(crate) fn report_issubclass_check_against_protocol_with_non_method_members<'
         "`{class_name}` cannot be used as the second argument to `issubclass` \
         as it is a protocol with non-method members"
     ));
-    diagnostic.set_primary_message("This call will raise `TypeError` at runtime");
+    diagnostic.set_primary_annotation_message("This call will raise `TypeError` at runtime");
     if let [single_member] = non_method_members {
         let mut sub = SubDiagnostic::new(
             SubDiagnosticSeverity::Info,
@@ -2667,7 +2668,7 @@ pub(crate) fn report_runtime_check_against_typed_dict(
         "`TypedDict` class `{class_name}` cannot be used as the second argument to `{function_name}`",
         function_name = function.name()
     ));
-    diagnostic.set_primary_message("This call will raise `TypeError` at runtime");
+    diagnostic.set_primary_annotation_message("This call will raise `TypeError` at runtime");
 }
 
 pub(crate) fn report_match_pattern_against_non_runtime_checkable_protocol<T: Ranged>(
@@ -2683,7 +2684,7 @@ pub(crate) fn report_match_pattern_against_non_runtime_checkable_protocol<T: Ran
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Class `{class_name}` cannot be used in a class pattern",
     ));
-    diagnostic.set_primary_message("This will raise `TypeError` at runtime");
+    diagnostic.set_primary_annotation_message("This will raise `TypeError` at runtime");
     add_non_runtime_checkable_protocol_context(db, &mut diagnostic, protocol);
     diagnostic.info(
         "A protocol class can only be used in a match class pattern if it is decorated \
@@ -2705,7 +2706,7 @@ pub(crate) fn report_match_pattern_against_typed_dict<T: Ranged>(
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "`TypedDict` class `{class_name}` cannot be used in a class pattern",
     ));
-    diagnostic.set_primary_message("This will raise `TypeError` at runtime");
+    diagnostic.set_primary_annotation_message("This will raise `TypeError` at runtime");
 }
 
 fn add_non_runtime_checkable_protocol_context<'db>(
@@ -2740,7 +2741,7 @@ pub(crate) fn report_attempted_protocol_instantiation(
     let class_name = protocol.name(db);
     let mut diagnostic =
         builder.into_diagnostic(format_args!("Cannot instantiate class `{class_name}`"));
-    diagnostic.set_primary_message("This call will raise `TypeError` at runtime");
+    diagnostic.set_primary_annotation_message("This call will raise `TypeError` at runtime");
 
     let mut class_def_diagnostic = SubDiagnostic::new(
         SubDiagnosticSeverity::Info,
@@ -2765,7 +2766,7 @@ pub(crate) fn report_call_to_abstract_method(
     let db = context.db();
     let name = function.name(db);
     let mut diag = builder.into_diagnostic(format_args!("Cannot call `{name}` on class object"));
-    diag.set_primary_message(format_args!(
+    diag.set_primary_annotation_message(format_args!(
         "`{name}` is an abstract {method_kind} with a trivial body"
     ));
     let span = abstract_method_span(
@@ -2876,17 +2877,17 @@ pub(crate) fn report_undeclared_protocol_member(
         let suggestion = binding_type.promote(db);
 
         if should_give_hint(db, suggestion) {
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Consider adding an annotation, e.g. `{symbol_name}: {} = ...`",
                 suggestion.display(db)
             ));
         } else {
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Consider adding an annotation for `{symbol_name}`"
             ));
         }
     } else {
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "`{symbol_name}` is not declared as a protocol member"
         ));
     }
@@ -2913,7 +2914,7 @@ pub(crate) fn report_undeclared_protocol_attribute(
     let symbol_name = target.attr.as_str();
     let mut diagnostic =
         builder.into_diagnostic("Cannot assign to an undeclared attribute in a protocol method");
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "`{symbol_name}` is not declared as a protocol member"
     ));
 
@@ -3120,7 +3121,7 @@ pub(crate) fn report_unsupported_base(
     };
     let db = context.db();
     let mut diagnostic = builder.into_diagnostic("Unsupported class base");
-    diagnostic.set_primary_message(format_args!("Has type `{}`", base_type.display(db)));
+    diagnostic.set_primary_annotation_message(format_args!("Has type `{}`", base_type.display(db)));
     diagnostic.set_concise_message(format_args!(
         "Unsupported class base with type `{}`",
         base_type.display(db)
@@ -3196,14 +3197,15 @@ pub(crate) fn report_invalid_key_on_typed_dict<'db>(
                             "{quote}{suggestion}{quote}",
                             quote = literal.value.first_literal_flags().quote_str()
                         );
-                        diagnostic
-                            .set_primary_message(format_args!("Did you mean {quoted_suggestion}?"));
+                        diagnostic.set_primary_annotation_message(format_args!(
+                            "Did you mean {quoted_suggestion}?"
+                        ));
                         diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                             quoted_suggestion,
                             key_node.range(),
                         )));
                     } else {
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Unknown key \"{key}\" - did you mean \"{suggestion}\"?",
                         ));
                     }
@@ -3211,7 +3213,8 @@ pub(crate) fn report_invalid_key_on_typed_dict<'db>(
                         "Unknown key \"{key}\" for TypedDict `{typed_dict_name}` - did you mean \"{suggestion}\"?",
                     ));
                 } else {
-                    diagnostic.set_primary_message(format_args!("Unknown key \"{key}\""));
+                    diagnostic
+                        .set_primary_annotation_message(format_args!("Unknown key \"{key}\""));
                     if let Some(full_ty) = full_object_ty {
                         diagnostic.set_concise_message(format_args!(
                             "Unknown key \"{key}\" for TypedDict `{typed_dict_name}` (subscripted object has type `{full_ty}`)",
@@ -3263,7 +3266,7 @@ pub(super) fn report_namedtuple_field_without_default_after_field_with_default<'
         "NamedTuple field without default value cannot follow field(s) with default value(s)",
     );
 
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "Field `{field}` defined here without a default value",
     ));
 
@@ -3312,11 +3315,11 @@ pub(super) fn report_named_tuple_field_with_leading_underscore<'db>(
         builder.into_diagnostic("NamedTuple field name cannot start with an underscore");
 
     if field_definition.is_some() {
-        diagnostic.set_primary_message(
+        diagnostic.set_primary_annotation_message(
             "Class definition will raise `TypeError` at runtime due to this field",
         );
     } else {
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "Class definition will raise `TypeError` at runtime due to field `{field_name}`",
         ));
     }
@@ -3484,14 +3487,14 @@ pub(crate) fn report_invalid_type_param_order<'db>(
     ));
 
     if let [single_typevar] = invalid_later_typevars {
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "Type variable `{}` does not have a default",
             single_typevar.name(db),
         ));
     } else {
         let later_typevars =
             format_enumeration(invalid_later_typevars.iter().map(|tv| tv.name(db)));
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "Type variables {later_typevars} do not have defaults",
         ));
     }
@@ -3716,7 +3719,7 @@ pub(crate) fn report_shadowed_type_variable<'db>(
     diagnostic.set_concise_message(format_args!(
         "Generic {kind} `{name}` uses {typevar_kind} `{typevar_name}` already bound by an enclosing scope",
     ));
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "`{typevar_name}` used in {kind} definition here"
     ));
     let Some(other_definition) = other_typevar.binding_context(db).definition() else {
@@ -3792,7 +3795,7 @@ pub(super) fn report_invalid_method_override<'db>(
     let mut diagnostic =
         builder.into_diagnostic(format_args!("Invalid override of method `{member}`"));
 
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "Definition is incompatible with `{overridden_method}`"
     ));
 
@@ -3967,7 +3970,7 @@ pub(super) fn report_incompatible_base_method<'db>(
         "Base classes for class `{}` define method `{member}` incompatibly",
         class.name(db)
     ));
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "`{selected_name}.{member}` is incompatible with `{contract_name}.{member}`"
     ));
     if selected_decorator != contract_decorator {
@@ -4036,7 +4039,7 @@ pub(super) fn report_overridden_final_method<'db>(
 
     let mut diagnostic =
         builder.into_diagnostic(format_args!("Cannot override `{superclass_name}.{member}`"));
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "Overrides a definition from superclass `{superclass_name}`"
     ));
     diagnostic.set_concise_message(format_args!(
@@ -4204,7 +4207,7 @@ pub(super) fn report_overridden_final_variable<'db>(
 
     let mut diagnostic =
         builder.into_diagnostic(format_args!("Cannot override `{superclass_name}.{member}`"));
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "Overrides a final variable from superclass `{superclass_name}`"
     ));
     diagnostic.set_concise_message(format_args!(
@@ -4257,7 +4260,7 @@ pub(super) fn report_unsupported_comparison<'db>(
         diagnostic_builder.into_diagnostic(format_args!("Unsupported `{}` operation", error.op));
 
     if left_ty.is_equivalent_to(db, right_ty) {
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "Both operands have type `{}`",
             left_ty.display_with(db, display_settings.clone())
         ));
@@ -4414,7 +4417,7 @@ fn report_unsupported_binary_operation_impl<'a>(
         diagnostic_builder.into_diagnostic(format_args!("Unsupported `{operator}` operation"));
 
     if left_ty.is_equivalent_to(db, right_ty) {
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "Both operands have type `{}`",
             left_ty.display_with(db, display_settings.clone())
         ));
@@ -4465,7 +4468,7 @@ pub(super) fn report_bad_frozen_dataclass_inheritance<'db>(
             class.name(db),
             base_class.name(db)
         ));
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "Subclass `{}` is not frozen but base class `{}` is",
             class.name(db),
             base_class.name(db)
@@ -4479,7 +4482,7 @@ pub(super) fn report_bad_frozen_dataclass_inheritance<'db>(
             class.name(db),
             base_class.name(db)
         ));
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "Subclass `{}` is frozen but base class `{}` is not",
             class.name(db),
             base_class.name(db)
@@ -4543,7 +4546,7 @@ pub(super) fn report_invalid_total_ordering(
     let mut diagnostic = builder.into_diagnostic(
         "Class decorated with `@total_ordering` must define at least one ordering method",
     );
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "`{}` does not define `__lt__`, `__le__`, `__gt__`, or `__ge__`",
         class.name(db)
     ));
@@ -4567,7 +4570,7 @@ pub(super) fn report_invalid_total_ordering_call(
     let mut diagnostic = builder.into_diagnostic(
         "`@functools.total_ordering` requires at least one ordering method (`__lt__`, `__le__`, `__gt__`, or `__ge__`) to be defined",
     );
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "`{}` does not define `__lt__`, `__le__`, `__gt__`, or `__ge__`",
         class.name(db)
     ));
@@ -4686,7 +4689,7 @@ pub(super) fn report_invalid_concatenate_last_arg<'db>(
             "The last argument to `typing.Concatenate` must be either `...` or a `ParamSpec` \
                 type variable",
         );
-        diag.set_primary_message(format_args!(
+        diag.set_primary_annotation_message(format_args!(
             "Got `{}`",
             last_arg_type.display(context.db())
         ));
@@ -4731,7 +4734,7 @@ pub(super) fn report_subclass_of_class_with_non_callable_init_subclass<'db>(
 
             if let Some((superclass, definition)) = class_and_def {
                 let superclass_name = superclass.name(db);
-                diagnostic.set_primary_message(format_args!(
+                diagnostic.set_primary_annotation_message(format_args!(
                     "Superclass `{superclass_name}` cannot be subclassed",
                 ));
                 let definition_module = parsed_module(db, definition.file(db));
@@ -4761,7 +4764,7 @@ pub(super) fn report_subclass_of_class_with_non_callable_init_subclass<'db>(
                 }
                 diagnostic.annotate(annotation);
             } else if err_kind == CallErrorKind::NotCallable {
-                diagnostic.set_primary_message(
+                diagnostic.set_primary_annotation_message(
                     "`class` statement will fail because `__init_subclass__` \
                     on a superclass is not callable",
                 );
@@ -4770,7 +4773,7 @@ pub(super) fn report_subclass_of_class_with_non_callable_init_subclass<'db>(
                     `__init_subclass__` definition on a superclass",
                 ));
             } else {
-                diagnostic.set_primary_message(
+                diagnostic.set_primary_annotation_message(
                     "`class` statement may fail because `__init_subclass__` \
                     on a superclass may not be callable",
                 );

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1615,7 +1615,8 @@ fn check_classinfo_in_isinstance<'db>(
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "`typing.Any` cannot be used with `isinstance()`"
             ));
-            diagnostic.set_primary_message("This call will raise `TypeError` at runtime");
+            diagnostic
+                .set_primary_annotation_message("This call will raise `TypeError` at runtime");
         }
         Type::KnownInstance(KnownInstanceType::UnionType(_)) => {
             report_invalid_union_type_elements(
@@ -2563,7 +2564,7 @@ impl KnownFunction {
                     };
                     let mut diagnostic =
                         builder.into_diagnostic("Invalid argument to `reveal_mro`");
-                    diagnostic.set_primary_message(format_args!(
+                    diagnostic.set_primary_annotation_message(format_args!(
                         "Can only pass a class object, generic alias or a union thereof"
                     ));
                     return;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3627,7 +3627,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .report_lint(&INVALID_NEWTYPE, &arguments.args[1])
             {
                 let mut diag = builder.into_diagnostic("invalid base for `typing.NewType`");
-                diag.set_primary_message("A `NewType` base cannot be generic");
+                diag.set_primary_annotation_message("A `NewType` base cannot be generic");
             }
             return;
         }
@@ -3653,7 +3653,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .report_lint(&INVALID_NEWTYPE, &arguments.args[1])
         {
             let mut diag = builder.into_diagnostic("invalid base for `typing.NewType`");
-            diag.set_primary_message(format!("type `{}`", inferred.display(self.db())));
+            diag.set_primary_annotation_message(format!("type `{}`", inferred.display(self.db())));
             if matches!(inferred, Type::ProtocolInstance(_)) {
                 diag.info("The base of a `NewType` is not allowed to be a protocol class.");
             } else if matches!(inferred, Type::TypedDict(_)) {
@@ -4086,7 +4086,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 .secondary(annotation.as_ref())
                                 .message("Declared type"),
                         );
-                        diag.set_primary_message(format_args!(
+                        diag.set_primary_annotation_message(format_args!(
                             "Incompatible value of type `{}`",
                             value_ty.display(self.db()),
                         ));
@@ -4948,7 +4948,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             };
             let mut diag =
                 builder.into_diagnostic(format_args!("Invalid global declaration of `{name}`"));
-            diag.set_primary_message(format_args!(
+            diag.set_primary_annotation_message(format_args!(
                 "`{name}` has no declarations or bindings in the global scope"
             ));
             diag.info("This limits ty's ability to make accurate inferences about the boundness and types of global-scope symbols");
@@ -7276,7 +7276,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         let mut diag = builder
                             .into_diagnostic("Argument expression after ** must be a mapping type");
 
-                        diag.set_primary_message(format_args!(
+                        diag.set_primary_annotation_message(format_args!(
                             "Found `{}`",
                             unpack_ty.display(self.db())
                         ));
@@ -8256,7 +8256,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             builder
                 .into_diagnostic("Argument expression after ** must be a mapping type")
-                .set_primary_message(format_args!("Found `{}`", mapping_type.display(self.db())));
+                .set_primary_annotation_message(format_args!(
+                    "Found `{}`",
+                    mapping_type.display(self.db())
+                ));
         }
 
         call_arguments
@@ -9294,7 +9297,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mut diag =
                 builder.into_diagnostic(format_args!(r#"The class `{class_name}` is deprecated"#));
             if let Some(message) = deprecated.message {
-                diag.set_primary_message(message.value(self.db()));
+                diag.set_primary_annotation_message(message.value(self.db()));
             }
             diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
             return;
@@ -9326,7 +9329,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut diag =
             builder.into_diagnostic(format_args!(r#"The function `{func_name}` is deprecated"#));
         if let Some(message) = deprecated.message {
-            diag.set_primary_message(message.value(self.db()));
+            diag.set_primary_annotation_message(message.value(self.db()));
         }
         diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
@@ -9878,7 +9881,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // because it's already caught by typing.Type.
         if Program::get(self.db()).python_version(self.db()) >= PythonVersion::PY39 {
             if let Some(("", builtin_name)) = as_pep_585_generic("typing", id) {
-                diagnostic.set_primary_message(format_args!("Did you mean `{builtin_name}`?"));
+                diagnostic
+                    .set_primary_annotation_message(format_args!("Did you mean `{builtin_name}`?"));
             }
         }
 
@@ -11970,7 +11974,7 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
                         "Reassignment of `Final` symbol `{place}` is not allowed"
                     ));
 
-                    diagnostic.set_primary_message("Reassignment of `Final` symbol");
+                    diagnostic.set_primary_annotation_message("Reassignment of `Final` symbol");
 
                     if let Some(previous_definition) = previous_definition {
                         // It is not very helpful to show the previous definition if it results from
@@ -11997,7 +12001,8 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
                                         .message("Symbol declared as `Final` here"),
                                 );
                             }
-                            diagnostic.set_primary_message("Symbol later reassigned here");
+                            diagnostic
+                                .set_primary_annotation_message("Symbol later reassigned here");
                         }
                     }
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
@@ -62,7 +62,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Invalid argument to parameter 2 (`bases`) of `{fn_name}`"
             ));
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Expected `{}`, found `{}`",
                 formal_parameter_type.display(db),
                 bases_type.display(db)
@@ -112,8 +112,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "Invalid base for class created via `{fn_name}`"
                         ));
-                        diagnostic
-                            .set_primary_message(format_args!("Has type `{}`", base.display(db)));
+                        diagnostic.set_primary_annotation_message(format_args!(
+                            "Has type `{}`",
+                            base.display(db)
+                        ));
                         match class_base {
                             ClassBase::Generic => {
                                 diagnostic.info(format_args!(
@@ -143,8 +145,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "Unsupported base for class created via `{fn_name}`"
                         ));
-                        diagnostic
-                            .set_primary_message(format_args!("Has type `{}`", base.display(db)));
+                        diagnostic.set_primary_annotation_message(format_args!(
+                            "Has type `{}`",
+                            base.display(db)
+                        ));
                         diagnostic.info(format_args!(
                             "Classes created via `{fn_name}` cannot be protocols",
                         ));
@@ -179,7 +183,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         {
                             let mut diagnostic = builder
                                 .into_diagnostic("Invalid base for class created via `type()`");
-                            diagnostic.set_primary_message(format_args!(
+                            diagnostic.set_primary_annotation_message(format_args!(
                                 "Has type `{}`",
                                 base.display(db)
                             ));
@@ -301,7 +305,7 @@ pub(super) fn report_mro_error_kind<'db>(
                         context.report_lint(&UNSUPPORTED_DYNAMIC_BASE, diagnostic_range)
                     {
                         let mut diagnostic = builder.into_diagnostic("Unsupported class base");
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Has type `{}`",
                             base_type.display(db)
                         ));

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -483,7 +483,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Invalid argument to parameter `value` of `{base_name}()`"
                 ));
-                diagnostic.set_primary_message(format_args!(
+                diagnostic.set_primary_annotation_message(format_args!(
                     "Expected `str`, found `{}`",
                     name_type.display(db)
                 ));
@@ -906,7 +906,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Invalid argument to parameter `names` of `{base_name}()`"
             ));
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Expected `{}`, found `{}`",
                 enum_names_type(db).display(db),
                 names_ty.display(db),

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -213,7 +213,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 "Cannot assign to final attribute `{attribute}` on type `{}`",
                 object_ty.display(db)
             ));
-            diagnostic.set_primary_message(if is_dataclass_like {
+            diagnostic.set_primary_annotation_message(if is_dataclass_like {
                 "`Final` attributes can only be assigned in the class body, `__init__`, or `__post_init__` on dataclass-like classes"
             } else {
                 "`Final` attributes can only be assigned in the class body or `__init__`"
@@ -262,7 +262,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 {
                     let mut diagnostic =
                         diag_builder.into_diagnostic("Invalid assignment to final attribute");
-                    diagnostic.set_primary_message(format_args!(
+                    diagnostic.set_primary_annotation_message(format_args!(
                         "`{attribute}` already has a value in the class body"
                     ));
                     if let Some(final_declaration) = final_declaration {
@@ -301,7 +301,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     "Cannot delete final attribute `{attribute}` on type `{}`",
                     object_ty.display(db)
                 ));
-                diagnostic.set_primary_message("`Final` attributes cannot be deleted");
+                diagnostic.set_primary_annotation_message("`Final` attributes cannot be deleted");
                 if let Some(final_declaration) = final_declaration {
                     self.annotate_final_declaration(&mut diagnostic, final_declaration);
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -491,7 +491,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     "Useless body for `@overload`-decorated function `{}`",
                     function.name
                 ));
-                diagnostic.set_primary_message("This statement will never be executed");
+                diagnostic.set_primary_annotation_message("This statement will never be executed");
                 diagnostic.info(
                     "`@overload`-decorated functions are solely for type checkers \
                     and must be overwritten at runtime by a non-`@overload`-decorated implementation",
@@ -925,7 +925,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 let mut diag = builder.into_diagnostic(format_args!(
                                     "`{name}.kwargs` is valid only in `**kwargs` annotation",
                                 ));
-                                diag.set_primary_message(format_args!(
+                                diag.set_primary_annotation_message(format_args!(
                                     "Did you mean `{name}.args`?"
                                 ));
                                 add_type_expression_reference_link(diag);
@@ -1054,7 +1054,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             let mut diag = builder.into_diagnostic(format_args!(
                                 "`{name}.args` is valid only in `*args` annotation",
                             ));
-                            diag.set_primary_message(format_args!("Did you mean `{name}.kwargs`?"));
+                            diag.set_primary_annotation_message(format_args!(
+                                "Did you mean `{name}.kwargs`?"
+                            ));
                             add_type_expression_reference_link(diag);
                         }
                         KnownClass::Dict.to_specialized_instance(

--- a/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
@@ -243,7 +243,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "Invalid argument to parameter `defaults` of `namedtuple()`"
                         ));
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Expected `Iterable[Any] | None`, found `{}`",
                             kw_type.display(db)
                         ));
@@ -260,7 +260,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "Invalid argument to parameter `rename` of `namedtuple()`"
                         ));
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Expected `bool`, found `{}`",
                             kw_type.display(db)
                         ));
@@ -280,7 +280,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "Invalid argument to parameter `module` of `namedtuple()`"
                         ));
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Expected `str | None`, found `{}`",
                             kw_type.display(db)
                         ));
@@ -335,7 +335,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Invalid argument to parameter `typename` of `{kind}()`"
             ));
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Expected `str`, found `{}`",
                 name_type.display(db)
             ));
@@ -464,7 +464,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Invalid argument to parameter `field_names` of `namedtuple()`"
                 ));
-                diagnostic.set_primary_message(format_args!(
+                diagnostic.set_primary_annotation_message(format_args!(
                     "Expected `str` or an iterable of strings, found `{}`",
                     fields_type.display(db)
                 ));
@@ -511,7 +511,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         {
             let mut diagnostic =
                 builder.into_diagnostic(format_args!("Too many defaults for `namedtuple()`"));
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Got {defaults_count} default values but only {num_fields} field names"
             ));
             diagnostic.info("This will raise `TypeError` at runtime");
@@ -564,7 +564,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     let mut diagnostic = builder.into_diagnostic(
                         "Invalid argument to parameter `fields` of `NamedTuple()`",
                     );
-                    diagnostic.set_primary_message("`fields` must be a literal list or tuple");
+                    diagnostic
+                        .set_primary_annotation_message("`fields` must be a literal list or tuple");
                 }
                 return NamedTupleSpec::unknown(db);
             }
@@ -600,7 +601,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let mut diagnostic = builder.into_diagnostic(
                             "Invalid argument to parameter `fields` of `NamedTuple()`",
                         );
-                        diagnostic.set_primary_message(
+                        diagnostic.set_primary_annotation_message(
                             "`fields` must be a sequence of literal lists or tuples",
                         );
                     }
@@ -626,7 +627,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     let mut diagnostic = builder.into_diagnostic(
                         "Invalid argument to parameter `fields` of `NamedTuple()`",
                     );
-                    diagnostic.set_primary_message(
+                    diagnostic.set_primary_annotation_message(
                         "Each element in `fields` must be a length-2 tuple or list",
                     );
                 }
@@ -662,7 +663,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 if let Some(builder) = self.context.report_lint(&INVALID_NAMED_TUPLE, name_expr) {
                     let mut diagnostic =
                         builder.into_diagnostic("Invalid `NamedTuple` field name definition");
-                    diagnostic.set_primary_message(format_args!(
+                    diagnostic.set_primary_annotation_message(format_args!(
                         "Expected a string literal for the field name, found `{}`",
                         name_type.display(db)
                     ));
@@ -707,7 +708,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Duplicate field name `{field_name}` in `{kind}()`"
                 ));
-                diagnostic.set_primary_message(format_args!(
+                diagnostic.set_primary_annotation_message(format_args!(
                     "Field `{field_name}` already defined; will raise `ValueError` at runtime"
                 ));
             }
@@ -718,21 +719,21 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Field name `{field_name}` in `{kind}()` cannot start with an underscore"
                 ));
-                diagnostic.set_primary_message("Will raise `ValueError` at runtime");
+                diagnostic.set_primary_annotation_message("Will raise `ValueError` at runtime");
             } else if is_keyword(field_name)
                 && let Some(builder) = self.context.report_lint(&INVALID_NAMED_TUPLE, fields_arg)
             {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Field name `{field_name}` in `{kind}()` cannot be a Python keyword"
                 ));
-                diagnostic.set_primary_message("Will raise `ValueError` at runtime");
+                diagnostic.set_primary_annotation_message("Will raise `ValueError` at runtime");
             } else if !is_identifier(field_name)
                 && let Some(builder) = self.context.report_lint(&INVALID_NAMED_TUPLE, fields_arg)
             {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Field name `{field_name}` in `{kind}()` is not a valid identifier"
                 ));
-                diagnostic.set_primary_message("Will raise `ValueError` at runtime");
+                diagnostic.set_primary_annotation_message("Will raise `ValueError` at runtime");
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
@@ -80,7 +80,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let mut diagnostic = builder.into_diagnostic(
                     "Invalid argument to parameter 1 (`name`) of `types.new_class()`",
                 );
-                diagnostic.set_primary_message(format_args!(
+                diagnostic.set_primary_annotation_message(format_args!(
                     "Expected `str`, found `{}`",
                     name_type.display(db)
                 ));

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -162,7 +162,7 @@ fn check_legacy_positional_only_convention<'db>(
                 "Invalid use of the legacy convention \
                     for positional-only parameters",
             );
-            diagnostic.set_primary_message(
+            diagnostic.set_primary_annotation_message(
                 "Parameter name begins with `__` but will not be treated as positional-only",
             );
             diagnostic.info(
@@ -253,7 +253,7 @@ fn check_legacy_typevar_defaults<'db>(
         ));
 
         if is_later_in_list {
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Default of `{typevar_name}` references later type parameter `{}`",
                 bad_typevar.name(db),
             ));
@@ -263,7 +263,7 @@ fn check_legacy_typevar_defaults<'db>(
                 bad_typevar.name(db)
             ));
         } else {
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Default of `{typevar_name}` references out-of-scope type variable `{}`",
                 bad_typevar.name(db),
             ));
@@ -392,14 +392,14 @@ fn check_legacy_typevar_ordering<'db>(
     ));
 
     if let [single_typevar] = &*state.invalid_later_tvars {
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "Type variable `{}` does not have a default",
             single_typevar.name(db),
         ));
     } else {
         let later_typevars =
             format_enumeration(state.invalid_later_tvars.iter().map(|tv| tv.name(db)));
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "Type variables {later_typevars} do not have defaults",
         ));
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -113,7 +113,7 @@ pub(crate) fn check_overloaded_function<'db>(
                 "Overloaded function `{}` requires at least two overloads",
                 function_node.name
             ));
-            diagnostic.set_primary_message("Only one overload defined here");
+            diagnostic.set_primary_annotation_message("Only one overload defined here");
             if let Some(decorator) =
                 single_overload.find_known_decorator_span(db, KnownFunction::Overload)
             {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -371,7 +371,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                     "TypedDict class `{}` can only inherit from TypedDict classes",
                     class.name(db),
                 ));
-                diagnostic.set_primary_message(format_args!(
+                diagnostic.set_primary_annotation_message(format_args!(
                     "`{}` is not a `TypedDict` class",
                     base_class.name(db)
                 ));
@@ -665,7 +665,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                                 "Invalid argument to parameter `{arg_name}` \
                                     in `TypedDict` definition",
                             ));
-                            diagnostic.set_primary_message(format_args!(
+                            diagnostic.set_primary_annotation_message(format_args!(
                                 "Expected either `True` or `False`, got object of type `{}`",
                                 passed_type.display(db)
                             ));
@@ -1270,7 +1270,8 @@ fn check_final_class_abstract_methods<'db>(
             "Final class `{class_name}` has unimplemented abstract method \
                 `{first_method_name}`",
         ));
-        diagnostic.set_primary_message(format_args!("`{first_method_name}` is unimplemented"));
+        diagnostic
+            .set_primary_annotation_message(format_args!("`{first_method_name}` is unimplemented"));
     } else {
         let verbose = db.verbose();
         let max_abstract_methods_to_print = if verbose { num_abstract_methods } else { 3 };
@@ -1278,7 +1279,7 @@ fn check_final_class_abstract_methods<'db>(
             format_enumeration(abstract_methods.keys().take(max_abstract_methods_to_print));
 
         if num_abstract_methods > max_abstract_methods_to_print {
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "{num_abstract_methods} abstract methods are unimplemented, \
                         including {formatted_methods}",
             ));
@@ -1295,7 +1296,7 @@ fn check_final_class_abstract_methods<'db>(
                 "Final class `{class_name}` has unimplemented \
                     abstract methods {formatted_methods}",
             ));
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Abstract methods {formatted_methods} are unimplemented"
             ));
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/type_param_validation.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/type_param_validation.rs
@@ -47,7 +47,7 @@ pub(crate) fn check_single_typevar_tuple_pep695(
             "{owner_kind} `{owner_name}` cannot have multiple `TypeVarTuple` type parameters"
         ));
 
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "`{}` is an additional TypeVarTuple",
             typevar_tuple.name
         ));
@@ -112,7 +112,7 @@ pub(crate) fn check_no_default_after_typevar_tuple_pep695(
             typevar_tuple.name
         ));
 
-        diagnostic.set_primary_message(format_args!("`{single_name}` has a default"));
+        diagnostic.set_primary_annotation_message(format_args!("`{single_name}` has a default"));
     } else {
         let names = format_enumeration(params_with_defaults.iter().map(|p| p.name()));
 
@@ -121,7 +121,7 @@ pub(crate) fn check_no_default_after_typevar_tuple_pep695(
             typevar_tuple.name
         ));
 
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "`{}` has a default",
             params_with_defaults[0].name()
         ));

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
@@ -481,7 +481,7 @@ fn report_typed_dict_field_override<'db>(
         ))
     };
 
-    diagnostic.set_primary_message(format_args!("{reason}"));
+    diagnostic.set_primary_annotation_message(format_args!("{reason}"));
 
     if own_field_definition.is_none() {
         add_definition_subdiagnostic(

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -517,7 +517,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let Some(builder) = self.context.report_lint(&NOT_SUBSCRIPTABLE, subscript) {
                 let mut diagnostic =
                     builder.into_diagnostic("Cannot specialize non-generic type alias");
-                diagnostic.set_primary_message("Double specialization is not allowed");
+                diagnostic.set_primary_annotation_message("Double specialization is not allowed");
             }
             return Type::unknown();
         }
@@ -1767,7 +1767,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 slice_ty.display(db),
                                 object_ty.display(db),
                             ));
-                            diagnostic.set_primary_message(format_args!(
+                            diagnostic.set_primary_annotation_message(format_args!(
                                 "Expected value assignable to `{}`",
                                 expected_ty.display(db)
                             ));

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -184,7 +184,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         {
             let mut diagnostic = builder
                 .into_diagnostic("Invalid argument to parameter 3 (`namespace`) of `type()`");
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Expected `dict[str, Any]`, found `{}`",
                 namespace_type.display(db)
             ));
@@ -199,7 +199,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             {
                 let mut diagnostic =
                     builder.into_diagnostic("Invalid argument to parameter 1 (`name`) of `type()`");
-                diagnostic.set_primary_message(format_args!(
+                diagnostic.set_primary_annotation_message(format_args!(
                     "Expected `str`, found `{}`",
                     name_type.display(db)
                 ));

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -298,7 +298,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                     builder.into_diagnostic("Unsupported `|` operation");
 
                                 if left_type_value.is_equivalent_to(self.db(), right_type_value) {
-                                    diagnostic.set_primary_message(format_args!(
+                                    diagnostic.set_primary_annotation_message(format_args!(
                                         "Both operands have type `{}`",
                                         left_type_value.display(self.db())
                                     ));
@@ -444,7 +444,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     if let Some(single_element) = bytes.as_single_part_bytestring()
                         && let Ok(valid_string) = String::from_utf8(single_element.value.to_vec())
                     {
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Did you mean `typing.Literal[b\"{valid_string}\"]`?"
                         ));
                     }
@@ -464,7 +464,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     ),
                 ) {
                     if let Some(int) = int.as_i64() {
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Did you mean `typing.Literal[{int}]`?"
                         ));
                     }
@@ -509,7 +509,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         self.type_expression_context()
                     ),
                 ) {
-                    diagnostic.set_primary_message(format_args!(
+                    diagnostic.set_primary_annotation_message(format_args!(
                         "Did you mean `typing.Literal[{}]`?",
                         if bool_value.value { "True" } else { "False" }
                     ));
@@ -539,7 +539,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let hinted_type =
                             KnownClass::List.to_specialized_instance(db, &[inner_type]);
 
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Did you mean `{}`?",
                             hinted_type.display(self.db()),
                         ));
@@ -572,7 +572,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                         if inner_types.iter().all(|ty| ty.is_hintable(self.db())) {
                             let hinted_type = Type::heterogeneous_tuple(self.db(), inner_types);
-                            diagnostic.set_primary_message(format_args!(
+                            diagnostic.set_primary_annotation_message(format_args!(
                                 "Did you mean `{}`?",
                                 hinted_type.display(self.db()),
                             ));
@@ -716,7 +716,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     if key_type.is_hintable(self.db()) && value_type.is_hintable(self.db()) {
                         let hinted_type = KnownClass::Dict
                             .to_specialized_instance(self.db(), &[key_type, value_type]);
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Did you mean `{}`?",
                             hinted_type.display(self.db()),
                         ));
@@ -744,7 +744,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let hinted_type =
                             KnownClass::Set.to_specialized_instance(self.db(), &[inner_type]);
 
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Did you mean `{}`?",
                             hinted_type.display(self.db()),
                         ));
@@ -1082,8 +1082,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     {
                         let mut diagnostic =
                             builder.into_diagnostic("Invalid `tuple` specialization");
-                        diagnostic
-                            .set_primary_message("`...` cannot be used after an unpacked element");
+                        diagnostic.set_primary_annotation_message(
+                            "`...` cannot be used after an unpacked element",
+                        );
                     }
                     let result = TupleType::homogeneous(self.db(), element_ty);
                     self.store_expression_type(&tuple.slice, Type::tuple(Some(result)));
@@ -1099,7 +1100,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, tuple) {
                             let mut diagnostic =
                                 builder.into_diagnostic("Invalid `tuple` specialization");
-                            diagnostic.set_primary_message(
+                            diagnostic.set_primary_annotation_message(
                                 "`...` can only be used as the second element \
                                 in a two-element `tuple` specialization",
                             );
@@ -1188,7 +1189,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, tuple) {
                         let mut diagnostic =
                             builder.into_diagnostic("Invalid `tuple` specialization");
-                        diagnostic.set_primary_message(
+                        diagnostic.set_primary_annotation_message(
                             "`...` can only be used as the second element \
                                 in a two-element `tuple` specialization",
                         );
@@ -1911,7 +1912,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     "`[...]` is not a valid parameter list for `Callable`",
                 ) {
                     if let Some(returns) = return_type {
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Did you mean `Callable[..., {}]`?",
                             returns.display(db)
                         ));

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -174,7 +174,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "Invalid argument to parameter `{arg_name}` of `TypedDict()`"
                         ));
-                        diagnostic.set_primary_message(format_args!(
+                        diagnostic.set_primary_annotation_message(format_args!(
                             "Expected either `True` or `False`, got object of type `{}`",
                             kw_type.display(db)
                         ));
@@ -275,7 +275,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Invalid argument to parameter `typename` of `TypedDict()`"
             ));
-            diagnostic.set_primary_message(format_args!(
+            diagnostic.set_primary_annotation_message(format_args!(
                 "Expected `str`, found `{}`",
                 name_type.display(db)
             ));
@@ -650,8 +650,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             "Expected a string-literal key \
                                 in the `fields` dict of `TypedDict()`",
                         );
-                        diagnostic
-                            .set_primary_message(format_args!("Found `{}`", key_type.display(db)));
+                        diagnostic.set_primary_annotation_message(format_args!(
+                            "Found `{}`",
+                            key_type.display(db)
+                        ));
                     }
                 } else {
                     self.infer_expression(value, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -261,7 +261,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 if let Some(mut diagnostic) = not_assignable_to_upper_bound() {
                                     annotate_default_definition(&mut diagnostic);
                                     if let Some(name) = name {
-                                        diagnostic.set_primary_message(format_args!(
+                                        diagnostic.set_primary_annotation_message(format_args!(
                                             "Constraint `{constraint}` of default \
                                             `{default_name}` is not assignable to upper \
                                             bound of `{name}`",
@@ -277,7 +277,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             constraint = constraint.display(db),
                                         ));
                                     } else {
-                                        diagnostic.set_primary_message(format_args!(
+                                        diagnostic.set_primary_annotation_message(format_args!(
                                             "Constraint `{constraint}` of `{default_name}` is \
                                             not assignable to upper bound `{bound}` of \
                                             outer TypeVar",
@@ -303,7 +303,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             if let Some(mut diagnostic) = not_assignable_to_upper_bound() {
                                 annotate_default_definition(&mut diagnostic);
                                 if let Some(name) = name {
-                                    diagnostic.set_primary_message(format_args!(
+                                    diagnostic.set_primary_annotation_message(format_args!(
                                         "Upper bound `{default_bound}` of default \
                                             `{default_name}` is not assignable to upper \
                                             bound of `{name}`",
@@ -319,7 +319,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         default_bound = default_bound.display(db),
                                     ));
                                 } else {
-                                    diagnostic.set_primary_message(format_args!(
+                                    diagnostic.set_primary_annotation_message(format_args!(
                                         "Upper bound `{default_bound}` of default \
                                             `{default_name}` is not assignable to upper \
                                             bound of outer TypeVar",
@@ -352,7 +352,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 if let Some(mut diagnostic) = inconsistent_with_constraints() {
                                     annotate_default_definition(&mut diagnostic);
                                     if let Some(name) = name {
-                                        diagnostic.set_primary_message(format_args!(
+                                        diagnostic.set_primary_annotation_message(format_args!(
                                             "Constraint `{constraint}` of default \
                                                 `{default_name}` is not one of the constraints \
                                                 of `{name}`",
@@ -367,7 +367,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             constraint = default_constraint.display(db),
                                         ));
                                     } else {
-                                        diagnostic.set_primary_message(format_args!(
+                                        diagnostic.set_primary_annotation_message(format_args!(
                                             "Constraint `{constraint}` of outer TypeVar default \
                                                 `{default_name}` is not one of the constraints \
                                                 of the outer TypeVar",
@@ -392,7 +392,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         if let Some(mut diagnostic) = inconsistent_with_constraints() {
                             annotate_default_definition(&mut diagnostic);
                             if let Some(default_bound) = default_typevar.upper_bound(db) {
-                                diagnostic.set_primary_message(
+                                diagnostic.set_primary_annotation_message(
                                     "Bounded TypeVar cannot be used as the default \
                                     for a constrained TypeVar",
                                 );
@@ -401,7 +401,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     default_bound = default_bound.display(db),
                                 ));
                             } else {
-                                diagnostic.set_primary_message(
+                                diagnostic.set_primary_annotation_message(
                                     "Unbounded TypeVar cannot be used as the default \
                                     for a constrained TypeVar",
                                 );
@@ -422,9 +422,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if !default_ty.is_assignable_to(db, bound) {
                     if let Some(mut diagnostic) = not_assignable_to_upper_bound() {
                         if let Some(name) = name {
-                            diagnostic.set_primary_message(format_args!("Default of `{name}`"));
+                            diagnostic.set_primary_annotation_message(format_args!(
+                                "Default of `{name}`"
+                            ));
                         } else {
-                            diagnostic.set_primary_message("TypeVar default");
+                            diagnostic.set_primary_annotation_message("TypeVar default");
                         }
                         diagnostic.set_concise_message(not_assignable_message);
                     }
@@ -439,12 +441,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 {
                     if let Some(mut diagnostic) = inconsistent_with_constraints() {
                         if let Some(name) = name {
-                            diagnostic.set_primary_message(format_args!(
+                            diagnostic.set_primary_annotation_message(format_args!(
                                 "`{default}` is not one of the constraints of `{name}`",
                                 default = default_ty.display(db),
                             ));
                         } else {
-                            diagnostic.set_primary_message(format_args!(
+                            diagnostic.set_primary_annotation_message(format_args!(
                                 "`{default}` is not one of the constraints",
                                 default = default_ty.display(db),
                             ));
@@ -510,7 +512,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut diagnostic = builder.into_diagnostic(format_args!(
             "Invalid default for type parameter `{typevar_name}`"
         ));
-        diagnostic.set_primary_message(format_args!(
+        diagnostic.set_primary_annotation_message(format_args!(
             "`{outer_name}` is a type parameter bound in an outer scope"
         ));
         diagnostic.set_concise_message(format_args!(

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -42,7 +42,7 @@ fn get_symbol<'db>(
 fn assert_diagnostic_messages(diagnostics: &[Diagnostic], expected: &[&str]) {
     let messages: Vec<&str> = diagnostics
         .iter()
-        .map(Diagnostic::primary_message)
+        .map(Diagnostic::headline_message)
         .collect();
     assert_eq!(&messages, expected);
 }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -1289,7 +1289,7 @@ fn report_invalid_attribute_override<'db>(
 
     let mut diagnostic =
         builder.into_diagnostic(format_args!("Invalid override of attribute `{member}`"));
-    diagnostic.set_primary_message(format_args!(
+    diagnostic.set_primary_annotation_message(format_args!(
         "{subclass_kind} cannot override {superclass_kind} `{superclass_member}`"
     ));
     diagnostic.info("This violates the Liskov Substitution Principle");

--- a/crates/ty_python_semantic/src/types/string_annotation.rs
+++ b/crates/ty_python_semantic/src/types/string_annotation.rs
@@ -82,7 +82,7 @@ pub(crate) fn parse_string_annotation(
                         let mut diagnostic =
                             builder.into_diagnostic("Syntax error in forward annotation");
 
-                        diagnostic.set_primary_message(&error);
+                        diagnostic.set_primary_annotation_message(&error);
 
                         let possible_secondary = string_literal
                             .range()

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1462,7 +1462,7 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
                     self.key,
                 ));
 
-                diagnostic.set_primary_message(format_args!("key is marked read-only"));
+                diagnostic.set_primary_annotation_message(format_args!("key is marked read-only"));
                 self.add_object_type_annotation(db, &mut diagnostic);
                 Self::add_item_definition_subdiagnostic(
                     db,
@@ -1502,7 +1502,7 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
                 self.key,
             ));
 
-            diagnostic.set_primary_message(format_args!("value of type `{value_d}`"));
+            diagnostic.set_primary_annotation_message(format_args!("value of type `{value_d}`"));
 
             diagnostic.annotate(
                 self.context

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -230,7 +230,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
                                 ResizeTupleError::TooManyValues => {
                                     let mut diag =
                                         builder.into_diagnostic("Too many values to unpack");
-                                    diag.set_primary_message(format_args!(
+                                    diag.set_primary_annotation_message(format_args!(
                                         "Expected {}",
                                         target_len.display_minimum(),
                                     ));
@@ -241,7 +241,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
                                 ResizeTupleError::TooFewValues => {
                                     let mut diag =
                                         builder.into_diagnostic("Not enough values to unpack");
-                                    diag.set_primary_message(format_args!(
+                                    diag.set_primary_annotation_message(format_args!(
                                         "Expected {}",
                                         target_len.display_minimum(),
                                     ));

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -540,9 +540,9 @@ pub(super) fn to_lsp_diagnostic(
             .primary_annotation()
             .and_then(|annotation| annotation.get_message())
         {
-            format!("{}: {annotation_message}", diagnostic.primary_message())
+            format!("{}: {annotation_message}", diagnostic.headline_message())
         } else {
-            diagnostic.primary_message().to_string()
+            diagnostic.headline_message().to_string()
         }
     } else {
         diagnostic.concise_message().to_string()

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -280,7 +280,7 @@ impl ProgressReporter for WorkspaceDiagnosticsProgressReporter<'_> {
             } else {
                 tracing::debug!(
                     "Ignoring diagnostic without a file: {diagnostic}",
-                    diagnostic = diagnostic.primary_message()
+                    diagnostic = diagnostic.headline_message()
                 );
             }
         }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -913,7 +913,7 @@ impl Diagnostic {
 
                 SubDiagnostic {
                     severity: sub_diagnostic.severity().into(),
-                    message: sub_diagnostic.primary_message().to_string(),
+                    message: sub_diagnostic.headline_message().to_string(),
                     annotations,
                 }
             })


### PR DESCRIPTION
## Summary

In main, we have some confusing/ambiguous naming in the diagnostic API; the term "primary" is sometimes used to refer to the "primary annotation" and sometimes to the headline diagnostic message. In fact, we currently have methods named `primary_message` and `set_primary_message`, but the latter sets the primary _annotation_ message, and the former fetches the headline message!

This PR prefers clarity over conciseness, always using `primary_annotation` to refer to the primary annotation (the fact that this is the primary _annotation_ message and not some other "primary message" is IMO key context the caller should be aware of), and always using the term "headline" to refer to the main diagnostic message.

Specifically:
- Rename both diagnostic-guard `set_primary_message` methods to `set_primary_annotation_message` and update all call sites.
- Rename `Diagnostic::primary_message` and `SubDiagnostic::primary_message` to `headline_message`, updating consumers and terminology in the diagnostic API documentation.

This is a fully mechanical rename that should have no behavior impact.

## Test plan

- Existing diagnostic-rendering and ty semantic coverage passes, including concise-message behavior; no snapshots changed.
- All workspace targets, tests, and benchmarks compile with the renamed APIs, and repository hooks pass.
