### PR TITLE
Cover `pycon` Markdown formatting

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -229,13 +229,14 @@ def f(x):
 
 The Ruff formatter can also format Python code blocks in Markdown files.
 In these files, Ruff will format any CommonMark [fenced code blocks][] with
-the following info strings: `python`, `py`, `python3`, `py3`, or `pyi`. The
-formatter will automatically skip a code block if the code does not parse as
+the following info strings: `python`, `py`, `python3`, `py3`, `pyi`, or `pycon`.
+The formatter will automatically skip a code block if the code does not parse as
 valid Python or if the reformatted code would produce an invalid Python program.
 
 Code blocks marked as `python`, `py`, `python3`, or `py3` will be formatted with
-the normal Python code formatting style, while any code blocks marked with
-`pyi` will be formatted like Python type stub files:
+the normal Python code formatting style, while any code blocks marked with `pyi`
+blocks are formatted like stub files, `pycon` blocks as REPL sessions, and the
+others use normal Python file formatting. For example:
 
 ````markdown
 ```py

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -233,10 +233,8 @@ the following info strings: `python`, `py`, `python3`, `py3`, `pyi`, or `pycon`.
 The formatter will automatically skip a code block if the code does not parse as
 valid Python or if the reformatted code would produce an invalid Python program.
 
-Code blocks marked as `python`, `py`, `python3`, or `py3` will be formatted with
-the normal Python code formatting style, while any code blocks marked with `pyi`
-blocks are formatted like stub files, `pycon` blocks as REPL sessions, and the
-others use normal Python file formatting. For example:
+Code blocks marked as `pyi` are formatted like stub files, `pycon` blocks as
+REPL sessions, and the others use normal Python file formatting. For example:
 
 ````markdown
 ```py


### PR DESCRIPTION
## Summary

Add a section on `pycon` handling to the *Markdown code formatting* section.

Fixes #27151

## Test Plan

- verified markdown output locally
- run `scripts/check_docs_formatted.py --generate-docs`
- run `mkdocs build --strict`
- run `mkdocs serve` and inspect the site preview
