### PR TITLE
[`pyupgrade`] Flag all outdated `sys.version_info` checks in `outdated-version-block` (`UP036`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_6.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_6.py
@@ -50,12 +50,25 @@ if foo:
 elif bar and sys.version_info < (3, 8):
     print(2)
 
-# Each link of a chained comparison is evaluated separately, and no link on its own
-# makes the branch removable.
+# Every link of the chain is a version check, so the whole branch can go.
 if (3, 8) <= sys.version_info < (3, 10):
     print("3.8 or 3.9")
 
+# Outside of a branch test there is nothing to remove, so each link is reported on its own.
 is_38_or_39 = (3, 8) <= sys.version_info < (3, 10)
+
+# Only the first link is outdated; the branch is still reachable, so it stays.
+if (3, 8) <= sys.version_info < (3, 15):
+    print("at most 3.14")
+
+# `foo` is not a version check, so the branch is left alone even though the second link
+# is always false.
+if foo < sys.version_info < (3, 10):
+    print("unreachable")
+
+# The second link cannot be resolved, so the branch is left alone.
+if (3, 8) <= sys.version_info <= (3, 13, foo):
+    print("maybe")
 
 
 ###

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_6.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP036_6.py
@@ -1,0 +1,120 @@
+import sys
+
+###
+# Outdated checks outside of an `if`/`elif` test.
+# https://github.com/astral-sh/ruff/issues/16487
+###
+
+PY37 = sys.version_info < (3, 8)
+
+old_pypy = hasattr(sys, "pypy_version_info") and sys.version_info < (3, 8)
+
+print("py3" if sys.version_info >= (3, 8) else "py2")
+
+print(sys.version_info >= (3, 8))
+
+assert sys.version_info >= (3, 8)
+
+while sys.version_info < (3, 8):
+    print("py2")
+
+legacy = not sys.version_info >= (3, 8)
+
+supported = [feature for feature in features if sys.version_info >= (3, 8)]
+
+
+def f(legacy=sys.version_info < (3, 8)):
+    return sys.version_info < (3, 8)
+
+
+class C:
+    LEGACY = sys.version_info < (3, 8)
+
+
+###
+# Outdated checks that are only part of an `if`/`elif` test.
+# https://github.com/astral-sh/ruff/issues/12093
+###
+
+if True and sys.version_info < (3, 5):
+    print("35")
+
+if sys.version_info < (3, 5) or sys.version_info > (3, 10):
+    print("both operands are outdated")
+
+if not sys.version_info < (3, 8):
+    print("py3")
+
+if foo:
+    print(1)
+elif bar and sys.version_info < (3, 8):
+    print(2)
+
+# Each link of a chained comparison is evaluated separately, and no link on its own
+# makes the branch removable.
+if (3, 8) <= sys.version_info < (3, 10):
+    print("3.8 or 3.9")
+
+is_38_or_39 = (3, 8) <= sys.version_info < (3, 10)
+
+
+###
+# The version comes first, so the operator has to be mirrored.
+###
+
+if (3, 0) > sys.version_info:
+    print("py2")
+
+is_py3 = (3, 0) < sys.version_info
+
+if 3 == sys.version_info[0]:
+    print("py3")
+
+while (3, 8) > sys.version_info:
+    print("py2")
+
+
+###
+# Invalid version specifiers are reported wherever they appear.
+###
+
+unsupported = sys.version_info < (3, 10000000)
+
+if foo or sys.version_info == 10000000:
+    print("py3")
+
+nonsense = 10000000 == sys.version_info[0]
+
+# Identity is symmetric, so both operand orders are reported.
+mistake = sys.version_info[0] is 10000000
+
+also_mistake = 10000000 is sys.version_info[0]
+
+
+###
+# `sys.version_info.major` is handled the same way.
+###
+
+major_is_py3 = sys.version_info.major >= 3
+
+if foo and sys.version_info.major < 3:
+    print("py2")
+
+
+###
+# No errors: these are not outdated for the minimum supported version.
+###
+
+not_outdated = sys.version_info < (3, 15)
+
+if foo and sys.version_info >= (3, 15):
+    print("3.15+")
+
+if (3, 15) <= sys.version_info:
+    print("3.15+")
+
+if (3, 15) <= sys.version_info < (3, 16):
+    print("3.15")
+
+# The version is not a literal, so nothing can be concluded.
+minimum = sys.version_info < (3, foo)

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1722,6 +1722,9 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
             if checker.is_rule_enabled(Rule::SingleItemMembershipTest) {
                 refurb::rules::single_item_membership_test(checker, expr, left, ops, comparators);
             }
+            if checker.is_rule_enabled(Rule::OutdatedVersionBlock) {
+                pyupgrade::rules::outdated_version_block(checker, expr, compare);
+            }
         }
         Expr::NumberLiteral(number_literal @ ast::ExprNumberLiteral { .. }) => {
             if checker.source_type.is_stub() && checker.is_rule_enabled(Rule::NumericLiteralTooLong)

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1045,9 +1045,6 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                     checker.semantic.current_statement_parent(),
                 );
             }
-            if checker.is_rule_enabled(Rule::OutdatedVersionBlock) {
-                pyupgrade::rules::outdated_version_block(checker, if_);
-            }
             if checker.is_rule_enabled(Rule::CollapsibleElseIf) {
                 pylint::rules::collapsible_else_if(checker, stmt);
             }

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -9,6 +9,12 @@ use crate::settings::{LinterSettings, types::PreviewMode};
 
 // Rule-specific behavior
 
+// https://github.com/astral-sh/ruff/issues/16487
+// https://github.com/astral-sh/ruff/issues/12093
+pub(crate) const fn is_outdated_version_check_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}
+
 // https://github.com/astral-sh/ruff/issues/25375
 pub(crate) const fn is_pytest_asyncio_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()

