### PR TITLE
[ty] Don't store `source_order` in BDD nodes

### DIFF
--- a/crates/ty_python_semantic/resources/corpus/recursive_bound_method_source_order.py
+++ b/crates/ty_python_semantic/resources/corpus/recursive_bound_method_source_order.py
@@ -1,0 +1,28 @@
+# Regression test for the steam.py ecosystem failure in
+# https://github.com/astral-sh/ruff/pull/27176.
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar
+
+
+class PartialApp:
+    pass
+
+
+AppT = TypeVar("AppT", bound=PartialApp, covariant=True)
+
+
+class BaseOwnedBadge(Protocol[AppT]):
+    app: AppT
+
+    def __init__(self, app: AppT) -> None:
+        pass
+
+    async def progress(self: BaseOwnedBadge[PartialApp]) -> None:
+        pass
+
+
+class FavouriteBadge(BaseOwnedBadge[AppT]):
+    def __init__(self, app: AppT) -> None:
+        super().__init__(app)

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1190,6 +1190,50 @@ class MyCallable:
 reveal_type(call(MyCallable()))  # revealed: int
 ```
 
+## Callable return union order does not affect inference
+
+```py
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+
+class Box(Generic[T_co]): ...
+
+def ensure_tuple(func: Callable[[], tuple[T, ...] | T]) -> tuple[T, ...]:
+    raise NotImplementedError
+
+def ensure_tuple_reversed(func: Callable[[], T | tuple[T, ...]]) -> tuple[T, ...]:
+    raise NotImplementedError
+
+def ensure_box(func: Callable[[], Box[T] | T]) -> Box[T]:
+    raise NotImplementedError
+
+def ensure_box_reversed(func: Callable[[], T | Box[T]]) -> Box[T]:
+    raise NotImplementedError
+
+def check(
+    scalar_first: Callable[[], str | tuple[str, ...]],
+    tuple_first: Callable[[], tuple[str, ...] | str],
+    nested_member_first: Callable[[], Box[str] | tuple[Box[str], ...]],
+    nested_tuple_first: Callable[[], tuple[Box[str], ...] | Box[str]],
+    box_scalar_first: Callable[[], str | Box[str]],
+    box_first: Callable[[], Box[str] | str],
+) -> None:
+    reveal_type(ensure_tuple(scalar_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple(tuple_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(scalar_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(tuple_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple(nested_member_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple(nested_tuple_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_member_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_tuple_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_box(box_scalar_first))  # revealed: Box[str]
+    reveal_type(ensure_box(box_first))  # revealed: Box[str]
+    reveal_type(ensure_box_reversed(box_scalar_first))  # revealed: Box[str]
+    reveal_type(ensure_box_reversed(box_first))  # revealed: Box[str]
+```
+
 ## Passing a constrained TypeVar to a function expecting a compatible constrained TypeVar
 
 A constrained TypeVar should be assignable to a different constrained TypeVar if each constraint of

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1234,6 +1234,24 @@ def check(
     reveal_type(ensure_box_reversed(box_first))  # revealed: Box[str]
 ```
 
+## Gradual container constraints preserve inference evidence
+
+`Collection` inherits from `Container[Any]`, so inferring a type variable from a collection passed
+to a contravariant `Container` must preserve the gradual constraint.
+
+```py
+from collections.abc import Container
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+def value(items: Container[T]) -> T:
+    raise NotImplementedError
+
+items: list[str] = []
+reveal_type(value(items))  # revealed: Any
+```
+
 ## Passing a constrained TypeVar to a function expecting a compatible constrained TypeVar
 
 A constrained TypeVar should be assignable to a different constrained TypeVar if each constraint of

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1226,6 +1226,49 @@ def get_int() -> int | None: ...
 reveal_type(my_iter(get_int))  # revealed: Box[int]
 ```
 
+### Callable return union order does not affect inference
+
+```py
+from typing import Callable
+
+class Box[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+def ensure_tuple[T](func: Callable[[], tuple[T, ...] | T]) -> tuple[T, ...]:
+    raise NotImplementedError
+
+def ensure_tuple_reversed[T](func: Callable[[], T | tuple[T, ...]]) -> tuple[T, ...]:
+    raise NotImplementedError
+
+def ensure_box[T](func: Callable[[], Box[T] | T]) -> Box[T]:
+    raise NotImplementedError
+
+def ensure_box_reversed[T](func: Callable[[], T | Box[T]]) -> Box[T]:
+    raise NotImplementedError
+
+def check(
+    scalar_first: Callable[[], str | tuple[str, ...]],
+    tuple_first: Callable[[], tuple[str, ...] | str],
+    nested_member_first: Callable[[], Box[str] | tuple[Box[str], ...]],
+    nested_tuple_first: Callable[[], tuple[Box[str], ...] | Box[str]],
+    box_scalar_first: Callable[[], str | Box[str]],
+    box_first: Callable[[], Box[str] | str],
+) -> None:
+    reveal_type(ensure_tuple(scalar_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple(tuple_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(scalar_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple_reversed(tuple_first))  # revealed: tuple[str, ...]
+    reveal_type(ensure_tuple(nested_member_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple(nested_tuple_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_member_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_tuple_reversed(nested_tuple_first))  # revealed: tuple[Box[str], ...]
+    reveal_type(ensure_box(box_scalar_first))  # revealed: Box[str]
+    reveal_type(ensure_box(box_first))  # revealed: Box[str]
+    reveal_type(ensure_box_reversed(box_scalar_first))  # revealed: Box[str]
+    reveal_type(ensure_box_reversed(box_first))  # revealed: Box[str]
+```
+
 ### Don't include identical lower/upper bounds in type mapping multiple times
 
 This is was a performance regression reported in

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1269,6 +1269,22 @@ def check(
     reveal_type(ensure_box_reversed(box_first))  # revealed: Box[str]
 ```
 
+### Gradual container constraints preserve inference evidence
+
+`Collection` inherits from `Container[Any]`, so inferring a type variable from a collection passed
+to a contravariant `Container` must preserve the gradual constraint.
+
+```py
+from collections.abc import Container
+from typing import Any
+
+def value[T](items: Container[T]) -> T:
+    raise NotImplementedError
+
+items: list[str] = []
+reveal_type(value(items))  # revealed: Any
+```
+
 ### Don't include identical lower/upper bounds in type mapping multiple times
 
 This is was a performance regression reported in

--- a/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
@@ -220,7 +220,7 @@ def chain_stu[S, T, U]() -> None:
     # TODO: sometimes: revealed tuple[Solution[S=int | U@chain_stu | T@chain_stu]]
     # revealed: tuple[Solution[S=int | T@chain_stu | U@chain_stu]]
     reveal_type(constraints.solutions_for(S, inferable=tuple[S, T, U]))
-    # revealed: tuple[Solution[T=S@chain_stu | U@chain_stu | int]]
+    # revealed: tuple[Solution[T=S@chain_stu | int | U@chain_stu]]
     reveal_type(constraints.solutions_for(T, inferable=tuple[S, T, U]))
     # revealed: tuple[Solution[U=S@chain_stu | int | T@chain_stu]]
     reveal_type(constraints.solutions_for(U, inferable=tuple[S, T, U]))
@@ -236,7 +236,7 @@ def chain_uts[U, T, S]() -> None:
     # TODO: sometimes: revealed tuple[Solution[S=int | U@chain_uts | T@chain_uts]]
     # revealed: tuple[Solution[S=int | T@chain_uts | U@chain_uts]]
     reveal_type(constraints.solutions_for(S, inferable=tuple[S, T, U]))
-    # revealed: tuple[Solution[T=S@chain_uts | U@chain_uts | int]]
+    # revealed: tuple[Solution[T=S@chain_uts | int | U@chain_uts]]
     reveal_type(constraints.solutions_for(T, inferable=tuple[S, T, U]))
     # revealed: tuple[Solution[U=S@chain_uts | int | T@chain_uts]]
     reveal_type(constraints.solutions_for(U, inferable=tuple[S, T, U]))

--- a/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
@@ -23,6 +23,25 @@ the `wobbling-ty-constraint-order` agent skill to automate this process.
 python-version = "3.13"
 ```
 
+## Constraint absorption is independent of source order
+
+```py
+from ty_extensions._internal import ConstraintSet
+
+def absorption[T]() -> None:
+    scalar = ConstraintSet.range(str, T, object)
+    tuple_ = ConstraintSet.range(tuple[str, ...], T, object)
+
+    # revealed: tuple[Solution[T=str]]
+    reveal_type((scalar & (scalar | tuple_)).solutions_for(T, inferable=tuple[T]))
+    # revealed: tuple[Solution[T=str]]
+    reveal_type(((scalar | tuple_) & scalar).solutions_for(T, inferable=tuple[T]))
+
+    # A genuine alternative still produces both solutions; absorption does not prefer one match.
+    # revealed: tuple[Solution[T=str], Solution[T=tuple[str, ...]]]
+    reveal_type((scalar | tuple_).solutions_for(T, inferable=tuple[T]))
+```
+
 ## Solution binding order follows constraint source order
 
 The order of bindings within a path must follow the first constraint that introduced each typevar.
@@ -49,6 +68,16 @@ def bindings_reverse_source[T, U, V]() -> None:
     constraints = ConstraintSet.range(bytes, V, bytes) & ConstraintSet.range(str, U, str) & ConstraintSet.range(int, T, int)
     # revealed: tuple[Solution[V=bytes, U=str, T=int]]
     reveal_type(constraints.solutions(inferable=tuple[T, U, V]))
+
+def bindings_absorbed[T, U, X]() -> None:
+    t = ConstraintSet.range(str, T, object)
+    u = ConstraintSet.range(bytes, U, object)
+    x = ConstraintSet.range(int, X, object)
+
+    # ((X ≥ int) ∧ (T ≥ str) ∧ (U ≥ bytes)) | ((U ≥ bytes) ∧ (T ≥ str))
+    constraints = (x & t & u) | (u & t)
+    # revealed: tuple[Solution[T=str, U=bytes]]
+    reveal_type(constraints.solutions(inferable=tuple[T, U, X]))
 ```
 
 ## Nested transitive constraints and an unrelated alternative
@@ -189,11 +218,11 @@ def chain_stu[S, T, U]() -> None:
     constraints = chain & ConstraintSet.range(int, S, object) & ConstraintSet.range(Never, U, int)
     # TODO: inferable typevars should not remain in these concrete solutions.
     # TODO: sometimes: revealed tuple[Solution[S=int | U@chain_stu | T@chain_stu]]
-    # revealed: tuple[Solution[S=T@chain_stu | int | U@chain_stu]]
+    # revealed: tuple[Solution[S=int | T@chain_stu | U@chain_stu]]
     reveal_type(constraints.solutions_for(S, inferable=tuple[S, T, U]))
-    # revealed: tuple[Solution[T=S@chain_stu | int | U@chain_stu]]
+    # revealed: tuple[Solution[T=S@chain_stu | U@chain_stu | int]]
     reveal_type(constraints.solutions_for(T, inferable=tuple[S, T, U]))
-    # revealed: tuple[Solution[U=T@chain_stu | S@chain_stu | int]]
+    # revealed: tuple[Solution[U=S@chain_stu | int | T@chain_stu]]
     reveal_type(constraints.solutions_for(U, inferable=tuple[S, T, U]))
 
 def chain_uts[U, T, S]() -> None:
@@ -205,11 +234,11 @@ def chain_uts[U, T, S]() -> None:
     constraints = chain & ConstraintSet.range(int, S, object) & ConstraintSet.range(Never, U, int)
     # TODO: inferable typevars should not remain in these concrete solutions.
     # TODO: sometimes: revealed tuple[Solution[S=int | U@chain_uts | T@chain_uts]]
-    # revealed: tuple[Solution[S=T@chain_uts | int | U@chain_uts]]
+    # revealed: tuple[Solution[S=int | T@chain_uts | U@chain_uts]]
     reveal_type(constraints.solutions_for(S, inferable=tuple[S, T, U]))
-    # revealed: tuple[Solution[T=S@chain_uts | int | U@chain_uts]]
+    # revealed: tuple[Solution[T=S@chain_uts | U@chain_uts | int]]
     reveal_type(constraints.solutions_for(T, inferable=tuple[S, T, U]))
-    # revealed: tuple[Solution[U=T@chain_uts | S@chain_uts | int]]
+    # revealed: tuple[Solution[U=S@chain_uts | int | T@chain_uts]]
     reveal_type(constraints.solutions_for(U, inferable=tuple[S, T, U]))
 ```
 
@@ -465,7 +494,7 @@ def high_fanout[
     # TODO: sometimes: revealed tuple[Solution[P=L0@high_fanout | Literal[0, 1, 2, 5, 6, 7, 8, 9, 10, 11] | L1@high_fanout | L2@high_fanout | L3@high_fanout | L4@high_fanout | L5@high_fanout | L6@high_fanout | L7@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout]]
     # TODO: sometimes: revealed tuple[Solution[P=L0@high_fanout | Literal[0, 1, 2, 3, 6, 7, 8, 9, 10, 11] | L1@high_fanout | L2@high_fanout | L3@high_fanout | L4@high_fanout | L5@high_fanout | L6@high_fanout | L7@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout]]
     # TODO: sometimes: revealed tuple[Solution[P=L0@high_fanout | Literal[0, 1, 2, 3, 4, 5, 6, 9, 10, 11] | L1@high_fanout | L2@high_fanout | L3@high_fanout | L4@high_fanout | L5@high_fanout | L6@high_fanout | L7@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout]]
-    # revealed: tuple[Solution[P=L0@high_fanout | L1@high_fanout | L2@high_fanout | Literal[2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | L3@high_fanout | L4@high_fanout | L5@high_fanout | L6@high_fanout | L7@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout]]
+    # revealed: tuple[Solution[P=L0@high_fanout | L1@high_fanout | Literal[2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | L2@high_fanout | L3@high_fanout | L4@high_fanout | L5@high_fanout | L6@high_fanout | L7@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout]]
     reveal_type(pivot)
 
     # TODO: sometimes: revealed tuple[Solution[R11=P@high_fanout]]
@@ -475,7 +504,7 @@ def high_fanout[
     # TODO: sometimes: revealed tuple[Solution[R11=L0@high_fanout | Literal[0, 1, 5, 6, 7, 8, 9, 10, 11] | L1@high_fanout | L2@high_fanout | L4@high_fanout | L5@high_fanout | L6@high_fanout | L7@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout | P@high_fanout]]
     # TODO: sometimes: revealed tuple[Solution[R11=L0@high_fanout | Literal[0, 1, 2, 3, 6, 7, 8, 9, 10, 11] | L1@high_fanout | L2@high_fanout | L3@high_fanout | L5@high_fanout | L6@high_fanout | L7@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout | P@high_fanout]]
     # TODO: sometimes: revealed tuple[Solution[R11=L0@high_fanout | Literal[0, 1, 2, 3, 4, 5, 6, 9, 10, 11] | L1@high_fanout | L2@high_fanout | L3@high_fanout | L4@high_fanout | L5@high_fanout | L6@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout | P@high_fanout]]
-    # revealed: tuple[Solution[R11=L1@high_fanout | L2@high_fanout | Literal[2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | L3@high_fanout | L4@high_fanout | L5@high_fanout | L6@high_fanout | L7@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout | P@high_fanout]]
+    # revealed: tuple[Solution[R11=L1@high_fanout | Literal[2, 3, 4, 5, 6, 7, 8, 9, 10, 11] | L2@high_fanout | L3@high_fanout | L4@high_fanout | L5@high_fanout | L6@high_fanout | L7@high_fanout | L8@high_fanout | L9@high_fanout | L10@high_fanout | L11@high_fanout | P@high_fanout]]
     reveal_type(result)
 
     impossible = constraints & ConstraintSet.range(Never, R11, Literal[0])

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
@@ -73,7 +73,7 @@ def relational_bridge[X, U, V]() -> None:
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[V=object, U=object]]
-    # revealed: tuple[Solution[V=U@relational_bridge, U=Never]]
+    # revealed: tuple[Solution[U=Never, V=U@relational_bridge]]
     reveal_type(quantified.solutions(inferable=tuple[U, V]))
 
     # U ≤ V
@@ -105,7 +105,7 @@ def inverse_image[X, A, B]() -> None:
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[A=Invariant[object], B=object, X=object]]
-    # revealed: tuple[Solution[A=Never, B=X@inverse_image, X=Never]]
+    # revealed: tuple[Solution[A=Never, X=Never, B=X@inverse_image]]
     reveal_type(body.solutions(inferable=tuple[X, A, B]))
     # TODO: revealed: tuple[Solution[A=Invariant[object], B=object]]
     # revealed: tuple[()]
@@ -149,7 +149,7 @@ def witness_sensitive[X, A, B]() -> None:
 
     # Each solution for A and B depends on the compatible choice of X.
     # TODO: revealed: tuple[Solution[X=object, A=object, B=Invariant[object]]]
-    # revealed: tuple[Solution[X=A@witness_sensitive, A=X@witness_sensitive, B=Invariant[X@witness_sensitive]]]
+    # revealed: tuple[Solution[A=X@witness_sensitive, X=A@witness_sensitive, B=Invariant[X@witness_sensitive]]]
     reveal_type(body.solutions(inferable=tuple[X, A, B]))
     # TODO: revealed: tuple[Solution[A=object, B=Invariant[object]]]
     # revealed: tuple[()]
@@ -199,9 +199,9 @@ def correlated_outputs[X, Y, Z]() -> None:
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
-    # revealed: tuple[Solution[X=int | Y@correlated_outputs, Z=Invariant[X@correlated_outputs] | Invariant[int], Y=int], Solution[X=str | Y@correlated_outputs, Z=Invariant[X@correlated_outputs] | Invariant[str], Y=str]]
+    # revealed: tuple[Solution[X=int | Y@correlated_outputs, Y=int, Z=Invariant[X@correlated_outputs] | Invariant[int]], Solution[X=str | Y@correlated_outputs, Z=Invariant[X@correlated_outputs] | Invariant[str], Y=str]]
     reveal_type(body.solutions(inferable=tuple[X, Y, Z]))
-    # revealed: tuple[Solution[Z=Invariant[int], Y=int], Solution[Z=Invariant[str], Y=str]]
+    # revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
     reveal_type(quantified.solutions(inferable=tuple[Y, Z]))
 
     # (Y = int ∧ Z = Invariant[int]) ∨ (Y = str ∧ Z = Invariant[str])

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/quantification.md
@@ -199,7 +199,7 @@ def correlated_outputs[X, Y, Z]() -> None:
     quantified = body.exists(tuple[X])
 
     # TODO: revealed: tuple[Solution[X=int, Y=int, Z=Invariant[int]], Solution[X=str, Y=str, Z=Invariant[str]]]
-    # revealed: tuple[Solution[X=int | Y@correlated_outputs, Y=int, Z=Invariant[X@correlated_outputs] | Invariant[int]], Solution[X=str | Y@correlated_outputs, Z=Invariant[X@correlated_outputs] | Invariant[str], Y=str]]
+    # revealed: tuple[Solution[X=int | Y@correlated_outputs, Z=Invariant[X@correlated_outputs] | Invariant[int], Y=int], Solution[X=str | Y@correlated_outputs, Z=Invariant[X@correlated_outputs] | Invariant[str], Y=str]]
     reveal_type(body.solutions(inferable=tuple[X, Y, Z]))
     # revealed: tuple[Solution[Y=int, Z=Invariant[int]], Solution[Y=str, Z=Invariant[str]]]
     reveal_type(quantified.solutions(inferable=tuple[Y, Z]))

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -2615,31 +2615,7 @@ impl NodeId {
     /// nodes.
     fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
         match (self.node(), other.node()) {
-            (Node::AlwaysTrue, Node::AlwaysTrue) => ALWAYS_TRUE,
-            (Node::AlwaysTrue, Node::Interior(_)) => {
-                let other_interior = builder.interior_node_data(other);
-                // If lhs is always true, then the overall result is true for any assignment of
-                // rhs.
-                NodeId::with_uncertain(
-                    builder,
-                    other_interior.constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_TRUE,
-                    ALWAYS_FALSE,
-                )
-            }
-            (Node::Interior(_), Node::AlwaysTrue) => {
-                let self_interior = builder.interior_node_data(self);
-                // If rhs is always true, then the overall result is true for any assignment of
-                // lhs.
-                NodeId::with_uncertain(
-                    builder,
-                    self_interior.constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_TRUE,
-                    ALWAYS_FALSE,
-                )
-            }
+            (Node::AlwaysTrue, _) | (_, Node::AlwaysTrue) => ALWAYS_TRUE,
             (Node::AlwaysFalse, _) => other,
             (_, Node::AlwaysFalse) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
@@ -2767,25 +2743,7 @@ impl NodeId {
     /// Returns the `and` or intersection of two BDDs.
     fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
         match (self.node(), other.node()) {
-            (Node::AlwaysFalse, Node::AlwaysFalse) => ALWAYS_FALSE,
-            (Node::AlwaysFalse, Node::Interior(_)) => {
-                let other_interior = builder.interior_node_data(other);
-                NodeId::new(
-                    builder,
-                    other_interior.constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_FALSE,
-                )
-            }
-            (Node::Interior(_), Node::AlwaysFalse) => {
-                let self_interior = builder.interior_node_data(self);
-                NodeId::new(
-                    builder,
-                    self_interior.constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_FALSE,
-                )
-            }
+            (Node::AlwaysFalse, _) | (_, Node::AlwaysFalse) => ALWAYS_FALSE,
             (Node::AlwaysTrue, _) => other,
             (_, Node::AlwaysTrue) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -648,8 +648,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         to_remove: TypeVarSet<'db>,
     ) -> Self {
         self.verify_builder(builder);
-        let node = self.node.exists(db, builder, to_remove);
-        Self::from_node(builder, node, self.source_order)
+        let (node, derived_source_order) = self.node.exists(db, builder, to_remove);
+        let source_order = builder.ordered_source_order(self.source_order, derived_source_order);
+        Self::from_node(builder, node, source_order)
     }
 
     /// Applies a type mapping to every constraint in this constraint set.
@@ -1476,6 +1477,21 @@ impl<'db> ConstraintSetBuilder<'db> {
     fn constraint_source_order(&self, constraint: ConstraintId) -> SourceOrderId {
         self.intern_source_order(SourceOrder::Constraint(constraint))
     }
+
+    #[expect(dead_code)]
+    fn source_order_data(&self, source_order: SourceOrderId) -> SourceOrder {
+        let storage = self.storage.borrow();
+        if let Some(compacted) = &storage.compacted {
+            let index = source_order.index();
+            let split = compacted.source_order_indices.len();
+            if index < split {
+                let compacted_index = compacted.retained_source_order_index(source_order);
+                return compacted.source_orders[compacted_index];
+            }
+            return storage.source_orders[SourceOrderId::from_usize(index - split)];
+        }
+        storage.source_orders[source_order]
+    }
 }
 
 impl<'db> BoundTypeVarInstance<'db> {
@@ -1973,9 +1989,9 @@ impl<'db> Constraint<'db> {
             {
                 let constraint =
                     ConstraintId::new(db, builder, typevar, Type::Never, Type::object());
-                let source_order = builder.constraint_source_order(constraint);
-                let node = Node::new_constraint(builder, constraint, 1).negate(builder);
-                return (node, Some(source_order));
+                let (node, source_order) = Node::new_constraint(builder, constraint, 1);
+                let node = node.negate(builder);
+                return (node, source_order);
             }
             _ => {}
         }
@@ -2033,9 +2049,7 @@ impl<'db> Constraint<'db> {
                     Type::TypeVar(bound),
                     Type::TypeVar(bound),
                 );
-                let source_order = builder.constraint_source_order(constraint);
-                let node = Node::new_constraint(builder, constraint, 1);
-                (node, Some(source_order))
+                Node::new_constraint(builder, constraint, 1)
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
@@ -2050,8 +2064,8 @@ impl<'db> Constraint<'db> {
                     None,
                     Some(Type::TypeVar(typevar)),
                 );
-                let lower_source_order = Some(builder.constraint_source_order(lower_constraint));
-                let lower_node = Node::new_constraint(builder, lower_constraint, 1);
+                let (lower_node, lower_source_order) =
+                    Node::new_constraint(builder, lower_constraint, 1);
                 let upper_constraint = ConstraintId::new_with_bounds(
                     db,
                     builder,
@@ -2059,8 +2073,8 @@ impl<'db> Constraint<'db> {
                     Some(Type::TypeVar(typevar)),
                     None,
                 );
-                let upper_source_order = Some(builder.constraint_source_order(upper_constraint));
-                let upper_node = Node::new_constraint(builder, upper_constraint, 1);
+                let (upper_node, upper_source_order) =
+                    Node::new_constraint(builder, upper_constraint, 1);
                 let node = lower_node.and(builder, upper_node);
                 let source_order =
                     builder.ordered_source_order(lower_source_order, upper_source_order);
@@ -2076,8 +2090,8 @@ impl<'db> Constraint<'db> {
                     None,
                     Some(Type::TypeVar(typevar)),
                 );
-                let lower_source_order = Some(builder.constraint_source_order(lower_constraint));
-                let lower_node = Node::new_constraint(builder, lower_constraint, 1);
+                let (lower_node, lower_source_order) =
+                    Node::new_constraint(builder, lower_constraint, 1);
                 let (upper_node, upper_source_order) = if upper.is_none() {
                     (ALWAYS_TRUE, None)
                 } else {
@@ -2103,8 +2117,8 @@ impl<'db> Constraint<'db> {
                     Some(Type::TypeVar(typevar)),
                     None,
                 );
-                let upper_source_order = Some(builder.constraint_source_order(upper_constraint));
-                let upper_node = Node::new_constraint(builder, upper_constraint, 1);
+                let (upper_node, upper_source_order) =
+                    Node::new_constraint(builder, upper_constraint, 1);
                 let node = lower_node.and(builder, upper_node);
                 let source_order =
                     builder.ordered_source_order(lower_source_order, upper_source_order);
@@ -2113,9 +2127,7 @@ impl<'db> Constraint<'db> {
 
             _ => {
                 let constraint = ConstraintId::new_with_bounds(db, builder, typevar, lower, upper);
-                let source_order = Some(builder.constraint_source_order(constraint));
-                let node = Node::new_constraint(builder, constraint, 1);
-                (node, source_order)
+                Node::new_constraint(builder, constraint, 1)
             }
         }
     }
@@ -2398,14 +2410,17 @@ impl Node {
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintId,
         source_order: usize,
-    ) -> NodeId {
-        NodeId::with_uncertain(
-            builder,
-            constraint,
-            ALWAYS_TRUE,
-            ALWAYS_FALSE,
-            ALWAYS_FALSE,
-            source_order,
+    ) -> (NodeId, Option<SourceOrderId>) {
+        (
+            NodeId::with_uncertain(
+                builder,
+                constraint,
+                ALWAYS_TRUE,
+                ALWAYS_FALSE,
+                ALWAYS_FALSE,
+                source_order,
+            ),
+            Some(builder.constraint_source_order(constraint)),
         )
     }
 
@@ -2418,29 +2433,35 @@ impl Node {
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintAssignment,
         source_order: usize,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         match constraint {
-            ConstraintAssignment::Positive(constraint) => NodeId::with_uncertain(
-                builder,
-                constraint,
-                ALWAYS_TRUE,
-                ALWAYS_FALSE,
-                ALWAYS_FALSE,
-                source_order,
+            ConstraintAssignment::Positive(constraint) => (
+                NodeId::with_uncertain(
+                    builder,
+                    constraint,
+                    ALWAYS_TRUE,
+                    ALWAYS_FALSE,
+                    ALWAYS_FALSE,
+                    source_order,
+                ),
+                Some(builder.constraint_source_order(constraint)),
             ),
-            ConstraintAssignment::Negative(constraint) => NodeId::with_uncertain(
-                builder,
-                constraint,
-                ALWAYS_FALSE,
-                ALWAYS_FALSE,
-                ALWAYS_TRUE,
-                source_order,
+            ConstraintAssignment::Negative(constraint) => (
+                NodeId::with_uncertain(
+                    builder,
+                    constraint,
+                    ALWAYS_FALSE,
+                    ALWAYS_FALSE,
+                    ALWAYS_TRUE,
+                    source_order,
+                ),
+                Some(builder.constraint_source_order(constraint)),
             ),
-            ConstraintAssignment::Unconstrained(constraint) => {
-                // The result holds regardless of the constraint's truth value, so only
-                // `if_uncertain` needs to be `ALWAYS_TRUE` — `n? 0: 1: 0`. It would also be
-                // correct to use `n? 1: 1: 1` (i.e., `ALWAYS_TRUE` for all outgoing edges), but
-                // that would throw away some of the efficiency gains this representation gives us.
+            // The result holds regardless of the constraint's truth value, so only
+            // `if_uncertain` needs to be `ALWAYS_TRUE` — `n? 0: 1: 0`. It would also be
+            // correct to use `n? 1: 1: 1` (i.e., `ALWAYS_TRUE` for all outgoing edges), but
+            // that would throw away some of the efficiency gains this representation gives us.
+            ConstraintAssignment::Unconstrained(constraint) => (
                 NodeId::with_uncertain(
                     builder,
                     constraint,
@@ -2448,8 +2469,9 @@ impl Node {
                     ALWAYS_TRUE,
                     ALWAYS_FALSE,
                     source_order,
-                )
-            }
+                ),
+                Some(builder.constraint_source_order(constraint)),
+            ),
         }
     }
 }
@@ -3097,10 +3119,10 @@ impl NodeId {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         inferable: TypeVarSet<'db>,
-    ) -> Self {
+    ) -> (Self, Option<SourceOrderId>) {
         match self.node() {
-            Node::AlwaysTrue => ALWAYS_TRUE,
-            Node::AlwaysFalse => ALWAYS_FALSE,
+            Node::AlwaysTrue => (ALWAYS_TRUE, None),
+            Node::AlwaysFalse => (ALWAYS_FALSE, None),
             Node::Interior(interior) => interior.remove_noninferable(db, builder, inferable),
         }
     }
@@ -3184,8 +3206,8 @@ impl NodeId {
         //     false
         //
         //  (Note that the `else` branch shouldn't be reachable, but we have to provide something!)
-        let left_node = Node::new_satisfied_constraint(builder, left, left_source_order);
-        let right_node = Node::new_satisfied_constraint(builder, right, right_source_order);
+        let (left_node, _) = Node::new_satisfied_constraint(builder, left, left_source_order);
+        let (right_node, _) = Node::new_satisfied_constraint(builder, right, right_source_order);
         let right_result = right_node.ite(builder, ALWAYS_FALSE, when_left_but_not_right);
         let left_result = left_node.ite(builder, right_result, when_not_left);
         let result = replacement.ite(builder, when_left_and_right, left_result);
@@ -3252,8 +3274,8 @@ impl NodeId {
         // Lastly, verify that the result is consistent with the input. (It must produce the same
         // results when `left ∨ right`.) If it doesn't, the substitution isn't valid, and we should
         // return the original BDD unmodified.
-        let left_node = Node::new_satisfied_constraint(builder, left, left_source_order);
-        let right_node = Node::new_satisfied_constraint(builder, right, right_source_order);
+        let (left_node, _) = Node::new_satisfied_constraint(builder, left, left_source_order);
+        let (right_node, _) = Node::new_satisfied_constraint(builder, right, right_source_order);
         let validity = replacement.iff(builder, left_node.or(builder, right_node));
         let constrained_original = self.and(builder, validity);
         let constrained_replacement = result.and(builder, validity);
@@ -4793,14 +4815,15 @@ impl InteriorNode {
                 if seen_constraints.contains(&new_constraint) {
                     continue;
                 }
-                let new_node = Node::new_constraint(builder, new_constraint, next_source_order);
+                let (new_node, _) =
+                    Node::new_constraint(builder, new_constraint, next_source_order);
                 next_source_order += 1;
-                let positive_left_node = Node::new_satisfied_constraint(
+                let (positive_left_node, _) = Node::new_satisfied_constraint(
                     builder,
                     left_constraint.when_true(),
                     left_source_order,
                 );
-                let positive_right_node = Node::new_satisfied_constraint(
+                let (positive_right_node, _) = Node::new_satisfied_constraint(
                     builder,
                     right_constraint.when_true(),
                     right_source_order,
@@ -4862,12 +4885,12 @@ impl InteriorNode {
                 smaller_source_order,
             )) = larger_smaller
             {
-                let positive_larger_node = Node::new_satisfied_constraint(
+                let (positive_larger_node, _) = Node::new_satisfied_constraint(
                     builder,
                     larger_constraint.when_true(),
                     larger_source_order,
                 );
-                let negative_larger_node = Node::new_satisfied_constraint(
+                let (negative_larger_node, _) = Node::new_satisfied_constraint(
                     builder,
                     larger_constraint.when_false(),
                     larger_source_order,
@@ -4939,35 +4962,35 @@ impl InteriorNode {
                                 .map(|seen| (seen, intersection_constraint)),
                         );
                     }
-                    let positive_intersection_node = Node::new_satisfied_constraint(
+                    let (positive_intersection_node, _) = Node::new_satisfied_constraint(
                         builder,
                         intersection_constraint.when_true(),
                         next_source_order,
                     );
-                    let negative_intersection_node = Node::new_satisfied_constraint(
+                    let (negative_intersection_node, _) = Node::new_satisfied_constraint(
                         builder,
                         intersection_constraint.when_false(),
                         next_source_order,
                     );
                     next_source_order += 1;
 
-                    let positive_left_node = Node::new_satisfied_constraint(
+                    let (positive_left_node, _) = Node::new_satisfied_constraint(
                         builder,
                         left_constraint.when_true(),
                         left_source_order,
                     );
-                    let negative_left_node = Node::new_satisfied_constraint(
+                    let (negative_left_node, _) = Node::new_satisfied_constraint(
                         builder,
                         left_constraint.when_false(),
                         left_source_order,
                     );
 
-                    let positive_right_node = Node::new_satisfied_constraint(
+                    let (positive_right_node, _) = Node::new_satisfied_constraint(
                         builder,
                         right_constraint.when_true(),
                         right_source_order,
                     );
-                    let negative_right_node = Node::new_satisfied_constraint(
+                    let (negative_right_node, _) = Node::new_satisfied_constraint(
                         builder,
                         right_constraint.when_false(),
                         right_source_order,
@@ -5054,12 +5077,12 @@ impl InteriorNode {
                     // All of the below hold because we just proved that the intersection of left
                     // and right is empty.
 
-                    let positive_left_node = Node::new_satisfied_constraint(
+                    let (positive_left_node, _) = Node::new_satisfied_constraint(
                         builder,
                         left_constraint.when_true(),
                         left_source_order,
                     );
-                    let positive_right_node = Node::new_satisfied_constraint(
+                    let (positive_right_node, _) = Node::new_satisfied_constraint(
                         builder,
                         right_constraint.when_true(),
                         right_source_order,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -530,8 +530,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
     /// Updates this constraint set to hold the union of itself and another constraint set.
     ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
+    /// In the result's source order, `self` will appear before `other`.
     pub(crate) fn union(
         &mut self,
         _db: &'db dyn Db,
@@ -546,8 +545,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
     /// Updates this constraint set to hold the intersection of itself and another constraint set.
     ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
+    /// In the result's source order, `self` will appear before `other`.
     pub(crate) fn intersect(
         &mut self,
         _db: &'db dyn Db,
@@ -570,8 +568,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// provided as a thunk, to implement short-circuiting: the thunk is not forced if the
     /// constraint set is already saturated.
     ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
+    /// In the result's source order, `self` will appear before `other`.
     #[inline]
     pub(crate) fn and(
         mut self,
@@ -592,8 +589,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// as a thunk, to implement short-circuiting: the thunk is not forced if the constraint set is
     /// already saturated.
     ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
+    /// In the result's source order, `self` will appear before `other`.
     pub(crate) fn or(
         mut self,
         db: &'db dyn Db,
@@ -611,8 +607,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
     /// Returns a constraint set encoding that this constraint set implies another.
     ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
+    /// In the result's source order, `self` will appear before `other`.
     pub(crate) fn implies(
         self,
         db: &'db dyn Db,
@@ -624,8 +619,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
     /// Returns a constraint set encoding that this constraint set is equivalent to another.
     ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
+    /// In the result's source order, `self` will appear before `other`.
     pub(crate) fn iff(
         self,
         _db: &'db dyn Db,
@@ -932,8 +926,8 @@ struct ConstraintSetStorage<'db> {
     /// appear in the source code. This ensures that any union and intersections types that appear
     /// in solutions are constructed in a stable (and source-consistent) order.
     ///
-    /// This is encoded as a binary tree over [`ConstraintId`]s. The pre-walk of that tree defines
-    /// the ordering.
+    /// This is encoded as a binary tree over [`ConstraintId`]s. A preorder traversal of that tree
+    /// defines the ordering.
     source_orders: IndexVec<SourceOrderId, SourceOrder>,
 
     // Everything below are the memoization tables for the arenas and for our BDD operations.
@@ -2466,42 +2460,23 @@ impl Node {
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintAssignment,
     ) -> (NodeId, Option<SourceOrderId>) {
-        match constraint {
-            ConstraintAssignment::Positive(constraint) => (
-                NodeId::with_uncertain(
-                    builder,
-                    constraint,
-                    ALWAYS_TRUE,
-                    ALWAYS_FALSE,
-                    ALWAYS_FALSE,
-                ),
-                Some(builder.constraint_source_order(constraint)),
-            ),
-            ConstraintAssignment::Negative(constraint) => (
-                NodeId::with_uncertain(
-                    builder,
-                    constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_FALSE,
-                    ALWAYS_TRUE,
-                ),
-                Some(builder.constraint_source_order(constraint)),
-            ),
+        let constraint_id = constraint.constraint();
+        let node = match constraint {
+            ConstraintAssignment::Positive(constraint) => {
+                NodeId::with_uncertain(builder, constraint, ALWAYS_TRUE, ALWAYS_FALSE, ALWAYS_FALSE)
+            }
+            ConstraintAssignment::Negative(constraint) => {
+                NodeId::with_uncertain(builder, constraint, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_TRUE)
+            }
             // The result holds regardless of the constraint's truth value, so only
             // `if_uncertain` needs to be `ALWAYS_TRUE` — `n? 0: 1: 0`. It would also be
             // correct to use `n? 1: 1: 1` (i.e., `ALWAYS_TRUE` for all outgoing edges), but
             // that would throw away some of the efficiency gains this representation gives us.
-            ConstraintAssignment::Unconstrained(constraint) => (
-                NodeId::with_uncertain(
-                    builder,
-                    constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_TRUE,
-                    ALWAYS_FALSE,
-                ),
-                Some(builder.constraint_source_order(constraint)),
-            ),
-        }
+            ConstraintAssignment::Unconstrained(constraint) => {
+                NodeId::with_uncertain(builder, constraint, ALWAYS_FALSE, ALWAYS_TRUE, ALWAYS_FALSE)
+            }
+        };
+        (node, Some(builder.constraint_source_order(constraint_id)))
     }
 }
 
@@ -2651,9 +2626,6 @@ impl NodeId {
     }
 
     /// Returns the `or` or union of two BDDs.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
     fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
         match (self.node(), other.node()) {
             (Node::AlwaysTrue, _) | (_, Node::AlwaysTrue) => ALWAYS_TRUE,
@@ -2785,9 +2757,6 @@ impl NodeId {
 
     /// Returns a new BDD that evaluates to `true` when both input BDDs evaluate to the same
     /// result.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
     fn iff(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
         // iff(a, b) = (a ∧ b) ∨ (¬a ∧ ¬b)
         let a_and_b = self.and(builder, other);
@@ -4386,9 +4355,7 @@ impl InteriorNode {
 
                     // If we are removing this node, we have to check if there are any derived facts
                     // that depend on the constraint we're about to remove. If so, we need to
-                    // "remember" them by AND-ing them in with the corresponding branch. We currently
-                    // reuse the `source_order` of the constraint being removed when we add these
-                    // derived facts.
+                    // "remember" them by AND-ing them in with the corresponding branch.
                     Disposition::Remove => {
                         ControlFlow::Continue(
                             path.assignments[new_range]
@@ -8385,9 +8352,8 @@ mod tests {
                     .and(builder, int_t)
                     .and(builder, u_int)
             },
-            // TODO: `SequentMap::for_constraint_pair` can receive its inputs in BDD order, not
-            // source order. That changes which equivalent upper-bound intersection is constructed
-            // first.
+            // TODO: Constraint-ID permutations can still change which equivalent upper-bound
+            // intersection is constructed first.
             [
                 "never=false always=false merged=[T=int | U, U=T & int] paths=[T=int | U, U=T & int]",
                 "never=false always=false merged=[T=int | U, U=int & T] paths=[T=int | U, U=int & T]",

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -255,8 +255,8 @@ struct OwnedConstraintSetInner<'db> {
     typevars: IndexVec<TypeVarId, BoundTypeVarIdentity<'db>>,
     nodes: Box<[InteriorNodeData]>,
     node_indices: RankBitBox,
+    /// A dense, canonical source-order tree whose IDs are independent of builder history.
     source_orders: Box<[SourceOrder]>,
-    source_order_indices: RankBitBox,
 }
 
 impl Default for OwnedConstraintSet<'_> {
@@ -338,16 +338,6 @@ impl OwnedConstraintSetInner<'_> {
             "should not access constraint set constraint that was marked unused",
         );
         self.constraint_indices.rank(index) as usize
-    }
-
-    fn retained_source_order_index(&self, id: SourceOrderId) -> usize {
-        let index = id.index();
-        debug_assert_eq!(
-            self.source_order_indices.get_bit(index),
-            Some(true),
-            "should not access constraint set source_order that was marked unused",
-        );
-        self.source_order_indices.rank(index) as usize
     }
 }
 
@@ -987,6 +977,14 @@ impl ConstraintSetStorage<'_> {
                 .zip(compacted.nodes.iter().copied())
                 .map(|(old_index, node)| (node, NodeId::from_usize(old_index))),
         );
+        self.source_order_cache.extend(
+            compacted
+                .source_orders
+                .iter()
+                .copied()
+                .enumerate()
+                .map(|(index, source_order)| (source_order, SourceOrderId::from_usize(index))),
+        );
     }
 
     fn adjusted_node_id(&self, id: NodeId) -> NodeId {
@@ -1005,7 +1003,7 @@ impl ConstraintSetStorage<'_> {
 
     fn adjusted_source_order_id(&self, id: SourceOrderId) -> SourceOrderId {
         if let Some(compacted) = &self.compacted {
-            return id + compacted.source_order_indices.len();
+            return id + compacted.source_orders.len();
         }
         id
     }
@@ -1048,22 +1046,13 @@ impl<'db> ConstraintSetBuilder<'db> {
 
         // The source-order tree can retain repeated constraints from intermediate operations. If
         // this constraint set participates in a Salsa cycle, retaining that construction history
-        // can make an otherwise stable result grow on every iteration and never converge.
-        let source_order = self
-            .calculate_source_orders(Some(source_order))
-            .into_iter()
-            .fold(None, |source_order, constraint| {
-                self.ordered_source_order(
-                    source_order,
-                    Some(self.constraint_source_order(constraint)),
-                )
-            })
-            .expect("non-terminal BDD should have source_order");
+        // can make an otherwise stable result grow on every iteration and never converge. Build
+        // the owned source-order tree densely so its IDs are independent of that history.
+        let source_constraints = self.calculate_source_orders(Some(source_order));
 
         let mut storage = self.storage.into_inner();
         let mut used_nodes = RankBitBox::bits_with_capacity(storage.nodes.len());
         let mut used_constraints = RankBitBox::bits_with_capacity(storage.constraints.len());
-        let mut used_source_orders = RankBitBox::bits_with_capacity(storage.source_orders.len());
 
         let mut stack = vec![node];
         while let Some(node) = stack.pop() {
@@ -1078,26 +1067,23 @@ impl<'db> ConstraintSetBuilder<'db> {
             stack.push(interior.if_false);
         }
 
-        let mut stack = vec![source_order];
-        while let Some(source_order) = stack.pop() {
-            if used_source_orders[source_order.index()] {
-                continue;
-            }
-            used_source_orders.set(source_order.index(), true);
-            match storage.source_orders[source_order] {
-                SourceOrder::Ordered(left, right) => {
-                    stack.push(left);
-                    stack.push(right);
-                }
-                SourceOrder::Constraint(constraint) => {
-                    used_constraints.set(constraint.index(), true);
-                }
-            }
-        }
+        let mut source_orders: IndexVec<SourceOrderId, SourceOrder> =
+            IndexVec::with_capacity(source_constraints.len().saturating_mul(2).saturating_sub(1));
+        let source_order = source_constraints
+            .into_iter()
+            .fold(None, |left, source_constraint| {
+                used_constraints.set(source_constraint.index(), true);
+                let right = source_orders.push(SourceOrder::Constraint(source_constraint));
+
+                Some(match left {
+                    Some(left) => source_orders.push(SourceOrder::Ordered(left, right)),
+                    None => right,
+                })
+            })
+            .expect("non-terminal BDD should have source_order");
 
         used_nodes.truncate(used_nodes.last_one().map_or(0, |last| last + 1));
         used_constraints.truncate(used_constraints.last_one().map_or(0, |last| last + 1));
-        used_source_orders.truncate(used_source_orders.last_one().map_or(0, |last| last + 1));
 
         let nodes = storage
             .nodes
@@ -1115,14 +1101,6 @@ impl<'db> ConstraintSetBuilder<'db> {
             .collect();
         let constraint_indices = RankBitBox::from_bits(used_constraints);
 
-        let source_orders = storage
-            .source_orders
-            .into_iter()
-            .zip(&used_source_orders)
-            .filter_map(|(source_order, used)| used.then_some(source_order))
-            .collect();
-        let source_order_indices = RankBitBox::from_bits(used_source_orders);
-
         storage.typevars.shrink_to_fit();
 
         OwnedConstraintSet {
@@ -1134,8 +1112,7 @@ impl<'db> ConstraintSetBuilder<'db> {
                 typevars: storage.typevars,
                 nodes,
                 node_indices,
-                source_orders,
-                source_order_indices,
+                source_orders: source_orders.raw.into_boxed_slice(),
             })),
         }
     }
@@ -1218,10 +1195,8 @@ impl<'db> ConstraintSetBuilder<'db> {
         for (i, old_source_order) in inner.source_orders.iter().copied().enumerate() {
             match old_source_order {
                 SourceOrder::Ordered(old_left, old_right) => {
-                    let old_left_index = inner.retained_source_order_index(old_left);
-                    let new_left = source_orders[old_left_index];
-                    let old_right_index = inner.retained_source_order_index(old_right);
-                    let new_right = source_orders[old_right_index];
+                    let new_left = source_orders[old_left.index()];
+                    let new_right = source_orders[old_right.index()];
                     source_orders[i] = self.ordered_source_order(new_left, new_right);
                 }
                 SourceOrder::Constraint(old_constraint) => {
@@ -1238,8 +1213,7 @@ impl<'db> ConstraintSetBuilder<'db> {
         let old_source_order = other
             .source_order
             .expect("non-terminal constraint set should have a source_order");
-        let old_source_order_index = inner.retained_source_order_index(old_source_order);
-        let source_order = source_orders[old_source_order_index];
+        let source_order = source_orders[old_source_order.index()];
         ConstraintSet::from_node(self, node, source_order)
     }
 
@@ -1495,10 +1469,9 @@ impl<'db> ConstraintSetBuilder<'db> {
         let storage = self.storage.borrow();
         if let Some(compacted) = &storage.compacted {
             let index = source_order.index();
-            let split = compacted.source_order_indices.len();
+            let split = compacted.source_orders.len();
             if index < split {
-                let compacted_index = compacted.retained_source_order_index(source_order);
-                return compacted.source_orders[compacted_index];
+                return compacted.source_orders[index];
             }
             return storage.source_orders[SourceOrderId::from_usize(index - split)];
         }
@@ -8854,8 +8827,10 @@ mod tests {
             .expect("nonterminal root should retain storage");
 
         assert_eq!(owned.node.index(), 2);
+        assert_eq!(owned.source_order.map(SourceOrderId::index), Some(0));
         assert_eq!(inner.nodes.len(), 1);
         assert_eq!(inner.constraints.len(), 1);
+        assert_eq!(inner.source_orders.len(), 1);
         assert_eq!(inner.node_indices.len(), 3);
         assert_eq!(inner.constraint_indices.len(), 3);
         assert_eq!(inner.node_indices.iter_ones().collect::<Vec<_>>(), vec![2]);
@@ -8865,6 +8840,28 @@ mod tests {
         );
         assert_eq!(inner.typevars.len(), 3);
         assert!(owned.node.index() >= inner.nodes.len());
+    }
+
+    #[test]
+    fn owned_constraint_set_source_order_ignores_construction_history() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+
+        let build = |include_unused_source_order| {
+            ConstraintSetBuilder::new().into_owned(|builder| {
+                let t_int = create_constraint(&db, builder, t, KnownClass::Int);
+                let u_str = create_constraint(&db, builder, u, KnownClass::Str);
+
+                if include_unused_source_order {
+                    let _ = builder.ordered_source_order(t_int.source_order, t_int.source_order);
+                }
+
+                t_int.and(&db, builder, || u_str)
+            })
+        };
+
+        assert_eq!(build(false), build(true));
     }
 
     #[test]
@@ -8899,7 +8896,7 @@ mod tests {
         let owned = create_compacted_owned_set(&db);
 
         owned.query(|builder, set| {
-            let (node_split, constraint_split, typevar_split) = {
+            let (node_split, constraint_split, typevar_split, source_order_split) = {
                 let storage = builder.storage.borrow();
                 let compacted = storage
                     .compacted
@@ -8909,8 +8906,15 @@ mod tests {
                     compacted.node_indices.len(),
                     compacted.constraint_indices.len(),
                     compacted.typevars.len(),
+                    compacted.source_orders.len(),
                 )
             };
+
+            let existing_constraint = builder.interior_node_data(set.node).constraint;
+            assert_eq!(
+                Some(builder.constraint_source_order(existing_constraint)),
+                set.source_order
+            );
 
             let w = create_typevar(&db, "W");
             let w_str = create_constraint(&db, builder, w, KnownClass::Str);
@@ -8922,6 +8926,11 @@ mod tests {
             assert!(w_str.node.index() >= node_split);
             assert!(new_constraint.index() >= constraint_split);
             assert!(builder.typevar_id(&db, w).index() >= typevar_split);
+            assert!(
+                w_str
+                    .source_order
+                    .is_some_and(|source_order| source_order.index() >= source_order_split)
+            );
 
             let combined = set.and(&db, builder, || w_str);
             assert!(!combined.is_never_satisfied(&db));

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -201,15 +201,16 @@ where
         builder: &'c ConstraintSetBuilder<'db>,
         mut f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        let node = NodeId::distributed_or(
+        let (node, source_order) = NodeId::distributed_or(
+            db,
             builder,
             self.map(|element| {
                 let constraint = f(element);
                 constraint.verify_builder(builder);
-                constraint.node
+                (constraint.node, constraint.source_order)
             }),
         );
-        ConstraintSet::from_node(builder, node)
+        ConstraintSet::from_node(builder, node, source_order)
     }
 
     fn when_all<'db, 'c>(
@@ -218,15 +219,16 @@ where
         builder: &'c ConstraintSetBuilder<'db>,
         mut f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        let node = NodeId::distributed_and(
+        let (node, source_order) = NodeId::distributed_and(
+            db,
             builder,
             self.map(|element| {
                 let constraint = f(element);
                 constraint.verify_builder(builder);
-                constraint.node
+                (constraint.node, constraint.source_order)
             }),
         );
-        ConstraintSet::from_node(builder, node)
+        ConstraintSet::from_node(builder, node, source_order)
     }
 }
 
@@ -244,6 +246,7 @@ where
 #[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub struct OwnedConstraintSet<'db> {
     node: NodeId,
+    source_order: Option<SourceOrderId>,
     inner: Option<Arc<OwnedConstraintSetInner<'db>>>,
 }
 
@@ -254,12 +257,15 @@ struct OwnedConstraintSetInner<'db> {
     typevars: IndexVec<TypeVarId, BoundTypeVarIdentity<'db>>,
     nodes: Box<[InteriorNodeData]>,
     node_indices: RankBitBox,
+    source_orders: Box<[SourceOrder]>,
+    source_order_indices: RankBitBox,
 }
 
 impl Default for OwnedConstraintSet<'_> {
     fn default() -> Self {
         Self {
             node: ALWAYS_FALSE,
+            source_order: None,
             inner: None,
         }
     }
@@ -269,6 +275,7 @@ impl<'db> OwnedConstraintSet<'db> {
     pub(crate) fn always() -> Self {
         Self {
             node: ALWAYS_TRUE,
+            source_order: None,
             inner: None,
         }
     }
@@ -299,7 +306,7 @@ impl<'db> OwnedConstraintSet<'db> {
         let builder = ConstraintSetBuilder {
             storage: RefCell::new(storage),
         };
-        let set = ConstraintSet::from_node(&builder, self.node);
+        let set = ConstraintSet::from_node(&builder, self.node, self.source_order);
         f(&builder, set)
     }
 
@@ -334,6 +341,16 @@ impl OwnedConstraintSetInner<'_> {
         );
         self.constraint_indices.rank(index) as usize
     }
+
+    fn retained_source_order_index(&self, id: SourceOrderId) -> usize {
+        let index = id.index();
+        debug_assert_eq!(
+            self.source_order_indices.get_bit(index),
+            Some(true),
+            "should not access constraint set source_order that was marked unused",
+        );
+        self.source_order_indices.rank(index) as usize
+    }
 }
 
 /// A set of constraints under which a type property holds.
@@ -351,6 +368,10 @@ pub struct ConstraintSet<'db, 'c> {
     /// The BDD representing this constraint set
     node: NodeId,
 
+    /// The source ordering of the constraints in this constraint set. Will be `None` for terminal
+    /// nodes.
+    source_order: Option<SourceOrderId>,
+
     /// A reference to the builder that holds the storage for this constraint set's BDD
     builder: &'c ConstraintSetBuilder<'db>,
 
@@ -359,20 +380,25 @@ pub struct ConstraintSet<'db, 'c> {
 }
 
 impl<'db, 'c> ConstraintSet<'db, 'c> {
-    fn from_node(builder: &'c ConstraintSetBuilder<'db>, node: NodeId) -> Self {
+    fn from_node(
+        builder: &'c ConstraintSetBuilder<'db>,
+        node: NodeId,
+        source_order: Option<SourceOrderId>,
+    ) -> Self {
         Self {
             node,
+            source_order,
             builder,
             _invariant: PhantomData,
         }
     }
 
     fn never(builder: &'c ConstraintSetBuilder<'db>) -> Self {
-        Self::from_node(builder, ALWAYS_FALSE)
+        Self::from_node(builder, ALWAYS_FALSE, None)
     }
 
     fn always(builder: &'c ConstraintSetBuilder<'db>) -> Self {
-        Self::from_node(builder, ALWAYS_TRUE)
+        Self::from_node(builder, ALWAYS_TRUE, None)
     }
 
     pub(crate) fn from_bool(builder: &'c ConstraintSetBuilder<'db>, b: bool) -> Self {
@@ -402,10 +428,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         lower: Option<Type<'db>>,
         upper: Option<Type<'db>>,
     ) -> Self {
-        Self::from_node(
-            builder,
-            Constraint::new_node_with_bounds(db, builder, typevar, lower, upper),
-        )
+        let (node, source_order) =
+            Constraint::new_node_with_bounds(db, builder, typevar, lower, upper);
+        Self::from_node(builder, node, source_order)
     }
 
     /// Returns a constraint set that constrains a typevar to be a supertype of `lower`.
@@ -473,7 +498,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         rhs: Type<'db>,
     ) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.implies_subtype_of(db, builder, lhs, rhs))
+        let (node, extra_source_order) = self.node.implies_subtype_of(db, builder, lhs, rhs);
+        let source_order = builder.ordered_source_order(self.source_order, extra_source_order);
+        Self::from_node(builder, node, source_order)
     }
 
     /// Returns whether this constraint set is satisfied by all of the typevars that it mentions.
@@ -512,6 +539,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     ) -> Self {
         self.verify_builder(builder);
         self.node = self.node.or_with_offset(builder, other.node);
+        self.source_order = builder.ordered_source_order(self.source_order, other.source_order);
         *self
     }
 
@@ -527,13 +555,14 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     ) -> Self {
         self.verify_builder(builder);
         self.node = self.node.and_with_offset(builder, other.node);
+        self.source_order = builder.ordered_source_order(self.source_order, other.source_order);
         *self
     }
 
     /// Returns the negation of this constraint set.
     pub(crate) fn negate(self, _db: &'db dyn Db, builder: &'c ConstraintSetBuilder<'db>) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.negate(builder))
+        Self::from_node(builder, self.node.negate(builder), self.source_order)
     }
 
     /// Returns the intersection of this constraint set and another. The other constraint set is
@@ -603,7 +632,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.iff_with_offset(builder, other.node))
+        let node = self.node.iff_with_offset(builder, other.node);
+        let source_order = builder.ordered_source_order(self.source_order, other.source_order);
+        Self::from_node(builder, node, source_order)
     }
 
     /// Reduces the set of inferable typevars for this constraint set. You provide the typevars that
@@ -617,7 +648,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         to_remove: TypeVarSet<'db>,
     ) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.exists(db, builder, to_remove))
+        let node = self.node.exists(db, builder, to_remove);
+        Self::from_node(builder, node, self.source_order)
     }
 
     /// Applies a type mapping to every constraint in this constraint set.
@@ -871,6 +903,15 @@ struct ConstraintSetStorage<'db> {
     /// The BDD nodes that appear in any of the constraint sets constructed in this builder.
     nodes: IndexVec<NodeId, InteriorNodeData>,
 
+    /// Encodes an ordering on the constraints in a constraint set, which is based on the order
+    /// that the constraints (or more accurately, the Python expressions they're derived from)
+    /// appear in the source code. This ensures that any union and intersections types that appear
+    /// in solutions are constructed in a stable (and source-consistent) order.
+    ///
+    /// This is encoded as a binary tree over [`ConstraintId`]s. The pre-walk of that tree defines
+    /// the ordering.
+    source_orders: IndexVec<SourceOrderId, SourceOrder>,
+
     // Everything below are the memoization tables for the arenas and for our BDD operations.
     constraint_cache: FxHashMap<Constraint<'db>, ConstraintId>,
     typevar_cache: FxHashMap<BoundTypeVarIdentity<'db>, TypeVarId>,
@@ -940,6 +981,13 @@ impl ConstraintSetStorage<'_> {
         id
     }
 
+    fn adjusted_source_order_id(&self, id: SourceOrderId) -> SourceOrderId {
+        if let Some(compacted) = &self.compacted {
+            return id + compacted.source_order_indices.len();
+        }
+        id
+    }
+
     fn adjusted_typevar_id(&self, id: TypeVarId) -> TypeVarId {
         if let Some(compacted) = &self.compacted {
             return id + compacted.typevars.len();
@@ -966,12 +1014,21 @@ impl<'db> ConstraintSetBuilder<'db> {
         let constraint = f(&self);
         let node = constraint.node;
         if node.is_terminal() {
-            return OwnedConstraintSet { node, inner: None };
+            return OwnedConstraintSet {
+                node,
+                source_order: None,
+                inner: None,
+            };
         }
+        let source_order = constraint
+            .source_order
+            .expect("non-terminal BDD should have source_order");
 
         let mut storage = self.storage.into_inner();
         let mut used_nodes = RankBitBox::bits_with_capacity(storage.nodes.len());
         let mut used_constraints = RankBitBox::bits_with_capacity(storage.constraints.len());
+        let mut used_source_orders = RankBitBox::bits_with_capacity(storage.source_orders.len());
+
         let mut stack = vec![node];
         while let Some(node) = stack.pop() {
             if node.is_terminal() || used_nodes[node.index()] {
@@ -984,8 +1041,23 @@ impl<'db> ConstraintSetBuilder<'db> {
             stack.push(interior.if_uncertain);
             stack.push(interior.if_false);
         }
-        used_nodes.truncate(used_nodes.last_one().map_or(0, |last| last + 1));
-        used_constraints.truncate(used_constraints.last_one().map_or(0, |last| last + 1));
+
+        let mut stack = vec![source_order];
+        while let Some(source_order) = stack.pop() {
+            if used_source_orders[source_order.index()] {
+                continue;
+            }
+            used_source_orders.set(source_order.index(), true);
+            match storage.source_orders[source_order] {
+                SourceOrder::Ordered(left, right) => {
+                    stack.push(left);
+                    stack.push(right);
+                }
+                SourceOrder::Constraint(constraint) => {
+                    used_constraints.set(constraint.index(), true);
+                }
+            }
+        }
 
         let nodes = storage
             .nodes
@@ -994,6 +1066,7 @@ impl<'db> ConstraintSetBuilder<'db> {
             .filter_map(|(node, used)| used.then_some(node))
             .collect();
         let node_indices = RankBitBox::from_bits(used_nodes);
+
         let constraints = storage
             .constraints
             .into_iter()
@@ -1001,16 +1074,28 @@ impl<'db> ConstraintSetBuilder<'db> {
             .filter_map(|(constraint, used)| used.then_some(constraint))
             .collect();
         let constraint_indices = RankBitBox::from_bits(used_constraints);
+
+        let source_orders = storage
+            .source_orders
+            .into_iter()
+            .zip(&used_source_orders)
+            .filter_map(|(source_order, used)| used.then_some(source_order))
+            .collect();
+        let source_order_indices = RankBitBox::from_bits(used_source_orders);
+
         storage.typevars.shrink_to_fit();
 
         OwnedConstraintSet {
             node,
+            source_order: Some(source_order),
             inner: Some(Arc::new(OwnedConstraintSetInner {
                 constraints,
                 constraint_indices,
                 typevars: storage.typevars,
                 nodes,
                 node_indices,
+                source_orders,
+                source_order_indices,
             })),
         }
     }
@@ -1033,7 +1118,7 @@ impl<'db> ConstraintSetBuilder<'db> {
         fn rebuild_node<'db>(
             builder: &ConstraintSetBuilder<'db>,
             inner: &OwnedConstraintSetInner<'db>,
-            constraints: &[NodeId],
+            constraints: &[(NodeId, Option<SourceOrderId>)],
             cache: &mut FxHashMap<NodeId, NodeId>,
             old_node: NodeId,
         ) -> NodeId {
@@ -1059,7 +1144,8 @@ impl<'db> ConstraintSetBuilder<'db> {
             // Shift the reloaded condition back to the source order recorded in the owned set;
             // solution extraction uses this order for deterministic unions and intersections.
             let old_constraint_index = inner.retained_constraint_index(old_interior.constraint);
-            let condition = constraints[old_constraint_index]
+            let (constraint_node, _) = constraints[old_constraint_index];
+            let condition = constraint_node
                 .with_adjusted_source_order(builder, old_interior.source_order.saturating_sub(1));
             let remapped = condition.ite_uncertain(builder, if_true, if_uncertain, if_false);
 
@@ -1068,7 +1154,7 @@ impl<'db> ConstraintSetBuilder<'db> {
         }
 
         if other.node.is_terminal() {
-            return ConstraintSet::from_node(self, other.node);
+            return ConstraintSet::from_node(self, other.node, None);
         }
         let inner = other
             .inner
@@ -1114,10 +1200,33 @@ impl<'db> ConstraintSetBuilder<'db> {
             })
             .collect();
 
+        let mut source_orders = vec![None; inner.source_orders.len()];
+        for (i, old_source_order) in inner.source_orders.iter().copied().enumerate() {
+            match old_source_order {
+                SourceOrder::Ordered(old_left, old_right) => {
+                    let old_left_index = inner.retained_source_order_index(old_left);
+                    let new_left = source_orders[old_left_index];
+                    let old_right_index = inner.retained_source_order_index(old_right);
+                    let new_right = source_orders[old_right_index];
+                    source_orders[i] = self.ordered_source_order(new_left, new_right);
+                }
+                SourceOrder::Constraint(old_constraint) => {
+                    let old_constraint_index = inner.retained_constraint_index(old_constraint);
+                    let (_, constraint_source_order) = constraints[old_constraint_index];
+                    source_orders[i] = constraint_source_order;
+                }
+            }
+        }
+
         // Maps NodeIds in the OwnedConstraintSet to the corresponding NodeIds in this builder.
         let mut cache = FxHashMap::default();
         let node = rebuild_node(self, inner, &constraints, &mut cache, other.node);
-        ConstraintSet::from_node(self, node)
+        let old_source_order = other
+            .source_order
+            .expect("non-terminal constraint set should have a source_order");
+        let old_source_order_index = inner.retained_source_order_index(old_source_order);
+        let source_order = source_orders[old_source_order_index];
+        ConstraintSet::from_node(self, node, source_order)
     }
 
     /// Interns a single typevar, giving it a stable order in this builder
@@ -1336,6 +1445,36 @@ impl<'db> ConstraintSetBuilder<'db> {
             return storage.nodes[NodeId::from_usize(index - split)];
         }
         storage.nodes[node]
+    }
+
+    fn intern_source_order(&self, data: SourceOrder) -> SourceOrderId {
+        let mut storage = self.storage.borrow_mut();
+        storage.ensure_overlay_identity_caches();
+        if let Some(id) = storage.source_order_cache.get(&data) {
+            return *id;
+        }
+        let id = storage.source_orders.push(data);
+        let id = storage.adjusted_source_order_id(id);
+        storage.source_order_cache.insert(data, id);
+        id
+    }
+
+    fn ordered_source_order(
+        &self,
+        left: Option<SourceOrderId>,
+        right: Option<SourceOrderId>,
+    ) -> Option<SourceOrderId> {
+        match (left, right) {
+            (None, None) => None,
+            (None, other) | (other, None) => other,
+            (Some(left), Some(right)) => {
+                Some(self.intern_source_order(SourceOrder::Ordered(left, right)))
+            }
+        }
+    }
+
+    fn constraint_source_order(&self, constraint: ConstraintId) -> SourceOrderId {
+        self.intern_source_order(SourceOrder::Constraint(constraint))
     }
 }
 
@@ -1733,7 +1872,7 @@ impl<'db> Constraint<'db> {
         typevar: BoundTypeVarInstance<'db>,
         lower: Type<'db>,
         upper: Type<'db>,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         Self::new_node_with_bounds(db, builder, typevar, Some(lower), Some(upper))
     }
 
@@ -1746,9 +1885,9 @@ impl<'db> Constraint<'db> {
         typevar: BoundTypeVarInstance<'db>,
         mut lower: Option<Type<'db>>,
         mut upper: Option<Type<'db>>,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         if lower.is_none() && upper.is_none() {
-            return ALWAYS_TRUE;
+            return (ALWAYS_TRUE, None);
         }
 
         // It's not useful for an upper bound to be an intersection type, or for a lower bound to
@@ -1761,19 +1900,19 @@ impl<'db> Constraint<'db> {
         //   (α | β) ≤ T   ⇔ (α ≤ T) ∧ (β ≤ T)
         if let Some(Type::Union(lower_union)) = lower {
             let mut result = ALWAYS_TRUE;
+            let mut source_order = None;
             for lower_element in lower_union.elements(db) {
-                result = result.and_with_offset(
+                let (element_node, element_source_order) = Constraint::new_node_with_bounds(
+                    db,
                     builder,
-                    Constraint::new_node_with_bounds(
-                        db,
-                        builder,
-                        typevar,
-                        Some(*lower_element),
-                        upper,
-                    ),
+                    typevar,
+                    Some(*lower_element),
+                    upper,
                 );
+                result = result.and_with_offset(builder, element_node);
+                source_order = builder.ordered_source_order(source_order, element_source_order);
             }
-            return result;
+            return (result, source_order);
         }
         // A negated type ¬α is represented as an intersection with no positive elements, and a
         // single negative element. We _don't_ want to treat that an "intersection" for the
@@ -1782,31 +1921,30 @@ impl<'db> Constraint<'db> {
             && !upper_intersection.is_simple_negation(db)
         {
             let mut result = ALWAYS_TRUE;
+            let mut source_order = None;
             for upper_element in upper_intersection.iter_positive(db) {
-                result = result.and_with_offset(
+                let (element_node, element_source_order) = Constraint::new_node_with_bounds(
+                    db,
                     builder,
-                    Constraint::new_node_with_bounds(
-                        db,
-                        builder,
-                        typevar,
-                        lower,
-                        Some(upper_element),
-                    ),
+                    typevar,
+                    lower,
+                    Some(upper_element),
                 );
+                result = result.and_with_offset(builder, element_node);
+                source_order = builder.ordered_source_order(source_order, element_source_order);
             }
             for upper_element in upper_intersection.iter_negative(db) {
-                result = result.and_with_offset(
+                let (element_node, element_source_order) = Constraint::new_node_with_bounds(
+                    db,
                     builder,
-                    Constraint::new_node_with_bounds(
-                        db,
-                        builder,
-                        typevar,
-                        lower,
-                        Some(upper_element.negate(db)),
-                    ),
+                    typevar,
+                    lower,
+                    Some(upper_element.negate(db)),
                 );
+                result = result.and_with_offset(builder, element_node);
+                source_order = builder.ordered_source_order(source_order, element_source_order);
             }
-            return result;
+            return (result, source_order);
         }
 
         // Two identical typevars must always solve to the same type, so it is not useful to have
@@ -1833,12 +1971,11 @@ impl<'db> Constraint<'db> {
                     })
                 }) =>
             {
-                return Node::new_constraint(
-                    builder,
-                    ConstraintId::new(db, builder, typevar, Type::Never, Type::object()),
-                    1,
-                )
-                .negate(builder);
+                let constraint =
+                    ConstraintId::new(db, builder, typevar, Type::Never, Type::object());
+                let source_order = builder.constraint_source_order(constraint);
+                let node = Node::new_constraint(builder, constraint, 1).negate(builder);
+                return (node, Some(source_order));
             }
             _ => {}
         }
@@ -1872,7 +2009,7 @@ impl<'db> Constraint<'db> {
         let when = effective_lower.when_constraint_set_assignable_to_owned(db, effective_upper);
         let is_never_satisfied = when.query(|_builder, when| when.is_never_satisfied(db));
         if is_never_satisfied {
-            return ALWAYS_FALSE;
+            return (ALWAYS_FALSE, None);
         }
 
         // We have an (arbitrary) ordering for typevars. If the upper and/or lower bounds are
@@ -1889,17 +2026,16 @@ impl<'db> Constraint<'db> {
                 } else {
                     (typevar, lower)
                 };
-                Node::new_constraint(
+                let constraint = ConstraintId::new(
+                    db,
                     builder,
-                    ConstraintId::new(
-                        db,
-                        builder,
-                        typevar,
-                        Type::TypeVar(bound),
-                        Type::TypeVar(bound),
-                    ),
-                    1,
-                )
+                    typevar,
+                    Type::TypeVar(bound),
+                    Type::TypeVar(bound),
+                );
+                let source_order = builder.constraint_source_order(constraint);
+                let node = Node::new_constraint(builder, constraint, 1);
+                (node, Some(source_order))
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
@@ -1907,78 +2043,80 @@ impl<'db> Constraint<'db> {
                 if typevar.can_be_bound_for(db, builder, lower)
                     && typevar.can_be_bound_for(db, builder, upper) =>
             {
-                let lower = Node::new_constraint(
+                let lower_constraint = ConstraintId::new_with_bounds(
+                    db,
                     builder,
-                    ConstraintId::new_with_bounds(
-                        db,
-                        builder,
-                        lower,
-                        None,
-                        Some(Type::TypeVar(typevar)),
-                    ),
-                    1,
+                    lower,
+                    None,
+                    Some(Type::TypeVar(typevar)),
                 );
-                let upper = Node::new_constraint(
+                let lower_source_order = Some(builder.constraint_source_order(lower_constraint));
+                let lower_node = Node::new_constraint(builder, lower_constraint, 1);
+                let upper_constraint = ConstraintId::new_with_bounds(
+                    db,
                     builder,
-                    ConstraintId::new_with_bounds(
-                        db,
-                        builder,
-                        upper,
-                        Some(Type::TypeVar(typevar)),
-                        None,
-                    ),
-                    1,
+                    upper,
+                    Some(Type::TypeVar(typevar)),
+                    None,
                 );
-                lower.and(builder, upper)
+                let upper_source_order = Some(builder.constraint_source_order(upper_constraint));
+                let upper_node = Node::new_constraint(builder, upper_constraint, 1);
+                let node = lower_node.and(builder, upper_node);
+                let source_order =
+                    builder.ordered_source_order(lower_source_order, upper_source_order);
+                (node, source_order)
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && ([T] ≤ U)
             (Type::TypeVar(lower), _) if typevar.can_be_bound_for(db, builder, lower) => {
-                let lower = Node::new_constraint(
+                let lower_constraint = ConstraintId::new_with_bounds(
+                    db,
                     builder,
-                    ConstraintId::new_with_bounds(
-                        db,
-                        builder,
-                        lower,
-                        None,
-                        Some(Type::TypeVar(typevar)),
-                    ),
-                    1,
+                    lower,
+                    None,
+                    Some(Type::TypeVar(typevar)),
                 );
-                let upper = if upper.is_none() {
-                    ALWAYS_TRUE
+                let lower_source_order = Some(builder.constraint_source_order(lower_constraint));
+                let lower_node = Node::new_constraint(builder, lower_constraint, 1);
+                let (upper_node, upper_source_order) = if upper.is_none() {
+                    (ALWAYS_TRUE, None)
                 } else {
                     Constraint::new_node_with_bounds(db, builder, typevar, None, upper)
                 };
-                lower.and(builder, upper)
+                let node = lower_node.and(builder, upper_node);
+                let source_order =
+                    builder.ordered_source_order(lower_source_order, upper_source_order);
+                (node, source_order)
             }
 
             // L ≤ T ≤ U == (L ≤ [T]) && (T ≤ [U])
             (_, Type::TypeVar(upper)) if typevar.can_be_bound_for(db, builder, upper) => {
-                let lower = if lower.is_none() {
-                    ALWAYS_TRUE
+                let (lower_node, lower_source_order) = if lower.is_none() {
+                    (ALWAYS_TRUE, None)
                 } else {
                     Constraint::new_node_with_bounds(db, builder, typevar, lower, None)
                 };
-                let upper = Node::new_constraint(
+                let upper_constraint = ConstraintId::new_with_bounds(
+                    db,
                     builder,
-                    ConstraintId::new_with_bounds(
-                        db,
-                        builder,
-                        upper,
-                        Some(Type::TypeVar(typevar)),
-                        None,
-                    ),
-                    1,
+                    upper,
+                    Some(Type::TypeVar(typevar)),
+                    None,
                 );
-                lower.and(builder, upper)
+                let upper_source_order = Some(builder.constraint_source_order(upper_constraint));
+                let upper_node = Node::new_constraint(builder, upper_constraint, 1);
+                let node = lower_node.and(builder, upper_node);
+                let source_order =
+                    builder.ordered_source_order(lower_source_order, upper_source_order);
+                (node, source_order)
             }
 
-            _ => Node::new_constraint(
-                builder,
-                ConstraintId::new_with_bounds(db, builder, typevar, lower, upper),
-                1,
-            ),
+            _ => {
+                let constraint = ConstraintId::new_with_bounds(db, builder, typevar, lower, upper);
+                let source_order = Some(builder.constraint_source_order(constraint));
+                let node = Node::new_constraint(builder, constraint, 1);
+                (node, source_order)
+            }
         }
     }
 }
@@ -2563,14 +2701,15 @@ impl NodeId {
     /// You must also provide the "zero" and "one" units of the operator. The "zero" is the value
     /// that has no effect (`0 ∨ a = a`). It is returned if the iterator is empty. The "one" is the
     /// value that saturates (`1 ∨ a = 1`). We use this to short-circuit; if any element BDD or any
-    /// intermediate result is the "one" terminal, we can return early.
-    fn tree_fold(
-        builder: &ConstraintSetBuilder<'_>,
-        nodes: impl Iterator<Item = Self>,
+    /// intermediate result evaluates to "one", we can return early.
+    fn tree_fold<'db>(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        nodes: impl Iterator<Item = (Self, Option<SourceOrderId>)>,
         zero: Self,
-        one: Self,
-        mut combine: impl FnMut(Self, &ConstraintSetBuilder<'_>, Self) -> Self,
-    ) -> Self {
+        is_one: impl Fn(Self, &'db dyn Db, &ConstraintSetBuilder<'db>) -> bool,
+        mut combine: impl FnMut(Self, &ConstraintSetBuilder<'db>, Self) -> Self,
+    ) -> (Self, Option<SourceOrderId>) {
         // To implement the "linear" shape described above, we could collect the iterator elements
         // into a vector, and then use the fold at the bottom of this method to combine the
         // elements using the operator.
@@ -2595,39 +2734,49 @@ impl NodeId {
         //
         // We use a SmallVec for the accumulator so that we don't have to spill over to the heap
         // until the iterator passes 256 elements.
-        let mut accumulator: SmallVec<[(NodeId, u8); 8]> = SmallVec::default();
-        for node in nodes {
-            if node == one {
-                return node;
+        let mut accumulator: SmallVec<[(NodeId, Option<SourceOrderId>, u8); 8]> =
+            SmallVec::default();
+        for (node, source_order) in nodes {
+            if is_one(node, db, builder) {
+                return (node, source_order);
             }
 
-            let (mut node, mut depth) = (node, 0);
+            let (mut node, mut source_order, mut depth) = (node, source_order, 0);
             while accumulator
                 .last()
-                .is_some_and(|(_, existing)| *existing == depth)
+                .is_some_and(|(_, _, existing)| *existing == depth)
             {
-                let (existing, _) = accumulator.pop().expect("accumulator should not be empty");
-                node = combine(existing, builder, node);
-                if node == one {
-                    return node;
+                let (existing_node, existing_source_order, _) =
+                    accumulator.pop().expect("accumulator should not be empty");
+                node = combine(existing_node, builder, node);
+                source_order = builder.ordered_source_order(existing_source_order, source_order);
+                if is_one(node, db, builder) {
+                    return (node, source_order);
                 }
                 depth += 1;
             }
-            accumulator.push((node, depth));
+            accumulator.push((node, source_order, depth));
         }
 
         // At this point, we've consumed all of the iterator. The length of the accumulator will be
         // the same as the number of 1 bits in the length of the iterator. We do a final fold to
         // produce the overall result.
-        accumulator
-            .into_iter()
-            .fold(zero, |result, (node, _)| combine(result, builder, node))
+        accumulator.into_iter().fold(
+            (zero, None),
+            |(result_node, result_source_order), (node, source_order, _)| {
+                (
+                    combine(result_node, builder, node),
+                    builder.ordered_source_order(result_source_order, source_order),
+                )
+            },
+        )
     }
 
-    fn distributed_or(
-        builder: &ConstraintSetBuilder<'_>,
-        nodes: impl Iterator<Item = NodeId>,
-    ) -> Self {
+    fn distributed_or<'db>(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        nodes: impl Iterator<Item = (NodeId, Option<SourceOrderId>)>,
+    ) -> (Self, Option<SourceOrderId>) {
         Self::tree_fold(
             builder,
             nodes,
@@ -2637,10 +2786,11 @@ impl NodeId {
         )
     }
 
-    fn distributed_and(
-        builder: &ConstraintSetBuilder<'_>,
-        nodes: impl Iterator<Item = NodeId>,
-    ) -> Self {
+    fn distributed_and<'db>(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        nodes: impl Iterator<Item = (NodeId, Option<SourceOrderId>)>,
+    ) -> (Self, Option<SourceOrderId>) {
         Self::tree_fold(
             builder,
             nodes,
@@ -2804,7 +2954,7 @@ impl NodeId {
         builder: &ConstraintSetBuilder<'db>,
         lhs: Type<'db>,
         rhs: Type<'db>,
-    ) -> Self {
+    ) -> (Self, Option<SourceOrderId>) {
         // When checking subtyping involving a typevar, we can turn the subtyping check into a
         // constraint (i.e, "is `T` a subtype of `int` becomes the constraint `T ≤ int`), and then
         // check when the BDD implies that constraint.
@@ -2813,7 +2963,7 @@ impl NodeId {
         // these types are coming in from arbitrary subtyping checks that the caller might want to
         // perform. So we have to take the appropriate materialization when translating the check
         // into a constraint.
-        let constraint = match (lhs, rhs) {
+        let (constraint, constraint_source_order) = match (lhs, rhs) {
             (Type::TypeVar(bound_typevar), _) => Constraint::new_node_with_bounds(
                 db,
                 builder,
@@ -2831,7 +2981,8 @@ impl NodeId {
             _ => panic!("at least one type should be a typevar"),
         };
 
-        self.implies(builder, constraint)
+        let node = self.implies(builder, constraint);
+        (node, constraint_source_order)
     }
 
     fn satisfied_by_all_typevars<'db>(
@@ -7526,17 +7677,18 @@ impl<'db> BoundTypeVarInstance<'db> {
             None => ALWAYS_TRUE,
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                 let bound = bound.top_materialization(db);
-                Constraint::new_node_with_bounds(db, builder, self, None, Some(bound))
+                let (node, _) =
+                    Constraint::new_node_with_bounds(db, builder, self, None, Some(bound));
+                node
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                 let mut specializations = ALWAYS_FALSE;
                 for constraint in constraints.elements(db) {
                     let constraint_lower = constraint.bottom_materialization(db);
                     let constraint_upper = constraint.top_materialization(db);
-                    specializations = specializations.or_with_offset(
-                        builder,
-                        Constraint::new_node(db, builder, self, constraint_lower, constraint_upper),
-                    );
+                    let (constraint_node, _) =
+                        Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
+                    specializations = specializations.or_with_offset(builder, constraint_node);
                 }
                 specializations
             }
@@ -7570,10 +7722,9 @@ impl<'db> BoundTypeVarInstance<'db> {
             None => (ALWAYS_TRUE, Vec::new()),
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                 let bound = bound.bottom_materialization(db);
-                (
-                    Constraint::new_node_with_bounds(db, builder, self, None, Some(bound)),
-                    Vec::new(),
-                )
+                let (node, _) =
+                    Constraint::new_node_with_bounds(db, builder, self, None, Some(bound));
+                (node, Vec::new())
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                 let mut non_gradual_constraints = ALWAYS_FALSE;
@@ -7581,7 +7732,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                 for constraint in constraints.elements(db) {
                     let constraint_lower = constraint.bottom_materialization(db);
                     let constraint_upper = constraint.top_materialization(db);
-                    let constraint =
+                    let (constraint, _) =
                         Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
                     if constraint_lower == constraint_upper {
                         non_gradual_constraints =

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -255,7 +255,8 @@ struct OwnedConstraintSetInner<'db> {
     typevars: IndexVec<TypeVarId, BoundTypeVarIdentity<'db>>,
     nodes: Box<[InteriorNodeData]>,
     node_indices: RankBitBox,
-    /// A dense, canonical source-order tree whose IDs are independent of builder history.
+    /// A dense, canonical source-order tree whose IDs are independent of sidecar construction
+    /// history.
     source_orders: Box<[SourceOrder]>,
 }
 
@@ -1041,10 +1042,11 @@ impl<'db> ConstraintSetBuilder<'db> {
             .source_order
             .expect("non-terminal BDD should have source_order");
 
-        // The source-order tree can retain repeated constraints from intermediate operations. If
-        // this constraint set participates in a Salsa cycle, retaining that construction history
-        // can make an otherwise stable result grow on every iteration and never converge. Build
-        // the owned source-order tree densely so its IDs are independent of that history.
+        // Combining constraint sets can allocate a new source-order tree even when the BDD is
+        // unchanged. Preserve each constraint's first source position, but rebuild the persisted
+        // sidecar densely so redundant combinations cannot affect its IDs or owned-set equality.
+        // Unlike node and constraint IDs, source-order IDs are not embedded in the BDD, so the
+        // sidecar can be rebuilt without remapping the BDD.
         let source_constraints = self.calculate_source_orders(Some(source_order));
 
         let mut storage = self.storage.into_inner();
@@ -8879,13 +8881,17 @@ mod tests {
         let t = create_typevar(&db, "T");
         let u = create_typevar(&db, "U");
 
-        let build = |include_unused_source_order| {
+        let build = |include_redundant_combination| {
             ConstraintSetBuilder::new().into_owned(|builder| {
                 let t_int = create_constraint(&db, builder, t, KnownClass::Int);
                 let u_str = create_constraint(&db, builder, u, KnownClass::Str);
 
-                if include_unused_source_order {
-                    let _ = builder.ordered_source_order(t_int.source_order, t_int.source_order);
+                if include_redundant_combination {
+                    // The redundant combination leaves the BDD unchanged but still creates an
+                    // intermediate source-order tree. It must not affect the final owned set.
+                    let redundant = t_int.and(&db, builder, || t_int);
+                    assert_eq!(redundant.node, t_int.node);
+                    assert_ne!(redundant.source_order, t_int.source_order);
                 }
 
                 t_int.and(&db, builder, || u_str)

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3676,7 +3676,10 @@ impl<'db> PathBounds<'db> {
             source_orders: &source_orders,
             sorted_paths: Vec::new(),
         };
-        let mut path = interior.path_assignments(builder);
+        // Sequent discovery must also happen in source order. Sorting the collected paths below
+        // is too late: sequent pairs are not commutative, and TDD traversal order can otherwise
+        // discard gradual evidence before solution extraction.
+        let mut path = interior.path_assignments_in_source_order(builder, &source_orders);
         let _ = path.visit(db, builder, node, &mut collect_visitor);
         collect_visitor.sorted_paths.sort_by(|path1, path2| {
             let source_orders1 = path1.iter().map(|(_, source_order)| *source_order);
@@ -4530,6 +4533,25 @@ impl InteriorNode {
             .for_each_unique_constraint(builder, &mut |constraint| {
                 constraints.push(constraint);
             });
+        PathAssignments::new(constraints)
+    }
+
+    fn path_assignments_in_source_order(
+        self,
+        builder: &ConstraintSetBuilder<'_>,
+        source_orders: &FxIndexSet<ConstraintId>,
+    ) -> PathAssignments {
+        let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
+        self.node()
+            .for_each_unique_constraint(builder, &mut |constraint| {
+                constraints.push(constraint);
+            });
+        // `PathAssignments` seeds its insertion-ordered discovered-constraint map from this list,
+        // and uses that order when constructing non-commutative sequent pairs. Do not replace this
+        // with TDD traversal order: doing so can change inference and lose gradual constraints.
+        // Keep any constraint absent from the sidecar in its stable traversal order after the rest.
+        constraints
+            .sort_by_key(|constraint| source_orders.get_index_of(constraint).unwrap_or(usize::MAX));
         PathAssignments::new(constraints)
     }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -927,9 +927,9 @@ struct ConstraintSetStorage<'db> {
     source_order_cache: FxHashMap<SourceOrder, SourceOrderId>,
     constraint_implication_cache: FxHashMap<(ConstraintId, ConstraintId), bool>,
     /// Only caches completed top-level results. Recursive results depend on active path
-    /// assignments and must not use this cache. Source order is part of the key because the same
-    /// TDD node can be traversed with different sidecar orderings, which changes sequent discovery.
-    never_satisfied_cache: FxHashMap<(NodeId, Option<SourceOrderId>), bool>,
+    /// assignments and must not use this cache. A BDD's satisfiability does not depend on the
+    /// source order used to traverse it.
+    never_satisfied_cache: FxHashMap<NodeId, bool>,
 
     negate_cache: FxHashMap<NodeId, NodeId>,
     or_cache: FxHashMap<(NodeId, NodeId), NodeId>,
@@ -2542,8 +2542,7 @@ impl NodeId {
             Node::AlwaysTrue => false,
             Node::AlwaysFalse => true,
             Node::Interior(interior) => {
-                let key = (self, source_order);
-                if let Some(result) = builder.storage.borrow().never_satisfied_cache.get(&key) {
+                if let Some(result) = builder.storage.borrow().never_satisfied_cache.get(&self) {
                     return *result;
                 }
 
@@ -2555,7 +2554,7 @@ impl NodeId {
                     .storage
                     .borrow_mut()
                     .never_satisfied_cache
-                    .insert(key, result);
+                    .insert(self, result);
                 result
             }
         }
@@ -7966,16 +7965,9 @@ mod tests {
 
         {
             let storage = builder.storage.borrow();
+            assert_eq!(storage.never_satisfied_cache.get(&t_int.node), Some(&false));
             assert_eq!(
-                storage
-                    .never_satisfied_cache
-                    .get(&(t_int.node, t_int.source_order)),
-                Some(&false)
-            );
-            assert_eq!(
-                storage
-                    .never_satisfied_cache
-                    .get(&(impossible.node, impossible.source_order)),
+                storage.never_satisfied_cache.get(&impossible.node),
                 Some(&true)
             );
             assert_eq!(storage.never_satisfied_cache.len(), 2);
@@ -7990,10 +7982,29 @@ mod tests {
                     .storage
                     .borrow()
                     .never_satisfied_cache
-                    .get(&(set.node, set.source_order)),
+                    .get(&set.node),
                 Some(&false)
             );
         });
+    }
+
+    #[test]
+    fn never_satisfied_cache_is_shared_across_source_orders() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let builder = ConstraintSetBuilder::new();
+        let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
+        let u_str = create_constraint(&db, &builder, u, KnownClass::Str);
+
+        let first = t_int.and(&db, &builder, || u_str);
+        let second = u_str.and(&db, &builder, || t_int);
+
+        assert_eq!(first.node, second.node);
+        assert_ne!(first.source_order, second.source_order);
+        assert!(!first.is_never_satisfied(&db));
+        assert!(!second.is_never_satisfied(&db));
+        assert_eq!(builder.storage.borrow().never_satisfied_cache.len(), 1);
     }
 
     #[derive(Clone, Copy)]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -96,6 +96,7 @@ use std::marker::PhantomData;
 use std::ops::{ControlFlow, Range};
 use std::sync::{Arc, LazyLock};
 
+use indexmap::map::Entry;
 use itertools::Itertools;
 use ruff_index::{Idx, IndexVec, newtype_index};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -6785,7 +6786,7 @@ impl PathAssignments {
             target: "ty_python_semantic::types::constraints::PathAssignment",
             before = %format_args!(
                 "[{}]",
-                self.assignments[..start].iter().map(|assignment| {
+                self.assignments[..start].iter().map(|(assignment, _)| {
                     assignment.display(db, builder)
                 }).format(", "),
             ),
@@ -6803,7 +6804,7 @@ impl PathAssignments {
                 target: "ty_python_semantic::types::constraints::PathAssignment",
                 new = %format_args!(
                     "[{}]",
-                    self.assignments[start..].iter().map(|assignment| {
+                    self.assignments[start..].iter().map(|(assignment, _)| {
                         assignment.display(db, builder)
                     }).format(", "),
                 ),
@@ -6827,7 +6828,9 @@ impl PathAssignments {
         result
     }
 
-    pub(crate) fn positive_constraints(&self) -> impl Iterator<Item = ConstraintId> + '_ {
+    pub(crate) fn positive_constraints(
+        &self,
+    ) -> impl Iterator<Item = (ConstraintId, ConstraintId)> + '_ {
         self.assignments
             .iter()
             .filter_map(|(assignment, (source_order, _))| match assignment {
@@ -6837,7 +6840,7 @@ impl PathAssignments {
     }
 
     fn assignment_holds(&self, assignment: ConstraintAssignment) -> bool {
-        self.assignments.contains(&assignment)
+        self.assignments.contains_key(&assignment)
     }
 
     fn contains_constraint(&self, constraint: ConstraintId) -> bool {
@@ -6933,7 +6936,7 @@ impl PathAssignments {
                 assignment = %assignment.display(db, builder),
                 facts = %format_args!(
                     "[{}]",
-                    self.assignments.iter().map(|assignment| {
+                    self.assignments.iter().map(|(assignment, _)| {
                         assignment.display(db, builder)
                     }).format(", "),
                 ),

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -537,7 +537,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        self.node = self.node.or_with_offset(builder, other.node);
+        self.node = self.node.or(builder, other.node);
         self.source_order = builder.ordered_source_order(self.source_order, other.source_order);
         *self
     }
@@ -553,7 +553,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        self.node = self.node.and_with_offset(builder, other.node);
+        self.node = self.node.and(builder, other.node);
         self.source_order = builder.ordered_source_order(self.source_order, other.source_order);
         *self
     }
@@ -631,7 +631,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        let node = self.node.iff_with_offset(builder, other.node);
+        let node = self.node.iff(builder, other.node);
         let source_order = builder.ordered_source_order(self.source_order, other.source_order);
         Self::from_node(builder, node, source_order)
     }
@@ -1144,9 +1144,7 @@ impl<'db> ConstraintSetBuilder<'db> {
             // Shift the reloaded condition back to the source order recorded in the owned set;
             // solution extraction uses this order for deterministic unions and intersections.
             let old_constraint_index = inner.retained_constraint_index(old_interior.constraint);
-            let (constraint_node, _) = constraints[old_constraint_index];
-            let condition = constraint_node
-                .with_adjusted_source_order(builder, old_interior.source_order.saturating_sub(1));
+            let (condition, _) = constraints[old_constraint_index];
             let remapped = condition.ite_uncertain(builder, if_true, if_uncertain, if_false);
 
             cache.insert(old_node, remapped);
@@ -1950,7 +1948,7 @@ impl<'db> Constraint<'db> {
                     Some(*lower_element),
                     upper,
                 );
-                result = result.and_with_offset(builder, element_node);
+                result = result.and(builder, element_node);
                 source_order = builder.ordered_source_order(source_order, element_source_order);
             }
             return (result, source_order);
@@ -1971,7 +1969,7 @@ impl<'db> Constraint<'db> {
                     lower,
                     Some(upper_element),
                 );
-                result = result.and_with_offset(builder, element_node);
+                result = result.and(builder, element_node);
                 source_order = builder.ordered_source_order(source_order, element_source_order);
             }
             for upper_element in upper_intersection.iter_negative(db) {
@@ -1982,7 +1980,7 @@ impl<'db> Constraint<'db> {
                     lower,
                     Some(upper_element.negate(db)),
                 );
-                result = result.and_with_offset(builder, element_node);
+                result = result.and(builder, element_node);
                 source_order = builder.ordered_source_order(source_order, element_source_order);
             }
             return (result, source_order);
@@ -2014,7 +2012,7 @@ impl<'db> Constraint<'db> {
             {
                 let constraint =
                     ConstraintId::new(db, builder, typevar, Type::Never, Type::object());
-                let (node, source_order) = Node::new_constraint(builder, constraint, 1);
+                let (node, source_order) = Node::new_constraint(builder, constraint);
                 let node = node.negate(builder);
                 return (node, source_order);
             }
@@ -2074,7 +2072,7 @@ impl<'db> Constraint<'db> {
                     Type::TypeVar(bound),
                     Type::TypeVar(bound),
                 );
-                Node::new_constraint(builder, constraint, 1)
+                Node::new_constraint(builder, constraint)
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
@@ -2090,7 +2088,7 @@ impl<'db> Constraint<'db> {
                     Some(Type::TypeVar(typevar)),
                 );
                 let (lower_node, lower_source_order) =
-                    Node::new_constraint(builder, lower_constraint, 1);
+                    Node::new_constraint(builder, lower_constraint);
                 let upper_constraint = ConstraintId::new_with_bounds(
                     db,
                     builder,
@@ -2099,7 +2097,7 @@ impl<'db> Constraint<'db> {
                     None,
                 );
                 let (upper_node, upper_source_order) =
-                    Node::new_constraint(builder, upper_constraint, 1);
+                    Node::new_constraint(builder, upper_constraint);
                 let node = lower_node.and(builder, upper_node);
                 let source_order =
                     builder.ordered_source_order(lower_source_order, upper_source_order);
@@ -2116,7 +2114,7 @@ impl<'db> Constraint<'db> {
                     Some(Type::TypeVar(typevar)),
                 );
                 let (lower_node, lower_source_order) =
-                    Node::new_constraint(builder, lower_constraint, 1);
+                    Node::new_constraint(builder, lower_constraint);
                 let (upper_node, upper_source_order) = if upper.is_none() {
                     (ALWAYS_TRUE, None)
                 } else {
@@ -2143,7 +2141,7 @@ impl<'db> Constraint<'db> {
                     None,
                 );
                 let (upper_node, upper_source_order) =
-                    Node::new_constraint(builder, upper_constraint, 1);
+                    Node::new_constraint(builder, upper_constraint);
                 let node = lower_node.and(builder, upper_node);
                 let source_order =
                     builder.ordered_source_order(lower_source_order, upper_source_order);
@@ -2152,7 +2150,7 @@ impl<'db> Constraint<'db> {
 
             _ => {
                 let constraint = ConstraintId::new_with_bounds(db, builder, typevar, lower, upper);
-                Node::new_constraint(builder, constraint, 1)
+                Node::new_constraint(builder, constraint)
             }
         }
     }
@@ -2342,16 +2340,8 @@ impl NodeId {
         constraint: ConstraintId,
         if_true: NodeId,
         if_false: NodeId,
-        source_order: usize,
     ) -> NodeId {
-        Self::with_uncertain(
-            builder,
-            constraint,
-            if_true,
-            ALWAYS_FALSE,
-            if_false,
-            source_order,
-        )
+        Self::with_uncertain(builder, constraint, if_true, ALWAYS_FALSE, if_false)
     }
 
     /// Creates a new TDD node with an explicit `if_uncertain` branch, applying local reductions.
@@ -2361,7 +2351,6 @@ impl NodeId {
         if_true: NodeId,
         if_uncertain: NodeId,
         if_false: NodeId,
-        source_order: usize,
     ) -> NodeId {
         debug_assert!(
             if_true
@@ -2413,17 +2402,11 @@ impl NodeId {
             return if_uncertain;
         }
 
-        let max_source_order = source_order
-            .max(if_true.max_source_order(builder))
-            .max(if_uncertain.max_source_order(builder))
-            .max(if_false.max_source_order(builder));
         builder.intern_interior_node(InteriorNodeData {
             constraint,
             if_true,
             if_uncertain,
             if_false,
-            source_order,
-            max_source_order,
         })
     }
 }
@@ -2434,17 +2417,9 @@ impl Node {
     fn new_constraint(
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintId,
-        source_order: usize,
     ) -> (NodeId, Option<SourceOrderId>) {
         (
-            NodeId::with_uncertain(
-                builder,
-                constraint,
-                ALWAYS_TRUE,
-                ALWAYS_FALSE,
-                ALWAYS_FALSE,
-                source_order,
-            ),
+            NodeId::with_uncertain(builder, constraint, ALWAYS_TRUE, ALWAYS_FALSE, ALWAYS_FALSE),
             Some(builder.constraint_source_order(constraint)),
         )
     }
@@ -2457,7 +2432,6 @@ impl Node {
     fn new_satisfied_constraint(
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintAssignment,
-        source_order: usize,
     ) -> (NodeId, Option<SourceOrderId>) {
         match constraint {
             ConstraintAssignment::Positive(constraint) => (
@@ -2467,7 +2441,6 @@ impl Node {
                     ALWAYS_TRUE,
                     ALWAYS_FALSE,
                     ALWAYS_FALSE,
-                    source_order,
                 ),
                 Some(builder.constraint_source_order(constraint)),
             ),
@@ -2478,7 +2451,6 @@ impl Node {
                     ALWAYS_FALSE,
                     ALWAYS_FALSE,
                     ALWAYS_TRUE,
-                    source_order,
                 ),
                 Some(builder.constraint_source_order(constraint)),
             ),
@@ -2493,7 +2465,6 @@ impl Node {
                     ALWAYS_FALSE,
                     ALWAYS_TRUE,
                     ALWAYS_FALSE,
-                    source_order,
                 ),
                 Some(builder.constraint_source_order(constraint)),
             ),
@@ -2530,37 +2501,6 @@ impl NodeId {
         }
         let interior = builder.interior_node_data(self);
         Some(interior.constraint)
-    }
-
-    fn max_source_order(self, builder: &ConstraintSetBuilder<'_>) -> usize {
-        if self.is_terminal() {
-            return 0;
-        }
-        let interior = builder.interior_node_data(self);
-        interior.max_source_order
-    }
-
-    /// Returns a copy of this BDD node with all `source_order`s adjusted by the given amount.
-    fn with_adjusted_source_order(self, builder: &ConstraintSetBuilder<'_>, delta: usize) -> Self {
-        if delta == 0 {
-            return self;
-        }
-        match self.node() {
-            Node::AlwaysTrue | Node::AlwaysFalse => self,
-            Node::Interior(_) => {
-                let interior = builder.interior_node_data(self);
-                NodeId::with_uncertain(
-                    builder,
-                    interior.constraint,
-                    interior.if_true.with_adjusted_source_order(builder, delta),
-                    interior
-                        .if_uncertain
-                        .with_adjusted_source_order(builder, delta),
-                    interior.if_false.with_adjusted_source_order(builder, delta),
-                    interior.source_order + delta,
-                )
-            }
-        }
     }
 
     /// Checks whether this BDD represents a single conjunction (of an arbitrary number of
@@ -2673,28 +2613,7 @@ impl NodeId {
     ///
     /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
     /// nodes.
-    fn or_with_offset(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        // To ensure that `self` appears before `other` in `source_order`, we add the maximum
-        // `source_order` of the lhs to all of the `source_order`s in the rhs.
-        //
-        // TODO: If we store `other_offset` as a new field on InteriorNode, we might be able to
-        // avoid all of the extra work in the calls to with_adjusted_source_order, and apply the
-        // adjustment lazily when walking a BDD tree. (ditto below in the other _with_offset
-        // methods)
-        let other_offset = self.max_source_order(builder);
-        self.or_inner(builder, other, other_offset)
-    }
-
     fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        self.or_inner(builder, other, 0)
-    }
-
-    fn or_inner(
-        self,
-        builder: &ConstraintSetBuilder<'_>,
-        other: Self,
-        other_offset: usize,
-    ) -> Self {
         match (self.node(), other.node()) {
             (Node::AlwaysTrue, Node::AlwaysTrue) => ALWAYS_TRUE,
             (Node::AlwaysTrue, Node::Interior(_)) => {
@@ -2707,7 +2626,6 @@ impl NodeId {
                     ALWAYS_FALSE,
                     ALWAYS_TRUE,
                     ALWAYS_FALSE,
-                    other_interior.source_order + other_offset,
                 )
             }
             (Node::Interior(_), Node::AlwaysTrue) => {
@@ -2720,13 +2638,12 @@ impl NodeId {
                     ALWAYS_FALSE,
                     ALWAYS_TRUE,
                     ALWAYS_FALSE,
-                    self_interior.source_order,
                 )
             }
-            (Node::AlwaysFalse, _) => other.with_adjusted_source_order(builder, other_offset),
+            (Node::AlwaysFalse, _) => other,
             (_, Node::AlwaysFalse) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
-                self_interior.or(builder, other_interior, other_offset)
+                self_interior.or(builder, other_interior)
             }
         }
     }
@@ -2828,8 +2745,8 @@ impl NodeId {
             builder,
             nodes,
             ALWAYS_FALSE,
-            ALWAYS_TRUE,
-            Self::or_with_offset,
+            Self::is_always_satisfied,
+            Self::or,
         )
     }
 
@@ -2842,32 +2759,13 @@ impl NodeId {
             builder,
             nodes,
             ALWAYS_TRUE,
-            ALWAYS_FALSE,
-            Self::and_with_offset,
+            Self::is_never_satisfied,
+            Self::and,
         )
     }
 
     /// Returns the `and` or intersection of two BDDs.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
-    fn and_with_offset(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        // To ensure that `self` appears before `other` in `source_order`, we add the maximum
-        // `source_order` of the lhs to all of the `source_order`s in the rhs.
-        let other_offset = self.max_source_order(builder);
-        self.and_inner(builder, other, other_offset)
-    }
-
     fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        self.and_inner(builder, other, 0)
-    }
-
-    fn and_inner(
-        self,
-        builder: &ConstraintSetBuilder<'_>,
-        other: Self,
-        other_offset: usize,
-    ) -> Self {
         match (self.node(), other.node()) {
             (Node::AlwaysFalse, Node::AlwaysFalse) => ALWAYS_FALSE,
             (Node::AlwaysFalse, Node::Interior(_)) => {
@@ -2877,7 +2775,6 @@ impl NodeId {
                     other_interior.constraint,
                     ALWAYS_FALSE,
                     ALWAYS_FALSE,
-                    other_interior.source_order + other_offset,
                 )
             }
             (Node::Interior(_), Node::AlwaysFalse) => {
@@ -2887,13 +2784,12 @@ impl NodeId {
                     self_interior.constraint,
                     ALWAYS_FALSE,
                     ALWAYS_FALSE,
-                    self_interior.source_order,
                 )
             }
-            (Node::AlwaysTrue, _) => other.with_adjusted_source_order(builder, other_offset),
+            (Node::AlwaysTrue, _) => other,
             (_, Node::AlwaysTrue) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
-                self_interior.and(builder, other_interior, other_offset)
+                self_interior.and(builder, other_interior)
             }
         }
     }
@@ -2908,28 +2804,10 @@ impl NodeId {
     ///
     /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
     /// nodes.
-    fn iff_with_offset(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        // To ensure that `self` appears before `other` in `source_order`, we add the maximum
-        // `source_order` of the lhs to all of the `source_order`s in the rhs.
-        let other_offset = self.max_source_order(builder);
-        self.iff_inner(builder, other, other_offset)
-    }
-
     fn iff(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        self.iff_inner(builder, other, 0)
-    }
-
-    fn iff_inner(
-        self,
-        builder: &ConstraintSetBuilder<'_>,
-        other: Self,
-        other_offset: usize,
-    ) -> Self {
         // iff(a, b) = (a ∧ b) ∨ (¬a ∧ ¬b)
-        let a_and_b = self.and_inner(builder, other, other_offset);
-        let not_a_and_not_b =
-            self.negate(builder)
-                .and_inner(builder, other.negate(builder), other_offset);
+        let a_and_b = self.and(builder, other);
+        let not_a_and_not_b = self.negate(builder).and(builder, other.negate(builder));
         a_and_b.or(builder, not_a_and_not_b)
     }
 
@@ -2981,7 +2859,6 @@ impl NodeId {
                         then_node,
                         uncertain_node,
                         else_node,
-                        interior.source_order,
                     );
                 }
 
@@ -3045,7 +2922,7 @@ impl NodeId {
         }
 
         let mut typevars = FxHashSet::default();
-        self.for_each_unique_constraint(builder, &mut |constraint, _| {
+        self.for_each_unique_constraint(builder, &mut |constraint| {
             let constraint = builder.constraint_data(constraint);
             typevars.insert(constraint.typevar);
         });
@@ -3189,15 +3066,12 @@ impl NodeId {
     }
 
     /// Returns a new BDD with any occurrence of `left ∧ right` replaced with `replacement`.
-    #[expect(clippy::too_many_arguments)]
     fn substitute_intersection<'db>(
         self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         left: ConstraintAssignment,
-        left_source_order: usize,
         right: ConstraintAssignment,
-        right_source_order: usize,
         replacement: NodeId,
     ) -> Self {
         // We perform a Shannon expansion to find out what the input BDD evaluates to when:
@@ -3231,8 +3105,8 @@ impl NodeId {
         //     false
         //
         //  (Note that the `else` branch shouldn't be reachable, but we have to provide something!)
-        let (left_node, _) = Node::new_satisfied_constraint(builder, left, left_source_order);
-        let (right_node, _) = Node::new_satisfied_constraint(builder, right, right_source_order);
+        let (left_node, _) = Node::new_satisfied_constraint(builder, left);
+        let (right_node, _) = Node::new_satisfied_constraint(builder, right);
         let right_result = right_node.ite(builder, ALWAYS_FALSE, when_left_but_not_right);
         let left_result = left_node.ite(builder, right_result, when_not_left);
         let result = replacement.ite(builder, when_left_and_right, left_result);
@@ -3251,15 +3125,12 @@ impl NodeId {
     }
 
     /// Returns a new BDD with any occurrence of `left ∨ right` replaced with `replacement`.
-    #[expect(clippy::too_many_arguments)]
     fn substitute_union<'db>(
         self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         left: ConstraintAssignment,
-        left_source_order: usize,
         right: ConstraintAssignment,
-        right_source_order: usize,
         replacement: NodeId,
     ) -> Self {
         // We perform a Shannon expansion to find out what the input BDD evaluates to when:
@@ -3299,8 +3170,8 @@ impl NodeId {
         // Lastly, verify that the result is consistent with the input. (It must produce the same
         // results when `left ∨ right`.) If it doesn't, the substitution isn't valid, and we should
         // return the original BDD unmodified.
-        let (left_node, _) = Node::new_satisfied_constraint(builder, left, left_source_order);
-        let (right_node, _) = Node::new_satisfied_constraint(builder, right, right_source_order);
+        let (left_node, _) = Node::new_satisfied_constraint(builder, left);
+        let (right_node, _) = Node::new_satisfied_constraint(builder, right);
         let validity = replacement.iff(builder, left_node.or(builder, right_node));
         let constrained_original = self.and(builder, validity);
         let constrained_replacement = result.and(builder, validity);
@@ -3319,19 +3190,19 @@ impl NodeId {
     fn for_each_unique_constraint(
         self,
         builder: &ConstraintSetBuilder<'_>,
-        f: &mut dyn FnMut(ConstraintId, usize),
+        f: &mut dyn FnMut(ConstraintId),
     ) {
         fn walk(
             node: NodeId,
             builder: &ConstraintSetBuilder<'_>,
             seen: &mut FxHashSet<NodeId>,
-            f: &mut dyn FnMut(ConstraintId, usize),
+            f: &mut dyn FnMut(ConstraintId),
         ) {
             if node.is_terminal() || !seen.insert(node) {
                 return;
             }
             let interior = builder.interior_node_data(node);
-            f(interior.constraint, interior.source_order);
+            f(interior.constraint);
             walk(interior.if_true, builder, seen, f);
             walk(interior.if_uncertain, builder, seen, f);
             walk(interior.if_false, builder, seen, f);
@@ -3492,13 +3363,7 @@ impl NodeId {
                         return write!(f, "<{index}> SHARED");
                     }
                     let interior = builder.interior_node_data(node);
-                    write!(
-                        f,
-                        "<{index}> {} {}/{}",
-                        interior.constraint.display(db, builder),
-                        interior.source_order,
-                        interior.max_source_order,
-                    )?;
+                    write!(f, "<{index}> {}", interior.constraint.display(db, builder))?;
                     // Calling display_graph recursively here causes rustc to claim that the
                     // expect(unused) up above is unfulfilled!
                     write!(f, "\n{prefix}┡━₁ ")?;
@@ -3596,16 +3461,6 @@ struct InteriorNodeData {
     if_true: NodeId,
     if_uncertain: NodeId,
     if_false: NodeId,
-
-    /// Represents the order in which this node's constraint was added to the containing constraint
-    /// set, relative to all of the other constraints in the set. This starts off at 1 for a simple
-    /// single-constraint set (e.g. created with [`Node::new_constraint`] or
-    /// [`Node::new_satisfied_constraint`]). It will get incremented, if needed, as that simple BDD
-    /// is combined into larger BDDs.
-    source_order: usize,
-
-    /// The maximum `source_order` across this node and all of its descendants.
-    max_source_order: usize,
 }
 
 /// Accumulates lower and upper bounds for a single typevar on a single BDD path.
@@ -3896,6 +3751,7 @@ impl<'db> PathBounds<'db> {
     fn compute_simple_bound_conjunction(
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
+        source_orders: &FxIndexSet<ConstraintId>,
         node: NodeId,
         inferable: TypeVarSet<'db>,
     ) -> Option<Self> {
@@ -4219,7 +4075,6 @@ impl InteriorNode {
             interior.constraint,
             not_true.and(builder, not_uncertain),
             not_false.and(builder, not_uncertain),
-            interior.source_order,
         );
 
         let mut storage = builder.storage.borrow_mut();
@@ -4227,8 +4082,8 @@ impl InteriorNode {
         result
     }
 
-    fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self, other_offset: usize) -> NodeId {
-        let key = (self.node(), other.node(), other_offset);
+    fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
+        let key = (self.node(), other.node());
         let storage = builder.storage.borrow();
         if let Some(result) = storage.or_cache.get(&key) {
             return *result;
@@ -4243,18 +4098,11 @@ impl InteriorNode {
             Ordering::Equal => NodeId::with_uncertain(
                 builder,
                 self_interior.constraint,
+                self_interior.if_true.or(builder, other_interior.if_true),
                 self_interior
-                    .if_true
-                    .or_inner(builder, other_interior.if_true, other_offset),
-                self_interior.if_uncertain.or_inner(
-                    builder,
-                    other_interior.if_uncertain,
-                    other_offset,
-                ),
-                self_interior
-                    .if_false
-                    .or_inner(builder, other_interior.if_false, other_offset),
-                self_interior.source_order,
+                    .if_uncertain
+                    .or(builder, other_interior.if_uncertain),
+                self_interior.if_false.or(builder, other_interior.if_false),
             ),
             // This is from Frisch's original description of TDDs. If self < other, we check self
             // first. Instead of distributing other into the if_true and if_false branches, we
@@ -4264,21 +4112,16 @@ impl InteriorNode {
                 builder,
                 self_interior.constraint,
                 self_interior.if_true,
-                self_interior
-                    .if_uncertain
-                    .or_inner(builder, other.node(), other_offset),
+                self_interior.if_uncertain.or(builder, other.node()),
                 self_interior.if_false,
-                self_interior.source_order,
             ),
             // Ditto above but for the other variable ordering
             Ordering::Greater => NodeId::with_uncertain(
                 builder,
                 other_interior.constraint,
                 other_interior.if_true,
-                self.node()
-                    .or_inner(builder, other_interior.if_uncertain, other_offset),
+                self.node().or(builder, other_interior.if_uncertain),
                 other_interior.if_false,
-                other_interior.source_order + other_offset,
             ),
         };
 
@@ -4287,8 +4130,8 @@ impl InteriorNode {
         result
     }
 
-    fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self, other_offset: usize) -> NodeId {
-        let key = (self.node(), other.node(), other_offset);
+    fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
+        let key = (self.node(), other.node());
         let storage = builder.storage.borrow();
         if let Some(result) = storage.and_cache.get(&key) {
             return *result;
@@ -4312,48 +4155,34 @@ impl InteriorNode {
             Ordering::Equal => {
                 let if_true = self_interior
                     .if_true
-                    .and_inner(
+                    .and(
                         builder,
-                        other_interior.if_true.or_inner(
-                            builder,
-                            other_interior.if_uncertain,
-                            other_offset,
-                        ),
-                        other_offset,
+                        other_interior
+                            .if_true
+                            .or(builder, other_interior.if_uncertain),
                     )
-                    .or_inner(
+                    .or(
                         builder,
-                        self_interior.if_uncertain.and_inner(
-                            builder,
-                            other_interior.if_true,
-                            other_offset,
-                        ),
-                        0,
+                        self_interior
+                            .if_uncertain
+                            .and(builder, other_interior.if_true),
                     );
-                let if_uncertain = self_interior.if_uncertain.and_inner(
-                    builder,
-                    other_interior.if_uncertain,
-                    other_offset,
-                );
+                let if_uncertain = self_interior
+                    .if_uncertain
+                    .and(builder, other_interior.if_uncertain);
                 let if_false = self_interior
                     .if_false
-                    .and_inner(
+                    .and(
                         builder,
-                        other_interior.if_uncertain.or_inner(
-                            builder,
-                            other_interior.if_false,
-                            other_offset,
-                        ),
-                        other_offset,
+                        other_interior
+                            .if_uncertain
+                            .or(builder, other_interior.if_false),
                     )
-                    .or_inner(
+                    .or(
                         builder,
-                        self_interior.if_uncertain.and_inner(
-                            builder,
-                            other_interior.if_false,
-                            other_offset,
-                        ),
-                        0,
+                        self_interior
+                            .if_uncertain
+                            .and(builder, other_interior.if_false),
                     );
                 NodeId::with_uncertain(
                     builder,
@@ -4361,33 +4190,21 @@ impl InteriorNode {
                     if_true,
                     if_uncertain,
                     if_false,
-                    self_interior.source_order,
                 )
             }
             Ordering::Less => NodeId::with_uncertain(
                 builder,
                 self_interior.constraint,
-                self_interior
-                    .if_true
-                    .and_inner(builder, other.node(), other_offset),
-                self_interior
-                    .if_uncertain
-                    .and_inner(builder, other.node(), other_offset),
-                self_interior
-                    .if_false
-                    .and_inner(builder, other.node(), other_offset),
-                self_interior.source_order,
+                self_interior.if_true.and(builder, other.node()),
+                self_interior.if_uncertain.and(builder, other.node()),
+                self_interior.if_false.and(builder, other.node()),
             ),
             Ordering::Greater => NodeId::with_uncertain(
                 builder,
                 other_interior.constraint,
-                self.node()
-                    .and_inner(builder, other_interior.if_true, other_offset),
-                self.node()
-                    .and_inner(builder, other_interior.if_uncertain, other_offset),
-                self.node()
-                    .and_inner(builder, other_interior.if_false, other_offset),
-                other_interior.source_order + other_offset,
+                self.node().and(builder, other_interior.if_true),
+                self.node().and(builder, other_interior.if_uncertain),
+                self.node().and(builder, other_interior.if_false),
             ),
         };
 
@@ -4687,7 +4504,6 @@ impl InteriorNode {
                         if_true,
                         if_uncertain,
                         if_false,
-                        self_interior.source_order,
                     ),
                     found_in_true || found_in_uncertain || found_in_false,
                 )
@@ -4700,18 +4516,12 @@ impl InteriorNode {
     }
 
     fn path_assignments(self, builder: &ConstraintSetBuilder<'_>) -> PathAssignments {
-        // Sort the constraints in this BDD by their `source_order`s before adding them to the
-        // sequent map. This ensures that constraints appear in the sequent map in a stable order.
-        // The constraints mentioned in a BDD should all have distinct `source_order`s, so an
-        // unstable sort is fine.
         let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
         self.node()
-            .for_each_unique_constraint(builder, &mut |constraint, source_order| {
-                constraints.push((constraint, source_order));
+            .for_each_unique_constraint(builder, &mut |constraint| {
+                constraints.push(constraint);
             });
-        constraints.sort_unstable_by_key(|(_, source_order)| *source_order);
-
-        PathAssignments::new(constraints.into_iter().map(|(constraint, _)| constraint))
+        PathAssignments::new(constraints)
     }
 
     /// Returns a simplified version of a BDD.
@@ -4743,14 +4553,9 @@ impl InteriorNode {
         // visit queue with all pairs of those constraints. (We use "combinations" because we don't
         // need to compare a constraint against itself, and because ordering doesn't matter.)
         let mut seen_constraints = FxHashSet::default();
-        let mut source_orders = FxHashMap::default();
         self.node()
-            .for_each_unique_constraint(builder, &mut |constraint, source_order| {
+            .for_each_unique_constraint(builder, &mut |constraint| {
                 seen_constraints.insert(constraint);
-                source_orders
-                    .entry(constraint)
-                    .and_modify(|existing: &mut usize| *existing = (*existing).min(source_order))
-                    .or_insert(source_order);
             });
         let mut to_visit: Vec<(_, _)> = (seen_constraints.iter().copied())
             .array_combinations()
@@ -4758,17 +4563,9 @@ impl InteriorNode {
             .collect();
 
         // Repeatedly pop constraint pairs off of the visit queue, checking whether each pair can
-        // be simplified. If we add any derived constraints, we will place them at the end in
-        // source order. (We do not have any test cases that depend on constraint sets being
-        // displayed in a consistent ordering, so we don't need to be clever in assigning these
-        // `source_order`s.)
+        // be simplified.
         let mut simplified = self.node();
-        let self_interior = builder.interior_node_data(self.node());
-        let mut next_source_order = self_interior.max_source_order + 1;
         while let Some((left_constraint, right_constraint)) = to_visit.pop() {
-            let left_source_order = source_orders[&left_constraint];
-            let right_source_order = source_orders[&right_constraint];
-
             // If the constraints refer to different typevars, the only simplifications we can make
             // are of the form `S ≤ T ∧ T ≤ int → S ≤ int`.
             let left_constraint_data = builder.constraint_data(left_constraint);
@@ -4840,19 +4637,11 @@ impl InteriorNode {
                 if seen_constraints.contains(&new_constraint) {
                     continue;
                 }
-                let (new_node, _) =
-                    Node::new_constraint(builder, new_constraint, next_source_order);
-                next_source_order += 1;
-                let (positive_left_node, _) = Node::new_satisfied_constraint(
-                    builder,
-                    left_constraint.when_true(),
-                    left_source_order,
-                );
-                let (positive_right_node, _) = Node::new_satisfied_constraint(
-                    builder,
-                    right_constraint.when_true(),
-                    right_source_order,
-                );
+                let (new_node, _) = Node::new_constraint(builder, new_constraint);
+                let (positive_left_node, _) =
+                    Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                let (positive_right_node, _) =
+                    Node::new_satisfied_constraint(builder, right_constraint.when_true());
                 let lhs = positive_left_node.and(builder, positive_right_node);
                 let intersection = new_node.ite(builder, lhs, ALWAYS_FALSE);
                 simplified = simplified.and(builder, intersection);
@@ -4887,48 +4676,24 @@ impl InteriorNode {
             // Containment: The range of one constraint might completely contain the range of the
             // other. If so, there are several potential simplifications.
             let larger_smaller = if left_constraint.implies(db, builder, right_constraint) {
-                Some((
-                    right_constraint,
-                    right_source_order,
-                    left_constraint,
-                    left_source_order,
-                ))
+                Some((right_constraint, left_constraint))
             } else if right_constraint.implies(db, builder, left_constraint) {
-                Some((
-                    left_constraint,
-                    left_source_order,
-                    right_constraint,
-                    right_source_order,
-                ))
+                Some((left_constraint, right_constraint))
             } else {
                 None
             };
-            if let Some((
-                larger_constraint,
-                larger_source_order,
-                smaller_constraint,
-                smaller_source_order,
-            )) = larger_smaller
-            {
-                let (positive_larger_node, _) = Node::new_satisfied_constraint(
-                    builder,
-                    larger_constraint.when_true(),
-                    larger_source_order,
-                );
-                let (negative_larger_node, _) = Node::new_satisfied_constraint(
-                    builder,
-                    larger_constraint.when_false(),
-                    larger_source_order,
-                );
+            if let Some((larger_constraint, smaller_constraint)) = larger_smaller {
+                let (positive_larger_node, _) =
+                    Node::new_satisfied_constraint(builder, larger_constraint.when_true());
+                let (negative_larger_node, _) =
+                    Node::new_satisfied_constraint(builder, larger_constraint.when_false());
 
                 // larger ∨ smaller = larger
                 simplified = simplified.substitute_union(
                     db,
                     builder,
                     larger_constraint.when_true(),
-                    larger_source_order,
                     smaller_constraint.when_true(),
-                    smaller_source_order,
                     positive_larger_node,
                 );
 
@@ -4937,9 +4702,7 @@ impl InteriorNode {
                     db,
                     builder,
                     larger_constraint.when_false(),
-                    larger_source_order,
                     smaller_constraint.when_false(),
-                    smaller_source_order,
                     negative_larger_node,
                 );
 
@@ -4949,9 +4712,7 @@ impl InteriorNode {
                     db,
                     builder,
                     larger_constraint.when_false(),
-                    larger_source_order,
                     smaller_constraint.when_true(),
-                    smaller_source_order,
                     ALWAYS_FALSE,
                 );
 
@@ -4961,9 +4722,7 @@ impl InteriorNode {
                     db,
                     builder,
                     larger_constraint.when_true(),
-                    larger_source_order,
                     smaller_constraint.when_false(),
-                    smaller_source_order,
                     ALWAYS_TRUE,
                 );
             }
@@ -4980,7 +4739,6 @@ impl InteriorNode {
                     // represent that intersection. We also need to add the new constraint to our
                     // seen set and (if we haven't already seen it) to the to-visit queue.
                     if seen_constraints.insert(intersection_constraint) {
-                        source_orders.insert(intersection_constraint, next_source_order);
                         to_visit.extend(
                             (seen_constraints.iter().copied())
                                 .filter(|seen| *seen != intersection_constraint)
@@ -4990,45 +4748,28 @@ impl InteriorNode {
                     let (positive_intersection_node, _) = Node::new_satisfied_constraint(
                         builder,
                         intersection_constraint.when_true(),
-                        next_source_order,
                     );
                     let (negative_intersection_node, _) = Node::new_satisfied_constraint(
                         builder,
                         intersection_constraint.when_false(),
-                        next_source_order,
-                    );
-                    next_source_order += 1;
-
-                    let (positive_left_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        left_constraint.when_true(),
-                        left_source_order,
-                    );
-                    let (negative_left_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        left_constraint.when_false(),
-                        left_source_order,
                     );
 
-                    let (positive_right_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        right_constraint.when_true(),
-                        right_source_order,
-                    );
-                    let (negative_right_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        right_constraint.when_false(),
-                        right_source_order,
-                    );
+                    let (positive_left_node, _) =
+                        Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                    let (negative_left_node, _) =
+                        Node::new_satisfied_constraint(builder, left_constraint.when_false());
+
+                    let (positive_right_node, _) =
+                        Node::new_satisfied_constraint(builder, right_constraint.when_true());
+                    let (negative_right_node, _) =
+                        Node::new_satisfied_constraint(builder, right_constraint.when_false());
 
                     // left ∧ right = intersection
                     simplified = simplified.substitute_intersection(
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         positive_intersection_node,
                     );
 
@@ -5037,9 +4778,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         negative_intersection_node,
                     );
 
@@ -5050,9 +4789,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         positive_left_node.and(builder, negative_intersection_node),
                     );
 
@@ -5062,9 +4799,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         positive_right_node.and(builder, negative_intersection_node),
                     );
 
@@ -5075,9 +4810,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         negative_right_node.or(builder, positive_intersection_node),
                     );
 
@@ -5087,9 +4820,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         negative_left_node.or(builder, positive_intersection_node),
                     );
                 }
@@ -5102,25 +4833,17 @@ impl InteriorNode {
                     // All of the below hold because we just proved that the intersection of left
                     // and right is empty.
 
-                    let (positive_left_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        left_constraint.when_true(),
-                        left_source_order,
-                    );
-                    let (positive_right_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        right_constraint.when_true(),
-                        right_source_order,
-                    );
+                    let (positive_left_node, _) =
+                        Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                    let (positive_right_node, _) =
+                        Node::new_satisfied_constraint(builder, right_constraint.when_true());
 
                     // left ∧ right = false
                     simplified = simplified.substitute_intersection(
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         ALWAYS_FALSE,
                     );
 
@@ -5129,9 +4852,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         ALWAYS_TRUE,
                     );
 
@@ -5141,9 +4862,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         positive_left_node,
                     );
 
@@ -5153,9 +4872,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         positive_right_node,
                     );
                 }
@@ -7730,7 +7447,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                     let constraint_upper = constraint.top_materialization(db);
                     let (constraint_node, _) =
                         Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
-                    specializations = specializations.or_with_offset(builder, constraint_node);
+                    specializations = specializations.or(builder, constraint_node);
                 }
                 specializations
             }
@@ -7777,8 +7494,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                     let (constraint, _) =
                         Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
                     if constraint_lower == constraint_upper {
-                        non_gradual_constraints =
-                            non_gradual_constraints.or_with_offset(builder, constraint);
+                        non_gradual_constraints = non_gradual_constraints.or(builder, constraint);
                     } else {
                         gradual_constraints.push(constraint);
                     }
@@ -8490,15 +8206,15 @@ mod tests {
             &constraints,
             set,
             indoc! {r#"
-                <0> (U = bool) 2/4
-                ┡━₁ <1> (T = bool) 4/4
+                <0> (U = bool)
+                ┡━₁ <1> (T = bool)
                 │   ┡━₁ always
-                │   ├─? <2> (T = str) 3/3
+                │   ├─? <2> (T = str)
                 │   │   ┡━₁ always
                 │   │   ├─? never
                 │   │   └─₀ never
                 │   └─₀ never
-                ├─? <3> (U = str) 1/4
+                ├─? <3> (U = str)
                 │   ┡━₁ <1> SHARED
                 │   ├─? never
                 │   └─₀ never
@@ -8521,7 +8237,7 @@ mod tests {
             &builder,
             t_int,
             indoc! {r#"
-                <0> (T = int) 1/1
+                <0> (T = int)
                 ┡━₁ always
                 ├─? never
                 └─₀ never
@@ -8549,9 +8265,9 @@ mod tests {
             &builder,
             union,
             indoc! {r#"
-                <0> (U = str) 2/2
+                <0> (U = str)
                 ┡━₁ always
-                ├─? <1> (T = int) 1/1
+                ├─? <1> (T = int)
                 │   ┡━₁ always
                 │   ├─? never
                 │   └─₀ never
@@ -8583,15 +8299,15 @@ mod tests {
             &builder,
             intersection,
             indoc! {r#"
-                <0> (U = int) 4/4
-                ┡━₁ <1> (U = str) 2/2
+                <0> (U = int)
+                ┡━₁ <1> (U = str)
                 │   ┡━₁ always
-                │   ├─? <2> (T = int) 1/1
+                │   ├─? <2> (T = int)
                 │   │   ┡━₁ always
                 │   │   ├─? never
                 │   │   └─₀ never
                 │   └─₀ never
-                ├─? <3> (T = bool) 3/3
+                ├─? <3> (T = bool)
                 │   ┡━₁ <1> SHARED
                 │   ├─? never
                 │   └─₀ never
@@ -8616,10 +8332,10 @@ mod tests {
             &builder,
             negated,
             indoc! {r#"
-                <0> (U = str) 2/2
+                <0> (U = str)
                 ┡━₁ never
                 ├─? never
-                └─₀ <1> (T = int) 1/1
+                └─₀ <1> (T = int)
                     ┡━₁ never
                     ├─? never
                     └─₀ always
@@ -8954,7 +8670,7 @@ mod tests {
                 builder,
                 set,
                 indoc! {r#"
-                    <0> (V = bool) 1/1
+                    <0> (V = bool)
                     ┡━₁ always
                     ├─? never
                     └─₀ never
@@ -9021,7 +8737,7 @@ mod tests {
             &builder,
             loaded,
             indoc! {r#"
-                <0> (V = bool) 1/1
+                <0> (V = bool)
                 ┡━₁ always
                 ├─? never
                 └─₀ never
@@ -9073,9 +8789,9 @@ mod tests {
                 builder,
                 result,
                 indoc! {r#"
-                    <0> (U = str) 2/2
+                    <0> (U = str)
                     ┡━₁ always
-                    ├─? <1> (T = int) 1/1
+                    ├─? <1> (T = int)
                     │   ┡━₁ always
                     │   ├─? never
                     │   └─₀ never
@@ -9093,9 +8809,9 @@ mod tests {
             &builder,
             loaded,
             indoc! {r#"
-                <0> (U = str) 2/2
+                <0> (U = str)
                 ┡━₁ always
-                ├─? <1> (T = int) 1/1
+                ├─? <1> (T = int)
                 │   ┡━₁ always
                 │   ├─? never
                 │   └─₀ never

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1899,19 +1899,6 @@ impl<'db> Constraint<'db> {
         keeps_lower || keeps_upper
     }
 
-    /// Returns a new range constraint.
-    ///
-    /// Panics if `lower` and `upper` are not both fully static.
-    fn new_node(
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
-        typevar: BoundTypeVarInstance<'db>,
-        lower: Type<'db>,
-        upper: Type<'db>,
-    ) -> (NodeId, Option<SourceOrderId>) {
-        Self::new_node_with_bounds(db, builder, typevar, Some(lower), Some(upper))
-    }
-
     /// Returns a new range constraint, preserving whether each bound was present explicitly.
     ///
     /// Panics if present `lower` and `upper` bounds are not fully static.
@@ -2832,10 +2819,10 @@ impl NodeId {
         (node, constraint_source_order)
     }
 
-    fn satisfied_by_all_typevars<'db>(
+    fn satisfied_by_all_typevars<'db, 'c>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+        builder: &'c ConstraintSetBuilder<'db>,
         inferable: TypeVarSet<'db>,
         source_order: Option<SourceOrderId>,
     ) -> bool {
@@ -2851,22 +2838,29 @@ impl NodeId {
             typevars.insert(constraint.typevar);
         });
 
+        // Specializations can introduce constraints that do not appear in the original BDD.
+        // Compose full constraint sets so those constraints retain their source orders when the
+        // resulting BDD is traversed.
+        let original = ConstraintSet::from_node(builder, self, source_order);
+
         // Returns if some specialization satisfies this constraint set.
-        let some_specialization_satisfies = move |specializations: NodeId| {
-            let when_satisfied = specializations
-                .implies(builder, self)
-                .and(builder, specializations);
-            !when_satisfied.is_never_satisfied(db, builder, source_order)
+        let some_specialization_satisfies = move |specializations: ConstraintSet<'db, 'c>| {
+            let when_satisfied =
+                specializations
+                    .implies(db, builder, || original)
+                    .and(db, builder, || specializations);
+            !when_satisfied.is_never_satisfied(db)
         };
 
         // Returns if all specializations satisfy this constraint set.
-        let all_specializations_satisfy = move |specializations: NodeId| {
-            let when_satisfied = specializations
-                .implies(builder, self)
-                .and(builder, specializations);
+        let all_specializations_satisfy = move |specializations: ConstraintSet<'db, 'c>| {
+            let when_satisfied =
+                specializations
+                    .implies(db, builder, || original)
+                    .and(db, builder, || specializations);
             when_satisfied
-                .iff(builder, specializations)
-                .is_always_satisfied(db, builder, source_order)
+                .iff(db, builder, specializations)
+                .is_always_satisfied(db)
         };
 
         #[expect(
@@ -4509,13 +4503,12 @@ impl InteriorNode {
         // `PathAssignments` seeds its insertion-ordered discovered-constraint map from this list,
         // and uses that order when constructing non-commutative sequent pairs. Do not replace this
         // with TDD traversal order: doing so can change inference and lose gradual constraints.
-        // Keep synthetic constraints absent from the sidecar after the rest, using their stable
-        // creation order rather than the perturbed TDD traversal order.
+        // Every constraint in the TDD must appear in the sidecar. If an operation introduces new
+        // constraints, it must preserve their source orders rather than invent an order here.
         constraints.sort_by_key(|constraint| {
-            (
-                source_orders.get_index_of(constraint).unwrap_or(usize::MAX),
-                constraint.index(),
-            )
+            source_orders
+                .get_index_of(constraint)
+                .expect("every BDD constraint should have a source-order entry")
         });
         PathAssignments::new(constraints)
     }
@@ -7414,10 +7407,14 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// Returns the valid specializations of a typevar. This is used when checking a constraint set
     /// when this typevar is in inferable position, where we only need _some_ specialization to
     /// satisfy the constraint set.
-    fn valid_specializations(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> NodeId {
+    fn valid_specializations<'c>(
+        self,
+        db: &'db dyn Db,
+        builder: &'c ConstraintSetBuilder<'db>,
+    ) -> ConstraintSet<'db, 'c> {
         if self.paramspec_attr(db).is_some() {
             // P.args and P.kwargs are variadic, and do not have an upper bound or constraints.
-            return ALWAYS_TRUE;
+            return ConstraintSet::always(builder);
         }
 
         // For gradual upper bounds and constraints, we are free to choose any materialization that
@@ -7431,21 +7428,24 @@ impl<'db> BoundTypeVarInstance<'db> {
         // that _some_ valid specialization satisfies the constraint set, it's correct for us to
         // return the range of valid materializations that we can choose from.
         match self.typevar(db).bound_or_constraints(db) {
-            None => ALWAYS_TRUE,
+            None => ConstraintSet::always(builder),
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                 let bound = bound.top_materialization(db);
-                let (node, _) =
-                    Constraint::new_node_with_bounds(db, builder, self, None, Some(bound));
-                node
+                ConstraintSet::constrain_typevar_upper_bound(db, builder, self, bound)
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                let mut specializations = ALWAYS_FALSE;
+                let mut specializations = ConstraintSet::never(builder);
                 for constraint in constraints.elements(db) {
                     let constraint_lower = constraint.bottom_materialization(db);
                     let constraint_upper = constraint.top_materialization(db);
-                    let (constraint_node, _) =
-                        Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
-                    specializations = specializations.or(builder, constraint_node);
+                    let constraint = ConstraintSet::constrain_typevar(
+                        db,
+                        builder,
+                        self,
+                        constraint_lower,
+                        constraint_upper,
+                    );
+                    specializations.union(db, builder, constraint);
                 }
                 specializations
             }
@@ -7465,34 +7465,40 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// specifies the required specializations, and the iterator will be empty. For a constrained
     /// typevar, the primary result will include the fully static constraints, and the iterator
     /// will include an entry for each non-fully-static constraint.
-    fn required_specializations(
+    fn required_specializations<'c>(
         self,
         db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
-    ) -> (NodeId, Vec<NodeId>) {
+        builder: &'c ConstraintSetBuilder<'db>,
+    ) -> (ConstraintSet<'db, 'c>, Vec<ConstraintSet<'db, 'c>>) {
         // For upper bounds and constraints, we are free to choose any materialization that makes
         // the check succeed. In non-inferable positions, it is most helpful to choose a
         // materialization that is as restrictive as possible, since that minimizes the number of
         // valid specializations that must satisfy the check. We therefore take the bottom
         // materialization of the bound or constraints.
         match self.typevar(db).bound_or_constraints(db) {
-            None => (ALWAYS_TRUE, Vec::new()),
+            None => (ConstraintSet::always(builder), Vec::new()),
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                 let bound = bound.bottom_materialization(db);
-                let (node, _) =
-                    Constraint::new_node_with_bounds(db, builder, self, None, Some(bound));
-                (node, Vec::new())
+                (
+                    ConstraintSet::constrain_typevar_upper_bound(db, builder, self, bound),
+                    Vec::new(),
+                )
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                let mut non_gradual_constraints = ALWAYS_FALSE;
+                let mut non_gradual_constraints = ConstraintSet::never(builder);
                 let mut gradual_constraints = Vec::new();
                 for constraint in constraints.elements(db) {
                     let constraint_lower = constraint.bottom_materialization(db);
                     let constraint_upper = constraint.top_materialization(db);
-                    let (constraint, _) =
-                        Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
+                    let constraint = ConstraintSet::constrain_typevar(
+                        db,
+                        builder,
+                        self,
+                        constraint_lower,
+                        constraint_upper,
+                    );
                     if constraint_lower == constraint_upper {
-                        non_gradual_constraints = non_gradual_constraints.or(builder, constraint);
+                        non_gradual_constraints.union(db, builder, constraint);
                     } else {
                         gradual_constraints.push(constraint);
                     }
@@ -8574,7 +8580,11 @@ mod tests {
     }
 
     impl ReconstructPathFold {
-        fn result(&self, at: PathFoldBreak, result: NodeId) -> ControlFlow<PathFoldBreak, NodeId> {
+        fn result(
+            &self,
+            at: PathFoldBreak,
+            result: (NodeId, Option<SourceOrderId>),
+        ) -> ControlFlow<PathFoldBreak, (NodeId, Option<SourceOrderId>)> {
             if self.break_at == Some(at) {
                 ControlFlow::Break(at)
             } else {
@@ -8584,7 +8594,7 @@ mod tests {
     }
 
     impl PathFold for ReconstructPathFold {
-        type Result = NodeId;
+        type Result = (NodeId, Option<SourceOrderId>);
         type Break = PathFoldBreak;
 
         fn satisfied<'db>(
@@ -8593,13 +8603,18 @@ mod tests {
             builder: &ConstraintSetBuilder<'db>,
             path: &PathAssignments,
         ) -> ControlFlow<Self::Break, Self::Result> {
-            let result = path
-                .assignments
-                .iter()
-                .fold(ALWAYS_TRUE, |result, (assignment, _)| {
-                    let (assignment, _) = Node::new_satisfied_constraint(builder, *assignment);
-                    result.and(builder, assignment)
-                });
+            let result =
+                path.assignments
+                    .iter()
+                    .fold((ALWAYS_TRUE, None), |result, (assignment, _)| {
+                        let (node, source_order) = result;
+                        let (assignment, assignment_source_order) =
+                            Node::new_satisfied_constraint(builder, *assignment);
+                        (
+                            node.and(builder, assignment),
+                            builder.ordered_source_order(source_order, assignment_source_order),
+                        )
+                    });
             self.result(PathFoldBreak::Satisfied, result)
         }
 
@@ -8609,7 +8624,7 @@ mod tests {
             _builder: &ConstraintSetBuilder<'db>,
             _path: &PathAssignments,
         ) -> ControlFlow<Self::Break, Self::Result> {
-            self.result(PathFoldBreak::Unsatisfied, ALWAYS_FALSE)
+            self.result(PathFoldBreak::Unsatisfied, (ALWAYS_FALSE, None))
         }
 
         fn impossible<'db>(
@@ -8618,7 +8633,7 @@ mod tests {
             _builder: &ConstraintSetBuilder<'db>,
             _path: &PathAssignments,
         ) -> ControlFlow<Self::Break, Self::Result> {
-            self.result(PathFoldBreak::Impossible, ALWAYS_FALSE)
+            self.result(PathFoldBreak::Impossible, (ALWAYS_FALSE, None))
         }
 
         fn combine<'db>(
@@ -8629,8 +8644,14 @@ mod tests {
             if_uncertain: Self::Result,
             if_false: Self::Result,
         ) -> ControlFlow<Self::Break, Self::Result> {
-            let result = if_true.or(builder, if_uncertain).or(builder, if_false);
-            self.result(PathFoldBreak::Combine, result)
+            let (if_true, if_true_source_order) = if_true;
+            let (if_uncertain, if_uncertain_source_order) = if_uncertain;
+            let (if_false, if_false_source_order) = if_false;
+            let node = if_true.or(builder, if_uncertain).or(builder, if_false);
+            let source_order =
+                builder.ordered_source_order(if_true_source_order, if_uncertain_source_order);
+            let source_order = builder.ordered_source_order(source_order, if_false_source_order);
+            self.result(PathFoldBreak::Combine, (node, source_order))
         }
     }
 
@@ -8711,12 +8732,13 @@ mod tests {
         ] {
             let mut path = path_assignments_for(&builder, set.node, set.source_order);
             let mut fold = ReconstructPathFold { break_at: None };
-            let ControlFlow::Continue(reconstructed) =
+            let ControlFlow::Continue((reconstructed, reconstructed_source_order)) =
                 path.visit(&db, &builder, set.node, &mut fold)
             else {
                 panic!("reconstruction unexpectedly aborted");
             };
-            let reconstructed = ConstraintSet::from_node(&builder, reconstructed, set.source_order);
+            let reconstructed =
+                ConstraintSet::from_node(&builder, reconstructed, reconstructed_source_order);
             assert!(
                 set.iff(&db, &builder, reconstructed)
                     .is_always_satisfied(&db)
@@ -8753,12 +8775,13 @@ mod tests {
             );
 
             let mut completing_fold = ReconstructPathFold { break_at: None };
-            let ControlFlow::Continue(reconstructed) =
+            let ControlFlow::Continue((reconstructed, reconstructed_source_order)) =
                 path.visit(&db, &builder, set.node, &mut completing_fold)
             else {
                 panic!("reconstruction unexpectedly aborted after {break_at:?}");
             };
-            let reconstructed = ConstraintSet::from_node(&builder, reconstructed, set.source_order);
+            let reconstructed =
+                ConstraintSet::from_node(&builder, reconstructed, reconstructed_source_order);
             assert!(
                 set.iff(&db, &builder, reconstructed)
                     .is_always_satisfied(&db)

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -202,7 +202,6 @@ where
         mut f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
         let (node, source_order) = NodeId::distributed_or(
-            db,
             builder,
             self.map(|element| {
                 let constraint = f(element);
@@ -220,7 +219,6 @@ where
         mut f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
         let (node, source_order) = NodeId::distributed_and(
-            db,
             builder,
             self.map(|element| {
                 let constraint = f(element);
@@ -664,7 +662,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         fn rebuild_node(
             builder: &ConstraintSetBuilder<'_>,
             old_node: NodeId,
-            mapped_constraints: &FxHashMap<ConstraintId, NodeId>,
+            mapped_constraints: &FxHashMap<ConstraintId, (NodeId, Option<SourceOrderId>)>,
             mapped_nodes: &mut FxHashMap<NodeId, NodeId>,
         ) -> NodeId {
             if old_node.is_terminal() {
@@ -675,8 +673,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
             }
 
             let old_interior = builder.interior_node_data(old_node);
-            let condition = mapped_constraints[&old_interior.constraint]
-                .with_adjusted_source_order(builder, old_interior.source_order.saturating_sub(1));
+            let (condition, _) = mapped_constraints[&old_interior.constraint];
             let if_true = rebuild_node(
                 builder,
                 old_interior.if_true,
@@ -703,7 +700,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         let builder = self.builder;
         let mut mapped_constraints = FxHashMap::default();
         self.node
-            .for_each_unique_constraint(builder, &mut |constraint_id, _| {
+            .for_each_unique_constraint(builder, &mut |constraint_id| {
                 if mapped_constraints.contains_key(&constraint_id) {
                     return;
                 }
@@ -727,27 +724,46 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                 let mapped = if let Type::TypeVar(typevar) = subject {
                     Constraint::new_node_with_bounds(db, builder, typevar, lower, upper)
                 } else {
-                    let lower_holds = lower.map_or(ALWAYS_TRUE, |lower| {
-                        builder
-                            .load(
+                    let lower_holds = lower.map_or_else(
+                        || ConstraintSet::always(builder),
+                        |lower| {
+                            builder.load(
                                 db,
                                 &lower.when_constraint_set_assignable_to_owned(db, subject),
                             )
-                            .node
-                    });
-                    let upper_holds = upper.map_or(ALWAYS_TRUE, |upper| {
-                        builder
-                            .load(
+                        },
+                    );
+                    let upper_holds = upper.map_or_else(
+                        || ConstraintSet::always(builder),
+                        |upper| {
+                            builder.load(
                                 db,
                                 &subject.when_constraint_set_assignable_to_owned(db, upper),
                             )
-                            .node
-                    });
-                    lower_holds.and_with_offset(builder, upper_holds)
+                        },
+                    );
+                    (
+                        lower_holds.node.and(builder, upper_holds.node),
+                        builder.ordered_source_order(
+                            lower_holds.source_order,
+                            upper_holds.source_order,
+                        ),
+                    )
                 };
                 mapped_constraints.insert(constraint_id, mapped);
             });
 
+        let source_order = builder
+            .calculate_source_orders(self.source_order)
+            .into_iter()
+            .fold(None, |source_order, constraint| {
+                mapped_constraints.get(&constraint).map_or(
+                    source_order,
+                    |(_, mapped_source_order)| {
+                        builder.ordered_source_order(source_order, *mapped_source_order)
+                    },
+                )
+            });
         Self::from_node(
             builder,
             rebuild_node(
@@ -756,6 +772,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
                 &mapped_constraints,
                 &mut FxHashMap::default(),
             ),
+            source_order,
         )
     }
 
@@ -783,13 +800,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
         // Universal and existential quantification are duals. Reusing existential abstraction
         // also keeps this operation on its cached, single-pass implementation.
-        Self::from_node(
-            builder,
-            self.node
-                .negate(builder)
-                .exists(db, builder, to_remove)
-                .negate(builder),
-        )
+        let (node, derived_source_order) = self.node.negate(builder).exists(db, builder, to_remove);
+        let source_order = builder.ordered_source_order(self.source_order, derived_source_order);
+        Self::from_node(builder, node.negate(builder), source_order)
     }
 
     /// Computes solutions for each BDD path, using a caller-provided hook to select solutions.
@@ -820,7 +833,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
     ) -> Solutions<'db> {
         self.verify_builder(builder);
-        self.node.solutions_with(db, builder, inferable, choose)
+        self.node
+            .solutions_with(db, builder, inferable, self.source_order, choose)
     }
 
     pub(crate) fn display(self, db: &'db dyn Db) -> impl Display {
@@ -920,15 +934,16 @@ struct ConstraintSetStorage<'db> {
     /// Avoid repeatedly walking deep constraint bounds without imposing Salsa-query overhead on
     /// the many shallow bounds that are cheap to walk once.
     constraint_bound_depth_cache: FxHashMap<ConstraintId, (u16, u16)>,
+    source_order_cache: FxHashMap<SourceOrder, SourceOrderId>,
     constraint_implication_cache: FxHashMap<(ConstraintId, ConstraintId), bool>,
     /// Only caches completed top-level results. Recursive results depend on active path
     /// assignments and must not use this cache.
     never_satisfied_cache: FxHashMap<NodeId, bool>,
 
     negate_cache: FxHashMap<NodeId, NodeId>,
-    or_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
-    and_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
-    exists_cache: FxHashMap<(NodeId, TypeVarSet<'db>), NodeId>,
+    or_cache: FxHashMap<(NodeId, NodeId), NodeId>,
+    and_cache: FxHashMap<(NodeId, NodeId), NodeId>,
+    exists_cache: FxHashMap<(NodeId, TypeVarSet<'db>), (NodeId, Option<SourceOrderId>)>,
     restrict_one_cache: FxHashMap<(NodeId, ConstraintAssignment), (NodeId, bool)>,
     simplify_cache: FxHashMap<NodeId, NodeId>,
 
@@ -1145,9 +1160,6 @@ impl<'db> ConstraintSetBuilder<'db> {
                 old_interior.if_uncertain,
             );
             let if_false = rebuild_node(builder, inner, constraints, cache, old_interior.if_false);
-            // `Constraint::new_node` creates standalone nodes whose source order starts at 1.
-            // Shift the reloaded condition back to the source order recorded in the owned set;
-            // solution extraction uses this order for deterministic unions and intersections.
             let old_constraint_index = inner.retained_constraint_index(old_interior.constraint);
             let (condition, _) = constraints[old_constraint_index];
             let remapped = condition.ite_uncertain(builder, if_true, if_uncertain, if_false);
@@ -1163,27 +1175,6 @@ impl<'db> ConstraintSetBuilder<'db> {
             .inner
             .as_ref()
             .expect("storage-free owned constraint sets must have terminal roots");
-
-        if inner.nodes.len() == 1 {
-            let old_interior = inner.nodes[inner.retained_node_index(other.node)];
-            let old_constraint =
-                inner.constraints[inner.retained_constraint_index(old_interior.constraint)];
-            let condition = Constraint::new_node_with_bounds(
-                db,
-                self,
-                old_constraint.typevar,
-                old_constraint.bounds.lower,
-                old_constraint.bounds.upper,
-            )
-            .with_adjusted_source_order(self, old_interior.source_order.saturating_sub(1));
-            let node = condition.ite_uncertain(
-                self,
-                old_interior.if_true,
-                old_interior.if_uncertain,
-                old_interior.if_false,
-            );
-            return ConstraintSet::from_node(self, node);
-        }
 
         // Load all of the constraints into the this builder first, to maximize the chance that the
         // constraints and typevars will appear in the same order. (This is important because many
@@ -1602,6 +1593,17 @@ pub struct TypeVarId;
 #[newtype_index]
 #[derive(get_size2::GetSize)]
 pub struct ConstraintId;
+
+#[newtype_index]
+#[derive(get_size2::GetSize)]
+struct SourceOrderId;
+
+/// The nodes of the tree that defines source ordering for a constraint set.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+enum SourceOrder {
+    Ordered(SourceOrderId, SourceOrderId),
+    Constraint(ConstraintId),
+}
 
 /// An individual constraint in a constraint set. This restricts a single typevar to be within a
 /// lower and upper bound.
@@ -2599,9 +2601,10 @@ impl NodeId {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         inferable: TypeVarSet<'db>,
+        source_order: Option<SourceOrderId>,
         choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
     ) -> Solutions<'db> {
-        let path_bounds = PathBounds::compute(db, builder, self, inferable);
+        let path_bounds = PathBounds::compute(db, builder, self, inferable, source_order);
         path_bounds.solve_with(choose)
     }
 
@@ -2646,14 +2649,13 @@ impl NodeId {
     /// You must also provide the "zero" and "one" units of the operator. The "zero" is the value
     /// that has no effect (`0 ∨ a = a`). It is returned if the iterator is empty. The "one" is the
     /// value that saturates (`1 ∨ a = 1`). We use this to short-circuit; if any element BDD or any
-    /// intermediate result evaluates to "one", we can return early.
-    fn tree_fold<'db>(
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+    /// intermediate result is the "one" terminal, we can return early.
+    fn tree_fold(
+        builder: &ConstraintSetBuilder<'_>,
         nodes: impl Iterator<Item = (Self, Option<SourceOrderId>)>,
         zero: Self,
-        is_one: impl Fn(Self, &'db dyn Db, &ConstraintSetBuilder<'db>) -> bool,
-        mut combine: impl FnMut(Self, &ConstraintSetBuilder<'db>, Self) -> Self,
+        one: Self,
+        mut combine: impl FnMut(Self, &ConstraintSetBuilder<'_>, Self) -> Self,
     ) -> (Self, Option<SourceOrderId>) {
         // To implement the "linear" shape described above, we could collect the iterator elements
         // into a vector, and then use the fold at the bottom of this method to combine the
@@ -2682,7 +2684,7 @@ impl NodeId {
         let mut accumulator: SmallVec<[(NodeId, Option<SourceOrderId>, u8); 8]> =
             SmallVec::default();
         for (node, source_order) in nodes {
-            if is_one(node, db, builder) {
+            if node == one {
                 return (node, source_order);
             }
 
@@ -2695,7 +2697,7 @@ impl NodeId {
                     accumulator.pop().expect("accumulator should not be empty");
                 node = combine(existing_node, builder, node);
                 source_order = builder.ordered_source_order(existing_source_order, source_order);
-                if is_one(node, db, builder) {
+                if node == one {
                     return (node, source_order);
                 }
                 depth += 1;
@@ -2717,32 +2719,18 @@ impl NodeId {
         )
     }
 
-    fn distributed_or<'db>(
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+    fn distributed_or(
+        builder: &ConstraintSetBuilder<'_>,
         nodes: impl Iterator<Item = (NodeId, Option<SourceOrderId>)>,
     ) -> (Self, Option<SourceOrderId>) {
-        Self::tree_fold(
-            builder,
-            nodes,
-            ALWAYS_FALSE,
-            Self::is_always_satisfied,
-            Self::or,
-        )
+        Self::tree_fold(builder, nodes, ALWAYS_FALSE, ALWAYS_TRUE, Self::or)
     }
 
-    fn distributed_and<'db>(
-        db: &'db dyn Db,
-        builder: &ConstraintSetBuilder<'db>,
+    fn distributed_and(
+        builder: &ConstraintSetBuilder<'_>,
         nodes: impl Iterator<Item = (NodeId, Option<SourceOrderId>)>,
     ) -> (Self, Option<SourceOrderId>) {
-        Self::tree_fold(
-            builder,
-            nodes,
-            ALWAYS_TRUE,
-            Self::is_never_satisfied,
-            Self::and,
-        )
+        Self::tree_fold(builder, nodes, ALWAYS_TRUE, ALWAYS_FALSE, Self::and)
     }
 
     /// Returns the `and` or intersection of two BDDs.
@@ -2956,13 +2944,13 @@ impl NodeId {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         bound_typevars: TypeVarSet<'db>,
-    ) -> Self {
+    ) -> (Self, Option<SourceOrderId>) {
         if bound_typevars == TypeVarSet::None {
-            return self;
+            return (self, None);
         }
 
         let Node::Interior(interior) = self.node() else {
-            return self;
+            return (self, None);
         };
 
         let key = (self, bound_typevars);
@@ -3549,7 +3537,9 @@ impl<'db> Type<'db> {
             inferable: TypeVarSet<'db>,
         ) -> PathBounds<'db> {
             let when = source.when_constraint_set_assignable_to_owned(db, target);
-            when.query(|builder, when| PathBounds::compute(db, builder, when.node, inferable))
+            when.query(|builder, when| {
+                PathBounds::compute(db, builder, when.node, inferable, when.source_order)
+            })
         }
 
         assignable_solutions_impl(db, self, target, inferable)
@@ -3586,13 +3576,14 @@ impl<'db> PathBounds<'db> {
         builder: &ConstraintSetBuilder<'db>,
         node: NodeId,
         inferable: TypeVarSet<'db>,
+        source_order: Option<SourceOrderId>,
     ) -> Self {
-        #[derive(Default)]
-        struct CollectVisitor {
+        struct CollectVisitor<'a> {
+            source_orders: &'a FxIndexSet<ConstraintId>,
             sorted_paths: Vec<Vec<(ConstraintId, usize)>>,
         }
 
-        impl PathFold for CollectVisitor {
+        impl PathFold for CollectVisitor<'_> {
             type Result = ();
             type Break = Infallible;
 
@@ -3602,7 +3593,16 @@ impl<'db> PathBounds<'db> {
                 _builder: &ConstraintSetBuilder<'db>,
                 path: &PathAssignments,
             ) -> ControlFlow<Self::Break, Self::Result> {
-                let mut path: Vec<_> = path.positive_constraints().collect();
+                let mut path: Vec<_> = path
+                    .positive_constraints()
+                    .map(|(constraint, source_constraint)| {
+                        let source_order = self
+                            .source_orders
+                            .get_index_of(&source_constraint)
+                            .expect("every TDD constraint should have a source order");
+                        (constraint, source_order)
+                    })
+                    .collect();
                 path.sort_by_key(|(_, source_order)| *source_order);
                 self.sorted_paths.push(path);
                 ControlFlow::Continue(())
@@ -3638,13 +3638,15 @@ impl<'db> PathBounds<'db> {
             }
         }
 
+        let mut source_orders = builder.calculate_source_orders(source_order);
         if let Some(path_bounds) =
-            Self::compute_simple_bound_conjunction(db, builder, node, inferable)
+            Self::compute_simple_bound_conjunction(db, builder, &source_orders, node, inferable)
         {
             return path_bounds;
         }
 
-        let node = node.remove_noninferable(db, builder, inferable);
+        let (node, derived_source_order) = node.remove_noninferable(db, builder, inferable);
+        source_orders.extend(builder.calculate_source_orders(derived_source_order));
         let interior = match node.node() {
             Node::AlwaysTrue => return PathBounds::Unconstrained,
             Node::AlwaysFalse => return PathBounds::Unsatisfiable,
@@ -3656,7 +3658,10 @@ impl<'db> PathBounds<'db> {
         // come out of `PathAssignment`s with identical `source_order`s, but if they do, those
         // "tied" constraints will still be ordered in a stable way. So we need a stable sort to
         // retain that stable per-tie ordering.
-        let mut collect_visitor = CollectVisitor::default();
+        let mut collect_visitor = CollectVisitor {
+            source_orders: &source_orders,
+            sorted_paths: Vec::new(),
+        };
         let mut path = interior.path_assignments(builder);
         let _ = path.visit(db, builder, node, &mut collect_visitor);
         collect_visitor.sorted_paths.sort_by(|path1, path2| {
@@ -3751,7 +3756,9 @@ impl<'db> PathBounds<'db> {
                     constraints.push((
                         constraint.typevar,
                         constraint.bounds,
-                        interior.source_order,
+                        source_orders
+                            .get_index_of(&interior.constraint)
+                            .expect("every TDD constraint should have a source order"),
                     ));
                 }
             }
@@ -4181,7 +4188,7 @@ impl InteriorNode {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         bound_typevars: TypeVarSet<'db>,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         let mentions_typevar = |ty: Type<'db>| match ty {
             Type::TypeVar(typevar) => typevar.is_inferable(db, bound_typevars),
             _ => false,
@@ -4213,7 +4220,7 @@ impl InteriorNode {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         inferable: TypeVarSet<'db>,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         let is_bare_inferable_typevar = |ty: Type<'db>| {
             ty.as_typevar()
                 .is_some_and(|bound_typevar| bound_typevar.is_inferable(db, inferable))
@@ -4250,7 +4257,7 @@ impl InteriorNode {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         should_remove: F,
-    ) -> NodeId
+    ) -> (NodeId, Option<SourceOrderId>)
     where
         F: FnMut(ConstraintId) -> bool,
     {
@@ -4268,8 +4275,8 @@ impl InteriorNode {
         where
             F: FnMut(ConstraintId) -> bool,
         {
-            type Result = NodeId;
-            type Interior = (Disposition, ConstraintId, usize);
+            type Result = (NodeId, Option<SourceOrderId>);
+            type Interior = (Disposition, ConstraintId);
             type Break = Infallible;
 
             fn visit_satisfied<'db>(
@@ -4278,7 +4285,7 @@ impl InteriorNode {
                 _builder: &ConstraintSetBuilder<'db>,
                 _path: &PathAssignments,
             ) -> ControlFlow<Self::Break, Self::Result> {
-                ControlFlow::Continue(ALWAYS_TRUE)
+                ControlFlow::Continue((ALWAYS_TRUE, None))
             }
 
             fn visit_unsatisfied<'db>(
@@ -4287,7 +4294,7 @@ impl InteriorNode {
                 _builder: &ConstraintSetBuilder<'db>,
                 _path: &PathAssignments,
             ) -> ControlFlow<Self::Break, Self::Result> {
-                ControlFlow::Continue(ALWAYS_FALSE)
+                ControlFlow::Continue((ALWAYS_FALSE, None))
             }
 
             fn visit_impossible<'db>(
@@ -4296,7 +4303,7 @@ impl InteriorNode {
                 _builder: &ConstraintSetBuilder<'db>,
                 _path: &PathAssignments,
             ) -> ControlFlow<Self::Break, Self::Result> {
-                ControlFlow::Continue(ALWAYS_FALSE)
+                ControlFlow::Continue((ALWAYS_FALSE, None))
             }
 
             fn enter_interior<'db>(
@@ -4311,7 +4318,7 @@ impl InteriorNode {
                 } else {
                     Disposition::Keep
                 };
-                ControlFlow::Continue((disposition, interior.constraint, interior.source_order))
+                ControlFlow::Continue((disposition, interior.constraint))
             }
 
             fn visit_edge<'db>(
@@ -4323,7 +4330,7 @@ impl InteriorNode {
                 path: &PathAssignments,
                 new_range: Range<usize>,
             ) -> ControlFlow<Self::Break, Self::Result> {
-                let (disposition, _, _) = interior;
+                let (disposition, _) = interior;
                 match disposition {
                     // If we are keeping this node, we don't need to add any derived facts to the
                     // result; we can always re-derive them later.
@@ -4343,16 +4350,20 @@ impl InteriorNode {
                                     // removed!
                                     !(self.should_remove)(assignment.constraint())
                                 })
-                                .fold(subtree, |subtree, (assignment, (source_order, _))| {
-                                    subtree.and(
-                                        builder,
-                                        Node::new_satisfied_constraint(
-                                            builder,
-                                            *assignment,
-                                            *source_order,
-                                        ),
-                                    )
-                                }),
+                                .fold(
+                                    subtree,
+                                    |(subtree, subtree_source_order), (assignment, _)| {
+                                        let (assignment, assignment_source_order) =
+                                            Node::new_satisfied_constraint(builder, *assignment);
+                                        (
+                                            subtree.and(builder, assignment),
+                                            builder.ordered_source_order(
+                                                subtree_source_order,
+                                                assignment_source_order,
+                                            ),
+                                        )
+                                    },
+                                ),
                         )
                     }
                 }
@@ -4367,7 +4378,7 @@ impl InteriorNode {
                 if_uncertain: Self::Result,
                 if_false: Self::Result,
             ) -> ControlFlow<Self::Break, Self::Result> {
-                let (disposition, constraint, source_order) = interior;
+                let (disposition, constraint) = interior;
                 match disposition {
                     // If we are keeping this node, absorb the uncertain branch into both the true
                     // and false branches before constructing the ITE, matching TDD semantics: when
@@ -4378,11 +4389,23 @@ impl InteriorNode {
                     // derived constraints into the result, and those constraints might appear before this
                     // one in the BDD ordering.
                     Disposition::Keep => {
-                        let guard = Node::new_constraint(builder, *constraint, *source_order);
-                        ControlFlow::Continue(guard.ite(
+                        let (guard, guard_source_order) =
+                            Node::new_constraint(builder, *constraint);
+                        let (if_true, if_true_source_order) = if_true;
+                        let (if_uncertain, if_uncertain_source_order) = if_uncertain;
+                        let (if_false, if_false_source_order) = if_false;
+                        let node = guard.ite(
                             builder,
                             if_true.or(builder, if_uncertain),
                             if_false.or(builder, if_uncertain),
+                        );
+                        let left_source_order =
+                            builder.ordered_source_order(guard_source_order, if_true_source_order);
+                        let right_source_order = builder
+                            .ordered_source_order(if_uncertain_source_order, if_false_source_order);
+                        ControlFlow::Continue((
+                            node,
+                            builder.ordered_source_order(left_source_order, right_source_order),
                         ))
                     }
 
@@ -4390,9 +4413,18 @@ impl InteriorNode {
                     // outgoing edges. That is, the result is true if there's any assignment of
                     // this node's constraint that is true. (We will have already added any
                     // necessary derived facts in the `visit_edge` method.)
-                    Disposition::Remove => ControlFlow::Continue(
-                        if_true.or(builder, if_uncertain).or(builder, if_false),
-                    ),
+                    Disposition::Remove => {
+                        let (if_true, if_true_source_order) = if_true;
+                        let (if_uncertain, if_uncertain_source_order) = if_uncertain;
+                        let (if_false, if_false_source_order) = if_false;
+                        let node = if_true.or(builder, if_uncertain).or(builder, if_false);
+                        let source_order = builder
+                            .ordered_source_order(if_true_source_order, if_uncertain_source_order);
+                        ControlFlow::Continue((
+                            node,
+                            builder.ordered_source_order(source_order, if_false_source_order),
+                        ))
+                    }
                 }
             }
         }
@@ -6499,8 +6531,9 @@ impl PathFold for IsNeverSatisfiedVisitor {
 pub(crate) struct PathAssignments {
     /// All of the rules that we know for inferring derived constraints on the current path.
     sequents: Vec<Sequent>,
-    /// Each assignment's source order and the first per-path fuel value with which it was derived.
-    assignments: FxIndexMap<ConstraintAssignment, (usize, u16)>,
+    /// Each assignment's source constraint and the first per-path fuel value with which it was
+    /// derived.
+    assignments: FxIndexMap<ConstraintAssignment, (ConstraintId, u16)>,
     /// Additional per-path fuel values that can derive an assignment, keyed by its index in
     /// `assignments`. These are stored separately so that branch-local additions can be rolled
     /// back by truncating the set. Only the greatest fuel value participates in further
@@ -6651,7 +6684,6 @@ impl PathAssignments {
                     db,
                     builder,
                     interior.constraint.when_true(),
-                    interior.source_order,
                     |path, new_range, found_conflict| {
                         let subtree = if found_conflict {
                             visitor.visit_impossible(db, builder, path)
@@ -6680,7 +6712,6 @@ impl PathAssignments {
                         db,
                         builder,
                         interior.constraint.when_unconstrained(),
-                        interior.source_order,
                         |path, new_range, found_conflict| {
                             let subtree = if found_conflict {
                                 visitor.visit_impossible(db, builder, path)
@@ -6711,7 +6742,6 @@ impl PathAssignments {
                     db,
                     builder,
                     interior.constraint.when_false(),
-                    interior.source_order,
                     |path, new_range, found_conflict| {
                         let subtree = if found_conflict {
                             visitor.visit_impossible(db, builder, path)
@@ -6771,7 +6801,6 @@ impl PathAssignments {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         assignment: ConstraintAssignment,
-        source_order: usize,
         f: impl FnOnce(&mut Self, Range<usize>, bool) -> R,
     ) -> R {
         // Record a snapshot of the assignments that we already knew held — both so that we can
@@ -6796,8 +6825,9 @@ impl PathAssignments {
         debug_assert!(self.assignment_queue.is_empty());
         self.assignment_queue
             .push_back((assignment, AssignmentFuel::origin()));
+        let source_constraint = assignment.constraint();
         let found_conflict = self
-            .drain_assignment_queue(db, builder, source_order)
+            .drain_assignment_queue(db, builder, source_constraint)
             .is_err();
         if !found_conflict {
             tracing::trace!(
@@ -6831,12 +6861,14 @@ impl PathAssignments {
     pub(crate) fn positive_constraints(
         &self,
     ) -> impl Iterator<Item = (ConstraintId, ConstraintId)> + '_ {
-        self.assignments
-            .iter()
-            .filter_map(|(assignment, (source_order, _))| match assignment {
-                ConstraintAssignment::Positive(constraint) => Some((*constraint, *source_order)),
+        self.assignments.iter().filter_map(
+            |(assignment, (source_constraint, _))| match assignment {
+                ConstraintAssignment::Positive(constraint) => {
+                    Some((*constraint, *source_constraint))
+                }
                 ConstraintAssignment::Negative(_) | ConstraintAssignment::Unconstrained(_) => None,
-            })
+            },
+        )
     }
 
     fn assignment_holds(&self, assignment: ConstraintAssignment) -> bool {
@@ -6893,10 +6925,10 @@ impl PathAssignments {
         &mut self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
-        source_order: usize,
+        source_constraint: ConstraintId,
     ) -> Result<(), PathAssignmentConflict> {
         while let Some((assignment, fuel)) = self.assignment_queue.pop_front() {
-            self.add_assignment(db, builder, assignment, source_order, fuel)?;
+            self.add_assignment(db, builder, assignment, source_constraint, fuel)?;
         }
         Ok(())
     }
@@ -6909,7 +6941,7 @@ impl PathAssignments {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         assignment: ConstraintAssignment,
-        source_order: usize,
+        source_constraint: ConstraintId,
         fuel: AssignmentFuel,
     ) -> Result<(), PathAssignmentConflict> {
         if matches!(assignment, ConstraintAssignment::Unconstrained(_)) {
@@ -6925,7 +6957,7 @@ impl PathAssignments {
             // assignment, but as an optimization we can return early without actually querying the
             // sequent map.
             self.assignments
-                .insert(assignment, (source_order, fuel.remaining));
+                .insert(assignment, (source_constraint, fuel.remaining));
             return Ok(());
         }
 
@@ -6954,19 +6986,19 @@ impl PathAssignments {
                             None => return Ok(()),
                         };
                 }
-                entry.insert((source_order, fuel.remaining));
+                entry.insert((source_constraint, fuel.remaining));
             }
 
             Entry::Occupied(mut entry) => {
                 let index = entry.index();
-                let (existing_source_order, existing_fuel) = entry.get_mut();
+                let (existing_source_constraint, existing_fuel) = entry.get_mut();
 
                 // If a constraint appears both as an "origin" constraint (it actually appears in
                 // the BDD structure) and as a "derived" constraint (we infer it from other
-                // constraints), we should prefer the origin source_order, regardless of which
+                // constraints), we should prefer the origin source constraint, regardless of which
                 // order we encounter the various constraints in the BDD.
                 if !fuel.is_derived() {
-                    *existing_source_order = source_order;
+                    *existing_source_constraint = source_constraint;
                 }
 
                 // We've already seen this assignment, and in theory have already queried the
@@ -7547,6 +7579,28 @@ mod tests {
     }
 
     #[test]
+    fn type_mapping_handles_absorbed_constraints_in_source_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let str = create_constraint(&db, &builder, t, KnownClass::Str);
+        let int = create_constraint(&db, &builder, t, KnownClass::Int);
+        let set = str.or(&db, &builder, || int).and(&db, &builder, || str);
+
+        let mapped = set.apply_type_mapping_impl(
+            &db,
+            &TypeMapping::ApplySpecialization(ApplySpecialization::Single(
+                t,
+                KnownClass::Str.to_instance(&db),
+            )),
+            TypeContext::default(),
+            &ApplyTypeMappingVisitor::default(),
+        );
+
+        assert!(mapped.is_always_satisfied(&db));
+    }
+
+    #[test]
     fn upper_bound_prunes_duplicates_and_redundant_supertypes() {
         let db = setup_db();
         let int = known_instance(&db, KnownClass::Int);
@@ -7938,7 +7992,7 @@ mod tests {
     impl<'db> PermutedConstraint<'db> {
         fn node(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> NodeId {
             let PermutedConstraint(typevar, lower, upper) = self;
-            Constraint::new_node_with_bounds(db, builder, typevar, lower, upper)
+            Constraint::new_node_with_bounds(db, builder, typevar, lower, upper).0
         }
     }
 
@@ -7977,7 +8031,22 @@ mod tests {
                 );
             }
 
-            let set = ConstraintSet::from_node(&builder, build_bdd(&builder));
+            let node = build_bdd(&builder);
+            let source_order = atoms.iter().fold(None, |source_order, atom| {
+                let PermutedConstraint(typevar, lower, upper) = *atom;
+                let constraint = builder.intern_constraint(
+                    db,
+                    Constraint {
+                        typevar,
+                        bounds: ConstraintBounds::new(lower, upper),
+                    },
+                );
+                builder.ordered_source_order(
+                    source_order,
+                    Some(builder.constraint_source_order(constraint)),
+                )
+            });
+            let set = ConstraintSet::from_node(&builder, node, source_order);
             let solutions = set.solutions(db, &builder, inferable);
             let mut merged = FxHashMap::default();
             if let Solutions::Constrained(paths) = &solutions {
@@ -8031,6 +8100,121 @@ mod tests {
     }
 
     #[test]
+    fn constraint_absorption_is_independent_of_constraint_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let str = KnownClass::Str.to_instance(&db);
+        let int = KnownClass::Int.to_instance(&db);
+        let atoms = [
+            PermutedConstraint(t, Some(str), None),
+            PermutedConstraint(t, Some(int), None),
+        ];
+
+        check_solutions_for_constraint_orderings(
+            &db,
+            &[t],
+            &atoms,
+            |builder| {
+                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, builder));
+                str_t.or(builder, int_t).and(builder, str_t)
+            },
+            ["never=false always=false merged=[T=str] paths=[T=str]"],
+        );
+
+        check_solutions_for_constraint_orderings(
+            &db,
+            &[t],
+            &atoms,
+            |builder| {
+                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, builder));
+                str_t.or(builder, int_t)
+            },
+            ["never=false always=false merged=[T=str | int] paths=[T=str; T=int]"],
+        );
+    }
+
+    #[test]
+    fn compound_constraint_absorption_is_independent_of_constraint_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let str = KnownClass::Str.to_instance(&db);
+        let bytes = KnownClass::Bytes.to_instance(&db);
+        let int = KnownClass::Int.to_instance(&db);
+        let atoms = [
+            PermutedConstraint(t, Some(str), None),
+            PermutedConstraint(u, Some(bytes), None),
+            PermutedConstraint(t, Some(int), None),
+        ];
+
+        check_solutions_for_constraint_orderings(
+            &db,
+            &[t, u],
+            &atoms,
+            |builder| {
+                let [str_t, bytes_u, int_t] = atoms.map(|atom| atom.node(&db, builder));
+                let compound = str_t.and(builder, bytes_u);
+                compound.or(builder, int_t).and(builder, compound)
+            },
+            ["never=false always=false merged=[T=str, U=bytes] paths=[T=str, U=bytes]"],
+        );
+    }
+
+    #[test]
+    fn compound_constraint_absorption_preserves_binding_source_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let x = create_typevar(&db, "X");
+        let str = KnownClass::Str.to_instance(&db);
+        let bytes = KnownClass::Bytes.to_instance(&db);
+        let int = KnownClass::Int.to_instance(&db);
+        let atoms = [
+            PermutedConstraint(t, Some(str), None),
+            PermutedConstraint(u, Some(bytes), None),
+            PermutedConstraint(x, Some(int), None),
+        ];
+
+        check_solutions_for_constraint_orderings(
+            &db,
+            &[t, u, x],
+            &atoms,
+            |builder| {
+                let [str_t, bytes_u, int_x] = atoms.map(|atom| atom.node(&db, builder));
+                let early = int_x.and(builder, str_t).and(builder, bytes_u);
+                let late = bytes_u.and(builder, str_t);
+                early.or(builder, late)
+            },
+            ["never=false always=false merged=[T=str, U=bytes] paths=[T=str, U=bytes]"],
+        );
+    }
+
+    #[test]
+    fn constraint_partition_is_independent_of_constraint_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let str = KnownClass::Str.to_instance(&db);
+        let int = KnownClass::Int.to_instance(&db);
+        let atoms = [
+            PermutedConstraint(t, Some(str), None),
+            PermutedConstraint(t, Some(int), None),
+        ];
+
+        check_solutions_for_constraint_orderings(
+            &db,
+            &[t],
+            &atoms,
+            |builder| {
+                let [str_t, int_t] = atoms.map(|atom| atom.node(&db, builder));
+                let true_path = int_t.and(builder, str_t);
+                let false_path = int_t.negate(builder).and(builder, str_t);
+                true_path.or(builder, false_path)
+            },
+            ["never=false always=false merged=[T=str] paths=[T=str]"],
+        );
+    }
+
+    #[test]
     fn constraint_ordering_changes_nested_transitive_solutions() {
         let db = setup_db();
         let t = create_typevar(&db, "T");
@@ -8055,9 +8239,9 @@ mod tests {
                 let [t_list_u, u_int, list_int_t, bytes_v] =
                     atoms.map(|atom| atom.node(&db, builder));
                 t_list_u
-                    .and_with_offset(builder, u_int)
-                    .and_with_offset(builder, list_int_t)
-                    .or_with_offset(builder, bytes_v)
+                    .and(builder, u_int)
+                    .and(builder, list_int_t)
+                    .or(builder, bytes_v)
             },
             // TODO: All permutations should produce the first result. TDD traversal currently
             // leaks irrelevant positive constraints onto the `V = bytes` alternative.
@@ -8091,9 +8275,9 @@ mod tests {
             |builder| {
                 let [t_int, t_str, bytes_u] = atoms.map(|atom| atom.node(&db, builder));
                 t_int
-                    .or_with_offset(builder, t_str)
+                    .or(builder, t_str)
                     .negate(builder)
-                    .or_with_offset(builder, bytes_u)
+                    .or(builder, bytes_u)
             },
             // TODO: All permutations should produce the first result. A satisfied alternative
             // should not infer `T` from unrelated positive decisions made earlier in a BDD path.
@@ -8126,9 +8310,9 @@ mod tests {
             |builder| {
                 let [t_int, t_str, int_t, u_int] = atoms.map(|atom| atom.node(&db, builder));
                 t_int
-                    .or_with_offset(builder, t_str)
-                    .and_with_offset(builder, int_t)
-                    .and_with_offset(builder, u_int)
+                    .or(builder, t_str)
+                    .and(builder, int_t)
+                    .and(builder, u_int)
             },
             // TODO: `SequentMap::for_constraint_pair` can receive its inputs in BDD order, not
             // source order. That changes which equivalent upper-bound intersection is constructed
@@ -8402,15 +8586,13 @@ mod tests {
             builder: &ConstraintSetBuilder<'db>,
             path: &PathAssignments,
         ) -> ControlFlow<Self::Break, Self::Result> {
-            let result = path.assignments.iter().fold(
-                ALWAYS_TRUE,
-                |result, (assignment, (source_order, _))| {
-                    result.and(
-                        builder,
-                        Node::new_satisfied_constraint(builder, *assignment, *source_order),
-                    )
-                },
-            );
+            let result = path
+                .assignments
+                .iter()
+                .fold(ALWAYS_TRUE, |result, (assignment, _)| {
+                    let (assignment, _) = Node::new_satisfied_constraint(builder, *assignment);
+                    result.and(builder, assignment)
+                });
             self.result(PathFoldBreak::Satisfied, result)
         }
 
@@ -8503,7 +8685,7 @@ mod tests {
             else {
                 panic!("reconstruction unexpectedly aborted");
             };
-            let reconstructed = ConstraintSet::from_node(&builder, reconstructed);
+            let reconstructed = ConstraintSet::from_node(&builder, reconstructed, set.source_order);
             assert!(
                 set.iff(&db, &builder, reconstructed)
                     .is_always_satisfied(&db)
@@ -8545,7 +8727,7 @@ mod tests {
             else {
                 panic!("reconstruction unexpectedly aborted after {break_at:?}");
             };
-            let reconstructed = ConstraintSet::from_node(&builder, reconstructed);
+            let reconstructed = ConstraintSet::from_node(&builder, reconstructed, set.source_order);
             assert!(
                 set.iff(&db, &builder, reconstructed)
                     .is_always_satisfied(&db)

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1040,6 +1040,20 @@ impl<'db> ConstraintSetBuilder<'db> {
             .source_order
             .expect("non-terminal BDD should have source_order");
 
+        // The source-order tree can retain repeated constraints from intermediate operations. If
+        // this constraint set participates in a Salsa cycle, retaining that construction history
+        // can make an otherwise stable result grow on every iteration and never converge.
+        let source_order = self
+            .calculate_source_orders(Some(source_order))
+            .into_iter()
+            .fold(None, |source_order, constraint| {
+                self.ordered_source_order(
+                    source_order,
+                    Some(self.constraint_source_order(constraint)),
+                )
+            })
+            .expect("non-terminal BDD should have source_order");
+
         let mut storage = self.storage.into_inner();
         let mut used_nodes = RankBitBox::bits_with_capacity(storage.nodes.len());
         let mut used_constraints = RankBitBox::bits_with_capacity(storage.constraints.len());

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1478,7 +1478,6 @@ impl<'db> ConstraintSetBuilder<'db> {
         self.intern_source_order(SourceOrder::Constraint(constraint))
     }
 
-    #[expect(dead_code)]
     fn source_order_data(&self, source_order: SourceOrderId) -> SourceOrder {
         let storage = self.storage.borrow();
         if let Some(compacted) = &storage.compacted {
@@ -1491,6 +1490,33 @@ impl<'db> ConstraintSetBuilder<'db> {
             return storage.source_orders[SourceOrderId::from_usize(index - split)];
         }
         storage.source_orders[source_order]
+    }
+
+    fn calculate_source_orders(
+        &self,
+        source_order: Option<SourceOrderId>,
+    ) -> FxIndexSet<ConstraintId> {
+        fn walk(
+            builder: &ConstraintSetBuilder,
+            current: SourceOrderId,
+            result: &mut FxIndexSet<ConstraintId>,
+        ) {
+            match builder.source_order_data(current) {
+                SourceOrder::Ordered(left, right) => {
+                    walk(builder, left, result);
+                    walk(builder, right, result);
+                }
+                SourceOrder::Constraint(constraint) => {
+                    result.insert(constraint);
+                }
+            }
+        }
+
+        let mut result = FxIndexSet::default();
+        if let Some(source_order) = source_order {
+            walk(self, source_order, &mut result);
+        }
+        result
     }
 }
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -459,7 +459,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
     /// Returns whether this constraint set never holds.
     pub(crate) fn is_never_satisfied(self, db: &'db dyn Db) -> bool {
-        self.node.is_never_satisfied(db, self.builder)
+        self.node
+            .is_never_satisfied(db, self.builder, self.source_order)
     }
 
     /// Returns whether this constraint set is the `never` terminal.
@@ -473,7 +474,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
     /// Returns whether this constraint set always holds.
     pub(crate) fn is_always_satisfied(self, db: &'db dyn Db) -> bool {
-        self.node.is_always_satisfied(db, self.builder)
+        self.node
+            .is_always_satisfied(db, self.builder, self.source_order)
     }
 
     /// Returns whether this constraint set is the `always` terminal.
@@ -522,7 +524,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         inferable: TypeVarSet<'db>,
     ) -> bool {
         self.verify_builder(builder);
-        self.node.satisfied_by_all_typevars(db, builder, inferable)
+        self.node
+            .satisfied_by_all_typevars(db, builder, inferable, self.source_order)
     }
 
     /// Updates this constraint set to hold the union of itself and another constraint set.
@@ -646,7 +649,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         to_remove: TypeVarSet<'db>,
     ) -> Self {
         self.verify_builder(builder);
-        let (node, derived_source_order) = self.node.exists(db, builder, to_remove);
+        let (node, derived_source_order) =
+            self.node.exists(db, builder, to_remove, self.source_order);
         let source_order = builder.ordered_source_order(self.source_order, derived_source_order);
         Self::from_node(builder, node, source_order)
     }
@@ -800,7 +804,10 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
         // Universal and existential quantification are duals. Reusing existential abstraction
         // also keeps this operation on its cached, single-pass implementation.
-        let (node, derived_source_order) = self.node.negate(builder).exists(db, builder, to_remove);
+        let (node, derived_source_order) =
+            self.node
+                .negate(builder)
+                .exists(db, builder, to_remove, self.source_order);
         let source_order = builder.ordered_source_order(self.source_order, derived_source_order);
         Self::from_node(builder, node.negate(builder), source_order)
     }
@@ -890,6 +897,8 @@ pub(crate) struct ConstraintSetBuilder<'db> {
     storage: RefCell<ConstraintSetStorage<'db>>,
 }
 
+type ExistsCacheKey<'db> = (NodeId, TypeVarSet<'db>, Option<SourceOrderId>);
+
 #[derive(Debug, Default)]
 struct ConstraintSetStorage<'db> {
     /// Compacted owned storage overlaid onto this builder. This is used by
@@ -937,13 +946,16 @@ struct ConstraintSetStorage<'db> {
     source_order_cache: FxHashMap<SourceOrder, SourceOrderId>,
     constraint_implication_cache: FxHashMap<(ConstraintId, ConstraintId), bool>,
     /// Only caches completed top-level results. Recursive results depend on active path
-    /// assignments and must not use this cache.
-    never_satisfied_cache: FxHashMap<NodeId, bool>,
+    /// assignments and must not use this cache. Source order is part of the key because the same
+    /// TDD node can be traversed with different sidecar orderings, which changes sequent discovery.
+    never_satisfied_cache: FxHashMap<(NodeId, Option<SourceOrderId>), bool>,
 
     negate_cache: FxHashMap<NodeId, NodeId>,
     or_cache: FxHashMap<(NodeId, NodeId), NodeId>,
     and_cache: FxHashMap<(NodeId, NodeId), NodeId>,
-    exists_cache: FxHashMap<(NodeId, TypeVarSet<'db>), (NodeId, Option<SourceOrderId>)>,
+    /// Abstraction also constructs sequents while traversing the TDD, so its cache key must retain
+    /// the sidecar source order for the same reason.
+    exists_cache: FxHashMap<ExistsCacheKey<'db>, (NodeId, Option<SourceOrderId>)>,
     restrict_one_cache: FxHashMap<(NodeId, ConstraintAssignment), (NodeId, bool)>,
     simplify_cache: FxHashMap<NodeId, NodeId>,
 
@@ -2574,12 +2586,13 @@ impl NodeId {
         self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
+        source_order: Option<SourceOrderId>,
     ) -> bool {
         match self.node() {
             Node::AlwaysTrue => true,
             Node::AlwaysFalse => false,
             Node::Interior(interior) => {
-                let mut path = interior.path_assignments(builder);
+                let mut path = interior.path_assignments(builder, source_order);
                 path.visit_negated(db, builder, self, &mut IsNeverSatisfiedVisitor)
                     .is_continue()
             }
@@ -2587,16 +2600,22 @@ impl NodeId {
     }
 
     /// Returns whether this BDD represent the constant function `false`.
-    fn is_never_satisfied<'db>(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> bool {
+    fn is_never_satisfied<'db>(
+        self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        source_order: Option<SourceOrderId>,
+    ) -> bool {
         match self.node() {
             Node::AlwaysTrue => false,
             Node::AlwaysFalse => true,
             Node::Interior(interior) => {
-                if let Some(result) = builder.storage.borrow().never_satisfied_cache.get(&self) {
+                let key = (self, source_order);
+                if let Some(result) = builder.storage.borrow().never_satisfied_cache.get(&key) {
                     return *result;
                 }
 
-                let mut path = interior.path_assignments(builder);
+                let mut path = interior.path_assignments(builder, source_order);
                 let result = path
                     .visit(db, builder, self, &mut IsNeverSatisfiedVisitor)
                     .is_continue();
@@ -2604,7 +2623,7 @@ impl NodeId {
                     .storage
                     .borrow_mut()
                     .never_satisfied_cache
-                    .insert(self, result);
+                    .insert(key, result);
                 result
             }
         }
@@ -2879,6 +2898,7 @@ impl NodeId {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         inferable: TypeVarSet<'db>,
+        source_order: Option<SourceOrderId>,
     ) -> bool {
         match self.node() {
             Node::AlwaysTrue => return true,
@@ -2897,7 +2917,7 @@ impl NodeId {
             let when_satisfied = specializations
                 .implies(builder, self)
                 .and(builder, specializations);
-            !when_satisfied.is_never_satisfied(db, builder)
+            !when_satisfied.is_never_satisfied(db, builder, source_order)
         };
 
         // Returns if all specializations satisfy this constraint set.
@@ -2907,7 +2927,7 @@ impl NodeId {
                 .and(builder, specializations);
             when_satisfied
                 .iff(builder, specializations)
-                .is_always_satisfied(db, builder)
+                .is_always_satisfied(db, builder, source_order)
         };
 
         #[expect(
@@ -2958,6 +2978,7 @@ impl NodeId {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         bound_typevars: TypeVarSet<'db>,
+        source_order: Option<SourceOrderId>,
     ) -> (Self, Option<SourceOrderId>) {
         if bound_typevars == TypeVarSet::None {
             return (self, None);
@@ -2967,14 +2988,14 @@ impl NodeId {
             return (self, None);
         };
 
-        let key = (self, bound_typevars);
+        let key = (self, bound_typevars, source_order);
         let storage = builder.storage.borrow();
         if let Some(result) = storage.exists_cache.get(&key) {
             return *result;
         }
         drop(storage);
 
-        let result = interior.exists_inner(db, builder, bound_typevars);
+        let result = interior.exists_inner(db, builder, bound_typevars, source_order);
 
         let mut storage = builder.storage.borrow_mut();
         storage.exists_cache.insert(key, result);
@@ -2986,11 +3007,14 @@ impl NodeId {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         inferable: TypeVarSet<'db>,
+        source_order: Option<SourceOrderId>,
     ) -> (Self, Option<SourceOrderId>) {
         match self.node() {
             Node::AlwaysTrue => (ALWAYS_TRUE, None),
             Node::AlwaysFalse => (ALWAYS_FALSE, None),
-            Node::Interior(interior) => interior.remove_noninferable(db, builder, inferable),
+            Node::Interior(interior) => {
+                interior.remove_noninferable(db, builder, inferable, source_order)
+            }
         }
     }
 
@@ -3659,7 +3683,8 @@ impl<'db> PathBounds<'db> {
             return path_bounds;
         }
 
-        let (node, derived_source_order) = node.remove_noninferable(db, builder, inferable);
+        let (node, derived_source_order) =
+            node.remove_noninferable(db, builder, inferable, source_order);
         source_orders.extend(builder.calculate_source_orders(derived_source_order));
         let interior = match node.node() {
             Node::AlwaysTrue => return PathBounds::Unconstrained,
@@ -3679,7 +3704,8 @@ impl<'db> PathBounds<'db> {
         // Sequent discovery must also happen in source order. Sorting the collected paths below
         // is too late: sequent pairs are not commutative, and TDD traversal order can otherwise
         // discard gradual evidence before solution extraction.
-        let mut path = interior.path_assignments_in_source_order(builder, &source_orders);
+        let path_source_order = builder.ordered_source_order(source_order, derived_source_order);
+        let mut path = interior.path_assignments(builder, path_source_order);
         let _ = path.visit(db, builder, node, &mut collect_visitor);
         collect_visitor.sorted_paths.sort_by(|path1, path2| {
             let source_orders1 = path1.iter().map(|(_, source_order)| *source_order);
@@ -4205,6 +4231,7 @@ impl InteriorNode {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         bound_typevars: TypeVarSet<'db>,
+        source_order: Option<SourceOrderId>,
     ) -> (NodeId, Option<SourceOrderId>) {
         let mentions_typevar = |ty: Type<'db>| match ty {
             Type::TypeVar(typevar) => typevar.is_inferable(db, bound_typevars),
@@ -4213,6 +4240,7 @@ impl InteriorNode {
         self.abstract_inner(
             db,
             builder,
+            source_order,
             // Remove any node that constrains one of `bound_typevars`, or that has a lower/upper
             // bound that mentions one of them. Removed constraints are still added to `path`, so
             // the sequent map can propagate any derived constraints that do not mention the
@@ -4237,6 +4265,7 @@ impl InteriorNode {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         inferable: TypeVarSet<'db>,
+        source_order: Option<SourceOrderId>,
     ) -> (NodeId, Option<SourceOrderId>) {
         let is_bare_inferable_typevar = |ty: Type<'db>| {
             ty.as_typevar()
@@ -4245,6 +4274,7 @@ impl InteriorNode {
         self.abstract_inner(
             db,
             builder,
+            source_order,
             // We only want to keep constraints on inferable typevars. If the constraint's typevar
             // is itself inferable, we keep it. We also need to keep some constraints in
             // non-inferable typevars, if their lower or upper bound is a bare inferable typevar.
@@ -4273,6 +4303,7 @@ impl InteriorNode {
         self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
+        source_order: Option<SourceOrderId>,
         should_remove: F,
     ) -> (NodeId, Option<SourceOrderId>)
     where
@@ -4446,7 +4477,7 @@ impl InteriorNode {
             }
         }
 
-        let mut path = self.path_assignments(builder);
+        let mut path = self.path_assignments(builder, source_order);
         let mut visitor = AbstractVisitor { should_remove };
         let ControlFlow::Continue(result) = path.visit(db, builder, self.node(), &mut visitor);
         result
@@ -4527,31 +4558,28 @@ impl InteriorNode {
         result
     }
 
-    fn path_assignments(self, builder: &ConstraintSetBuilder<'_>) -> PathAssignments {
-        let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
-        self.node()
-            .for_each_unique_constraint(builder, &mut |constraint| {
-                constraints.push(constraint);
-            });
-        PathAssignments::new(constraints)
-    }
-
-    fn path_assignments_in_source_order(
+    fn path_assignments(
         self,
         builder: &ConstraintSetBuilder<'_>,
-        source_orders: &FxIndexSet<ConstraintId>,
+        source_order: Option<SourceOrderId>,
     ) -> PathAssignments {
         let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
         self.node()
             .for_each_unique_constraint(builder, &mut |constraint| {
                 constraints.push(constraint);
             });
+        let source_orders = builder.calculate_source_orders(source_order);
         // `PathAssignments` seeds its insertion-ordered discovered-constraint map from this list,
         // and uses that order when constructing non-commutative sequent pairs. Do not replace this
         // with TDD traversal order: doing so can change inference and lose gradual constraints.
-        // Keep any constraint absent from the sidecar in its stable traversal order after the rest.
-        constraints
-            .sort_by_key(|constraint| source_orders.get_index_of(constraint).unwrap_or(usize::MAX));
+        // Keep synthetic constraints absent from the sidecar after the rest, using their stable
+        // creation order rather than the perturbed TDD traversal order.
+        constraints.sort_by_key(|constraint| {
+            (
+                source_orders.get_index_of(constraint).unwrap_or(usize::MAX),
+                constraint.index(),
+            )
+        });
         PathAssignments::new(constraints)
     }
 
@@ -7995,9 +8023,16 @@ mod tests {
 
         {
             let storage = builder.storage.borrow();
-            assert_eq!(storage.never_satisfied_cache.get(&t_int.node), Some(&false));
             assert_eq!(
-                storage.never_satisfied_cache.get(&impossible.node),
+                storage
+                    .never_satisfied_cache
+                    .get(&(t_int.node, t_int.source_order)),
+                Some(&false)
+            );
+            assert_eq!(
+                storage
+                    .never_satisfied_cache
+                    .get(&(impossible.node, impossible.source_order)),
                 Some(&true)
             );
             assert_eq!(storage.never_satisfied_cache.len(), 2);
@@ -8012,7 +8047,7 @@ mod tests {
                     .storage
                     .borrow()
                     .never_satisfied_cache
-                    .get(&set.node),
+                    .get(&(set.node, set.source_order)),
                 Some(&false)
             );
         });
@@ -8663,11 +8698,35 @@ mod tests {
         }
     }
 
-    fn path_assignments_for(builder: &ConstraintSetBuilder<'_>, node: NodeId) -> PathAssignments {
+    fn path_assignments_for(
+        builder: &ConstraintSetBuilder<'_>,
+        node: NodeId,
+        source_order: Option<SourceOrderId>,
+    ) -> PathAssignments {
         match node.node() {
             Node::AlwaysTrue | Node::AlwaysFalse => PathAssignments::new([]),
-            Node::Interior(interior) => interior.path_assignments(builder),
+            Node::Interior(interior) => interior.path_assignments(builder, source_order),
         }
+    }
+
+    #[test]
+    fn path_assignments_follow_constraint_source_order() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let builder = ConstraintSetBuilder::new();
+        let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
+        let u_str = create_constraint(&db, &builder, u, KnownClass::Str);
+
+        // Construct the set in the opposite order from constraint creation. This ensures the
+        // initializer follows the sidecar rather than either TDD traversal or constraint IDs.
+        let set = u_str.and(&db, &builder, || t_int);
+        let path = path_assignments_for(&builder, set.node, set.source_order);
+        let expected =
+            [u_str.node, t_int.node].map(|node| builder.interior_node_data(node).constraint);
+        let actual: Vec<_> = path.discovered.keys().copied().collect();
+
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -8714,7 +8773,7 @@ mod tests {
             tautology,
             transitive,
         ] {
-            let mut path = path_assignments_for(&builder, set.node);
+            let mut path = path_assignments_for(&builder, set.node, set.source_order);
             let mut fold = ReconstructPathFold { break_at: None };
             let ControlFlow::Continue(reconstructed) =
                 path.visit(&db, &builder, set.node, &mut fold)
@@ -8748,7 +8807,7 @@ mod tests {
             PathFoldBreak::Impossible,
             PathFoldBreak::Combine,
         ] {
-            let mut path = path_assignments_for(&builder, set.node);
+            let mut path = path_assignments_for(&builder, set.node, set.source_order);
             let mut aborting_fold = ReconstructPathFold {
                 break_at: Some(break_at),
             };

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -788,12 +788,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
 
         // Universal and existential quantification are duals. Reusing existential abstraction
         // also keeps this operation on its cached, single-pass implementation.
-        let (node, derived_source_order) =
-            self.node
-                .negate(builder)
-                .exists(db, builder, to_remove, self.source_order);
-        let source_order = builder.ordered_source_order(self.source_order, derived_source_order);
-        Self::from_node(builder, node.negate(builder), source_order)
+        self.negate(db, builder)
+            .reduce_inferable(db, builder, to_remove)
+            .negate(db, builder)
     }
 
     /// Computes solutions for each BDD path, using a caller-provided hook to select solutions.

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -935,8 +935,8 @@ struct ConstraintSetStorage<'db> {
     negate_cache: FxHashMap<NodeId, NodeId>,
     or_cache: FxHashMap<(NodeId, NodeId), NodeId>,
     and_cache: FxHashMap<(NodeId, NodeId), NodeId>,
-    /// Abstraction also constructs sequents while traversing the TDD, so its cache key must retain
-    /// the sidecar source order for the same reason.
+    /// Existential abstraction derives new constraints in source order and returns their
+    /// source-order sidecar, so distinct orderings of the same BDD must not share a cache entry.
     exists_cache: FxHashMap<ExistsCacheKey<'db>, (NodeId, Option<SourceOrderId>)>,
     restrict_one_cache: FxHashMap<(NodeId, ConstraintAssignment), (NodeId, bool)>,
     simplify_cache: FxHashMap<NodeId, NodeId>,
@@ -1446,6 +1446,8 @@ impl<'db> ConstraintSetBuilder<'db> {
         id
     }
 
+    /// Repeating a source-order tree cannot change the first occurrence of any constraint, so
+    /// combining identical trees must reuse their existing sidecar.
     fn ordered_source_order(
         &self,
         left: Option<SourceOrderId>,
@@ -1454,6 +1456,7 @@ impl<'db> ConstraintSetBuilder<'db> {
         match (left, right) {
             (None, None) => None,
             (None, other) | (other, None) => other,
+            (Some(left), Some(right)) if left == right => Some(left),
             (Some(left), Some(right)) => {
                 Some(self.intern_source_order(SourceOrder::Ordered(left, right)))
             }
@@ -8838,6 +8841,32 @@ mod tests {
         assert!(tdd.iff(&db, &builder, negated).is_never_satisfied(&db));
     }
 
+    #[test]
+    fn constraint_set_source_order_combination_is_idempotent() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let u = create_typevar(&db, "U");
+        let builder = ConstraintSetBuilder::new();
+        let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
+        let u_str = create_constraint(&db, &builder, u, KnownClass::Str);
+        let combined = t_int.and(&db, &builder, || u_str);
+
+        for original in [t_int, combined] {
+            let original_source_order_count = builder.storage.borrow().source_orders.len();
+            let intersection = original.and(&db, &builder, || original);
+            let union = original.or(&db, &builder, || original);
+
+            assert_eq!(intersection.node, original.node);
+            assert_eq!(intersection.source_order, original.source_order);
+            assert_eq!(union.node, original.node);
+            assert_eq!(union.source_order, original.source_order);
+            assert_eq!(
+                builder.storage.borrow().source_orders.len(),
+                original_source_order_count
+            );
+        }
+    }
+
     fn create_compacted_owned_set(db: &dyn Db) -> OwnedConstraintSet<'_> {
         let t = create_typevar(db, "T");
         let u = create_typevar(db, "U");
@@ -8885,16 +8914,19 @@ mod tests {
             ConstraintSetBuilder::new().into_owned(|builder| {
                 let t_int = create_constraint(&db, builder, t, KnownClass::Int);
                 let u_str = create_constraint(&db, builder, u, KnownClass::Str);
+                let combined = t_int.and(&db, builder, || u_str);
 
                 if include_redundant_combination {
-                    // The redundant combination leaves the BDD unchanged but still creates an
-                    // intermediate source-order tree. It must not affect the final owned set.
-                    let redundant = t_int.and(&db, builder, || t_int);
-                    assert_eq!(redundant.node, t_int.node);
-                    assert_ne!(redundant.source_order, t_int.source_order);
+                    // Repeating one constraint leaves the BDD and first-occurrence source order
+                    // unchanged, but creates a distinct, reachable source-order tree. Both trees
+                    // must compact to the same owned set.
+                    let redundant = combined.and(&db, builder, || t_int);
+                    assert_eq!(redundant.node, combined.node);
+                    assert_ne!(redundant.source_order, combined.source_order);
+                    redundant
+                } else {
+                    combined
                 }
-
-                t_int.and(&db, builder, || u_str)
             })
         };
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1059,6 +1059,10 @@ impl<'db> ConstraintSetBuilder<'db> {
             }
         }
 
+        used_nodes.truncate(used_nodes.last_one().map_or(0, |last| last + 1));
+        used_constraints.truncate(used_constraints.last_one().map_or(0, |last| last + 1));
+        used_source_orders.truncate(used_source_orders.last_one().map_or(0, |last| last + 1));
+
         let nodes = storage
             .nodes
             .into_iter()

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -96,7 +96,6 @@ use std::marker::PhantomData;
 use std::ops::{ControlFlow, Range};
 use std::sync::{Arc, LazyLock};
 
-use indexmap::map::Entry;
 use itertools::Itertools;
 use ruff_index::{Idx, IndexVec, newtype_index};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -7107,7 +7106,7 @@ impl PathAssignments {
             target: "ty_python_semantic::types::constraints::PathAssignment",
             before = %format_args!(
                 "[{}]",
-                self.assignments[..start].iter().map(|(assignment, _)| {
+                self.assignments[..start].iter().map(|assignment| {
                     assignment.display(db, builder)
                 }).format(", "),
             ),
@@ -7125,7 +7124,7 @@ impl PathAssignments {
                 target: "ty_python_semantic::types::constraints::PathAssignment",
                 new = %format_args!(
                     "[{}]",
-                    self.assignments[start..].iter().map(|(assignment, _)| {
+                    self.assignments[start..].iter().map(|assignment| {
                         assignment.display(db, builder)
                     }).format(", "),
                 ),
@@ -7149,7 +7148,7 @@ impl PathAssignments {
         result
     }
 
-    pub(crate) fn positive_constraints(&self) -> impl Iterator<Item = (ConstraintId, usize)> + '_ {
+    pub(crate) fn positive_constraints(&self) -> impl Iterator<Item = ConstraintId> + '_ {
         self.assignments
             .iter()
             .filter_map(|(assignment, (source_order, _))| match assignment {
@@ -7159,7 +7158,7 @@ impl PathAssignments {
     }
 
     fn assignment_holds(&self, assignment: ConstraintAssignment) -> bool {
-        self.assignments.contains_key(&assignment)
+        self.assignments.contains(&assignment)
     }
 
     fn contains_constraint(&self, constraint: ConstraintId) -> bool {
@@ -7255,7 +7254,7 @@ impl PathAssignments {
                 assignment = %assignment.display(db, builder),
                 facts = %format_args!(
                     "[{}]",
-                    self.assignments.iter().map(|(assignment, _)| {
+                    self.assignments.iter().map(|assignment| {
                         assignment.display(db, builder)
                     }).format(", "),
                 ),
@@ -7316,13 +7315,7 @@ impl PathAssignments {
             }
         }
 
-        // Then use our sequents to add additional facts that we know to be true. We currently
-        // reuse the `source_order` of the "real" constraint passed into `walk_edge` when we add
-        // these derived facts.
-        //
-        // TODO: This might not be stable enough, if we add more than one derived fact for this
-        // constraint. If we still see inconsistent test output, we might need a more complex
-        // way of tracking source order for derived facts.
+        // Then use our sequents to add additional facts that we know to be true.
         //
         // TODO: This is very naive at the moment, partly for expediency, and partly because we
         // don't anticipate the sequent maps to be very large. We might consider avoiding the


### PR DESCRIPTION
## Summary

Rebases and continues #26245 on the latest `main`, keeping constraint source ordering in a sidecar instead of TDD nodes and integrating it with current abstraction, type-mapping, and path-traversal code. Normalizes owned source-order sidecars into a dense, canonical representation, preventing irrelevant construction history from affecting Salsa equality or cycle convergence.

Brings over the behavior-focused regressions from #27141 (astral-sh/ty#4073), covering union-order-independent callable inference and constraint absorption without adding the shape-cache implementation that the sidecar representation makes unnecessary.

Fixes astral-sh/ty#4073

## Test plan

- Adds legacy-TypeVar and PEP 695 mdtests covering callable-return inference across actual/formal union orders, nested tuples, covariant generic members, and gradual `Container[Any]` constraints.
- Adds constraint-set regressions covering absorption, compound and partitioned constraints, preserved binding order, distinct solutions, type mapping, and source-ordered sequent initialization across constraint traversals.
- Adds owned-constraint-set regression coverage for canonical source-order identity across different construction histories and source-order reuse in compacted overlays.
- Adds a Steam corpus reproducer covering the previously observed constraint-cycle panic.
- Updates revealed-type ordering expectations for quantification and high-fanout constraints.


### Ecosystem

- Reproduces all the same favorable ecosystem changes as #27141, plus a bunch of ordering changes in diagnostics.
- There is one regression relative to main, in `static-frame`. This shows up because of a subtle difference in the way constraints are ordered in this PR compared to main -- the sidecar's reconstructed ordering is not always identical to main's effective ordering. That exposes this bug, but the real bug is protocol inference collecting constraints from all overloads without accounting for overlapping-overload precedence. This should be a separate fix. (Or alternately, the real bug is that the constraint solver is not commutative -- this is also out of scope :) ).