### PR TITLE
[ty] Make reachability analysis idempotent

### DIFF
--- a/crates/ty_python_semantic/resources/corpus/ty_4080_fuzzed_reachability_cycle.py
+++ b/crates/ty_python_semantic/resources/corpus/ty_4080_fuzzed_reachability_cycle.py
@@ -28,3 +28,20 @@ finally:
 match 0:
     case {**name_0}:
         pass
+
+# Together with the two calls above, keep this scope just above the prefix-warming threshold.
+extra_00()
+extra_01()
+extra_02()
+extra_03()
+extra_04()
+extra_05()
+extra_06()
+extra_07()
+extra_08()
+extra_09()
+extra_10()
+extra_11()
+extra_12()
+extra_13()
+extra_14()

--- a/crates/ty_python_semantic/resources/corpus/ty_4080_fuzzed_reachability_cycle.py
+++ b/crates/ty_python_semantic/resources/corpus/ty_4080_fuzzed_reachability_cycle.py
@@ -1,0 +1,30 @@
+# Regression test for https://github.com/astral-sh/ty/issues/4080
+# Minimized from py-fuzzer seed 945. Prefix warming must not cause this cycle to diverge.
+
+lambda: name_3
+
+for name_0 in {lambda: name_0: 0}:
+    pass
+else:
+    try:
+        while name_0:
+            pass
+        unique_name_0()
+    except* 0:
+        pass
+    finally:
+        with 0 as name_0:
+            pass
+
+try:
+    assert lambda: name_0
+    unique_name_1()
+except:
+    while unique_name_2:
+        pass
+finally:
+    import name_3
+
+match 0:
+    case {**name_0}:
+        pass

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -200,19 +200,18 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        ActiveRecursionDetector, CallableTypes, ComparisonSoundnessPolicy, EnumClassLiteral,
-        KnownInstanceType, NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType,
-        callable_pattern_type, definite_match_pattern_type,
-        definite_match_pattern_type_for_subject, equality_truthiness, expand_type,
-        infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
-        pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
+        CallableTypes, ComparisonSoundnessPolicy, EnumClassLiteral, KnownInstanceType,
+        NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType, callable_pattern_type,
+        definite_match_pattern_type, definite_match_pattern_type_for_subject, equality_truthiness,
+        expand_type, infer_narrowing_constraints, infer_same_file_expression_type,
+        mapping_pattern_type, pattern_binding_fallthrough_type, sequence_pattern_type_builder,
+        singleton_pattern_type,
     },
 };
 use ruff_index::{Idx, IndexSlice};
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
-use salsa::plumbing::AsId;
 use smallvec::SmallVec;
 use ty_python_core::{
     BindingWithConstraints, DeclarationWithConstraint, DeclarationsIterator, FileScopeId,
@@ -523,10 +522,6 @@ fn accumulate_constraint<'db>(
     }
 }
 
-std::thread_local! {
-    static ACTIVE_NON_TERMINAL_CALL_PREFIXES: ActiveRecursionDetector<salsa::Id> = ActiveRecursionDetector::default();
-}
-
 const NON_TERMINAL_CALL_CHUNK_SIZE: usize = 16;
 const REACHABILITY_EVALUATION_CHUNK_SIZE: usize = 256;
 
@@ -557,10 +552,9 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
 /// accept the broader eager pass because it keeps the ordering simple, and checking a scope will
 /// typically exercise most of its predicates eventually.
 ///
-/// Reentrant analysis of the same predicate graph skips the prefix pass: because the outer pass is
-/// proceeding in source order, any preceding call needed by the current expression has already
-/// been inferred. A different predicate graph performs its own pass, which is necessary when
-/// inferring a call crosses into another large scope.
+/// Reentrant analysis is handled by Salsa cycle recovery on the call and cached-range queries.
+/// Keeping the prefix pass unconditional ensures that tracked callers record the same dependencies
+/// on every thread.
 fn analyze_non_terminal_call_prefix<'db>(
     db: &'db dyn Db,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
@@ -573,49 +567,35 @@ fn analyze_non_terminal_call_prefix<'db>(
         .nth(NON_TERMINAL_CALL_CHUNK_SIZE)
         .is_some();
 
