### PR TITLE
[ty] Improve importer performance

### DIFF
--- a/crates/ty_ide/src/importer.rs
+++ b/crates/ty_ide/src/importer.rs
@@ -366,10 +366,7 @@ impl<'ast> MembersInScope<'ast> {
     }
 
     pub(crate) fn find_member(&self, symbol_name: &str) -> Option<&MemberInScope> {
-        self.map
-            .iter()
-            .find(|(name, _)| *name == symbol_name)
-            .map(|(_, member)| member)
+        self.map.get(symbol_name)
     }
 
     pub(crate) fn satisfies(


### PR DESCRIPTION
## Summary

On Linux x86_64, the median aggregate request-time measurement for three cached auto-import completion workloads fell from 3,514,303 ns/request to 3,007,003 ns/request (14.4%). The workloads use 64 completion candidates with 64 in-scope members, 256 candidates with 256 members, and 512 candidates with 1,024 members.

Completion count was unchanged (median 859 → 859, 10 samples per arm).

## Change

Updates the scope-member lookup in `crates/ty_ide/src/importer.rs` for the auto-import completion path.

## Test Plan

- `cargo test -p ty_ide auto_import_`
- The repository completion CLI returned 521 completions for the large auto-import workload.

## Limitations

The timing result is an aggregate cached-completion measurement across the three listed workloads, not separate timing results for each workload. It does not measure cold requests, arbitrary workspace layouts, end-to-end editor latency, or platforms other than Linux x86_64.

Full measured evidence: https://app.perfloop.ai/t/oss/case_ydxbe2gn1p