### PR TITLE
[ty] narrow `TypeGuard` targets to an intersection of the previous type and the narrowed type to avoid unintended widening and for consistency with `TypeIs`

### DIFF
--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3777,7 +3777,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 let (_, place) = type_guard.place_info(self.db)?;
                 Some((
                     place,
-                    NarrowingConstraint::replacement(type_guard.return_type(self.db)),
+                    NarrowingConstraint::intersection(type_guard.return_type(self.db)),
                 ))
             }
             _ => None,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

see discussion on https://github.com/astral-sh/ty/issues/4090

## Test Plan

just seeing what mypy_primer says for now. if there's no unintended consequences i'll add a test