### PR TITLE
[`flake8-pytest-style`] Make fixes safe by default and unsafe only when comments are present (`PT018`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT018.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pytest_style/PT018.py
@@ -70,3 +70,10 @@ def test_parenthesized_not():
 
     assert (not self.find_graph_output(node.output[0]) or
             self.find_graph_input(node.input[0]))
+
+
+def test_comments():
+    assert (
+        # comment
+        something and something_else
+    )

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -56,6 +56,11 @@ pub(crate) const fn is_fix_f_string_logging_enabled(settings: &LinterSettings) -
     settings.preview.is_enabled()
 }
 
+// https://github.com/astral-sh/ruff/pull/27201
+pub(crate) const fn is_fix_pytest_composite_assertion_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}
+
 // https://github.com/astral-sh/ruff/pull/16719
 pub(crate) const fn is_fix_manual_dict_comprehension_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
@@ -379,6 +379,7 @@ mod tests {
     }
 
     #[test_case(Rule::PytestExtraneousScopeFunction, Path::new("PT003.py"))]
+    #[test_case(Rule::PytestCompositeAssertion, Path::new("PT018.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -28,7 +28,7 @@ use crate::cst::matchers::match_indented_block;
 use crate::cst::matchers::match_module;
 use crate::fix::codemods::CodegenStylist;
 use crate::importer::ImportRequest;
-use crate::{Edit, Fix, FixAvailability, Violation};
+use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 
 use super::unittest_assert::UnittestAssert;
 
