### PR TITLE
[ty] Improve tuple membership and rich comparison inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
@@ -165,7 +165,9 @@ reveal_type(C() <= C())  # revealed: NeReturnType
 
 When subclasses override comparison methods, these overridden methods take precedence over those in
 the parent class. Class `B` inherits from `A` and redefines comparison methods to return types other
-than `A`.
+than `A`. However, because `A` is not final, its instances could have runtime classes other than
+`A`. The reflected method therefore has priority only for some possible operands, so both methods'
+return types are included in the result.
 
 ```py
 from __future__ import annotations
@@ -215,14 +217,14 @@ class B(A):
     def __ge__(self, other: A) -> GeReturnType:  # error: [invalid-method-override]
         return GeReturnType()
 
-reveal_type(A() == B())  # revealed: EqReturnType
-reveal_type(A() != B())  # revealed: NeReturnType
+reveal_type(A() == B())  # revealed: A | EqReturnType
+reveal_type(A() != B())  # revealed: A | NeReturnType
 
-reveal_type(A() < B())  # revealed: GtReturnType
-reveal_type(A() <= B())  # revealed: GeReturnType
+reveal_type(A() < B())  # revealed: A | GtReturnType
+reveal_type(A() <= B())  # revealed: A | GeReturnType
 
-reveal_type(A() > B())  # revealed: LtReturnType
-reveal_type(A() >= B())  # revealed: LeReturnType
+reveal_type(A() > B())  # revealed: A | LtReturnType
+reveal_type(A() >= B())  # revealed: A | LeReturnType
 ```
 
 ## Reflected Comparisons with Subclass But Falls Back to LHS

