### PR TITLE
[ty] docs: fix setup_primer_project.py link in ty CONTRIBUTING

### DIFF
--- a/crates/ty/CONTRIBUTING.md
+++ b/crates/ty/CONTRIBUTING.md
@@ -144,7 +144,7 @@ ensure that the changes do not break any of the properties.
 ## Ecosystem CI (`ecosystem-analyzer`)
 
 GitHub Actions will run your changes against a number of real-world projects from GitHub and report
-any differences in ty's diagnostic output. You can use [`setup_primer_project.py`](./scripts/setup_primer_project.py)
+any differences in ty's diagnostic output. You can use [`setup_primer_project.py`](../../scripts/setup_primer_project.py)
 to reproduce the same testing conditions locally.
 
 ## Coding guidelines


### PR DESCRIPTION
`crates/ty/CONTRIBUTING.md` links `[\`setup_primer_project.py\`](./scripts/setup_primer_project.py)`, which resolves to `crates/ty/scripts/setup_primer_project.py` — a path that doesn't exist. The script lives at the repository root under `scripts/`, so from `crates/ty/` the link should be `../../scripts/setup_primer_project.py`. Verified the target exists. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)