### PR TITLE
[`ruff`] Drop `ruff-ecosystem` override for `apache/airflow`

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -23,12 +23,6 @@ DEFAULT_TARGETS = [
     Project(
         repo=Repository(owner="apache", name="airflow", ref="main"),
         check_options=CheckOptions(select="ALL"),
-        config_overrides={
-            # Broken symlink
-            "exclude": [
-                "task-sdk/src/airflow/sdk/_shared/AGENTS.md",
-            ]
-        },
     ),
     Project(
         repo=Repository(owner="apache", name="superset", ref="master"),


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This reverts commit dd16d689abd9d0fa1caf4316e70479fd422b6142 (#23921), since issue upstream is fixed in https://github.com/apache/airflow/pull/64920 and workaround is no longer needed.

https://patch-diff.githubusercontent.com/raw/apache/airflow/pull/64920.diff

```diff
diff --git a/task-sdk/src/airflow/sdk/_shared/AGENTS.md b/task-sdk/src/airflow/sdk/_shared/AGENTS.md
index 8d2c7cf9d3367..57a3a75046e45 120000
--- a/task-sdk/src/airflow/sdk/_shared/AGENTS.md
+++ b/task-sdk/src/airflow/sdk/_shared/AGENTS.md
@@ -1 +1 @@
-../../../../../airflow-core/src/airflow/_shared/AGENTS..md
\ No newline at end of file
+../../../../../airflow-core/src/airflow/_shared/AGENTS.md
\ No newline at end of file
```

So workaround is no longer needed.

## Test Plan

`ruff-ecosystem` runs without issues.
