### PR TITLE
[ty] Preserve frozen-dataclass setter delegation

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -833,14 +833,12 @@ class ChildWithRejectingAssignmentBase(Frozen, RejectsAssignment): ...
 ChildWithRejectingAssignmentBase().y = 2
 ```
 
-A later base class can instead allow assignment to an otherwise read-only property. Its setter still
-determines which values are accepted:
+A later base class can customize assignment to an ordinary attribute. The value must satisfy both
+the later `__setattr__` and the attribute declaration:
 
 ```py
 class AllowsAssignment:
-    @property
-    def y(self) -> int:
-        return 1
+    y: object = 1
 
     def __setattr__(self, name: str, value: int) -> None: ...
 
@@ -851,6 +849,82 @@ allowed.y = 2
 
 # error: [invalid-assignment] "Cannot assign object of type"
 allowed.y = "invalid"
+```
+
+A later `__setattr__` can forward to `object.__setattr__`, which still invokes data descriptors:
+
+```py
+class ForwardsAssignment:
+    def __setattr__(self, name: str, value: object) -> None:
+        super().__setattr__(name, value)
+```
+
+A read-only property therefore remains read-only:
+
+```py
+class ReadOnlyPropertyBase(ForwardsAssignment):
+    @property
+    def y(self) -> int:
+        return 1
+
+class ChildWithReadOnlyProperty(Frozen, ReadOnlyPropertyBase): ...
+
+# error: [invalid-assignment] "Cannot assign to read-only property `y` on object of type `ChildWithReadOnlyProperty`"
+ChildWithReadOnlyProperty().y = 2
+```
+
+The property's setter still determines which values it accepts:
+
+```py
+class TypedPropertyBase(ForwardsAssignment):
+    @property
+    def y(self) -> int:
+        return 1
+
+    @y.setter
+    def y(self, value: int) -> None: ...
+
+class ChildWithTypedProperty(Frozen, TypedPropertyBase): ...
+
+# error: [invalid-assignment] "Expected `int`, found `Literal["invalid"]`"
+ChildWithTypedProperty().y = "invalid"
+```
+
+A property setter that never returns prevents assignment:
+
+```py
+class TerminalPropertyBase(ForwardsAssignment):
+    @property
+    def y(self) -> int:
+        return 1
+
+    @y.setter
+    def y(self, value: int) -> NoReturn:
+        raise AttributeError
+
+class ChildWithTerminalProperty(Frozen, TerminalPropertyBase): ...
+
+# error: [invalid-assignment] "Cannot assign to attribute `y` on type `ChildWithTerminalProperty` whose `__set__` method returns `Never`/`NoReturn`"
+ChildWithTerminalProperty().y = 2
+```
+
+The same rule applies to a custom descriptor whose setter never returns:
+
+```py
+class TerminalDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    def __set__(self, instance: object, value: int) -> NoReturn:
+        raise AttributeError
+
+class TerminalDescriptorBase(ForwardsAssignment):
+    y: TerminalDescriptor = TerminalDescriptor()
+
+class ChildWithTerminalDescriptor(Frozen, TerminalDescriptorBase): ...
+
+# error: [invalid-assignment] "Cannot assign to attribute `y` on type `ChildWithTerminalDescriptor` whose `__set__` method returns `Never`/`NoReturn`"
+ChildWithTerminalDescriptor().y = 2
 ```
 
 A later `__setattr__` does not make the declared type of an ordinary attribute disappear:

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -810,6 +810,141 @@ grandchild.z = 2
 grandchild.unknown = 2
 ```
 