--- a/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
@@ -324,6 +324,96 @@ def _(n: int):
     reveal_type(a not in d)  # revealed: bool
 ```
 
+Membership in a fixed-length tuple compares each element with the needle, regardless of whether the
+needle is itself a tuple:
+
+```py
+from typing import Literal
+
+def scalar_membership(value: int, values: tuple[Literal[1], Literal[2]]):
+    reveal_type(1 in values)  # revealed: Literal[True]
+    reveal_type(3 in values)  # revealed: Literal[False]
+    reveal_type(value in values)  # revealed: bool
+
+    reveal_type(1 not in values)  # revealed: Literal[False]
+    reveal_type(3 not in values)  # revealed: Literal[True]
+    reveal_type(value not in values)  # revealed: bool
+
+def empty_tuple(value: object, values: tuple[()]):
+    reveal_type(value in values)  # revealed: Literal[False]
+    reveal_type(value not in values)  # revealed: Literal[True]
+```
+
+A variable-length tuple might be empty, even if all its possible elements would compare equal to the
+needle:
+
+```py
+from typing import Literal
+
+def variable_length(
+    nested: tuple[tuple[()], ...],
+    values: tuple[Literal[1], ...],
+):
+    reveal_type(() in nested)  # revealed: bool
+    reveal_type(() not in nested)  # revealed: bool
+
+    reveal_type(1 in values)  # revealed: bool
+    reveal_type(1 not in values)  # revealed: bool
+```
+
+Tuple membership checks whether the needle is the same object as an element before comparing the
+objects for equality. A non-reflexive equality method therefore cannot establish that membership is
+always false:
+
+```py
+from typing import Literal
+
+class NeverEqual:
+    def __eq__(self, other: object) -> Literal[False]:
+        return False
+
+class AlwaysEqual:
+    def __eq__(self, other: object) -> Literal[True]:
+        return True
+
+def identity_before_equality(value: NeverEqual):
+    reveal_type(value == value)  # revealed: Literal[False]
+    reveal_type(value in (value,))  # revealed: bool
+    reveal_type(value not in (value,))  # revealed: bool
+
+def custom_equality(value: AlwaysEqual):
+    reveal_type(value in (1,))  # revealed: bool
+    reveal_type(value not in (1,))  # revealed: bool
+    reveal_type((value,) == (1,))  # revealed: Literal[True]
+    reveal_type((value,) != (1,))  # revealed: Literal[False]
+
+def custom_equality_union(value: AlwaysEqual | None):
+    reveal_type(value in (1,))  # revealed: bool
+    reveal_type(value not in (1,))  # revealed: bool
+
+def custom_equality_union_member(value: AlwaysEqual | None, member: AlwaysEqual):
+    reveal_type(value.__eq__(member))  # revealed: bool
+    reveal_type(member.__eq__(value))  # revealed: Literal[True]
+    reveal_type(value in (member,))  # revealed: Literal[True]
+    reveal_type(value not in (member,))  # revealed: Literal[False]
+    reveal_type((value,) == (member,))  # revealed: bool
+    reveal_type((value,) != (member,))  # revealed: bool
+
+class Base:
+    def __eq__(self, other: object) -> bool:
+        return False
+
+class AlwaysEqualChild(Base):
+    def __eq__(self, other: object) -> Literal[True]:
+        return True
+
+def reflected_custom_equality(value: Base, child: AlwaysEqualChild):
+    reveal_type(value == child)  # revealed: bool
+    reveal_type(child == value)  # revealed: Literal[True]
+    reveal_type(value in (child,))  # revealed: Literal[True]
+    reveal_type(value not in (child,))  # revealed: Literal[False]
+```
+
 ### Identity Comparisons
 
 "Identity Comparisons" refers to `is` and `is not`.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -628,11 +628,11 @@ E = TypeVar("E", Literal[ReflexiveEnum.A], Literal[ReflexiveEnum.B])
 
 def reflexive_enum_literal_slot(x: Literal[ReflexiveEnum.A] | None, value: Literal[ReflexiveEnum.A]) -> None:
     if x not in (value,):
-        reveal_type(x)  # revealed: None
+        reveal_type(x)  # revealed: Never
 
 def reflexive_enum_typevar_slot(x: E | None, value: E) -> None:
     if x not in (value,):
-        reveal_type(x)  # revealed: None
+        reveal_type(x)  # revealed: Never
 
 def tuple_with_any_slot(x: str | None, missing: Any) -> None:
     if x not in (missing, None):

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -91,6 +91,52 @@ fn reflected_method_priority<'db>(
 }
 
 impl<'db> Type<'db> {
+    /// Return the result of dispatching a rich comparison method between two operands.
+    ///
+    /// A strict subclass on the right takes precedence over the normal method on the left.
+    /// The caller remains responsible for operator-specific fallbacks such as identity-based
+    /// equality when neither comparison method is available.
+    pub(super) fn try_call_rich_comparison_dunder(
+        db: &'db dyn Db,
+        left: Type<'db>,
+        right: Type<'db>,
+        dunder: &'static str,
+        reflected_dunder: &'static str,
+        policy: MemberLookupPolicy,
+    ) -> Option<Type<'db>> {
+        let call_dunder = |name, receiver: Type<'db>, argument: Type<'db>| {
+            receiver
+                .try_call_dunder_with_policy(
+                    db,
+                    name,
+                    &mut CallArguments::positional([argument]),
+                    TypeContext::default(),
+                    policy,
+                )
+                .map(|outcome| outcome.return_type(db))
+                .ok()
+        };
+
+        match reflected_method_priority(db, left, right) {
+            ReflectedMethodPriority::Never => call_dunder(dunder, left, right)
+                .or_else(|| call_dunder(reflected_dunder, right, left)),
+            ReflectedMethodPriority::Possibly => {
+                match (
+                    call_dunder(dunder, left, right),
+                    call_dunder(reflected_dunder, right, left),
+                ) {
+                    (Some(normal), Some(reflected)) => {
+                        Some(UnionType::from_two_elements(db, normal, reflected))
+                    }
+                    (Some(result), None) | (None, Some(result)) => Some(result),
+                    (None, None) => None,
+                }
+            }
+            ReflectedMethodPriority::Definitely => call_dunder(reflected_dunder, right, left)
+                .or_else(|| call_dunder(dunder, left, right)),
+        }
+    }
+
     /// Memoize the pure return-type part of binary dunder resolution so repeated identical
     /// expressions don't re-run overload selection at every call site.
     pub(crate) fn try_call_bin_op_return_type(

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -12,6 +12,7 @@ use super::{
     CallArguments, EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass,
     LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Truthiness, Type, TypeContext,
     TypeVarBoundOrConstraints, UnionBuilder,
+    bool::BoolError,
     enums::{enum_member_literals, enum_metadata},
 };
 
@@ -293,14 +294,29 @@ impl<'db> TupleEqualityEvaluator<'db> {
         &mut self,
         left: Type<'db>,
         right: Type<'db>,
-        inferred_truthiness: Truthiness,
-    ) -> Truthiness {
-        // Identity can turn a false equality result true, but cannot turn a true result false.
-        if inferred_truthiness == Truthiness::AlwaysTrue {
-            return Truthiness::AlwaysTrue;
+    ) -> Result<Truthiness, BoolError<'db>> {
+        let db = self.evaluator.db;
+        let truthiness = evaluate_tuple_element_equality(&mut self.evaluator, left, right);
+        if !truthiness.is_ambiguous() {
+            return Ok(truthiness);
         }
 
-        evaluate_tuple_element_equality(&mut self.evaluator, left, right)
+        let Some(result) = Type::try_call_rich_comparison_dunder(
+            db,
+            left,
+            right,
+            "__eq__",
+            "__eq__",
+            MemberLookupPolicy::default(),
+        ) else {
+            return Ok(Truthiness::Ambiguous);
+        };
+
+        // Identity can turn a false equality result true, but cannot turn a true result false.
+        Ok(match result.try_bool(db)? {
+            Truthiness::AlwaysTrue => Truthiness::AlwaysTrue,
+            Truthiness::AlwaysFalse | Truthiness::Ambiguous => Truthiness::Ambiguous,
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -10,7 +10,7 @@ use crate::types::cyclic::CycleDetector;
 use crate::types::equality::{
     ComparisonSoundnessPolicy, TupleEqualityEvaluator, equality_truthiness, inequality_truthiness,
 };
-use crate::types::tuple::TupleSpec;
+use crate::types::tuple::{Tuple, TupleSpec};
 use crate::types::{
     DynamicType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
     LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext, TypeTransformer,
@@ -330,33 +330,24 @@ fn infer_binary_type_comparison_inner<'db>(
     }
 
     if let NonIdentityOperator::Membership(op) = op
-        && left.tuple_instance_spec(db).is_some()
         && let Some(right_tuple) = right.tuple_instance_spec(db)
+        && let Tuple::Fixed(right_tuple) = &*right_tuple
     {
         let mut any_eq = false;
         let mut any_ambiguous = false;
+        let mut equality = TupleEqualityEvaluator::new(db, soundness_policy);
 
-        for ty in right_tuple.iter_element_types(db) {
-            let eq_result = infer_binary_type_comparison_inner(
-                context,
-                left,
-                NonIdentityOperator::Rich(RichCompareOperator::Eq),
-                ty,
-                range,
-                visitor,
-            )
-            .expect("equality comparisons should always be supported");
-
-            match eq_result {
-                todo @ Type::Dynamic(DynamicType::Todo(_)) => return Ok(todo),
-                // It's okay to ignore errors here because Python doesn't call `__bool__`
-                // for different union variants. Instead, this is just for us to
-                // evaluate a possibly truthy value to `false` or `true`.
-                ty => match ty.bool(db) {
-                    Truthiness::AlwaysTrue => any_eq = true,
-                    Truthiness::AlwaysFalse => (),
-                    Truthiness::Ambiguous => any_ambiguous = true,
-                },
+        for &element_ty in right_tuple.elements_slice() {
+            // It's okay to ignore errors here because Python doesn't call `__bool__`
+            // for different union variants. Instead, this is just for us to
+            // evaluate a possibly truthy value to `false` or `true`.
+            match equality
+                .element_truthiness(element_ty, left)
+                .unwrap_or_else(|error| error.fallback_truthiness())
+            {
+                Truthiness::AlwaysTrue => any_eq = true,
+                Truthiness::AlwaysFalse => (),
+                Truthiness::Ambiguous => any_ambiguous = true,
             }
         }
 
@@ -1005,26 +996,14 @@ fn infer_rich_comparison<'db>(
     op: RichCompareOperator,
     policy: MemberLookupPolicy,
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
-    // The following resource has details about the rich comparison algorithm:
-    // https://snarky.ca/unravelling-rich-comparison-operators/
-    let call_dunder = |op: RichCompareOperator, left: Type<'db>, right: Type<'db>| {
-        left.try_call_dunder_with_policy(
-            db,
-            op.dunder(),
-            &mut CallArguments::positional([right]),
-            TypeContext::default(),
-            policy,
-        )
-        .map(|outcome| outcome.return_type(db))
-        .ok()
-    };
-
-    // The reflected dunder has priority if the right-hand side is a strict subclass of the left-hand side.
-    if left != right && right.is_subtype_of(db, left) {
-        call_dunder(op.reflect(), right, left).or_else(|| call_dunder(op, left, right))
-    } else {
-        call_dunder(op, left, right).or_else(|| call_dunder(op.reflect(), right, left))
-    }
+    Type::try_call_rich_comparison_dunder(
+        db,
+        left,
+        right,
+        op.dunder(),
+        op.reflect().dunder(),
+        policy,
+    )
     .or_else(|| {
         // When no appropriate method returns any value other than NotImplemented,
         // the `==` and `!=` operators will fall back to `is` and `is not`, respectively.
@@ -1126,24 +1105,14 @@ fn infer_tuple_rich_comparison<'db>(
             let mut equality = TupleEqualityEvaluator::new(db, soundness_policy);
 
             for (l_ty, r_ty) in left_iter.zip(right_iter) {
-                let pairwise_eq_result = infer_binary_type_comparison_inner(
-                    context,
-                    l_ty,
-                    NonIdentityOperator::Rich(RichCompareOperator::Eq),
-                    r_ty,
-                    range,
-                    visitor,
-                )
-                .expect("infer_binary_type_comparison should never return None for `==`");
-
-                let inferred_truthiness = pairwise_eq_result.try_bool(db).unwrap_or_else(|err| {
-                    // TODO: We should, whenever possible, pass the range of the left and right elements
-                    //   instead of the range of the whole tuple.
-                    err.report_diagnostic(context, range);
-                    Truthiness::Ambiguous
-                });
-
-                let eq_truthiness = equality.element_truthiness(l_ty, r_ty, inferred_truthiness);
+                let eq_truthiness = equality
+                    .element_truthiness(l_ty, r_ty)
+                    .unwrap_or_else(|err| {
+                        // TODO: We should, whenever possible, pass the range of the left and right elements
+                        //   instead of the range of the whole tuple.
+                        err.report_diagnostic(context, range);
+                        Truthiness::Ambiguous
+                    });
 
                 match eq_truthiness {
                     // - AlwaysTrue : Continue to the next pair for lexicographic comparison


### PR DESCRIPTION
Stacked on #26992.

## Summary

- Infer fixed-length tuple membership for scalar operands and empty tuples while keeping variable-length tuples conservative.
- Reuse tuple-element equality evaluation for membership and lexicographic comparisons, accounting for identity-before-equality, custom comparison methods, and correlated enum/type-variable values.
- Centralize rich-comparison dispatch and preserve both possible return types when reflected subclass methods may take precedence.