### PR TITLE
[ty] Add `--exclude-scripts`  and `--include-scripts`

### DIFF
--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -56,6 +56,7 @@ over all configuration files.</p>
 <p>Cannot be used in combination with <code>--exit-zero</code> or <code>--exit-zero-on-warning</code>.</p>
 </dd><dt id="ty-check--exclude"><a href="#ty-check--exclude"><code>--exclude</code></a> <i>exclude</i></dt><dd><p>Glob patterns for files to exclude from type checking.</p>
 <p>Uses gitignore-style syntax to exclude files and directories from type checking. Supports patterns like <code>tests/</code>, <code>*.tmp</code>, <code>**/__pycache__/**</code>.</p>
+</dd><dt id="ty-check--exclude-scripts"><a href="#ty-check--exclude-scripts"><code>--exclude-scripts</code></a></dt><dd><p>Exclude files containing PEP 723 inline script metadata unless passed explicitly. Use <code>--include-scripts</code> to disable</p>
 </dd><dt id="ty-check--exit-zero"><a href="#ty-check--exit-zero"><code>--exit-zero</code></a></dt><dd><p>Always use exit code 0, even when there are error-level diagnostics.</p>
 <p>Cannot be used in combination with <code>--error-on-warning</code>.</p>
 </dd><dt id="ty-check--exit-zero-on-warning"><a href="#ty-check--exit-zero-on-warning"><code>--exit-zero-on-warning</code></a></dt><dd><p>Use exit code 0 if there are no error-level diagnostics.</p>

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -948,6 +948,33 @@ to re-include `dist` use `exclude = ["!dist"]`
 
 ---
 
+### `exclude-scripts`
+
+Whether to exclude files containing PEP 723 inline script metadata unless they are
+explicitly passed on the command line.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.src]
+    exclude-scripts = true
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [src]
+    exclude-scripts = true
+    ```
+
+---
+
 ### `include`
 
 A list of files and directories to check. The `include` option

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -204,6 +204,19 @@ pub(crate) struct CheckCommand {
     #[clap(long, overrides_with("force_exclude"), hide = true)]
     no_force_exclude: bool,
 
+    /// Exclude files containing PEP 723 inline script metadata unless passed explicitly.
+    /// Use `--include-scripts` to disable.
+    #[arg(
+        long,
+        overrides_with("include_scripts"),
+        help_heading = "File selection",
+        default_missing_value = "true",
+        num_args = 0..1
+    )]
+    exclude_scripts: Option<bool>,
+    #[clap(long, overrides_with("exclude_scripts"), hide = true)]
+    include_scripts: bool,
+
     /// Glob patterns for files to exclude from type checking.
     ///
     /// Uses gitignore-style syntax to exclude files and directories from type checking.
@@ -251,6 +264,10 @@ impl CheckCommand {
             .no_respect_ignore_files
             .then_some(false)
             .or(self.respect_ignore_files);
+        let exclude_scripts = self
+            .include_scripts
+            .then_some(false)
+            .or(self.exclude_scripts);
         let error_on_warning = self
             .exit_zero_on_warning
             .then_some(false)
@@ -279,6 +296,7 @@ impl CheckCommand {
             }),
             src: Some(SrcOptions {
                 respect_ignore_files,
+                exclude_scripts,
                 exclude: self.exclude.map(|excludes| {
                     RangedValue::cli(excludes.iter().map(RelativeGlobPattern::cli).collect())
                 }),

--- a/crates/ty/tests/cli/file_selection.rs
+++ b/crates/ty/tests/cli/file_selection.rs
@@ -2,6 +2,94 @@ use insta_cmd::assert_cmd_snapshot;
 
 use crate::CliTest;
 
+#[test]
+fn exclude_scripts_only_applies_to_implicitly_discovered_files() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("main.py", "value: int = 'project'"),
+        (
+            "script.py",
+            r#"
+            # /// script
+            # dependencies = []
+            # ///
+            value: int = "script"
+            "#,
+        ),
+        (
+            "nested/script.py",
+            r#"
+            # /// script
+            # dependencies = []
+            # ///
+            value: int = "nested-script"
+            "#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(case.command().env("TY_OUTPUT_FORMAT", "concise"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    main.py:1:14: error[invalid-assignment] Object of type `Literal["project"]` is not assignable to `int`
+    nested/script.py:5:14: error[invalid-assignment] Object of type `Literal["nested-script"]` is not assignable to `int`
+    script.py:5:14: error[invalid-assignment] Object of type `Literal["script"]` is not assignable to `int`
+    Found 3 diagnostics
+
+    ----- stderr -----
+    "#);
+
+    assert_cmd_snapshot!(case.command().env("TY_OUTPUT_FORMAT", "concise").arg("--exclude-scripts"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    main.py:1:14: error[invalid-assignment] Object of type `Literal["project"]` is not assignable to `int`
+    Found 1 diagnostic
+
+    ----- stderr -----
+    "#);
+
+    assert_cmd_snapshot!(case.command().env("TY_OUTPUT_FORMAT", "concise").arg("--exclude-scripts").arg("script.py"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    script.py:5:14: error[invalid-assignment] Object of type `Literal["script"]` is not assignable to `int`
+    Found 1 diagnostic
+
+    ----- stderr -----
+    "#);
+
+    case.write_file(
+        "ty.toml",
+        r#"
+        [src]
+        exclude-scripts = true
+        "#,
+    )?;
+
+    assert_cmd_snapshot!(case.command().env("TY_OUTPUT_FORMAT", "concise"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    main.py:1:14: error[invalid-assignment] Object of type `Literal["project"]` is not assignable to `int`
+    Found 1 diagnostic
+
+    ----- stderr -----
+    "#);
+    assert_cmd_snapshot!(case.command().env("TY_OUTPUT_FORMAT", "concise").arg("--include-scripts"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    main.py:1:14: error[invalid-assignment] Object of type `Literal["project"]` is not assignable to `int`
+    nested/script.py:5:14: error[invalid-assignment] Object of type `Literal["nested-script"]` is not assignable to `int`
+    script.py:5:14: error[invalid-assignment] Object of type `Literal["script"]` is not assignable to `int`
+    Found 3 diagnostics
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
 /// Test exclude CLI argument functionality
 #[test]
 fn exclude_argument() -> anyhow::Result<()> {

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -24,7 +24,7 @@ mod configuration_file;
 pub mod options;
 pub mod pyproject;
 pub mod python_version;
-mod script;
+pub(crate) mod script;
 pub mod settings;
 mod uv;
 pub mod value;

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -943,6 +943,18 @@ pub struct SrcOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub respect_ignore_files: Option<bool>,
 
+    /// Whether to exclude files containing PEP 723 inline script metadata unless they are
+    /// explicitly passed on the command line.
+    #[option(
+        default = r#"false"#,
+        value_type = r#"bool"#,
+        example = r#"
+            exclude-scripts = true
+        "#
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclude_scripts: Option<bool>,
+
     /// A list of files and directories to check. The `include` option
     /// follows a similar syntax to `.gitignore` but reversed:
     /// Including a file or directory will make it so that it (and its contents)
@@ -1062,6 +1074,7 @@ impl SrcOptions {
 
         Ok(SrcSettings {
             respect_ignore_files: self.respect_ignore_files.unwrap_or(true),
+            exclude_scripts: self.exclude_scripts.unwrap_or(false),
             files,
         })
     }

--- a/crates/ty_project/src/metadata/settings.rs
+++ b/crates/ty_project/src/metadata/settings.rs
@@ -81,12 +81,14 @@ impl Default for TerminalSettings {
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
 pub struct SrcSettings {
     pub respect_ignore_files: bool,
+    pub exclude_scripts: bool,
     pub files: IncludeExcludeFilter,
 }
 impl SrcSettings {
     pub(crate) fn default() -> Self {
         Self {
             respect_ignore_files: true,
+            exclude_scripts: false,
             files: IncludeExcludeFilter::default(),
         }
     }

--- a/crates/ty_project/src/walk.rs
+++ b/crates/ty_project/src/walk.rs
@@ -1,4 +1,5 @@
 use crate::glob::IncludeExcludeFilter;
+use crate::metadata::script::script_metadata;
 use crate::{Db, GlobFilterCheckMode, IncludeResult, Project};
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
 use ruff_db::files::{File, system_path_to_file};
@@ -167,6 +168,7 @@ impl ProjectFilesWalker {
         };
 
         let filter = ProjectFilesFilter::from_project(db, project);
+        let exclude_scripts = project.settings(db).src().exclude_scripts;
         let files = std::sync::Mutex::new(Vec::new());
         let diagnostics = std::sync::Mutex::new(Vec::new());
 
@@ -259,6 +261,18 @@ impl ProjectFilesWalker {
                             // If this returns `Err`, then the file was deleted between now and when the walk callback was called.
                             // We can ignore this.
                             if let Ok(file) = system_path_to_file(&*db, entry.path()) {
+                                if entry.depth() > 0
+                                    && exclude_scripts
+                                    && script_metadata(&*db, file).is_some()
+                                {
+                                    tracing::debug!(
+                                        "Ignoring implicitly discovered PEP 723 script `{path}` \
+                                        because `exclude-scripts` is enabled.",
+                                        path = entry.path()
+                                    );
+                                    return WalkState::Skip;
+                                }
+
                                 files.lock().unwrap().push(file);
                             }
                         }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -46,6 +46,7 @@ Settings: Settings {
     },
     src: SrcSettings {
         respect_ignore_files: true,
+        exclude_scripts: false,
         files: IncludeExcludeFilter {
             include: IncludeFilter(
                 [

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -1586,6 +1586,13 @@
             }
           ]
         },
+        "exclude-scripts": {
+          "description": "Whether to exclude files containing PEP 723 inline script metadata unless they are\nexplicitly passed on the command line.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "include": {
           "description": "A list of files and directories to check. The `include` option\nfollows a similar syntax to `.gitignore` but reversed:\nIncluding a file or directory will make it so that it (and its contents)\nare type checked.\n\n- `./src/` matches only a directory\n- `./src` matches both files and directories\n- `src` matches a file or directory named `src`\n- `*` matches any (possibly empty) sequence of characters (except `/`).\n- `**` matches zero or more path components.\n  This sequence **must** form a single path component, so both `**a` and `b**` are invalid and will result in an error.\n  A sequence of more than two consecutive `*` characters is also invalid.\n- `?` matches any single character except `/`\n- `[abc]` matches any character inside the brackets. Character sequences can also specify ranges of characters, as ordered by Unicode,\n  so e.g. `[0-9]` specifies any character between `0` and `9` inclusive. An unclosed bracket is invalid.\n\nAll paths are anchored relative to the project root (`src` only\nmatches `<project_root>/src` and not `<project_root>/test/src`).\n\n`exclude` takes precedence over `include`.",
           "anyOf": [


### PR DESCRIPTION
This is a 3rd pseudo-alternative to 

* https://github.com/astral-sh/uv/pull/20676
* https://github.com/astral-sh/ruff/pull/27165

which @MichaReiser suggested as a way to ask for the desired behaviour that becomes "standard API" and not like, some random "oh are we doing uv?" escape-hatch.

Notably here a PEP 723 script is only excluded if it's "implicitly selected" in much the same way that this still checks `bar.py`: `ty check --exclude foo/ -- foo/bar.py`

`--include-scripts` is the default and exists only to negate `--exclude-scripts` in e.g. config-vs-cli-arg fights (and maybe will be nice if we ever change the default).