--- a/crates/ruff_linter/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/mod.rs
@@ -59,6 +59,7 @@ mod tests {
     #[test_case(Rule::OutdatedVersionBlock, Path::new("UP036_3.py"))]
     #[test_case(Rule::OutdatedVersionBlock, Path::new("UP036_4.py"))]
     #[test_case(Rule::OutdatedVersionBlock, Path::new("UP036_5.py"))]
+    #[test_case(Rule::OutdatedVersionBlock, Path::new("UP036_6.py"))]
     #[test_case(Rule::PrintfStringFormatting, Path::new("UP031_0.py"))]
     #[test_case(Rule::PrintfStringFormatting, Path::new("UP031_1.py"))]
     #[test_case(Rule::QuotedAnnotation, Path::new("UP037_0.py"))]
@@ -235,6 +236,7 @@ mod tests {
     }
 
     #[test_case(Rule::OSErrorAlias, Path::new("UP024_0.py"))]
+    #[test_case(Rule::OutdatedVersionBlock, Path::new("UP036_6.py"))]
     fn rules_preview(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}__preview", path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::ptr;
 
 use anyhow::Result;
 
@@ -6,26 +7,28 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::helpers::map_subscript;
 use ruff_python_ast::stmt_if::{BranchKind, IfElifBranch, if_elif_branches};
 use ruff_python_ast::whitespace::indentation;
-use ruff_python_ast::{self as ast, CmpOp, ElifElseClause, Expr, Int, StmtIf};
+use ruff_python_ast::{self as ast, CmpOp, ElifElseClause, Expr, Int, PythonVersion, Stmt, StmtIf};
+use ruff_python_semantic::SemanticModel;
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange};
 
 use crate::checkers::ast::Checker;
 use crate::fix::edits::{adjust_indentation, delete_stmt};
+use crate::preview::is_outdated_version_check_enabled;
 use crate::{Edit, Fix, FixAvailability, Violation};
-use ruff_python_ast::PythonVersion;
-use ruff_python_semantic::SemanticModel;
 
 /// ## What it does
-/// Checks for conditional blocks gated on `sys.version_info` comparisons
-/// that are outdated for the minimum supported Python version.
+/// Checks for `sys.version_info` comparisons that are outdated for the minimum
+/// supported Python version.
 ///
 /// ## Why is this bad?
 /// In Python, code can be conditionally executed based on the active
 /// Python version by comparing against the `sys.version_info` tuple.
 ///
-/// If a code block is only executed for Python versions older than the
-/// minimum supported version, it should be removed.
+/// If a comparison always evaluates to the same value for every supported Python
+/// version, the code it guards is either dead or unconditional, and should be
+/// simplified. For example, if a code block is only executed for Python versions
+/// older than the minimum supported version, it should be removed.
 ///
 /// ## Example
 /// ```python
@@ -42,8 +45,28 @@ use ruff_python_semantic::SemanticModel;
 /// print("py3")
 /// ```
 ///
+/// By default, this rule only applies to comparisons that make up the entire test
+/// of an `if` or `elif` branch. In [preview], it flags every outdated
+/// `sys.version_info` comparison, wherever it appears:
+///
+/// ```python
+/// import sys
+///
+/// PY2 = sys.version_info < (3, 0)
+///
+/// if force_legacy or sys.version_info < (3, 0):
+///     print("py2")
+/// ```
+///
 /// ## Options
 /// - `target-version`
+///
+/// ## Fix availability
+/// A fix is only offered when a single comparison makes up the entire test of an `if`
+/// or `elif` branch, since only then is it clear which code is unreachable. Elsewhere,
+/// such as in an assignment or as one operand of a boolean expression, replacing the
+/// comparison with `True` or `False` would be sound, but it would defeat the purpose
+/// of flagging obsolete code that can be migrated.
 ///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe because it will remove all code,
@@ -51,10 +74,15 @@ use ruff_python_semantic::SemanticModel;
 ///
 /// ## References
 /// - [Python documentation: `sys.version_info`](https://docs.python.org/3/library/sys.html#sys.version_info)
