### PR TITLE
[ty] Use trivial sat checks for constraint set short circuits

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -693,6 +693,95 @@ help: A TypedDict is not usually assignable to any `dict[..]` type; `dict` types
 help: Consider using `Mapping[..]` instead of `dict[..]`.
 ```
 
+## Generic `TypedDict` field conflicts in overload diagnostics
+
+A generic `TypedDict` relation can be unsatisfiable without being the `never` terminal. The
+resulting overload diagnostic should still explain which field introduced the conflicting
+constraints.
+
+```py
+from typing import Generic, Self, TypeVar, TypedDict, overload
+
+T = TypeVar("T")
+
+class Pair(TypedDict, Generic[T]):
+    first: T
+    second: T
+
+class Fixed(TypedDict):
+    first: int
+    second: str
+
+class OverloadedSelf:
+    @overload
+    def method(self, value: Fixed) -> None: ...  # snapshot: invalid-overload
+    @overload
+    def method(self, value: str) -> None: ...
+    def method(self, value: Pair[Self] | str) -> None: ...
+```
+
+```snapshot
+error[invalid-overload]: Implementation does not accept all arguments of this overload
+  --> src/mdtest_snippet.py:15:9
+   |
+15 |     def method(self, value: Fixed) -> None: ...  # snapshot: invalid-overload
+   |         ^^^^^^
+16 |     @overload
+17 |     def method(self, value: str) -> None: ...
+18 |     def method(self, value: Pair[Self] | str) -> None: ...
+   |         ------ Implementation defined here
+   |
+info: Implementation signature `(self, value: Pair[Self@method] | str) -> None` is not assignable to overload signature `(self, value: Fixed) -> None`
+info: parameter `value` has an incompatible type: `Fixed` is not assignable to `Pair[Self@method] | str`
+info: └── type `Fixed` is not assignable to any element of the union `Pair[Self@method] | str`
+info:     ├── field "second" on TypedDict `Fixed` has type `str` which is not assignable to type `Self@method` expected by TypedDict `Pair`
+info:     └── ... omitted 1 union element without additional context
+```
+
+## Stop checking callable parameters after incompatible generic constraints
+
+Once earlier parameters produce an unsatisfiable nonterminal constraint set, continuing to a later
+parameter must not replace the diagnostic context that explains the original incompatibility.
+
+```py
+from typing import Generic, Self, TypeVar, TypedDict, overload
+
+T = TypeVar("T")
+
+class Pair(TypedDict, Generic[T]):
+    first: T
+    second: T
+
+class Fixed(TypedDict):
+    first: int
+    second: str
+
+class OverloadedSelf:
+    @overload
+    def method(self, value: Fixed, later: int) -> None: ...  # snapshot: invalid-overload
+    @overload
+    def method(self, value: str, later: str) -> None: ...
+    def method(self, value: Pair[Self] | str, later: str) -> None: ...
+```
+
+```snapshot
+error[invalid-overload]: Implementation does not accept all arguments of this overload
+  --> src/mdtest_snippet.py:15:9
+   |
+15 |     def method(self, value: Fixed, later: int) -> None: ...  # snapshot: invalid-overload
+   |         ^^^^^^
+16 |     @overload
+17 |     def method(self, value: str, later: str) -> None: ...
+18 |     def method(self, value: Pair[Self] | str, later: str) -> None: ...
+   |         ------ Implementation defined here
+   |
+info: Implementation signature `(self, value: Pair[Self@method] | str, later: str) -> None` is not assignable to overload signature `(self, value: Fixed, later: int) -> None`
+info: parameter `value` has an incompatible type: `Fixed` is not assignable to `Pair[Self@method] | str`
+info: └── type `Fixed` is not assignable to any element of the union `Pair[Self@method] | str`
+info:     ├── field "second" on TypedDict `Fixed` has type `str` which is not assignable to type `Self@method` expected by TypedDict `Pair`
+info:     └── ... omitted 1 union element without additional context
+```
+
 ## Type variable upper bounds
 
 Assignability context is included when an explicit type argument does not satisfy a type variable's

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -1009,7 +1009,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             }
             (ClassBase::TypedDict(_), _) => self.never(),
         };
-        if class_equivalence.is_never_satisfied(db) {
+        if class_equivalence.is_trivially_never_satisfied() {
             return self.never();
         }
         let owner_equivalence = match (left.owner(db), right.owner(db)) {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -170,8 +170,8 @@ pub(crate) trait IteratorConstraintsExtension<T> {
     /// Returns the constraints under which any element of the iterator holds.
     ///
     /// This method short-circuits; if we encounter any element that
-    /// [`is_always_satisfied`][ConstraintSet::is_always_satisfied], then the overall result
-    /// must be as well, and we stop consuming elements from the iterator.
+    /// [`is_trivially_always_satisfied`][ConstraintSet::is_trivially_always_satisfied], then the
+    /// overall result must be as well, and we stop consuming elements from the iterator.
     fn when_any<'db, 'c>(
         self,
         db: &'db dyn Db,
@@ -182,8 +182,8 @@ pub(crate) trait IteratorConstraintsExtension<T> {
     /// Returns the constraints under which every element of the iterator holds.
     ///
     /// This method short-circuits; if we encounter any element that
-    /// [`is_never_satisfied`][ConstraintSet::is_never_satisfied], then the overall result
-    /// must be as well, and we stop consuming elements from the iterator.
+    /// [`is_trivially_never_satisfied`][ConstraintSet::is_trivially_never_satisfied], then the
+    /// overall result must be as well, and we stop consuming elements from the iterator.
     fn when_all<'db, 'c>(
         self,
         db: &'db dyn Db,
@@ -198,12 +198,11 @@ where
 {
     fn when_any<'db, 'c>(
         self,
-        db: &'db dyn Db,
+        _db: &'db dyn Db,
         builder: &'c ConstraintSetBuilder<'db>,
         mut f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
         let node = NodeId::distributed_or(
-            db,
             builder,
             self.map(|element| {
                 let constraint = f(element);
@@ -216,12 +215,11 @@ where
 
     fn when_all<'db, 'c>(
         self,
-        db: &'db dyn Db,
+        _db: &'db dyn Db,
         builder: &'c ConstraintSetBuilder<'db>,
         mut f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
         let node = NodeId::distributed_and(
-            db,
             builder,
             self.map(|element| {
                 let constraint = f(element);
@@ -437,14 +435,32 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         debug_assert!(std::ptr::eq(self.builder, builder));
     }
 
-    /// Returns whether this constraint set never holds
+    /// Returns whether this constraint set never holds.
     pub(crate) fn is_never_satisfied(self, db: &'db dyn Db) -> bool {
         self.node.is_never_satisfied(db, self.builder)
     }
 
-    /// Returns whether this constraint set always holds
+    /// Returns whether this constraint set is the `never` terminal.
+    ///
+    /// A nonterminal constraint set can also never be satisfied, so `false` does not prove that
+    /// the set is satisfiable. Use [`Self::is_never_satisfied`] when false negatives are not
+    /// acceptable.
+    pub(crate) fn is_trivially_never_satisfied(self) -> bool {
+        self.node == ALWAYS_FALSE
+    }
+
+    /// Returns whether this constraint set always holds.
     pub(crate) fn is_always_satisfied(self, db: &'db dyn Db) -> bool {
         self.node.is_always_satisfied(db, self.builder)
+    }
+
+    /// Returns whether this constraint set is the `always` terminal.
+    ///
+    /// A nonterminal constraint set can also always be satisfied, so `false` does not prove that
+    /// the set is not always satisfied. Use [`Self::is_always_satisfied`] when false negatives are
+    /// not acceptable.
+    pub(crate) fn is_trivially_always_satisfied(self) -> bool {
+        self.node == ALWAYS_TRUE
     }
 
     /// Returns the constraints under which `lhs` is a subtype of `rhs`, assuming that the
@@ -535,7 +551,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: impl FnOnce() -> Self,
     ) -> Self {
         self.verify_builder(builder);
-        if !self.is_never_satisfied(db) {
+        if !self.is_trivially_never_satisfied() {
             let other = other();
             other.verify_builder(builder);
             self.intersect(db, builder, other);
@@ -556,7 +572,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: impl FnOnce() -> Self,
     ) -> Self {
         self.verify_builder(builder);
-        if !self.is_always_satisfied(db) {
+        if !self.is_trivially_always_satisfied() {
             let other = other();
             other.verify_builder(builder);
             self.union(db, builder, other);
@@ -2548,14 +2564,13 @@ impl NodeId {
     /// You must also provide the "zero" and "one" units of the operator. The "zero" is the value
     /// that has no effect (`0 ∨ a = a`). It is returned if the iterator is empty. The "one" is the
     /// value that saturates (`1 ∨ a = 1`). We use this to short-circuit; if any element BDD or any
-    /// intermediate result evaluates to "one", we can return early.
-    fn tree_fold<'db>(
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+    /// intermediate result is the "one" terminal, we can return early.
+    fn tree_fold(
+        builder: &ConstraintSetBuilder<'_>,
         nodes: impl Iterator<Item = Self>,
         zero: Self,
-        is_one: impl Fn(Self, &'db dyn Db, &ConstraintSetBuilder<'db>) -> bool,
-        mut combine: impl FnMut(Self, &ConstraintSetBuilder<'db>, Self) -> Self,
+        one: Self,
+        mut combine: impl FnMut(Self, &ConstraintSetBuilder<'_>, Self) -> Self,
     ) -> Self {
         // To implement the "linear" shape described above, we could collect the iterator elements
         // into a vector, and then use the fold at the bottom of this method to combine the
@@ -2583,7 +2598,7 @@ impl NodeId {
         // until the iterator passes 256 elements.
         let mut accumulator: SmallVec<[(NodeId, u8); 8]> = SmallVec::default();
         for node in nodes {
-            if is_one(node, db, builder) {
+            if node == one {
                 return node;
             }
 
@@ -2594,7 +2609,7 @@ impl NodeId {
             {
                 let (existing, _) = accumulator.pop().expect("accumulator should not be empty");
                 node = combine(existing, builder, node);
-                if is_one(node, db, builder) {
+                if node == one {
                     return node;
                 }
                 depth += 1;
@@ -2610,32 +2625,28 @@ impl NodeId {
             .fold(zero, |result, (node, _)| combine(result, builder, node))
     }
 
-    fn distributed_or<'db>(
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+    fn distributed_or(
+        builder: &ConstraintSetBuilder<'_>,
         nodes: impl Iterator<Item = NodeId>,
     ) -> Self {
         Self::tree_fold(
-            db,
             builder,
             nodes,
             ALWAYS_FALSE,
-            Self::is_always_satisfied,
+            ALWAYS_TRUE,
             Self::or_with_offset,
         )
     }
 
-    fn distributed_and<'db>(
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+    fn distributed_and(
+        builder: &ConstraintSetBuilder<'_>,
         nodes: impl Iterator<Item = NodeId>,
     ) -> Self {
         Self::tree_fold(
-            db,
             builder,
             nodes,
             ALWAYS_TRUE,
-            Self::is_never_satisfied,
+            ALWAYS_FALSE,
             Self::and_with_offset,
         )
     }
@@ -7886,6 +7897,126 @@ mod tests {
             Some(&false)
         );
         assert_eq!(storage.constraint_implication_cache.len(), 2);
+    }
+
+    #[test]
+    fn trivial_satisfaction_only_recognizes_terminals() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
+        let t_str = create_constraint(&db, &builder, t, KnownClass::Str);
+        let impossible = t_int.and(&db, &builder, || t_str);
+
+        assert!(ConstraintSet::always(&builder).is_trivially_always_satisfied());
+        assert!(!ConstraintSet::always(&builder).is_trivially_never_satisfied());
+        assert!(ConstraintSet::never(&builder).is_trivially_never_satisfied());
+        assert!(!ConstraintSet::never(&builder).is_trivially_always_satisfied());
+        assert!(!t_int.is_trivially_always_satisfied());
+        assert!(!t_int.is_trivially_never_satisfied());
+        assert!(impossible.is_never_satisfied(&db));
+        assert!(!impossible.is_trivially_never_satisfied());
+
+        let t_bool_upper = ConstraintSet::constrain_typevar_upper_bound(
+            &db,
+            &builder,
+            t,
+            KnownClass::Bool.to_instance(&db),
+        );
+        let t_int_upper = ConstraintSet::constrain_typevar_upper_bound(
+            &db,
+            &builder,
+            t,
+            KnownClass::Int.to_instance(&db),
+        );
+        let tautology = t_bool_upper
+            .negate(&db, &builder)
+            .or(&db, &builder, || t_int_upper);
+
+        assert!(tautology.is_always_satisfied(&db));
+        assert!(!tautology.is_trivially_always_satisfied());
+    }
+
+    #[test]
+    fn combinators_only_short_circuit_on_terminal_saturation() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
+        let t_str = create_constraint(&db, &builder, t, KnownClass::Str);
+        let impossible = t_int.and(&db, &builder, || t_str);
+        let t_bool_upper = ConstraintSet::constrain_typevar_upper_bound(
+            &db,
+            &builder,
+            t,
+            KnownClass::Bool.to_instance(&db),
+        );
+        let t_int_upper = ConstraintSet::constrain_typevar_upper_bound(
+            &db,
+            &builder,
+            t,
+            KnownClass::Int.to_instance(&db),
+        );
+        let tautology = t_bool_upper
+            .negate(&db, &builder)
+            .or(&db, &builder, || t_int_upper);
+
+        let forced = Cell::new(0);
+        ConstraintSet::never(&builder).and(&db, &builder, || {
+            forced.set(forced.get() + 1);
+            t_int
+        });
+        ConstraintSet::always(&builder).or(&db, &builder, || {
+            forced.set(forced.get() + 1);
+            t_int
+        });
+        assert_eq!(forced.get(), 0);
+
+        impossible.and(&db, &builder, || {
+            forced.set(forced.get() + 1);
+            t_int
+        });
+        tautology.or(&db, &builder, || {
+            forced.set(forced.get() + 1);
+            t_int
+        });
+        assert_eq!(forced.get(), 2);
+
+        let visited = Cell::new(0);
+        [impossible, t_int]
+            .into_iter()
+            .when_all(&db, &builder, |set| {
+                visited.set(visited.get() + 1);
+                set
+            });
+        assert_eq!(visited.get(), 2);
+
+        visited.set(0);
+        [tautology, t_int]
+            .into_iter()
+            .when_any(&db, &builder, |set| {
+                visited.set(visited.get() + 1);
+                set
+            });
+        assert_eq!(visited.get(), 2);
+
+        visited.set(0);
+        [ConstraintSet::never(&builder), t_int]
+            .into_iter()
+            .when_all(&db, &builder, |set| {
+                visited.set(visited.get() + 1);
+                set
+            });
+        assert_eq!(visited.get(), 1);
+
+        visited.set(0);
+        [ConstraintSet::always(&builder), t_int]
+            .into_iter()
+            .when_any(&db, &builder, |set| {
+                visited.set(visited.get() + 1);
+                set
+            });
+        assert_eq!(visited.get(), 1);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -528,7 +528,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
             if result
                 .union(db, self.constraints, nominally_satisfied)
-                .is_always_satisfied(db)
+                .is_trivially_always_satisfied()
             {
                 return result;
             }
@@ -800,7 +800,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             let compatible = self.check_tuple_spec_pair(db, &left_spec, &right_spec);
             if result
                 .union(db, self.constraints, compatible)
-                .is_always_satisfied(db)
+                .is_trivially_always_satisfied()
             {
                 return result;
             }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2044,7 +2044,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         value_ty,
                     );
                     result = result.and(db, self.constraints, || element_result);
-                    if result.is_never_satisfied(db) {
+                    if result.is_trivially_never_satisfied() {
                         break;
                     }
                 }
@@ -2061,7 +2061,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         value_ty,
                     );
                     result = result.or(db, self.constraints, || element_result);
-                    if result.is_always_satisfied(db) {
+                    if result.is_trivially_always_satisfied() {
                         break;
                     }
                 }
@@ -2152,7 +2152,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             ClassAttributeWriteMember::Explicit { member, fallback } => {
                 let member_result =
                     self.check_explicit_property_write(db, object_ty, member, value_ty);
-                if member_result.is_never_satisfied(db) {
+                if member_result.is_trivially_never_satisfied() {
                     return member_result;
                 }
                 if let Some(fallback) = fallback {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1590,7 +1590,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     // check each literal individually.
                     let supertype_result = self
                         .without_context_collection(|| self.check_type_pair(db, supertype, target));
-                    if supertype_result.is_always_satisfied(db) {
+                    if supertype_result.is_trivially_always_satisfied() {
                         return supertype_result;
                     }
                 }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2283,7 +2283,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
             !result
                 .intersect(db, self.constraints, constraint_set)
-                .is_never_satisfied(db)
+                .is_trivially_never_satisfied()
         };
 
         if self.typevar_evaluation == TypeVarEvaluation::Lazy {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2281,9 +2281,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     parameter,
                 });
             }
+            // Continuing past a nonterminal contradiction can bind later `ParamSpec`s or
+            // replace the diagnostic context that explains the incompatible parameter.
             !result
                 .intersect(db, self.constraints, constraint_set)
-                .is_trivially_never_satisfied()
+                .is_never_satisfied(db)
         };
 
         if self.typevar_evaluation == TypeVarEvaluation::Lazy {

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -387,7 +387,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     let element_constraints = self.check_type_pair(db, source_ty, target_ty);
                     if result
                         .intersect(db, self.constraints, element_constraints)
-                        .is_never_satisfied(db)
+                        .is_trivially_never_satisfied()
                     {
                         return result;
                     }
@@ -399,7 +399,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     let element_constraints = self.check_type_pair(db, source_ty, target_ty);
                     if result
                         .intersect(db, self.constraints, element_constraints)
-                        .is_never_satisfied(db)
+                        .is_trivially_never_satisfied()
                     {
                         return result;
                     }
@@ -465,7 +465,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     let element_constraints = self.check_type_pair(db, source_ty, target_ty);
                     if result
                         .intersect(db, self.constraints, element_constraints)
-                        .is_never_satisfied(db)
+                        .is_trivially_never_satisfied()
                     {
                         return result;
                     }
@@ -478,7 +478,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     let element_constraints = self.check_type_pair(db, source_ty, target_ty);
                     if result
                         .intersect(db, self.constraints, element_constraints)
-                        .is_never_satisfied(db)
+                        .is_trivially_never_satisfied()
                     {
                         return result;
                     }
@@ -601,7 +601,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     };
                     if result
                         .intersect(db, self.constraints, pair_constraints)
-                        .is_never_satisfied(db)
+                        .is_trivially_never_satisfied()
                     {
                         return result;
                     }
@@ -638,7 +638,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     };
                     if result
                         .intersect(db, self.constraints, pair_constraints)
-                        .is_never_satisfied(db)
+                        .is_trivially_never_satisfied()
                     {
                         return result;
                     }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -661,7 +661,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     self.check_type_pair(db, source_item_field.declared_ty, target_ty),
                 );
 
-                if result.is_never_satisfied(db) {
+                if result.is_trivially_never_satisfied() {
                     return result;
                 }
             }
@@ -685,7 +685,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             target_item_field.declared_ty,
                         ),
                     );
-                    if result.is_never_satisfied(db) {
+                    if result.is_trivially_never_satisfied() {
                         return result;
                     }
                 }
@@ -880,7 +880,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
             };
             result.intersect(db, self.constraints, field_constraints);
-            if result.is_never_satisfied(db) {
+            if result.is_trivially_never_satisfied() {
                 if let Some(context) = self.report_context()
                     && let Some(source_item_field) = source_items.get(target_item_name)
                 {

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -880,7 +880,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
             };
             result.intersect(db, self.constraints, field_constraints);
-            if result.is_trivially_never_satisfied() {
+            if result.is_trivially_never_satisfied()
+                || (self.is_context_collection_enabled() && result.is_never_satisfied(db))
+            {
                 if let Some(context) = self.report_context()
                     && let Some(source_item_field) = source_items.get(target_item_name)
                 {


### PR DESCRIPTION
There are many places where we check whether a constraint set is always true or never true as a short circuit, since `false ∧ C == false` and `true ∨ C == true` for all `C`.

Previously, we did a "deep" satisfiability check, which gives a 100% accurate answer, but requires walking through the entire BDD, using the sequent map to calculate derived facts and detect contradictions.

Since these checks are only used for optimizations, we can instead use a simpler check against the `ALWAYS_TRUE` and `ALWAYS_FALSE` terminals. These "trivial" checks can return false negatives, but that's okay; we'll just fall back on calculating the actual AND or OR, which is fine.

To be extra careful, before implementing this I had Codex collect some data about how often the previous short-circuit check would engage for a non-terminal-but-always/never-satisfied BDD (data aggregated over `DateType`, `Expression`, `scipy`, `ibis`, `scipy-stubs`, `pandas`, `pandas-stubs`, `pydantic`, `sympy`, `mypy`, `jax`, `beartype`, and `attrs`):

| Short-circuit location | Engaged | Missed by terminal comparison | Terminal coverage |
|---|---:|---:|---:|
| `ConstraintSet::and` / `or` | 13,057,040 | 42 | 99.9997% |
| Iterator `when_all` / `when_any` | 7,569,371 | 177 | 99.9977% |
| Post-`intersect`: `is_never_satisfied` | 1,022,067 | 367 | 99.9641% |
| Post-`union`: `is_always_satisfied` | 585,184 | 125 | 99.9786% |

The answer: not often at all.