-    ACTIVE_NON_TERMINAL_CALL_PREFIXES.with(|active| {
-        active.visit(
-            &scope.as_id(),
-            || {},
-            || {
-                if !has_many_calls {
-                    for predicate in &predicates.raw[..=root_predicate.index()] {
-                        if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
-                            analyze_single(db, predicate);
-                        }
-                    }
-                    return;
-                }
+    if !has_many_calls {
+        for predicate in &predicates.raw[..=root_predicate.index()] {
+            if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
+                analyze_single(db, predicate);
+            }
+        }
+        return false;
+    }
 
-                let call_predicates = non_terminal_call_predicates(db, scope);
-                let call_count =
-                    call_predicates.partition_point(|predicate| *predicate <= root_predicate);
-                if call_count <= NON_TERMINAL_CALL_CHUNK_SIZE {
-                    analyze_non_terminal_calls(db, predicates, &call_predicates[..call_count]);
-                    return;
-                }
+    let call_predicates = non_terminal_call_predicates(db, scope);
+    let call_count = call_predicates.partition_point(|predicate| *predicate <= root_predicate);
+    if call_count <= NON_TERMINAL_CALL_CHUNK_SIZE {
+        analyze_non_terminal_calls(db, predicates, &call_predicates[..call_count]);
+        return true;
+    }
 
-                let mut start = 0;
-                let mut remaining = call_count / NON_TERMINAL_CALL_CHUNK_SIZE;
+    let mut start = 0;
+    let mut remaining = call_count / NON_TERMINAL_CALL_CHUNK_SIZE;
 
-                while remaining > 0 {
-                    let level = remaining.ilog2();
-                    let length = 1 << level;
-                    analyze_non_terminal_call_range(db, scope, level, start >> level);
-                    start += length;
-                    remaining -= length;
-                }
+    while remaining > 0 {
+        let level = remaining.ilog2();
+        let length = 1 << level;
+        analyze_non_terminal_call_range(db, scope, level, start >> level);
+        start += length;
+        remaining -= length;
+    }
 
-                let tail_start =
-                    call_count / NON_TERMINAL_CALL_CHUNK_SIZE * NON_TERMINAL_CALL_CHUNK_SIZE;
-                analyze_non_terminal_calls(
-                    db,
-                    predicates,
-                    &call_predicates[tail_start..call_count],
-                );
-            },
-        );
-    });
+    let tail_start = call_count / NON_TERMINAL_CALL_CHUNK_SIZE * NON_TERMINAL_CALL_CHUNK_SIZE;
+    analyze_non_terminal_calls(db, predicates, &call_predicates[tail_start..call_count]);
 
     has_many_calls
 }
@@ -654,7 +634,15 @@ fn analyze_non_terminal_calls<'db>(
 /// queries. Splitting ranges in half keeps the Salsa query stack logarithmic even when the first
 /// requested prefix contains thousands of calls. Each leaf handles multiple calls iteratively to
 /// avoid retaining a Salsa argument and query result for every individual predicate.
-#[salsa::tracked(returns(copy), heap_size = get_size2::GetSize::get_heap_size)]
+///
+/// Analyzing a call can re-enter reachability through expression inference and request this same
+/// range. Recovery is a no-op because the range only warms call queries; any call still needed for
+/// reachability is evaluated directly by the decision-diagram walk.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial = |_, _, _, _, _| (),
+    heap_size = get_size2::GetSize::get_heap_size
+)]
 fn analyze_non_terminal_call_range<'db>(
     db: &'db dyn Db,
     scope: ScopeId<'db>,
