### PR TITLE
Normalize rule selectors in ecosystem checks

### DIFF
--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -331,6 +331,8 @@ pub(crate) const fn is_pep604_future_annotations_fix_enabled(settings: &LinterSe
 }
 
 // https://github.com/astral-sh/ruff/pull/25614
+// TODO(brent) Remove ecosystem selector normalization when stabilizing human-readable rule names:
+// https://github.com/astral-sh/ruff/pull/27158
 pub const fn is_human_readable_names_enabled(preview: PreviewMode) -> bool {
     preview.is_enabled()
 }

--- a/python/ruff-ecosystem/ruff_ecosystem/check.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/check.py
@@ -22,6 +22,7 @@ from ruff_ecosystem.markdown import (
     markdown_plus_minus,
     markdown_project_section,
 )
+from ruff_ecosystem.projects import rule_name_to_code
 from ruff_ecosystem.types import (
     Comparison,
     Diff,
@@ -508,7 +509,12 @@ async def compare_check(
     config_overrides: ConfigOverrides,
     cloned_repo: ClonedRepository,
 ) -> Comparison:
-    with config_overrides.patch_config(cloned_repo.path, options.preview):
+    rule_names = (
+        rule_name_to_code(ruff_comparison_executable.resolve())
+        if not options.preview
+        else {}
+    )
+    with config_overrides.patch_config(cloned_repo.path, options.preview, rule_names):
         async with asyncio.TaskGroup() as tg:
             baseline_task = tg.create_task(
                 ruff_check(

--- a/python/ruff-ecosystem/ruff_ecosystem/check.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/check.py
@@ -509,6 +509,7 @@ async def compare_check(
     config_overrides: ConfigOverrides,
     cloned_repo: ClonedRepository,
 ) -> Comparison:
+    # TODO(brent) Remove this workaround when human-readable rule names are stabilized.
     rule_names = (
         rule_name_to_code(ruff_comparison_executable.resolve())
         if not options.preview

--- a/python/ruff-ecosystem/ruff_ecosystem/format.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/format.py
@@ -16,6 +16,7 @@ from unidiff import PatchSet
 
 from ruff_ecosystem import logger
 from ruff_ecosystem.markdown import markdown_project_section
+from ruff_ecosystem.projects import rule_name_to_code
 from ruff_ecosystem.types import Comparison, Diff, Result, ToolError
 
 if TYPE_CHECKING:
@@ -173,7 +174,12 @@ async def format_then_format(
     config_overrides: ConfigOverrides,
     cloned_repo: ClonedRepository,
 ) -> Sequence[str]:
-    with config_overrides.patch_config(cloned_repo.path, options.preview):
+    rule_names = (
+        rule_name_to_code(ruff_comparison_executable.resolve())
+        if not options.preview
+        else {}
+    )
+    with config_overrides.patch_config(cloned_repo.path, options.preview, rule_names):
         # Run format to get the baseline
         await format(
             formatter=baseline_formatter,
@@ -201,7 +207,12 @@ async def format_and_format(
     config_overrides: ConfigOverrides,
     cloned_repo: ClonedRepository,
 ) -> Sequence[str]:
-    with config_overrides.patch_config(cloned_repo.path, options.preview):
+    rule_names = (
+        rule_name_to_code(ruff_comparison_executable.resolve())
+        if not options.preview
+        else {}
+    )
+    with config_overrides.patch_config(cloned_repo.path, options.preview, rule_names):
         # Run format without diff to get the baseline
         await format(
             formatter=baseline_formatter,
@@ -218,7 +229,7 @@ async def format_and_format(
     # Then reset
     await cloned_repo.reset()
 
-    with config_overrides.patch_config(cloned_repo.path, options.preview):
+    with config_overrides.patch_config(cloned_repo.path, options.preview, rule_names):
         # Then run format again
         await format(
             formatter=Formatter.ruff,

--- a/python/ruff-ecosystem/ruff_ecosystem/format.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/format.py
@@ -174,6 +174,7 @@ async def format_then_format(
     config_overrides: ConfigOverrides,
     cloned_repo: ClonedRepository,
 ) -> Sequence[str]:
+    # TODO(brent) Remove this workaround when human-readable rule names are stabilized.
     rule_names = (
         rule_name_to_code(ruff_comparison_executable.resolve())
         if not options.preview
@@ -207,6 +208,7 @@ async def format_and_format(
     config_overrides: ConfigOverrides,
     cloned_repo: ClonedRepository,
 ) -> Sequence[str]:
+    # TODO(brent) Remove this workaround when human-readable rule names are stabilized.
     rule_names = (
         rule_name_to_code(ruff_comparison_executable.resolve())
         if not options.preview

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -56,6 +56,7 @@ ALWAYS_CONFIG_OVERRIDES = {
     "required-version": None
 }
 
+# TODO(brent) Remove selector normalization when human-readable rule names are stabilized.
 RULE_SELECTOR_OPTIONS = (
     "select",
     "extend-select",

--- a/python/ruff-ecosystem/ruff_ecosystem/projects.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/projects.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 import abc
 import contextlib
 import dataclasses
+import json
 from asyncio import create_subprocess_exec
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import cache
 from pathlib import Path
-from subprocess import DEVNULL, PIPE
+from subprocess import DEVNULL, PIPE, check_output
 from typing import Any, Self
 
 import tomli
@@ -55,6 +56,60 @@ ALWAYS_CONFIG_OVERRIDES = {
     "required-version": None
 }
 
+RULE_SELECTOR_OPTIONS = (
+    "select",
+    "extend-select",
+    "ignore",
+    "extend-ignore",
+    "fixable",
+    "extend-fixable",
+    "unfixable",
+    "extend-unfixable",
+    "extend-safe-fixes",
+    "extend-unsafe-fixes",
+)
+
+
+@cache
+def rule_name_to_code(executable: Path) -> dict[str, str]:
+    rules = json.loads(
+        check_output(
+            [executable, "rule", "--all", "--output-format", "json"],
+            encoding="utf8",
+        )
+    )
+    return {rule["name"]: rule["code"] for rule in rules}
+
+
+def normalize_rule_selectors(
+    config: dict[str, Any], rule_names: dict[str, str]
+) -> None:
+    selector_lists: list[list[Any]] = []
+
+    for section in (config, config.get("lint")):
+        if not isinstance(section, dict):
+            continue
+
+        for option in RULE_SELECTOR_OPTIONS:
+            if isinstance(selectors := section.get(option), list):
+                selector_lists.append(selectors)
+
+        for option in ("per-file-ignores", "extend-per-file-ignores"):
+            if isinstance(per_file_ignores := section.get(option), dict):
+                selector_lists.extend(
+                    selectors
+                    for selectors in per_file_ignores.values()
+                    if isinstance(selectors, list)
+                )
+
+    for selectors in selector_lists:
+        selectors[:] = [
+            rule_names.get(selector, selector)
+            if isinstance(selector, str)
+            else selector
+            for selector in selectors
+        ]
+
 
 @dataclass(frozen=True)
 class ConfigOverrides(Serializable):
@@ -91,6 +146,7 @@ class ConfigOverrides(Serializable):
         self,
         dirpath: Path,
         preview: bool,
+        rule_names: dict[str, str],
     ) -> None:
         """
         Temporarily patch the Ruff configuration file in the given directory.
@@ -152,6 +208,12 @@ class ConfigOverrides(Serializable):
                 target.pop(names[-1], None)
             else:
                 target[names[-1]] = value
+
+        if not preview:
+            ruff_config = toml
+            for name in base:
+                ruff_config = ruff_config[name]
+            normalize_rule_selectors(ruff_config, rule_names)
 
         tomli_w.dump(toml, path.open("wb"))
 


### PR DESCRIPTION
Summary
--

Now that we allow rule names in selectors in preview, we need to normalize them back to codes to
allow running on stable. This PR implements this normalization as one of our config overrides,
using the comparison executable to extract the rule mapping from `ruff rule`.

Test Plan
--

CI on this PR and then #27154
