### PR TITLE
[ty] Offer completions for cases in `match` statements

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -2164,12 +2164,14 @@ fn match_case_completion_context<'db>(
         match node {
             ast::AnyNodeRef::StmtMatch(match_stmt) => {
                 if let Some((current_case, position)) = current_case {
+                    let candidates = model.match_case_completions(
+                        match_stmt,
+                        current_case,
+                        position.or_pattern_arm_path(),
+                    );
+
                     return Some(MatchCaseCompletionContext {
-                        candidates: model.match_case_completions(
-                            match_stmt,
-                            current_case,
-                            position.or_pattern_index(),
-                        ),
+                        candidates,
                         replacement_range: position.replacement_range(),
                     });
                 }
@@ -2177,10 +2179,10 @@ fn match_case_completion_context<'db>(
                 return None;
             }
             ast::AnyNodeRef::MatchCase(case) => {
-                if let Some(current_or_pattern_index) =
+                if let Some(completion_position) =
                     match_case_completion_position(&case.pattern, cursor.range)
                 {
-                    current_case = Some((case, current_or_pattern_index));
+                    current_case = Some((case, completion_position));
                 }
             }
             _ => {}
@@ -2190,23 +2192,30 @@ fn match_case_completion_context<'db>(
     None
 }
 
-#[derive(Copy, Clone)]
 enum MatchCaseCompletionPosition {
     Pattern(TextRange),
-    OrArm { index: usize, range: TextRange },
+    OrArm {
+        /// Zero-based arm indices of the position in a possibly nested OR pattern.
+        ///
+        /// - `case A<CURSOR> | B | C:` maps to `[0]`.
+        /// - `case A | B | C<CURSOR>:` maps to `[2]`.
+        /// - `case A | (B | (C | D<CURSOR>)):` maps to `[1, 1, 1]`.
+        arm_path: Vec<usize>,
+        range: TextRange,
+    },
 }
 
 impl MatchCaseCompletionPosition {
-    fn or_pattern_index(self) -> Option<usize> {
+    fn or_pattern_arm_path(&self) -> &[usize] {
         match self {
-            Self::Pattern(_) => None,
-            Self::OrArm { index, .. } => Some(index),
+            Self::Pattern(_) => &[],
+            Self::OrArm { arm_path, .. } => arm_path,
         }
     }
 
-    fn replacement_range(self) -> TextRange {
+    fn replacement_range(&self) -> TextRange {
         match self {
-            Self::Pattern(range) | Self::OrArm { range, .. } => range,
+            Self::Pattern(range) | Self::OrArm { range, .. } => *range,
         }
     }
 }
@@ -2215,8 +2224,8 @@ impl MatchCaseCompletionPosition {
 ///
 /// A standalone target such as `case C<CURSOR>` returns
 /// [`MatchCaseCompletionPosition::Pattern`]. An alternative such as
-/// `case "ready" | w<CURSOR>` returns [`MatchCaseCompletionPosition::OrArm`] with the active
-/// arm's index. Positions inside structural patterns return `None`.
+/// `case "ready" | w<CURSOR>` returns [`MatchCaseCompletionPosition::OrArm`] with the path to the
+/// active arm. Positions inside structural patterns return `None`.
 ///
 /// Structural subpatterns are not supported.
 fn match_case_completion_position(
@@ -2250,27 +2259,43 @@ fn match_case_completion_position(
             )
     }
 
-    let pattern = unwrap_enclosing_as_patterns_at_cursor(pattern, cursor_range);
+    fn supported_completion_range(
+        pattern: &ast::Pattern,
+        cursor_range: TextRange,
+        or_pattern_arm_path: &mut Vec<usize>,
+    ) -> Option<TextRange> {
+        let pattern = unwrap_enclosing_as_patterns_at_cursor(pattern, cursor_range);
 
-    if let ast::Pattern::MatchOr(or_pattern) = pattern {
-        // The semantic model uses this index to narrow candidates by all preceding alternatives.
-        let index = or_pattern
-            .patterns
-            .iter()
-            .position(|pattern| pattern.range().contains_range(cursor_range))?;
+        if let ast::Pattern::MatchOr(or_pattern) = pattern {
+            let index = or_pattern
+                .patterns
+                .iter()
+                .position(|pattern| pattern.range().contains_range(cursor_range))?;
 
-        let arm = unwrap_enclosing_as_patterns_at_cursor(&or_pattern.patterns[index], cursor_range);
+            // Record the cursor's path from the outermost OR pattern to the innermost one.
+            or_pattern_arm_path.push(index);
 
-        return is_supported_completion_target(arm, cursor_range).then_some(
-            MatchCaseCompletionPosition::OrArm {
-                index,
-                range: arm.range(),
-            },
-        );
+            return supported_completion_range(
+                &or_pattern.patterns[index],
+                cursor_range,
+                or_pattern_arm_path,
+            );
+        }
+
+        is_supported_completion_target(pattern, cursor_range).then_some(pattern.range())
     }
 
-    is_supported_completion_target(pattern, cursor_range)
-        .then_some(MatchCaseCompletionPosition::Pattern(pattern.range()))
+    let mut or_pattern_arm_path = Vec::new();
+    let range = supported_completion_range(pattern, cursor_range, &mut or_pattern_arm_path)?;
+
+    if or_pattern_arm_path.is_empty() {
+        Some(MatchCaseCompletionPosition::Pattern(range))
+    } else {
+        Some(MatchCaseCompletionPosition::OrArm {
+            arm_path: or_pattern_arm_path,
+            range,
+        })
+    }
 }
 
 /// Detect and add completions for unset class arguments.
@@ -9872,6 +9897,52 @@ def handle(status: Color):
 
         test.not_contains("Color.RED");
         test.not_contains("Color.BLUE");
+    }
+
+    #[test]
+    fn nested_match_or_pattern_omits_members_matched_by_previous_alternatives() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+def handle(status: Color):
+    match status:
+        case Color.RED | (Color.GREEN | C<CURSOR>):
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        test.not_contains("Color.RED");
+        test.not_contains("Color.GREEN");
+        test.contains("Color.BLUE");
+    }
+
+    #[test]
+    fn nested_match_or_pattern_includes_members_matched_by_later_alternative() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+def handle(status: Color):
+    match status:
+        case Color.RED | (C<CURSOR> | Color.GREEN):
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        test.not_contains("Color.RED");
+        test.contains("Color.GREEN");
+        test.contains("Color.BLUE");
     }
 
     #[test]

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -8,18 +8,20 @@ use ruff_db::source::{SourceText, source_text};
 use ruff_diagnostics::Edit;
 use ruff_python_ast::find_node::{CoveringNode, covering_node};
 use ruff_python_ast::name::{Name, UnqualifiedName};
-use ruff_python_ast::str::Quote;
+use ruff_python_ast::str::{Quote, TripleQuotes};
+use ruff_python_ast::str_prefix::{AnyStringPrefix, ByteStringPrefix, StringLiteralPrefix};
 use ruff_python_ast::token::{Token, TokenKind, Tokens};
-use ruff_python_ast::{self as ast, AnyNodeRef};
+use ruff_python_ast::{self as ast, AnyNodeRef, StringFlags};
 use ruff_python_codegen::Stylist;
-use ruff_python_literal::escape::{Escape, UnicodeEscape};
+use ruff_python_literal::escape::{AsciiEscape, Escape, UnicodeEscape};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashSet;
 use ty_module_resolver::{KnownModule, Module, ModuleName};
 use ty_python_semantic::HasType;
 use ty_python_semantic::types::{SpecialFormType, UnionType};
 use ty_python_semantic::{
-    Completion as SemanticCompletion, NameKind, SemanticModel,
+    Completion as SemanticCompletion, MatchCaseCompletion, MatchCaseCompletionKind,
+    MatchCaseCompletions, NameKind, SemanticModel,
     types::{CycleDetector, KnownClass, Type},
 };
 
@@ -43,19 +45,31 @@ pub fn completion<'db>(
         return vec![];
     };
     let model = SemanticModel::new(db, file);