@@ -1778,6 +1766,94 @@ mod tests {
     use ty_python_core::narrowing_constraints::InteriorNode;
     use ty_python_core::predicate::Predicates;
     use ty_python_core::semantic_index;
+
+    #[test]
+    fn non_terminal_call_range_recovers_cross_file_cycle() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        let calls = "        other.target.ping()\n".repeat(NON_TERMINAL_CALL_CHUNK_SIZE + 1);
+        let a = format!(
+            r#"from b import B
+
+class A:
+    def setup(self, other: B) -> None:
+{calls}        self.target = TargetA()
+
+class TargetA:
+    def ping(self) -> None: ...
+"#
+        );
+        let b = format!(
+            r#"from a import A
+
+class B:
+    def setup(self, other: A) -> None:
+{calls}        self.target = TargetB()
+
+class TargetB:
+    def ping(self) -> None: ...
+"#
+        );
+        db.write_files([("/src/a.py", a.as_str()), ("/src/b.py", b.as_str())])?;
+
+        let file = system_path_to_file(&db, "/src/a.py").unwrap();
+        let index = semantic_index(&db, file);
+        let class_scope = index
+            .child_scopes(FileScopeId::global())
+            .find(|(_, scope)| scope.node().as_class().is_some())
+            .unwrap()
+            .0;
+        let setup_scope = index
+            .child_scopes(class_scope)
+            .find(|(_, scope)| scope.node().as_function().is_some())
+            .unwrap()
+            .0
+            .to_scope_id(&db, file);
+
+        // Enter the range directly so it becomes the cycle head when inferring `other.target`
+        // reaches the other module and then re-enters this scope.
+        analyze_non_terminal_call_range(&db, setup_scope, 0, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn non_terminal_call_range_invalidates_when_callable_changes() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        let source = format!(
+            "from dependency import callback\n\ndef f() -> None:\n{}",
+            "    callback()\n".repeat(NON_TERMINAL_CALL_CHUNK_SIZE + 1)
+        );
+        db.write_files([
+            ("/src/dependency.py", "def callback() -> None: ..."),
+            ("/src/test.py", source.as_str()),
+        ])?;
+
+        let file = system_path_to_file(&db, "/src/test.py").unwrap();
+        let function_scope = {
+            let index = semantic_index(&db, file);
+            index.child_scopes(FileScopeId::global()).next().unwrap().0
+        };
+        {
+            let scope = function_scope.to_scope_id(&db, file);
+            let use_def = use_def_map(&db, scope);
+            assert!(
+                evaluate_reachability_constraint(&db, scope, use_def.end_of_scope_reachability())
+                    .may_be_true()
+            );
+        }
+
+        db.write_file(
+            "/src/dependency.py",
+            "from typing import NoReturn\ndef callback() -> NoReturn: ...",
+        )?;
+
+        let scope = function_scope.to_scope_id(&db, file);
+        let use_def = use_def_map(&db, scope);
+        assert!(
+            evaluate_reachability_constraint(&db, scope, use_def.end_of_scope_reachability())
+                .is_always_false()
+        );
+        Ok(())
+    }
 
     #[test]
     fn deep_constraint_projection_does_not_overflow() -> anyhow::Result<()> {

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -538,7 +538,7 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
     }
 }
 
-/// Infers preceding call predicates in source order.
+/// Infers complete preceding blocks of call predicates in source order.
 ///
 /// Predicate IDs are assigned in source order, but the decision diagrams intentionally order
 /// predicates in reverse to reduce their size. Inferring a later call can depend on the
@@ -552,10 +552,12 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
 /// accept the broader eager pass because it keeps the ordering simple, and checking a scope will
 /// typically exercise most of its predicates eventually.
 ///
-/// Reentrant analysis is handled by Salsa cycle recovery on the call and cached-range queries. For
-/// large scopes, keeping the prefix pass unconditional ensures that tracked callers record the same
-/// dependencies on every thread. Small scopes do not need prefix warming to bound the Salsa stack,
-/// and evaluating their call predicates on demand avoids introducing unnecessary inference cycles.
+/// Reentrant analysis is handled by Salsa cycle recovery on the cached-range queries. The final
+/// incomplete block is left for the reachability walk: it can add at most 15 nested call queries,
+/// and analyzing it eagerly would bypass the range query's cycle recovery and could introduce a
+/// divergent inference cycle. For large scopes, keeping the complete-block pass unconditional
+/// ensures that tracked callers record the same dependencies on every thread. Small scopes do not
+/// need prefix warming to bound the Salsa stack, so their calls are evaluated entirely on demand.
 fn analyze_non_terminal_call_prefix<'db>(
     db: &'db dyn Db,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
@@ -574,12 +576,9 @@ fn analyze_non_terminal_call_prefix<'db>(
 
     let call_predicates = non_terminal_call_predicates(db, scope);
     let call_count = call_predicates.partition_point(|predicate| *predicate <= root_predicate);
-    if call_count <= NON_TERMINAL_CALL_CHUNK_SIZE {
-        analyze_non_terminal_calls(db, predicates, &call_predicates[..call_count]);
-        return true;
-    }
-
     let mut start = 0;
