### PR TITLE
[`pylint`] Ignore stub files in `import-private-name` (`PLC2701`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/import_private_name/submodule/stub.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/import_private_name/submodule/stub.pyi
@@ -1,0 +1,12 @@
+# Stub files are exempt from this rule, so none of these are errors.
+from _a import b
+from c._d import e
+from _f.g import h
+from i import _j
+from k import _l as m
+import _aaa
+import bbb.ccc._ddd as eee
+from _typeshed import Incomplete
+
+value: b
+other: Incomplete

--- a/crates/ruff_linter/src/rules/pylint/mod.rs
+++ b/crates/ruff_linter/src/rules/pylint/mod.rs
@@ -85,6 +85,10 @@ mod tests {
         Rule::ImportPrivateName,
         Path::new("import_private_name/submodule/__main__.py")
     )]
+    #[test_case(
+        Rule::ImportPrivateName,
+        Path::new("import_private_name/submodule/stub.pyi")
+    )]
     #[test_case(Rule::ImportSelf, Path::new("import_self/module.py"))]
     #[test_case(Rule::InvalidAllFormat, Path::new("invalid_all_format.py"))]
     #[test_case(Rule::InvalidAllObject, Path::new("invalid_all_object.py"))]

--- a/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/import_private_name.rs
@@ -30,6 +30,10 @@ use crate::package::PackageRoot;
 /// annotations. Ideally, types would be public; however, this is not always
 /// possible when using third-party libraries.
 ///
+/// This rule is not enforced in stub files (`.pyi`), which routinely import
+/// private names in order to describe the runtime accurately, or to reuse
+/// private helper types from typeshed (such as those in `_typeshed`).
+///
 /// ## Known problems
 /// Does not ignore private name imports from within the module that defines
 /// the private name if the module is defined with [PEP 420] namespace packages
@@ -72,6 +76,13 @@ impl Violation for ImportPrivateName {
 
 /// PLC2701
 pub(crate) fn import_private_name(checker: &Checker, scope: &Scope) {
+    // Stub files describe the runtime rather than being part of it, so importing a private name
+    // is often the only way to be accurate (e.g., re-exporting a private base class, or using the
+    // private helper types from `_typeshed`).
+    if checker.source_type.is_stub() {
+        return;
+    }
+
     for binding_id in scope.binding_ids() {
         let binding = checker.semantic().binding(binding_id);
         let Some(import) = binding.as_any_import() else {

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2701_import_private_name__submodule__stub.pyi.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2701_import_private_name__submodule__stub.pyi.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/pylint/mod.rs
+---
+


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

- Closes #15294
  - Allows stubs to more accurately reflect runtime or typeshed tricks.
- Closes #15295
  - Usage of `_typeshed` import in `.py` file should already be ignored by this rule if only used for annotations.
  - Issue was open before fixes from https://github.com/astral-sh/ruff/pull/24576)
- Helps towards https://github.com/astral-sh/ruff/issues/27051

## Test Plan

1. Look at new test fixtures and snapshots
2. Ecosystem results unfortunately don't say much ...

## Coding Agent disclaimer

Used Claude Opus 5 to help me generate complete test and reword in-code comments. PR description fully handwritten.