+///
+/// [preview]: https://docs.astral.sh/ruff/preview/
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.240")]
 pub(crate) struct OutdatedVersionBlock {
     reason: Reason,
+    /// Whether the comparison makes up the entire test of an `if` or `elif` branch,
+    /// in which case the branch as a whole (not just the comparison) is outdated.
+    is_block: bool,
 }
 
 impl Violation for OutdatedVersionBlock {
@@ -64,7 +92,11 @@ impl Violation for OutdatedVersionBlock {
     fn message(&self) -> String {
         match self.reason {
             Reason::AlwaysFalse | Reason::AlwaysTrue => {
-                "Version block is outdated for minimum Python version".to_string()
+                if self.is_block {
+                    "Version block is outdated for minimum Python version".to_string()
+                } else {
+                    "Version check is outdated for minimum Python version".to_string()
+                }
             }
             Reason::Invalid => "Version specifier is invalid".to_string(),
         }
@@ -72,15 +104,15 @@ impl Violation for OutdatedVersionBlock {
 
     fn fix_title(&self) -> Option<String> {
         match self.reason {
-            Reason::AlwaysFalse | Reason::AlwaysTrue => {
+            Reason::AlwaysFalse | Reason::AlwaysTrue if self.is_block => {
                 Some("Remove outdated version block".to_string())
             }
-            Reason::Invalid => None,
+            _ => None,
         }
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum Reason {
     AlwaysTrue,
     AlwaysFalse,
@@ -88,124 +120,162 @@ enum Reason {
 }
 
 /// UP036
-pub(crate) fn outdated_version_block(checker: &Checker, stmt_if: &StmtIf) {
-    for branch in if_elif_branches(stmt_if) {
-        let Expr::Compare(ast::ExprCompare {
-            left,
-            ops,
-            comparators,
-            range: _,
-            node_index: _,
-        }) = &branch.test
-        else {
-            continue;
+pub(crate) fn outdated_version_block(checker: &Checker, expr: &Expr, compare: &ast::ExprCompare) {
+    // A comparison that makes up the _entire_ test of an `if` or `elif` branch gates the whole
+    // branch, which is what makes the branch itself removable. Chained comparisons are excluded:
+    // each link is reported on its own, and an outdated link does not necessarily make the branch
+    // outdated. For example, in `if (3, 8) <= sys.version_info < (3, 10)`, the `(3, 8) <=` link is
+    // always true on Python 3.8+, but the branch is still only taken on Python 3.8 and 3.9.
+    let is_chained = compare.ops.len() > 1;
+    let branch = if is_chained {
+        None
+    } else {
+        gated_branch(checker.semantic(), expr)
+    };
+
+    // `a < b < c` is equivalent to `a < b and b < c`, so evaluate each adjacent pair separately.
+    for (index, (op, right)) in compare.ops.iter().zip(&compare.comparators).enumerate() {
+        let left = if index == 0 {
+            &*compare.left
+        } else {
+            &compare.comparators[index - 1]
         };
 
-        let ([op], [comparison]) = (&**ops, &**comparators) else {
-            continue;
-        };
+        // Normalize to `sys.version_info <op> <version>`, mirroring the operator when the check is
+        // written the other way around (e.g., `(3, 0) > sys.version_info`).
+        let (op, comparison, version_info_on_left) =
+            if is_valid_version_info(checker.semantic(), left) {
+                (*op, right, true)
+            } else if is_valid_version_info(checker.semantic(), right) {
+                let Some(op) = mirror(*op) else {
+                    continue;
+                };
+                (op, left, false)
+            } else {
+                continue;
+            };
 
-        if !is_valid_version_info(checker.semantic(), left) {
+        // Outside of preview, the rule is limited to the canonical `sys.version_info <op>
+        // <version>` form gating an entire branch.
+        let reportable = (version_info_on_left && branch.is_some())
+            || is_outdated_version_check_enabled(checker.settings());
+        if !reportable {
             continue;
         }
 
-        match comparison {
-            Expr::Tuple(ast::ExprTuple { elts, .. }) => match op {
-                CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE => {
-                    let Some(version) = extract_version(elts) else {
-                        return;
-                    };
-                    let target = checker.target_version();
-                    match version_always_less_than(
-                        &version,
-                        target,
-                        // `x <= y` and `x > y` are cases where `x == y` will not stop the comparison
-                        // from always evaluating to true or false respectively
-                        op.is_lt_e() || op.is_gt(),
-                    ) {
-                        Ok(false) => {}
-                        Ok(true) => {
-                            let mut diagnostic = checker.report_diagnostic(
-                                OutdatedVersionBlock {
-                                    reason: if op.is_lt() || op.is_lt_e() {
-                                        Reason::AlwaysFalse
-                                    } else {
-                                        Reason::AlwaysTrue
-                                    },
-                                },
-                                branch.test.range(),
-                            );
-                            if let Some(fix) = if op.is_lt() || op.is_lt_e() {
-                                fix_always_false_branch(checker, stmt_if, &branch)
-                            } else {
-                                fix_always_true_branch(checker, stmt_if, &branch)
-                            } {
-                                diagnostic.set_fix(fix);
-                            }
-                        }
-                        Err(_) => {
-                            checker.report_diagnostic(
-                                OutdatedVersionBlock {
-                                    reason: Reason::Invalid,
-                                },
-                                comparison.range(),
-                            );
-                        }
-                    }
-                }
-                _ => {}
-            },
-            Expr::NumberLiteral(ast::ExprNumberLiteral {
-                value: ast::Number::Int(int),
-                ..
-            }) => {
-                let reason = match (int.as_u8(), op) {
-                    (Some(2), CmpOp::Eq) => Reason::AlwaysFalse,
-                    (Some(3), CmpOp::Eq) => Reason::AlwaysTrue,
-                    (Some(2), CmpOp::NotEq) => Reason::AlwaysTrue,
-                    (Some(3), CmpOp::NotEq) => Reason::AlwaysFalse,
-                    (Some(2), CmpOp::Lt) => Reason::AlwaysFalse,
-                    (Some(3), CmpOp::Lt) => Reason::AlwaysFalse,
-                    (Some(2), CmpOp::LtE) => Reason::AlwaysFalse,
-                    (Some(3), CmpOp::LtE) => Reason::AlwaysTrue,
-                    (Some(2), CmpOp::Gt) => Reason::AlwaysTrue,
-                    (Some(3), CmpOp::Gt) => Reason::AlwaysFalse,
-                    (Some(2), CmpOp::GtE) => Reason::AlwaysTrue,
-                    (Some(3), CmpOp::GtE) => Reason::AlwaysTrue,
-                    (None, _) => Reason::Invalid,
-                    _ => return,
-                };
-                match reason {
-                    Reason::AlwaysTrue => {
-                        let mut diagnostic = checker.report_diagnostic(
-                            OutdatedVersionBlock { reason },
-                            branch.test.range(),
-                        );
-                        if let Some(fix) = fix_always_true_branch(checker, stmt_if, &branch) {
-                            diagnostic.set_fix(fix);
-                        }
-                    }
-                    Reason::AlwaysFalse => {
-                        let mut diagnostic = checker.report_diagnostic(
-                            OutdatedVersionBlock { reason },
-                            branch.test.range(),
-                        );
-                        if let Some(fix) = fix_always_false_branch(checker, stmt_if, &branch) {
-                            diagnostic.set_fix(fix);
-                        }
-                    }
-                    Reason::Invalid => {
-                        checker.report_diagnostic(
-                            OutdatedVersionBlock {
-                                reason: Reason::Invalid,
-                            },
-                            comparison.range(),
-                        );
-                    }
+        let Some(reason) = version_check_reason(op, comparison, checker.target_version()) else {
+            continue;
+        };
+
+        let range = match reason {
+            Reason::Invalid => comparison.range(),
+            Reason::AlwaysTrue | Reason::AlwaysFalse => {
+                if is_chained {
+                    TextRange::new(left.start(), right.end())
+                } else {
+                    compare.range()
                 }
             }
-            _ => (),
+        };
+
+        let mut diagnostic = checker.report_diagnostic(
+            OutdatedVersionBlock {
+                reason,
+                is_block: branch.is_some(),
+            },
+            range,
+        );
+
+        if let Some((stmt_if, branch)) = &branch {
+            let fix = match reason {
+                Reason::AlwaysFalse => fix_always_false_branch(checker, stmt_if, branch),
+                Reason::AlwaysTrue => fix_always_true_branch(checker, stmt_if, branch),
+                Reason::Invalid => None,
+            };
+            if let Some(fix) = fix {
+                diagnostic.set_fix(fix);
+            }
         }
+    }
+}
+
+/// If `expr` is the entire test of an `if` or `elif` branch, return that branch along with the
+/// `if` statement that owns it.
+fn gated_branch<'a>(
+    semantic: &SemanticModel<'a>,
+    expr: &Expr,
+) -> Option<(&'a StmtIf, IfElifBranch<'a>)> {
+    let Stmt::If(stmt_if) = semantic.current_statement() else {
+        return None;
+    };
+    let branch = if_elif_branches(stmt_if).find(|branch| ptr::eq(branch.test, expr))?;
+    Some((stmt_if, branch))
+}
+
+/// Return the operator that yields the same result once the operands are swapped, if any.
+///
+/// For example, `(3, 0) > sys.version_info` is equivalent to `sys.version_info < (3, 0)`.
+fn mirror(op: CmpOp) -> Option<CmpOp> {
+    match op {
+        // Equality and identity are symmetric.
+        CmpOp::Eq => Some(CmpOp::Eq),
+        CmpOp::NotEq => Some(CmpOp::NotEq),
+        CmpOp::Is => Some(CmpOp::Is),
+        CmpOp::IsNot => Some(CmpOp::IsNot),
+        CmpOp::Lt => Some(CmpOp::Gt),
+        CmpOp::LtE => Some(CmpOp::GtE),
+        CmpOp::Gt => Some(CmpOp::Lt),
+        CmpOp::GtE => Some(CmpOp::LtE),
+        // Containment is not: `a in b` says nothing about `b in a`.
+        CmpOp::In | CmpOp::NotIn => None,
+    }
+}
+
+/// Determine whether `sys.version_info <op> <comparison>` always evaluates to the same value for
+/// every Python version supported by `target`, or is not a well-formed version check at all.
+fn version_check_reason(op: CmpOp, comparison: &Expr, target: PythonVersion) -> Option<Reason> {
+    match comparison {
+        Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+            if !matches!(op, CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE) {
+                return None;
+            }
+            let version = extract_version(elts)?;
+            match version_always_less_than(
+                &version,
+                target,
+                // `x <= y` and `x > y` are cases where `x == y` will not stop the comparison
+                // from always evaluating to true or false respectively
+                op.is_lt_e() || op.is_gt(),
+            ) {
+                Ok(false) => None,
+                Ok(true) => Some(if op.is_lt() || op.is_lt_e() {
+                    Reason::AlwaysFalse
+                } else {
+                    Reason::AlwaysTrue
+                }),
+                Err(_) => Some(Reason::Invalid),
+            }
+        }
+        Expr::NumberLiteral(ast::ExprNumberLiteral {
+            value: ast::Number::Int(int),
+            ..
+        }) => match (int.as_u8(), op) {
+            (Some(2), CmpOp::Eq) => Some(Reason::AlwaysFalse),
+            (Some(3), CmpOp::Eq) => Some(Reason::AlwaysTrue),
+            (Some(2), CmpOp::NotEq) => Some(Reason::AlwaysTrue),
+            (Some(3), CmpOp::NotEq) => Some(Reason::AlwaysFalse),
+            (Some(2), CmpOp::Lt) => Some(Reason::AlwaysFalse),
+            (Some(3), CmpOp::Lt) => Some(Reason::AlwaysFalse),
+            (Some(2), CmpOp::LtE) => Some(Reason::AlwaysFalse),
+            (Some(3), CmpOp::LtE) => Some(Reason::AlwaysTrue),
+            (Some(2), CmpOp::Gt) => Some(Reason::AlwaysTrue),
+            (Some(3), CmpOp::Gt) => Some(Reason::AlwaysFalse),
+            (Some(2), CmpOp::GtE) => Some(Reason::AlwaysTrue),
+            (Some(3), CmpOp::GtE) => Some(Reason::AlwaysTrue),
+            (None, _) => Some(Reason::Invalid),
+            _ => None,
+        },
+        _ => None,
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -62,11 +62,13 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// - `target-version`
 ///
 /// ## Fix availability
-/// A fix is only offered when a single comparison makes up the entire test of an `if`
-/// or `elif` branch, since only then is it clear which code is unreachable. Elsewhere,
-/// such as in an assignment or as one operand of a boolean expression, replacing the
-/// comparison with `True` or `False` would be sound, but it would defeat the purpose
-/// of flagging obsolete code that can be migrated.
+/// A fix is only offered when the entire test of an `if` or `elif` branch is made up of
+/// `sys.version_info` comparisons, since only then is it clear which code is
+/// unreachable. This includes chained comparisons such as
+/// `if (3, 8) <= sys.version_info < (3, 10)`, as long as every link is a version check.
+/// Elsewhere, such as in an assignment or alongside an unrelated condition, replacing
+/// the comparison with `True` or `False` would be sound, but it would defeat the
+/// purpose of flagging obsolete code that can be migrated.
 ///
 /// ## Fix safety
 /// This rule's fix is marked as unsafe because it will remove all code,
@@ -119,84 +121,154 @@ enum Reason {
     Invalid,
 }
 
-/// UP036
-pub(crate) fn outdated_version_block(checker: &Checker, expr: &Expr, compare: &ast::ExprCompare) {
-    // A comparison that makes up the _entire_ test of an `if` or `elif` branch gates the whole
-    // branch, which is what makes the branch itself removable. Chained comparisons are excluded:
-    // each link is reported on its own, and an outdated link does not necessarily make the branch
-    // outdated. For example, in `if (3, 8) <= sys.version_info < (3, 10)`, the `(3, 8) <=` link is
-    // always true on Python 3.8+, but the branch is still only taken on Python 3.8 and 3.9.
-    let is_chained = compare.ops.len() > 1;
-    let branch = if is_chained {
-        None
-    } else {
-        gated_branch(checker.semantic(), expr)
-    };
+/// One adjacent pair of a (possibly chained) comparison, normalized to the
+/// `sys.version_info <op> <version>` form.
+struct Link {
+    /// Why the check is outdated, or `None` if this pair is not a decidable version check.
+    reason: Option<Reason>,
+    /// Where to report: the version operand for an invalid specifier, the whole pair otherwise.
+    range: TextRange,
+    /// Whether `sys.version_info` was written on the left-hand side.
+    version_info_on_left: bool,
+}
 
-    // `a < b < c` is equivalent to `a < b and b < c`, so evaluate each adjacent pair separately.
-    for (index, (op, right)) in compare.ops.iter().zip(&compare.comparators).enumerate() {
-        let left = if index == 0 {
-            &*compare.left
-        } else {
-            &compare.comparators[index - 1]
-        };
+/// Whether an entire branch test is known to evaluate the same way on every supported version.
+#[derive(Debug, Copy, Clone)]
+enum BranchVerdict {
+    AlwaysTrue,
+    AlwaysFalse,
+}
 
-        // Normalize to `sys.version_info <op> <version>`, mirroring the operator when the check is
-        // written the other way around (e.g., `(3, 0) > sys.version_info`).
-        let (op, comparison, version_info_on_left) =
-            if is_valid_version_info(checker.semantic(), left) {
-                (*op, right, true)
-            } else if is_valid_version_info(checker.semantic(), right) {
-                let Some(op) = mirror(*op) else {
-                    continue;
-                };
-                (op, left, false)
-            } else {
-                continue;
-            };
-
-        // Outside of preview, the rule is limited to the canonical `sys.version_info <op>
-        // <version>` form gating an entire branch.
-        let reportable = (version_info_on_left && branch.is_some())
-            || is_outdated_version_check_enabled(checker.settings());
-        if !reportable {
-            continue;
-        }
-
-        let Some(reason) = version_check_reason(op, comparison, checker.target_version()) else {
-            continue;
-        };
-
-        let range = match reason {
-            Reason::Invalid => comparison.range(),
-            Reason::AlwaysTrue | Reason::AlwaysFalse => {
-                if is_chained {
-                    TextRange::new(left.start(), right.end())
-                } else {
-                    compare.range()
-                }
-            }
-        };
-
-        let mut diagnostic = checker.report_diagnostic(
-            OutdatedVersionBlock {
-                reason,
-                is_block: branch.is_some(),
-            },
-            range,
-        );
-
-        if let Some((stmt_if, branch)) = &branch {
-            let fix = match reason {
-                Reason::AlwaysFalse => fix_always_false_branch(checker, stmt_if, branch),
-                Reason::AlwaysTrue => fix_always_true_branch(checker, stmt_if, branch),
-                Reason::Invalid => None,
-            };
-            if let Some(fix) = fix {
-                diagnostic.set_fix(fix);
-            }
+impl From<BranchVerdict> for Reason {
+    fn from(verdict: BranchVerdict) -> Self {
+        match verdict {
+            BranchVerdict::AlwaysTrue => Reason::AlwaysTrue,
+            BranchVerdict::AlwaysFalse => Reason::AlwaysFalse,
         }
     }
+}
+
+/// UP036
+pub(crate) fn outdated_version_block(checker: &Checker, expr: &Expr, compare: &ast::ExprCompare) {
+    let branch = gated_branch(checker.semantic(), expr);
+    let is_chained = compare.ops.len() > 1;
+
+    // `a < b < c` is equivalent to `a < b and b < c`, so judge each adjacent pair on its own.
+    let links: Vec<Link> = compare
+        .ops
+        .iter()
+        .zip(&compare.comparators)
+        .enumerate()
+        .map(|(index, (op, right))| {
+            let left = if index == 0 {
+                &*compare.left
+            } else {
+                &compare.comparators[index - 1]
+            };
+            // For a lone comparison, prefer the range of the comparison itself, so that any
+            // parentheses around the left operand are covered.
+            let link_range = if is_chained {
+                TextRange::new(left.start(), right.end())
+            } else {
+                compare.range()
+            };
+
+            // Normalize to `sys.version_info <op> <version>`, mirroring the operator when the
+            // check is written the other way around (e.g., `(3, 0) > sys.version_info`).
+            let (op, comparison, version_info_on_left) =
+                if is_valid_version_info(checker.semantic(), left) {
+                    (*op, right, true)
+                } else if is_valid_version_info(checker.semantic(), right)
+                    && let Some(mirrored) = mirror(*op)
+                {
+                    (mirrored, left, false)
+                } else {
+                    return Link {
+                        reason: None,
+                        range: link_range,
+                        version_info_on_left: false,
+                    };
+                };
+
+            let reason = version_check_reason(op, comparison, checker.target_version());
+            Link {
+                reason,
+                range: if reason == Some(Reason::Invalid) {
+                    comparison.range()
+                } else {
+                    link_range
+                },
+                version_info_on_left,
+            }
+        })
+        .collect();
+
+    // Outside of preview, the rule is limited to a single canonical
+    // `sys.version_info <op> <version>` comparison gating an entire branch.
+    let stable_shape = branch.is_some()
+        && !is_chained
+        && links.first().is_some_and(|link| link.version_info_on_left);
+    if !stable_shape && !is_outdated_version_check_enabled(checker.settings()) {
+        return;
+    }
+
+    // When the comparison is the entire test of a branch and every link is a decidable version
+    // check, the branch as a whole is either dead or unconditional, so it can be removed. Report
+    // it once, against the whole test, rather than once per outdated link.
+    if let Some((stmt_if, branch)) = &branch
+        && let Some(verdict) = branch_verdict(&links)
+    {
+        let mut diagnostic = checker.report_diagnostic(
+            OutdatedVersionBlock {
+                reason: verdict.into(),
+                is_block: true,
+            },
+            compare.range(),
+        );
+        let fix = match verdict {
+            BranchVerdict::AlwaysFalse => fix_always_false_branch(checker, stmt_if, branch),
+            BranchVerdict::AlwaysTrue => fix_always_true_branch(checker, stmt_if, branch),
+        };
+        if let Some(fix) = fix {
+            diagnostic.set_fix(fix);
+        }
+        return;
+    }
+
+    // Otherwise the branch (if any) survives, so only the individual outdated links are at fault.
+    for link in &links {
+        let Some(reason) = link.reason else {
+            continue;
+        };
+        checker.report_diagnostic(
+            OutdatedVersionBlock {
+                reason,
+                is_block: !is_chained && branch.is_some(),
+            },
+            link.range,
+        );
+    }
+}
+
+/// Determine whether every link of a comparison gating a branch resolves the same way.
+///
+/// Returns `None` unless *all* links are decidable version checks. A branch guarded by anything
+/// else may still be reachable, and removing it would drop a condition that matters at runtime.
+fn branch_verdict(links: &[Link]) -> Option<BranchVerdict> {
+    if links.is_empty() {
+        return None;
+    }
+    // The links of a chain are joined by `and`, so one always-false link is enough to make the
+    // whole test always false, while an always-true test needs every link to be always true.
+    let mut verdict = BranchVerdict::AlwaysTrue;
+    for link in links {
+        match link.reason? {
+            Reason::Invalid => return None,
+            Reason::AlwaysFalse => verdict = BranchVerdict::AlwaysFalse,
+            Reason::AlwaysTrue => {}
+        }
+    }
+    Some(verdict)
 }
 
 /// If `expr` is the entire test of an `if` or `elif` branch, return that branch along with the

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_6.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_6.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_6.py__preview.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_6.py__preview.snap
@@ -160,170 +160,197 @@ UP036 Version check is outdated for minimum Python version
 51 |     print(2)
    |
 
-UP036 Version check is outdated for minimum Python version
-  --> UP036_6.py:55:4
+UP036 [*] Version block is outdated for minimum Python version
+  --> UP036_6.py:54:4
    |
-53 | # Each link of a chained comparison is evaluated separately, and no link on its own
-54 | # makes the branch removable.
-55 | if (3, 8) <= sys.version_info < (3, 10):
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-56 |     print("3.8 or 3.9")
+53 | # Every link of the chain is a version check, so the whole branch can go.
+54 | if (3, 8) <= sys.version_info < (3, 10):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+55 |     print("3.8 or 3.9")
    |
-
-UP036 Version check is outdated for minimum Python version
-  --> UP036_6.py:55:14
+help: Remove outdated version block
    |
-53 | # Each link of a chained comparison is evaluated separately, and no link on its own
-54 | # makes the branch removable.
-55 | if (3, 8) <= sys.version_info < (3, 10):
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
-56 |     print("3.8 or 3.9")
+53 | # Every link of the chain is a version check, so the whole branch can go.
+   - if (3, 8) <= sys.version_info < (3, 10):
+   -     print("3.8 or 3.9")
+54 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP036 Version check is outdated for minimum Python version
   --> UP036_6.py:58:15
    |
-56 |     print("3.8 or 3.9")
-57 |
+57 | # Outside of a branch test there is nothing to remove, so each link is reported on its own.
 58 | is_38_or_39 = (3, 8) <= sys.version_info < (3, 10)
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+59 |
+60 | # Only the first link is outdated; the branch is still reachable, so it stays.
    |
 
 UP036 Version check is outdated for minimum Python version
   --> UP036_6.py:58:25
    |
-56 |     print("3.8 or 3.9")
-57 |
+57 | # Outside of a branch test there is nothing to remove, so each link is reported on its own.
 58 | is_38_or_39 = (3, 8) <= sys.version_info < (3, 10)
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+59 |
+60 | # Only the first link is outdated; the branch is still reachable, so it stays.
    |
-
-UP036 [*] Version block is outdated for minimum Python version
-  --> UP036_6.py:65:4
-   |
-63 | ###
-64 |
-65 | if (3, 0) > sys.version_info:
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
-66 |     print("py2")
-   |
-help: Remove outdated version block
-   |
-64 |
-   - if (3, 0) > sys.version_info:
-   -     print("py2")
-65 |
-   |
-note: This is an unsafe fix and may change runtime behavior
 
 UP036 Version check is outdated for minimum Python version
-  --> UP036_6.py:68:10
+  --> UP036_6.py:61:4
    |
-66 |     print("py2")
-67 |
-68 | is_py3 = (3, 0) < sys.version_info
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^
-69 |
-70 | if 3 == sys.version_info[0]:
+60 | # Only the first link is outdated; the branch is still reachable, so it stays.
+61 | if (3, 8) <= sys.version_info < (3, 15):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+62 |     print("at most 3.14")
    |
 
-UP036 [*] Version block is outdated for minimum Python version
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:66:10
+   |
+64 | # `foo` is not a version check, so the branch is left alone even though the second link
+65 | # is always false.
+66 | if foo < sys.version_info < (3, 10):
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+67 |     print("unreachable")
+   |
+
+UP036 Version check is outdated for minimum Python version
   --> UP036_6.py:70:4
    |
-68 | is_py3 = (3, 0) < sys.version_info
-69 |
-70 | if 3 == sys.version_info[0]:
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^
-71 |     print("py3")
+69 | # The second link cannot be resolved, so the branch is left alone.
+70 | if (3, 8) <= sys.version_info <= (3, 13, foo):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+71 |     print("maybe")
+   |
+
+UP036 [*] Version block is outdated for minimum Python version
+  --> UP036_6.py:78:4
+   |
+76 | ###
+77 |
+78 | if (3, 0) > sys.version_info:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+79 |     print("py2")
    |
 help: Remove outdated version block
    |
-69 |
-   - if 3 == sys.version_info[0]:
-   -     print("py3")
-70 + print("py3")
-71 |
+77 |
+   - if (3, 0) > sys.version_info:
+   -     print("py2")
+78 |
    |
 note: This is an unsafe fix and may change runtime behavior
 
 UP036 Version check is outdated for minimum Python version
-  --> UP036_6.py:73:7
+  --> UP036_6.py:81:10
    |
-71 |     print("py3")
-72 |
-73 | while (3, 8) > sys.version_info:
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
-74 |     print("py2")
-   |
-
-UP036 Version specifier is invalid
-  --> UP036_6.py:81:34
-   |
-79 | ###
+79 |     print("py2")
 80 |
-81 | unsupported = sys.version_info < (3, 10000000)
-   |                                  ^^^^^^^^^^^^^
+81 | is_py3 = (3, 0) < sys.version_info
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^
 82 |
-83 | if foo or sys.version_info == 10000000:
+83 | if 3 == sys.version_info[0]:
    |
 
-UP036 Version specifier is invalid
-  --> UP036_6.py:83:31
+UP036 [*] Version block is outdated for minimum Python version
+  --> UP036_6.py:83:4
    |
-81 | unsupported = sys.version_info < (3, 10000000)
+81 | is_py3 = (3, 0) < sys.version_info
 82 |
-83 | if foo or sys.version_info == 10000000:
-   |                               ^^^^^^^^
+83 | if 3 == sys.version_info[0]:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^
 84 |     print("py3")
    |
+help: Remove outdated version block
+   |
+82 |
+   - if 3 == sys.version_info[0]:
+   -     print("py3")
+83 + print("py3")
+84 |
+   |
+note: This is an unsafe fix and may change runtime behavior
 
-UP036 Version specifier is invalid
-  --> UP036_6.py:86:12
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:86:7
    |
 84 |     print("py3")
 85 |
-86 | nonsense = 10000000 == sys.version_info[0]
-   |            ^^^^^^^^
-87 |
-88 | # Identity is symmetric, so both operand orders are reported.
+86 | while (3, 8) > sys.version_info:
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+87 |     print("py2")
    |
 
 UP036 Version specifier is invalid
-  --> UP036_6.py:89:34
+  --> UP036_6.py:94:34
    |
-88 | # Identity is symmetric, so both operand orders are reported.
-89 | mistake = sys.version_info[0] is 10000000
-   |                                  ^^^^^^^^
-90 |
-91 | also_mistake = 10000000 is sys.version_info[0]
+92 | ###
+93 |
+94 | unsupported = sys.version_info < (3, 10000000)
+   |                                  ^^^^^^^^^^^^^
+95 |
+96 | if foo or sys.version_info == 10000000:
    |
 
 UP036 Version specifier is invalid
-  --> UP036_6.py:91:16
+  --> UP036_6.py:96:31
    |
-89 | mistake = sys.version_info[0] is 10000000
-90 |
-91 | also_mistake = 10000000 is sys.version_info[0]
-   |                ^^^^^^^^
+94 | unsupported = sys.version_info < (3, 10000000)
+95 |
+96 | if foo or sys.version_info == 10000000:
+   |                               ^^^^^^^^
+97 |     print("py3")
    |
+
+UP036 Version specifier is invalid
+   --> UP036_6.py:99:12
+    |
+ 97 |     print("py3")
+ 98 |
+ 99 | nonsense = 10000000 == sys.version_info[0]
+    |            ^^^^^^^^
+100 |
+101 | # Identity is symmetric, so both operand orders are reported.
+    |
+
+UP036 Version specifier is invalid
+   --> UP036_6.py:102:34
+    |
+101 | # Identity is symmetric, so both operand orders are reported.
+102 | mistake = sys.version_info[0] is 10000000
+    |                                  ^^^^^^^^
+103 |
+104 | also_mistake = 10000000 is sys.version_info[0]
+    |
+
+UP036 Version specifier is invalid
+   --> UP036_6.py:104:16
+    |
+102 | mistake = sys.version_info[0] is 10000000
+103 |
+104 | also_mistake = 10000000 is sys.version_info[0]
+    |                ^^^^^^^^
+    |
 
 UP036 Version check is outdated for minimum Python version
-   --> UP036_6.py:98:16
+   --> UP036_6.py:111:16
     |
- 96 | ###
- 97 |
- 98 | major_is_py3 = sys.version_info.major >= 3
+109 | ###
+110 |
+111 | major_is_py3 = sys.version_info.major >= 3
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 99 |
-100 | if foo and sys.version_info.major < 3:
+112 |
+113 | if foo and sys.version_info.major < 3:
     |
 
 UP036 Version check is outdated for minimum Python version
-   --> UP036_6.py:100:12
+   --> UP036_6.py:113:12
     |
- 98 | major_is_py3 = sys.version_info.major >= 3
- 99 |
-100 | if foo and sys.version_info.major < 3:
+111 | major_is_py3 = sys.version_info.major >= 3
+112 |
+113 | if foo and sys.version_info.major < 3:
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
-101 |     print("py2")
+114 |     print("py2")
     |

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_6.py__preview.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP036_6.py__preview.snap
@@ -1,0 +1,329 @@
+---
+source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
+---
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:8:8
+   |
+ 6 | ###
+ 7 |
+ 8 | PY37 = sys.version_info < (3, 8)
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+ 9 |
+10 | old_pypy = hasattr(sys, "pypy_version_info") and sys.version_info < (3, 8)
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:10:50
+   |
+ 8 | PY37 = sys.version_info < (3, 8)
+ 9 |
+10 | old_pypy = hasattr(sys, "pypy_version_info") and sys.version_info < (3, 8)
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
+11 |
+12 | print("py3" if sys.version_info >= (3, 8) else "py2")
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:12:16
+   |
+10 | old_pypy = hasattr(sys, "pypy_version_info") and sys.version_info < (3, 8)
+11 |
+12 | print("py3" if sys.version_info >= (3, 8) else "py2")
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+13 |
+14 | print(sys.version_info >= (3, 8))
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:14:7
+   |
+12 | print("py3" if sys.version_info >= (3, 8) else "py2")
+13 |
+14 | print(sys.version_info >= (3, 8))
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+15 |
+16 | assert sys.version_info >= (3, 8)
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:16:8
+   |
+14 | print(sys.version_info >= (3, 8))
+15 |
+16 | assert sys.version_info >= (3, 8)
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+17 |
+18 | while sys.version_info < (3, 8):
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:18:7
+   |
+16 | assert sys.version_info >= (3, 8)
+17 |
+18 | while sys.version_info < (3, 8):
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+19 |     print("py2")
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:21:14
+   |
+19 |     print("py2")
+20 |
+21 | legacy = not sys.version_info >= (3, 8)
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+22 |
+23 | supported = [feature for feature in features if sys.version_info >= (3, 8)]
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:23:49
+   |
+21 | legacy = not sys.version_info >= (3, 8)
+22 |
+23 | supported = [feature for feature in features if sys.version_info >= (3, 8)]
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:26:14
+   |
+26 | def f(legacy=sys.version_info < (3, 8)):
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+27 |     return sys.version_info < (3, 8)
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:27:12
+   |
+26 | def f(legacy=sys.version_info < (3, 8)):
+27 |     return sys.version_info < (3, 8)
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:31:14
+   |
+30 | class C:
+31 |     LEGACY = sys.version_info < (3, 8)
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:39:13
+   |
+37 | ###
+38 |
+39 | if True and sys.version_info < (3, 5):
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+40 |     print("35")
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:42:4
+   |
+40 |     print("35")
+41 |
+42 | if sys.version_info < (3, 5) or sys.version_info > (3, 10):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+43 |     print("both operands are outdated")
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:42:33
+   |
+40 |     print("35")
+41 |
+42 | if sys.version_info < (3, 5) or sys.version_info > (3, 10):
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+43 |     print("both operands are outdated")
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:45:8
+   |
+43 |     print("both operands are outdated")
+44 |
+45 | if not sys.version_info < (3, 8):
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+46 |     print("py3")
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:50:14
+   |
+48 | if foo:
+49 |     print(1)
+50 | elif bar and sys.version_info < (3, 8):
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+51 |     print(2)
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:55:4
+   |
+53 | # Each link of a chained comparison is evaluated separately, and no link on its own
+54 | # makes the branch removable.
+55 | if (3, 8) <= sys.version_info < (3, 10):
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+56 |     print("3.8 or 3.9")
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:55:14
+   |
+53 | # Each link of a chained comparison is evaluated separately, and no link on its own
+54 | # makes the branch removable.
+55 | if (3, 8) <= sys.version_info < (3, 10):
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+56 |     print("3.8 or 3.9")
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:58:15
+   |
+56 |     print("3.8 or 3.9")
+57 |
+58 | is_38_or_39 = (3, 8) <= sys.version_info < (3, 10)
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:58:25
+   |
+56 |     print("3.8 or 3.9")
+57 |
+58 | is_38_or_39 = (3, 8) <= sys.version_info < (3, 10)
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+UP036 [*] Version block is outdated for minimum Python version
+  --> UP036_6.py:65:4
+   |
+63 | ###
+64 |
+65 | if (3, 0) > sys.version_info:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^
+66 |     print("py2")
+   |
+help: Remove outdated version block
+   |
+64 |
+   - if (3, 0) > sys.version_info:
+   -     print("py2")
+65 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:68:10
+   |
+66 |     print("py2")
+67 |
+68 | is_py3 = (3, 0) < sys.version_info
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^
+69 |
+70 | if 3 == sys.version_info[0]:
+   |
+
+UP036 [*] Version block is outdated for minimum Python version
+  --> UP036_6.py:70:4
+   |
+68 | is_py3 = (3, 0) < sys.version_info
+69 |
+70 | if 3 == sys.version_info[0]:
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^
+71 |     print("py3")
+   |
+help: Remove outdated version block
+   |
+69 |
+   - if 3 == sys.version_info[0]:
+   -     print("py3")
+70 + print("py3")
+71 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+UP036 Version check is outdated for minimum Python version
+  --> UP036_6.py:73:7
+   |
+71 |     print("py3")
+72 |
+73 | while (3, 8) > sys.version_info:
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+74 |     print("py2")
+   |
+
+UP036 Version specifier is invalid
+  --> UP036_6.py:81:34
+   |
+79 | ###
+80 |
+81 | unsupported = sys.version_info < (3, 10000000)
+   |                                  ^^^^^^^^^^^^^
+82 |
+83 | if foo or sys.version_info == 10000000:
+   |
+
+UP036 Version specifier is invalid
+  --> UP036_6.py:83:31
+   |
+81 | unsupported = sys.version_info < (3, 10000000)
+82 |
+83 | if foo or sys.version_info == 10000000:
+   |                               ^^^^^^^^
+84 |     print("py3")
+   |
+
+UP036 Version specifier is invalid
+  --> UP036_6.py:86:12
+   |
+84 |     print("py3")
+85 |
+86 | nonsense = 10000000 == sys.version_info[0]
+   |            ^^^^^^^^
+87 |
+88 | # Identity is symmetric, so both operand orders are reported.
+   |
+
+UP036 Version specifier is invalid
+  --> UP036_6.py:89:34
+   |
+88 | # Identity is symmetric, so both operand orders are reported.
+89 | mistake = sys.version_info[0] is 10000000
+   |                                  ^^^^^^^^
+90 |
+91 | also_mistake = 10000000 is sys.version_info[0]
+   |
+
+UP036 Version specifier is invalid
+  --> UP036_6.py:91:16
+   |
+89 | mistake = sys.version_info[0] is 10000000
+90 |
+91 | also_mistake = 10000000 is sys.version_info[0]
+   |                ^^^^^^^^
+   |
+
+UP036 Version check is outdated for minimum Python version
+   --> UP036_6.py:98:16
+    |
+ 96 | ###
+ 97 |
+ 98 | major_is_py3 = sys.version_info.major >= 3
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 99 |
+100 | if foo and sys.version_info.major < 3:
+    |
+
+UP036 Version check is outdated for minimum Python version
+   --> UP036_6.py:100:12
+    |
+ 98 | major_is_py3 = sys.version_info.major >= 3
+ 99 |
+100 | if foo and sys.version_info.major < 3:
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+101 |     print("py2")
+    |


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Flag *all* outdated `sys.version_info` with `UP036`. Also fixes for inverted and chained comparisons (such as `(3, 8) <= sys.version_info` and `(3, 8) <= sys.version_info < (3, 10)`.

I did not add an autofix for non-`sys.version` only or non-conditionals. In other words, only `if` blocks that only contain `sys.version_info` check gets autofixed. This is not a matter of correctness or code soundness, but rather that we want to force developers to look at the code that may be simplified by removing obsolete assignments and checks.

Closes #16487
Closes #12093

## Open questions
1. @MichaReiser had a good point that this rule may be renamed `unnecessary-version-check`. I'm leaving this as an open question as I'm not sure of the standard process for renaming rules.
    In which case, the message `"Version block is outdated for minimum Python version"` can also be dropped in favor of always showing the "check" variant.
2. Should we add more autofixes where other Ruff rules may correctly simplify. For example `[feature for feature in features if sys.version_info >= (3, 10)]` becomes `[feature for feature in features]` which [unnecessary-comprehension (C416)](https://docs.astral.sh/ruff/rules/unnecessary-comprehension/#unnecessary-comprehension-c416) can turn to `list(features)`
3. Should this new behavior be locked behind preview ?

## Test Plan

1. Look at the added snapshot
2. Look at the ecosystem changes
4. Run `cargo run -p ruff -- check --no-cache --fix --unsafe-fixes --select=UP036 --preview ../distutils` on https://github.com/pypa/distutils/blob/fd45200236b8fa1b2277a797091816787d143a44/distutils/command/install.py

## Coding Agent disclaimer

Code was fully written by Claude Opus 5 with a pass of caveman-review. I did a glancing review of code changes given my limited Rust knowledge. PR description fully handwritten. Docs and tests human reviewed.