### PR TITLE
[`flake8-import-conventions`] Document that `extend-aliases` can override default aliases

### DIFF
--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1623,12 +1623,8 @@ pub struct Flake8ImportConventionsOptions {
     pub aliases: Option<FxHashMap<ModuleName, Alias>>,
 
     /// A mapping from module to conventional import alias. These aliases will
-    /// be added to the [`aliases`](#lint_flake8-import-conventions_aliases) mapping.
-    ///
-    /// Entries here take precedence over [`aliases`](#lint_flake8-import-conventions_aliases),
-    /// so this option can also be used to change or opt out of a default alias without
-    /// restating the entire mapping. Mapping a module to its own name requires it to be
-    /// imported unaliased.
+    /// be added to the [`aliases`](#lint_flake8-import-conventions_aliases) mapping
+    /// and will override any existing `aliases` if the two settings overlap.
     #[option(
         default = r#"{}"#,
         value_type = "dict[str, str]",
@@ -1636,8 +1632,6 @@ pub struct Flake8ImportConventionsOptions {
         example = r#"
             # Declare a custom alias for the `dask` module.
             "dask.dataframe" = "dd"
-            # Require `numpy` to be imported unaliased, overriding the default `np` alias.
-            numpy = "numpy"
         "#
     )]
     pub extend_aliases: Option<FxHashMap<ModuleName, Alias>>,

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1624,6 +1624,11 @@ pub struct Flake8ImportConventionsOptions {
 
     /// A mapping from module to conventional import alias. These aliases will
     /// be added to the [`aliases`](#lint_flake8-import-conventions_aliases) mapping.
+    ///
+    /// Entries here take precedence over [`aliases`](#lint_flake8-import-conventions_aliases),
+    /// so this option can also be used to change or opt out of a default alias without
+    /// restating the entire mapping. Mapping a module to its own name requires it to be
+    /// imported unaliased.
     #[option(
         default = r#"{}"#,
         value_type = "dict[str, str]",
@@ -1631,6 +1636,8 @@ pub struct Flake8ImportConventionsOptions {
         example = r#"
             # Declare a custom alias for the `dask` module.
             "dask.dataframe" = "dd"
+            # Require `numpy` to be imported unaliased, overriding the default `np` alias.
+            numpy = "numpy"
         "#
     )]
     pub extend_aliases: Option<FxHashMap<ModuleName, Alias>>,

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1254,7 +1254,7 @@
           "uniqueItems": true
         },
         "extend-aliases": {
-          "description": "A mapping from module to conventional import alias. These aliases will\nbe added to the [`aliases`](#lint_flake8-import-conventions_aliases) mapping.\n\nEntries here take precedence over [`aliases`](#lint_flake8-import-conventions_aliases),\nso this option can also be used to change or opt out of a default alias without\nrestating the entire mapping. Mapping a module to its own name requires it to be\nimported unaliased.",
+          "description": "A mapping from module to conventional import alias. These aliases will\nbe added to the [`aliases`](#lint_flake8-import-conventions_aliases) mapping\nand will override any existing `aliases` if the two settings overlap.",
           "type": [
             "object",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1254,7 +1254,7 @@
           "uniqueItems": true
         },
         "extend-aliases": {
-          "description": "A mapping from module to conventional import alias. These aliases will\nbe added to the [`aliases`](#lint_flake8-import-conventions_aliases) mapping.",
+          "description": "A mapping from module to conventional import alias. These aliases will\nbe added to the [`aliases`](#lint_flake8-import-conventions_aliases) mapping.\n\nEntries here take precedence over [`aliases`](#lint_flake8-import-conventions_aliases),\nso this option can also be used to change or opt out of a default alias without\nrestating the entire mapping. Mapping a module to its own name requires it to be\nimported unaliased.",
           "type": [
             "object",
             "null"


### PR DESCRIPTION
Closes #17097

## Summary

The `extend-aliases` documentation only stated that entries "will be added to the `aliases`
mapping", which does not convey that an entry for a module that already has a default alias
*replaces* that default. As noted in the issue, this makes it possible to change or opt out
of a default alias without restating the whole `aliases` mapping.

This is a documentation-only change; the behaviour already works this way because the
settings resolver applies `extend-aliases` on top of `aliases` via `HashMap::extend`, so
matching keys are overwritten.

## Test Plan

Verified the documented behaviour against `ruff 0.12.4` using this sample file:

```python
import numpy
import numpy as np
```

| Config | Result |
| --- | --- |
| default | `ICN001 `numpy` should be imported as `np`` on line 1 |
| `numpy = "numpy"` under `extend-aliases` | `ICN001 `numpy` should be imported as `numpy`` on line 2, i.e. the aliased import is now the violation |
| `numpy = "nmp"` under `extend-aliases` | both lines flagged, requiring `nmp`, so the default `np` is fully replaced |

Also ran:

- `cargo fmt --check` - passes.
- `cargo dev generate-all` - regenerated `ruff.schema.json` so the new description is
  reflected there; confirmed the file is still valid JSON and contains the updated text.