### PR TITLE
[`pyupgrade`] Make fix unsafe if it deletes comments (`UP015`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP015.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP015.py
@@ -81,3 +81,26 @@ open("foo", "rb")
 open("foo", "r+b")
 open("foo", "UU")
 open("foo", "wtt")
+
+# Comments between arguments that would be deleted when removing the mode.
+open(
+    "foo",  # path comment
+    "r",
+)
+
+open(
+    "foo",  # path comment
+    mode="r",
+)
+
+open(
+    # comment before redundant mode keyword
+    mode="r",
+    file="foo",
+)
+
+# End-of-line comment after the mode argument (not in the deletion range).
+open(
+    "foo",
+    "r",  # trailing mode comment
+)

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ruff_diagnostics::Applicability;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::token::{TokenKind, Tokens};
 use ruff_python_ast::{self as ast, Expr};
@@ -26,6 +27,10 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// with open("foo.txt") as f:
 ///     ...
 /// ```
+///
+/// ## Fix safety
+/// This rule's fix is marked as unsafe if removing the mode argument would
+/// delete any comments within the edit range.
 ///
 /// ## References
 /// - [Python documentation: `open`](https://docs.python.org/3/library/functions.html#open)
@@ -96,7 +101,13 @@ fn create_diagnostic(call: &ast::ExprCall, mode_arg: &Expr, mode: OpenMode, chec
 
     if mode.is_empty() {
         diagnostic.try_set_fix(|| {
-            create_remove_argument_fix(call, mode_arg, checker.tokens()).map(Fix::safe_edit)
+            let edit = create_remove_argument_fix(call, mode_arg, checker.tokens())?;
+            let applicability = if checker.comment_ranges().intersects(edit.range()) {
+                Applicability::Unsafe
+            } else {
+                Applicability::Safe
+            };
+            Ok(Fix::applicable_edit(edit, applicability))
         });
     } else {
         let stylist = checker.stylist();

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP015.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP015.py.snap
@@ -841,3 +841,81 @@ help: Remove mode argument
 77 + aiofiles.open("foo")
 78 |
    |
+
+UP015 [*] Unnecessary mode argument
+  --> UP015.py:88:5
+   |
+86 | open(
+87 |     "foo",  # path comment
+88 |     "r",
+   |     ^^^
+89 | )
+   |
+help: Remove mode argument
+   |
+86 | open(
+   -     "foo",  # path comment
+   -     "r",
+87 +     "foo",
+88 | )
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+UP015 [*] Unnecessary mode argument
+  --> UP015.py:93:10
+   |
+91 | open(
+92 |     "foo",  # path comment
+93 |     mode="r",
+   |          ^^^
+94 | )
+   |
+help: Remove mode argument
+   |
+91 | open(
+   -     "foo",  # path comment
+   -     mode="r",
+92 +     "foo",
+93 | )
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+UP015 [*] Unnecessary mode argument
+   --> UP015.py:98:10
+    |
+ 96 | open(
+ 97 |     # comment before redundant mode keyword
+ 98 |     mode="r",
+    |          ^^^
+ 99 |     file="foo",
+100 | )
+    |
+help: Remove mode argument
+   |
+95 |
+   - open(
+   -     # comment before redundant mode keyword
+   -     mode="r",
+   -     file="foo",
+96 + open(file="foo",
+97 | )
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+UP015 [*] Unnecessary mode argument
+   --> UP015.py:105:5
+    |
+103 | open(
+104 |     "foo",
+105 |     "r",  # trailing mode comment
+    |     ^^^
+106 | )
+    |
+help: Remove mode argument
+    |
+103 | open(
+    -     "foo",
+    -     "r",  # trailing mode comment
+104 +     "foo",  # trailing mode comment
+105 | )
+    |


### PR DESCRIPTION
## Summary

`UP015` (`redundant-open-modes`) advertised a safe autofix for removing a redundant `open(..., "r")` / `mode="r"` argument, but the deletion range can include nearby comments. Applying `--fix` therefore dropped those comments without requiring `--unsafe-fixes`.

This matches Ruff's established comment-safety policy for linter fixes: if applying a fix would delete comments in the edit range, mark the fix unsafe (same approach as recent `UP039` / `UP017` / `UP041` changes).

**Before** (`ruff check --select UP015 --fix`):

```python
open(
    "foo",  # path comment
    "r",
)
```

became:

```python
open(
    "foo",
)
```

**After**: the diagnostic remains, but the fix is hidden unless `--unsafe-fixes` is enabled. Comment-free cases stay safe and still autofix with `--fix`.

Root cause: `create_remove_argument_fix` builds a deletion from the preceding comma (or call open-paren) through the mode literal. Comments between those bounds sit inside the edit range, but the fix was always created with `Fix::safe_edit`.

The change is minimal: reuse the existing edit, check `comment_ranges().intersects(edit.range())`, and set `Applicability::Unsafe` when needed. Also document fix safety on the rule.

## Test Plan

- Added fixture cases in `UP015.py` covering:
  - comment between path and positional `"r"`
  - comment between path and `mode="r"`
  - comment before a leading `mode="r"` keyword
  - trailing EOL comment after the mode arg (preserved; fix remains safe)
- Regenerated `UP015.py` snapshot; comment-deleting cases now include `note: This is an unsafe fix...`
- Pre-fix: snapshot test failed on new fixtures with safe `[*]` fixes that deleted comments
- Post-fix:
  - `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_DEBUG="line-tables-only" cargo nextest run -p ruff_linter -- rule_redundantopenmodes_path_new_up015` → pass
  - Manual: `--fix` leaves comment-deleting case alone; `--fix --unsafe-fixes` applies it
  - `cargo fmt --all -- --check` → pass
  - `cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings` → pass
  - `cargo clippy --workspace --all-targets --all-features -- -D warnings` → pass
  - `uv run --only-group dev --locked prek run --files <changed files>` → pass
  - `git diff --check` → pass

Did not run the full workspace `cargo nextest run` / `cargo test` suite (resource cost); focused `UP015` coverage and workspace clippy were run instead.
