### PR TITLE
[`refurb`] Parenthesize `yield` arguments in the `FURB192` fixer

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB192_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB192_1.py
@@ -1,0 +1,17 @@
+# A `yield` expression is only valid as a call argument when it is
+# parenthesized, so the parentheses have to be preserved by the fix.
+#
+# These live in their own fixture because `FURB192.py` shadows `sorted` with a
+# module-level function, which suppresses the rule inside function bodies.
+
+
+def f(l, key_fn):
+    sorted((yield))[0]
+
+    sorted((yield l))[-1]
+
+    sorted((yield), key=key_fn)[0]
+
+    sorted((yield from l))[0]
+
+    sorted((yield), reverse=True)[-1]

--- a/crates/ruff_linter/src/rules/refurb/mod.rs
+++ b/crates/ruff_linter/src/rules/refurb/mod.rs
@@ -53,6 +53,7 @@ mod tests {
     #[test_case(Rule::WriteWholeFile, Path::new("FURB103_2.py"))]
     #[test_case(Rule::FStringNumberFormat, Path::new("FURB116.py"))]
     #[test_case(Rule::SortedMinMax, Path::new("FURB192.py"))]
+    #[test_case(Rule::SortedMinMax, Path::new("FURB192_1.py"))]
     #[test_case(Rule::SliceToRemovePrefixOrSuffix, Path::new("FURB188.py"))]
     #[test_case(Rule::SubclassBuiltin, Path::new("FURB189.py"))]
     #[test_case(Rule::FromisoformatReplaceZ, Path::new("FURB162.py"))]

--- a/crates/ruff_linter/src/rules/refurb/rules/sorted_min_max.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/sorted_min_max.rs
@@ -1,5 +1,6 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::Number;
+use ruff_python_ast::token::parenthesized_range;
 use ruff_python_ast::{self as ast, Expr};
 use ruff_text_size::Ranged;
 
@@ -187,14 +188,17 @@ pub(crate) fn sorted_min_max(checker: &Checker, subscript: &ast::ExprSubscript) 
 
     if checker.semantic().has_builtin_binding(min_max.as_str()) {
         diagnostic.set_fix({
+            // Preserve any parentheses around the argument. Some expressions are
+            // only valid as a call argument when parenthesized (e.g., `yield`),
+            // so slicing the bare node would produce invalid syntax.
+            let list_expr = checker.locator().slice(
+                parenthesized_range(list_expr.into(), arguments.into(), checker.tokens())
+                    .unwrap_or(list_expr.range()),
+            );
             let replacement = if let Some(key) = key_keyword_expr {
-                format!(
-                    "{min_max}({}, {})",
-                    checker.locator().slice(list_expr),
-                    checker.locator().slice(key),
-                )
+                format!("{min_max}({list_expr}, {})", checker.locator().slice(key))
             } else {
-                format!("{min_max}({})", checker.locator().slice(list_expr))
+                format!("{min_max}({list_expr})")
             };
 
             let replacement = Edit::range_replacement(replacement, subscript.range());

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB192_FURB192_1.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB192_FURB192_1.py.snap
@@ -1,0 +1,93 @@
+---
+source: crates/ruff_linter/src/rules/refurb/mod.rs
+---
+FURB192 [*] Prefer `min` over `sorted()` to compute the minimum value in a sequence
+  --> FURB192_1.py:9:5
+   |
+ 8 | def f(l, key_fn):
+ 9 |     sorted((yield))[0]
+   |     ^^^^^^^^^^^^^^^^^^
+10 |
+11 |     sorted((yield l))[-1]
+   |
+help: Replace with `min`
+   |
+8  | def f(l, key_fn):
+   -     sorted((yield))[0]
+9  +     min((yield))
+10 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB192 [*] Prefer `max` over `sorted()` to compute the maximum value in a sequence
+  --> FURB192_1.py:11:5
+   |
+ 9 |     sorted((yield))[0]
+10 |
+11 |     sorted((yield l))[-1]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+12 |
+13 |     sorted((yield), key=key_fn)[0]
+   |
+help: Replace with `max`
+   |
+10 |
+   -     sorted((yield l))[-1]
+11 +     max((yield l))
+12 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB192 [*] Prefer `min` over `sorted()` to compute the minimum value in a sequence
+  --> FURB192_1.py:13:5
+   |
+11 |     sorted((yield l))[-1]
+12 |
+13 |     sorted((yield), key=key_fn)[0]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+14 |
+15 |     sorted((yield from l))[0]
+   |
+help: Replace with `min`
+   |
+12 |
+   -     sorted((yield), key=key_fn)[0]
+13 +     min((yield), key=key_fn)
+14 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB192 [*] Prefer `min` over `sorted()` to compute the minimum value in a sequence
+  --> FURB192_1.py:15:5
+   |
+13 |     sorted((yield), key=key_fn)[0]
+14 |
+15 |     sorted((yield from l))[0]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+16 |
+17 |     sorted((yield), reverse=True)[-1]
+   |
+help: Replace with `min`
+   |
+14 |
+   -     sorted((yield from l))[0]
+15 +     min((yield from l))
+16 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB192 [*] Prefer `min` over `sorted()` to compute the minimum value in a sequence
+  --> FURB192_1.py:17:5
+   |
+15 |     sorted((yield from l))[0]
+16 |
+17 |     sorted((yield), reverse=True)[-1]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: Replace with `min`
+   |
+16 |
+   -     sorted((yield), reverse=True)[-1]
+17 +     min((yield))
+   |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

The `FURB192` fix rebuilds the call by slicing the source text of the `sorted()` argument node. That range doesn't include surrounding parentheses, so a parenthesized `yield` loses them and the result is invalid syntax:

```python
def f():
    x = sorted((yield))[0]
```

```
$ ruff check --isolated --select FURB192 --fix --unsafe-fixes t.py
error: Fix introduced a syntax error. Reverting all changes.
This indicates a bug in Ruff.
```

The replacement it tries to write is `x = min(yield)`. A `yield` expression is only valid as a call argument when it's parenthesized, so the fix gets discarded and the diagnostic is left unfixable.

All four forms are affected on `main` (a5cdc6d):

| source | fix produced today |
| --- | --- |
| `sorted((yield))[0]` | `min(yield)` |
| `sorted((yield x))[-1]` | `max(yield x)` |
| `sorted((yield), key=k)[0]` | `min(yield, key=k)` |
| `sorted((yield from g()))[0]` | `min(yield from g())` |

This slices `parenthesized_range()` for the argument and falls back to the node range, which is what `quadratic-list-summation` and a few other rules already do. #24200 fixed the same kind of thing in the `FURB142` fixer.

One deliberate side effect worth flagging: parentheses are now kept for *any* parenthesized argument, so `sorted((a := b))[0]` becomes `min((a := b))` rather than `min(a := b)`. Both are valid; keeping them seemed more consistent than special-casing `yield`. Happy to narrow it to just `Expr::Yield`/`Expr::YieldFrom` if you'd rather not change the other cases.

## Test Plan

Added `FURB192_1.py`. It has to be a separate fixture: `FURB192.py` shadows `sorted` with a module-level `def sorted()` at the bottom, and because function bodies are resolved against the final module scope, the rule doesn't fire inside *any* function in that file — so `yield` cases can't go there.

- `cargo test -p ruff_linter` — 2807 passed, 0 failed
- `cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings` — clean
- `prek run --files <changed files>` — clean

I also ran `--select FURB192 --fix --unsafe-fixes` over all 1599 files under `crates/ruff_linter/resources/test/fixtures`, once with 0.16.0 and once with this branch, and diffed the output. The only file whose result changes is the new fixture, and neither build produces unparseable output anywhere else.