@@ -831,14 +831,19 @@ pub(crate) fn composite_condition(checker: &Checker, stmt: &Stmt, test: &Expr, m
         let mut diagnostic = checker.report_diagnostic(PytestCompositeAssertion, stmt.range());
         if matches!(composite, CompositionKind::Simple)
             && msg.is_none()
-            && !checker.comment_ranges().intersects(stmt.range())
             && !checker
                 .indexer()
                 .in_multi_statement_line(stmt, checker.source())
         {
             diagnostic.try_set_fix(|| {
-                fix_composite_condition(stmt, checker.locator(), checker.stylist())
-                    .map(Fix::unsafe_edit)
+                fix_composite_condition(stmt, checker.locator(), checker.stylist()).map(|edit| {
+                    let applicability = if checker.comment_ranges().intersects(edit.range()) {
+                        Applicability::Unsafe
+                    } else {
+                        Applicability::Safe
+                    };
+                    Fix::applicable_edit(edit, applicability)
+                })
             });
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -61,6 +61,14 @@ use super::unittest_assert::UnittestAssert;
 ///     assert not something
 ///     assert not something_else
 /// ```
+///
+/// ## Fix safety
+///
+/// On stable, the rule's fix is always unsafe and not offered when it would remove comments in the
+/// compound assertion. In [preview], the fix is only unsafe when it would delete such comments and
+/// safe otherwise.
+///
+/// [preview]: https://docs.astral.sh/ruff/preview/
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.208")]
 pub(crate) struct PytestCompositeAssertion;

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -28,6 +28,7 @@ use crate::cst::matchers::match_indented_block;
 use crate::cst::matchers::match_module;
 use crate::fix::codemods::CodegenStylist;
 use crate::importer::ImportRequest;
+use crate::preview::is_fix_pytest_composite_assertion_enabled;
 use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 
 use super::unittest_assert::UnittestAssert;
@@ -829,19 +830,22 @@ pub(crate) fn composite_condition(checker: &Checker, stmt: &Stmt, test: &Expr, m
     let composite = is_composite_condition(test);
     if matches!(composite, CompositionKind::Simple | CompositionKind::Mixed) {
         let mut diagnostic = checker.report_diagnostic(PytestCompositeAssertion, stmt.range());
+        let preview_fix = is_fix_pytest_composite_assertion_enabled(checker.settings());
         if matches!(composite, CompositionKind::Simple)
             && msg.is_none()
+            && (preview_fix || !checker.comment_ranges().intersects(stmt.range()))
             && !checker
                 .indexer()
                 .in_multi_statement_line(stmt, checker.source())
         {
             diagnostic.try_set_fix(|| {
                 fix_composite_condition(stmt, checker.locator(), checker.stylist()).map(|edit| {
-                    let applicability = if checker.comment_ranges().intersects(edit.range()) {
-                        Applicability::Unsafe
-                    } else {
-                        Applicability::Safe
-                    };
+                    let applicability =
+                        if preview_fix && !checker.comment_ranges().intersects(edit.range()) {
+                            Applicability::Safe
+                        } else {
+                            Applicability::Unsafe
+                        };
                     Fix::applicable_edit(edit, applicability)
                 })
             });

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT018.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT018.snap
@@ -18,7 +18,6 @@ help: Break down assertion into multiple parts
 15 +     assert something_else
 16 |     assert something and something_else and something_third
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:15:5
@@ -38,7 +37,6 @@ help: Break down assertion into multiple parts
 16 +     assert something_third
 17 |     assert something and not something_else
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:16:5
@@ -58,7 +56,6 @@ help: Break down assertion into multiple parts
 17 +     assert not something_else
 18 |     assert something and (something_else or something_third)
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:17:5
@@ -78,7 +75,6 @@ help: Break down assertion into multiple parts
 18 +     assert (something_else or something_third)
 19 |     assert not something and something_else
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:18:5
@@ -98,7 +94,6 @@ help: Break down assertion into multiple parts
 19 +     assert something_else
 20 |     assert not (something or something_else)
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:19:5
@@ -118,7 +113,6 @@ help: Break down assertion into multiple parts
 20 +     assert not something_else
 21 |     assert not (something or something_else or something_third)
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:20:5
@@ -138,7 +132,6 @@ help: Break down assertion into multiple parts
 21 +     assert not something_third
 22 |     assert something and something_else == """error
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:21:5
@@ -160,7 +153,6 @@ help: Break down assertion into multiple parts
 22 +     assert something_else == """error
 23 |     message
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:24:5
@@ -188,7 +180,6 @@ help: Break down assertion into multiple parts
 26 +         something_else
 27 |         == """error
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:33:5
@@ -206,7 +197,6 @@ help: Break down assertion into multiple parts
 34 +     assert (b or c)
 35 |     assert not (a or not (b and c))
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:34:5
@@ -226,7 +216,6 @@ help: Break down assertion into multiple parts
 35 +     assert (b and c)
 36 |
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 Assertion should be broken down into multiple parts
   --> PT018.py:37:5
@@ -353,7 +342,6 @@ help: Break down assertion into multiple parts
 65 +     )
 66 |
    |
-note: This is an unsafe fix and may change runtime behavior
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:65:5
@@ -383,5 +371,26 @@ help: Break down assertion into multiple parts
 70 +         self.find_graph_output(node.input[0])
 71 +     )
 72 |
+   |
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:76:5
+   |
+75 |   def test_comments():
+76 | /     assert (
+77 | |         # comment
+78 | |         something and something_else
+79 | |     )
+   | |_____^
+   |
+help: Break down assertion into multiple parts
+   |
+75 | def test_comments():
+   -     assert (
+   -         # comment
+   -         something and something_else
+   -     )
+76 +     assert something
+77 +     assert something_else
    |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__preview__PT018_PT018.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__preview__PT018_PT018.py.snap
@@ -1,7 +1,16 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
-assertion_line: 358
+assertion_line: 389
 ---
+--- Linter settings ---
+-linter.preview = disabled
++linter.preview = enabled
+
+--- Summary ---
+Removed: 14
+Added: 14
+
+--- Removed ---
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:14:5
    |
@@ -20,6 +29,7 @@ help: Break down assertion into multiple parts
 16 |     assert something and something_else and something_third
    |
 note: This is an unsafe fix and may change runtime behavior
+
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:15:5
@@ -41,6 +51,7 @@ help: Break down assertion into multiple parts
    |
 note: This is an unsafe fix and may change runtime behavior
 
+
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:16:5
    |
@@ -60,6 +71,7 @@ help: Break down assertion into multiple parts
 18 |     assert something and (something_else or something_third)
    |
 note: This is an unsafe fix and may change runtime behavior
+
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:17:5
@@ -81,6 +93,7 @@ help: Break down assertion into multiple parts
    |
 note: This is an unsafe fix and may change runtime behavior
 
+
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:18:5
    |
@@ -100,6 +113,7 @@ help: Break down assertion into multiple parts
 20 |     assert not (something or something_else)
    |
 note: This is an unsafe fix and may change runtime behavior
+
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:19:5
@@ -121,6 +135,7 @@ help: Break down assertion into multiple parts
    |
 note: This is an unsafe fix and may change runtime behavior
 
+
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:20:5
    |
@@ -140,6 +155,7 @@ help: Break down assertion into multiple parts
 22 |     assert something and something_else == """error
    |
 note: This is an unsafe fix and may change runtime behavior
+
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:21:5
@@ -162,6 +178,7 @@ help: Break down assertion into multiple parts
 23 |     message
    |
 note: This is an unsafe fix and may change runtime behavior
+
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:24:5
@@ -191,6 +208,7 @@ help: Break down assertion into multiple parts
    |
 note: This is an unsafe fix and may change runtime behavior
 
+
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:33:5
    |
@@ -208,6 +226,7 @@ help: Break down assertion into multiple parts
 35 |     assert not (a or not (b and c))
    |
 note: This is an unsafe fix and may change runtime behavior
+
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:34:5
@@ -229,106 +248,6 @@ help: Break down assertion into multiple parts
    |
 note: This is an unsafe fix and may change runtime behavior
 
-PT018 Assertion should be broken down into multiple parts
-  --> PT018.py:37:5
-   |
-36 |     # detected, but no fix for messages
-37 |     assert something and something_else, "error message"
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-38 |     assert not (something or something_else and something_third), "with message"
-39 |     # detected, but no fix for mixed conditions (e.g. `a or b and c`)
-   |
-help: Break down assertion into multiple parts
-
-PT018 Assertion should be broken down into multiple parts
-  --> PT018.py:38:5
-   |
-36 |     # detected, but no fix for messages
-37 |     assert something and something_else, "error message"
-38 |     assert not (something or something_else and something_third), "with message"
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-39 |     # detected, but no fix for mixed conditions (e.g. `a or b and c`)
-40 |     assert not (something or something_else and something_third)
-   |
-help: Break down assertion into multiple parts
-
-PT018 Assertion should be broken down into multiple parts
-  --> PT018.py:40:5
-   |
-38 |     assert not (something or something_else and something_third), "with message"
-39 |     # detected, but no fix for mixed conditions (e.g. `a or b and c`)
-40 |     assert not (something or something_else and something_third)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: Break down assertion into multiple parts
-
-PT018 [*] Assertion should be broken down into multiple parts
-  --> PT018.py:44:1
-   |
-43 | assert something  # OK
-44 | assert something and something_else  # Error
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-45 | assert something and something_else and something_third  # Error
-   |
-help: Break down assertion into multiple parts
-   |
-43 | assert something  # OK
-   - assert something and something_else  # Error
-44 + assert something
-45 + assert something_else
-46 | assert something and something_else and something_third  # Error
-   |
-note: This is an unsafe fix and may change runtime behavior
-
-PT018 [*] Assertion should be broken down into multiple parts
-  --> PT018.py:45:1
-   |
-43 | assert something  # OK
-44 | assert something and something_else  # Error
-45 | assert something and something_else and something_third  # Error
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: Break down assertion into multiple parts
-   |
-44 | assert something and something_else  # Error
-   - assert something and something_else and something_third  # Error
-45 + assert something and something_else
-46 + assert something_third
-47 |
-   |
-note: This is an unsafe fix and may change runtime behavior
-
-PT018 Assertion should be broken down into multiple parts
-  --> PT018.py:49:5
-   |
-48 | def test_multiline():
-49 |     assert something and something_else; x = 1
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-50 |
-51 |     x = 1; assert something and something_else
-   |
-help: Break down assertion into multiple parts
-
-PT018 Assertion should be broken down into multiple parts
-  --> PT018.py:51:12
-   |
-49 |     assert something and something_else; x = 1
-50 |
-51 |     x = 1; assert something and something_else
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-52 |
-53 |     x = 1; \
-   |
-help: Break down assertion into multiple parts
-
-PT018 Assertion should be broken down into multiple parts
-  --> PT018.py:54:9
-   |
-53 |     x = 1; \
-54 |         assert something and something_else
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: Break down assertion into multiple parts
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:59:5
@@ -355,6 +274,7 @@ help: Break down assertion into multiple parts
 66 |
    |
 note: This is an unsafe fix and may change runtime behavior
+
 
 PT018 [*] Assertion should be broken down into multiple parts
   --> PT018.py:65:5
@@ -387,6 +307,7 @@ help: Break down assertion into multiple parts
    |
 note: This is an unsafe fix and may change runtime behavior
 
+
 PT018 Assertion should be broken down into multiple parts
   --> PT018.py:76:5
    |
@@ -398,3 +319,312 @@ PT018 Assertion should be broken down into multiple parts
    | |_____^
    |
 help: Break down assertion into multiple parts
+
+
+
+--- Added ---
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:14:5
+   |
+13 | def test_error():
+14 |     assert something and something_else
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+15 |     assert something and something_else and something_third
+16 |     assert something and not something_else
+   |
+help: Break down assertion into multiple parts
+   |
+13 | def test_error():
+   -     assert something and something_else
+14 +     assert something
+15 +     assert something_else
+16 |     assert something and something_else and something_third
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:15:5
+   |
+13 | def test_error():
+14 |     assert something and something_else
+15 |     assert something and something_else and something_third
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+16 |     assert something and not something_else
+17 |     assert something and (something_else or something_third)
+   |
+help: Break down assertion into multiple parts
+   |
+14 |     assert something and something_else
+   -     assert something and something_else and something_third
+15 +     assert something and something_else
+16 +     assert something_third
+17 |     assert something and not something_else
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:16:5
+   |
+14 |     assert something and something_else
+15 |     assert something and something_else and something_third
+16 |     assert something and not something_else
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+17 |     assert something and (something_else or something_third)
+18 |     assert not something and something_else
+   |
+help: Break down assertion into multiple parts
+   |
+15 |     assert something and something_else and something_third
+   -     assert something and not something_else
+16 +     assert something
+17 +     assert not something_else
+18 |     assert something and (something_else or something_third)
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:17:5
+   |
+15 |     assert something and something_else and something_third
+16 |     assert something and not something_else
+17 |     assert something and (something_else or something_third)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+18 |     assert not something and something_else
+19 |     assert not (something or something_else)
+   |
+help: Break down assertion into multiple parts
+   |
+16 |     assert something and not something_else
+   -     assert something and (something_else or something_third)
+17 +     assert something
+18 +     assert (something_else or something_third)
+19 |     assert not something and something_else
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:18:5
+   |
+16 |     assert something and not something_else
+17 |     assert something and (something_else or something_third)
+18 |     assert not something and something_else
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+19 |     assert not (something or something_else)
+20 |     assert not (something or something_else or something_third)
+   |
+help: Break down assertion into multiple parts
+   |
+17 |     assert something and (something_else or something_third)
+   -     assert not something and something_else
+18 +     assert not something
+19 +     assert something_else
+20 |     assert not (something or something_else)
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:19:5
+   |
+17 |     assert something and (something_else or something_third)
+18 |     assert not something and something_else
+19 |     assert not (something or something_else)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+20 |     assert not (something or something_else or something_third)
+21 |     assert something and something_else == """error
+   |
+help: Break down assertion into multiple parts
+   |
+18 |     assert not something and something_else
+   -     assert not (something or something_else)
+19 +     assert not something
+20 +     assert not something_else
+21 |     assert not (something or something_else or something_third)
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:20:5
+   |
+18 |     assert not something and something_else
+19 |     assert not (something or something_else)
+20 |     assert not (something or something_else or something_third)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+21 |     assert something and something_else == """error
+22 |     message
+   |
+help: Break down assertion into multiple parts
+   |
+19 |     assert not (something or something_else)
+   -     assert not (something or something_else or something_third)
+20 +     assert not (something or something_else)
+21 +     assert not something_third
+22 |     assert something and something_else == """error
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:21:5
+   |
+19 |       assert not (something or something_else)
+20 |       assert not (something or something_else or something_third)
+21 | /     assert something and something_else == """error
+22 | |     message
+23 | |     """
+   | |_______^
+24 |       assert (
+25 |           something
+   |
+help: Break down assertion into multiple parts
+   |
+20 |     assert not (something or something_else or something_third)
+   -     assert something and something_else == """error
+21 +     assert something
+22 +     assert something_else == """error
+23 |     message
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:24:5
+   |
+22 |       message
+23 |       """
+24 | /     assert (
+25 | |         something
+26 | |         and something_else
+27 | |         == """error
+28 | | message
+29 | | """
+30 | |     )
+   | |_____^
+31 |
+32 |       # recursive case
+   |
+help: Break down assertion into multiple parts
+   |
+23 |     """
+24 +     assert something
+25 |     assert (
+   -         something
+   -         and something_else
+26 +         something_else
+27 |         == """error
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:33:5
+   |
+32 |     # recursive case
+33 |     assert not (a or not (b or c))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+34 |     assert not (a or not (b and c))
+   |
+help: Break down assertion into multiple parts
+   |
+32 |     # recursive case
+   -     assert not (a or not (b or c))
+33 +     assert not a
+34 +     assert (b or c)
+35 |     assert not (a or not (b and c))
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:34:5
+   |
+32 |     # recursive case
+33 |     assert not (a or not (b or c))
+34 |     assert not (a or not (b and c))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+35 |
+36 |     # detected, but no fix for messages
+   |
+help: Break down assertion into multiple parts
+   |
+33 |     assert not (a or not (b or c))
+   -     assert not (a or not (b and c))
+34 +     assert not a
+35 +     assert (b and c)
+36 |
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:59:5
+   |
+57 |   # Regression test for: https://github.com/astral-sh/ruff/issues/7143
+58 |   def test_parenthesized_not():
+59 | /     assert not (
+60 | |         self.find_graph_output(node.output[0])
+61 | |         or self.find_graph_input(node.input[0])
+62 | |         or self.find_graph_output(node.input[0])
+63 | |     )
+   | |_____^
+64 |
+65 |       assert (not (
+   |
+help: Break down assertion into multiple parts
+   |
+61 |         or self.find_graph_input(node.input[0])
+   -         or self.find_graph_output(node.input[0])
+62 |     )
+63 +     assert not (
+64 +         self.find_graph_output(node.input[0])
+65 +     )
+66 |
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:65:5
+   |
+63 |       )
+64 |
+65 | /     assert (not (
+66 | |         self.find_graph_output(node.output[0])
+67 | |         or self.find_graph_input(node.input[0])
+68 | |         or self.find_graph_output(node.input[0])
+69 | |     ))
+   | |______^
+70 |
+71 |       assert (not self.find_graph_output(node.output[0]) or
+   |
+help: Break down assertion into multiple parts
+   |
+64 |
+   -     assert (not (
+65 +     assert not (
+66 |         self.find_graph_output(node.output[0])
+67 |         or self.find_graph_input(node.input[0])
+   -         or self.find_graph_output(node.input[0])
+   -     ))
+68 +     )
+69 +     assert not (
+70 +         self.find_graph_output(node.input[0])
+71 +     )
+72 |
+   |
+
+
+PT018 [*] Assertion should be broken down into multiple parts
+  --> PT018.py:76:5
+   |
+75 |   def test_comments():
+76 | /     assert (
+77 | |         # comment
+78 | |         something and something_else
+79 | |     )
+   | |_____^
+   |
+help: Break down assertion into multiple parts
+   |
+75 | def test_comments():
+   -     assert (
+   -         # comment
+   -         something and something_else
+   -     )
+76 +     assert something
+77 +     assert something_else
+   |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
 ## Summary

   Fixes #20698.

* **Default Fix Safety:** The `PT018` rule splits composite assertions into individual `assert` statements. Because standard transformations (without custom messages) maintain short-circuiting and original runtime behavior, these fixes are now classified as **safe** by default, rather than marking every fix as unsafe.
* **Handling Comments:** Previously, Ruff completely disabled fixes for assertions containing comments. Now, assertions with internal comments will still offer a fix, but marked with an **unsafe** classification to ensure user verification while preserving functionality.

Proposed fixed will now composite assertion with an internal comment. Ordinary transformations are safe while the comment-bearing case receives an unsafe fix and this is verified.

   ## Test Plan

   - Ran the focused PT018 fixture and snapshot test:
     `cargo test -p ruff_linter --lib rule_pytestcompositeassertion_path_new_pt018_py_settings_default_pt018_expects`
   - Ran `cargo fmt --all --check`