### PR TITLE
[ty] Decorate only overload implementation signatures

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -649,12 +649,11 @@ def remove_param[**P, R](func: Callable[Concatenate[int, P], R]) -> Callable[P, 
 def f1(x: int, y: str) -> str: ...
 @overload
 def f1(x: int, y: int) -> int: ...
-@remove_param
 def f1(x: int, y: str | int) -> str | int:
     return y
 
 # TODO: Should reveal `Overloaded[(y: str) -> str, (y: int) -> int]`
-reveal_type(f1)  # revealed: (y: str) -> str | int
+reveal_type(remove_param(f1))  # revealed: (y: str) -> str | int
 ```
 
 But, it's not possible to _add_ a parameter to an overloaded function using `Concatenate` because
@@ -666,18 +665,17 @@ def add_param[**P, R](func: Callable[P, R]) -> Callable[Concatenate[int, P], R]:
         return func(*args, **kwargs)
     return wrapper
 
-# TODO: Raise a diagnostic stating that the signature of the implementation doesn't match the
-# overloads because the overloads don't have the extra `int` parameter.
 @overload
+# error: [invalid-overload] "Implementation does not accept all arguments of this overload"
 def f2(y: str) -> str: ...
 @overload
+# error: [invalid-overload] "Implementation does not accept all arguments of this overload"
 def f2(y: int) -> int: ...
 @add_param
 def f2(y: str | int) -> str | int:
     return y
 
-# TODO: Should this reveal `Overloaded[(int, /, y: str) -> str, (int, /, y: int) -> int]` ?
-reveal_type(f2)  # revealed: Overload[(int, /, y: str) -> str | int, (int, /, y: int) -> str | int]
+reveal_type(f2)  # revealed: Overload[(y: str) -> str, (y: int) -> int]
 ```
 
 But, it's possible to add the additional parameter just to the overload signatures and not the
@@ -692,8 +690,7 @@ def f3(x: int, /, y: int) -> int: ...
 def f3(y: str | int) -> str | int:
     return y
 
-# TODO: Should reveal `Overloaded[(int, /, y: str) -> str, (int, /, y: int) -> int]`
-reveal_type(f3)  # revealed: Overload[(int, x: int, /, y: str) -> str | int, (int, x: int, /, y: int) -> str | int]
+reveal_type(f3)  # revealed: Overload[(x: int, /, y: str) -> str, (x: int, /, y: int) -> int]
 ```
 
 ## `Concatenate` with protocol classes

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1103,11 +1103,10 @@ def unwrap_awaitable(function: Callable[P, Awaitable[R]], /) -> Callable[P, R]:
 async def unwrapped(value: int) -> int: ...
 @overload
 async def unwrapped(value: str) -> str: ...
-@unwrap_awaitable
 async def unwrapped(value: int | str) -> int | str:
     raise NotImplementedError
 
-reveal_type(unwrapped(1))  # revealed: int | str
+reveal_type(unwrap_awaitable(unwrapped)(1))  # revealed: int | str
 ```
 
 The selected decorator overload can use an `Awaitable` return type.

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -874,6 +874,40 @@ reveal_type(decorated(1))  # revealed: int
 reveal_type(decorated("one"))  # revealed: str
 ```
 
+### Decorated overloads with `Concatenate`
+
+Each decorated overload applies its decorator to its own signature, without including any preceding
+overloads in the decorator call.
+
+```py
+from collections.abc import Callable
+from typing import Any, Concatenate, ParamSpec, TypeVar, overload
+
+P = ParamSpec("P")
+A = TypeVar("A")
+R = TypeVar("R")
+
+def curry1(func: Callable[Concatenate[A, P], R]) -> Callable[[A], Callable[P, R]]:
+    raise NotImplementedError
+
+@curry1
+@overload
+def starmap(mapper: Callable[[int, int], int], parser: int) -> int: ...
+@curry1
+@overload
+def starmap(mapper: Callable[[str, str, str], str], parser: str) -> str: ...
+@curry1
+def starmap(mapper: Callable[..., Any], parser: Any) -> Any:
+    raise NotImplementedError
+
+def add(x: int, y: int) -> int:
+    return x + y
+
+# revealed: Overload[((int, int, /) -> int, /) -> ((parser: int) -> int), ((str, str, str, /) -> str, /) -> ((parser: str) -> str)]
+reveal_type(starmap)
+reveal_type(starmap(add))  # revealed: (parser: int) -> int
+```
+
 ### Decorated implementation replaced by a function
 
 A decorator can replace an overload implementation with another function. The overload set remains

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -846,6 +846,34 @@ reveal_type(narrowed(1))  # revealed: int
 reveal_type(narrowed("one"))  # revealed: str
 ```
 
+### Decorated overload consistency
+
+Decorators on individual overloads transform those overload signatures before implementation
+consistency is checked. The transformed signatures remain visible to callers.
+
+```py
+from typing import Callable, overload
+
+def decorate_overload(func: Callable[..., object]) -> Callable[[int], int]:
+    raise NotImplementedError
+
+def decorate_implementation(func: Callable[..., object]) -> Callable[[int | str], int | str]:
+    raise NotImplementedError
+
+@overload
+@decorate_overload
+def decorated() -> None: ...
+@overload
+def decorated(x: str, /) -> str: ...
+@decorate_implementation
+def decorated(y: bytes, z: bytes) -> bytes:
+    raise NotImplementedError
+
+reveal_type(decorated)  # revealed: Overload[(int, /) -> int, (x: str, /) -> str]
+reveal_type(decorated(1))  # revealed: int
+reveal_type(decorated("one"))  # revealed: str
+```
+
 ### Decorated implementation replaced by a function
 
 A decorator can replace an overload implementation with another function. The overload set remains

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -806,6 +806,173 @@ def generic_parameter_type(x: int) -> int | str:
     return x
 ```
 
+### Decorated implementation consistency
+
+Decorators on an overload implementation apply only to the implementation signature. The decorated
+signature is checked against the overloads, while callers continue to see only the overloads.
+
+```py
+from typing import Callable, overload
+
+def widen_return(func: Callable[[int | str], int]) -> Callable[[int | str], int | str]:
+    raise NotImplementedError
+
+@overload
+def widened(x: int, /) -> int: ...
+@overload
+def widened(x: str, /) -> str: ...
+@widen_return
+def widened(x: int | str) -> int:
+    return 1
+
+reveal_type(widened)  # revealed: Overload[(x: int, /) -> int, (x: str, /) -> str]
+reveal_type(widened(1))  # revealed: int
+reveal_type(widened("one"))  # revealed: str
+
+def narrow_parameter(func: Callable[[int | str], int | str]) -> Callable[[int], int | str]:
+    raise NotImplementedError
+
+@overload
+def narrowed(x: int, /) -> int: ...
+@overload
+# error: [invalid-overload] "Implementation does not accept all arguments of this overload"
+def narrowed(x: str, /) -> str: ...
+@narrow_parameter
+def narrowed(x: int | str) -> int | str:
+    return x
+
+reveal_type(narrowed)  # revealed: Overload[(x: int, /) -> int, (x: str, /) -> str]
+reveal_type(narrowed(1))  # revealed: int
+reveal_type(narrowed("one"))  # revealed: str
+```
+
+### Decorated implementation replaced by a function
+
+A decorator can replace an overload implementation with another function. The overload set remains
+visible to callers, the replacement signature is checked for consistency, and an outer `@deprecated`
+decorator still applies to the overload set.
+
+```py
+from collections.abc import Callable
+from typing import Any, TypeVar, overload
+from typing_extensions import deprecated
+
+R = TypeVar("R")
+
+def replacement(x: int, /) -> int:
+    return x
+
+def replace_with(value: R) -> Callable[[Callable[..., Any]], R]:
+    def decorator(_function: Callable[..., Any]) -> R:
+        return value
+    return decorator
+
+@overload
+def replaced(x: int, /) -> int: ...
+@overload
+# error: [invalid-overload] "Overload signature is not consistent with implementation"
+def replaced(x: str, /) -> str: ...
+@deprecated("use replacement directly")
+@replace_with(replacement)
+def replaced(x: int | str) -> int | str:
+    return x
+
+# error: [deprecated] "use replacement directly"
+reveal_type(replaced)  # revealed: Overload[(x: int, /) -> int, (x: str, /) -> str]
+# error: [deprecated] "use replacement directly"
+reveal_type(replaced("one"))  # revealed: str
+```
+
+### Decorated implementation with multiple callable signatures
+
+An overloaded callback protocol can provide one implementation signature for each overload. Every
+callable in a union must support every overload. A decorator that returns a non-callable cannot
+implement any overload.
+
+```py
+from typing import Callable, Protocol, overload
+
+class ValidCallback(Protocol):
+    @overload
+    def __call__(self, x: int, /) -> int: ...
+    @overload
+    def __call__(self, x: str, /) -> str: ...
+
+class NarrowCallback(Protocol):
+    @overload
+    def __call__(self, x: int, /) -> int: ...
+    @overload
+    def __call__(self, x: bytes, /) -> bytes: ...
+
+def valid_callback(func: Callable[[int | str], int | str]) -> ValidCallback:
+    raise NotImplementedError
+
+def narrow_callback(func: Callable[[int | str], int | str]) -> NarrowCallback:
+    raise NotImplementedError
+
+def valid_union(
+    func: Callable[[int | str], int | str],
+) -> Callable[[int | str], int | str] | Callable[[object], object]:
+    raise NotImplementedError
+
+def narrow_union(
+    func: Callable[[int | str], int | str],
+) -> Callable[[int | str], int | str] | Callable[[int], int]:
+    raise NotImplementedError
+
+def noncallable(func: Callable[[int | str], int | str]) -> int:
+    raise NotImplementedError
+
+@overload
+def callback_valid(x: int, /) -> int: ...
+@overload
+def callback_valid(x: str, /) -> str: ...
+@valid_callback
+def callback_valid(x: int | str) -> int | str:
+    return x
+
+@overload
+def callback_narrowed(x: int, /) -> int: ...
+@overload
+# error: [invalid-overload] "Overload signature is not consistent with implementation"
+def callback_narrowed(x: str, /) -> str: ...
+@narrow_callback
+def callback_narrowed(x: int | str) -> int | str:
+    return x
+
+@overload
+def union_valid(x: int, /) -> int: ...
+@overload
+def union_valid(x: str, /) -> str: ...
+@valid_union
+def union_valid(x: int | str) -> int | str:
+    return x
+
+@overload
+def union_narrowed(x: int, /) -> int: ...
+@overload
+# error: [invalid-overload] "Overload signature is not consistent with implementation"
+def union_narrowed(x: str, /) -> str: ...
+@narrow_union
+def union_narrowed(x: int | str) -> int | str:
+    return x
+
+@overload
+def not_callable(x: int, /) -> int: ...
+@overload
+def not_callable(x: str, /) -> str: ...
+@noncallable
+# error: [invalid-overload] "Overload implementation is not callable after applying decorators"
+def not_callable(x: int | str) -> int | str:
+    return x
+
+reveal_type(callback_valid)  # revealed: Overload[(x: int, /) -> int, (x: str, /) -> str]
+reveal_type(callback_narrowed)  # revealed: Overload[(x: int, /) -> int, (x: str, /) -> str]
+reveal_type(union_valid)  # revealed: Overload[(x: int, /) -> int, (x: str, /) -> str]
+reveal_type(union_narrowed)  # revealed: Overload[(x: int, /) -> int, (x: str, /) -> str]
+reveal_type(not_callable)  # revealed: Overload[(x: int, /) -> int, (x: str, /) -> str]
+```
+
 ### Implementation consistency parameter mismatch diagnostics
 
 Non-generic implementation checks require parameter names and positional-only forms to line up with

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -783,6 +783,7 @@ class Spam:
 
     @overload
     @override
+    # error: [invalid-overload] "`@override` decorator should be applied only to the overload implementation"
     def quux(self, x: str) -> str: ...
     @overload
     def quux(self, x: int) -> int: ...

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -49,7 +49,7 @@
 //! the public type of `f` is resolved at position 3, correctly giving you all of the overloads
 //! (and the implementation).
 
-use std::str::FromStr;
+use std::{borrow::Cow, str::FromStr};
 
 use bitflags::bitflags;
 use ruff_db::diagnostic::{Annotation, DiagnosticId, Severity, Span};
@@ -740,6 +740,36 @@ impl<'db> FunctionLiteral<'db> {
         }
     }
 
+    /// Ignore previous overloads when applying decorators to an implementation.
+    pub(super) const fn without_overloads(self) -> Self {
+        Self {
+            overloaded: false,
+            ..self
+        }
+    }
+
+    /// Preserve the overload set and implementation identity while updating decorator metadata.
+    pub(super) fn with_last_definition_metadata(
+        self,
+        db: &'db dyn Db,
+        decorated: OverloadLiteral<'db>,
+    ) -> Self {
+        let implementation = self.last_definition;
+        Self {
+            last_definition: OverloadLiteral::new(
+                db,
+                implementation.name(db),
+                implementation.known(db),
+                implementation.body_scope(db),
+                implementation.decorators(db),
+                decorated.deprecated(db),
+                decorated.dataclass_transformer_params(db),
+                implementation.has_explicit_return_annotation(db),
+            ),
+            ..self
+        }
+    }
+
     fn name(self, db: &'db dyn Db) -> &'db ast::name::Name {
         // All of the overloads of a function literal should have the same name.
         self.last_definition.name(db)
@@ -820,9 +850,8 @@ impl<'db> FunctionLiteral<'db> {
         (overloads.as_ref(), *implementation)
     }
 
-    fn has_separate_implementation(self, db: &'db dyn Db) -> bool {
-        !self.last_definition.is_overload(db)
-            && self.last_definition.previous_overload(db).is_some()
+    pub(super) fn has_separate_implementation(self, db: &'db dyn Db) -> bool {
+        self.overloaded && !self.last_definition.is_overload(db)
     }
 
     fn iter_overloads_and_implementation(
@@ -1013,22 +1042,23 @@ pub struct UpdatedFunctionSignatures<'db> {
     /// See also: [`FunctionLiteral::signature`].
     signature: Option<CallableSignature<'db>>,
 
-    /// Contains a potentially modified signature for the implementation of an overloaded function,
-    /// in case certain operations (like type mappings) have been applied to it.
+    /// Contains the potentially modified callables for the implementation of an overloaded
+    /// function, in case decorators or type mappings have been applied to it. Each callable can
+    /// itself be overloaded.
     ///
     /// See also: [`FunctionLiteral::last_definition_signature`].
-    implementation_signature: Option<Signature<'db>>,
+    implementation_callables: Option<Box<[CallableType<'db>]>>,
 }
 
 impl<'db> UpdatedFunctionSignatures<'db> {
     fn new(
         signature: Option<CallableSignature<'db>>,
-        implementation_signature: Option<Signature<'db>>,
+        implementation_callables: Option<Box<[CallableType<'db>]>>,
     ) -> Option<Box<Self>> {
-        (signature.is_some() || implementation_signature.is_some()).then(|| {
+        (signature.is_some() || implementation_callables.is_some()).then(|| {
             Box::new(Self {
                 signature,
-                implementation_signature,
+                implementation_callables,
             })
         })
     }
@@ -1058,8 +1088,10 @@ pub(super) fn walk_function_type<'db, V: super::visitor::TypeVisitor<'db> + ?Siz
             walk_signature(db, signature, visitor);
         }
     }
-    if let Some(signature) = function.updated_implementation_signature(db) {
-        walk_signature(db, signature, visitor);
+    if let Some(callables) = function.updated_implementation_callables(db) {
+        for callable in callables {
+            visitor.visit_callable_type(db, *callable);
+        }
     }
 }
 
@@ -1072,9 +1104,48 @@ impl<'db> FunctionType<'db> {
     }
 
     fn updated_implementation_signature(self, db: &'db dyn Db) -> Option<&'db Signature<'db>> {
+        let [callable] = self.updated_implementation_callables(db)? else {
+            return None;
+        };
+        let [signature] = callable.signatures(db).overloads.as_slice() else {
+            return None;
+        };
+        Some(signature)
+    }
+
+    fn updated_implementation_callables(self, db: &'db dyn Db) -> Option<&'db [CallableType<'db>]> {
         self.updated_signatures(db)
             .as_deref()
-            .and_then(|updated| updated.implementation_signature.as_ref())
+            .and_then(|updated| updated.implementation_callables.as_deref())
+    }
+
+    /// Return all effective implementation callables, falling back to the raw implementation.
+    pub(super) fn implementation_callables(self, db: &'db dyn Db) -> Cow<'db, [CallableType<'db>]> {
+        self.updated_implementation_callables(db).map_or_else(
+            || {
+                Cow::Owned(vec![CallableType::single(
+                    db,
+                    self.last_definition_signature(db).clone(),
+                )])
+            },
+            Cow::Borrowed,
+        )
+    }
+
+    /// Retain decorated implementation callables without changing the caller-visible overloads.
+    pub(super) fn with_implementation_callables(
+        self,
+        db: &'db dyn Db,
+        implementation_callables: Box<[CallableType<'db>]>,
+    ) -> Self {
+        Self::new(
+            db,
+            self.literal(db),
+            UpdatedFunctionSignatures::new(
+                self.updated_signature(db).cloned(),
+                Some(implementation_callables),
+            ),
+        )
     }
 
     pub(crate) fn with_inherited_generic_context(
@@ -1086,17 +1157,27 @@ impl<'db> FunctionType<'db> {
             .signature(db)
             .with_inherited_generic_context(db, inherited_generic_context);
         let literal = self.literal(db);
-        let updated_implementation_signature = literal.has_separate_implementation(db).then(|| {
-            self.last_definition_signature(db)
-                .clone()
-                .with_inherited_generic_context(db, inherited_generic_context)
+        let updated_implementation_callables = literal.has_separate_implementation(db).then(|| {
+            self.implementation_callables(db)
+                .iter()
+                .map(|callable| {
+                    CallableType::new(
+                        db,
+                        callable
+                            .signatures(db)
+                            .with_inherited_generic_context(db, inherited_generic_context),
+                        callable.kind(db),
+                        callable.provenance(db),
+                    )
+                })
+                .collect()
         });
         Self::new(
             db,
             literal,
             UpdatedFunctionSignatures::new(
                 Some(updated_signature),
-                updated_implementation_signature,
+                updated_implementation_callables,
             ),
         )
     }
@@ -1111,7 +1192,7 @@ impl<'db> FunctionType<'db> {
         // Returned-callable rescoping and type-alias specialization should not rebuild signatures from the
         // function literal; doing so can re-enter recursive `TypeOf` evaluation.
         let literal = self.literal(db);
-        let (updated_signature, updated_implementation_signature) = if matches!(
+        let (updated_signature, updated_implementation_callables) = if matches!(
             type_mapping,
             TypeMapping::ApplySpecialization(
                 ApplySpecialization::ReturnCallables(_) | ApplySpecialization::TypeAlias(_)
@@ -1125,8 +1206,13 @@ impl<'db> FunctionType<'db> {
                 self.updated_signature(db).map(|signature| {
                     signature.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
                 }),
-                self.updated_implementation_signature(db).map(|signature| {
-                    signature.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                self.updated_implementation_callables(db).map(|callables| {
+                    callables
+                        .iter()
+                        .map(|callable| {
+                            callable.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                        })
+                        .collect()
                 }),
             )
         } else {
@@ -1136,23 +1222,23 @@ impl<'db> FunctionType<'db> {
                         .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ),
                 literal.has_separate_implementation(db).then(|| {
-                    self.last_definition_signature(db).apply_type_mapping_impl(
-                        db,
-                        type_mapping,
-                        tcx,
-                        visitor,
-                    )
+                    self.implementation_callables(db)
+                        .iter()
+                        .map(|callable| {
+                            callable.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                        })
+                        .collect()
                 }),
             )
         };
 
-        if updated_signature.is_none() && updated_implementation_signature.is_none() {
+        if updated_signature.is_none() && updated_implementation_callables.is_none() {
             self
         } else {
             Self::new(
                 db,
                 literal,
-                UpdatedFunctionSignatures::new(updated_signature, updated_implementation_signature),
+                UpdatedFunctionSignatures::new(updated_signature, updated_implementation_callables),
             )
         }
     }
@@ -1524,11 +1610,16 @@ impl<'db> FunctionType<'db> {
                     }
                     None => None,
                 };
-                let updated_implementation_signature =
-                    match self.updated_implementation_signature(db) {
-                        Some(signature) => {
-                            Some(signature.recursive_type_normalized_impl(db, div, nested)?)
-                        }
+                let updated_implementation_callables =
+                    match self.updated_implementation_callables(db) {
+                        Some(callables) => Some(
+                            callables
+                                .iter()
+                                .map(|callable| {
+                                    callable.recursive_type_normalized_impl(db, div, nested)
+                                })
+                                .collect::<Option<Box<_>>>()?,
+                        ),
                         None => None,
                     };
                 Some(Self::new(
@@ -1536,7 +1627,7 @@ impl<'db> FunctionType<'db> {
                     literal,
                     UpdatedFunctionSignatures::new(
                         updated_signature,
-                        updated_implementation_signature,
+                        updated_implementation_callables,
                     ),
                 ))
             },

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -517,12 +517,12 @@ impl<'db> OverloadLiteral<'db> {
     }
 
     /// Returns the effective signatures of this overload after applying decorators.
-    pub(crate) fn decorated_signatures(self, db: &'db dyn Db) -> Cow<'db, [Signature<'db>]> {
+    pub(crate) fn decorated_signatures(self, db: &'db dyn Db) -> Vec<Signature<'db>> {
         let Type::Callable(callable) = binding_type(db, self.definition(db)) else {
-            return Cow::Owned(vec![self.signature(db)]);
+            return vec![self.signature(db)];
         };
 
-        Cow::Borrowed(callable.signatures(db).overloads.as_slice())
+        callable.signatures(db).overloads.to_vec()
     }
 
     /// Typed internally-visible "raw" signature for this function.
@@ -907,7 +907,7 @@ impl<'db> FunctionLiteral<'db> {
             if *overload == self.last_definition {
                 vec![overload.signature(db)]
             } else {
-                overload.decorated_signatures(db).into_owned()
+                overload.decorated_signatures(db)
             }
         }))
     }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -79,7 +79,7 @@ use crate::types::diagnostic::{
 };
 use crate::types::display::DisplaySettings;
 use crate::types::generics::{ApplySpecialization, GenericContext, typing_self};
-use crate::types::infer::{nearest_enclosing_class, original_class_type};
+use crate::types::infer::{infer_definition_types, nearest_enclosing_class, original_class_type};
 use crate::types::known_instance::DeprecatedInstance;
 use crate::types::list_members::all_members;
 use crate::types::narrow::ClassInfoConstraintFunction;
@@ -93,7 +93,7 @@ use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassType, FindLegacyTypeVarsVisitor,
     IntersectionBuilder, KnownClass, KnownInstanceType, SpecialFormType, SubclassOfInner,
     SubclassOfType, Truthiness, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
-    UnionBuilder, UnionType, definition_expression_type, walk_signature,
+    UnionBuilder, UnionType, binding_type, definition_expression_type, walk_signature,
 };
 use crate::{Db, FxOrderSet};
 use ty_python_core::ast_ids::HasScopedUseId;
@@ -452,15 +452,25 @@ impl<'db> OverloadLiteral<'db> {
             .scoped_use_id(db, self.file(db));
 
         let Place::Defined(DefinedPlace {
-            ty: Type::FunctionLiteral(previous_type),
+            ty: previous_type,
             definedness: Definedness::AlwaysDefined,
+            provenance,
             ..
         }) = place_from_bindings(db, use_def.bindings_at_use(use_id)).place
         else {
             return None;
         };
 
-        let previous_literal = previous_type.literal(db);
+        let previous_literal = match previous_type {
+            Type::FunctionLiteral(previous_type) => previous_type.literal(db),
+            Type::Callable(_) => {
+                let definition = provenance.definition()?;
+                infer_definition_types(db, definition)
+                    .function_type(definition)?
+                    .literal(db)
+            }
+            _ => return None,
+        };
         let previous_overload = previous_literal.last_definition;
         if !previous_overload.is_overload(db) {
             return None;
@@ -504,6 +514,15 @@ impl<'db> OverloadLiteral<'db> {
         }
 
         signature
+    }
+
+    /// Returns the effective signatures of this overload after applying decorators.
+    pub(crate) fn decorated_signatures(self, db: &'db dyn Db) -> Cow<'db, [Signature<'db>]> {
+        let Type::Callable(callable) = binding_type(db, self.definition(db)) else {
+            return Cow::Owned(vec![self.signature(db)]);
+        };
+
+        Cow::Borrowed(callable.signatures(db).overloads.as_slice())
     }
 
     /// Typed internally-visible "raw" signature for this function.
@@ -883,7 +902,14 @@ impl<'db> FunctionLiteral<'db> {
             return CallableSignature::single(implementation.signature(db));
         }
 
-        CallableSignature::from_overloads(overloads.iter().map(|overload| overload.signature(db)))
+        CallableSignature::from_overloads(overloads.iter().flat_map(|overload| {
+            // The last overload may still be inferred, so querying its binding would create a cycle.
+            if *overload == self.last_definition {
+                vec![overload.signature(db)]
+            } else {
+                overload.decorated_signatures(db).into_owned()
+            }
+        }))
     }
 
     /// Typed externally-visible signature of the last overload or implementation of this function.

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -759,7 +759,7 @@ impl<'db> FunctionLiteral<'db> {
         }
     }
 
-    /// Ignore previous overloads when applying decorators to an implementation.
+    /// Ignore previous overloads when applying decorators to an individual definition.
     pub(super) const fn without_overloads(self) -> Self {
         Self {
             overloaded: false,
@@ -767,23 +767,23 @@ impl<'db> FunctionLiteral<'db> {
         }
     }
 
-    /// Preserve the overload set and implementation identity while updating decorator metadata.
+    /// Preserve the overload set and last-definition identity while updating decorator metadata.
     pub(super) fn with_last_definition_metadata(
         self,
         db: &'db dyn Db,
         decorated: OverloadLiteral<'db>,
     ) -> Self {
-        let implementation = self.last_definition;
+        let definition = self.last_definition;
         Self {
             last_definition: OverloadLiteral::new(
                 db,
-                implementation.name(db),
-                implementation.known(db),
-                implementation.body_scope(db),
-                implementation.decorators(db),
+                definition.name(db),
+                definition.known(db),
+                definition.body_scope(db),
+                definition.decorators(db),
                 decorated.deprecated(db),
                 decorated.dataclass_transformer_params(db),
-                implementation.has_explicit_return_annotation(db),
+                definition.has_explicit_return_annotation(db),
             ),
             ..self
         }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -52,6 +52,7 @@
 use std::{borrow::Cow, str::FromStr};
 
 use bitflags::bitflags;
+use itertools::Either;
 use ruff_db::diagnostic::{Annotation, DiagnosticId, Severity, Span};
 use ruff_db::files::{File, FileRange};
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
@@ -517,12 +518,16 @@ impl<'db> OverloadLiteral<'db> {
     }
 
     /// Returns the effective signatures of this overload after applying decorators.
-    pub(crate) fn decorated_signatures(self, db: &'db dyn Db) -> Vec<Signature<'db>> {
-        let Type::Callable(callable) = binding_type(db, self.definition(db)) else {
-            return vec![self.signature(db)];
-        };
-
-        callable.signatures(db).overloads.to_vec()
+    pub(crate) fn decorated_signatures(
+        self,
+        db: &'db dyn Db,
+    ) -> impl Iterator<Item = Signature<'db>> + Clone + 'db {
+        match binding_type(db, self.definition(db)) {
+            Type::Callable(callable) => {
+                Either::Left(callable.signatures(db).overloads.iter().cloned())
+            }
+            _ => Either::Right(std::iter::once(self.signature(db))),
+        }
     }
 
     /// Typed internally-visible "raw" signature for this function.
@@ -905,9 +910,9 @@ impl<'db> FunctionLiteral<'db> {
         CallableSignature::from_overloads(overloads.iter().flat_map(|overload| {
             // The last overload may still be inferred, so querying its binding would create a cycle.
             if *overload == self.last_definition {
-                vec![overload.signature(db)]
+                Either::Left(std::iter::once(overload.signature(db)))
             } else {
-                overload.decorated_signatures(db)
+                Either::Right(overload.decorated_signatures(db))
             }
         }))
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -420,8 +420,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             function.returns.is_some(),
         );
         let function_literal = FunctionLiteral::new(db, overload_literal);
+        let function_type = FunctionType::new(db, function_literal, None);
+        let is_decorated_overload_implementation = !decorator_types_and_nodes.is_empty()
+            && function_literal.has_separate_implementation(db);
 
-        let mut inferred_ty = Type::FunctionLiteral(FunctionType::new(db, function_literal, None));
+        let mut inferred_ty = Type::FunctionLiteral(if is_decorated_overload_implementation {
+            FunctionType::new(db, function_literal.without_overloads(), None)
+        } else {
+            function_type
+        });
         if !decorator_list.is_empty() {
             self.undecorated_type = Some(inferred_ty);
         }
@@ -462,6 +469,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 self.apply_decorator(*decorator_ty, inferred_ty, decorator_node)
             };
+        }
+
+        if is_decorated_overload_implementation {
+            let function_type = if let Type::FunctionLiteral(function) = inferred_ty {
+                FunctionType::new(
+                    db,
+                    function_literal
+                        .with_last_definition_metadata(db, function.literal(db).last_definition),
+                    None,
+                )
+            } else {
+                function_type
+            };
+            let implementation_callables = inferred_ty
+                .try_upcast_to_callable(db)
+                .map_or_else(Box::default, |callables| {
+                    callables.iter().copied().collect()
+                });
+            inferred_ty = Type::FunctionLiteral(
+                function_type.with_implementation_callables(db, implementation_callables),
+            );
         }
 
         self.add_declaration_with_binding(

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -423,12 +423,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let function_type = FunctionType::new(db, function_literal, None);
         let is_decorated_overload_implementation = !decorator_types_and_nodes.is_empty()
             && function_literal.has_separate_implementation(db);
+        let is_decorated_overload =
+            !decorator_types_and_nodes.is_empty() && overload_literal.is_overload(db);
 
-        let mut inferred_ty = Type::FunctionLiteral(if is_decorated_overload_implementation {
-            FunctionType::new(db, function_literal.without_overloads(), None)
-        } else {
-            function_type
-        });
+        let mut inferred_ty = Type::FunctionLiteral(
+            if is_decorated_overload_implementation || is_decorated_overload {
+                FunctionType::new(db, function_literal.without_overloads(), None)
+            } else {
+                function_type
+            },
+        );
         if !decorator_list.is_empty() {
             self.undecorated_type = Some(inferred_ty);
         }
@@ -490,6 +494,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             inferred_ty = Type::FunctionLiteral(
                 function_type.with_implementation_callables(db, implementation_callables),
             );
+        } else if is_decorated_overload && let Type::FunctionLiteral(function) = inferred_ty {
+            inferred_ty = Type::FunctionLiteral(FunctionType::new(
+                db,
+                function_literal
+                    .with_last_definition_metadata(db, function.literal(db).last_definition),
+                None,
+            ));
         }
 
         self.add_declaration_with_binding(

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -317,7 +317,6 @@ fn check_non_generic_overload_implementation_consistency<'db>(
     let overload_signatures = overloads.iter().flat_map(|overload| {
         overload
             .decorated_signatures(db)
-            .into_owned()
             .into_iter()
             .map(move |signature| (overload, signature))
     });

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -314,9 +314,13 @@ fn check_non_generic_overload_implementation_consistency<'db>(
         return;
     }
 
-    let overload_signatures = overloads
-        .iter()
-        .map(|overload| (overload, overload.signature(db)));
+    let overload_signatures = overloads.iter().flat_map(|overload| {
+        overload
+            .decorated_signatures(db)
+            .into_owned()
+            .into_iter()
+            .map(move |signature| (overload, signature))
+    });
 
     if overload_signatures
         .clone()

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -9,7 +9,7 @@ use crate::{
     Db,
     place::{DefinedPlace, Definedness, Place, place_from_bindings},
     types::{
-        KnownClass, Type,
+        CallableType, KnownClass, Type,
         context::InferContext,
         diagnostic::INVALID_OVERLOAD,
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
@@ -101,8 +101,15 @@ pub(crate) fn check_overloaded_function<'db>(
 
     if let Some(implementation) = implementation
         && binding_decorator_inconsistencies.is_empty()
+        && context.is_lint_enabled(&INVALID_OVERLOAD)
     {
-        check_non_generic_overload_implementation_consistency(context, overloads, implementation);
+        let implementation_callables = function.implementation_callables(db);
+        check_non_generic_overload_implementation_consistency(
+            context,
+            overloads,
+            implementation,
+            &implementation_callables,
+        );
     }
 
     // Check that the overloaded function has at least two overloads
@@ -272,24 +279,38 @@ pub(crate) fn check_overloaded_function<'db>(
 
 /// Check non-generic overload signatures against their implementation.
 ///
-/// This is the first, deliberately narrow pass at overload implementation consistency. It reports
-/// only when the overloads and implementation are all non-generic; generic signatures require
-/// careful treatment of type-variable domains.
+/// This is the first, deliberately narrow pass at overload implementation consistency. Signature
+/// compatibility is checked only when the overloads and implementation are all non-generic;
+/// generic signatures require careful treatment of type-variable domains. Each callable
+/// alternative of the implementation must contain a signature consistent with each overload.
 fn check_non_generic_overload_implementation_consistency<'db>(
     context: &InferContext<'db, '_>,
     overloads: &'db [OverloadLiteral<'db>],
     implementation: OverloadLiteral<'db>,
+    implementation_callables: &[CallableType<'db>],
 ) {
-    if !context.is_lint_enabled(&INVALID_OVERLOAD) {
+    let db = context.db();
+    if implementation_callables.is_empty()
+        || implementation_callables
+            .iter()
+            .any(|callable| callable.signatures(db).overloads.is_empty())
+    {
+        let function_node = implementation.node(db, context.file(), context.module());
+        if let Some(builder) = context.report_lint(&INVALID_OVERLOAD, &function_node.name) {
+            builder.into_diagnostic(format_args!(
+                "Overload implementation is not callable after applying decorators"
+            ));
+        }
         return;
     }
 
-    let db = context.db();
-    let implementation_signature = implementation.signature(db);
-
     // TODO: Remove this temporary non-generic restriction once overload implementation consistency
     // handles type-variable domains.
-    if !implementation_signature.is_non_generic() {
+    if implementation_callables
+        .iter()
+        .flat_map(|callable| &callable.signatures(db).overloads)
+        .any(|signature| !signature.is_non_generic())
+    {
         return;
     }
 
@@ -306,10 +327,40 @@ fn check_non_generic_overload_implementation_consistency<'db>(
 
     for (overload, overload_signature) in overload_signatures {
         let function_node = overload.node(db, context.file(), context.module());
-        let parameter_consistency = implementation_signature
-            .non_generic_implementation_parameters_consistency_with(db, &overload_signature);
-        let return_type_consistency = implementation_signature
-            .non_generic_implementation_return_type_consistency_with(db, &overload_signature);
+        let Some((implementation_signature, parameter_consistency, return_type_consistency)) =
+            implementation_callables.iter().find_map(|callable| {
+                let mut inconsistency = None;
+                for implementation_signature in &callable.signatures(db).overloads {
+                    let parameter_consistency = implementation_signature
+                        .non_generic_implementation_parameters_consistency_with(
+                            db,
+                            &overload_signature,
+                        );
+                    let return_type_consistency = implementation_signature
+                        .non_generic_implementation_return_type_consistency_with(
+                            db,
+                            &overload_signature,
+                        );
+                    if matches!(
+                        (&parameter_consistency, &return_type_consistency),
+                        (
+                            ParameterConsistency::Consistent,
+                            ReturnTypeConsistency::Consistent
+                        )
+                    ) {
+                        return None;
+                    }
+                    inconsistency = Some((
+                        implementation_signature,
+                        parameter_consistency,
+                        return_type_consistency,
+                    ));
+                }
+                inconsistency
+            })
+        else {
+            continue;
+        };
 
         let (parameter_error_context, return_type_error_context, message) =
             match (parameter_consistency, return_type_consistency) {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -317,7 +317,6 @@ fn check_non_generic_overload_implementation_consistency<'db>(
     let overload_signatures = overloads.iter().flat_map(|overload| {
         overload
             .decorated_signatures(db)
-            .into_iter()
             .map(move |signature| (overload, signature))
     });
 


### PR DESCRIPTION
## Summary

The typing specification says that decorators applied to an overloaded function implementation are applied only to that implementation signature (not to the entire overloaded signature), and this happens before consistency is checked with the overload signatures. External callers only see overload signatures as written (with the effect of any decorators applied to the _overload_), they don't see the effect of decorators applied to the implementation.

On main we do this wrong; we apply implementation decorators to the entire overloaded signature. This PR fixes that, and also fixes application of decorators to specific overloads, notably handling the case where application of a decorator to an overload results in a `Callable` type instead of a `FunctionLiteral` type -- previously that broke the chain of overloads.

Fixes https://github.com/astral-sh/ty/issues/3859, relates to https://github.com/astral-sh/ty/issues/2278 and https://github.com/astral-sh/ty/issues/2057

## Test plan

- Added mdtests for return widening, parameter narrowing, callable-protocol and callable-union alternatives, non-callable decorator results, and function-literal replacement with preserved deprecation metadata.
- Updated `Concatenate`, `ParamSpec`, async-overload, and override fixtures to distinguish implementation decoration from regular application to an entire overloaded callable and to verify caller-visible overloads and consistency diagnostics.