### PR TITLE
[ty] Handle concurrent creation of vendored cache files

### DIFF
--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -44,6 +44,7 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 similar = { workspace = true }
 supports-hyperlinks = { workspace = true }
+tempfile = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
@@ -63,7 +64,7 @@ tempfile = { workspace = true }
 [features]
 cache = ["ruff_cache"]
 junit = ["dep:quick-junit"]
-os = ["ignore", "dep:etcetera", "dep:same-file", "dep:which"]
+os = ["ignore", "dep:etcetera", "dep:same-file", "dep:tempfile", "dep:which"]
 serde = [
     "camino/serde1",
     "dep:serde",

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -253,11 +253,13 @@ pub trait WritableSystem: System {
 
         // Create and write to the file on the system.
         //
-        // Note that `create_new_file` will fail if the file has already been created. This
-        // ensures that only one thread/process ever attempts to write to it to avoid corrupting
-        // the cache.
-        self.create_new_file(&cache_path)?;
-        self.write_file(&cache_path, &contents)?;
+        // Only the thread or process that creates the file should write to it. Another caller
+        // may have populated the cache after the existence check above.
+        match self.create_new_file(&cache_path) {
+            Ok(()) => self.write_file(&cache_path, &contents)?,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error),
+        }
 
         Ok(Some(cache_path))
     }

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -253,13 +253,11 @@ pub trait WritableSystem: System {
 
         // Create and write to the file on the system.
         //
-        // Only the thread or process that creates the file should write to it. Another caller
-        // may have populated the cache after the existence check above.
-        match self.create_new_file(&cache_path) {
-            Ok(()) => self.write_file(&cache_path, &contents)?,
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
-            Err(error) => return Err(error),
-        }
+        // Note that `create_new_file` will fail if the file has already been created. This
+        // ensures that only one thread/process ever attempts to write to it to avoid corrupting
+        // the cache.
+        self.create_new_file(&cache_path)?;
+        self.write_file(&cache_path, &contents)?;
 
         Ok(Some(cache_path))
     }

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -558,12 +558,185 @@ pub(super) mod testing {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+    use std::sync::Barrier;
+
     use tempfile::TempDir;
 
-    use crate::system::DirectoryEntry;
     use crate::system::walk_directory::tests::DirectoryEntryToString;
+    use crate::system::{DirectoryEntry, TestSystem};
 
     use super::*;
+
+    fn assert_concurrent_cache_writes(system: &dyn WritableSystem, cache_path: &SystemPath) {
+        let barrier = Barrier::new(2);
+        let expected_contents = "fully written vendored cache contents\n".repeat(1024);
+
+        std::thread::scope(|scope| {
+            let workers = (0..2)
+                .map(|_| {
+                    scope.spawn(|| {
+                        let cached_path = system
+                            .get_or_cache(cache_path, &|| {
+                                barrier.wait();
+                                Ok(expected_contents.clone())
+                            })
+                            .unwrap()
+                            .unwrap();
+
+                        assert_eq!(cached_path.as_path(), cache_path);
+                        assert_eq!(
+                            std::fs::read_to_string(cached_path.as_std_path()).unwrap(),
+                            expected_contents
+                        );
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for worker in workers {
+                worker.join().unwrap();
+            }
+        });
+    }
+
+    #[test]
+    fn get_or_cache_concurrent_writers() {
+        let tempdir = TempDir::new().unwrap();
+        let root = SystemPath::from_std_path(tempdir.path()).unwrap();
+        let system = OsSystem::new(root);
+        let cache_path = root.join("vendored/typeshed/cached.pyi");
+
+        assert_concurrent_cache_writes(&system, &cache_path);
+
+        assert_eq!(
+            std::fs::read_dir(cache_path.parent().unwrap().as_std_path())
+                .unwrap()
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn get_or_cache_forwards_to_inner_system() {
+        let tempdir = TempDir::new().unwrap();
+        let root = SystemPath::from_std_path(tempdir.path()).unwrap();
+        let system = TestSystem::new(OsSystem::new(root));
+        let cache_path = root.join("vendored/typeshed/cached.pyi");
+
+        assert_concurrent_cache_writes(&system, &cache_path);
+    }
+
+    #[test]
+    fn get_or_cache_interrupted_write() {
+        let tempdir = TempDir::new().unwrap();
+        let root = SystemPath::from_std_path(tempdir.path()).unwrap();
+        let system = OsSystem::new(root);
+        let cache_path = root.join("cached.pyi");
+        let expected_contents = b"fully written vendored cache contents";
+
+        let error = system
+            .write_cache_file(&cache_path, expected_contents, |file, contents| {
+                file.write_all(&contents[..7])?;
+                Err(std::io::Error::new(
+                    ErrorKind::Interrupted,
+                    "interrupted cache write",
+                ))
+            })
+            .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::Interrupted);
+        assert!(!cache_path.as_std_path().exists());
+        assert_eq!(std::fs::read_dir(tempdir.path()).unwrap().count(), 0);
+
+        let cached_path = system
+            .get_or_cache(&cache_path, &|| {
+                Ok(String::from_utf8(expected_contents.to_vec()).unwrap())
+            })
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read(cached_path.as_std_path()).unwrap(),
+            expected_contents
+        );
+    }
+
+    #[test]
+    fn get_or_cache_existing_complete_file() {
+        let tempdir = TempDir::new().unwrap();
+        let root = SystemPath::from_std_path(tempdir.path()).unwrap();
+        let system = OsSystem::new(root);
+        let cache_path = root.join("cached.pyi");
+        let expected_contents = "fully written vendored cache contents";
+        std::fs::write(cache_path.as_std_path(), expected_contents).unwrap();
+
+        let cached_path = system
+            .get_or_cache(&cache_path, &|| {
+                Err(std::io::Error::other("cache hit unexpectedly read source"))
+            })
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(cached_path, cache_path);
+        assert_eq!(
+            std::fs::read_to_string(cached_path.as_std_path()).unwrap(),
+            expected_contents
+        );
+    }
+
+    #[test]
+    fn get_or_cache_rejects_incomplete_concurrent_file() {
+        let tempdir = TempDir::new().unwrap();
+        let root = SystemPath::from_std_path(tempdir.path()).unwrap();
+        let system = OsSystem::new(root);
+        let cache_path = root.join("cached.pyi");
+
+        let result = system.get_or_cache(&cache_path, &|| {
+            std::fs::write(cache_path.as_std_path(), "partial")?;
+            Ok("fully written vendored cache contents".to_owned())
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::fs::read_to_string(cache_path.as_std_path()).unwrap(),
+            "partial"
+        );
+    }
+
+    #[test]
+    fn get_or_cache_rejects_directory() {
+        let tempdir = TempDir::new().unwrap();
+        let root = SystemPath::from_std_path(tempdir.path()).unwrap();
+        let system = OsSystem::new(root);
+        let cache_path = root.join("cached.pyi");
+        std::fs::create_dir(cache_path.as_std_path()).unwrap();
+
+        let result = system.get_or_cache(&cache_path, &|| Ok("complete contents".to_owned()));
+
+        assert!(result.is_err());
+        assert!(cache_path.as_std_path().is_dir());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn get_or_cache_rejects_dangling_symlink() {
+        let tempdir = TempDir::new().unwrap();
+        let root = SystemPath::from_std_path(tempdir.path()).unwrap();
+        let system = OsSystem::new(root);
+        let cache_path = root.join("cached.pyi");
+        symlink(tempdir.path().join("missing.pyi"), cache_path.as_std_path()).unwrap();
+
+        let result = system.get_or_cache(&cache_path, &|| Ok("complete contents".to_owned()));
+
+        assert!(result.is_err());
+        assert!(
+            std::fs::symlink_metadata(cache_path.as_std_path())
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
 
     #[test]
     fn read_directory() {

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -14,7 +14,11 @@ use crate::system::{
 };
 use filetime::FileTime;
 use ruff_notebook::{Notebook, NotebookError};
+use std::fs::File;
+use std::io::{ErrorKind, Write};
 use std::num::NonZeroUsize;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::sync::Arc;
 use std::{any::Any, path::PathBuf};
 
@@ -64,6 +68,38 @@ impl OsSystem {
     #[cfg(not(unix))]
     fn permissions(_metadata: &std::fs::Metadata) -> Option<u32> {
         None
+    }
+
+    fn write_cache_file(
+        &self,
+        cache_path: &SystemPath,
+        contents: &[u8],
+        write_contents: impl FnOnce(&mut File, &[u8]) -> Result<()>,
+    ) -> Result<()> {
+        let parent = cache_path.parent().ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::InvalidInput,
+                "cache file has no parent directory",
+            )
+        })?;
+
+        let mut builder = tempfile::Builder::new();
+
+        #[cfg(unix)]
+        builder.permissions(std::fs::Permissions::from_mode(0o666));
+
+        let mut temporary_file = builder.tempfile_in(parent.as_std_path())?;
+        write_contents(temporary_file.as_file_mut(), contents)?;
+
+        match temporary_file.persist_noclobber(cache_path.as_std_path()) {
+            Ok(_) => Ok(()),
+            Err(error)
+                if error.error.kind() == ErrorKind::AlreadyExists && self.is_file(cache_path) =>
+            {
+                Ok(())
+            }
+            Err(error) => Err(error.error),
+        }
     }
 }
 
@@ -234,6 +270,33 @@ impl WritableSystem for OsSystem {
 
     fn create_directory_all(&self, path: &SystemPath) -> Result<()> {
         std::fs::create_dir_all(path.as_std_path())
+    }
+
+    fn get_or_cache(
+        &self,
+        path: &SystemPath,
+        read_contents: &dyn Fn() -> Result<String>,
+    ) -> Result<Option<SystemPathBuf>> {
+        let Some(cache_dir) = self.cache_dir() else {
+            return Ok(None);
+        };
+
+        let cache_path = cache_dir.join(path);
+        if self.is_file(&cache_path) {
+            return Ok(Some(cache_path));
+        }
+
+        let contents = read_contents()?;
+        let parent = cache_path.parent().ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::InvalidInput,
+                "cache file has no parent directory",
+            )
+        })?;
+        self.create_directory_all(parent)?;
+        self.write_cache_file(&cache_path, contents.as_bytes(), File::write_all)?;
+
+        Ok(Some(cache_path))
     }
 
     fn dyn_clone(&self) -> Box<dyn WritableSystem> {

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -93,8 +93,9 @@ impl OsSystem {
 
         match temporary_file.persist_noclobber(cache_path.as_std_path()) {
             Ok(_) => Ok(()),
-            Err(error)
-                if error.error.kind() == ErrorKind::AlreadyExists && self.is_file(cache_path) =>
+            Err(_)
+                if std::fs::read(cache_path.as_std_path())
+                    .is_ok_and(|cached_contents| cached_contents == contents) =>
             {
                 Ok(())
             }

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -199,6 +199,14 @@ impl WritableSystem for TestSystem {
         self.system().create_directory_all(path)
     }
 
+    fn get_or_cache(
+        &self,
+        path: &SystemPath,
+        read_contents: &dyn Fn() -> Result<String>,
+    ) -> Result<Option<SystemPathBuf>> {
+        self.system().get_or_cache(path, read_contents)
+    }
+
     fn dyn_clone(&self) -> Box<dyn WritableSystem> {
         Box::new(self.clone())
     }


### PR DESCRIPTION
`ty` can panic while resolving a type hierarchy when concurrent server processes race to extract the same vendored typeshed file: the losing process receives `AlreadyExists`, which is discarded and causes the vendored URI to disappear. Treat an existing file as a cache hit after the creation race while preserving the single-writer behavior. See the [reproducing run](https://github.com/astral-sh/ruff/actions/runs/30048308720) and [follow-up run](https://github.com/astral-sh/ruff/actions/runs/30048757773).