+When another base class rejects assignment, a frozen dataclass must not hide its `__setattr__`
+method:
+
+```py
+from dataclasses import dataclass
+from typing import NoReturn
+
+@dataclass(frozen=True)
+class Frozen:
+    x: int = 1
+
+class RejectsAssignment:
+    y: int = 1
+
+    def __setattr__(self, name: str, value: object) -> NoReturn:
+        raise AttributeError(name)
+
+class ChildWithRejectingAssignmentBase(Frozen, RejectsAssignment): ...
+
+# error: [invalid-assignment] "Cannot assign to attribute `y` on type `ChildWithRejectingAssignmentBase` whose `__setattr__` method returns `Never`/`NoReturn`"
+ChildWithRejectingAssignmentBase().y = 2
+```
+
+A later base class can instead allow assignment to an otherwise read-only property. Its setter still
+determines which values are accepted:
+
+```py
+class AllowsAssignment:
+    @property
+    def y(self) -> int:
+        return 1
+
+    def __setattr__(self, name: str, value: int) -> None: ...
+
+class ChildWithAllowingAssignmentBase(Frozen, AllowsAssignment): ...
+
+allowed = ChildWithAllowingAssignmentBase()
+allowed.y = 2
+
+# error: [invalid-assignment] "Cannot assign object of type"
+allowed.y = "invalid"
+```
+
+A later `__setattr__` does not make the declared type of an ordinary attribute disappear:
+
+```py
+class AllowsUntypedAssignment:
+    y: int = 1
+
+    def __setattr__(self, name: str, value: object) -> None: ...
+
+class ChildWithUntypedAssignmentBase(Frozen, AllowsUntypedAssignment): ...
+
+# error: [invalid-assignment]
+ChildWithUntypedAssignmentBase().y = "invalid"
+```
+
+A specialized `Generic[T]` frozen base must also preserve the next `__setattr__` in the MRO:
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+@dataclass(frozen=True)
+class GenericFrozen(Generic[T]):
+    value: T
+
+class RejectingGenericAssignmentChild(GenericFrozen[int], RejectsAssignment): ...
+
+# error: [invalid-assignment] "Cannot assign to attribute `y` on type `RejectingGenericAssignmentChild` whose `__setattr__` method returns `Never`/`NoReturn`"
+RejectingGenericAssignmentChild(1).y = 2
+```
+
+The same behavior applies to Python 3.12 type-parameter syntax:
+
+```py
+@dataclass(frozen=True)
+class TypeParameterFrozen[T]:
+    value: T
+
+class RejectingTypeParameterAssignmentChild(TypeParameterFrozen[int], RejectsAssignment): ...
+
+# error: [invalid-assignment] "Cannot assign to attribute `y` on type `RejectingTypeParameterAssignmentChild` whose `__setattr__` method returns `Never`/`NoReturn`"
+RejectingTypeParameterAssignmentChild(1).y = 2
+```
+
+When a subclass inherits from two frozen dataclasses, assignments to fields from both bases remain
+frozen:
+
+```py
+@dataclass(frozen=True)
+class FirstFrozen:
+    first: int = 1
+
+@dataclass(frozen=True)
+class SecondFrozen:
+    second: int = 1
+
+class ChildWithTwoFrozenBases(FirstFrozen, SecondFrozen): ...
+
+multiple = ChildWithTwoFrozenBases()
+# revealed: Overload[(name: Literal["first"], value) -> Never, (name: Literal["second"], value) -> Never, (name: str, value) -> None]
+reveal_type(multiple.__setattr__)
+
+multiple.second = 2  # error: [invalid-assignment]
+```
+
+An `InitVar` is a constructor argument, not a frozen field. A subclass can assign to an attribute
+with the same name:
+
+```py
+from dataclasses import InitVar
+
+@dataclass(frozen=True)
+class FrozenWithInitVar:
+    temporary: InitVar[int] = 0
+
+class ChildWithInitVar(FrozenWithInitVar):
+    temporary: int = 1
+
+init_var_child = ChildWithInitVar()
+init_var_child.temporary = 4
+```
+
+The same rule applies when the `InitVar` belongs to a second frozen base:
+
+```py
+class ChildWithSecondBaseInitVar(Frozen, FrozenWithInitVar):
+    temporary: int = 1
+
+second_init_var_child = ChildWithSecondBaseInitVar()
+second_init_var_child.temporary = 4
+```
+
 Non-field attributes on subclasses of slotted frozen dataclasses are still rejected. This correctly
 models the runtime behavior, but is somewhat surprising and may be a CPython bug, as subclasses of
 slotted classes usually allow arbitrary attributes to be set on them unless the subclass also

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -10,7 +10,8 @@ pub(super) use self::named_tuple::{
     DynamicNamedTupleAnchor, DynamicNamedTupleLiteral, NamedTupleField, NamedTupleSpec,
 };
 pub(crate) use self::static_literal::{
-    ExpandedClassBaseEntry, StaticClassLiteral, expanded_class_base_entries,
+    ExpandedClassBaseEntry, FrozenDataclassDispatch, StaticClassLiteral,
+    expanded_class_base_entries,
 };
 pub(super) use self::typed_dict::{DynamicTypedDictAnchor, DynamicTypedDictLiteral};
 use super::dedicated::pydantic;

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -120,17 +120,26 @@ pub struct StaticClassLiteral<'db> {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for StaticClassLiteral<'_> {}
 
-/// The outcome of dispatching a frozen-dataclass method on a subclass instance.
+/// The result of [`StaticClassLiteral::inherited_frozen_dataclass_dispatch`].
+///
+/// See that method for details on how generated frozen-dataclass methods handle fields and
+/// non-fields on subclass instances.
 #[derive(Clone, Copy)]
 pub(crate) enum FrozenDataclassDispatch<'db> {
     /// A reachable frozen dataclass rejects modification of one of its fields.
     FrozenField,
-    /// Every reachable frozen method delegates past this base.
+    /// Every reachable frozen method delegates, with lookup resuming after this base.
     Delegate(StaticClassLiteral<'db>),
 }
 
 impl<'db> FrozenDataclassDispatch<'db> {
-    /// Returns `object` for a frozen field or `super(frozen_base, object)` for a non-field.
+    /// Returns the receiver for the next step of assignment or deletion validation.
+    ///
+    /// Validation stays on `object_ty` for a frozen field because the generated method rejects the
+    /// mutation. For a non-field, the generated method calls `super(frozen_base, object_ty)`, so
+    /// lookup must resume after the last frozen base. For example, assigning `Child().y` for
+    /// `class Child(Frozen, Later)` uses `super(Frozen, child)` when `y` is not a field of `Frozen`;
+    /// this preserves a later `__setattr__` or a descriptor for `y`.
     pub(crate) fn receiver(self, db: &'db dyn Db, object_ty: Type<'db>) -> Type<'db> {
         match self {
             Self::FrozenField => object_ty,
@@ -147,6 +156,9 @@ impl<'db> FrozenDataclassDispatch<'db> {
 /// Fields protected by reachable frozen-dataclass methods.
 struct InheritedFrozenDataclassFields<'db> {
     names: Box<[Name]>,
+    /// The final frozen dataclass whose generated method participates in dispatch.
+    ///
+    /// For a non-field, mutation validation resumes after this class in the MRO.
     last_frozen_base: StaticClassLiteral<'db>,
 }
 
@@ -1915,11 +1927,33 @@ impl<'db> StaticClassLiteral<'db> {
         )))
     }
 
-    /// Returns the outcome of an inherited frozen-dataclass method for `name`.
+    /// Determines how an inherited generated frozen-dataclass `method` handles `name`.
     ///
-    /// For a non-field, CPython delegates past each generated frozen method. Preserving the final
-    /// frozen base lets assignment validation perform the same `super()` lookup without hiding a
-    /// later method or an attribute's descriptor.
+    /// CPython's generated `__setattr__` and `__delattr__` reject every mutation when called on an
+    /// instance of the exact frozen class. On an ordinary subclass instance, they reject only
+    /// dataclass fields and delegate other names with `super(frozen_class, instance)`.
+    ///
+    /// For example:
+    ///
+    /// ```python
+    /// @dataclass(frozen=True)
+    /// class Frozen:
+    ///     x: int
+    ///
+    /// class Later:
+    ///     y: int
+    ///
+    /// class Child(Frozen, Later): ...
+    /// ```
+    ///
+    /// Assigning to `Child().x` is rejected because `x` is a field of `Frozen`. Assigning to
+    /// `Child().y` instead delegates to `super(Frozen, child).__setattr__`, where a later
+    /// `__setattr__` or the descriptor for `y` can still reject the assignment.
+    ///
+    /// If multiple frozen dataclasses are reachable before an explicit implementation of
+    /// `method`, a non-field delegates past each generated method. [`FrozenDataclassDispatch::Delegate`]
+    /// stores the last frozen base so the caller can perform the equivalent lookup once, after all
+    /// of them.
     pub(crate) fn inherited_frozen_dataclass_dispatch(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -24,6 +24,7 @@ use crate::{
         Parameter, Parameters, PropertyInstanceType, Signature, SpecialFormType, StaticMroError,
         SubclassOfType, Truthiness, Type, TypeContext, TypeMapping, TypeVarVariance,
         TypedDictModule, UnionBuilder, UnionType,
+        bound_super::BoundSuperType,
         call::{CallError, CallErrorKind},
         callable::{CallableFunctionProvenance, CallableTypeKind},
         class::{
@@ -118,6 +119,36 @@ pub struct StaticClassLiteral<'db> {
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for StaticClassLiteral<'_> {}
+
+/// The outcome of dispatching a frozen-dataclass method on a subclass instance.
+#[derive(Clone, Copy)]
+pub(crate) enum FrozenDataclassDispatch<'db> {
+    /// A reachable frozen dataclass rejects modification of one of its fields.
+    FrozenField,
+    /// Every reachable frozen method delegates past this base.
+    Delegate(StaticClassLiteral<'db>),
+}
+
+impl<'db> FrozenDataclassDispatch<'db> {
+    /// Returns `object` for a frozen field or `super(frozen_base, object)` for a non-field.
+    pub(crate) fn receiver(self, db: &'db dyn Db, object_ty: Type<'db>) -> Type<'db> {
+        match self {
+            Self::FrozenField => object_ty,
+            Self::Delegate(frozen_base) => BoundSuperType::build(
+                db,
+                Type::ClassLiteral(ClassLiteral::Static(frozen_base)),
+                object_ty,
+            )
+            .unwrap_or(object_ty),
+        }
+    }
+}
+
+/// Fields protected by reachable frozen-dataclass methods.
+struct InheritedFrozenDataclassFields<'db> {
+    names: Box<[Name]>,
+    last_frozen_base: StaticClassLiteral<'db>,
+}
 
 #[salsa::tracked]
 impl<'db> StaticClassLiteral<'db> {
@@ -1850,7 +1881,7 @@ impl<'db> StaticClassLiteral<'db> {
         }
 
         let frozen_base_fields =
-            self.inherited_non_slotted_frozen_dataclass_fields(db, specialization)?;
+            self.inherited_non_slotted_frozen_dataclass_fields(db, specialization, "__setattr__")?;
 
         let instance_ty =
             Type::instance(db, self.apply_optional_specialization(db, specialization));
@@ -1868,7 +1899,8 @@ impl<'db> StaticClassLiteral<'db> {
         };
 
         let overloads = frozen_base_fields
-            .keys()
+            .names
+            .iter()
             .map(|field| setattr_signature(Type::string_literal(db, field), Type::Never))
             .chain([setattr_signature(
                 KnownClass::Str.to_instance(db),
@@ -1883,15 +1915,60 @@ impl<'db> StaticClassLiteral<'db> {
         )))
     }
 
-    /// Return the inherited frozen dataclass fields whose generated `__setattr__` still controls
-    /// assignments on this class.
+    /// Returns the outcome of an inherited frozen-dataclass method for `name`.
+    ///
+    /// For a non-field, CPython delegates past each generated frozen method. Preserving the final
+    /// frozen base lets assignment validation perform the same `super()` lookup without hiding a
+    /// later method or an attribute's descriptor.
+    pub(crate) fn inherited_frozen_dataclass_dispatch(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+        method: &str,
+        name: &str,
+    ) -> Option<FrozenDataclassDispatch<'db>> {
+        if CodeGeneratorKind::from_static_class(db, self).is_some()
+            || class_member(db, self.body_scope(db), method)
+                .ignore_possibly_undefined()
+                .is_some()
+        {
+            return None;
+        }
+
+        let frozen_base_fields =
+            self.inherited_non_slotted_frozen_dataclass_fields(db, specialization, method)?;
+
+        if frozen_base_fields
+            .names
+            .iter()
+            .any(|field| field.as_str() == name)
+        {
+            Some(FrozenDataclassDispatch::FrozenField)
+        } else {
+            Some(FrozenDataclassDispatch::Delegate(
+                frozen_base_fields.last_frozen_base,
+            ))
+        }
+    }
+
+    /// Returns the inherited fields protected by a generated frozen-dataclass method.
     fn inherited_non_slotted_frozen_dataclass_fields(
         self,
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
-    ) -> Option<&'db FxIndexMap<Name, Field<'db>>> {
+        method: &str,
+    ) -> Option<InheritedFrozenDataclassFields<'db>> {
+        let mut names = FxIndexSet::default();
+        let mut last_frozen_base = None;
+
         for base in self.iter_mro(db, specialization).skip(1) {
-            let (base_class, base_specialization) = base.into_class()?.static_class_literal(db)?;
+            let Some(base_class_type) = base.into_class() else {
+                break;
+            };
+            let Some((base_class, base_specialization)) = base_class_type.static_class_literal(db)
+            else {
+                break;
+            };
 
             // Stop if another class in the MRO replaces the generated frozen setter:
             //
@@ -1905,29 +1982,47 @@ impl<'db> StaticClassLiteral<'db> {
             //
             // Writes to `Child().x` dispatch to `Mutable.__setattr__`, not to the synthesized
             // `Frozen.__setattr__`.
-            if class_member(db, base_class.body_scope(db), "__setattr__")
+            if class_member(db, base_class.body_scope(db), method)
                 .ignore_possibly_undefined()
                 .is_some()
             {
-                return None;
+                break;
             }
 
             if base_class.is_frozen_dataclass(db) == Some(true) {
                 let field_policy @ CodeGeneratorKind::DataclassLike(_) =
                     CodeGeneratorKind::from_static_class(db, base_class)?
                 else {
-                    return None;
+                    break;
                 };
 
                 if base_class.has_dataclass_param(db, field_policy, DataclassFlags::SLOTS) {
-                    return None;
+                    break;
                 }
 
-                return Some(base_class.fields(db, base_specialization, field_policy));
+                names.extend(
+                    base_class
+                        .fields(db, base_specialization, field_policy)
+                        .iter()
+                        .filter(|(_, field)| {
+                            !matches!(
+                                field.kind,
+                                FieldKind::Dataclass {
+                                    init_only: true,
+                                    ..
+                                }
+                            )
+                        })
+                        .map(|(name, _)| name.clone()),
+                );
+                last_frozen_base = Some(base_class);
             }
         }
 
-        None
+        Some(InheritedFrozenDataclassFields {
+            names: names.into_iter().collect(),
+            last_frozen_base: last_frozen_base?,
+        })
     }
 
     /// Member lookup for classes that inherit from `typing.TypedDict`.

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -433,27 +433,15 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 if matches!(
                     frozen_dataclass_dispatch,
                     Some(FrozenDataclassDispatch::Delegate(_))
-                ) {
-                    match setattr_result {
-                        Ok(_) | Err(CallDunderError::PossiblyUnbound { .. })
-                            if matches!(
-                                member,
-                                ExplicitAttributeWriteRequirement::Descriptor { .. }
-                            ) =>
-                        {
-                            return true;
-                        }
-                        Err(CallDunderError::CallError(kind, bindings, _)) => {
-                            if emit_diagnostics {
-                                self.report(AssignmentAttributeWriteDiagnostic::BadSetAttr {
-                                    value_ty,
-                                    failure: CallError(kind, bindings),
-                                });
-                            }
-                            return false;
-                        }
-                        _ => {}
+                ) && let Err(CallDunderError::CallError(kind, bindings, _)) = setattr_result
+                {
+                    if emit_diagnostics {
+                        self.report(AssignmentAttributeWriteDiagnostic::BadSetAttr {
+                            value_ty,
+                            failure: CallError(kind, bindings),
+                        });
                     }
+                    return false;
                 }
                 let member_valid =
                     self.evaluate_explicit_member(object_ty, member, value_ty, emit_diagnostics);
@@ -679,17 +667,27 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         emit_diagnostics: bool,
     ) -> bool {
         let db = self.builder.db();
-        if property_setter_returns_never(db, descriptor_ty, object_ty, value_ty) {
+        let setter_result = setter_ty.try_call(
+            db,
+            &CallArguments::positional([descriptor_ty, object_ty, value_ty]),
+        );
+        // `Never` supports arbitrary operations only because there can be no runtime value to
+        // mutate; it is not a concrete descriptor with a terminal setter.
+        let setter_returns_never = !descriptor_ty.is_never()
+            && match &setter_result {
+                Ok(bindings) => bindings.return_type(db).is_never(),
+                Err(error) => error.return_type(db).is_never(),
+            };
+        if setter_returns_never
+            || property_setter_returns_never(db, descriptor_ty, object_ty, value_ty)
+        {
             if emit_diagnostics {
                 self.report(AssignmentAttributeWriteDiagnostic::TerminalDescriptor);
             }
             return false;
         }
 
-        match setter_ty.try_call(
-            db,
-            &CallArguments::positional([descriptor_ty, object_ty, value_ty]),
-        ) {
+        match setter_result {
             Ok(_) => true,
             Err(error) => {
                 if emit_diagnostics {

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -9,6 +9,7 @@ use crate::types::attribute_write::{
     ProtocolMemberWriteRequirement, attribute_write_requirement, property_setter_returns_never,
 };
 use crate::types::call::{Bindings, CallArguments, CallDiagnosticOverride, CallError};
+use crate::types::class::FrozenDataclassDispatch;
 use crate::types::diagnostic::{
     INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_ACCESS, UNRESOLVED_ATTRIBUTE, report_bad_dunder_set_call,
     report_invalid_attribute_assignment, report_possibly_missing_attribute,
@@ -126,11 +127,17 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             ast::ArgOrKeyword::Arg(self.value),
         ];
         let mut call_arguments = CallArguments::positional([name_ty, Type::unknown()]);
+        // A bound `super` must use its own MRO lookup rather than the normal instance fallback.
+        let lookup_policy = if matches!(object_ty, Type::BoundSuper(_)) {
+            MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
+        } else {
+            MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK | MemberLookupPolicy::NO_INSTANCE_FALLBACK
+        };
         let setattr_result = self.builder.infer_and_try_call_dunder(
             db,
             object_ty,
             "__setattr__",
-            MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+            lookup_policy,
             ArgumentsIter::synthesized(&ast_arguments),
             &mut call_arguments,
             &mut |builder, (argument_index, _, tcx)| {
@@ -343,12 +350,29 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         emit_diagnostics: bool,
     ) -> bool {
         let db = self.builder.db();
+        let frozen_dataclass_dispatch = object_ty
+            .nominal_class(db)
+            .and_then(|class| class.static_class_literal(db))
+            .and_then(|(class, specialization)| {
+                class.inherited_frozen_dataclass_dispatch(
+                    db,
+                    specialization,
+                    "__setattr__",
+                    self.attribute,
+                )
+            });
+        let setattr_receiver = frozen_dataclass_dispatch
+            .map_or(object_ty, |dispatch| dispatch.receiver(db, object_ty));
+
         let (setattr_result, value_ty) = if matches!(member, InstanceAttributeWriteMember::SetAttr)
-        {
-            self.infer_and_try_call_setattr(object_ty, emit_diagnostics)
+            || matches!(
+                frozen_dataclass_dispatch,
+                Some(FrozenDataclassDispatch::Delegate(_))
+            ) {
+            self.infer_and_try_call_setattr(setattr_receiver, emit_diagnostics)
         } else {
             let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
-            let setattr_result = object_ty.try_call_dunder_with_policy(
+            let setattr_result = setattr_receiver.try_call_dunder_with_policy(
                 db,
                 "__setattr__",
                 &mut CallArguments::positional([
@@ -362,13 +386,19 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         };
 
         // A terminal `__setattr__` blocks even explicitly declared attributes.
-        let setattr_returns_never = match &setattr_result {
+        let setattr_returns_never = matches!(
+            frozen_dataclass_dispatch,
+            Some(FrozenDataclassDispatch::FrozenField)
+        ) || match &setattr_result {
             Ok(bindings) => bindings.return_type(db).is_never(),
             Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
         };
         if setattr_returns_never {
             if emit_diagnostics {
-                let is_setattr_synthesized = match object_ty.class_member_with_policy(
+                let is_setattr_synthesized = !matches!(
+                    frozen_dataclass_dispatch,
+                    Some(FrozenDataclassDispatch::Delegate(_))
+                ) && match object_ty.class_member_with_policy(
                     db,
                     "__setattr__",
                     MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
@@ -400,6 +430,31 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 {
                     return false;
                 }
+                if matches!(
+                    frozen_dataclass_dispatch,
+                    Some(FrozenDataclassDispatch::Delegate(_))
+                ) {
+                    match setattr_result {
+                        Ok(_) | Err(CallDunderError::PossiblyUnbound { .. })
+                            if matches!(
+                                member,
+                                ExplicitAttributeWriteRequirement::Descriptor { .. }
+                            ) =>
+                        {
+                            return true;
+                        }
+                        Err(CallDunderError::CallError(kind, bindings, _)) => {
+                            if emit_diagnostics {
+                                self.report(AssignmentAttributeWriteDiagnostic::BadSetAttr {
+                                    value_ty,
+                                    failure: CallError(kind, bindings),
+                                });
+                            }
+                            return false;
+                        }
+                        _ => {}
+                    }
+                }
                 let member_valid =
                     self.evaluate_explicit_member(object_ty, member, value_ty, emit_diagnostics);
                 if let Some(fallback) = fallback {
@@ -423,6 +478,14 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         });
                     }
                     false
+                }
+                Err(CallDunderError::MethodNotAvailable)
+                    if matches!(
+                        frozen_dataclass_dispatch,
+                        Some(FrozenDataclassDispatch::Delegate(_))
+                    ) =>
+                {
+                    true
                 }
                 Err(CallDunderError::MethodNotAvailable) => {
                     if emit_diagnostics {


### PR DESCRIPTION
## Summary

Prior to this change, we modeled a frozen dataclass's inherited `__setattr__` as an overload that rejects known frozen fields and returns `None` for every other attribute. That catch-all loses the actual setter that Python calls after the frozen base.

For example, this assignment must be rejected because the next base's setter never returns:

```python
from dataclasses import dataclass
from typing import Never

@dataclass(frozen=True)
class Frozen:
    x: int = 1

class RejectsAssignment:
    y: int = 1

    def __setattr__(self, name: str, value: object) -> Never:
        raise AttributeError(name)

class Child(Frozen, RejectsAssignment): ...

Child().y = 2
```

Previously, we accepted it. We also rejected valid assignments when a later setter explicitly accepts a value for an otherwise read-only property.

We now collect fields from every reachable frozen base, distinguish frozen fields from attributes that are delegated through `super()`, and validate delegated assignments against the actual next setter. This preserves setter argument checking and declared attribute types, handles both generic syntaxes, excludes `InitVar` arguments, and keeps the existing behavior for slotted frozen dataclasses.

This is a prerequisite for #27001: it fixes the existing assignment behavior and establishes the shared frozen-method dispatch that the deletion change can reuse without expanding its scope.
