### PR TITLE
[`ruff`] reintroduce `sphinx-doc/sphinx` to `ruff-ecosystem`

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/defaults.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/defaults.py
@@ -88,19 +88,17 @@ DEFAULT_TARGETS = [
     Project(
         repo=Repository(owner="scikit-build", name="scikit-build-core", ref="main")
     ),
-    # TODO(charlie): Ecosystem check fails in non-preview due to the direct
-    # selection of preview rules.
-    # Project(
-    #     repo=Repository(
-    #         owner="sphinx-doc",
-    #         name="sphinx",
-    #         ref="master",
-    #     ),
-    #     format_options=FormatOptions(
-    #         # Does not contain valid UTF-8
-    #         exclude="tests/roots/test-pycode/cp_1251_coded.py"
-    #     ),
-    # ),
+    Project(
+        repo=Repository(
+            owner="sphinx-doc",
+            name="sphinx",
+            ref="master",
+        ),
+        format_options=FormatOptions(
+            # Does not contain valid UTF-8
+            exclude="tests/roots/test-pycode/cp_1251_coded.py"
+        ),
+    ),
     Project(repo=Repository(owner="spruceid", name="siwe-py", ref="main")),
     Project(repo=Repository(owner="tiangolo", name="fastapi", ref="master")),
     Project(repo=Repository(owner="yandex", name="ch-backup", ref="main")),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Previously disabled in https://github.com/astral-sh/ruff/pull/9854

Not sure which preview rule was the blocker exactly, but apparently it's now stabilized and we can use `sphinx` in `ruff-ecosystem`.


## Test Plan

I ran `ruff-ecosystem` locally with and without `--force-preview` and it worked without issues.