### PR TITLE
[ty] Clean up abbreviated Sphinx cross-references in rendered docstrings

### DIFF
--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -32,12 +32,13 @@
 
 use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_python_trivia::Cursor;
-use ruff_text_size::{TextRange, TextSize};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use super::preformatted::PreformattedBlockScanner;
 use super::syntax::{
-    ParsedLine, consume_quoted_string, container_block_end, indentation, is_dotted_identifier,
-    parsed_lines, split_once_at_top_level_colon, split_trailing_parenthetical,
+    InlineMarkupScanner, InlineMarkupToken, ParsedLine, consume_quoted_string, container_block_end,
+    indentation, is_dotted_identifier, parsed_lines, split_once_at_top_level_colon,
+    split_trailing_parenthetical,
 };
 use super::{DescriptionBuilder, HeaderKind, SectionKind};
 use crate::FxIndexMap;
@@ -847,42 +848,14 @@ fn split_once_at_field_delimiter(line: &str) -> Option<(&str, &str)> {
 /// :exc:`ValueError`
 /// ```
 fn consume_rest_prefix_role(cursor: &mut Cursor<'_>) -> bool {
-    let mut role = cursor.clone();
-
-    // First, require the candidate delimiter to be the opening colon of a role.
-    if !role.eat_char(':') {
+    let Some(InlineMarkupToken::RestPrefixRole { span, .. }) =
+        InlineMarkupScanner::new(cursor.as_str()).next()
+    else {
         return false;
-    }
+    };
 
-    // Role names start with a Unicode alphanumeric run. Rejecting punctuation here preserves the
-    // first colon in `value::class:` as the field delimiter.
-    if !role.eat_if(char::is_alphanumeric) {
-        return false;
-    }
-
-    // Next, scan the rest of the role name until its closing colon and the opening content
-    // backtick.
-    loop {
-        role.eat_while(char::is_alphanumeric);
-        if role.eat_char2(':', '`') {
-            break;
-        }
-
-        // `-._+:` separators are allowed, but only internally to alphanumeric characters.
-        if !role.eat_if(|character| matches!(character, '-' | '.' | '_' | '+' | ':'))
-            || !role.eat_if(char::is_alphanumeric)
-        {
-            return false;
-        }
-    }
-
-    // Finally, skip the role content so delimiter scanning resumes after its closing backtick.
-    role.eat_while(|character| character != '`');
-    if !role.eat_char('`') {
-        return false;
-    }
-
-    *cursor = role;
+    // Resume delimiter scanning after the closing backtick in e.g., `` :exc:`ValueError` ``.
+    cursor.skip_bytes(span.end().to_usize());
     true
 }
 
@@ -1614,6 +1587,7 @@ Returns:
         for (line, description) in [
             ("value:foo..bar:`X`", "foo..bar:`X`"),
             ("value:foo-:`X`", "foo-:`X`"),
+            ("value:class:``X``", "class:``X``"),
         ] {
             assert_eq!(
                 split_once_at_field_delimiter(line),

--- a/crates/ty_ide/src/docstring/document/numpy.rs
+++ b/crates/ty_ide/src/docstring/document/numpy.rs
@@ -28,8 +28,8 @@ use ruff_text_size::{TextRange, TextSize};
 
 use super::preformatted::{PreformattedBlockScanner, starts_preformatted_block};
 use super::syntax::{
-    ParsedLine, container_block_end, is_dotted_identifier, is_markdown_code_span, parsed_lines,
-    split_once_at_top_level_colon, starts_container_block,
+    ParsedLine, container_block_end, is_dotted_identifier, is_wrapped_in_markdown_code_span,
+    parsed_lines, split_once_at_top_level_colon, starts_container_block,
 };
 use super::{DescriptionBuilder, HeaderKind, SectionKind};
 use crate::FxIndexMap;
@@ -652,7 +652,7 @@ impl<'a> ItemLine<'a> {
         }
 
         // A complete code span is an anonymous type even when its contents contain a colon.
-        if is_markdown_code_span(text) {
+        if is_wrapped_in_markdown_code_span(text) {
             return Some(Self::new(ItemBuilder::new(None, Some(text), ""), false));
         }
 
@@ -689,7 +689,7 @@ impl<'a> ItemLine<'a> {
             .map_or((text, ""), |(name, description)| {
                 (name.trim(), description.trim())
             });
-        if !is_item_name(name) && !is_markdown_code_span(name) {
+        if !is_item_name(name) && !is_wrapped_in_markdown_code_span(name) {
             return None;
         }
 

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -58,11 +58,11 @@ pub(in crate::docstring) fn starts_with_markdown_list_item(line: &str) -> bool {
         && matches!(bytes.get(digits + 1), Some(b' ' | b'\t'))
 }
 
-/// Returns whether `text` consists of a complete Markdown code span.
+/// Returns whether `text` is wrapped in a Markdown code span.
 ///
 /// For example, this returns `true` for ``"`value`"`` and `false` for
 /// ``"`value` trailing"``.
-pub(crate) fn is_markdown_code_span(text: &str) -> bool {
+pub(crate) fn is_wrapped_in_markdown_code_span(text: &str) -> bool {
     let mut tokens = InlineMarkupScanner::new(text);
     let Some(InlineMarkupToken::Code(_)) = tokens.next() else {
         return false;
@@ -530,8 +530,9 @@ pub(super) fn indentation(line: &str) -> TextSize {
 #[cfg(test)]
 mod tests {
     use super::{
-        BacktickScanner, InlineMarkupScanner, InlineMarkupToken, TextSize, is_markdown_code_span,
-        split_once_at_top_level_colon, split_trailing_parenthetical,
+        BacktickScanner, InlineMarkupScanner, InlineMarkupToken, TextSize,
+        is_wrapped_in_markdown_code_span, split_once_at_top_level_colon,
+        split_trailing_parenthetical,
     };
 
     #[test]
@@ -581,7 +582,7 @@ mod tests {
     }
 
     #[test]
-    fn recognizes_complete_markdown_code_spans() {
+    fn recognizes_wrapped_markdown_code_spans() {
         for (text, expected) in [
             ("`value`", true),
             ("``value`with:ticks``", true),
@@ -592,7 +593,7 @@ mod tests {
             ("``", false),
             ("value", false),
         ] {
-            assert_eq!(is_markdown_code_span(text), expected, "{text:?}");
+            assert_eq!(is_wrapped_in_markdown_code_span(text), expected, "{text:?}");
         }
     }
 

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -73,33 +73,32 @@ pub(crate) fn is_wrapped_in_markdown_code_span(text: &str) -> bool {
 
 /// Emits non-overlapping tokens that completely span the source text.
 ///
-/// Currently supports `Code` for complete, unescaped backtick-delimited segments and `Text`
-/// for everything else.
+/// Supports complete backtick-delimited segments, reStructuredText prefix roles, and plain text.
 ///
 /// For example:
 ///
 /// ```text
-/// InlineMarkupScanner::new("before `code` after")
-///     => Text("before "), Code("code"), Text(" after")
+/// InlineMarkupScanner::new("before :class:`Value` and `code`")
+///     => Text("before "), RestPrefixRole("class", "Value"), Text(" and "), Code("code")
 /// ```
-struct InlineMarkupScanner<'a> {
+pub(crate) struct InlineMarkupScanner<'a> {
     /// The scanner used to find complete code spans.
     scanner: BacktickScanner<'a>,
     /// The end of the last token returned to the caller.
     last_token_end: TextSize,
-    /// A span saved while its preceding text is returned first.
-    pending_span: Option<BacktickSpan<'a>>,
+    /// A token saved while its preceding text is returned first.
+    pending_token: Option<InlineMarkupToken<'a>>,
 }
 
 impl<'a> InlineMarkupScanner<'a> {
-    /// Creates a lossless iterator over plain text and complete backtick-delimited code spans.
+    /// Creates a lossless iterator over plain text and complete inline markup.
     ///
     /// Escaped or unmatched backticks remain part of an [`InlineMarkupToken::Text`] token.
-    fn new(source: &'a str) -> Self {
+    pub(crate) fn new(source: &'a str) -> Self {
         Self {
             scanner: BacktickScanner::new(source),
             last_token_end: TextSize::ZERO,
-            pending_span: None,
+            pending_token: None,
         }
     }
 
@@ -115,43 +114,50 @@ impl<'a> Iterator for InlineMarkupScanner<'a> {
     type Item = InlineMarkupToken<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let span = if let Some(span) = self.pending_span.take() {
-            // Emit the span saved while returning its preceding text on the previous call.
-            span
-        } else {
-            loop {
-                // Without another backtick run, the remaining source is all plain text.
-                let Some(opening) = self.scanner.next() else {
-                    return self.take_remaining_text();
-                };
-
-                // Escaped runs are literal source text, so continue looking for the next possible
-                // opening without emitting a token boundary.
-                if opening.is_escaped() {
-                    continue;
-                }
-
-                // Without a closing delimiter, callers cannot treat the opening or any later runs as
-                // structured markup. Emit the remainder as one text token.
-                let Some(span) = self.scanner.eat_span(opening) else {
-                    return self.take_remaining_text();
-                };
-                break span;
-            }
-        };
-
-        if self.last_token_end < span.start() {
-            let preceding_text = TextRange::new(self.last_token_end, span.start());
-            self.last_token_end = span.start();
-            self.pending_span = Some(span);
-            return Some(InlineMarkupToken::Text(
-                &self.scanner.source[preceding_text],
-            ));
+        if let Some(token) = self.pending_token.take() {
+            return Some(token);
         }
 
-        debug_assert_eq!(self.last_token_end, span.start());
+        let span = loop {
+            // Without another backtick run, the remaining source is all plain text.
+            let Some(opening) = self.scanner.next() else {
+                return self.take_remaining_text();
+            };
+
+            // Escaped runs are literal source text, so continue looking for the next possible
+            // opening without emitting a token boundary.
+            if opening.is_escaped() {
+                continue;
+            }
+
+            // Without a closing delimiter, callers cannot treat the opening or any later runs as
+            // structured markup. Emit the remainder as one text token.
+            let Some(span) = self.scanner.eat_span(opening) else {
+                return self.take_remaining_text();
+            };
+            break span;
+        };
+
+        let preceding_range = TextRange::new(self.last_token_end, span.start());
+        let preceding_text = &self.scanner.source[preceding_range];
+        let (preceding_text, token) = if span.is_single()
+            && let Some((preceding_text, name)) = split_trailing_rest_prefix_role(preceding_text)
+        {
+            (
+                preceding_text,
+                InlineMarkupToken::RestPrefixRole { name, span },
+            )
+        } else {
+            (preceding_text, InlineMarkupToken::Code(span))
+        };
+
         self.last_token_end = span.end();
-        Some(InlineMarkupToken::Code(span))
+        if preceding_text.is_empty() {
+            Some(token)
+        } else {
+            self.pending_token = Some(token);
+            Some(InlineMarkupToken::Text(preceding_text))
+        }
     }
 }
 
@@ -160,17 +166,58 @@ impl<'a> Iterator for InlineMarkupScanner<'a> {
 /// For example:
 ///
 /// ```text
-/// source      "before `code` after"
-/// tokens      Text("before "), Code("code"), Text(" after")
+/// source      "before :class:`Value` and `code`"
+/// tokens      Text("before "), RestPrefixRole("class", "Value"), Text(" and "), Code("code")
 /// ```
 ///
 /// Escaped and unmatched backticks remain text.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum InlineMarkupToken<'a> {
+pub(crate) enum InlineMarkupToken<'a> {
     /// Source text outside a complete, unescaped backtick span.
     Text(&'a str),
     /// A complete code span whose backtick delimiters have equal lengths.
     Code(BacktickSpan<'a>),
+    /// A valid reStructuredText prefix role and its single-backtick span.
+    RestPrefixRole {
+        /// The role name between the colons, for example `py:class`.
+        name: &'a str,
+        /// The complete single-backtick span following the role name.
+        span: BacktickSpan<'a>,
+    },
+}
+
+/// Splits a valid trailing reStructuredText prefix role from its preceding text.
+///
+/// For example, `"before :py:class:"` becomes `("before ", "py:class")`.
+fn split_trailing_rest_prefix_role(text: &str) -> Option<(&str, &str)> {
+    let without_closing_colon = text.strip_suffix(':')?;
+    let mut role_start = without_closing_colon.len();
+    let mut expects_alphanumeric = true;
+
+    // Walk `before :py:class` backwards; separators must be between alphanumeric components.
+    for (index, character) in without_closing_colon.char_indices().rev() {
+        if character.is_alphanumeric() {
+            expects_alphanumeric = false;
+            role_start = index;
+            continue;
+        }
+        if !matches!(character, '-' | '.' | '_' | '+' | ':') {
+            break;
+        }
+        if expects_alphanumeric {
+            break;
+        }
+
+        expects_alphanumeric = true;
+        role_start = index;
+    }
+
+    if !expects_alphanumeric {
+        return None;
+    }
+
+    let role_name = without_closing_colon[role_start..].strip_prefix(':')?;
+    Some((&without_closing_colon[..role_start], role_name))
 }
 
 /// Source text delimited by ordered backtick runs of equal length.
@@ -557,12 +604,17 @@ mod tests {
         assert_eq!(
             token_contents(source),
             vec![
-                ("text", "é :class:"),
-                ("code", "~pkg.Widget"),
+                ("text", "é "),
+                ("rest role", "~pkg.Widget"),
                 ("text", " or "),
                 ("code", "literal`tick"),
                 ("text", " β"),
             ]
+        );
+
+        assert_eq!(
+            token_contents("int-:class:`pkg.Model`"),
+            vec![("text", "int-"), ("rest role", "pkg.Model")]
         );
     }
 
@@ -594,6 +646,29 @@ mod tests {
             ("value", false),
         ] {
             assert_eq!(is_wrapped_in_markdown_code_span(text), expected, "{text:?}");
+        }
+    }
+
+    #[test]
+    fn recognizes_rest_prefix_roles() {
+        for (source, expected) in [
+            (":class:`Value`", Some(("class", "Value"))),
+            (":py:class:`Value`", Some(("py:class", "Value"))),
+            (
+                ":external+python:py:class:`Value`",
+                Some(("external+python:py:class", "Value")),
+            ),
+            (":étiquette:`valeur`", Some(("étiquette", "valeur"))),
+            (":foo..bar:`Value`", None),
+        ] {
+            let actual = InlineMarkupScanner::new(source).next().and_then(|token| {
+                if let InlineMarkupToken::RestPrefixRole { name, span } = token {
+                    Some((name, span.content()))
+                } else {
+                    None
+                }
+            });
+            assert_eq!(actual, expected, "{source:?}");
         }
     }
 
@@ -710,6 +785,7 @@ mod tests {
             .map(|token| match token {
                 InlineMarkupToken::Text(text) => ("text", text),
                 InlineMarkupToken::Code(code) => ("code", code.content()),
+                InlineMarkupToken::RestPrefixRole { span, .. } => ("rest role", span.content()),
             })
             .collect()
     }

--- a/crates/ty_ide/src/docstring/markdown.rs
+++ b/crates/ty_ide/src/docstring/markdown.rs
@@ -3,6 +3,67 @@ mod structured;
 
 use super::DocstringFragment;
 
+/// Returns the display label for an explicit reStructuredText role.
+///
+/// For example, `("py:meth", "~list.pop")` becomes `"pop"` and
+/// `("class", "Widget <package.Widget>")` becomes `"Widget"`.
+fn rest_role_display_label<'a>(name: &str, markup: &'a str) -> &'a str {
+    let explicit_title = markup
+        .strip_suffix('>')
+        .and_then(|markup| markup.split_once('<'))
+        .map(|(title, _)| title.trim_end());
+
+    explicit_title.unwrap_or_else(|| interpreted_text_label(markup, is_python_domain_role(name)))
+}
+
+/// Returns whether `name` is a Sphinx Python-domain cross-reference role.
+fn is_python_domain_role(name: &str) -> bool {
+    let mut components = name.rsplit(':');
+    let Some(role) = components.next() else {
+        return false;
+    };
+
+    matches!(components.next(), None | Some("py"))
+        && matches!(
+            role,
+            "attr"
+                | "class"
+                | "const"
+                | "data"
+                | "deco"
+                | "exc"
+                | "func"
+                | "meth"
+                | "mod"
+                | "obj"
+                | "type"
+        )
+}
+
+/// Returns the display label for reStructuredText interpreted text.
+///
+/// For example, `"~pkg.Widget"` becomes `"Widget"`; a Python role target like `".lines.line"`
+/// becomes `"lines.line"`.
+fn interpreted_text_label(text: &str, is_python_role_target: bool) -> &str {
+    let (abbreviated, target) = text
+        .strip_prefix('~')
+        .map_or((false, text), |target| (true, target));
+    let target = if is_python_role_target {
+        target.strip_prefix('.').unwrap_or(target)
+    } else {
+        target
+    };
+    if target.is_empty() {
+        return text;
+    }
+
+    if abbreviated {
+        target.rsplit_once('.').map_or(target, |(_, label)| label)
+    } else {
+        target
+    }
+}
+
 /// Render Markdown for a source docstring.
 ///
 /// `source` must have already undergone PEP-257 trimming and universal newline

--- a/crates/ty_ide/src/docstring/markdown/general/inline.rs
+++ b/crates/ty_ide/src/docstring/markdown/general/inline.rs
@@ -4,10 +4,12 @@
 //! The following forms are unsupported and are passed through this rendered
 //! without modification:
 //!
-//! - Sphinx roles such as `:ref:`, because they depend on Sphinx context
 //! - Relative targets, because a standalone docstring has no document base
 //! - Named references, because they require collecting and resolving target
 //!   definitions across the entire docstring
+//!
+//! Explicit Sphinx roles are rendered as inline code using their display label,
+//! but are not resolved as hyperlinks because that requires Sphinx context.
 //!
 //! The set of links we've chosen to support was informed by a point-in-time
 //! review of 475 direct links that appeared in a sample of popular public
@@ -51,7 +53,9 @@ use std::borrow::Cow;
 
 use ruff_text_size::{Ranged, TextSize};
 
-use crate::docstring::document::syntax::BacktickScanner;
+use crate::docstring::document::syntax::{BacktickScanner, InlineMarkupScanner, InlineMarkupToken};
+
+use super::super::rest_role_display_label;
 
 /// Exposes an interface for rendering a line of prose that may contain a hyperlink.
 #[derive(Default)]
@@ -535,6 +539,33 @@ fn render_markdown_link(output: &mut String, label: Option<&str>, uri: &str) {
 ///
 /// Inline code is assumed not to span lines.
 fn render_inline_text(output: &mut String, text: &str) {
+    let mut source_offset = 0;
+    let mut rendered_end = 0;
+
+    for token in InlineMarkupScanner::new(text) {
+        match token {
+            InlineMarkupToken::Text(text) => {
+                source_offset += text.len();
+            }
+            InlineMarkupToken::Code(span) => {
+                source_offset = span.end().to_usize();
+            }
+            InlineMarkupToken::RestPrefixRole { name, span } => {
+                render_inline_text_without_roles(output, &text[rendered_end..source_offset]);
+                output.push('`');
+                output.push_str(rest_role_display_label(name, span.content()));
+                output.push('`');
+
+                source_offset = span.end().to_usize();
+                rendered_end = source_offset;
+            }
+        }
+    }
+
+    render_inline_text_without_roles(output, &text[rendered_end..]);
+}
+
+fn render_inline_text_without_roles(output: &mut String, text: &str) {
     let mut in_inline_code = false;
     let mut first_chunk = true;
     let mut opening_tick_count = 0;
@@ -867,6 +898,32 @@ localization
             ("``C:\\`` and __dunder__", r"``C:\`` and \_\_dunder\_\_"),
             ("This is `unclosed", "This is `unclosed"),
             (r"\` literal `__dunder__", r"\` literal `\_\_dunder\_\_"),
+        ]);
+    }
+
+    #[test]
+    fn renders_sphinx_cross_references() {
+        assert_rendered(&[
+            (
+                "Remove the last item using :py:meth:`~list.pop`.",
+                "Remove the last item using `pop`.",
+            ),
+            (
+                "Wrap with :class:`~package.module.Widget`, if needed.",
+                "Wrap with `Widget`, if needed.",
+            ),
+            (
+                "Use :py:func:`~package.prepare`, then :py:meth:`~list.pop`.",
+                "Use `prepare`, then `pop`.",
+            ),
+            (
+                "Accept files ending in `.py`; `~value` is treated literally.",
+                "Accept files ending in `.py`; `~value` is treated literally.",
+            ),
+            (
+                "See :py:class:`package.Widget` and :py:class:`Widget <package.Widget>`.",
+                "See `package.Widget` and `Widget`.",
+            ),
         ]);
     }
 

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -6,7 +6,9 @@ use strum::IntoEnumIterator;
 use super::general;
 use crate::docstring::document::SectionKind;
 use crate::docstring::document::preformatted::MarkdownFence;
-use crate::docstring::document::syntax::{is_markdown_code_span, starts_with_markdown_list_item};
+use crate::docstring::document::syntax::{
+    is_wrapped_in_markdown_code_span, starts_with_markdown_list_item,
+};
 
 mod google;
 mod numpy;
@@ -372,7 +374,7 @@ fn description_block_start(description: &str) -> Option<usize> {
 fn render_type_code_span_into(output: &mut String, ty: &str) {
     let normalized = normalize_type_for_code_span(ty);
 
-    if is_markdown_code_span(&normalized) {
+    if is_wrapped_in_markdown_code_span(&normalized) {
         output.push_str(&normalized);
         return;
     }

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -7,7 +7,8 @@ use super::general;
 use crate::docstring::document::SectionKind;
 use crate::docstring::document::preformatted::MarkdownFence;
 use crate::docstring::document::syntax::{
-    is_wrapped_in_markdown_code_span, starts_with_markdown_list_item,
+    InlineMarkupScanner, InlineMarkupToken, is_wrapped_in_markdown_code_span,
+    starts_with_markdown_list_item,
 };
 
 mod google;
@@ -379,7 +380,44 @@ fn render_type_code_span_into(output: &mut String, ty: &str) {
         return;
     }
 
+    let normalized = normalize_embedded_type_markup(&normalized);
     render_code_span_into(output, normalized.as_ref());
+}
+
+/// Removes embedded backticks, reStructuredText role prefixes, and punctuation escapes before
+/// wrapping a type in a code span.
+///
+/// For example, ``"str or :class:`pkg.Type` or `pkg.Other`"`` becomes
+/// `"str or pkg.Type or pkg.Other"`, and `"-\\|>"` becomes `"-|>"`.
+fn normalize_embedded_type_markup(ty: &str) -> Cow<'_, str> {
+    if !ty.contains('`') && !ty.contains('\\') {
+        return Cow::Borrowed(ty);
+    }
+
+    let mut normalized = String::with_capacity(ty.len());
+    for token in InlineMarkupScanner::new(ty) {
+        match token {
+            InlineMarkupToken::Text(text) => push_unescaped(&mut normalized, text),
+            InlineMarkupToken::Code(span) | InlineMarkupToken::RestPrefixRole { span, .. } => {
+                push_unescaped(&mut normalized, span.content());
+            }
+        }
+    }
+
+    Cow::Owned(normalized)
+}
+
+fn push_unescaped(output: &mut String, text: &str) {
+    let mut characters = text.chars().peekable();
+    while let Some(character) = characters.next() {
+        if character == '\\'
+            && let Some(escaped) = characters.next_if(char::is_ascii_punctuation)
+        {
+            output.push(escaped);
+        } else {
+            output.push(character);
+        }
+    }
 }
 
 /// Normalizes type text so it fits in a single Markdown code span.
@@ -602,6 +640,43 @@ mod tests {
 
         **&lt;value&gt; &amp; \[docs\](target) \| \~deleted\~**<HB>
         Escaped name.
+        ");
+    }
+
+    #[test]
+    fn section_items_normalize_source_markup_in_types() {
+        let _snap = bind_markdown_snapshot_filters();
+        let section = section_block(vec![
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("rng"),
+                Some("{None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional"),
+                "Random number generator.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("arrowstyle"),
+                Some(r"str (default='-\|>')"),
+                "Arrow style.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("model"),
+                Some("str or :class:`pkg.Model`"),
+                "Model type.",
+            ),
+        ]);
+
+        assert_snapshot!(render_markdown(&section), @"
+        ## Parameters
+        **rng**: `{None, int, numpy.random.Generator, numpy.random.RandomState}, optional`<HB>
+        Random number generator.
+
+        **arrowstyle**: `str (default='-|>')`<HB>
+        Arrow style.
+
+        **model**: `str or pkg.Model`<HB>
+        Model type.
         ");
     }
 

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use strum::IntoEnumIterator;
 
-use super::general;
+use super::{general, interpreted_text_label, rest_role_display_label};
 use crate::docstring::document::SectionKind;
 use crate::docstring::document::preformatted::MarkdownFence;
 use crate::docstring::document::syntax::{
@@ -413,67 +413,13 @@ fn normalize_embedded_type_markup(ty: &str) -> Cow<'_, str> {
             }
             InlineMarkupToken::RestPrefixRole { name, span } => {
                 // ":class:`Model <pkg.Model>`" -> "Model"; ":obj:`.lines.line`" -> "lines.line".
-                let markup = span.content();
-                let explicit_title = markup
-                    .strip_suffix('>')
-                    .and_then(|markup| markup.split_once('<'))
-                    .map(|(title, _)| title.trim_end());
-                let display_text = explicit_title
-                    .unwrap_or_else(|| interpreted_text_label(markup, is_python_domain_role(name)));
+                let display_text = rest_role_display_label(name, span.content());
                 push_unescaped(&mut normalized, display_text);
             }
         }
     }
 
     Cow::Owned(normalized)
-}
-
-/// Returns whether `name` is a Sphinx Python-domain cross-reference role.
-fn is_python_domain_role(name: &str) -> bool {
-    let mut components = name.rsplit(':');
-    let Some(role) = components.next() else {
-        return false;
-    };
-
-    matches!(components.next(), None | Some("py"))
-        && matches!(
-            role,
-            "attr"
-                | "class"
-                | "const"
-                | "data"
-                | "deco"
-                | "exc"
-                | "func"
-                | "meth"
-                | "mod"
-                | "obj"
-                | "type"
-        )
-}
-
-/// Returns the display label for reStructuredText interpreted text.
-///
-/// For example, `"~pkg.Widget"` becomes `"Widget"`; a Python role target like `".lines.line"`
-/// becomes `"lines.line"`.
-fn interpreted_text_label(text: &str, is_python_role_target: bool) -> &str {
-    let (abbreviated, target) = text
-        .strip_prefix('~')
-        .map_or((false, text), |target| (true, target));
-    let target = if is_python_role_target {
-        target.strip_prefix('.').unwrap_or(target)
-    } else {
-        target
-    };
-    if target.is_empty() {
-        return text;
-    }
-
-    if abbreviated {
-        target.rsplit_once('.').map_or(target, |(_, label)| label)
-    } else {
-        target
-    }
 }
 
 fn push_unescaped(output: &mut String, text: &str) {

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -375,7 +375,9 @@ fn description_block_start(description: &str) -> Option<usize> {
 fn render_type_code_span_into(output: &mut String, ty: &str) {
     let normalized = normalize_type_for_code_span(ty);
 
-    if is_wrapped_in_markdown_code_span(&normalized) {
+    // Preserve existing code spans, except abbreviated Sphinx references such as
+    // "`~pkg.Model`", whose display label is "Model".
+    if !normalized.starts_with("`~") && is_wrapped_in_markdown_code_span(&normalized) {
         output.push_str(&normalized);
         return;
     }
@@ -384,11 +386,12 @@ fn render_type_code_span_into(output: &mut String, ty: &str) {
     render_code_span_into(output, normalized.as_ref());
 }
 
-/// Removes embedded backticks, reStructuredText role prefixes, and punctuation escapes before
-/// wrapping a type in a code span.
+/// Removes markup before wrapping a type in a code span. For example:
 ///
-/// For example, ``"str or :class:`pkg.Type` or `pkg.Other`"`` becomes
-/// `"str or pkg.Type or pkg.Other"`, and `"-\\|>"` becomes `"-|>"`.
+/// ```text
+/// str or :class:`~pkg.Widget` or `pkg.Other` -> str or Widget or pkg.Other
+/// -\|> -> -|>
+/// ```
 fn normalize_embedded_type_markup(ty: &str) -> Cow<'_, str> {
     if !ty.contains('`') && !ty.contains('\\') {
         return Cow::Borrowed(ty);
@@ -398,13 +401,79 @@ fn normalize_embedded_type_markup(ty: &str) -> Cow<'_, str> {
     for token in InlineMarkupScanner::new(ty) {
         match token {
             InlineMarkupToken::Text(text) => push_unescaped(&mut normalized, text),
-            InlineMarkupToken::Code(span) | InlineMarkupToken::RestPrefixRole { span, .. } => {
-                push_unescaped(&mut normalized, span.content());
+            InlineMarkupToken::Code(span) => {
+                let markup = span.content();
+                // "`~pkg.Widget`" -> "Widget"; "``literal`tick``" -> "literal`tick".
+                let display_text = if span.is_single() {
+                    interpreted_text_label(markup, false)
+                } else {
+                    markup
+                };
+                push_unescaped(&mut normalized, display_text);
+            }
+            InlineMarkupToken::RestPrefixRole { name, span } => {
+                // ":class:`Model <pkg.Model>`" -> "Model"; ":obj:`.lines.line`" -> "lines.line".
+                let markup = span.content();
+                let explicit_title = markup
+                    .strip_suffix('>')
+                    .and_then(|markup| markup.split_once('<'))
+                    .map(|(title, _)| title.trim_end());
+                let display_text = explicit_title
+                    .unwrap_or_else(|| interpreted_text_label(markup, is_python_domain_role(name)));
+                push_unescaped(&mut normalized, display_text);
             }
         }
     }
 
     Cow::Owned(normalized)
+}
+
+/// Returns whether `name` is a Sphinx Python-domain cross-reference role.
+fn is_python_domain_role(name: &str) -> bool {
+    let mut components = name.rsplit(':');
+    let Some(role) = components.next() else {
+        return false;
+    };
+
+    matches!(components.next(), None | Some("py"))
+        && matches!(
+            role,
+            "attr"
+                | "class"
+                | "const"
+                | "data"
+                | "deco"
+                | "exc"
+                | "func"
+                | "meth"
+                | "mod"
+                | "obj"
+                | "type"
+        )
+}
+
+/// Returns the display label for reStructuredText interpreted text.
+///
+/// For example, `"~pkg.Widget"` becomes `"Widget"`; a Python role target like `".lines.line"`
+/// becomes `"lines.line"`.
+fn interpreted_text_label(text: &str, is_python_role_target: bool) -> &str {
+    let (abbreviated, target) = text
+        .strip_prefix('~')
+        .map_or((false, text), |target| (true, target));
+    let target = if is_python_role_target {
+        target.strip_prefix('.').unwrap_or(target)
+    } else {
+        target
+    };
+    if target.is_empty() {
+        return text;
+    }
+
+    if abbreviated {
+        target.rsplit_once('.').map_or(target, |(_, label)| label)
+    } else {
+        target
+    }
 }
 
 fn push_unescaped(output: &mut String, text: &str) {
@@ -677,6 +746,72 @@ mod tests {
 
         **model**: `str or pkg.Model`<HB>
         Model type.
+        ");
+    }
+
+    #[test]
+    fn section_items_remove_rest_roles_from_types() {
+        let _snap = bind_markdown_snapshot_filters();
+        let section = section_block(vec![
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("colormap"),
+                Some(
+                    "str or :class:`~matplotlib.colors.Colormap` or :mod:`matplotlib.colors` or `~.pandas.Index`",
+                ),
+                "Color mapping.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("model"),
+                Some("`~astropy.modeling.core.Model`"),
+                "Model.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("extension"),
+                Some("`.py`"),
+                "File extension.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("config"),
+                Some("str or `.env` or `.Figure` or `.lines.Line2D`"),
+                "Configuration source.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("line"),
+                Some(":py:obj:`.lines.line`"),
+                "Line helper.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("model"),
+                Some(":class:`Model <pkg.Model>`"),
+                "Named model.",
+            ),
+        ]);
+
+        assert_snapshot!(render_markdown(&section), @"
+        ## Parameters
+        **colormap**: `str or Colormap or matplotlib.colors or Index`<HB>
+        Color mapping.
+
+        **model**: `Model`<HB>
+        Model.
+
+        **extension**: `.py`<HB>
+        File extension.
+
+        **config**: `str or .env or .Figure or .lines.Line2D`<HB>
+        Configuration source.
+
+        **line**: `lines.line`<HB>
+        Line helper.
+
+        **model**: `Model`<HB>
+        Named model.
         ");
     }
 

--- a/crates/ty_ide/src/docstring/markdown/structured/numpy.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/numpy.rs
@@ -211,6 +211,23 @@ beta : float
     }
 
     #[test]
+    fn renders_sphinx_cross_reference_in_parameter_description() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Parameters
+----------
+widget : object
+    Wrap with :class:`~package.module.Widget`, if needed.
+";
+
+        assert_snapshot!(render_numpy(docstring), @"
+        ## Parameters
+        **widget**: `object`<HB>
+        Wrap with `Widget`, if needed.
+        ");
+    }
+
+    #[test]
     fn renders_shifted_top_level_sections() {
         let _snap = bind_markdown_snapshot_filters();
         let docstring = "\

--- a/crates/ty_ide/src/docstring/markdown/structured/rst.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/rst.rs
@@ -382,7 +382,7 @@ Summary.
     }
 
     #[test]
-    fn preserve_inline_roles_in_prose() {
+    fn renders_inline_roles_in_prose() {
         let _snap = bind_markdown_snapshot_filters();
         let docstring = "\
 This is a function description.
@@ -394,7 +394,7 @@ This is a function description.
 
         assert_snapshot!(rendered, @"
         This is a function description.<HB>
-        :class:`Foo` instances can be passed here.
+        `Foo` instances can be passed here.
 
         ## Parameters
         **value**<HB>


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4088.

This change improves the rendering of Sphinx cross-references in docstrings by extending the role-aware parsing introduced in #26923 to general docstring prose and parameter descriptions.

Specifically, it:

- Renders Sphinx cross-references as inline code using their display label.
- Applies Sphinx's `~` abbreviation convention (for example, `:py:meth:\`~list.pop\`` renders as `` `pop` ``).
- Supports multiple references within the same sentence, including surrounding punctuation.
- Handles cross-references in parameter descriptions as well as ordinary prose.
- Preserves non-Sphinx text such as `.py` and `~value`.
- Shares the display-label selection logic between structured type rendering and general docstring rendering to keep the behavior consistent.

> **Note:** This change builds on the role-aware Sphinx parsing introduced in #26923 and should be reviewed after that PR lands.

## Testing

```text
cargo test -p ty_ide
cargo test -p ty_ide docstring::
cargo clippy -p ty_ide --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
uv run --only-group dev --locked prek run --files ...