### PR TITLE
scripts: add script metadata for `check_docs_formatted`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -928,7 +928,7 @@ jobs:
       - name: "Generate docs"
         run: python scripts/generate_mkdocs.py
       - name: "Check docs formatting"
-        run: python scripts/check_docs_formatted.py
+        run: ./scripts/check_docs_formatted.py
       - name: "Build docs"
         run: mkdocs build --strict -f mkdocs.yml
 

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
 """Check code snippets in docs are formatted by Ruff."""
 
 from __future__ import annotations

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -2,7 +2,12 @@
 # /// script
 # requires-python = ">=3.10"
 # ///
-"""Check code snippets in docs are formatted by Ruff."""
+"""Check code snippets in docs are formatted by Ruff.
+
+Intended to be executed from the repository root:
+
+    uv run scripts/check_docs_formatted.py
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

To make it `uv run`'able in an isolated environment with the expected Python version (it has `match` - so I've set it to be 3.10+).

Before this change `uv run scripts/check_docs_formatted.py` would try to build `ruff` package and `uv run check_docs_formatted.py` would fail since script is intended to be executed from repo root.

Also added a shebang to run it in script mode automatically.

## Test Plan

Tested locally, no issues found.
