### PR TITLE
[ty] Improve union and intersection builder performance

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5877,10 +5877,10 @@ impl<'db> Type<'db> {
                 // Flatten each positive element and rebuild through the intersection builder.
                 let mut builder = IntersectionBuilder::new(db);
                 for pos in intersection.positive(db) {
-                    builder = builder.add_positive(pos.flatten_typevars(db));
+                    builder.add_positive_in_place(pos.flatten_typevars(db));
                 }
                 for neg in intersection.negative(db) {
-                    builder = builder.add_negative(neg.flatten_typevars(db));
+                    builder.add_negative_in_place(neg.flatten_typevars(db));
                 }
                 builder.build()
             }
@@ -6758,8 +6758,12 @@ impl<'db> Type<'db> {
             Type::Intersection(intersection) => {
                 let mut builder = IntersectionBuilder::new(db);
                 for positive in intersection.positive(db) {
-                    builder =
-                        builder.add_positive(positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+                    builder.add_positive_in_place(positive.apply_type_mapping_impl(
+                        db,
+                        type_mapping,
+                        tcx,
+                        visitor,
+                    ));
                 }
                 // Regular promotion should remove negative contributions from intersections,
                 // so we don't preserve them here when regular promotion is enabled.
@@ -6768,7 +6772,7 @@ impl<'db> Type<'db> {
                     TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular)
                 ) {
                     for negative in intersection.negative(db) {
-                        builder = builder.add_negative(
+                        builder.add_negative_in_place(
                             negative.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
                         );
                     }

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -726,7 +726,7 @@ impl<'db> BoundSuperType<'db> {
                 for positive in intersection.positive(db) {
                     if let Ok(good_element) = delegate_to(*positive) {
                         one_good_element_found = true;
-                        builder = builder.add_positive(good_element);
+                        builder.add_positive_in_place(good_element);
                     }
                 }
                 if !one_good_element_found {
@@ -738,7 +738,7 @@ impl<'db> BoundSuperType<'db> {
                 }
                 for negative in intersection.negative(db) {
                     if let Ok(good_element) = delegate_to(*negative) {
-                        builder = builder.add_negative(good_element);
+                        builder.add_negative_in_place(good_element);
                     }
                 }
                 return Ok(builder.build());

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -780,7 +780,7 @@ impl<'db> EnumComplementType<'db> {
 
         let mut builder = IntersectionBuilder::new(db).add_positive(literal);
         for rest in self.rest(db) {
-            builder = builder.add_positive(*rest);
+            builder.add_positive_in_place(*rest);
         }
         builder.build()
     }

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1121,7 +1121,7 @@ fn evaluate_intersection_left<'db>(
             ComparisonResult::AlwaysFalse => any_false = true,
             ComparisonResult::CanNarrow(narrowed) => {
                 any_narrowing = true;
-                builder = builder.add_positive(narrowed);
+                builder.add_positive_in_place(narrowed);
             }
             ComparisonResult::Ambiguous => any_ambiguous = true,
         }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1789,10 +1789,10 @@ fn is_instance_truthiness<'db>(
                 } else if let Type::TypeVar(tvar) = positive {
                     match tvar.typevar(db).bound_or_constraints(db) {
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            effective = effective.add_positive(bound);
+                            effective.add_positive_in_place(bound);
                         }
                         Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                            effective = effective.add_positive(constraints.as_type(db));
+                            effective.add_positive_in_place(constraints.as_type(db));
                         }
                         // A typevar without bounds/constraints has `object` as its implicit upper bound,
                         // and adding `object` to an intersection is a no-op
@@ -1801,9 +1801,9 @@ fn is_instance_truthiness<'db>(
                     found_tvars_or_newtypes = true;
                 } else if let Type::NewTypeInstance(newtype) = positive {
                     found_tvars_or_newtypes = true;
-                    effective = effective.add_positive(newtype.concrete_base_type(db));
+                    effective.add_positive_in_place(newtype.concrete_base_type(db));
                 } else {
-                    effective = effective.add_positive(positive);
+                    effective.add_positive_in_place(positive);
                 }
             }
 
@@ -1815,7 +1815,7 @@ fn is_instance_truthiness<'db>(
                 if is_instance_truthiness(db, negative, class).is_always_true() {
                     return Truthiness::AlwaysFalse;
                 }
-                effective = effective.add_negative(negative);
+                effective.add_negative_in_place(negative);
             }
 
             let effective = effective.build();

--- a/crates/ty_python_semantic/src/types/narrow/containment.rs
+++ b/crates/ty_python_semantic/src/types/narrow/containment.rs
@@ -175,7 +175,7 @@ pub(super) fn narrow_string_membership<'db>(
     {
         let mut builder = IntersectionBuilder::new(db).add_positive(narrowed);
         for character in haystack.chars() {
-            builder = builder.add_negative(Type::single_char_string_literal(db, character));
+            builder.add_negative_in_place(Type::single_char_string_literal(db, character));
         }
         narrowed = builder.build();
     }

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -208,10 +208,10 @@ impl Ty {
             Ty::Intersection { pos, neg } => {
                 let mut builder = IntersectionBuilder::new(db);
                 for p in pos {
-                    builder = builder.add_positive(p.into_type(db));
+                    builder.add_positive_in_place(p.into_type(db));
                 }
                 for n in neg {
-                    builder = builder.add_negative(n.into_type(db));
+                    builder.add_negative_in_place(n.into_type(db));
                 }
                 builder.build()
             }

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -55,10 +55,13 @@ impl<'db> UnionType<'db> {
 
         if let Some(first) = iter_elements.next() {
             if let Some(second) = iter_elements.next() {
-                let builder = UnionBuilder::new(db).add(first.into()).add(second.into());
-                iter_elements
-                    .fold(builder, |builder, element| builder.add(element.into()))
-                    .build()
+                let mut builder = UnionBuilder::new(db);
+                builder.add_in_place(first.into());
+                builder.add_in_place(second.into());
+                for element in iter_elements {
+                    builder.add_in_place(element.into());
+                }
+                builder.build()
             } else {
                 first.into()
             }
@@ -93,13 +96,11 @@ impl<'db> UnionType<'db> {
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
     {
-        elements
-            .into_iter()
-            .fold(
-                UnionBuilder::new(db).unpack_aliases(false),
-                |builder, element| builder.add(element.into()),
-            )
-            .build()
+        let mut builder = UnionBuilder::new(db).unpack_aliases(false);
+        for element in elements {
+            builder.add_in_place(element.into());
+        }
+        builder.build()
     }
 
     /// Returns `true` if any direct element of this union is a type alias.
@@ -122,13 +123,11 @@ impl<'db> UnionType<'db> {
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
     {
-        elements
-            .into_iter()
-            .fold(
-                UnionBuilder::new(db).cycle_recovery(true),
-                |builder, element| builder.add(element.into()),
-            )
-            .build()
+        let mut builder = UnionBuilder::new(db).cycle_recovery(true);
+        for element in elements {
+            builder.add_in_place(element.into());
+        }
+        builder.build()
     }
 
     /// A fallible version of [`UnionType::from_elements`].
@@ -143,7 +142,7 @@ impl<'db> UnionType<'db> {
     {
         let mut builder = UnionBuilder::new(db);
         for element in elements {
-            builder = builder.add(element?.into());
+            builder.add_in_place(element?.into());
         }
         Some(builder.build())
     }
@@ -173,11 +172,11 @@ impl<'db> UnionType<'db> {
             if &new_ty != ty {
                 let mut builder = UnionBuilder::new(db).unpack_aliases(false);
                 for prev in &elements[..i] {
-                    builder = builder.add(*prev);
+                    builder.add_in_place(*prev);
                 }
-                builder = builder.add(new_ty);
+                builder.add_in_place(new_ty);
                 for (_, element) in iter {
-                    builder = builder.add(transform_fn(element));
+                    builder.add_in_place(transform_fn(element));
                 }
                 return builder
                     .recursively_defined(self.recursively_defined(db))
@@ -214,13 +213,13 @@ impl<'db> UnionType<'db> {
         while let Some((i, ty)) = iter.next() {
             let new_ty = transform_fn(ty)?;
             if &new_ty != ty || matches!(new_ty, Type::TypeAlias(_)) {
-                let mut builder = elements[..i]
-                    .iter()
-                    .copied()
-                    .fold(UnionBuilder::new(db), UnionBuilder::add);
-                builder = builder.add(new_ty);
+                let mut builder = UnionBuilder::new(db);
+                for prev in &elements[..i] {
+                    builder.add_in_place(*prev);
+                }
+                builder.add_in_place(new_ty);
                 for (_, element) in iter {
-                    builder = builder.add(transform_fn(element)?);
+                    builder.add_in_place(transform_fn(element)?);
                 }
                 return Ok(builder
                     .recursively_defined(self.recursively_defined(db))
@@ -307,7 +306,7 @@ impl<'db> UnionType<'db> {
                     provenance = provenance.or(member_provenance);
 
                     all_unbound = false;
-                    builder = builder.add(ty_member);
+                    builder.add_in_place(ty_member);
                 }
             }
         }
@@ -367,7 +366,7 @@ impl<'db> UnionType<'db> {
                     provenance = provenance.or(member_provenance);
 
                     all_unbound = false;
-                    builder = builder.add(ty_member);
+                    builder.add_in_place(ty_member);
                 }
             }
         }
@@ -411,7 +410,7 @@ impl<'db> UnionType<'db> {
                 if ty.same_divergent_marker(div) {
                     return Some(ty);
                 }
-                builder = builder.add(ty);
+                builder.add_in_place(ty);
                 empty = false;
             } else {
                 // `Divergent` in a union type does not mean true divergence, so we skip it if not nested.
@@ -420,7 +419,7 @@ impl<'db> UnionType<'db> {
                     builder = builder.recursively_defined(RecursivelyDefined::Yes);
                     continue;
                 }
-                builder = builder.add(
+                builder.add_in_place(
                     ty.recursive_type_normalized_impl(db, div, nested)
                         .unwrap_or(div),
                 );
@@ -428,7 +427,7 @@ impl<'db> UnionType<'db> {
             }
         }
         if empty {
-            builder = builder.add(div);
+            builder.add_in_place(div);
         }
         Some(builder.build())
     }
@@ -768,13 +767,12 @@ impl<'db> IntersectionType<'db> {
 
         if let Some(first) = elements_iter.next() {
             if let Some(second) = elements_iter.next() {
-                let builder =
+                let mut builder =
                     IntersectionBuilder::new(db).positive_elements([first.into(), second.into()]);
-                elements_iter
-                    .fold(builder, |builder, element| {
-                        builder.add_positive(element.into())
-                    })
-                    .build()
+                for element in elements_iter {
+                    builder.add_positive_in_place(element.into());
+                }
+                builder.build()
             } else {
                 first.into()
             }
@@ -936,10 +934,10 @@ impl<'db> IntersectionType<'db> {
     ) -> Type<'db> {
         let mut builder = IntersectionBuilder::new(db);
         for ty in self.positive(db) {
-            builder = builder.add_positive(transform_fn(ty));
+            builder.add_positive_in_place(transform_fn(ty));
         }
         for ty in self.negative(db) {
-            builder = builder.add_negative(*ty);
+            builder.add_negative_in_place(*ty);
         }
         builder.build()
     }
@@ -959,13 +957,11 @@ impl<'db> IntersectionType<'db> {
             return None;
         }
 
-        Some(
-            self.iter_positive(db)
-                .fold(IntersectionBuilder::new(db), |builder, positive| {
-                    builder.add_positive(positive.dunder_class(db))
-                })
-                .build(),
-        )
+        let mut builder = IntersectionBuilder::new(db);
+        for positive in self.iter_positive(db) {
+            builder.add_positive_in_place(positive.dunder_class(db));
+        }
+        Some(builder.build())
     }
 
     pub(crate) fn map_with_boundness(
@@ -997,7 +993,7 @@ impl<'db> IntersectionType<'db> {
                     }
                     provenance = provenance.or(member_provenance);
 
-                    builder = builder.add_positive(ty_member);
+                    builder.add_positive_in_place(ty_member);
                 }
             }
         }
@@ -1053,7 +1049,7 @@ impl<'db> IntersectionType<'db> {
                     }
                     provenance = provenance.or(member_provenance);
 
-                    builder = builder.add_positive(ty_member);
+                    builder.add_positive_in_place(ty_member);
                 }
             }
         }
@@ -1127,7 +1123,7 @@ impl<'db> IntersectionType<'db> {
             if let Some(projection) = positive.to_instance(db) {
                 has_projected_positive = true;
                 is_exact &= projection.is_exact();
-                builder = builder.add_positive(projection.into_inner());
+                builder.add_positive_in_place(projection.into_inner());
             } else {
                 is_exact = false;
             }
@@ -1159,10 +1155,10 @@ fn expand_intersection_typevars_and_newtypes<'db>(
             Type::TypeVar(tvar) => {
                 match tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        builder = builder.add_positive(bound);
+                        builder.add_positive_in_place(bound);
                     }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                        builder = builder.add_positive(constraints.as_type(db));
+                        builder.add_positive_in_place(constraints.as_type(db));
                     }
                     // Type variables without bounds or constraints implicitly have `object`
                     // as their upper bound, and adding `object` to an intersection is always a no-op
@@ -1170,14 +1166,14 @@ fn expand_intersection_typevars_and_newtypes<'db>(
                 }
             }
             Type::NewTypeInstance(newtype) => {
-                builder = builder.add_positive(newtype.concrete_base_type(db));
+                builder.add_positive_in_place(newtype.concrete_base_type(db));
             }
-            _ => builder = builder.add_positive(element),
+            _ => builder.add_positive_in_place(element),
         }
     }
 
     for &element in negative {
-        builder = builder.add_negative(element);
+        builder.add_negative_in_place(element);
     }
 
     builder.build()

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -267,13 +267,13 @@ fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'
             let mut builder =
                 IntersectionBuilder::new(db).add_positive(enum_class.to_non_generic_instance(db));
             for rest in complement.rest(db) {
-                builder = builder.add_positive(*rest);
+                builder.add_positive_in_place(*rest);
             }
             for name in enum_class_literal
                 .member_names(db)
                 .filter(|name| shared_excluded_names.contains(*name))
             {
-                builder = builder.add_negative(Type::enum_literal(EnumLiteralType::new(
+                builder.add_negative_in_place(Type::enum_literal(EnumLiteralType::new(
                     db,
                     enum_class_literal,
                     name,
@@ -1228,15 +1228,16 @@ impl<'db> IntersectionBuilder<'db> {
         );
     }
 
-    pub(crate) fn add_positive(self, ty: Type<'db>) -> Self {
-        self.add_positive_impl(ty, &mut vec![])
+    pub(crate) fn add_positive(mut self, ty: Type<'db>) -> Self {
+        self.add_positive_in_place(ty);
+        self
     }
 
-    pub(crate) fn add_positive_impl(
-        mut self,
-        ty: Type<'db>,
-        seen_aliases: &mut Vec<Type<'db>>,
-    ) -> Self {
+    pub(crate) fn add_positive_in_place(&mut self, ty: Type<'db>) {
+        self.add_positive_impl(ty, &mut vec![]);
+    }
+
+    pub(crate) fn add_positive_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
         match ty {
             Type::TypeAlias(alias) => {
                 if seen_aliases.contains(&ty) {
@@ -1244,11 +1245,11 @@ impl<'db> IntersectionBuilder<'db> {
                     for inner in &mut self.intersections {
                         inner.positive.insert(ty);
                     }
-                    return self;
+                    return;
                 }
                 seen_aliases.push(ty);
                 let value_type = alias.value_type(self.db);
-                self.add_positive_impl(value_type, seen_aliases)
+                self.add_positive_impl(value_type, seen_aliases);
             }
             Type::Union(union) => {
                 // Distribute ourself over this union: for each union element, clone ourself and
@@ -1259,29 +1260,27 @@ impl<'db> IntersectionBuilder<'db> {
                 // (T2 & T4)`. If `self` is already a union-of-intersections `(T1 & T2) | (T3 & T4)`
                 // and we add `T5 | T6` to it, that flattens all the way out to `(T1 & T2 & T5) | (T1 &
                 // T2 & T6) | (T3 & T4 & T5) ...` -- you get the idea.
-                union
-                    .elements(self.db)
-                    .iter()
-                    .map(|elem| self.clone().add_positive_impl(*elem, seen_aliases))
-                    .fold(IntersectionBuilder::empty(self.db), |mut builder, sub| {
-                        builder.extend(sub);
-                        builder
-                    })
+                let mut distributed = IntersectionBuilder::empty(self.db);
+                for elem in union.elements(self.db) {
+                    let mut branch = self.clone();
+                    branch.add_positive_impl(*elem, seen_aliases);
+                    distributed.extend(branch);
+                }
+                self.intersections = distributed.intersections;
             }
             // `(A & B & ~C) & (D & E & ~F)` -> `A & B & D & E & ~C & ~F`
             Type::Intersection(other) => {
                 let db = self.db;
                 for pos in other.positive(db) {
-                    self = self.add_positive_impl(*pos, seen_aliases);
+                    self.add_positive_impl(*pos, seen_aliases);
                 }
                 for neg in other.negative(db) {
-                    self = self.add_negative_impl(*neg, seen_aliases);
+                    self.add_negative_impl(*neg, seen_aliases);
                 }
-                self
             }
             Type::EnumComplement(complement) => {
                 let db = self.db;
-                self.add_positive_impl(complement.to_intersection(db), seen_aliases)
+                self.add_positive_impl(complement.to_intersection(db), seen_aliases);
             }
             _ => {
                 // If we are already a union-of-intersections, distribute the new intersected element
@@ -1289,20 +1288,20 @@ impl<'db> IntersectionBuilder<'db> {
                 for inner in &mut self.intersections {
                     inner.add_positive(self.db, ty);
                 }
-                self
             }
         }
     }
 
-    pub(crate) fn add_negative(self, ty: Type<'db>) -> Self {
-        self.add_negative_impl(ty, &mut vec![])
+    pub(crate) fn add_negative(mut self, ty: Type<'db>) -> Self {
+        self.add_negative_in_place(ty);
+        self
     }
 
-    pub(crate) fn add_negative_impl(
-        mut self,
-        ty: Type<'db>,
-        seen_aliases: &mut Vec<Type<'db>>,
-    ) -> Self {
+    pub(crate) fn add_negative_in_place(&mut self, ty: Type<'db>) {
+        self.add_negative_impl(ty, &mut vec![]);
+    }
+
+    pub(crate) fn add_negative_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
         // See comments above in `add_positive`; this is just the negated version.
         match ty {
             Type::TypeAlias(alias) => {
@@ -1311,17 +1310,16 @@ impl<'db> IntersectionBuilder<'db> {
                     for inner in &mut self.intersections {
                         inner.negative.insert(ty);
                     }
-                    return self;
+                    return;
                 }
                 seen_aliases.push(ty);
                 let value_type = alias.value_type(self.db);
-                self.add_negative_impl(value_type, seen_aliases)
+                self.add_negative_impl(value_type, seen_aliases);
             }
             Type::Union(union) => {
                 for elem in union.elements(self.db) {
-                    self = self.add_negative_impl(*elem, seen_aliases);
+                    self.add_negative_impl(*elem, seen_aliases);
                 }
-                self
             }
             Type::Intersection(intersection) => {
                 // (A | B) & ~(C & ~D)
@@ -1331,41 +1329,29 @@ impl<'db> IntersectionBuilder<'db> {
                 // and negative constraints D, then our new intersection
                 // is (existing & ~C) | (existing & D)
 
-                let positive_side = intersection
-                    .positive(self.db)
-                    .iter()
-                    // we negate all the positive constraints while distributing
-                    .map(|elem| {
-                        self.clone()
-                            .add_negative_impl(*elem, &mut seen_aliases.clone())
-                    });
-
-                let negative_side = intersection
-                    .negative(self.db)
-                    .iter()
-                    // all negative constraints end up becoming positive constraints
-                    .map(|elem| {
-                        self.clone()
-                            .add_positive_impl(*elem, &mut seen_aliases.clone())
-                    });
-
-                positive_side.chain(negative_side).fold(
-                    IntersectionBuilder::empty(self.db),
-                    |mut builder, sub| {
-                        builder.extend(sub);
-                        builder
-                    },
-                )
+                let mut distributed = IntersectionBuilder::empty(self.db);
+                // We negate all the positive constraints while distributing.
+                for elem in intersection.positive(self.db) {
+                    let mut branch = self.clone();
+                    branch.add_negative_impl(*elem, &mut seen_aliases.clone());
+                    distributed.extend(branch);
+                }
+                // All negative constraints end up becoming positive constraints.
+                for elem in intersection.negative(self.db) {
+                    let mut branch = self.clone();
+                    branch.add_positive_impl(*elem, &mut seen_aliases.clone());
+                    distributed.extend(branch);
+                }
+                self.intersections = distributed.intersections;
             }
             Type::EnumComplement(complement) => {
                 let db = self.db;
-                self.add_negative_impl(complement.to_intersection(db), seen_aliases)
+                self.add_negative_impl(complement.to_intersection(db), seen_aliases);
             }
             _ => {
                 for inner in &mut self.intersections {
                     inner.add_negative(self.db, ty);
                 }
-                self
             }
         }
     }
@@ -1376,7 +1362,7 @@ impl<'db> IntersectionBuilder<'db> {
         T: Into<Type<'db>>,
     {
         for element in elements {
-            self = self.add_positive(element.into());
+            self.add_positive_in_place(element.into());
         }
         self
     }

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1237,7 +1237,7 @@ impl<'db> IntersectionBuilder<'db> {
         self.add_positive_impl(ty, &mut vec![]);
     }
 
-    pub(crate) fn add_positive_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
+    fn add_positive_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
         match ty {
             Type::TypeAlias(alias) => {
                 if seen_aliases.contains(&ty) {
@@ -1301,7 +1301,7 @@ impl<'db> IntersectionBuilder<'db> {
         self.add_negative_impl(ty, &mut vec![]);
     }
 
-    pub(crate) fn add_negative_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
+    fn add_negative_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
         // See comments above in `add_positive`; this is just the negated version.
         match ty {
             Type::TypeAlias(alias) => {

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -441,7 +441,7 @@ where
     if !results.is_empty() {
         let mut builder = IntersectionBuilder::new(db);
         for result in results {
-            builder = builder.add_positive(result);
+            builder.add_positive_in_place(result);
         }
         return Ok(builder.build());
     }
@@ -457,7 +457,7 @@ where
 
     for error in errors {
         if !any_has_method || error.any_method_available() {
-            builder = builder.add_positive(error.result_type());
+            builder.add_positive_in_place(error.result_type());
             let error_iter = error.into_errors().into_iter();
             if any_has_method {
                 collected_errors.extend(

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1824,7 +1824,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 for unpacked in &unpacked_elements {
                     if let Some(unpacked_key) = unpacked.keys.get(&key) {
                         saw_key = true;
-                        value_ty = value_ty.add(unpacked_key.value_ty);
+                        value_ty.add_in_place(unpacked_key.value_ty);
                         is_required &= unpacked_key.is_required;
                         definition = Some(if let Some(definition) = definition {
                             merge_unpacked_key_definitions(definition, unpacked_key.definition)
@@ -1833,7 +1833,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                         });
                     } else if let Some(extra_items) = unpacked.openness.effective_extra_items() {
                         saw_key = true;
-                        value_ty = value_ty.add(extra_items.declared_ty);
+                        value_ty.add_in_place(extra_items.declared_ty);
                         is_required = false;
                         definition = Some(None);
                     } else {


### PR DESCRIPTION
## Summary

The `add` operations move the `Union`/`IntersectionBuilder`. This can be noticeable in hot mappings and normalization where the fluent API also isn't required. This PR uses `add_in_place` in more places and also adds such an API to `IntersectionBuilder`. 

This improves performance by about 1%. I extracted this out of the scripts PR, so please remind that when considering the regression of this PR. I discovered this optimization because the scripts refactor PR increased the size of `UnionBuilder`, making the move more expensive.

Since I'm out Monday/Tuesday, feel free to merge.