### PR TITLE
[ty] Model try exception flow with checkpoints

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1333,6 +1333,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     }
 
     fn flow_snapshot_for_condition(&mut self, condition: &ast::Expr) -> ConditionFlowSnapshot {
+        self.record_exception_checkpoint_if(!Self::condition_evaluation_is_known_safe(condition));
+
         if let Some(snapshots) = self.take_condition_flow_snapshots(condition) {
             ConditionFlowSnapshot::Branches(snapshots)
         } else {
@@ -1618,10 +1620,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             self.record_pending_capture_binding(id, definition_id);
             self.update_lazy_snapshots(id);
         }
-
-        let mut try_node_stack_manager = std::mem::take(&mut self.try_node_context_stack_manager);
-        try_node_stack_manager.record_definition(self);
-        self.try_node_context_stack_manager = try_node_stack_manager;
     }
 
     // Creates a definition for each key-value assignment in the dictionary.
@@ -2206,6 +2204,245 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.try_node_context_stack_manager = try_node_stack_manager;
     }
 
+    /// Returns whether an exception raised while evaluating `scope` can propagate directly to its
+    /// enclosing scope. Generator-expression bodies are lazy even though they share the
+    /// comprehension scope kind; their eagerly evaluated first iterable is visited before entering
+    /// the generator scope.
+    fn exception_checkpoint_crosses_scope_boundary(&self, scope_id: FileScopeId) -> bool {
+        let scope = &self.scopes[scope_id];
+        scope.is_eager() && !matches!(scope.node(), NodeWithScopeKind::GeneratorExpression(_))
+    }
+
+    /// Captures comprehension walrus bindings that have completed before an exception escapes.
+    ///
+    /// Comprehensions normally publish their bindings only after their scope is popped. An
+    /// exception can escape before then, so an enclosing handler needs an outer-scoped proxy for
+    /// each binding that is live at the checkpoint, without changing normal comprehension flow.
+    fn exception_checkpoint_snapshot(
+        &mut self,
+        scope_id: FileScopeId,
+        crossed_comprehensions: &[FileScopeId],
+    ) -> FlowSnapshot {
+        if crossed_comprehensions.is_empty() {
+            return self.use_def_maps[scope_id].snapshot();
+        }
+
+        let original = self.use_def_maps[scope_id].snapshot();
+
+        for &comprehension_scope in crossed_comprehensions.iter().rev() {
+            let Some(comprehension_stack_index) = self
+                .scope_stack
+                .iter()
+                .position(|scope| scope.file_scope_id == comprehension_scope)
+            else {
+                continue;
+            };
+
+            let containing_scope = self.scope_stack[..comprehension_stack_index]
+                .iter()
+                .rev()
+                .find(|scope| self.scopes[scope.file_scope_id].kind() != ScopeKind::Comprehension)
+                .map(|scope| scope.file_scope_id);
+
+            let mut named_bindings = self.scope_stack[comprehension_stack_index]
+                .this_scope_global_or_nonlocal_declarations
+                .iter()
+                .map(|(name, range)| (name.clone(), *range))
+                .collect::<SmallVec<[(Name, TextRange); 2]>>();
+            named_bindings.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+
+            for (name, range) in named_bindings {
+                let Some(source_symbol) = self.place_tables[comprehension_scope].symbol_id(&name)
+                else {
+                    continue;
+                };
+
+                let is_global = self.place_tables[comprehension_scope]
+                    .symbol(source_symbol)
+                    .is_global();
+                let owning_scope = if is_global {
+                    Some(FileScopeId::global())
+                } else {
+                    containing_scope
+                };
+
+                if owning_scope != Some(scope_id) {
+                    continue;
+                }
+
+                let binding_status = self.use_def_maps[comprehension_scope]
+                    .symbol_live_binding_status(source_symbol);
+                if binding_status == LiveBindingStatus::Unbound {
+                    continue;
+                }
+
+                let source_definitions = self.use_def_maps[comprehension_scope]
+                    .current_bindings(source_symbol.into())
+                    .filter(|binding| {
+                        binding.reachability_constraint()
+                            != ScopedReachabilityConstraintId::ALWAYS_FALSE
+                    })
+                    .map(|binding| binding.binding())
+                    .filter(|definition| !definition.is_unbound())
+                    .collect::<SmallVec<[ScopedDefinitionId; 2]>>();
+                if source_definitions.is_empty() {
+                    continue;
+                }
+
+                let (symbol, added) =
+                    self.place_tables[scope_id].add_symbol(Symbol::new(name.clone()));
+                let place = ScopedPlaceId::from(symbol);
+                if added {
+                    self.use_def_maps[scope_id].add_place(place);
+                }
+
+                let declaration = NestedDeclaration {
+                    kind: if is_global {
+                        GlobalOrNonlocal::Global
+                    } else {
+                        GlobalOrNonlocal::Nonlocal
+                    },
+                    file_scope_id: comprehension_scope,
+                    range,
+                    is_bound: true,
+                };
+
+                for (index, source_definition) in source_definitions.into_iter().enumerate() {
+                    let definition = Definition::new(
+                        self.db,
+                        self.scope_ids_by_scope[scope_id],
+                        place,
+                        DefinitionKind::NestedBindings(Box::new(NestedBindingsDefinitionKind {
+                            name: name.clone(),
+                            execution: NestedBindingExecution::EagerAtException {
+                                source_definition,
+                            },
+                            nested_declarations: SmallVec::from_slice(&[declaration]),
+                        })),
+                        false,
+                    );
+
+                    let previous = if index == 0 && binding_status == LiveBindingStatus::Bound {
+                        PreviousDefinitions::AreShadowed
+                    } else {
+                        PreviousDefinitions::AreKept
+                    };
+                    self.use_def_maps[scope_id].record_binding(
+                        place,
+                        definition,
+                        previous,
+                        FutureDefinitions::ShadowThisOne,
+                    );
+                }
+            }
+        }
+
+        let checkpoint = self.use_def_maps[scope_id].snapshot();
+        self.use_def_maps[scope_id].restore(original);
+        checkpoint
+    }
+
+    /// Records the current flow state immediately before an operation that may raise an exception.
+    fn record_exception_checkpoint(&mut self) {
+        if !self
+            .try_node_context_stack_manager
+            .has_active_exception_handler()
+        {
+            return;
+        }
+
+        let mut try_node_stack_manager = std::mem::take(&mut self.try_node_context_stack_manager);
+        try_node_stack_manager.record_exception_checkpoint(self);
+        self.try_node_context_stack_manager = try_node_stack_manager;
+    }
+
+    fn record_exception_checkpoint_if(&mut self, can_raise: bool) {
+        if can_raise {
+            self.record_exception_checkpoint();
+        }
+    }
+
+    /// Returns whether evaluating and truth-testing `expr` cannot invoke Python user code.
+    fn condition_evaluation_is_known_safe(expr: &ast::Expr) -> bool {
+        if expr.is_literal_expr() || matches!(expr, ast::Expr::Lambda(_)) {
+            return true;
+        }
+
+        match expr {
+            ast::Expr::List(_) | ast::Expr::Tuple(_) => {
+                Self::expression_evaluation_is_known_safe(expr)
+            }
+            ast::Expr::BoolOp(ast::ExprBoolOp { values, .. }) => {
+                values.iter().all(Self::condition_evaluation_is_known_safe)
+            }
+            ast::Expr::UnaryOp(ast::ExprUnaryOp {
+                op: ast::UnaryOp::Not,
+                operand,
+                ..
+            }) => Self::condition_evaluation_is_known_safe(operand),
+            ast::Expr::Compare(ast::ExprCompare {
+                left,
+                ops,
+                comparators,
+                ..
+            }) => {
+                ops.iter()
+                    .all(|op| matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot))
+                    && Self::expression_evaluation_is_known_safe(left)
+                    && comparators
+                        .iter()
+                        .all(Self::expression_evaluation_is_known_safe)
+            }
+            _ => false,
+        }
+    }
+
+    /// Returns whether evaluating `expr` cannot invoke Python user code.
+    fn expression_evaluation_is_known_safe(expr: &ast::Expr) -> bool {
+        if expr.is_literal_expr() || matches!(expr, ast::Expr::Name(_) | ast::Expr::Lambda(_)) {
+            return true;
+        }
+
+        match expr {
+            ast::Expr::List(ast::ExprList { elts, .. })
+            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                elts.iter().all(Self::expression_evaluation_is_known_safe)
+            }
+            ast::Expr::Compare(_) => Self::condition_evaluation_is_known_safe(expr),
+            _ => false,
+        }
+    }
+
+    /// Returns whether iterating `expr` uses an exact builtin iterator that cannot raise anything
+    /// other than `StopIteration` (ignoring ambient failures such as `MemoryError`).
+    fn iteration_is_known_safe(expr: &ast::Expr) -> bool {
+        matches!(
+            expr,
+            ast::Expr::StringLiteral(_)
+                | ast::Expr::BytesLiteral(_)
+                | ast::Expr::List(_)
+                | ast::Expr::Tuple(_)
+        ) && Self::expression_evaluation_is_known_safe(expr)
+    }
+
+    fn target_assignment_can_raise(target: &ast::Expr) -> bool {
+        !target.is_name_expr()
+    }
+
+    /// Returns `true` if the parser reported invalid or version-incompatible syntax within
+    /// `range`.
+    fn has_syntax_error_in_range(&self, range: TextRange) -> bool {
+        self.module
+            .errors()
+            .iter()
+            .any(|error| range.contains_range(error.range()))
+            || self
+                .module
+                .unsupported_syntax_errors()
+                .iter()
+                .any(|error| range.contains_range(error.range()))
+    }
+
     /// Records a reachability constraint that always evaluates to "ambiguous".
     fn record_ambiguous_reachability(&mut self) {
         self.current_use_def_map_mut()
@@ -2618,6 +2855,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // nodes are evaluated in the inner scope.
         let value = self.add_standalone_expression(&generator.iter);
         self.visit_expr(&generator.iter);
+        let first_iteration_can_raise =
+            generator.is_async || !Self::iteration_is_known_safe(&generator.iter);
+        self.record_exception_checkpoint_if(first_iteration_can_raise);
+        let mut loopback_can_raise =
+            first_iteration_can_raise || Self::target_assignment_can_raise(&generator.target);
 
         // Clear the assignment stack before entering the comprehension scope.
         // If the comprehension appears inside an assignment target (e.g., error-recovered
@@ -2649,6 +2891,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         for generator in generators_iter {
             let value = self.add_standalone_expression(&generator.iter);
             self.visit_expr(&generator.iter);
+            let iteration_can_raise =
+                generator.is_async || !Self::iteration_is_known_safe(&generator.iter);
+            self.record_exception_checkpoint_if(iteration_can_raise);
+            loopback_can_raise |=
+                iteration_can_raise || Self::target_assignment_can_raise(&generator.target);
 
             self.add_unpackable_assignment(
                 &Unpackable::Comprehension {
@@ -2668,6 +2915,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         for filtered_out_path in filtered_out_paths {
             self.flow_merge(filtered_out_path);
         }
+        self.record_exception_checkpoint_if(loopback_can_raise);
         let nested_bindings = self.pop_scope();
         self.synthesize_comprehension_binding_definitions(nested_bindings);
 
@@ -2828,6 +3076,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         target: &'ast ast::Expr,
         value: Expression<'db>,
     ) {
+        self.record_exception_checkpoint_if(matches!(
+            target,
+            ast::Expr::List(_) | ast::Expr::Tuple(_)
+        ));
+
         let current_assignment = match target {
             ast::Expr::List(_) | ast::Expr::Tuple(_) => {
                 if matches!(unpackable, Unpackable::Comprehension { .. }) {
@@ -3124,6 +3377,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
             ast::Stmt::Import(node) => {
                 for (alias_index, alias) in node.names.iter().enumerate() {
+                    self.record_exception_checkpoint();
+
                     // Mark the imported module, and all of its parents, as being imported in this
                     // file.
                     if let Some(module_name) = ModuleName::new(&alias.name) {
@@ -3150,6 +3405,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 }
             }
             ast::Stmt::ImportFrom(node) => {
+                self.record_exception_checkpoint();
+
                 // If we see:
                 //
                 // * `from .x.y import z` (or `from whatever.thispackage.x.y`)
@@ -3225,6 +3482,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 let mut found_star = false;
                 for (alias_index, alias) in node.names.iter().enumerate() {
+                    // Loading each imported name can fail after the module import and any earlier
+                    // names or package-submodule side effects have completed.
+                    self.record_exception_checkpoint();
+
                     if &alias.name == "*" {
                         // The following line maintains the invariant that every AST node that
                         // implements `Into<DefinitionNodeKey>` must have an entry in the
@@ -3401,7 +3662,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let condition_flow_snapshot = self.flow_snapshot_for_condition(test);
                 let predicate = self.build_predicate(test);
 
-                if let Some(msg) = msg {
+                if msg.is_some()
+                    || self
+                        .try_node_context_stack_manager
+                        .has_active_exception_handler()
+                {
                     let truthy = if let Some(snapshots) = condition_flow_snapshot.into_branches() {
                         self.flow_restore(snapshots.falsy);
                         snapshots.truthy
@@ -3411,12 +3676,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     let negated_predicate = predicate.negated();
                     self.record_narrowing_constraint(negated_predicate);
                     self.record_reachability_constraint(negated_predicate);
-                    self.visit_expr(msg);
-                    self.flow_restore(truthy);
-                } else {
-                    if let Some(truthy) = condition_flow_snapshot.into_truthy() {
-                        self.flow_restore(truthy);
+                    if let Some(msg) = msg {
+                        self.visit_expr(msg);
                     }
+                    self.record_exception_checkpoint();
+                    self.flow_restore(truthy);
+                } else if let Some(truthy) = condition_flow_snapshot.into_truthy() {
+                    self.flow_restore(truthy);
                 }
 
                 self.record_narrowing_constraint(predicate);
@@ -3514,32 +3780,46 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 },
             ) => {
                 debug_assert_eq!(&self.current_assignments, &[]);
+
+                // An augmented assignment loads its target before evaluating the right-hand side,
+                // but only defines the target after the operation succeeds.
+                let is_place_target = matches!(
+                    &**target,
+                    ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_)
+                );
+                if is_place_target {
+                    self.push_assignment(CurrentAssignment::AugAssign(aug_assign));
+                    self.visit_expr(target);
+                    self.pop_assignment();
+                } else {
+                    self.visit_expr(target);
+                }
+
                 self.visit_expr(value);
 
-                match &**target {
-                    ast::Expr::Name(ast::ExprName { id, .. })
-                        if id == "__all__" && op.is_add() && self.in_module_scope() =>
-                    {
-                        if let ast::Expr::Attribute(ast::ExprAttribute { value, attr, .. }) =
-                            &**value
-                        {
-                            if attr == "__all__" {
-                                self.add_standalone_expression(value);
-                            }
-                        }
+                if let ast::Expr::Name(ast::ExprName { id, .. }) = &**target
+                    && id == "__all__"
+                    && op.is_add()
+                    && self.in_module_scope()
+                    && let ast::Expr::Attribute(ast::ExprAttribute {
+                        value: module,
+                        attr,
+                        ..
+                    }) = &**value
+                    && attr == "__all__"
+                {
+                    self.add_standalone_expression(module);
+                }
 
-                        self.push_assignment(CurrentAssignment::AugAssign(aug_assign));
-                        self.visit_expr(target);
-                        self.pop_assignment();
-                    }
-                    ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
-                        self.push_assignment(CurrentAssignment::AugAssign(aug_assign));
-                        self.visit_expr(target);
-                        self.pop_assignment();
-                    }
-                    _ => {
-                        self.visit_expr(target);
-                    }
+                self.record_exception_checkpoint();
+
+                if is_place_target
+                    && let Some(place_expr) = PlaceExpr::try_from_expr(target.as_ref())
+                {
+                    let place_id = self.add_place(place_expr);
+                    self.push_assignment(CurrentAssignment::AugAssign(aug_assign));
+                    self.record_place_definition(place_id, target);
+                    self.pop_assignment();
                 }
             }
             ast::Stmt::If(node) => {
@@ -3712,6 +3992,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.populate_loop_header(&bound_place_ids, header_id, loop_min_definition_id);
                 }
 
+                self.record_exception_checkpoint_if(!Self::condition_evaluation_is_known_safe(
+                    test,
+                ));
+
                 // We execute the `else` branch once the condition evaluates to false. This could
                 // happen without ever executing the body, if the condition is false the first time
                 // it's tested. Or it could happen if a _later_ evaluation of the condition yields
@@ -3783,6 +4067,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 let iter_expr = self.add_standalone_expression(iter);
                 self.visit_expr(iter);
+                let iteration_can_raise = *is_async || !Self::iteration_is_known_safe(iter);
+                self.record_exception_checkpoint_if(iteration_can_raise);
 
                 let literal_iterable_is_non_empty = (!*is_async)
                     .then(|| literal_iterable_truthiness(iter))
@@ -3849,6 +4135,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 {
                     self.populate_loop_header(&bound_place_ids, header_id, loop_min_definition_id);
                 }
+
+                self.record_exception_checkpoint_if(
+                    iteration_can_raise || Self::target_assignment_can_raise(target),
+                );
 
                 if let Some(after_iter) = after_empty_iter {
                     self.flow_restore(after_iter);
@@ -4060,31 +4350,35 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 orelse,
                 finalbody,
                 is_star,
-                range: _,
+                range,
                 node_index: _,
             }) => {
                 let was_in_try = std::mem::replace(&mut self.in_try, true);
                 self.record_ambiguous_reachability();
 
-                // Save the state prior to visiting any of the `try` block.
-                //
-                // Potentially none of the `try` block could have been executed prior to executing
-                // the `except` block(s) and/or the `finally` block.
-                // We will merge this state with all of the intermediate
-                // states during the `try` block before visiting those suites.
-                let pre_try_block_state = self.flow_snapshot();
+                let has_bare_handler = handlers.iter().any(|handler| {
+                    let ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    handler.type_.is_none()
+                });
+                self.try_node_context_stack_manager
+                    .push_context(!handlers.is_empty(), has_bare_handler);
 
-                self.try_node_context_stack_manager.push_context();
+                // Invalid syntax means that the runtime behavior of this statement is undefined.
+                // Treat it as a possible exception edge so that parser recovery does not make its
+                // handlers spuriously unreachable.
+                if self.has_syntax_error_in_range(*range) {
+                    self.record_exception_checkpoint();
+                }
 
                 // Visit the `try` block!
                 self.visit_body(body);
 
                 let mut post_except_states = vec![];
 
-                // Take a record also of all the intermediate states we encountered
-                // while visiting the `try` block. Keep the context itself on the stack so that
-                // terminal statements in `except` and `else` suites can still be recorded as
-                // entries to the associated `finally` suite.
+                // Take all checkpoints recorded immediately before operations in the `try` suite
+                // that may raise. Keep the context itself on the stack so that terminal statements
+                // in `except` and `else` suites can still be recorded as entries to the associated
+                // `finally` suite.
                 let try_block_snapshots = self
                     .try_node_context_stack_manager
                     .take_try_suite_snapshots();
@@ -4098,10 +4392,17 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     // if we hit the `else` block.
                     let post_try_block_state = self.flow_snapshot();
 
-                    // Prepare for visiting the `except` block(s)
-                    self.flow_restore(pre_try_block_state);
-                    for state in try_block_snapshots {
-                        self.flow_merge(state);
+                    // Prepare for visiting the `except` block(s). If the `try` suite contained no
+                    // exception checkpoints, its handlers are unreachable.
+                    let mut try_block_snapshots = try_block_snapshots.into_iter();
+                    if let Some(first_snapshot) = try_block_snapshots.next() {
+                        self.flow_restore(first_snapshot);
+                        for snapshot in try_block_snapshots {
+                            self.flow_merge(snapshot);
+                        }
+                    } else {
+                        self.flow_restore(post_try_block_state.clone());
+                        self.mark_unreachable();
                     }
 
                     let pre_except_state = self.flow_snapshot();
@@ -4204,7 +4505,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 self.in_try = was_in_try;
             }
 
-            ast::Stmt::Raise(_) | ast::Stmt::Return(_) => {
+            ast::Stmt::Raise(_) => {
+                walk_stmt(self, stmt);
+                self.record_exception_checkpoint();
+                self.record_terminal_finally_entry();
+                // Everything in the current block after a terminal statement is unreachable.
+                self.mark_unreachable();
+            }
+
+            ast::Stmt::Return(_) => {
                 walk_stmt(self, stmt);
                 self.record_terminal_finally_entry();
                 // Everything in the current block after a terminal statement is unreachable.
@@ -4642,8 +4951,9 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
 
                     let (is_use, is_definition) = match (ctx, self.current_assignment()) {
                         (ast::ExprContext::Store, Some(CurrentAssignment::AugAssign(_))) => {
-                            // For augmented assignment, the target expression is also used.
-                            (true, true)
+                            // Record the target load now; the definition is recorded separately
+                            // after visiting the right-hand side.
+                            (true, false)
                         }
                         (ast::ExprContext::Load, _) => (true, false),
                         (ast::ExprContext::Store, _) => (false, true),
@@ -4654,6 +4964,8 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 }
 
                 walk_expr(self, expr);
+
+                self.record_exception_checkpoint_if(!matches!(expr, ast::Expr::Name(_)));
 
                 if let Some((place_expr, is_use, is_definition)) = deferred_effects {
                     let place_id = self.add_place(place_expr);
@@ -4812,6 +5124,32 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     self.mark_current_comprehension_async();
                 }
             }
+            ast::Expr::Call(_) | ast::Expr::BinOp(_) => {
+                walk_expr(self, expr);
+                self.record_exception_checkpoint();
+            }
+            ast::Expr::UnaryOp(unary) => {
+                walk_expr(self, expr);
+                self.record_exception_checkpoint_if(
+                    unary.op != ast::UnaryOp::Not
+                        || !Self::condition_evaluation_is_known_safe(&unary.operand),
+                );
+            }
+            ast::Expr::Compare(ast::ExprCompare {
+                left,
+                ops,
+                comparators,
+                ..
+            }) => {
+                self.visit_expr(left);
+                for (op, comparator) in ops.iter().zip(comparators) {
+                    self.visit_expr(comparator);
+                    self.record_exception_checkpoint_if(!matches!(
+                        op,
+                        ast::CmpOp::Is | ast::CmpOp::IsNot
+                    ));
+                }
+            }
             ast::Expr::BoolOp(ast::ExprBoolOp {
                 values,
                 range: _,
@@ -4836,6 +5174,9 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     // Only non-final values can short-circuit this boolean operation. The final
                     // value can still have its own outcome-specific flow if it is nested.
                     if index < values.len() - 1 {
+                        self.record_exception_checkpoint_if(
+                            !Self::condition_evaluation_is_known_safe(value),
+                        );
                         let condition_flow_snapshots = self.take_condition_flow_snapshots(value);
                         let predicate = self.build_predicate(value);
                         let possibly_narrowed = self.compute_possibly_narrowed_places(&predicate);
@@ -4929,10 +5270,12 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     self.generator_functions.insert(scope);
                 }
                 walk_expr(self, expr);
+                self.record_exception_checkpoint();
             }
             ast::Expr::Await(_) => {
                 self.mark_current_comprehension_async();
                 walk_expr(self, expr);
+                self.record_exception_checkpoint();
             }
             _ => {
                 walk_expr(self, expr);

--- a/crates/ty_python_core/src/builder/except_handlers.rs
+++ b/crates/ty_python_core/src/builder/except_handlers.rs
@@ -1,3 +1,6 @@
+use smallvec::SmallVec;
+
+use crate::scope::{FileScopeId, ScopeKind};
 use crate::use_def::FlowSnapshot;
 
 use super::SemanticIndexBuilder;
@@ -26,10 +29,11 @@ impl TryNodeContextStackManager {
         );
     }
 
-    /// Push a [`TryNodeContext`] onto the [`TryNodeContextStack`]
-    /// at the top of our stack of stacks
-    pub(super) fn push_context(&mut self) {
-        self.current_try_context_stack().push_context();
+    /// Push a [`TryNodeContext`] onto the [`TryNodeContextStack`] at the top of our stack of
+    /// stacks.
+    pub(super) fn push_context(&mut self, has_handlers: bool, has_bare_handler: bool) {
+        self.current_try_context_stack()
+            .push_context(has_handlers, has_bare_handler);
     }
 
     /// Pop a [`TryNodeContext`] off the [`TryNodeContextStack`] at the top of our stack of stacks.
@@ -43,10 +47,43 @@ impl TryNodeContextStackManager {
         self.current_try_context_stack().take_try_suite_snapshots()
     }
 
-    /// Retrieve the stack that is at the top of our stack of stacks.
-    /// For each `try` block on that stack, push the snapshot onto the `try` block
-    pub(super) fn record_definition(&mut self, builder: &SemanticIndexBuilder) {
-        self.current_try_context_stack().record_definition(builder);
+    /// Record a checkpoint for every active `try` suite that could handle an exception raised at
+    /// the current point in control flow.
+    pub(super) fn record_exception_checkpoint(&mut self, builder: &mut SemanticIndexBuilder) {
+        debug_assert_eq!(self.0.len(), builder.scope_stack.len());
+
+        let mut crossed_comprehensions = SmallVec::<[FileScopeId; 2]>::new();
+
+        for (scope_stack_index, try_context_stack) in self.0.iter_mut().enumerate().rev() {
+            let scope_id = builder.scope_stack[scope_stack_index].file_scope_id;
+            let snapshot = if try_context_stack.has_active_exception_handler() {
+                builder.exception_checkpoint_snapshot(scope_id, &crossed_comprehensions)
+            } else {
+                builder.use_def_maps[scope_id].snapshot()
+            };
+
+            // Each scope has an independent flow state, so an enclosing scope can still be
+            // reachable while we analyze an unreachable nested scope.
+            if snapshot.is_always_unreachable() {
+                break;
+            }
+
+            if !try_context_stack.record_exception_checkpoint(&snapshot)
+                || !builder.exception_checkpoint_crosses_scope_boundary(scope_id)
+            {
+                break;
+            }
+
+            if builder.scopes[scope_id].kind() == ScopeKind::Comprehension {
+                crossed_comprehensions.push(scope_id);
+            }
+        }
+    }
+
+    pub(super) fn has_active_exception_handler(&self) -> bool {
+        self.0
+            .iter()
+            .any(TryNodeContextStack::has_active_exception_handler)
     }
 
     /// Retrieve the stack that is at the top of our stack of stacks.
@@ -70,10 +107,20 @@ impl TryNodeContextStackManager {
 struct TryNodeContextStack(Vec<TryNodeContext>);
 
 impl TryNodeContextStack {
-    /// Push a new [`TryNodeContext`] for recording intermediate states
-    /// while visiting a [`ruff_python_ast::StmtTry`] node that has a `finally` branch.
-    fn push_context(&mut self) {
-        self.0.push(TryNodeContext::default());
+    fn has_active_exception_handler(&self) -> bool {
+        self.0
+            .iter()
+            .any(|context| context.try_suite_snapshots.is_some())
+    }
+
+    /// Push a new [`TryNodeContext`] for recording exception checkpoints and terminal entries
+    /// while visiting a [`ruff_python_ast::StmtTry`] node.
+    fn push_context(&mut self, has_handlers: bool, has_bare_handler: bool) {
+        self.0.push(TryNodeContext {
+            try_suite_snapshots: has_handlers.then(Vec::new),
+            has_bare_handler,
+            ..TryNodeContext::default()
+        });
     }
 
     /// Pop a [`TryNodeContext`] off the stack.
@@ -85,20 +132,28 @@ impl TryNodeContextStack {
 
     /// Take all snapshots recorded while visiting the `try` suite.
     fn take_try_suite_snapshots(&mut self) -> Vec<FlowSnapshot> {
-        std::mem::take(
-            &mut self
-                .0
-                .last_mut()
-                .expect("Cannot take snapshots from an empty `TryBlockContexts` stack")
-                .try_suite_snapshots,
-        )
+        let context = self
+            .0
+            .last_mut()
+            .expect("Cannot take snapshots from an empty `TryBlockContexts` stack");
+        context.try_suite_snapshots.take().unwrap_or_default()
     }
 
-    /// For each `try` block on the stack, push the snapshot onto the `try` block
-    fn record_definition(&mut self, builder: &SemanticIndexBuilder) {
-        for context in &mut self.0 {
-            context.record_definition(builder.flow_snapshot());
+    /// Records the checkpoint for all enclosing active `try` suites in this scope. Returns whether
+    /// the checkpoint should continue propagating to an enclosing scope.
+    fn record_exception_checkpoint(&mut self, snapshot: &FlowSnapshot) -> bool {
+        for context in self.0.iter_mut().rev() {
+            let Some(try_suite_snapshots) = &mut context.try_suite_snapshots else {
+                continue;
+            };
+
+            try_suite_snapshots.push(snapshot.clone());
+            if context.has_bare_handler {
+                return false;
+            }
         }
+
+        true
     }
 
     /// Push the snapshot onto the innermost `try` block's terminal-entry snapshots for its
@@ -110,25 +165,21 @@ impl TryNodeContextStack {
     }
 }
 
-/// Context for tracking definitions over the course of a single
-/// [`ruff_python_ast::StmtTry`] node
+/// Context for tracking exception and `finally` entry states for a single
+/// [`ruff_python_ast::StmtTry`] node.
 ///
 /// It will likely be necessary to add more fields to this struct in the future
 /// when we add more advanced handling of `finally` branches.
 #[derive(Debug, Default)]
 pub(super) struct TryNodeContext {
-    try_suite_snapshots: Vec<FlowSnapshot>,
+    try_suite_snapshots: Option<Vec<FlowSnapshot>>,
     terminal_finally_entry_snapshots: Vec<FlowSnapshot>,
+    has_bare_handler: bool,
 }
 
 impl TryNodeContext {
     pub(super) fn into_terminal_finally_entry_snapshots(self) -> Vec<FlowSnapshot> {
         self.terminal_finally_entry_snapshots
-    }
-
-    /// Take a record of what the internal state looked like after a definition
-    fn record_definition(&mut self, snapshot: FlowSnapshot) {
-        self.try_suite_snapshots.push(snapshot);
     }
 
     /// Take a record of what the internal state looked like before a terminal control-flow

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -20,7 +20,7 @@ use crate::predicate::PatternPredicate;
 use crate::scope::{FileScopeId, ScopeId};
 use crate::symbol::ScopedSymbolId;
 use crate::unpack::{Unpack, UnpackPosition};
-use crate::use_def::BindingWithConstraintsIterator;
+use crate::use_def::{BindingWithConstraintsIterator, ScopedDefinitionId};
 use crate::{Db, Program, SemanticIndex};
 
 /// A definition of a place.
@@ -1623,8 +1623,10 @@ impl NestedBindingsDefinitionKind {
                 .symbol_id(&self.name)?;
             let use_def = index.use_def_map(declaration.file_scope_id);
             let bindings = match self.execution {
-                NestedBindingExecution::Lazy => use_def.reachable_bindings(symbol.into()),
                 NestedBindingExecution::Eager => use_def.end_of_scope_bindings(symbol.into()),
+                NestedBindingExecution::Lazy | NestedBindingExecution::EagerAtException { .. } => {
+                    use_def.reachable_bindings(symbol.into())
+                }
             };
             Some((declaration.is_global(), bindings))
         })
@@ -1685,6 +1687,10 @@ pub enum NestedBindingExecution {
     Lazy,
     /// The nested scope is modeled as running while evaluating the containing expression.
     Eager,
+    /// An exception escaped after this specific comprehension binding was evaluated.
+    EagerAtException {
+        source_definition: ScopedDefinitionId,
+    },
 }
 
 #[derive(

--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -171,13 +171,13 @@ def silence4[T: type[BaseException] | tuple[type[BaseException], ...]](
 
 ```py
 try:
-    pass
+    raise Exception
 # error: [invalid-exception-caught]
 except 3 as e:
     reveal_type(e)  # revealed: Unknown
 
 try:
-    pass
+    raise Exception
 # error: [invalid-exception-caught]
 except (ValueError, OSError, "foo", b"bar") as e:
     reveal_type(e)  # revealed: ValueError | OSError | Unknown

--- a/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/control_flow.md
@@ -8,9 +8,368 @@ For a full writeup on the semantics of exception handlers, see [this document][1
 The tests throughout this Markdown document use functions with names starting with `could_raise_*`
 to mark definitions that might or might not succeed (as the function could raise an exception). A
 type checker must assume that any arbitrary function call could raise an exception in Python; this
-is just a naming convention used in these tests for clarity, and to future-proof the tests against
-possible future improvements whereby certain statements or expressions could potentially be inferred
-as being incapable of causing an exception to be raised.
+is just a naming convention used in these tests for clarity.
+
+## Exception checkpoints
+
+Exception handlers are reachable only from operations that can raise. A local assignment of a
+literal cannot raise, so it does not make the handler reachable:
+
+```py
+x = 1
+try:
+    x = 2
+except:
+    x = "unreachable"
+
+reveal_type(x)  # revealed: Literal[2]
+```
+
+Truth-testing literals, identity comparisons, and Boolean combinations of known-safe expressions
+cannot raise either:
+
+```py
+def known_safe_conditions(value: int | None) -> None:
+    state = 0
+    try:
+        if not False:
+            state = 1
+        if not (value is None):
+            state = 1
+        if True and True:
+            state = 1
+        if False or True:
+            state = 1
+        for _ in [0]:
+            state = 1
+    except:
+        state = 2
+
+    reveal_type(state)  # revealed: Literal[1]
+```
+
+A checkpoint is recorded immediately before the raising operation, after evaluating its child
+expressions. If the outer call below raises, the assignment expression has therefore completed:
+
+```py
+def may_raise(value: object) -> None: ...
+
+x = 0
+try:
+    may_raise(x := 1)
+except:
+    reveal_type(x)  # revealed: Literal[1]
+```
+
+Imports also checkpoint between aliases because a later import can fail after an earlier name has
+been bound:
+
+```py
+first = 0
+try:
+    from collections.abc import Awaitable as first, Iterable as second
+except:
+    reveal_type(first)  # revealed: Literal[0] | <class 'Awaitable'>
+```
+
+Explicit raises and failing assertions also create checkpoints after their child expressions have
+been evaluated:
+
+```py
+x = 1
+try:
+    x = 2
+    raise RuntimeError
+except:
+    reveal_type(x)  # revealed: Literal[2]
+
+def check_assertion(x: int | None) -> None:
+    try:
+        assert x is not None
+    except:
+        reveal_type(x)  # revealed: None
+
+def check_short_circuit_assertion(flag: bool) -> None:
+    state = 2
+    try:
+        assert flag and (state := 0)
+    except:
+        reveal_type(state)  # revealed: Literal[2, 0]
+```
+
+Operations implemented by Python protocols create checkpoints after their operands have been
+evaluated:
+
+```py
+from collections.abc import AsyncIterable, Awaitable, Iterable
+
+class C:
+    value: int
+
+class Number:
+    def __truediv__(self, other: int) -> int:
+        raise NotImplementedError
+
+    def __getitem__(self, key: int) -> "Number":
+        return self
+
+    def __setitem__(self, key: int, value: "Number") -> None:
+        pass
+
+    def __add__(self, other: int) -> "Number":
+        return self
+
+def protocol_operations(c: C, number: Number, values: list[int]) -> None:
+    state: C | int = 0
+    try:
+        (state := c).value
+    except:
+        reveal_type(state)  # revealed: C
+
+    state = 0
+    try:
+        values[state := 1]
+    except:
+        reveal_type(state)  # revealed: Literal[1]
+
+    state = 0
+    try:
+        number / (state := 1)
+    except:
+        reveal_type(state)  # revealed: Literal[1]
+
+    state = 0
+    try:
+        0 < (state := 1)
+    except:
+        reveal_type(state)  # revealed: Literal[1]
+
+def augmented_assignment(number: Number) -> None:
+    target_state = 0
+    rhs_state = 0
+    try:
+        number[target_state := 1] += (rhs_state := 1)
+    except:
+        reveal_type(target_state)  # revealed: Literal[1]
+        reveal_type(rhs_state)  # revealed: Literal[0, 1]
+
+def truthiness(value: object) -> None:
+    state = 0
+    try:
+        if value:
+            state = 1
+    except:
+        reveal_type(state)  # revealed: Literal[0]
+
+    state = 0
+    try:
+        while value:
+            state = 1
+    except:
+        reveal_type(state)  # revealed: Literal[0, 1]
+
+def iteration(values: Iterable[int], target: C) -> None:
+    state = 0
+    try:
+        for _ in values:
+            state = 1
+    except:
+        # Iteration can fail before the first item or after a completed iteration.
+        reveal_type(state)  # revealed: Literal[0, 1]
+
+    state = 0
+    try:
+        for target.value in [0, 1]:
+            state = 1
+    except:
+        # Assigning the target can likewise fail on the first or a later iteration.
+        reveal_type(state)  # revealed: Literal[0, 1]
+
+async def async_iteration(values: AsyncIterable[int]) -> None:
+    state = 0
+    try:
+        async for _ in values:
+            state = 1
+    except:
+        reveal_type(state)  # revealed: Literal[0, 1]
+
+def unpacking(values: Iterable[int]) -> None:
+    state = 0
+    try:
+        first, second = values
+        state = 1
+    except:
+        reveal_type(state)  # revealed: Literal[0]
+
+async def awaiting(value: Awaitable[int]) -> None:
+    state = 0
+    try:
+        await value
+    except:
+        reveal_type(state)  # revealed: Literal[0]
+
+def yielding_from(values: Iterable[int]):
+    state = 0
+    try:
+        yield from values
+    except:
+        reveal_type(state)  # revealed: Literal[0]
+
+def yielding():
+    state = 0
+    try:
+        yield
+    except:
+        reveal_type(state)  # revealed: Literal[0]
+```
+
+Checkpoints propagate through eagerly evaluated nested scopes, but not through lazy generator
+expression bodies:
+
+```py
+def may_raise() -> None: ...
+
+x = 0
+try:
+    class C:
+        may_raise()
+
+except:
+    x = 1
+
+reveal_type(x)  # revealed: Literal[0, 1]
+
+y = 0
+try:
+    [may_raise() for _ in [0]]
+except:
+    y = 1
+
+reveal_type(y)  # revealed: Literal[0, 1]
+
+z = 0
+try:
+    (may_raise() for _ in [0])
+except:
+    z = 1
+
+reveal_type(z)  # revealed: Literal[0]
+
+def comprehension_may_raise() -> None: ...
+def comprehension_walrus_exception() -> None:
+    state = 0
+    try:
+        [(state := 1, comprehension_may_raise()) for _ in [0]]
+    except:
+        reveal_type(state)  # revealed: int
+
+def comprehension_exception_before_walrus() -> None:
+    state = 0
+    try:
+        [(comprehension_may_raise(), state := 1) for _ in [0]]
+    except:
+        reveal_type(state)  # revealed: Literal[0]
+
+def comprehension_exception_before_later_walrus() -> None:
+    state = 0
+    try:
+        [(state := 1, comprehension_may_raise(), state := "later") for _ in [0]]
+    except:
+        reveal_type(state)  # revealed: int
+
+def comprehension_exception_after_conditional_walrus(flag: bool) -> None:
+    state = "before"
+    try:
+        [((state := 1) if flag else 0, comprehension_may_raise(), state := 2) for _ in [0]]
+    except:
+        reveal_type(state)  # revealed: Literal["before"] | int
+
+def comprehension_exception_with_multiple_walruses() -> None:
+    first = 0
+    second = 0
+    try:
+        [(first := 1, second := "bound", comprehension_may_raise(), second := 2) for _ in [0]]
+    except:
+        reveal_type(first)  # revealed: int
+        reveal_type(second)  # revealed: str
+
+def nested_comprehension_walrus_exception() -> None:
+    state = 0
+    try:
+        [[(state := 1, comprehension_may_raise()) for _ in [0]] for _ in [0]]
+    except:
+        reveal_type(state)  # revealed: int
+
+def nested_comprehension_walrus_order() -> None:
+    state = 0
+    try:
+        [((state := "outer"), [(state := 1, comprehension_may_raise()) for _ in [0]]) for _ in [0]]
+    except:
+        reveal_type(state)  # revealed: int
+
+module_comprehension_state = "before"
+try:
+    [(module_comprehension_state := 1, comprehension_may_raise()) for _ in [0]]
+except:
+    reveal_type(module_comprehension_state)  # revealed: int
+
+global_comprehension_state = "before"
+
+def global_comprehension_walrus_exception() -> None:
+    global global_comprehension_state
+    try:
+        [(global_comprehension_state := 1, comprehension_may_raise()) for _ in [0]]
+    except:
+        reveal_type(global_comprehension_state)  # revealed: Literal["before"] | int
+
+async def async_comprehension_walrus_exception(values: AsyncIterable[int], awaitable: Awaitable[int]) -> None:
+    state = "before"
+    try:
+        [(state := 1, await awaitable) async for _ in values]
+    except:
+        reveal_type(state)  # revealed: Literal["before"] | int
+```
+
+An active bare handler receives a checkpoint and prevents it from propagating to an enclosing
+handler. Once execution is inside that handler, however, a new checkpoint can propagate outward:
+
+```py
+def may_raise() -> None: ...
+
+x = 0
+try:
+    try:
+        x = 1
+        may_raise()
+    except:
+        x = 2
+except:
+    x = "outer"
+
+reveal_type(x)  # revealed: Literal[1, 2]
+
+try:
+    try:
+        may_raise()
+    except:
+        x = 3
+        may_raise()
+except:
+    reveal_type(x)  # revealed: Literal[3]
+
+z = 0
+try:
+    class C:
+        try:
+            pass
+        except:
+            may_raise()
+
+except:
+    z = 1
+
+reveal_type(z)  # revealed: Literal[0]
+```
 
 ## A single bare `except`
 
@@ -20,14 +379,10 @@ have been taken from the perspective of code following this block. The inferred 
 block's conclusion is therefore the union of the type at the end of the `try` suite (`str`) and the
 type at the end of the `except` suite (`Literal[2]`).
 
-*Within* the `except` suite, we must infer a union of all possible "definition states" we could have
-been in at any point during the `try` suite. This is because control flow could have jumped to the
-`except` suite without any of the `try`-suite definitions successfully completing, with only *some*
-of the `try`-suite definitions successfully completing, or indeed with *all* of them successfully
-completing. The type of `x` at the beginning of the `except` suite in this example is therefore
-`Literal[1] | str`, taking into account that we might have jumped to the `except` suite before the
-`x = could_raise_returns_str()` redefinition, but we *also* could have jumped to the `except` suite
-*after* that redefinition.
+*Within* the `except` suite, we infer a union of the definition states at each exception checkpoint
+in the `try` suite. The type of `x` at the beginning of the `except` suite in this example is
+therefore `Literal[1] | str`: the call on the right-hand side can raise before the redefinition
+completes, while the later `reveal_type` call can raise after it completes.
 
 ```py
 def could_raise_returns_str() -> str:
@@ -436,13 +791,10 @@ reveal_type(x)  # revealed: C | E | G
 
 ## Nested `try`/`except` blocks
 
-It would take advanced analysis, which we are not yet capable of, to be able to determine that an
-exception handler always suppresses all exceptions. This is partly because it is possible for
-statements in `except`, `else` and `finally` suites to raise exceptions as well as statements in
-`try` suites. This means that if an exception handler is nested inside the `try` statement of an
-enclosing exception handler, it should (at least for now) be treated the same as any other node: as
-a suite containing statements that could possibly raise exceptions, which would lead to control flow
-jumping out of that suite prior to the suite running to completion.
+A checkpoint in a nested `try` suite propagates to both the nested and enclosing handlers unless the
+nested statement has a bare handler. Checkpoints in its `except`, `else`, and `finally` suites
+propagate only to the enclosing handler, because exceptions raised there are not handled by the same
+`try` statement.
 
 ```py
 class A: ...

--- a/crates/ty_python_semantic/resources/mdtest/exception/invalid_syntax.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/invalid_syntax.md
@@ -3,8 +3,13 @@
 ## Invalid syntax
 
 ```py
+state = 1
+
 try:
     print
 except as e:  # error: [invalid-syntax]
     reveal_type(e)  # revealed: Unknown
+    state = "handled"
+
+reveal_type(state)  # revealed: Literal[1, "handled"]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/regression/paramspec_on_python39.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/paramspec_on_python39.md
@@ -12,7 +12,7 @@ diagnostic message for `invalid-exception-caught` expects to construct `typing.P
 # error: [invalid-syntax]
 def foo[**P]() -> None:
     try:
-        pass
+        raise Exception
     # error: [invalid-exception-caught] "Invalid object caught in an exception handler: Object has type `ParamSpec`"
     except P:
         pass

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Exception_Handling_-_Invalid_exception_ha…_(d394c561bdd35078).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/basic.md_-_Exception_Handling_-_Invalid_exception_ha…_(d394c561bdd35078).snap
@@ -14,13 +14,13 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/exception/basic.md
 
 ```
  1 | try:
- 2 |     pass
+ 2 |     raise Exception
  3 | # error: [invalid-exception-caught]
  4 | except 3 as e:
  5 |     reveal_type(e)  # revealed: Unknown
  6 | 
  7 | try:
- 8 |     pass
+ 8 |     raise Exception
  9 | # error: [invalid-exception-caught]
 10 | except (ValueError, OSError, "foo", b"bar") as e:
 11 |     reveal_type(e)  # revealed: ValueError | OSError | Unknown

--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -77,17 +77,17 @@ def return_in_both_branches(cond: bool):
 def return_in_try(cond: bool):
     x = "before"
     try:
-        if cond:
+        if cond is True:
             x = "test"
             return
     except:
-        # TODO: Literal["before"]
-        reveal_type(x)  # revealed: Literal["before", "test"]
+        reveal_type(x)  # revealed: Never
     else:
         reveal_type(x)  # revealed: Literal["before"]
     finally:
-        reveal_type(x)  # revealed: Literal["before", "test"]
-    reveal_type(x)  # revealed: Literal["before", "test"]
+        # TODO: should include `Literal["test"]` from the terminal entry state
+        reveal_type(x)  # revealed: Literal["before"]
+    reveal_type(x)  # revealed: Literal["before"]
 
 def return_in_nested_then_branch(cond1: bool, cond2: bool):
     if cond1:
@@ -361,23 +361,19 @@ def break_in_both_nested_branches(cond1: bool, cond2: bool, i: int):
 
 ## `raise`
 
-A `raise` statement is terminal. If it occurs in a lexically containing `try` statement, it will
-jump to one of the `except` clauses (if it matches the value being raised), or to the `else` clause
-(if none match). Currently, we assume definitions from before the `raise` are visible in all
-`except` and `else` clauses. (In the future, we might analyze the `except` clauses to see which ones
-match the value being raised, and limit visibility to those clauses.) Definitions from before the
-`raise` are not visible in any `else` clause, but are visible in `except` clauses or after the
-containing `try` statement (since control flow may have passed through an `except`).
+A `raise` statement is terminal. If it occurs in a lexically containing `try` statement, it jumps to
+a matching `except` clause or propagates out of the statement. We do not yet analyze which typed
+handler matches the raised value, so every handler sees the same checkpoint states.
 
-Currently we assume that an exception could be raised anywhere within a `try` block. We may want to
-implement a more precise understanding of where exceptions (barring `KeyboardInterrupt` and
-`MemoryError`) can and cannot actually be raised.
+We record exception checkpoints immediately before operations that may invoke Python protocols or
+otherwise raise. An exception handler sees the union of the flow states at those checkpoints, rather
+than every definition state in the `try` suite.
 
 ```py
 def raise_in_then_branch(cond: bool):
     x = "before"
     try:
-        if cond:
+        if cond is True:
             x = "raise"
             reveal_type(x)  # revealed: Literal["raise"]
             raise ValueError
@@ -386,23 +382,19 @@ def raise_in_then_branch(cond: bool):
             reveal_type(x)  # revealed: Literal["else"]
         reveal_type(x)  # revealed: Literal["else"]
     except ValueError:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "raise", "else"]
+        reveal_type(x)  # revealed: Literal["raise", "else"]
     except:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "raise", "else"]
+        reveal_type(x)  # revealed: Literal["raise", "else"]
     else:
         reveal_type(x)  # revealed: Literal["else"]
     finally:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "raise", "else"]
-    # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-    reveal_type(x)  # revealed: Literal["before", "raise", "else"]
+        reveal_type(x)  # revealed: Literal["raise", "else"]
+    reveal_type(x)  # revealed: Literal["raise", "else"]
 
 def raise_in_else_branch(cond: bool):
     x = "before"
     try:
-        if cond:
+        if cond is True:
             x = "else"
             reveal_type(x)  # revealed: Literal["else"]
         else:
@@ -411,23 +403,19 @@ def raise_in_else_branch(cond: bool):
             raise ValueError
         reveal_type(x)  # revealed: Literal["else"]
     except ValueError:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else", "raise"]
+        reveal_type(x)  # revealed: Literal["else", "raise"]
     except:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else", "raise"]
+        reveal_type(x)  # revealed: Literal["else", "raise"]
     else:
         reveal_type(x)  # revealed: Literal["else"]
     finally:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else", "raise"]
-    # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-    reveal_type(x)  # revealed: Literal["before", "else", "raise"]
+        reveal_type(x)  # revealed: Literal["else", "raise"]
+    reveal_type(x)  # revealed: Literal["else", "raise"]
 
 def raise_in_both_branches(cond: bool):
     x = "before"
     try:
-        if cond:
+        if cond is True:
             x = "raise1"
             reveal_type(x)  # revealed: Literal["raise1"]
             raise ValueError
@@ -436,30 +424,26 @@ def raise_in_both_branches(cond: bool):
             reveal_type(x)  # revealed: Literal["raise2"]
             raise ValueError
     except ValueError:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "raise1", "raise2"]
+        reveal_type(x)  # revealed: Literal["raise1", "raise2"]
     except:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "raise1", "raise2"]
+        reveal_type(x)  # revealed: Literal["raise1", "raise2"]
     else:
         # This branch is unreachable, since all control flows in the `try` clause raise exceptions.
         # As a result, this binding should never be reachable, since new bindings are visible only
         # when they are reachable.
         x = "unreachable"
     finally:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "raise1", "raise2"]
-    # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-    reveal_type(x)  # revealed: Literal["before", "raise1", "raise2"]
+        reveal_type(x)  # revealed: Literal["raise1", "raise2"]
+    reveal_type(x)  # revealed: Literal["raise1", "raise2"]
 
 def raise_in_nested_then_branch(cond1: bool, cond2: bool):
     x = "before"
     try:
-        if cond1:
+        if cond1 is True:
             x = "else1"
             reveal_type(x)  # revealed: Literal["else1"]
         else:
-            if cond2:
+            if cond2 is True:
                 x = "raise"
                 reveal_type(x)  # revealed: Literal["raise"]
                 raise ValueError
@@ -469,27 +453,23 @@ def raise_in_nested_then_branch(cond1: bool, cond2: bool):
             reveal_type(x)  # revealed: Literal["else2"]
         reveal_type(x)  # revealed: Literal["else1", "else2"]
     except ValueError:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else1", "raise", "else2"]
+        reveal_type(x)  # revealed: Literal["else1", "raise", "else2"]
     except:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else1", "raise", "else2"]
+        reveal_type(x)  # revealed: Literal["else1", "raise", "else2"]
     else:
         reveal_type(x)  # revealed: Literal["else1", "else2"]
     finally:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else1", "raise", "else2"]
-    # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-    reveal_type(x)  # revealed: Literal["before", "else1", "raise", "else2"]
+        reveal_type(x)  # revealed: Literal["else1", "raise", "else2"]
+    reveal_type(x)  # revealed: Literal["else1", "raise", "else2"]
 
 def raise_in_nested_else_branch(cond1: bool, cond2: bool):
     x = "before"
     try:
-        if cond1:
+        if cond1 is True:
             x = "else1"
             reveal_type(x)  # revealed: Literal["else1"]
         else:
-            if cond2:
+            if cond2 is True:
                 x = "else2"
                 reveal_type(x)  # revealed: Literal["else2"]
             else:
@@ -499,27 +479,23 @@ def raise_in_nested_else_branch(cond1: bool, cond2: bool):
             reveal_type(x)  # revealed: Literal["else2"]
         reveal_type(x)  # revealed: Literal["else1", "else2"]
     except ValueError:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else1", "else2", "raise"]
+        reveal_type(x)  # revealed: Literal["else1", "else2", "raise"]
     except:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else1", "else2", "raise"]
+        reveal_type(x)  # revealed: Literal["else1", "else2", "raise"]
     else:
         reveal_type(x)  # revealed: Literal["else1", "else2"]
     finally:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else1", "else2", "raise"]
-    # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-    reveal_type(x)  # revealed: Literal["before", "else1", "else2", "raise"]
+        reveal_type(x)  # revealed: Literal["else1", "else2", "raise"]
+    reveal_type(x)  # revealed: Literal["else1", "else2", "raise"]
 
 def raise_in_both_nested_branches(cond1: bool, cond2: bool):
     x = "before"
     try:
-        if cond1:
+        if cond1 is True:
             x = "else"
             reveal_type(x)  # revealed: Literal["else"]
         else:
-            if cond2:
+            if cond2 is True:
                 x = "raise1"
                 reveal_type(x)  # revealed: Literal["raise1"]
                 raise ValueError
@@ -529,18 +505,14 @@ def raise_in_both_nested_branches(cond1: bool, cond2: bool):
                 raise ValueError
         reveal_type(x)  # revealed: Literal["else"]
     except ValueError:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else", "raise1", "raise2"]
+        reveal_type(x)  # revealed: Literal["else", "raise1", "raise2"]
     except:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else", "raise1", "raise2"]
+        reveal_type(x)  # revealed: Literal["else", "raise1", "raise2"]
     else:
         reveal_type(x)  # revealed: Literal["else"]
     finally:
-        # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-        reveal_type(x)  # revealed: Literal["before", "else", "raise1", "raise2"]
-    # Exceptions can occur anywhere, so "before" and "raise" are valid possibilities
-    reveal_type(x)  # revealed: Literal["before", "else", "raise1", "raise2"]
+        reveal_type(x)  # revealed: Literal["else", "raise1", "raise2"]
+    reveal_type(x)  # revealed: Literal["else", "raise1", "raise2"]
 ```
 
 ## Terminal in `try` with `finally` clause
@@ -587,7 +559,7 @@ def finally_runs_after_except_and_else_are_terminal():
         x = "else-return"
         return
     finally:
-        reveal_type(x)  # revealed: Literal["except-return", "else-return"]
+        reveal_type(x)  # revealed: Literal["else-return"]
 
 def finally_runs_after_mixed_except_paths(cond: bool):
     x = "before"

--- a/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
@@ -812,4 +812,40 @@ mod tests {
         assert_snapshot!(UnreachableTest::new().render(source)?, @"");
         Ok(())
     }
+
+    #[test]
+    fn protocol_operations_make_exception_handlers_reachable() -> anyhow::Result<()> {
+        let source = r#"
+            def f(value, iterable):
+                try:
+                    value.attribute
+                except:
+                    print("attribute access can raise")
+
+                try:
+                    value[0]
+                except:
+                    print("subscripting can raise")
+
+                try:
+                    value + 1
+                except:
+                    print("operators can raise")
+
+                try:
+                    if value:
+                        pass
+                except:
+                    print("truthiness can raise")
+
+                try:
+                    for _ in iterable:
+                        pass
+                except:
+                    print("iteration can raise")
+            "#;
+
+        assert_snapshot!(UnreachableTest::new().render(source)?, @"");
+        Ok(())
+    }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2512,16 +2512,31 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let recursively_defined = match nested_bindings_kind.execution {
             NestedBindingExecution::Lazy => RecursivelyDefined::Yes,
-            NestedBindingExecution::Eager => RecursivelyDefined::No,
+            NestedBindingExecution::Eager | NestedBindingExecution::EagerAtException { .. } => {
+                RecursivelyDefined::No
+            }
+        };
+        let exception_source = match nested_bindings_kind.execution {
+            NestedBindingExecution::EagerAtException { source_definition } => {
+                Some(source_definition)
+            }
+            NestedBindingExecution::Lazy | NestedBindingExecution::Eager => None,
         };
         let env = self.program_environment();
         let mut union = UnionBuilder::new(db, env).recursively_defined(recursively_defined);
         for bindings in binding_sources {
-            if nested_bindings_kind.execution == NestedBindingExecution::Eager {
+            if matches!(
+                nested_bindings_kind.execution,
+                NestedBindingExecution::Eager | NestedBindingExecution::EagerAtException { .. }
+            ) {
                 // A comprehension can execute repeatedly, so a source that is unreachable in the
                 // first modeled iteration may become reachable in a later one. Preserve each
                 // source's narrowed type and let the proxy's outer use-def state track boundness.
                 for binding in bindings {
+                    if exception_source.is_some_and(|source| source != binding.binding_order) {
+                        continue;
+                    }
+
                     let DefinitionState::Defined(source) = binding.binding else {
                         continue;
                     };
@@ -2551,7 +2566,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ty = union.build();
         let ty = match nested_bindings_kind.execution {
             NestedBindingExecution::Lazy => ty,
-            NestedBindingExecution::Eager => ty.promote(db, env),
+            NestedBindingExecution::Eager | NestedBindingExecution::EagerAtException { .. } => {
+                ty.promote(db, env)
+            }
         };
         self.bindings.insert(definition, ty);
     }


### PR DESCRIPTION
Part of astral-sh/ty#152; this is the shared `try`-checkpoint prerequisite for context-manager exception-flow handling.

## Summary

- Replace definition-based exception flow with checkpoints immediately before Python operations that can raise, without making guaranteed-safe assignments, identity checks, Boolean expressions, or literal iteration spuriously reach handlers.
- Preserve evaluation order across calls, imports, augmented assignments, attribute and subscript protocols, comparisons, truthiness, synchronous and asynchronous loops, assertions, `await`, and both yield forms.
- Propagate checkpoints through eager scopes and nested handlers while respecting lazy generators and bare-handler barriers; capture already-executed comprehension walrus bindings with exact, temporary outer-scope proxies.
- Keep the ordinary no-active-handler path inexpensive and preserve current main-branch comprehension, asynchronous-scope, loop, and short-circuit behavior.

## Test plan

- Markdown tests cover reachable and unreachable handlers, safe literal/identity/Boolean/iteration cases, partial import aliases, augmented-assignment target and right-hand-side ordering, raising Python protocols, nested handlers, recovered invalid syntax, assertions, `await`, and `yield`/`yield from`.
- Comprehension regressions cover eager versus lazy scopes, walrus assignments before and after an exception, later differently typed assignments, conditional and multiple bindings, nested same-name evaluation order, module and global scopes, and asynchronous comprehensions.
- IDE regression coverage verifies that valid protocol operations do not produce false unreachable-code diagnostics.