+    let match_case_context = match_case_completion_context(&model, &context.cursor);
 
     if !matches!(context.kind, ContextKind::Keywords(_)) && context.cursor.is_in_string() {
-        let Some(string_expr) = context.cursor.enclosing_string_literal_expr() else {
+        let Some(literal_context) = context.cursor.string_literal_context() else {
             return vec![];
         };
 
         let mut completions =
             Completions::new(db, CollectionContext::none(), UserQuery::fuzzy(None));
 
-        add_string_literal_completions(
-            &model,
-            string_expr,
-            context.cursor.string_quote_style(),
+        if let Some(string_expr) = context.cursor.enclosing_string_literal_expr()
+            && let AnyStringPrefix::Regular(prefix) = literal_context.prefix
+        {
+            add_string_literal_completions(
+                &model,
+                string_expr,
+                literal_context.quote,
+                prefix,
+                literal_context.triple_quotes,
+                &mut completions,
+            );
+        }
+        add_match_case_string_literal_completions(
+            match_case_context.as_ref(),
+            literal_context,
             &mut completions,
         );
 
@@ -80,7 +94,13 @@ pub fn completion<'db>(
         }
         ContextKind::NonImport(ref non_import) => match non_import.target {
             CompletionTargetAst::ObjectDot { expr } => {
-                completions.extend(model.attribute_completions(expr));
+                add_attribute_completions(
+                    &model,
+                    expr,
+                    &context.cursor,
+                    match_case_context.as_ref(),
+                    &mut completions,
+                );
             }
             CompletionTargetAst::Scoped(scoped) => {
                 for semantic_completion in model.scoped_completions(scoped.node) {
@@ -94,8 +114,14 @@ pub fn completion<'db>(
                             .module_dependency_kind(module_dependency_kind),
                     );
                 }
-                add_keyword_completions(db, &mut completions);
+                add_keyword_completions(db, match_case_context.as_ref(), &mut completions);
                 add_argument_completions(db, &model, &context.cursor, &mut completions);
+                add_match_case_completions(
+                    &model,
+                    &context.cursor,
+                    match_case_context.as_ref(),
+                    &mut completions,
+                );
                 if settings.auto_import {
                     add_unimported_completions(
                         db,
@@ -328,6 +354,10 @@ pub struct Completion<'db> {
     /// An import statement to insert (or ensure is already
     /// present) when this completion is selected.
     pub import: Option<Edit>,
+    /// The primary text edit to apply when this completion is selected.
+    ///
+    /// When present, this is used instead of [`Self::insert`].
+    pub text_edit: Option<Edit>,
     /// Whether this suggestion came from builtins or not.
     ///
     /// At time of writing (2025-06-26), this information
@@ -378,12 +408,14 @@ struct CompletionBuilder<'db> {
     kind: Option<CompletionKind>,
     module_name: Option<&'db ModuleName>,
     import: Option<Edit>,
+    text_edit: Option<Edit>,
     builtin: bool,
     is_context_specific: bool,
     is_type_check_only: bool,
     documentation: Option<Docstring>,
     module_dependency_kind: Option<ModuleDependencyKind>,
     deprecated: bool,
+    source_order: Option<usize>,
 }
 
 impl<'db> CompletionBuilder<'db> {
@@ -401,12 +433,14 @@ impl<'db> CompletionBuilder<'db> {
             kind: None,
             module_name: None,
             import: None,
+            text_edit: None,
             builtin: false,
             is_context_specific: false,
             is_type_check_only: false,
             documentation: None,
             module_dependency_kind: None,
             deprecated: false,
+            source_order: None,
         }
     }
 
@@ -519,6 +553,7 @@ impl<'db> CompletionBuilder<'db> {
             module_name: self.module_name,
             module_dependency_kind: self.module_dependency_kind,
             import: self.import,
+            text_edit: self.text_edit,
             builtin: self.builtin,
             is_type_check_only: self.is_type_check_only,
             is_context_specific: self.is_context_specific,
@@ -557,6 +592,11 @@ impl<'db> CompletionBuilder<'db> {
         self
     }
 
+    fn text_edit(mut self, edit: Edit) -> CompletionBuilder<'db> {
+        self.text_edit = Some(edit);
+        self
+    }
+
     fn deprecated(mut self, deprecated: bool) -> CompletionBuilder<'db> {
         self.deprecated = deprecated;
         self
@@ -569,6 +609,11 @@ impl<'db> CompletionBuilder<'db> {
 
     fn context_specific(mut self, yes: bool) -> CompletionBuilder<'db> {
         self.is_context_specific = yes;
+        self
+    }
+
+    fn source_order(mut self, order: usize) -> CompletionBuilder<'db> {
+        self.source_order = Some(order);
         self
     }
 
@@ -823,6 +868,13 @@ struct ContextCursor<'m> {
     covering_node: CoveringNode<'m>,
 }
 
+#[derive(Copy, Clone)]
+struct StringLiteralContext {
+    prefix: AnyStringPrefix,
+    quote: Quote,
+    triple_quotes: TripleQuotes,
+}
+
 /// The cursor position relative to an AST range and its surrounding parentheses.
 enum RangeEndPosition {
     /// The cursor follows the complete range, including any surrounding parentheses.
@@ -955,11 +1007,26 @@ impl<'m> ContextCursor<'m> {
         }
     }
 
-    /// Returns the quote style of the string literal that the cursor is positioned within, if any.
-    fn string_quote_style(&self) -> Option<Quote> {
-        self.tokens_before
-            .last()
-            .map(|token| token.string_quote_style())
+    /// Returns the source spelling of the string or bytes literal containing the cursor.
+    fn string_literal_context(&self) -> Option<StringLiteralContext> {
+        let flags = self.tokens_before.last()?.string_flags()?;
+        let prefix = flags.prefix();
+        if matches!(
+            prefix,
+            AnyStringPrefix::Format(_) | AnyStringPrefix::Template(_)
+        ) {
+            return None;
+        }
+
+        Some(StringLiteralContext {
+            prefix,
+            quote: flags.quote_style(),
+            triple_quotes: if flags.is_triple_quoted() {
+                TripleQuotes::Yes
+            } else {
+                TripleQuotes::No
+            },
+        })
     }
 
     fn suppress_callable_parentheses(&self) -> bool {
@@ -1704,6 +1771,8 @@ struct Relevance {
     /// A coarse measure of how tightly the completion label matches
     /// the user's query.
     match_quality: MatchQuality,
+    /// Preserves the source order of candidates produced by the same contextual completion.
+    source_order: Option<usize>,
 }
 
 impl Relevance {
@@ -1762,6 +1831,7 @@ impl Relevance {
                 .module_dependency_kind
                 .map(ModuleDependencyKind::origin_rank),
             match_quality: query.match_quality(&c.name),
+            source_order: c.source_order,
         }
     }
 }
@@ -1937,6 +2007,272 @@ fn add_argument_completions<'db>(
     }
 }
 
+fn add_attribute_completions<'db>(
+    model: &SemanticModel<'db>,
+    expr: &ast::ExprAttribute,
+    cursor: &ContextCursor<'_>,
+    match_context: Option<&MatchCaseCompletionContext<'db>>,
+    completions: &mut Completions<'db>,
+) {
+    let (Some(match_context), Some(qualifier_ty)) =
+        (match_context, expr.value.inferred_type(model))
+    else {
+        completions.extend(model.attribute_completions(expr));
+        return;
+    };
+
+    let known_members = match_context
+        .candidates
+        .known
+        .iter()
+        .filter_map(|candidate| match &candidate.kind {
+            MatchCaseCompletionKind::EnumMember {
+                enum_class,
+                member_name,
+            } if *enum_class == qualifier_ty => Some(member_name.as_str()),
+            _ => None,
+        })
+        .collect::<FxHashSet<&str>>();
+
+    if known_members.is_empty() {
+        completions.extend(model.attribute_completions(expr));
+        return;
+    }
+
+    for candidate in model.attribute_completions(expr) {
+        if !known_members.contains(candidate.name.as_str()) {
+            completions.add_semantic(candidate);
+        }
+    }
+
+    let qualifier = &cursor.source[expr.value.range()];
+    for (source_order, candidate) in match_context.candidates.remaining.iter().enumerate() {
+        let MatchCaseCompletionKind::EnumMember {
+            enum_class,
+            member_name,
+        } = &candidate.kind
+        else {
+            continue;
+        };
+        if *enum_class != qualifier_ty {
+            continue;
+        }
+
+        let replacement = format!("{qualifier}.{member_name}");
+        completions.add(
+            Completion::builder(member_name.as_str())
+                .ty(candidate.ty)
+                .kind(CompletionKind::EnumMember)
+                .text_edit(Edit::replacement(
+                    replacement,
+                    match_context.replacement_range.start(),
+                    match_context.replacement_range.end(),
+                ))
+                .context_specific(true)
+                .source_order(source_order),
+        );
+    }
+}
+
+/// Detect and add completions for match pattern cases.
+fn add_match_case_completions<'db>(
+    model: &SemanticModel<'db>,
+    cursor: &ContextCursor<'_>,
+    context: Option<&MatchCaseCompletionContext<'db>>,
+    completions: &mut Completions<'db>,
+) {
+    let Some(context) = context else {
+        return;
+    };
+
+    let scope_node = cursor
+        .covering_node
+        .ancestors()
+        .find(|node| node.is_statement())
+        .unwrap_or_else(|| cursor.covering_node.node());
+
+    for (source_order, candidate) in context.candidates.remaining.iter().enumerate() {
+        let Some(value) = match_case_completion_value(model, scope_node, candidate) else {
+            continue;
+        };
+
+        let text_edit = Edit::replacement(
+            value.clone(),
+            context.replacement_range.start(),
+            context.replacement_range.end(),
+        );
+        completions.add_skip_query(
+            Completion::builder(value)
+                .ty(candidate.ty)
+                .text_edit(text_edit)
+                .context_specific(true)
+                .source_order(source_order),
+        );
+    }
+}
+
+fn match_case_completion_value<'db>(
+    model: &SemanticModel<'db>,
+    scope_node: ast::AnyNodeRef<'_>,
+    candidate: &MatchCaseCompletion<'db>,
+) -> Option<String> {
+    let MatchCaseCompletionKind::EnumMember {
+        enum_class,
+        member_name,
+    } = &candidate.kind
+    else {
+        return match_case_literal_source(&candidate.kind);
+    };
+
+    let qualifier = model.visible_qualifier_for_type(scope_node, *enum_class)?;
+    Some(format!("{qualifier}.{member_name}"))
+}
+
+fn match_case_literal_source(kind: &MatchCaseCompletionKind<'_>) -> Option<String> {
+    match kind {
+        MatchCaseCompletionKind::None => Some("None".to_string()),
+        MatchCaseCompletionKind::Bool(value) => {
+            Some(if *value { "True" } else { "False" }.to_string())
+        }
+        MatchCaseCompletionKind::Int(value) => Some(value.to_string()),
+        MatchCaseCompletionKind::String(value) => {
+            UnicodeEscape::with_preferred_quote(value, Quote::Double)
+                .str_repr(TripleQuotes::No)
+                .to_string()
+        }
+        MatchCaseCompletionKind::Bytes(value) => {
+            AsciiEscape::with_preferred_quote(value, Quote::Double)
+                .bytes_repr(TripleQuotes::No)
+                .to_string()
+        }
+        MatchCaseCompletionKind::EnumMember { .. } => None,
+    }
+}
+
+struct MatchCaseCompletionContext<'db> {
+    candidates: MatchCaseCompletions<'db>,
+    replacement_range: TextRange,
+}
+
+fn match_case_completion_context<'db>(
+    model: &SemanticModel<'db>,
+    cursor: &ContextCursor<'_>,
+) -> Option<MatchCaseCompletionContext<'db>> {
+    let mut current_case: Option<(&ast::MatchCase, MatchCaseCompletionPosition)> = None;
+
+    for node in cursor.covering_node.ancestors() {
+        match node {
+            ast::AnyNodeRef::StmtMatch(match_stmt) => {
+                if let Some((current_case, position)) = current_case {
+                    return Some(MatchCaseCompletionContext {
+                        candidates: model.match_case_completions(
+                            match_stmt,
+                            current_case,
+                            position.or_pattern_index(),
+                        ),
+                        replacement_range: position.replacement_range(),
+                    });
+                }
+
+                return None;
+            }
+            ast::AnyNodeRef::MatchCase(case) => {
+                if let Some(current_or_pattern_index) =
+                    match_case_completion_position(&case.pattern, cursor.range)
+                {
+                    current_case = Some((case, current_or_pattern_index));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+#[derive(Copy, Clone)]
+enum MatchCaseCompletionPosition {
+    Pattern(TextRange),
+    OrArm { index: usize, range: TextRange },
+}
+
+impl MatchCaseCompletionPosition {
+    fn or_pattern_index(self) -> Option<usize> {
+        match self {
+            Self::Pattern(_) => None,
+            Self::OrArm { index, .. } => Some(index),
+        }
+    }
+
+    fn replacement_range(self) -> TextRange {
+        match self {
+            Self::Pattern(range) | Self::OrArm { range, .. } => range,
+        }
+    }
+}
+
+/// Classifies a supported pattern position under the cursor.
+///
+/// A standalone target such as `case C<CURSOR>` returns
+/// [`MatchCaseCompletionPosition::Pattern`]. An alternative such as
+/// `case "ready" | w<CURSOR>` returns [`MatchCaseCompletionPosition::OrArm`] with the active
+/// arm's index. Positions inside structural patterns return `None`.
+///
+/// Structural subpatterns are not supported.
+fn match_case_completion_position(
+    pattern: &ast::Pattern,
+    cursor_range: TextRange,
+) -> Option<MatchCaseCompletionPosition> {
+    // In `case ("ready" | w) as state`, the case root is `MatchAs`, but a cursor on `w`
+    // belongs to the inner `MatchOr`. A cursor on the bound name `state` does not.
+    fn unwrap_enclosing_as_patterns_at_cursor(
+        mut pattern: &ast::Pattern,
+        cursor_range: TextRange,
+    ) -> &ast::Pattern {
+        while let ast::Pattern::MatchAs(as_pattern) = pattern
+            && let Some(inner) = as_pattern.pattern.as_deref()
+            && inner.range().contains_range(cursor_range)
+        {
+            pattern = inner;
+        }
+        pattern
+    }
+
+    fn is_supported_completion_target(pattern: &ast::Pattern, cursor_range: TextRange) -> bool {
+        // A capture or wildcard is represented as `MatchAs` without an inner pattern. A `MatchAs`
+        // with an inner pattern is handled by `unwrap_enclosing_as_patterns_at_cursor` instead.
+        pattern.range().contains_range(cursor_range)
+            && matches!(
+                pattern,
+                ast::Pattern::MatchValue(_)
+                    | ast::Pattern::MatchSingleton(_)
+                    | ast::Pattern::MatchAs(ast::PatternMatchAs { pattern: None, .. })
+            )
+    }
+
+    let pattern = unwrap_enclosing_as_patterns_at_cursor(pattern, cursor_range);
+
+    if let ast::Pattern::MatchOr(or_pattern) = pattern {
+        // The semantic model uses this index to narrow candidates by all preceding alternatives.
+        let index = or_pattern
+            .patterns
+            .iter()
+            .position(|pattern| pattern.range().contains_range(cursor_range))?;
+
+        let arm = unwrap_enclosing_as_patterns_at_cursor(&or_pattern.patterns[index], cursor_range);
+
+        return is_supported_completion_target(arm, cursor_range).then_some(
+            MatchCaseCompletionPosition::OrArm {
+                index,
+                range: arm.range(),
+            },
+        );
+    }
+
+    is_supported_completion_target(pattern, cursor_range)
+        .then_some(MatchCaseCompletionPosition::Pattern(pattern.range()))
+}
+
 /// Detect and add completions for unset class arguments.
 ///
 /// Some arguments we know are always valid and thus they are easy
@@ -2109,13 +2445,34 @@ pub(crate) fn unresolved_fixes(
 /// This should generally only be used when offering "scoped" completions.
 /// This will include keywords corresponding to Python values (like `None`)
 /// and general language keywords (like `raise`).
-fn add_keyword_completions<'db>(db: &'db dyn Db, completions: &mut Completions<'db>) {
+fn add_keyword_completions<'db>(
+    db: &'db dyn Db,
+    match_context: Option<&MatchCaseCompletionContext<'db>>,
+    completions: &mut Completions<'db>,
+) {
     let keyword_values = [
-        ("None", Type::none(db)),
-        ("True", Type::bool_literal(true)),
-        ("False", Type::bool_literal(false)),
+        ("None", Type::none(db), MatchCaseCompletionKind::None),
+        (
+            "True",
+            Type::bool_literal(true),
+            MatchCaseCompletionKind::Bool(true),
+        ),
+        (
+            "False",
+            Type::bool_literal(false),
+            MatchCaseCompletionKind::Bool(false),
+        ),
     ];
-    for (name, ty) in keyword_values {
+    for (name, ty, kind) in keyword_values {
+        if match_context.is_some_and(|context| {
+            context
+                .candidates
+                .known
+                .iter()
+                .any(|candidate| candidate.kind == kind)
+        }) {
+            continue;
+        }
         completions.add(CompletionBuilder::keyword(name).ty(ty).builtin(true));
     }
 
@@ -2139,9 +2496,84 @@ fn add_keyword_completions<'db>(db: &'db dyn Db, completions: &mut Completions<'
 fn add_string_literal_completions<'db>(
     model: &SemanticModel<'db>,
     string_expr: &ast::ExprStringLiteral,
-    quote_style: Option<Quote>,
+    quote: Quote,
+    prefix: StringLiteralPrefix,
+    triple_quotes: TripleQuotes,
     completions: &mut Completions<'db>,
 ) {
+    let candidates = model.expected_string_literal_completions(string_expr);
+    if candidates.is_empty() {
+        return;
+    }
+
+    for candidate in candidates {
+        let Some(insert) =
+            escape_string_literal_for_quote(&candidate.value, quote, prefix, triple_quotes)
+        else {
+            continue;
+        };
+        completions.add_skip_query(
+            Completion::builder(candidate.value.as_str())
+                .insert(insert)
+                .ty(candidate.ty)
+                .context_specific(true),
+        );
+    }
+}
+
+fn add_match_case_string_literal_completions<'db>(
+    context: Option<&MatchCaseCompletionContext<'db>>,
+    literal_context: StringLiteralContext,
+    completions: &mut Completions<'db>,
+) {
+    let Some(context) = context else {
+        return;
+    };
+
+    for (source_order, candidate) in context.candidates.remaining.iter().enumerate() {
+        let (name, insert) = match (&candidate.kind, literal_context.prefix) {
+            (MatchCaseCompletionKind::String(value), AnyStringPrefix::Regular(prefix)) => {
+                let Some(insert) = escape_string_literal_for_quote(
+                    value,
+                    literal_context.quote,
+                    prefix,
+                    literal_context.triple_quotes,
+                ) else {
+                    continue;
+                };
+                (value.clone(), insert)
+            }
+            (MatchCaseCompletionKind::Bytes(value), AnyStringPrefix::Bytes(prefix)) => {
+                let Some(insert) = escape_bytes_literal_for_quote(
+                    value,
+                    literal_context.quote,
+                    prefix,
+                    literal_context.triple_quotes,
+                ) else {
+                    continue;
+                };
+                (insert.clone(), insert)
+            }
+            _ => continue,
+        };
+
+        completions.add_skip_query(
+            Completion::builder(name)
+                .insert(insert)
+                .ty(candidate.ty)
+                .context_specific(true)
+                .source_order(source_order),
+        );
+    }
+}
+
+/// Escapes a string-literal completion using the quote style of the surrounding literal.
+fn escape_string_literal_for_quote(
+    value: &str,
+    quote: Quote,
+    prefix: StringLiteralPrefix,
+    triple_quotes: TripleQuotes,
+) -> Option<String> {
     fn force_escape_quote(body: &str, quote: Quote) -> String {
         let quote_char = quote.as_char();
         let mut escaped = String::with_capacity(body.len());
@@ -2164,33 +2596,82 @@ fn add_string_literal_completions<'db>(
         escaped
     }
 
-    // When we insert a completion for a string literal, we need to make sure
-    // to properly escape any special characters in the completion value and
-    // to use the appropriate quote style.
-    fn escape_for_quote(value: &str, quote: Quote) -> Option<String> {
-        let escaped = UnicodeEscape::with_preferred_quote(value, quote);
-        let mut out = String::new();
-        escaped.write_body(&mut out).ok()?;
-        Some(force_escape_quote(&out, quote))
+    if matches!(prefix, StringLiteralPrefix::Raw { .. }) {
+        return raw_literal_body(value, quote, triple_quotes).then(|| value.to_string());
     }
 
-    let candidates = model.expected_string_literal_completions(string_expr);
-    if candidates.is_empty() {
-        return;
+    let escaped = UnicodeEscape::with_preferred_quote(value, quote);
+    let mut out = String::new();
+    escaped.write_body(&mut out).ok()?;
+    Some(force_escape_quote(&out, quote))
+}
+
+fn escape_bytes_literal_for_quote(
+    value: &[u8],
+    quote: Quote,
+    prefix: ByteStringPrefix,
+    triple_quotes: TripleQuotes,
+) -> Option<String> {
+    if prefix.is_raw() {
+        let value = std::str::from_utf8(value).ok()?;
+        return value
+            .is_ascii()
+            .then_some(value)
+            .filter(|value| raw_literal_body(value, quote, triple_quotes))
+            .map(ToString::to_string);
     }
 
-    let quote_style = quote_style.unwrap_or(Quote::Double);
-    for candidate in candidates {
-        let Some(insert) = escape_for_quote(&candidate.value, quote_style) else {
+    let escaped = AsciiEscape::with_preferred_quote(value, quote);
+    let mut out = String::new();
+    escaped.write_body(&mut out).ok()?;
+    Some(force_escape_literal_quote(&out, quote))
+}
+
+fn raw_literal_body(value: &str, quote: Quote, triple_quotes: TripleQuotes) -> bool {
+    let trailing_backslashes = value.chars().rev().take_while(|ch| *ch == '\\').count();
+    if !trailing_backslashes.is_multiple_of(2) {
+        return false;
+    }
+
+    if triple_quotes.is_yes() {
+        let delimiter = quote.as_char().to_string().repeat(3);
+        !value.contains(&delimiter)
+    } else {
+        let mut consecutive_backslashes = 0usize;
+        for ch in value.chars() {
+            if ch == '\\' {
+                consecutive_backslashes += 1;
+                continue;
+            }
+            if ch == quote.as_char() && consecutive_backslashes.is_multiple_of(2) {
+                return false;
+            }
+            consecutive_backslashes = 0;
+        }
+        true
+    }
+}
+
+fn force_escape_literal_quote(body: &str, quote: Quote) -> String {
+    let quote_char = quote.as_char();
+    let mut escaped = String::with_capacity(body.len());
+    let mut consecutive_backslashes = 0usize;
+
+    for ch in body.chars() {
+        if ch == '\\' {
+            consecutive_backslashes += 1;
+            escaped.push(ch);
             continue;
-        };
-        completions.add_skip_query(
-            Completion::builder(candidate.value.as_str())
-                .insert(insert)
-                .ty(candidate.ty)
-                .context_specific(true),
-        );
+        }
+
+        if ch == quote_char && consecutive_backslashes.is_multiple_of(2) {
+            escaped.push('\\');
+        }
+        consecutive_backslashes = 0;
+        escaped.push(ch);
     }
+
+    escaped
 }
 
 /// Adds completions not in scope.
@@ -3211,6 +3692,7 @@ mod tests {
     use ruff_python_ast::helpers::is_dunder;
     use ruff_python_ast::token::{TokenKind, Tokens};
     use ruff_python_parser::{Mode, ParseOptions};
+    use ruff_text_size::{Ranged, TextSize};
     use ty_module_resolver::ModuleName;
 
     use crate::CompletionCapabilities;
@@ -8370,6 +8852,1119 @@ match status:
             builder.build().snapshot(),
             @"<No completions found>",
         );
+    }
+
+    #[test]
+    fn match_pattern_suggests_cases() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color):
+    match status:
+        case C<CURSOR>:
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.contains("Color.RED");
+        test.contains("Color.BLUE");
+    }
+
+    #[test]
+    fn match_pattern_preserves_enum_member_definition_order() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    ZEBRA = 1
+    ALPHA = 2
+    MIDDLE = 3
+
+def handle(status: Color):
+    match status:
+        case C<CURSOR>:
+            pass
+";
+
+        let builder = completion_test_builder(source)
+            .filter(|completion| completion.name.starts_with("Color."));
+        assert_eq!(
+            builder.build().snapshot(),
+            "Color.ZEBRA\nColor.ALPHA\nColor.MIDDLE"
+        );
+    }
+
+    #[test]
+    fn match_pattern_uses_scope_resolvable_enum_qualifier() {
+        const COLORS_SOURCE: &str = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+";
+
+        let builder = CursorTest::builder()
+            .source(
+                "main.py",
+                "\
+import colors
+
+def handle(status: colors.Color):
+    match status:
+        case c<CURSOR>:
+            pass
+",
+            )
+            .source("colors.py", COLORS_SOURCE)
+            .completion_test_builder()
+            .filter(|completion| completion.name.starts_with("colors.Color."));
+        assert_eq!(
+            builder.build().snapshot(),
+            "colors.Color.RED\ncolors.Color.BLUE"
+        );
+
+        let builder = CursorTest::builder()
+            .source(
+                "main.py",
+                "\
+import colors as Palette
+
+def handle(status: Palette.Color):
+    match status:
+        case P<CURSOR>:
+            pass
+",
+            )
+            .source("colors.py", COLORS_SOURCE)
+            .completion_test_builder()
+            .filter(|completion| completion.name.starts_with("Palette.Color."));
+        assert_eq!(
+            builder.build().snapshot(),
+            "Palette.Color.RED\nPalette.Color.BLUE"
+        );
+
+        let builder = CursorTest::builder()
+            .source(
+                "main.py",
+                "\
+from colors import Color as Palette
+
+def handle(status: Palette):
+    match status:
+        case P<CURSOR>:
+            pass
+",
+            )
+            .source("colors.py", COLORS_SOURCE)
+            .completion_test_builder()
+            .filter(|completion| completion.name.starts_with("Palette."));
+        assert_eq!(builder.build().snapshot(), "Palette.RED\nPalette.BLUE");
+    }
+
+    #[test]
+    fn match_pattern_suggests_literal_values() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\", 1, -2, b\"bytes\"]):
+    match status:
+        case \"r<CURSOR>\":
+            pass
+";
+        completion_test_builder(source).build().contains("ready");
+
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\", 1, -2, b\"bytes\"]):
+    match status:
+        case \"w<CURSOR>\":
+            pass
+";
+        completion_test_builder(source).build().contains("waiting");
+
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\", 1, -2, b\"bytes\"]):
+    match status:
+        case 1<CURSOR>:
+            pass
+";
+        completion_test_builder(source).build().contains("1");
+
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\", 1, -2, b\"bytes\"]):
+    match status:
+        case -2<CURSOR>:
+            pass
+";
+        completion_test_builder(source).build().contains("-2");
+
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\", 1, -2, b\"bytes\"]):
+    match status:
+        case b<CURSOR>:
+            pass
+";
+        completion_test_builder(source)
+            .build()
+            .contains("b\"bytes\"");
+    }
+
+    #[test]
+    fn match_pattern_replaces_the_active_negative_literal() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[-2]):
+    match status:
+        case -<CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        let matching = test
+            .completions()
+            .iter()
+            .filter(|completion| completion.name == "-2")
+            .collect::<Vec<_>>();
+        assert_eq!(matching.len(), 1, "expected one completion for `-2`");
+        if let [completion] = matching.as_slice() {
+            assert!(
+                completion.text_edit.is_some(),
+                "expected a primary replacement edit"
+            );
+            if let Some(edit) = completion.text_edit.as_ref() {
+                assert_eq!(edit.content(), Some("-2"));
+                assert_eq!(edit.range().len(), TextSize::new(1));
+            }
+        }
+
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[-2]):
+    match status:
+        case -2<CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        let matching = test
+            .completions()
+            .iter()
+            .filter(|completion| completion.name == "-2")
+            .collect::<Vec<_>>();
+        assert_eq!(matching.len(), 1, "expected one completion for `-2`");
+        if let [completion] = matching.as_slice() {
+            assert!(
+                completion.text_edit.is_some(),
+                "expected a primary replacement edit"
+            );
+            if let Some(edit) = completion.text_edit.as_ref() {
+                assert_eq!(edit.content(), Some("-2"));
+                assert_eq!(edit.range().len(), TextSize::new(2));
+            }
+        }
+    }
+
+    #[test]
+    fn match_pattern_preserves_literal_definition_order() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"zebra\", \"alpha\", \"middle\"]):
+    match status:
+        case \"<CURSOR>\":
+            pass
+";
+
+        let builder =
+            completion_test_builder(source).filter(|completion| completion.is_context_specific);
+        assert_eq!(builder.build().snapshot(), "zebra\nalpha\nmiddle");
+    }
+
+    #[test]
+    fn match_pattern_suggests_string_literals_inside_string() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\"]):
+    match status:
+        case \"w<CURSOR>\":
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        assert_eq!(test.snapshot(), "ready\nwaiting");
+    }
+
+    #[test]
+    fn match_pattern_inside_string_omits_literal_matched_by_previous_case() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\"]):
+    match status:
+        case \"ready\":
+            pass
+        case \"w<CURSOR>\":
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        assert_eq!(test.snapshot(), "waiting");
+    }
+
+    #[test]
+    fn match_pattern_inside_string_uses_existing_quote_style() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"it's ready\"]):
+    match status:
+        case '<CURSOR>':
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        let insert = test
+            .completions()
+            .iter()
+            .find(|completion| completion.name == "it's ready")
+            .and_then(|completion| completion.insert.as_deref());
+
+        assert_eq!(insert, Some("it\\'s ready"));
+    }
+
+    #[test]
+    fn match_pattern_inside_raw_string_preserves_backslashes() {
+        let source = r#"
+from typing import Literal
+
+def handle(status: Literal[r"a\b"]):
+    match status:
+        case r"<CURSOR>":
+            pass
+"#;
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        let insert = test
+            .completions()
+            .iter()
+            .find(|completion| completion.name == r"a\b")
+            .and_then(|completion| completion.insert.as_deref());
+
+        assert_eq!(insert, Some(r"a\b"));
+    }
+
+    #[test]
+    fn match_pattern_inside_raw_string_omits_unrepresentable_value() {
+        let source = r#"
+from typing import Literal
+
+def handle(status: Literal['a"b']):
+    match status:
+        case r"<CURSOR>":
+            pass
+"#;
+
+        completion_test_builder(source).build().not_contains("a\"b");
+    }
+
+    #[test]
+    fn match_pattern_suggests_bytes_literals_inside_bytes() {
+        let source = r#"
+from typing import Literal
+
+def handle(status: Literal[b"ready", b"a'b", b"\xff"]):
+    match status:
+        case b"<CURSOR>":
+            pass
+"#;
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.contains("ready");
+        test.contains("a'b");
+        test.contains(r"\xff");
+    }
+
+    #[test]
+    fn match_pattern_inside_raw_bytes_preserves_representable_values() {
+        let source = r#"
+from typing import Literal
+
+def handle(status: Literal[b"a\\b", b'a"b', b"\xff"]):
+    match status:
+        case rb"<CURSOR>":
+            pass
+"#;
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.contains(r"a\b");
+        test.not_contains("a\"b");
+        test.not_contains(r"\xff");
+    }
+
+    #[test]
+    fn match_pattern_suggests_bytes_inside_triple_quoted_bytes() {
+        let source = r#"
+from typing import Literal
+
+def handle(status: Literal[b"line\nbreak", b"a'b"]):
+    match status:
+        case b'''<CURSOR>''':
+            pass
+"#;
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.contains(r"line\nbreak");
+        test.contains(r"a\'b");
+    }
+
+    #[test]
+    fn match_pattern_raw_triple_quoted_bytes_allow_single_quotes() {
+        let source = r#"
+from typing import Literal
+
+def handle(status: Literal[b'a"b']):
+    match status:
+        case rb"""<CURSOR>""":
+            pass
+"#;
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.contains("a\"b");
+    }
+
+    #[test]
+    fn match_pattern_suggests_boolean_literals() {
+        let source = "\
+def handle(status: bool):
+    match status:
+        case T<CURSOR>:
+            pass
+";
+        completion_test_builder(source).build().contains("True");
+
+        let source = "\
+def handle(status: bool):
+    match status:
+        case F<CURSOR>:
+            pass
+";
+        completion_test_builder(source).build().contains("False");
+    }
+
+    #[test]
+    fn match_pattern_recursively_expands_union_members() {
+        let source = "\
+def handle(status: bool | None):
+    match status:
+        case T<CURSOR>:
+            pass
+";
+        completion_test_builder(source).build().contains("True");
+
+        let source = "\
+def handle(status: bool | None):
+    match status:
+        case F<CURSOR>:
+            pass
+";
+        completion_test_builder(source).build().contains("False");
+
+        let source = "\
+def handle(status: bool | None):
+    match status:
+        case N<CURSOR>:
+            pass
+";
+        completion_test_builder(source).build().contains("None");
+    }
+
+    #[test]
+    fn match_pattern_ranks_literal_above_exact_scope_match() {
+        let source = "\
+def handle(status: bool | None):
+    match status:
+        case T<CURSOR>:
+            pass
+    ";
+
+        let builder = CursorTest::builder()
+            .source("main.py", source)
+            .source("package/__init__.py", "T = object()\n")
+            .completion_test_builder();
+        let test = builder.build();
+        let first_relevant = test
+            .completions()
+            .iter()
+            .find(|completion| matches!(completion.name.as_str(), "T" | "True"));
+
+        test.contains("T");
+        test.contains("True");
+        assert!(
+            first_relevant.is_some_and(|completion| {
+                completion.name == "True" && completion.is_context_specific
+            }),
+            "Expected the context-specific `True` completion to rank above the exact `T` match",
+        );
+    }
+
+    #[test]
+    fn match_pattern_suggests_none_literal() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\"] | None):
+    match status:
+        case N<CURSOR>:
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.contains("None");
+    }
+
+    #[test]
+    fn match_pattern_deduplicates_and_exhausts_singletons() {
+        let source = "\
+def handle(status: bool | None):
+    match status:
+        case <CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        assert_eq!(
+            test.completions()
+                .iter()
+                .filter(|completion| completion.name == "True")
+                .count(),
+            1,
+            "expected exactly one `True` completion",
+        );
+        assert_eq!(
+            test.completions()
+                .iter()
+                .filter(|completion| completion.name == "False")
+                .count(),
+            1,
+            "expected exactly one `False` completion",
+        );
+        assert_eq!(
+            test.completions()
+                .iter()
+                .filter(|completion| completion.name == "None")
+                .count(),
+            1,
+            "expected exactly one `None` completion",
+        );
+
+        let exhausted_builder = completion_test_builder(
+            "\
+def handle(status: bool | None):
+    match status:
+        case None:
+            pass
+        case N<CURSOR>:
+            pass
+",
+        );
+        let exhausted = exhausted_builder.build();
+        exhausted.not_contains("None");
+    }
+
+    #[test]
+    fn match_pattern_escapes_string_and_bytes_literals() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal['say \"hello\"', \"line\\nbreak\", b\"\\x00\"]):
+    match status:
+        case s<CURSOR>:
+            pass
+";
+        completion_test_builder(source)
+            .build()
+            .contains("'say \"hello\"'");
+
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal['say \"hello\"', \"line\\nbreak\", b\"\\x00\"]):
+    match status:
+        case l<CURSOR>:
+            pass
+";
+        completion_test_builder(source)
+            .build()
+            .contains("\"line\\nbreak\"");
+
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal['say \"hello\"', \"line\\nbreak\", b\"\\x00\"]):
+    match status:
+        case b<CURSOR>:
+            pass
+";
+        completion_test_builder(source)
+            .build()
+            .contains("b\"\\x00\"");
+    }
+
+    #[test]
+    fn match_pattern_suggests_single_literal_value() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\"]):
+    match status:
+        case r<CURSOR>:
+            pass
+    ";
+
+        completion_test_builder(source)
+            .build()
+            .contains("\"ready\"");
+    }
+
+    #[test]
+    fn match_pattern_omits_literal_matched_by_previous_case() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\"]):
+    match status:
+        case \"ready\":
+            pass
+        case w<CURSOR>:
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("\"ready\"");
+        test.contains("\"waiting\"");
+    }
+
+    #[test]
+    fn match_pattern_omits_enum_members_matched_by_previous_case() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color):
+    match status:
+        case Color.RED:
+            pass
+        case C<CURSOR>:
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("Color.RED");
+        test.contains("Color.BLUE");
+    }
+
+    #[test]
+    fn match_pattern_filters_qualified_enum_completions() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color):
+    match status:
+        case Color.RED:
+            pass
+        case Color.<CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("RED");
+        test.contains("BLUE");
+
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color):
+    match status:
+        case Color.RED | Color.<CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("RED");
+        test.contains("BLUE");
+    }
+
+    #[test]
+    fn match_pattern_qualified_completion_replaces_the_active_or_arm() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color):
+    match status:
+        case Color.RED | Color.B<CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        let matching = test
+            .completions()
+            .iter()
+            .filter(|completion| completion.name == "BLUE")
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matching.len(),
+            1,
+            "expected one completion for `Color.BLUE`"
+        );
+        if let [completion] = matching.as_slice() {
+            assert!(
+                completion.text_edit.is_some(),
+                "expected a primary replacement edit"
+            );
+            if let Some(edit) = completion.text_edit.as_ref() {
+                assert_eq!(edit.content(), Some("Color.BLUE"));
+                assert_eq!(edit.range().len(), TextSize::new(7));
+            }
+        }
+    }
+
+    #[test]
+    fn match_pattern_omits_exhausted_qualified_enum_members() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color):
+    match status:
+        case Color.RED:
+            pass
+        case Color.BLUE:
+            pass
+        case Color.<CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("RED");
+        test.not_contains("BLUE");
+    }
+
+    #[test]
+    fn match_pattern_suggests_nested_enum_members() {
+        let source = "\
+from enum import Enum
+
+class Palette:
+    class Color(Enum):
+        RED = 1
+        BLUE = 2
+
+def handle(status: Palette.Color):
+    match status:
+        case P<CURSOR>:
+            pass
+";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        test.contains("Palette.Color.RED");
+        test.contains("Palette.Color.BLUE");
+    }
+
+    #[test]
+    fn match_pattern_uses_nested_enum_owner_alias() {
+        let source = "\
+from enum import Enum
+
+class Palette:
+    class Color(Enum):
+        RED = 1
+        BLUE = 2
+
+P = Palette
+
+def handle(status: P.Color):
+    match status:
+        case P<CURSOR>:
+            pass
+";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        test.contains("P.Color.RED");
+        test.contains("P.Color.BLUE");
+    }
+
+    #[test]
+    fn match_pattern_filters_qualified_nested_enum_members() {
+        let source = "\
+from enum import Enum
+
+class Palette:
+    class Color(Enum):
+        RED = 1
+        BLUE = 2
+
+def handle(status: Palette.Color):
+    match status:
+        case Palette.Color.RED | Palette.Color.<CURSOR>:
+            pass
+";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        test.not_contains("RED");
+        test.contains("BLUE");
+    }
+
+    #[test]
+    fn match_pattern_suggests_flag_members() {
+        let source = "\
+from enum import Flag, auto
+
+class Permission(Flag):
+    READ = auto()
+    WRITE = auto()
+
+def handle(permission: Permission):
+    match permission:
+        case Permission.READ:
+            pass
+        case P<CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("Permission.READ");
+        test.contains("Permission.WRITE");
+
+        let source = "\
+from enum import IntFlag, auto
+
+class Permission(IntFlag):
+    READ = auto()
+    WRITE = auto()
+
+def handle(permission: Permission):
+    match permission:
+        case Permission.READ:
+            pass
+        case P<CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("Permission.READ");
+        test.contains("Permission.WRITE");
+    }
+
+    #[test]
+    fn match_or_pattern_filters_flag_members() {
+        let source = "\
+from enum import Flag, auto
+
+class Permission(Flag):
+    READ = auto()
+    WRITE = auto()
+
+def handle(permission: Permission):
+    match permission:
+        case Permission.READ | P<CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("Permission.READ");
+        test.contains("Permission.WRITE");
+    }
+
+    #[test]
+    fn match_pattern_includes_enum_members_from_previous_guarded_case() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color, condition: bool):
+    match status:
+        case Color.RED if condition:
+            pass
+        case C<CURSOR>:
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.contains("Color.RED");
+        test.contains("Color.BLUE");
+    }
+
+    #[test]
+    fn match_or_pattern_omits_literal_matched_by_previous_alternative() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\"]):
+    match status:
+        case \"ready\" | w<CURSOR>:
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("\"ready\"");
+        test.contains("\"waiting\"");
+    }
+
+    #[test]
+    fn match_or_pattern_inside_string_omits_literal_matched_by_previous_alternative() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\"]):
+    match status:
+        case \"ready\" | \"w<CURSOR>\":
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        assert_eq!(test.snapshot(), "waiting");
+    }
+
+    #[test]
+    fn match_or_pattern_wrapped_in_as_omits_literal_matched_by_previous_alternative() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"ready\", \"waiting\"]):
+    match status:
+        case (\"ready\" | w<CURSOR>) as state:
+            pass
+";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("\"ready\"");
+        test.contains("\"waiting\"");
+    }
+
+    #[test]
+    fn match_or_pattern_omits_enum_members_matched_by_previous_alternative() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color):
+    match status:
+        case Color.RED | C<CURSOR>:
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("Color.RED");
+        test.contains("Color.BLUE");
+    }
+
+    #[test]
+    fn match_or_pattern_omits_all_enum_members_matched_by_previous_alternatives() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color):
+    match status:
+        case Color.RED | Color.BLUE | C<CURSOR>:
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("Color.RED");
+        test.not_contains("Color.BLUE");
+    }
+
+    #[test]
+    fn match_or_pattern_includes_enum_members_matched_by_later_alternative() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color):
+    match status:
+        case C<CURSOR> | Color.RED:
+            pass
+    ";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.contains("Color.RED");
+        test.contains("Color.BLUE");
+    }
+
+    #[test]
+    fn match_pattern_does_not_suggest_cases_outside_pattern() {
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color, condition: bool):
+    match status:
+        case _ if C<CURSOR>:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("Color.RED");
+        test.not_contains("Color.BLUE");
+
+        let source = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(status: Color):
+    match status:
+        case _:
+            C<CURSOR>
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("Color.RED");
+        test.not_contains("Color.BLUE");
+    }
+
+    #[test]
+    fn match_pattern_nested_subpatterns_are_not_supported() {
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"not-a-list\"] | list[Literal[1]]):
+    match status:
+        case [1<CURSOR>]:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("\"not-a-list\"");
+        test.not_contains("1");
+
+        let source = "\
+from typing import Literal
+
+def handle(status: Literal[\"not-a-mapping\"] | dict[str, Literal[1]]):
+    match status:
+        case {\"key\": 1<CURSOR>}:
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("\"not-a-mapping\"");
+        test.not_contains("1");
+
+        let source = "\
+from typing import Literal
+
+class Response:
+    __match_args__ = (\"status\",)
+    status: Literal[1]
+
+def handle(status: Literal[\"not-a-response\"] | Response):
+    match status:
+        case Response(1<CURSOR>):
+            pass
+";
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+
+        test.not_contains("\"not-a-response\"");
+        test.not_contains("1");
     }
 
     #[test]

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -9306,6 +9306,23 @@ def handle(status: bool | None):
     }
 
     #[test]
+    fn match_pattern_does_not_expand_recursive_fixed_tuple_aliases() {
+        let source = "\
+type Recursive = bool | tuple[Recursive]
+
+def handle(status: Recursive):
+    match status:
+        case <CURSOR>:
+            pass
+";
+
+        let builder = completion_test_builder(source);
+        let test = builder.build();
+        test.contains("True");
+        test.contains("False");
+    }
+
+    #[test]
     fn match_pattern_ranks_literal_above_exact_scope_match() {
         let source = "\
 def handle(status: bool | None):

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -44,9 +44,10 @@ use crate::place::{
 };
 use crate::predicate::{
     CallableAndCallExpr, ClassPatternKeywordPredicateKind, ClassPatternPredicateKind,
-    MappingPatternEntryPredicateKind, MappingPatternPredicateKind, PatternPredicate,
-    PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral, ScopedPredicateId,
-    SequencePatternPredicateKind, StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
+    MappingPatternEntryPredicateKind, MappingPatternPredicateKind, MatchCaseNodeKey,
+    PatternPredicate, PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral,
+    ScopedPredicateId, SequencePatternPredicateKind, StarImportPlaceholderPredicate,
+    SubjectElementPatternPredicate,
 };
 use crate::program::Program;
 use crate::re_exports::exported_names;
@@ -307,6 +308,9 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
 
     /// Alias metadata for predicate leaf names in the current file.
     alias_predicates: FxHashMap<ExpressionNodeKey, NarrowingAliasPredicate<'db>>,
+
+    /// A collection of pattern predicates in the file collected during indexing.
+    match_case_predicates: Vec<(MatchCaseNodeKey, PatternPredicate<'db>)>,
 }
 
 impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
@@ -336,6 +340,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             scopes_by_node: FxHashMap::default(),
             definitions_by_node: FxHashMap::default(),
             expressions_by_node: FxHashMap::default(),
+            match_case_predicates: Vec::new(),
             unpacks_by_target: FxHashMap::default(),
             condition_flow_snapshots_by_node: FxHashMap::default(),
             statements_by_node: FxHashMap::default(),
@@ -2936,6 +2941,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             generator_functions: FrozenSet::from(self.generator_functions),
             async_comprehensions: FrozenSet::from(self.async_comprehensions),
             narrowing_alias_predicates: FrozenMap::from(self.alias_predicates),
+            match_case_predicates: FrozenMap::from_entries(self.match_case_predicates),
         }
     }
 
@@ -3956,6 +3962,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         case.guard.as_deref(),
                         previous_pattern,
                     );
+                    self.match_case_predicates
+                        .push((case.into(), match_pattern_predicate));
                     self.current_match_case = Some(CurrentMatchCase::new(
                         &case.pattern,
                         match_pattern_predicate,

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -19,6 +19,7 @@ use ty_module_resolver::ModuleName;
 
 use crate::frozen::{FrozenMap, FrozenSet};
 use crate::place::ScopedPlaceId;
+use crate::predicate::{MatchCaseNodeKey, PatternPredicate};
 pub use crate::statement::{Statement, StatementNodeKey};
 use ast_ids::AstIds;
 pub use ast_ids::ExpressionNodeKey;
@@ -345,6 +346,9 @@ pub struct SemanticIndex<'db> {
     /// When a predicate references an alias variable (e.g., `is_none` from `is_none = x is None`),
     /// the alias Name node is mapped to its aliased expression for constraint-generation time.
     narrowing_alias_predicates: FrozenMap<ExpressionNodeKey, NarrowingAliasPredicate<'db>>,
+
+    /// Map of pattern predicates in the file, keyed by their match case node.
+    match_case_predicates: FrozenMap<MatchCaseNodeKey, PatternPredicate<'db>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
@@ -757,6 +761,12 @@ impl<'db> SemanticIndex<'db> {
 
     pub fn semantic_syntax_errors(&self) -> &[SemanticSyntaxError] {
         &self.semantic_syntax_errors
+    }
+
+    pub fn try_match_case_predicate(&self, case: &ast::MatchCase) -> Option<PatternPredicate<'db>> {
+        self.match_case_predicates
+            .get(&MatchCaseNodeKey::from(case))
+            .copied()
     }
 }
 

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -9,12 +9,14 @@
 
 use ruff_db::files::File;
 use ruff_index::{FrozenIndexVec, Idx, IndexVec};
+use ruff_python_ast::MatchCase;
 use ruff_python_ast::{Singleton, name::Name};
 
 use crate::ast_ids::ExpressionNodeKey;
 use crate::db::Db;
 use crate::expression::Expression;
 use crate::global_scope;
+use crate::node_key::NodeKey;
 use crate::scope::{FileScopeId, ScopeId};
 use crate::symbol::ScopedSymbolId;
 
@@ -212,6 +214,17 @@ impl MappingPatternPredicateKind<'_> {
 pub struct MappingPatternEntryPredicateKind<'db> {
     pub key: Expression<'db>,
     pub pattern: PatternPredicateKind<'db>,
+}
+
+#[derive(
+    Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd, get_size2::GetSize, salsa::SalsaValue,
+)]
+pub(crate) struct MatchCaseNodeKey(NodeKey);
+
+impl From<&MatchCase> for MatchCaseNodeKey {
+    fn from(node: &MatchCase) -> Self {
+        Self(NodeKey::from_node(node))
+    }
 }
 
 /// Pattern structure used for type narrowing, static reachability, and inferring the types of

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -20,7 +20,8 @@ use ruff_db::source::{SourceTextError, source_text};
 use rustc_hash::FxHasher;
 pub use semantic_model::{
     Completion, ExpectedStringLiteralCompletion, HasDefinition, HasOptionalDefinition, HasType,
-    MemberDefinition, NameKind, SemanticModel,
+    MatchCaseCompletion, MatchCaseCompletionKind, MatchCaseCompletions, MemberDefinition, NameKind,
+    SemanticModel,
 };
 use std::hash::BuildHasherDefault;
 pub use suppression::{

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -589,7 +589,7 @@ impl<'db> SemanticModel<'db> {
         &self,
         match_stmt: &ast::StmtMatch,
         current_case: &ast::MatchCase,
-        current_or_pattern_index: Option<usize>,
+        current_or_pattern_arm_path: &[usize],
     ) -> MatchCaseCompletions<'db> {
         struct MatchCaseCandidates;
         type MatchCaseCandidatesVisitor<'db> =
@@ -671,28 +671,38 @@ impl<'db> SemanticModel<'db> {
         };
 
         // Narrow `subject_ty` by all preceding unguarded match patterns.
-        let remaining_ty = type_narrowed_by_previous_patterns(self.db, predicate, subject_ty);
+        let mut remaining_ty = type_narrowed_by_previous_patterns(self.db, predicate, subject_ty);
+        let mut current_pattern = predicate.kind(self.db);
 
-        let remaining_ty = match (
-            current_or_pattern_index,
-            or_patterns(predicate.kind(self.db)),
-        ) {
-            (Some(index), Some(patterns)) => {
-                let Some(previous_patterns) = patterns.get(..index) else {
-                    return MatchCaseCompletions::default();
-                };
+        // Follow the OR arm path from the outermost OR pattern to the cursor. For `A | (B | C)`
+        // with the cursor on `C`, `[1, 1]` first rules out `A` and then rules out `B`.
+        for &index in current_or_pattern_arm_path {
+            let Some(patterns) = or_patterns(current_pattern) else {
+                return MatchCaseCompletions::default();
+            };
 
-                previous_patterns
-                    .iter()
-                    .fold(remaining_ty, |remaining_ty, pattern| {
-                        pattern_binding_fallthrough_type(self.db, pattern, remaining_ty)
-                    })
-            }
-            _ => remaining_ty,
-        };
+            // Every arm before the selected one has already failed to match. In the example above,
+            // `previous_patterns` is `[A]` on the first iteration and `[B]` on the second.
+            let Some(previous_patterns) = patterns.get(..index) else {
+                return MatchCaseCompletions::default();
+            };
+
+            // Keep only the values that fall through all of those previous arms.
+            remaining_ty = previous_patterns
+                .iter()
+                .fold(remaining_ty, |remaining_ty, pattern| {
+                    pattern_binding_fallthrough_type(self.db, pattern, remaining_ty)
+                });
+
+            let Some(pattern) = patterns.get(index) else {
+                return MatchCaseCompletions::default();
+            };
+            current_pattern = pattern;
+        }
 
         let visitor = MatchCaseCandidatesVisitor::default();
         let mut seen = FxHashSet::default();
+
         let known = visitor
             .visit(self.db, subject_ty, || {
                 collect(self.db, subject_ty, &visitor)
@@ -700,6 +710,7 @@ impl<'db> SemanticModel<'db> {
             .into_iter()
             .filter(|candidate| seen.insert(candidate.clone()))
             .collect::<Vec<_>>();
+
         let remaining = known
             .iter()
             .filter(|candidate| !candidate.ty.is_disjoint_from(self.db, remaining_ty))

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -8,21 +8,24 @@ use ruff_python_ast::{Expr, ExprRef, name::Name};
 use ruff_python_parser::Parsed;
 use ruff_source_file::LineIndex;
 use ruff_text_size::Ranged;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use ty_module_resolver::{
     KnownModule, Module, ModuleName, list_modules, resolve_module, resolve_real_shadowable_module,
 };
 
 use crate::Db;
 use crate::place::implicit_globals::all_implicit_module_globals;
+use crate::reachability::type_narrowed_by_previous_patterns;
 use crate::types::ide_support::{ImportAliasResolution, definition_for_name};
 use crate::types::list_members::{Member, all_members, all_reachable_members};
 use crate::types::{
-    CycleDetector, SpecialFormType, Type, TypeQualifiers, binding_type, infer_complete_scope_types,
-    inferred_declaration,
+    CycleDetector, EnumLiteralType, LiteralValueTypeKind, SpecialFormType, Type, TypeQualifiers,
+    binding_type, expand_type, infer_complete_scope_types, inferred_declaration,
+    pattern_binding_fallthrough_type,
 };
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place_table;
+use ty_python_core::predicate::PatternPredicateKind;
 use ty_python_core::scope::{FileScopeId, Scope};
 use ty_python_core::semantic_index;
 use ty_python_core::symbol::Symbol;
@@ -228,6 +231,63 @@ impl<'db> SemanticModel<'db> {
                 builtin: false,
             })
             .collect()
+    }
+
+    /// Returns the shortest expression in scope that resolves to `target`.
+    ///
+    /// This also follows class and module namespaces so that a nested class can be spelled through
+    /// a visible owner, such as `Palette.Color`.
+    pub fn visible_qualifier_for_type(
+        &self,
+        node: ast::AnyNodeRef<'_>,
+        target: Type<'db>,
+    ) -> Option<String> {
+        let qualified_name = target
+            .as_class_literal()?
+            .qualified_name(self.db)
+            .to_string();
+        let components = qualified_name.split('.').collect::<Vec<_>>();
+        let mut roots = self
+            .members_in_scope_at(node)
+            .into_iter()
+            .collect::<Vec<_>>();
+        roots.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+
+        let mut candidates = Vec::new();
+        for (root_name, root) in roots {
+            if root.ty == target {
+                candidates.push(root_name.to_string());
+                continue;
+            }
+
+            for start in 0..components.len() {
+                let mut current = root.ty;
+                let mut path = root_name.to_string();
+                for component in &components[start..] {
+                    let Some(member) = all_members(self.db, current)
+                        .into_iter()
+                        .find(|member| member.name.as_str() == *component)
+                    else {
+                        break;
+                    };
+                    current = member.ty;
+                    path.push('.');
+                    path.push_str(component);
+                }
+
+                if current == target {
+                    candidates.push(path);
+                }
+            }
+        }
+
+        candidates.into_iter().min_by(|left, right| {
+            left.matches('.')
+                .count()
+                .cmp(&right.matches('.').count())
+                .then_with(|| left.len().cmp(&right.len()))
+                .then_with(|| left.cmp(right))
+        })
     }
 
     /// Returns completions for symbols available in the scope containing the
@@ -524,6 +584,123 @@ impl<'db> SemanticModel<'db> {
         }
     }
 
+    /// Returns completion candidates for a pattern in a `match` statement.
+    pub fn match_case_completions(
+        &self,
+        match_stmt: &ast::StmtMatch,
+        current_case: &ast::MatchCase,
+        current_or_pattern_index: Option<usize>,
+    ) -> MatchCaseCompletions<'db> {
+        struct MatchCaseCandidates;
+        type MatchCaseCandidatesVisitor<'db> =
+            CycleDetector<'db, MatchCaseCandidates, Type<'db>, Vec<MatchCaseCompletion<'db>>, 3>;
+
+        // Recursively expand types because a finite type can contain other expandable types. For
+        // example, expanding `bool | None` once produces `bool` and `None`, and `bool` must then be
+        // expanded again to produce `Literal[True]` and `Literal[False]`.
+        fn collect<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            visitor: &MatchCaseCandidatesVisitor<'db>,
+        ) -> Vec<MatchCaseCompletion<'db>> {
+            if let Some(candidate) = MatchCaseCompletion::try_from_ty(db, ty) {
+                return vec![candidate];
+            }
+
+            if let Type::NominalInstance(instance) = ty
+                && let Some(enum_class) = instance.class_literal(db).into_enum_class(db)
+            {
+                return enum_class
+                    .member_names(db)
+                    .map(|member_name| {
+                        let ty =
+                            Type::enum_literal(EnumLiteralType::new(db, enum_class, member_name));
+                        MatchCaseCompletion {
+                            ty,
+                            kind: MatchCaseCompletionKind::EnumMember {
+                                enum_class: Type::ClassLiteral(enum_class.class_literal(db)),
+                                member_name: member_name.clone(),
+                            },
+                        }
+                    })
+                    .collect();
+            }
+
+            let expanded = match ty {
+                Type::TypeAlias(alias) => vec![alias.value_type(db)],
+                _ => expand_type(db, ty).unwrap_or_default(),
+            };
+
+            expanded
+                .into_iter()
+                .flat_map(|expanded_ty| {
+                    visitor.visit(db, expanded_ty, || collect(db, expanded_ty, visitor))
+                })
+                .collect()
+        }
+
+        // Narrow `subject_ty` by all preceding alternatives in an OR pattern. For example, at the
+        // cursor in `case Color.RED | Color.GREEN | <CURSOR>`, neither `Color.RED` nor
+        // `Color.GREEN` should be suggested.
+        fn or_patterns<'db>(
+            pattern: &'db PatternPredicateKind<'db>,
+        ) -> Option<&'db [PatternPredicateKind<'db>]> {
+            match pattern {
+                PatternPredicateKind::Or(patterns) => Some(patterns),
+                PatternPredicateKind::As(Some(pattern), _) => or_patterns(pattern),
+                _ => None,
+            }
+        }
+
+        let index = semantic_index(self.db, self.file);
+
+        let Some(predicate) = index.try_match_case_predicate(current_case) else {
+            return MatchCaseCompletions::default();
+        };
+
+        let Some(subject_ty) = match_stmt.subject.inferred_type(self) else {
+            return MatchCaseCompletions::default();
+        };
+
+        // Narrow `subject_ty` by all preceding unguarded match patterns.
+        let remaining_ty = type_narrowed_by_previous_patterns(self.db, predicate, subject_ty);
+
+        let remaining_ty = match (
+            current_or_pattern_index,
+            or_patterns(predicate.kind(self.db)),
+        ) {
+            (Some(index), Some(patterns)) => {
+                let Some(previous_patterns) = patterns.get(..index) else {
+                    return MatchCaseCompletions::default();
+                };
+
+                previous_patterns
+                    .iter()
+                    .fold(remaining_ty, |remaining_ty, pattern| {
+                        pattern_binding_fallthrough_type(self.db, pattern, remaining_ty)
+                    })
+            }
+            _ => remaining_ty,
+        };
+
+        let visitor = MatchCaseCandidatesVisitor::default();
+        let mut seen = FxHashSet::default();
+        let known = visitor
+            .visit(self.db, subject_ty, || {
+                collect(self.db, subject_ty, &visitor)
+            })
+            .into_iter()
+            .filter(|candidate| seen.insert(candidate.clone()))
+            .collect::<Vec<_>>();
+        let remaining = known
+            .iter()
+            .filter(|candidate| !candidate.ty.is_disjoint_from(self.db, remaining_ty))
+            .cloned()
+            .collect();
+
+        MatchCaseCompletions { known, remaining }
+    }
+
     /// Returns completion candidates for a string-literal expression based on its expected type.
     pub fn expected_string_literal_completions(
         &self,
@@ -663,6 +840,60 @@ pub struct Completion<'db> {
 pub struct ExpectedStringLiteralCompletion<'db> {
     pub value: String,
     pub ty: Type<'db>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct MatchCaseCompletion<'db> {
+    pub ty: Type<'db>,
+    pub kind: MatchCaseCompletionKind<'db>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum MatchCaseCompletionKind<'db> {
+    None,
+    Bool(bool),
+    Int(i64),
+    String(String),
+    Bytes(Box<[u8]>),
+    EnumMember {
+        enum_class: Type<'db>,
+        member_name: Name,
+    },
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MatchCaseCompletions<'db> {
+    pub known: Vec<MatchCaseCompletion<'db>>,
+    pub remaining: Vec<MatchCaseCompletion<'db>>,
+}
+
+impl<'db> MatchCaseCompletion<'db> {
+    fn try_from_ty(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+        if ty.is_none(db) {
+            return Some(Self {
+                ty,
+                kind: MatchCaseCompletionKind::None,
+            });
+        }
+
+        let kind = match ty.as_literal_value_kind()? {
+            LiteralValueTypeKind::Int(number) => MatchCaseCompletionKind::Int(number.as_i64()),
+            LiteralValueTypeKind::Bool(value) => MatchCaseCompletionKind::Bool(value),
+            LiteralValueTypeKind::String(string) => {
+                MatchCaseCompletionKind::String(string.value(db).to_string())
+            }
+            LiteralValueTypeKind::Bytes(bytes) => {
+                MatchCaseCompletionKind::Bytes(bytes.value(db).to_vec().into_boxed_slice())
+            }
+            LiteralValueTypeKind::Enum(enum_literal) => MatchCaseCompletionKind::EnumMember {
+                enum_class: Type::ClassLiteral(enum_literal.enum_class(db)),
+                member_name: enum_literal.name(db).clone(),
+            },
+            LiteralValueTypeKind::LiteralString => return None,
+        };
+
+        Some(Self { ty, kind })
+    }
 }
 
 pub trait HasType {

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -19,8 +19,8 @@ use crate::reachability::type_narrowed_by_previous_patterns;
 use crate::types::ide_support::{ImportAliasResolution, definition_for_name};
 use crate::types::list_members::{Member, all_members, all_reachable_members};
 use crate::types::{
-    CycleDetector, EnumLiteralType, LiteralValueTypeKind, SpecialFormType, Type, TypeQualifiers,
-    binding_type, expand_type, infer_complete_scope_types, inferred_declaration,
+    CycleDetector, EnumLiteralType, KnownClass, LiteralValueTypeKind, SpecialFormType, Type,
+    TypeQualifiers, binding_type, expand_type, infer_complete_scope_types, inferred_declaration,
     pattern_binding_fallthrough_type,
 };
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -628,7 +628,15 @@ impl<'db> SemanticModel<'db> {
 
             let expanded = match ty {
                 Type::TypeAlias(alias) => vec![alias.value_type(db)],
-                _ => expand_type(db, ty).unwrap_or_default(),
+                Type::EnumComplement(_) | Type::Intersection(_) | Type::Union(_) => {
+                    expand_type(db, ty).unwrap_or_default()
+                }
+                Type::NominalInstance(instance)
+                    if instance.class_literal(db).is_known(db, KnownClass::Bool) =>
+                {
+                    expand_type(db, ty).unwrap_or_default()
+                }
+                _ => Vec::new(),
             };
 
             expanded

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -815,7 +815,7 @@ impl<'db> ClassLiteral<'db> {
     }
 
     /// Returns the qualified name of this class.
-    pub(super) fn qualified_name(self, db: &'db dyn Db) -> QualifiedClassName<'db> {
+    pub(crate) fn qualified_name(self, db: &'db dyn Db) -> QualifiedClassName<'db> {
         QualifiedClassName::from_class_literal(db, self)
     }
 
@@ -2788,13 +2788,13 @@ pub(super) enum InstanceMemberResult<'db> {
 // have the same components. You'd expect them to compare equal, but they'd compare
 // unequal if `PartialEq`/`Eq` were naively derived.
 #[derive(Clone, Copy)]
-pub(super) struct QualifiedClassName<'db> {
+pub(crate) struct QualifiedClassName<'db> {
     db: &'db dyn Db,
     class: ClassLiteral<'db>,
 }
 
 impl<'db> QualifiedClassName<'db> {
-    pub(super) fn from_class_literal(db: &'db dyn Db, class: ClassLiteral<'db>) -> Self {
+    pub(crate) fn from_class_literal(db: &'db dyn Db, class: ClassLiteral<'db>) -> Self {
         Self { db, class }
     }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -247,7 +247,7 @@ impl<'db> NominalInstanceType<'db> {
     }
 
     /// Returns the class literal for this instance.
-    pub(super) fn class_literal(&self, db: &'db dyn Db) -> ClassLiteral<'db> {
+    pub(crate) fn class_literal(&self, db: &'db dyn Db) -> ClassLiteral<'db> {
         self.class(db).class_literal(db)
     }
 

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::time::Instant;
 
 use lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionList,
-    CompletionParams, CompletionRequest, CompletionResponse, Documentation, InsertTextFormat,
-    TextEdit, Uri,
+    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionItemTextEdit,
+    CompletionList, CompletionParams, CompletionRequest, CompletionResponse, Documentation,
+    InsertTextFormat, TextEdit, Uri,
 };
 use ruff_source_file::OneIndexed;
 use ruff_text_size::Ranged;
@@ -87,6 +87,16 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
                         new_text: edit.content().map(ToString::to_string).unwrap_or_default(),
                     })
                 });
+                let text_edit = comp.text_edit.as_ref().and_then(|edit| {
+                    let range = edit
+                        .range()
+                        .to_lsp_range(db, file, snapshot.encoding())?
+                        .local_range();
+                    Some(CompletionItemTextEdit::TextEdit(TextEdit {
+                        range,
+                        new_text: edit.content().map(ToString::to_string).unwrap_or_default(),
+                    }))
+                });
 
                 let label = comp.label().to_string();
                 let import_suffix = comp
@@ -123,7 +133,10 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
 
                     Documentation::MarkupContent(lsp_types::MarkupContent { kind, value })
                 });
-                let insert_text = comp.insert.map(String::from);
+                let insert_text = text_edit
+                    .is_none()
+                    .then(|| comp.insert.map(String::from))
+                    .flatten();
                 let insert_text_format = match comp.insert_text_format {
                     CompletionInsertTextFormat::PlainText => None,
                     CompletionInsertTextFormat::Snippet => Some(InsertTextFormat::Snippet),
@@ -137,6 +150,7 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
                     label_details,
                     insert_text,
                     insert_text_format,
+                    text_edit,
                     additional_text_edits: import_edit.map(|edit| vec![edit]),
                     documentation,
                     ..Default::default()

--- a/crates/ty_server/tests/e2e/completions.rs
+++ b/crates/ty_server/tests/e2e/completions.rs
@@ -537,6 +537,43 @@ x: Literal[\"apple\"] = \"app\"
 }
 
 #[test]
+fn match_case_completion_uses_primary_text_edit() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = "\
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+def handle(color: Color):
+    match color:
+        case Color.RED | Color.B:
+            pass
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_initialization_options(ClientOptions::default().with_auto_import(false))
+        .with_workspace(workspace_root, None)?
+        .with_file(foo, foo_content)?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+
+    let completions = server
+        .completion_request(&server.file_uri(foo), Position::new(8, 32))
+        .into_iter()
+        .filter(|completion| completion.label == "BLUE")
+        .collect::<Vec<_>>();
+
+    insta::assert_json_snapshot!("match_case_completion_uses_primary_text_edit", completions);
+
+    Ok(())
+}
+
+#[test]
 fn typed_dict_literal_key_completion_before_colon() -> Result<()> {
     let workspace_root = SystemPath::new("src");
     let foo = SystemPath::new("src/foo.py");

--- a/crates/ty_server/tests/e2e/snapshots/e2e__completions__match_case_completion_uses_primary_text_edit.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__completions__match_case_completion_uses_primary_text_edit.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ty_server/tests/e2e/completions.rs
+expression: completions
+---
+[
+  {
+    "label": "BLUE",
+    "kind": 20,
+    "detail": "Literal[Color.BLUE]",
+    "sortText": " 0",
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 25
+        },
+        "end": {
+          "line": 8,
+          "character": 32
+        }
+      },
+      "newText": "Color.BLUE"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
https://github.com/astral-sh/ty/issues/3329

This PR implements initial support for completions for cases in `match` statements.

I took a guess on scope as it looks like there had not been much (any) discussion on that front 🙂, happy to revisit design, expand or decrease scope, etc.

### Behavior
The following candidates are supported:
  - Enum members, including `Enum`, `Flag`, and `IntFlag`
  - Literal strings, bytes, and integers
  - `True`, `False`, and `None`
  - Finite candidates recursively expanded from unions and type aliases

Selecting a completion replaces the active pattern (or only the active OR alternative if within a `MatchOr`).

### Implementation
- A match case context is created once at the start of the completion request, then provided both to existing completions to filter down their results, as well as to a new `add_match_case_completions` that adds literals and enum members.
  - If the cursor is in a case guard, body, sub-pattern, or anywhere else unsupported in a case statement, this is `None` and the pre-existing completions fall back to their ordinary non-match behavior
- During semantic index building, a map of `MatchCase` -> `PatternPredicate` is built up
  - This is used during completion candidate generation so the subject type of the match statement can be narrowed to the remaining types for the specific case under the cursor, first, via `type_narrowed_by_previous_patterns`, then, by all preceding alternatives in an OR pattern. Preceding unguarded cases and earlier OR alternatives are excluded; guarded cases do not exhaust a candidate
- Types are recursively expanded so things like `bool | None` will provide `True, False, None` as completions
- Source order is preserved in the results (for example enum member position)

### Limitations
- This is limited in scope to top-level match statement cases and does not support sub-patterns
- Match-specific enum member completions do not add imports. The enum class must already be resolvable in scope

## Test Plan
- New snapshot tests
- E2E testing in Neovim

<img width="348" height="137" alt="Screenshot 2026-07-25 at 10 40 45" src="https://github.com/user-attachments/assets/7a6605e4-89c6-42da-b02c-ec51e92935d1" />
<img width="346" height="131" alt="Screenshot 2026-07-25 at 10 40 37" src="https://github.com/user-attachments/assets/28b68101-d9b2-4b49-a1fe-8f3a13f58662" />
<img width="711" height="86" alt="Screenshot 2026-07-25 at 10 39 58" src="https://github.com/user-attachments/assets/65d495d5-1c21-448a-8ebe-082eb9c9f208" />
<img width="347" height="232" alt="Screenshot 2026-07-25 at 10 39 24" src="https://github.com/user-attachments/assets/16a04871-28a9-49d7-a0aa-0ff01ec7fbeb" />
<img width="226" height="192" alt="Screenshot 2026-07-25 at 10 39 12" src="https://github.com/user-attachments/assets/8e43db05-c112-40da-a8fe-42e45298411a" />
<img width="752" height="256" alt="Screenshot 2026-07-25 at 10 58 55" src="https://github.com/user-attachments/assets/67aaf428-6be7-408f-9fef-df1e231e68c9" />
