### PR TITLE
[ty] Fix `missing-override-decorator` suggestion before Python 3.12

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -558,6 +558,82 @@ class StubAbstractImplementation(StubAbstractInterface):
     def method(self) -> int: ...  # error: [missing-override-decorator]
 ```
 
+## Missing `@override` decorator on Python 3.11
+
+```toml
+[environment]
+python-version = "3.11"
+
+[rules]
+missing-override-decorator = "error"
+```
+
+```py
+from typing_extensions import override
+
+class Parent:
+    def method(self) -> None: ...
+
+class Child(Parent):
+    def method(self) -> None: ...  # snapshot: missing-override-decorator
+
+class ExplicitChild(Parent):
+    @override
+    def method(self) -> None: ...
+```
+
+```snapshot
+error[missing-override-decorator]: Method `method` overrides `Parent.method` but is not decorated with `@override`
+ --> src/mdtest_snippet.py:4:9
+  |
+4 |     def method(self) -> None: ...
+  |         ------ `Parent.method` defined here
+5 |
+6 | class Child(Parent):
+7 |     def method(self) -> None: ...  # snapshot: missing-override-decorator
+  |         ^^^^^^
+  |
+info: Decorate the method with `@typing_extensions.override` to make the override explicit
+```
+
+## Missing `@override` decorator on Python 3.12
+
+```toml
+[environment]
+python-version = "3.12"
+
+[rules]
+missing-override-decorator = "error"
+```
+
+```py
+from typing import override
+
+class Parent:
+    def method(self) -> None: ...
+
+class Child(Parent):
+    def method(self) -> None: ...  # snapshot: missing-override-decorator
+
+class ExplicitChild(Parent):
+    @override
+    def method(self) -> None: ...
+```
+
+```snapshot
+error[missing-override-decorator]: Method `method` overrides `Parent.method` but is not decorated with `@override`
+ --> src/mdtest_snippet.py:4:9
+  |
+4 |     def method(self) -> None: ...
+  |         ------ `Parent.method` defined here
+5 |
+6 | class Child(Parent):
+7 |     def method(self) -> None: ...  # snapshot: missing-override-decorator
+  |         ^^^^^^
+  |
+info: Decorate the method with `@typing.override` to make the override explicit
+```
+
 ## Possibly-unbound definitions
 
 ```py

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -1553,7 +1553,14 @@ fn check_missing_overrides<'db>(
         "Method `{}` overrides `{superclass_member}` but is not decorated with `@override`",
         member.name
     ));
-    diagnostic.info("Decorate the method with `@typing.override` to make the override explicit");
+    let override_module = if Program::get(db).python_version(db) >= PythonVersion::PY312 {
+        "typing"
+    } else {
+        "typing_extensions"
+    };
+    diagnostic.info(format_args!(
+        "Decorate the method with `@{override_module}.override` to make the override explicit"
+    ));
 
     if let Some(superclass_definition) = superclass_definition
         && superclass_definition.file(db) == context.file()


### PR DESCRIPTION
## Summary

`missing-override-decorator` always suggested `@typing.override`, even when checking code targeting Python versions earlier than 3.12, where that decorator is unavailable. Select the suggested module from the configured Python version so older targets are directed to `@typing_extensions.override` while Python 3.12+ continues to use `@typing.override`.

Closes https://github.com/astral-sh/ty/issues/4085.

## Test plan

- Add mdtests for Python 3.11 and 3.12 that snapshot the version-appropriate suggestion.
- Cover explicit overrides imported from `typing_extensions` on Python 3.11 and from `typing` on Python 3.12, confirming both satisfy the rule.
- Verify concise diagnostic output remains clear.