### PR TITLE
Mark uncertain FURB188 fixes unsafe

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB188.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB188.py
@@ -214,3 +214,21 @@ def example(filename: str, text: str):
         else filename
     )
 
+
+# Regression test for
+# https://github.com/astral-sh/ruff/issues/20724
+def issue_20724_custom_sequence(seq):
+    if seq.startswith("123"):
+        seq = seq[3:]
+    return seq
+
+
+def issue_20724_tuple_prefix(text: str):
+    prefix = ("123",)
+    if text.startswith(prefix):
+        text = text[len(prefix):]
+    return text
+
+
+def known_bytes(data: bytes, prefix: bytes) -> bytes:
+    return data[len(prefix):] if data.startswith(prefix) else data

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
@@ -1,7 +1,7 @@
 use ruff_diagnostics::Applicability;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{self as ast, PythonVersion};
-use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::{Binding, SemanticModel, analyze::typing};
 use ruff_text_size::Ranged;
 
 use crate::Locator;
@@ -40,7 +40,10 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as safe, unless the expression contains comments.
+/// This rule's fix is marked as safe when the receiver and affix are known to be
+/// strings or bytes of the same kind, unless the expression contains comments.
+/// Otherwise, the fix is marked as unsafe. The diagnostic is suppressed when
+/// the receiver and affix have known incompatible types.
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "0.9.0")]
 pub(crate) struct SliceToRemovePrefixOrSuffix {
@@ -72,6 +75,53 @@ impl AlwaysFixableViolation for SliceToRemovePrefixOrSuffix {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+enum ValueKind {
+    String,
+    Bytes,
+    Other,
+}
+
+impl ValueKind {
+    fn from_expr(expr: &ast::Expr, semantic: &SemanticModel) -> Option<Self> {
+        match expr {
+            ast::Expr::StringLiteral(_) => Some(Self::String),
+            ast::Expr::BytesLiteral(_) => Some(Self::Bytes),
+            ast::Expr::Tuple(_) => Some(Self::Other),
+            ast::Expr::List(_)
+            | ast::Expr::Set(_)
+            | ast::Expr::Dict(_)
+            | ast::Expr::NumberLiteral(_)
+            | ast::Expr::BooleanLiteral(_)
+            | ast::Expr::NoneLiteral(_) => Some(Self::Other),
+            ast::Expr::Name(name) => semantic
+                .only_binding(name)
+                .and_then(|binding_id| Self::from_binding(semantic.binding(binding_id), semantic)),
+            _ => semantic
+                .lookup_attribute(expr)
+                .and_then(|binding_id| Self::from_binding(semantic.binding(binding_id), semantic)),
+        }
+    }
+
+    fn from_binding(binding: &Binding<'_>, semantic: &SemanticModel) -> Option<Self> {
+        if typing::is_string(binding, semantic) {
+            Some(Self::String)
+        } else if typing::is_bytes(binding, semantic) {
+            Some(Self::Bytes)
+        } else if typing::is_list(binding, semantic)
+            || typing::is_dict(binding, semantic)
+            || typing::is_int(binding, semantic)
+            || typing::is_float(binding, semantic)
+            || typing::is_set(binding, semantic)
+            || typing::is_tuple(binding, semantic)
+        {
+            Some(Self::Other)
+        } else {
+            None
+        }
+    }
+}
+
 /// FURB188
 pub(crate) fn slice_to_remove_affix_expr(checker: &Checker, if_expr: &ast::ExprIf) {
     if checker.target_version() < PythonVersion::PY39 {
@@ -80,6 +130,14 @@ pub(crate) fn slice_to_remove_affix_expr(checker: &Checker, if_expr: &ast::ExprI
 
     if let Some(removal_data) = affix_removal_data_expr(if_expr) {
         if affix_matches_slice_bound(&removal_data, checker.semantic()) {
+            let Some(applicability) = fix_applicability(
+                &removal_data,
+                checker.semantic(),
+                checker.comment_ranges().intersects(if_expr.range),
+            ) else {
+                return;
+            };
+
             let kind = removal_data.affix_query.kind;
             let text = removal_data.text;
 
@@ -92,12 +150,6 @@ pub(crate) fn slice_to_remove_affix_expr(checker: &Checker, if_expr: &ast::ExprI
             );
             let replacement =
                 generate_removeaffix_expr(text, &removal_data.affix_query, checker.locator());
-
-            let applicability = if checker.comment_ranges().intersects(if_expr.range) {
-                Applicability::Unsafe
-            } else {
-                Applicability::Safe
-            };
 
             diagnostic.set_fix(Fix::applicable_edit(
                 Edit::replacement(replacement, if_expr.start(), if_expr.end()),
@@ -114,6 +166,14 @@ pub(crate) fn slice_to_remove_affix_stmt(checker: &Checker, if_stmt: &ast::StmtI
     }
     if let Some(removal_data) = affix_removal_data_stmt(if_stmt) {
         if affix_matches_slice_bound(&removal_data, checker.semantic()) {
+            let Some(applicability) = fix_applicability(
+                &removal_data,
+                checker.semantic(),
+                checker.comment_ranges().intersects(if_stmt.range),
+            ) else {
+                return;
+            };
+
             let kind = removal_data.affix_query.kind;
             let text = removal_data.text;
 
@@ -131,17 +191,31 @@ pub(crate) fn slice_to_remove_affix_stmt(checker: &Checker, if_stmt: &ast::StmtI
                 checker.locator(),
             );
 
-            let applicability = if checker.comment_ranges().intersects(if_stmt.range) {
-                Applicability::Unsafe
-            } else {
-                Applicability::Safe
-            };
-
             diagnostic.set_fix(Fix::applicable_edit(
                 Edit::replacement(replacement, if_stmt.start(), if_stmt.end()),
                 applicability,
             ));
         }
+    }
+}
+
+fn fix_applicability(
+    data: &RemoveAffixData,
+    semantic: &SemanticModel,
+    intersects_comments: bool,
+) -> Option<Applicability> {
+    match (
+        ValueKind::from_expr(data.text, semantic),
+        ValueKind::from_expr(data.affix_query.affix, semantic),
+    ) {
+        (Some(ValueKind::String), Some(ValueKind::String))
+        | (Some(ValueKind::Bytes), Some(ValueKind::Bytes)) => Some(if intersects_comments {
+            Applicability::Unsafe
+        } else {
+            Applicability::Safe
+        }),
+        (Some(_), Some(_)) => None,
+        _ => Some(Applicability::Unsafe),
     }
 }
 

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB188_FURB188.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB188_FURB188.py.snap
@@ -116,6 +116,7 @@ help: Use removesuffix instead of ternary expression conditional upon endswith.
 146 +     x = foo.bar.baz.removesuffix(SUFFIX)
 147 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB188 [*] Prefer `str.removeprefix()` over conditionally replacing with slice.
    --> FURB188.py:149:12
@@ -191,6 +192,7 @@ help: Use removeprefix instead of assignment conditional upon startswith.
 160 +     text = text.removeprefix("!")
 161 |     if text.startswith("!"):
     |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB188 [*] Prefer `str.removeprefix()` over conditionally replacing with slice.
    --> FURB188.py:162:5
@@ -210,6 +212,7 @@ help: Use removeprefix instead of assignment conditional upon startswith.
 162 +     text = text.removeprefix("!")
 163 |     print(text)
     |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB188 [*] Prefer `str.removeprefix()` over conditionally replacing with slice.
    --> FURB188.py:183:5
@@ -228,6 +231,7 @@ help: Use removeprefix instead of assignment conditional upon startswith.
 183 +     text = text.removeprefix("ř")
 184 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB188 [*] Prefer `str.removeprefix()` over conditionally replacing with slice.
    --> FURB188.py:190:5
@@ -268,6 +272,7 @@ help: Use removeprefix instead of assignment conditional upon startswith.
 193 +     text = text.removeprefix("\U00010000")
 194 |     
     |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB188 [*] Prefer `str.removesuffix()` over conditionally replacing with slice.
    --> FURB188.py:205:5
@@ -309,3 +314,37 @@ help: Use removesuffix instead of ternary expression conditional upon endswith.
 213 |     )
     |
 note: This is an unsafe fix and may change runtime behavior
+
+FURB188 [*] Prefer `str.removeprefix()` over conditionally replacing with slice.
+   --> FURB188.py:221:5
+    |
+219 |   # https://github.com/astral-sh/ruff/issues/20724
+220 |   def issue_20724_custom_sequence(seq):
+221 | /     if seq.startswith("123"):
+222 | |         seq = seq[3:]
+    | |_____________________^
+223 |       return seq
+    |
+help: Use removeprefix instead of assignment conditional upon startswith.
+    |
+220 | def issue_20724_custom_sequence(seq):
+    -     if seq.startswith("123"):
+    -         seq = seq[3:]
+221 +     seq = seq.removeprefix("123")
+222 |     return seq
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB188 [*] Prefer `str.removeprefix()` over conditionally replacing with slice.
+   --> FURB188.py:234:12
+    |
+233 | def known_bytes(data: bytes, prefix: bytes) -> bytes:
+234 |     return data[len(prefix):] if data.startswith(prefix) else data
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+help: Use removeprefix instead of ternary expression conditional upon startswith.
+    |
+233 | def known_bytes(data: bytes, prefix: bytes) -> bytes:
+    -     return data[len(prefix):] if data.startswith(prefix) else data
+234 +     return data.removeprefix(prefix)
+    |


### PR DESCRIPTION
## Summary

Fixes #20724.

Rule `FURB188` replaces manual string slicing conditioned on a `startswith` or `endswith` check with Python 3.9+'s built-in `removeprefix` or `removesuffix` methods. 

However, this replacement is not always behavior-preserving:
1. Custom sequence types may implement `startswith()` and slicing (`[len(prefix):]`), but might lack a `.removeprefix()` method. Replacing slicing with `.removeprefix()` on these objects results in a runtime `AttributeError`.
2. Python's `str.startswith()` accepts a `tuple` of prefixes, whereas `str.removeprefix()` strictly requires a single string argument. Passing a tuple to `.removeprefix()` raises a `TypeError` at runtime.

To prevent auto-fixes from breaking valid code, this PR introduces type-aware applicability rules for `FURB188`:
- **Safe fix:** Marked as safe when both the receiver and the affix are known to be built-in `str` types or both are known `bytes` types, provided there are no comments within the replaced expression.
- **Unsafe fix:** Marked as unsafe when either the receiver or affix type cannot be definitively determined, or when comments are present within the expression.
- **Suppressed diagnostic:** Suppressed entirely when the receiver and affix types are known to be incompatible with `.removeprefix()` / `.removesuffix()` (such as passing a tuple prefix to a string target).

### Test Coverage
The added regression test cases in `crates/ruff_linter/resources/test/fixtures/refurb/FURB188.py` verify this behavior:
- `issue_20724_custom_sequence`: Tests an untyped sequence parameter. The diagnostic triggers, but the fix is marked as **unsafe** because the target type isn't known to be a string or bytes.
- `issue_20724_tuple_prefix`: Tests passing a tuple prefix (`("123",)`) to a string's `startswith()`. The diagnostic is **suppressed** because `removeprefix()` does not support tuple arguments.
- `known_bytes`: Tests a function with annotated `bytes` receiver and prefix arguments, demonstrating that the fix remains **safe** for `bytes` types.

## Test Plan

- Ran the focused FURB188 fixture and snapshot test:
  `cargo test -p ruff_linter --lib rule_slicetoremoveprefixorsuffix_path_new_furb188_py_expects`
- Ran `cargo fmt --all --check`