+    // Leave the incomplete final block demand-driven. Its reverse dependency chain is bounded by
+    // the block size, and every eagerly analyzed call remains behind a recoverable range query.
     let mut remaining = call_count / NON_TERMINAL_CALL_CHUNK_SIZE;
 
     while remaining > 0 {
@@ -589,9 +588,6 @@ fn analyze_non_terminal_call_prefix<'db>(
         start += length;
         remaining -= length;
     }
-
-    let tail_start = call_count / NON_TERMINAL_CALL_CHUNK_SIZE * NON_TERMINAL_CALL_CHUNK_SIZE;
-    analyze_non_terminal_calls(db, predicates, &call_predicates[tail_start..call_count]);
 
     true
 }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -552,9 +552,10 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
 /// accept the broader eager pass because it keeps the ordering simple, and checking a scope will
 /// typically exercise most of its predicates eventually.
 ///
-/// Reentrant analysis is handled by Salsa cycle recovery on the call and cached-range queries.
-/// Keeping the prefix pass unconditional ensures that tracked callers record the same dependencies
-/// on every thread.
+/// Reentrant analysis is handled by Salsa cycle recovery on the call and cached-range queries. For
+/// large scopes, keeping the prefix pass unconditional ensures that tracked callers record the same
+/// dependencies on every thread. Small scopes do not need prefix warming to bound the Salsa stack,
+/// and evaluating their call predicates on demand avoids introducing unnecessary inference cycles.
 fn analyze_non_terminal_call_prefix<'db>(
     db: &'db dyn Db,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
@@ -568,11 +569,6 @@ fn analyze_non_terminal_call_prefix<'db>(
         .is_some();
 
     if !has_many_calls {
-        for predicate in &predicates.raw[..=root_predicate.index()] {
-            if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
-                analyze_single(db, predicate);
-            }
-        }
         return false;
     }
 
@@ -597,7 +593,7 @@ fn analyze_non_terminal_call_prefix<'db>(
     let tail_start = call_count / NON_TERMINAL_CALL_CHUNK_SIZE * NON_TERMINAL_CALL_CHUNK_SIZE;
     analyze_non_terminal_calls(db, predicates, &call_predicates[tail_start..call_count]);
 
-    has_many_calls
+    true
 }
 
 /// Returns the statement-call predicates for `scope` in source order.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -24,7 +24,7 @@ use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
 
 pub(crate) use self::callable::UpcastPolicy;
 pub use self::cyclic::CycleDetector;
-pub(crate) use self::cyclic::{ActiveRecursionDetector, TypeTransformer};
+pub(crate) use self::cyclic::TypeTransformer;
 pub(crate) use self::diagnostic::register_lints;
 pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
 pub(crate) use self::infer::{


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/4080 and the missing range-cycle recovery reported in https://github.com/astral-sh/ty/issues/4077.

The non-terminal-call prefix pass used thread-local recursion state to decide whether to warm preceding calls. Because the pass runs inside tracked queries, re-entry on different threads could record different Salsa dependencies and make reachability analysis non-idempotent.

Remove the thread-local guard and make complete-prefix warming unconditional for large scopes, with no-op Salsa cycle recovery on cached call ranges. Crucially, leave the incomplete final call block demand-driven: warming that tail inline bypasses the range query's recovery boundary and can create a divergent inference cycle. The tail contains at most 15 calls, so the reverse query chain stays bounded without retaining per-call Salsa memos or eagerly inferring future calls. Small scopes retain the performance threshold and evaluate their calls on demand.

## Test plan

- Added a focused cross-file implicit-attribute regression with more than one call block; it enters the cached range directly and reproduces the original `analyze_non_terminal_call_range` Salsa-cycle panic without recovery.
- Added an incremental invalidation regression that changes a repeatedly called dependency from returning `None` to `NoReturn` and verifies end-of-scope reachability is recomputed.
- Extended the deterministic corpus regression minimized from py-fuzzer seed 945 to exactly 17 module-scope call predicates, exercising the large-scope path. The prior implementation reliably fails with `infer_definition_types(...): execute: too many cycle iterations`; the corrected implementation completes immediately.
- Verified the existing large implicit-attribute/stack-depth and terminal-narrowing scenarios, repeated-call performance shapes, the full `ty_python_semantic` suite, crate Clippy/hooks, and the complete CPython-3.14 differential fuzzer range (seeds 0–1000).
