### PR TITLE
[ty] Fix gradual class assignability with generic receivers

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1146,6 +1146,32 @@ c: Callable[[Any], str] = A().f
 c: Callable[[Any], str] = A().g
 ```
 
+### Generic method types with gradual class return types
+
+A generic receiver makes signature comparison lazy without changing whether gradual class types are
+assignable.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, Callable
+from ty_extensions import Unknown
+
+class C:
+    def concrete[T](self: T) -> type[int]:
+        return int
+
+    def gradual[T](self: T) -> type[Any]:
+        return int
+
+accepts_any: Callable[[], type[Any]] = C().concrete
+accepts_unknown: Callable[[], type[Unknown]] = C().concrete
+accepts_concrete: Callable[[], type[int]] = C().gradual
+```
+
 ### Class literal types
 
 ```py

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -374,11 +374,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             (SubclassOfInner::Dynamic(_), SubclassOfInner::Class(target_class)) => {
                 ConstraintSet::from_bool(
                     self.constraints,
-                    target_class.is_object(db) || self.is_eager_assignability(),
+                    target_class.is_object(db) || self.relation.is_assignability(),
                 )
             }
             (SubclassOfInner::Class(_), SubclassOfInner::Dynamic(_)) => {
-                ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
+                ConstraintSet::from_bool(self.constraints, self.relation.is_assignability())
             }
 
             // For example, `type[bool]` describes all possible runtime subclasses of the class `bool`,


### PR DESCRIPTION
## Summary

Fix assignability between concrete and gradual class types when a generic method receiver switches callable comparison into lazy constraint evaluation.

Previously, `type[int]` and `type[Any]` were incorrectly treated as incompatible in either direction because class-type comparison required eager assignability. Base the decision on the assignability relation instead, preserving strict subtyping behavior and handling `type[Unknown]` as well.

(This bug came up as part of sample user code for the otherwise unrelated issue https://github.com/astral-sh/ty/issues/4078.)

## Test plan

- Add focused mdtests for generic bound methods returning concrete and gradual class types.
- Cover `type[Any]` and `type[Unknown]`, including concrete-to-gradual and gradual-to-concrete callable assignments.
- Verify the complete `ty_python_semantic` test suite and file-scoped repository hooks.