### PR TITLE
[ty] Make callable return inference invariant to union order

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1204,7 +1204,13 @@ class Box(Generic[T_co]): ...
 def ensure_tuple(func: Callable[P, tuple[T, ...] | T]) -> Callable[P, tuple[T, ...]]:
     raise NotImplementedError
 
+def ensure_tuple_reversed(func: Callable[P, T | tuple[T, ...]]) -> Callable[P, tuple[T, ...]]:
+    raise NotImplementedError
+
 def ensure_box(func: Callable[P, Box[T] | T]) -> Callable[P, Box[T]]:
+    raise NotImplementedError
+
+def ensure_box_reversed(func: Callable[P, T | Box[T]]) -> Callable[P, Box[T]]:
     raise NotImplementedError
 
 def check(
@@ -1217,10 +1223,16 @@ def check(
 ) -> None:
     reveal_type(ensure_tuple(scalar_first))  # revealed: (int, /) -> tuple[str, ...]
     reveal_type(ensure_tuple(tuple_first))  # revealed: (int, /) -> tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(scalar_first))  # revealed: (int, /) -> tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(tuple_first))  # revealed: (int, /) -> tuple[str, ...]
     reveal_type(ensure_tuple(nested_member_first))  # revealed: (int, /) -> tuple[Box[str], ...]
     reveal_type(ensure_tuple(nested_tuple_first))  # revealed: (int, /) -> tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_member_first))  # revealed: (int, /) -> tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_tuple_first))  # revealed: (int, /) -> tuple[Box[str], ...]
     reveal_type(ensure_box(box_scalar_first))  # revealed: (int, /) -> Box[str]
     reveal_type(ensure_box(box_first))  # revealed: (int, /) -> Box[str]
+    reveal_type(ensure_box_reversed(box_scalar_first))  # revealed: (int, /) -> Box[str]
+    reveal_type(ensure_box_reversed(box_first))  # revealed: (int, /) -> Box[str]
 ```
 
 ## Passing a constrained TypeVar to a function expecting a compatible constrained TypeVar

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1190,6 +1190,39 @@ class MyCallable:
 reveal_type(call(MyCallable()))  # revealed: int
 ```
 
+## Callable return union order does not affect inference
+
+```py
+from typing import Callable, Generic, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+
+class Box(Generic[T_co]): ...
+
+def ensure_tuple(func: Callable[P, tuple[T, ...] | T]) -> Callable[P, tuple[T, ...]]:
+    raise NotImplementedError
+
+def ensure_box(func: Callable[P, Box[T] | T]) -> Callable[P, Box[T]]:
+    raise NotImplementedError
+
+def check(
+    scalar_first: Callable[[int], str | tuple[str, ...]],
+    tuple_first: Callable[[int], tuple[str, ...] | str],
+    nested_member_first: Callable[[int], Box[str] | tuple[Box[str], ...]],
+    nested_tuple_first: Callable[[int], tuple[Box[str], ...] | Box[str]],
+    box_scalar_first: Callable[[int], str | Box[str]],
+    box_first: Callable[[int], Box[str] | str],
+) -> None:
+    reveal_type(ensure_tuple(scalar_first))  # revealed: (int, /) -> tuple[str, ...]
+    reveal_type(ensure_tuple(tuple_first))  # revealed: (int, /) -> tuple[str, ...]
+    reveal_type(ensure_tuple(nested_member_first))  # revealed: (int, /) -> tuple[Box[str], ...]
+    reveal_type(ensure_tuple(nested_tuple_first))  # revealed: (int, /) -> tuple[Box[str], ...]
+    reveal_type(ensure_box(box_scalar_first))  # revealed: (int, /) -> Box[str]
+    reveal_type(ensure_box(box_first))  # revealed: (int, /) -> Box[str]
+```
+
 ## Passing a constrained TypeVar to a function expecting a compatible constrained TypeVar
 
 A constrained TypeVar should be assignable to a different constrained TypeVar if each constraint of

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1193,46 +1193,45 @@ reveal_type(call(MyCallable()))  # revealed: int
 ## Callable return union order does not affect inference
 
 ```py
-from typing import Callable, Generic, ParamSpec, TypeVar
+from typing import Callable, Generic, TypeVar
 
-P = ParamSpec("P")
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
 
 class Box(Generic[T_co]): ...
 
-def ensure_tuple(func: Callable[P, tuple[T, ...] | T]) -> Callable[P, tuple[T, ...]]:
+def ensure_tuple(func: Callable[[], tuple[T, ...] | T]) -> tuple[T, ...]:
     raise NotImplementedError
 
-def ensure_tuple_reversed(func: Callable[P, T | tuple[T, ...]]) -> Callable[P, tuple[T, ...]]:
+def ensure_tuple_reversed(func: Callable[[], T | tuple[T, ...]]) -> tuple[T, ...]:
     raise NotImplementedError
 
-def ensure_box(func: Callable[P, Box[T] | T]) -> Callable[P, Box[T]]:
+def ensure_box(func: Callable[[], Box[T] | T]) -> Box[T]:
     raise NotImplementedError
 
-def ensure_box_reversed(func: Callable[P, T | Box[T]]) -> Callable[P, Box[T]]:
+def ensure_box_reversed(func: Callable[[], T | Box[T]]) -> Box[T]:
     raise NotImplementedError
 
 def check(
-    scalar_first: Callable[[int], str | tuple[str, ...]],
-    tuple_first: Callable[[int], tuple[str, ...] | str],
-    nested_member_first: Callable[[int], Box[str] | tuple[Box[str], ...]],
-    nested_tuple_first: Callable[[int], tuple[Box[str], ...] | Box[str]],
-    box_scalar_first: Callable[[int], str | Box[str]],
-    box_first: Callable[[int], Box[str] | str],
+    scalar_first: Callable[[], str | tuple[str, ...]],
+    tuple_first: Callable[[], tuple[str, ...] | str],
+    nested_member_first: Callable[[], Box[str] | tuple[Box[str], ...]],
+    nested_tuple_first: Callable[[], tuple[Box[str], ...] | Box[str]],
+    box_scalar_first: Callable[[], str | Box[str]],
+    box_first: Callable[[], Box[str] | str],
 ) -> None:
-    reveal_type(ensure_tuple(scalar_first))  # revealed: (int, /) -> tuple[str, ...]
-    reveal_type(ensure_tuple(tuple_first))  # revealed: (int, /) -> tuple[str, ...]
-    reveal_type(ensure_tuple_reversed(scalar_first))  # revealed: (int, /) -> tuple[str, ...]
-    reveal_type(ensure_tuple_reversed(tuple_first))  # revealed: (int, /) -> tuple[str, ...]
-    reveal_type(ensure_tuple(nested_member_first))  # revealed: (int, /) -> tuple[Box[str], ...]
-    reveal_type(ensure_tuple(nested_tuple_first))  # revealed: (int, /) -> tuple[Box[str], ...]
-    reveal_type(ensure_tuple_reversed(nested_member_first))  # revealed: (int, /) -> tuple[Box[str], ...]
-    reveal_type(ensure_tuple_reversed(nested_tuple_first))  # revealed: (int, /) -> tuple[Box[str], ...]
-    reveal_type(ensure_box(box_scalar_first))  # revealed: (int, /) -> Box[str]
-    reveal_type(ensure_box(box_first))  # revealed: (int, /) -> Box[str]
-    reveal_type(ensure_box_reversed(box_scalar_first))  # revealed: (int, /) -> Box[str]
-    reveal_type(ensure_box_reversed(box_first))  # revealed: (int, /) -> Box[str]
+    reveal_type(ensure_tuple(scalar_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple(tuple_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(scalar_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(tuple_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple(nested_member_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple(nested_tuple_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_member_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_tuple_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_box(box_scalar_first))  # revealed: Box[str]
+    reveal_type(ensure_box(box_first))  # revealed: Box[str]
+    reveal_type(ensure_box_reversed(box_scalar_first))  # revealed: Box[str]
+    reveal_type(ensure_box_reversed(box_first))  # revealed: Box[str]
 ```
 
 ## Passing a constrained TypeVar to a function expecting a compatible constrained TypeVar

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1238,7 +1238,13 @@ class Box[T]:
 def ensure_tuple[T, **P](func: Callable[P, tuple[T, ...] | T]) -> Callable[P, tuple[T, ...]]:
     raise NotImplementedError
 
+def ensure_tuple_reversed[T, **P](func: Callable[P, T | tuple[T, ...]]) -> Callable[P, tuple[T, ...]]:
+    raise NotImplementedError
+
 def ensure_box[T, **P](func: Callable[P, Box[T] | T]) -> Callable[P, Box[T]]:
+    raise NotImplementedError
+
+def ensure_box_reversed[T, **P](func: Callable[P, T | Box[T]]) -> Callable[P, Box[T]]:
     raise NotImplementedError
 
 def check(
@@ -1251,10 +1257,16 @@ def check(
 ) -> None:
     reveal_type(ensure_tuple(scalar_first))  # revealed: (int, /) -> tuple[str, ...]
     reveal_type(ensure_tuple(tuple_first))  # revealed: (int, /) -> tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(scalar_first))  # revealed: (int, /) -> tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(tuple_first))  # revealed: (int, /) -> tuple[str, ...]
     reveal_type(ensure_tuple(nested_member_first))  # revealed: (int, /) -> tuple[Box[str], ...]
     reveal_type(ensure_tuple(nested_tuple_first))  # revealed: (int, /) -> tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_member_first))  # revealed: (int, /) -> tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_tuple_first))  # revealed: (int, /) -> tuple[Box[str], ...]
     reveal_type(ensure_box(box_scalar_first))  # revealed: (int, /) -> Box[str]
     reveal_type(ensure_box(box_first))  # revealed: (int, /) -> Box[str]
+    reveal_type(ensure_box_reversed(box_scalar_first))  # revealed: (int, /) -> Box[str]
+    reveal_type(ensure_box_reversed(box_first))  # revealed: (int, /) -> Box[str]
 ```
 
 ### Don't include identical lower/upper bounds in type mapping multiple times

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1226,6 +1226,37 @@ def get_int() -> int | None: ...
 reveal_type(my_iter(get_int))  # revealed: Box[int]
 ```
 
+### Callable return union order does not affect inference
+
+```py
+from typing import Callable
+
+class Box[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+def ensure_tuple[T, **P](func: Callable[P, tuple[T, ...] | T]) -> Callable[P, tuple[T, ...]]:
+    raise NotImplementedError
+
+def ensure_box[T, **P](func: Callable[P, Box[T] | T]) -> Callable[P, Box[T]]:
+    raise NotImplementedError
+
+def check(
+    scalar_first: Callable[[int], str | tuple[str, ...]],
+    tuple_first: Callable[[int], tuple[str, ...] | str],
+    nested_member_first: Callable[[int], Box[str] | tuple[Box[str], ...]],
+    nested_tuple_first: Callable[[int], tuple[Box[str], ...] | Box[str]],
+    box_scalar_first: Callable[[int], str | Box[str]],
+    box_first: Callable[[int], Box[str] | str],
+) -> None:
+    reveal_type(ensure_tuple(scalar_first))  # revealed: (int, /) -> tuple[str, ...]
+    reveal_type(ensure_tuple(tuple_first))  # revealed: (int, /) -> tuple[str, ...]
+    reveal_type(ensure_tuple(nested_member_first))  # revealed: (int, /) -> tuple[Box[str], ...]
+    reveal_type(ensure_tuple(nested_tuple_first))  # revealed: (int, /) -> tuple[Box[str], ...]
+    reveal_type(ensure_box(box_scalar_first))  # revealed: (int, /) -> Box[str]
+    reveal_type(ensure_box(box_first))  # revealed: (int, /) -> Box[str]
+```
+
 ### Don't include identical lower/upper bounds in type mapping multiple times
 
 This is was a performance regression reported in

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1235,38 +1235,38 @@ class Box[T]:
     def get(self) -> T:
         raise NotImplementedError
 
-def ensure_tuple[T, **P](func: Callable[P, tuple[T, ...] | T]) -> Callable[P, tuple[T, ...]]:
+def ensure_tuple[T](func: Callable[[], tuple[T, ...] | T]) -> tuple[T, ...]:
     raise NotImplementedError
 
-def ensure_tuple_reversed[T, **P](func: Callable[P, T | tuple[T, ...]]) -> Callable[P, tuple[T, ...]]:
+def ensure_tuple_reversed[T](func: Callable[[], T | tuple[T, ...]]) -> tuple[T, ...]:
     raise NotImplementedError
 
-def ensure_box[T, **P](func: Callable[P, Box[T] | T]) -> Callable[P, Box[T]]:
+def ensure_box[T](func: Callable[[], Box[T] | T]) -> Box[T]:
     raise NotImplementedError
 
-def ensure_box_reversed[T, **P](func: Callable[P, T | Box[T]]) -> Callable[P, Box[T]]:
+def ensure_box_reversed[T](func: Callable[[], T | Box[T]]) -> Box[T]:
     raise NotImplementedError
 
 def check(
-    scalar_first: Callable[[int], str | tuple[str, ...]],
-    tuple_first: Callable[[int], tuple[str, ...] | str],
-    nested_member_first: Callable[[int], Box[str] | tuple[Box[str], ...]],
-    nested_tuple_first: Callable[[int], tuple[Box[str], ...] | Box[str]],
-    box_scalar_first: Callable[[int], str | Box[str]],
-    box_first: Callable[[int], Box[str] | str],
+    scalar_first: Callable[[], str | tuple[str, ...]],
+    tuple_first: Callable[[], tuple[str, ...] | str],
+    nested_member_first: Callable[[], Box[str] | tuple[Box[str], ...]],
+    nested_tuple_first: Callable[[], tuple[Box[str], ...] | Box[str]],
+    box_scalar_first: Callable[[], str | Box[str]],
+    box_first: Callable[[], Box[str] | str],
 ) -> None:
-    reveal_type(ensure_tuple(scalar_first))  # revealed: (int, /) -> tuple[str, ...]
-    reveal_type(ensure_tuple(tuple_first))  # revealed: (int, /) -> tuple[str, ...]
-    reveal_type(ensure_tuple_reversed(scalar_first))  # revealed: (int, /) -> tuple[str, ...]
-    reveal_type(ensure_tuple_reversed(tuple_first))  # revealed: (int, /) -> tuple[str, ...]
-    reveal_type(ensure_tuple(nested_member_first))  # revealed: (int, /) -> tuple[Box[str], ...]
-    reveal_type(ensure_tuple(nested_tuple_first))  # revealed: (int, /) -> tuple[Box[str], ...]
-    reveal_type(ensure_tuple_reversed(nested_member_first))  # revealed: (int, /) -> tuple[Box[str], ...]
-    reveal_type(ensure_tuple_reversed(nested_tuple_first))  # revealed: (int, /) -> tuple[Box[str], ...]
-    reveal_type(ensure_box(box_scalar_first))  # revealed: (int, /) -> Box[str]
-    reveal_type(ensure_box(box_first))  # revealed: (int, /) -> Box[str]
-    reveal_type(ensure_box_reversed(box_scalar_first))  # revealed: (int, /) -> Box[str]
-    reveal_type(ensure_box_reversed(box_first))  # revealed: (int, /) -> Box[str]
+    reveal_type(ensure_tuple(scalar_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple(tuple_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(scalar_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(tuple_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple(nested_member_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple(nested_tuple_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_member_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_tuple_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_box(box_scalar_first))  # revealed: Box[str]
+    reveal_type(ensure_box(box_first))  # revealed: Box[str]
+    reveal_type(ensure_box_reversed(box_scalar_first))  # revealed: Box[str]
+    reveal_type(ensure_box_reversed(box_first))  # revealed: Box[str]
 ```
 
 ### Don't include identical lower/upper bounds in type mapping multiple times

--- a/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
@@ -23,6 +23,25 @@ the `wobbling-ty-constraint-order` agent skill to automate this process.
 python-version = "3.13"
 ```
 
+## Constraint absorption is independent of source order
+
+```py
+from ty_extensions._internal import ConstraintSet
+
+def absorption[T]() -> None:
+    scalar = ConstraintSet.range(str, T, object)
+    tuple_ = ConstraintSet.range(tuple[str, ...], T, object)
+
+    # revealed: tuple[Solution[T=str]]
+    reveal_type((scalar & (scalar | tuple_)).solutions_for(T, inferable=tuple[T]))
+    # revealed: tuple[Solution[T=str]]
+    reveal_type(((scalar | tuple_) & scalar).solutions_for(T, inferable=tuple[T]))
+
+    # A genuine alternative still produces both solutions; absorption does not prefer one match.
+    # revealed: tuple[Solution[T=str], Solution[T=tuple[str, ...]]]
+    reveal_type((scalar | tuple_).solutions_for(T, inferable=tuple[T]))
+```
+
 ## Solution binding order follows constraint source order
 
 The order of bindings within a path must follow the first constraint that introduced each typevar.
@@ -49,6 +68,16 @@ def bindings_reverse_source[T, U, V]() -> None:
     constraints = ConstraintSet.range(bytes, V, bytes) & ConstraintSet.range(str, U, str) & ConstraintSet.range(int, T, int)
     # revealed: tuple[Solution[V=bytes, U=str, T=int]]
     reveal_type(constraints.solutions(inferable=tuple[T, U, V]))
+
+def bindings_absorbed[T, U, X]() -> None:
+    t = ConstraintSet.range(str, T, object)
+    u = ConstraintSet.range(bytes, U, object)
+    x = ConstraintSet.range(int, X, object)
+
+    # ((X ≥ int) ∧ (T ≥ str) ∧ (U ≥ bytes)) | ((U ≥ bytes) ∧ (T ≥ str))
+    constraints = (x & t & u) | (u & t)
+    # revealed: tuple[Solution[T=str, U=bytes]]
+    reveal_type(constraints.solutions(inferable=tuple[T, U, X]))
 ```
 
 ## Nested transitive constraints and an unrelated alternative

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -2199,15 +2199,15 @@ impl NodeId {
             return ALWAYS_TRUE;
         }
 
-        if if_true == if_false {
-            if if_true == if_uncertain {
-                return if_true;
+        if let Some(if_true_false) = if_true.merge_same_shape(builder, if_false) {
+            if let Some(result) = if_true_false.merge_same_shape(builder, if_uncertain) {
+                return result;
             }
             if if_true == ALWAYS_FALSE {
                 return if_uncertain;
             }
             if if_uncertain == ALWAYS_FALSE {
-                return if_true;
+                return if_true_false;
             }
 
             // TODO: A future reduction can handle this remaining `if_true == if_false` case by
@@ -2215,12 +2215,16 @@ impl NodeId {
             // the local equality check has already engaged.
         }
 
-        if if_true == if_uncertain && if_false == ALWAYS_FALSE {
-            return if_uncertain;
+        if if_false == ALWAYS_FALSE
+            && let Some(result) = if_true.merge_same_shape(builder, if_uncertain)
+        {
+            return result;
         }
 
-        if if_false == if_uncertain && if_true == ALWAYS_FALSE {
-            return if_uncertain;
+        if if_true == ALWAYS_FALSE
+            && let Some(result) = if_false.merge_same_shape(builder, if_uncertain)
+        {
+            return result;
         }
 
         let max_source_order = source_order
@@ -2330,6 +2334,58 @@ impl NodeId {
         }
         let interior = builder.interior_node_data(self);
         Some(interior.constraint)
+    }
+
+    /// Merges two TDDs with the same shape, preserving the earliest source order at each node.
+    fn merge_same_shape(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Option<Self> {
+        fn merge(
+            builder: &ConstraintSetBuilder<'_>,
+            left: NodeId,
+            right: NodeId,
+            cache: &mut FxHashMap<(NodeId, NodeId), NodeId>,
+        ) -> Option<NodeId> {
+            if left == right {
+                return Some(left);
+            }
+            let key = (left, right);
+            if let Some(result) = cache.get(&key) {
+                return Some(*result);
+            }
+            let (Node::Interior(_), Node::Interior(_)) = (left.node(), right.node()) else {
+                return None;
+            };
+            let left = builder.interior_node_data(left);
+            let right = builder.interior_node_data(right);
+            if left.constraint != right.constraint {
+                return None;
+            }
+
+            let if_true = merge(builder, left.if_true, right.if_true, cache)?;
+            let if_uncertain = merge(builder, left.if_uncertain, right.if_uncertain, cache)?;
+            let if_false = merge(builder, left.if_false, right.if_false, cache)?;
+            let result = NodeId::with_uncertain(
+                builder,
+                left.constraint,
+                if_true,
+                if_uncertain,
+                if_false,
+                left.source_order.min(right.source_order),
+            );
+            cache.insert(key, result);
+            Some(result)
+        }
+
+        if self == other {
+            return Some(self);
+        }
+        if self.is_terminal()
+            || other.is_terminal()
+            || self.root_constraint(builder) != other.root_constraint(builder)
+        {
+            return None;
+        }
+
+        merge(builder, self, other, &mut FxHashMap::default())
     }
 
     fn max_source_order(self, builder: &ConstraintSetBuilder<'_>) -> usize {
@@ -8035,6 +8091,127 @@ mod tests {
 
         let expected: FxIndexSet<_> = expected.into_iter().map(String::from).collect();
         assert_eq!(signatures, expected);
+    }
+
+    #[test]
+    fn constraint_absorption_is_independent_of_constraint_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let str = KnownClass::Str.to_instance(&db);
+        let int = KnownClass::Int.to_instance(&db);
+        let atoms = [
+            PermutedConstraint(t, Some(str), None),
+            PermutedConstraint(t, Some(int), None),
+        ];
+
+        check_solutions_for_constraint_orderings(
+            &db,
+            &[t],
+            &atoms,
+            |builder| {
+                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, builder));
+                str_t
+                    .or_with_offset(builder, int_t)
+                    .and_with_offset(builder, str_t)
+            },
+            ["never=false always=false merged=[T=str] paths=[T=str]"],
+        );
+
+        check_solutions_for_constraint_orderings(
+            &db,
+            &[t],
+            &atoms,
+            |builder| {
+                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, builder));
+                str_t.or_with_offset(builder, int_t)
+            },
+            ["never=false always=false merged=[T=str | int] paths=[T=str; T=int]"],
+        );
+    }
+
+    #[test]
+    fn compound_constraint_absorption_is_independent_of_constraint_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let str = KnownClass::Str.to_instance(&db);
+        let bytes = KnownClass::Bytes.to_instance(&db);
+        let int = KnownClass::Int.to_instance(&db);
+        let atoms = [
+            PermutedConstraint(t, Some(str), None),
+            PermutedConstraint(u, Some(bytes), None),
+            PermutedConstraint(t, Some(int), None),
+        ];
+
+        check_solutions_for_constraint_orderings(
+            &db,
+            &[t, u],
+            &atoms,
+            |builder| {
+                let [str_t, bytes_u, int_t] = atoms.map(|atom| atom.node(&db, builder));
+                let compound = str_t.and_with_offset(builder, bytes_u);
+                compound
+                    .or_with_offset(builder, int_t)
+                    .and_with_offset(builder, compound)
+            },
+            ["never=false always=false merged=[T=str, U=bytes] paths=[T=str, U=bytes]"],
+        );
+    }
+
+    #[test]
+    fn compound_constraint_absorption_preserves_binding_source_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let x = create_typevar(&db, "X");
+        let str = KnownClass::Str.to_instance(&db);
+        let bytes = KnownClass::Bytes.to_instance(&db);
+        let int = KnownClass::Int.to_instance(&db);
+        let atoms = [
+            PermutedConstraint(t, Some(str), None),
+            PermutedConstraint(u, Some(bytes), None),
+            PermutedConstraint(x, Some(int), None),
+        ];
+
+        check_solutions_for_constraint_orderings(
+            &db,
+            &[t, u, x],
+            &atoms,
+            |builder| {
+                let [str_t, bytes_u, int_x] = atoms.map(|atom| atom.node(&db, builder));
+                let early = int_x
+                    .and_with_offset(builder, str_t)
+                    .and_with_offset(builder, bytes_u);
+                let late = bytes_u.and_with_offset(builder, str_t);
+                early.or_with_offset(builder, late)
+            },
+            ["never=false always=false merged=[T=str, U=bytes] paths=[T=str, U=bytes]"],
+        );
+    }
+
+    #[test]
+    fn constraint_partition_is_independent_of_constraint_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let str = KnownClass::Str.to_instance(&db);
+        let int = KnownClass::Int.to_instance(&db);
+        let atoms = [
+            PermutedConstraint(t, Some(str), None),
+            PermutedConstraint(t, Some(int), None),
+        ];
+
+        check_solutions_for_constraint_orderings(
+            &db,
+            &[t],
+            &atoms,
+            |builder| {
+                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, builder));
+                let true_path = int_t.and_with_offset(builder, str_t);
+                let false_path = int_t.negate(builder).and_with_offset(builder, str_t);
+                true_path.or_with_offset(builder, false_path)
+            },
+            ["never=false always=false merged=[T=str] paths=[T=str]"],
+        );
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -860,6 +860,11 @@ struct ConstraintSetStorage<'db> {
     constraint_cache: FxHashMap<Constraint<'db>, ConstraintId>,
     typevar_cache: FxHashMap<BoundTypeVarIdentity<'db>, TypeVarId>,
     node_cache: FxHashMap<InteriorNodeData, NodeId>,
+    /// Source-independent identities for TDD shapes. The identity is a representative node in
+    /// this builder; owned-set overlays populate these caches lazily in the current builder.
+    node_shape_identity_cache: FxHashMap<NodeId, NodeId>,
+    node_shape_cache: FxHashMap<InteriorNodeShape, NodeId>,
+    node_shape_merge_cache: FxHashMap<(NodeId, NodeId), NodeId>,
     /// Avoid repeatedly walking deep constraint bounds without imposing Salsa-query overhead on
     /// the many shallow bounds that are cheap to walk once.
     constraint_bound_depth_cache: FxHashMap<ConstraintId, (u16, u16)>,
@@ -1198,6 +1203,27 @@ impl<'db> ConstraintSetBuilder<'db> {
         let id = storage.adjusted_node_id(id);
         storage.node_cache.insert(data, id);
         id
+    }
+
+    fn node_shape_identity(&self, node: NodeId) -> NodeId {
+        if node.is_terminal() {
+            return node;
+        }
+        if let Some(identity) = self.storage.borrow().node_shape_identity_cache.get(&node) {
+            return *identity;
+        }
+
+        let interior = self.interior_node_data(node);
+        let shape = InteriorNodeShape {
+            constraint: interior.constraint,
+            if_true: self.node_shape_identity(interior.if_true),
+            if_uncertain: self.node_shape_identity(interior.if_uncertain),
+            if_false: self.node_shape_identity(interior.if_false),
+        };
+        let mut storage = self.storage.borrow_mut();
+        let identity = *storage.node_shape_cache.entry(shape).or_insert(node);
+        storage.node_shape_identity_cache.insert(node, identity);
+        identity
     }
 
     fn typevar_id(&self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
@@ -2342,13 +2368,16 @@ impl NodeId {
             builder: &ConstraintSetBuilder<'_>,
             left: NodeId,
             right: NodeId,
-            cache: &mut FxHashMap<(NodeId, NodeId), NodeId>,
         ) -> Option<NodeId> {
             if left == right {
                 return Some(left);
             }
-            let key = (left, right);
-            if let Some(result) = cache.get(&key) {
+            let key = if left.0 < right.0 {
+                (left, right)
+            } else {
+                (right, left)
+            };
+            if let Some(result) = builder.storage.borrow().node_shape_merge_cache.get(&key) {
                 return Some(*result);
             }
             let (Node::Interior(_), Node::Interior(_)) = (left.node(), right.node()) else {
@@ -2360,9 +2389,9 @@ impl NodeId {
                 return None;
             }
 
-            let if_true = merge(builder, left.if_true, right.if_true, cache)?;
-            let if_uncertain = merge(builder, left.if_uncertain, right.if_uncertain, cache)?;
-            let if_false = merge(builder, left.if_false, right.if_false, cache)?;
+            let if_true = merge(builder, left.if_true, right.if_true)?;
+            let if_uncertain = merge(builder, left.if_uncertain, right.if_uncertain)?;
+            let if_false = merge(builder, left.if_false, right.if_false)?;
             let result = NodeId::with_uncertain(
                 builder,
                 left.constraint,
@@ -2371,21 +2400,25 @@ impl NodeId {
                 if_false,
                 left.source_order.min(right.source_order),
             );
-            cache.insert(key, result);
+            builder
+                .storage
+                .borrow_mut()
+                .node_shape_merge_cache
+                .insert(key, result);
             Some(result)
         }
 
         if self == other {
             return Some(self);
         }
-        if self.is_terminal()
-            || other.is_terminal()
-            || self.root_constraint(builder) != other.root_constraint(builder)
-        {
+        if self.root_constraint(builder) != other.root_constraint(builder) {
+            return None;
+        }
+        if builder.node_shape_identity(self) != builder.node_shape_identity(other) {
             return None;
         }
 
-        merge(builder, self, other, &mut FxHashMap::default())
+        merge(builder, self, other)
     }
 
     fn max_source_order(self, builder: &ConstraintSetBuilder<'_>) -> usize {
@@ -3454,6 +3487,15 @@ struct InteriorNodeData {
 
     /// The maximum `source_order` across this node and all of its descendants.
     max_source_order: usize,
+}
+
+/// The source-independent shape of an interior TDD node.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct InteriorNodeShape {
+    constraint: ConstraintId,
+    if_true: NodeId,
+    if_uncertain: NodeId,
+    if_false: NodeId,
 }
 
 /// Accumulates lower and upper bounds for a single typevar on a single BDD path.
@@ -8187,6 +8229,58 @@ mod tests {
             },
             ["never=false always=false merged=[T=str, U=bytes] paths=[T=str, U=bytes]"],
         );
+    }
+
+    #[test]
+    fn source_independent_node_shapes_and_merges_are_cached() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let builder = ConstraintSetBuilder::new();
+        let t_str = create_constraint(&db, &builder, t, KnownClass::Str);
+        let u_bytes = create_constraint(&db, &builder, u, KnownClass::Bytes);
+        let original = t_str.or(&db, &builder, || u_bytes).node;
+        let shifted = original.with_adjusted_source_order(&builder, 8);
+
+        assert_ne!(original, shifted);
+        let original_shape = builder.node_shape_identity(original);
+        let shifted_shape = builder.node_shape_identity(shifted);
+        assert_eq!(original_shape, shifted_shape);
+
+        let identities = builder.storage.borrow().node_shape_identity_cache.len();
+        assert_eq!(builder.node_shape_identity(original), original_shape);
+        assert_eq!(builder.node_shape_identity(shifted), shifted_shape);
+        assert_eq!(
+            builder.storage.borrow().node_shape_identity_cache.len(),
+            identities
+        );
+
+        let Some(merged) = original.merge_same_shape(&builder, shifted) else {
+            panic!("source-order-only changes should have the same shape");
+        };
+        assert_eq!(merged, original);
+        let merges = builder.storage.borrow().node_shape_merge_cache.len();
+        assert!(merges > 0);
+        assert_eq!(original.merge_same_shape(&builder, shifted), Some(original));
+        assert_eq!(shifted.merge_same_shape(&builder, original), Some(original));
+        assert_eq!(
+            builder.storage.borrow().node_shape_merge_cache.len(),
+            merges
+        );
+
+        let owned = ConstraintSetBuilder::new().into_owned(|builder| {
+            let t_str = create_constraint(&db, builder, t, KnownClass::Str);
+            let u_bytes = create_constraint(&db, builder, u, KnownClass::Bytes);
+            t_str.or(&db, builder, || u_bytes)
+        });
+        owned.query(|builder, set| {
+            let shifted = set.node.with_adjusted_source_order(builder, 8);
+            assert_eq!(
+                builder.node_shape_identity(set.node),
+                builder.node_shape_identity(shifted)
+            );
+            assert_eq!(set.node.merge_same_shape(builder, shifted), Some(set.node));
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/4073.

Constraint-set TDD reductions compared branch identities that included `source_order`. Equivalent branches produced by opposite union-member orders could therefore fail absorption, leaving an extra TypeVar solution and widening callable-return inference. This makes branch-shape comparison source-independent, preserves the earliest source order when equivalent branches collapse, and caches both structural identities and successful merges.

## Test plan

- Add constraint-set regressions for absorption, compound and partitioned constraints, preserved binding order, genuinely distinct solutions, repeated/reversed cache lookups, and compacted overlays.
- Add legacy-TypeVar and PEP 695 mdtests covering both actual and formal callable-return union orders, nested tuple members, and ordinary covariant generic members.
- All ecosystem changes are desirable improvements in inference.
