### PR TITLE
[ty] Fix ParamSpec declaration hover and type navigation

### DIFF
--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -460,6 +460,7 @@ impl GotoTarget<'_> {
             // (i.e. the type of `MyClass` in `MyClass()` is `<class MyClass>` and not `() -> MyClass`)
             GotoTarget::Call { callable, .. } => callable.inferred_type(model),
             GotoTarget::TypeParamTypeVarName(typevar) => typevar.inferred_type(model),
+            GotoTarget::TypeParamParamSpecName(typevar) => typevar.inferred_type(model),
             GotoTarget::ImportModuleComponent {
                 module_name,
                 component_index,
@@ -521,7 +522,6 @@ impl GotoTarget<'_> {
             | GotoTarget::PatternKeywordArgument(_)
             | GotoTarget::PatternMatchStarName(_)
             | GotoTarget::PatternMatchAsName(_)
-            | GotoTarget::TypeParamParamSpecName(_)
             | GotoTarget::TypeParamTypeVarTupleName(_)
             | GotoTarget::NonLocal { .. }
             | GotoTarget::Globals { .. } => None,

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -1546,7 +1546,20 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No goto target found");
+        assert_snapshot!(test.goto_type_definition(), @"
+        info[goto-type definition]: Go to type definition
+         --> main.py:3:15
+          |
+        3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
+          |               ^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:3:15
+          |
+        3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
+          |               --
+          |
+        ");
     }
 
     #[test]

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -4083,7 +4083,23 @@ def function():
             "#,
         );
 
-        assert_snapshot!(test.hover(), @"Hover provided no content");
+        assert_snapshot!(test.hover(), @"
+        AB@Alias2 (contravariant)
+        ---------------------------------------------
+        ```python
+        AB@Alias2 (contravariant)
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:3:15
+          |
+        3 | type Alias2[**AB = [int, str]] = Callable[AB, tuple[AB]]
+          |               ^-
+          |               ||
+          |               |Cursor offset
+          |               source
+          |
+        ");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix hover and go-to-type-definition on PEP 695 `ParamSpec` declarations by resolving the declared parameter's inferred type in the shared IDE target resolver.

## Test plan

- Existing hover regression confirms a declared `ParamSpec` now displays its inferred type and variance.
- Existing navigation regression confirms go-to-type-definition resolves the declared `ParamSpec`.

