### PR TITLE
[ty] Narrow tagged unions through all type kinds

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -2224,18 +2224,40 @@ def never_unequal_narrowing(x: Any, value: Literal[NeverUnequalEnum.A]) -> None:
         reveal_type(x)  # revealed: Any & ~Literal[NeverUnequalEnum.A]
 ```
 
-## Narrowing tagged unions of nominal classes by attribute
+## Narrowing tagged unions by attribute
 
 ```py
-from typing import Literal
+from typing import Literal, Protocol
 
-class A:
+from ty_extensions import Intersection
+
+class BaseA:
     tag: Literal["a"]
+
+class A(BaseA):
     field_a: int
 
 class B:
     tag: Literal["b"]
     field_b: str
+
+class Marker(Protocol):
+    marked: bool
+
+class TaggedA(Protocol):
+    field_a: int
+
+    @property
+    def tag(self) -> Literal["a"]: ...
+
+class TaggedB(Protocol):
+    field_b: str
+
+    @property
+    def tag(self) -> Literal["b"]: ...
+
+class Container:
+    value: A | B | None
 
 def _(x: A | B):
     if x.tag == "a":
@@ -2254,6 +2276,44 @@ def _(x: A | B):
         reveal_type(x)  # revealed: B
     else:
         reveal_type(x)  # revealed: A
+
+def truthiness_guard(value: A | B | None):
+    if not value:
+        return
+
+    reveal_type(value)  # revealed: (A & ~AlwaysFalsy) | (B & ~AlwaysFalsy)
+
+    if value.tag == "a":
+        reveal_type(value)  # revealed: A & ~AlwaysFalsy
+        reveal_type(value.field_a)  # revealed: int
+    else:
+        reveal_type(value)  # revealed: B & ~AlwaysFalsy
+        reveal_type(value.field_b)  # revealed: str
+
+def nested_attribute_after_truthiness_guard(container: Container):
+    if not container.value:
+        return
+
+    if container.value.tag == "a":
+        reveal_type(container.value)  # revealed: A & ~AlwaysFalsy
+        reveal_type(container.value.field_a)  # revealed: int
+    else:
+        reveal_type(container.value)  # revealed: B & ~AlwaysFalsy
+        reveal_type(container.value.field_b)  # revealed: str
+
+def positive_intersection(value: Intersection[A, Marker] | Intersection[B, Marker]):
+    if value.tag == "a":
+        reveal_type(value)  # revealed: A & Marker
+    else:
+        reveal_type(value)  # revealed: B & Marker
+
+def protocol_union(value: TaggedA | TaggedB):
+    if value.tag == "a":
+        reveal_type(value)  # revealed: TaggedA
+        reveal_type(value.field_a)  # revealed: int
+    else:
+        reveal_type(value)  # revealed: TaggedB
+        reveal_type(value.field_b)  # revealed: str
 ```
 
 Enum literals are also supported as attribute tags:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -146,6 +146,15 @@ def nonsingleton_newtype_tag(value: Foo | Bar, tag: BoolTag):
         reveal_type(value)  # revealed: Foo | Bar
     else:
         reveal_type(value)  # revealed: Foo | Bar
+
+def boolean_tags_after_truthiness(value: Foo | Bar | None):
+    if not value:
+        return
+
+    if value.tag is True:
+        reveal_type(value)  # revealed: Bar & ~AlwaysFalsy
+    else:
+        reveal_type(value)  # revealed: Foo & ~AlwaysFalsy
 ```
 
 ## `is` in chained comparisons

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -111,6 +111,17 @@ def _(response: Success | Failure | TruthyIntTag | FalsyIntTag | AmbiguousTag):
         reveal_type(response)  # revealed: Success | TruthyIntTag | AmbiguousTag
     else:
         reveal_type(response)  # revealed: Failure | FalsyIntTag | AmbiguousTag
+
+def truthiness_after_value_guard(response: Success | Failure | None):
+    if not response:
+        return
+
+    if response.success:
+        reveal_type(response)  # revealed: Success & ~AlwaysFalsy
+        reveal_type(response.result)  # revealed: int
+    else:
+        reveal_type(response)  # revealed: Failure & ~AlwaysFalsy
+        reveal_type(response.errors)  # revealed: list[str]
 ```
 
 ## Function Literals

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4324,8 +4324,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
 
         let narrowed = union.filter(self.db, |element| {
-            nominal_attribute_type(self.db, *element, attribute_name).is_none_or(|attribute_type| {
-                match (comparison, is_positive) {
+            tag_attribute_type(self.db, *element, attribute_name).is_none_or(
+                |attribute_type| match (comparison, is_positive) {
                     (NominalAttributeComparison::Equality, true) => {
                         !is_supported_tag_literal(attribute_type)
                             || !attribute_type.is_disjoint_from(self.db, rhs_type)
@@ -4337,8 +4337,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         .identity_comparison_truthiness(self.db, rhs_type)
                         .negate_if(!is_positive)
                         .may_be_true(),
-                }
-            })
+                },
+            )
         });
 
         if narrowed == Type::Union(union) {
@@ -4362,7 +4362,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         };
 
         let narrowed = union.filter(self.db, |element| {
-            nominal_attribute_type(self.db, *element, attribute_name).is_none_or(|attribute_type| {
+            tag_attribute_type(self.db, *element, attribute_name).is_none_or(|attribute_type| {
                 let truthiness = attribute_type.bool(self.db);
                 if is_positive {
                     !truthiness.is_always_false()
@@ -4518,20 +4518,15 @@ fn is_supported_tag_literal(ty: Type) -> bool {
     )
 }
 
-fn nominal_attribute_type<'db>(
+fn tag_attribute_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
     attribute_name: &str,
 ) -> Option<Type<'db>> {
-    let resolved_ty = ty.resolve_type_alias(db);
-    if resolved_ty.is_nominal_instance() {
-        resolved_ty
-            .member(db, attribute_name)
-            .place
-            .ignore_possibly_undefined()
-    } else {
-        None
-    }
+    ty.resolve_type_alias(db)
+        .member(db, attribute_name)
+        .place
+        .ignore_possibly_undefined()
 }
 
 // Return true if the given type is a `TypedDict` whose `field_name` field has a supported tag literal

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4324,8 +4324,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
 
         let narrowed = union.filter(self.db, |element| {
-            tag_attribute_type(self.db, *element, attribute_name).is_none_or(
-                |attribute_type| match (comparison, is_positive) {
+            element
+                .resolve_type_alias(self.db)
+                .member(self.db, attribute_name)
+                .place
+                .ignore_possibly_undefined()
+                .is_none_or(|attribute_type| match (comparison, is_positive) {
                     (NominalAttributeComparison::Equality, true) => {
                         !is_supported_tag_literal(attribute_type)
                             || !attribute_type.is_disjoint_from(self.db, rhs_type)
@@ -4337,8 +4341,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         .identity_comparison_truthiness(self.db, rhs_type)
                         .negate_if(!is_positive)
                         .may_be_true(),
-                },
-            )
+                })
         });
 
         if narrowed == Type::Union(union) {
@@ -4362,14 +4365,19 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         };
 
         let narrowed = union.filter(self.db, |element| {
-            tag_attribute_type(self.db, *element, attribute_name).is_none_or(|attribute_type| {
-                let truthiness = attribute_type.bool(self.db);
-                if is_positive {
-                    !truthiness.is_always_false()
-                } else {
-                    !truthiness.is_always_true()
-                }
-            })
+            element
+                .resolve_type_alias(self.db)
+                .member(self.db, attribute_name)
+                .place
+                .ignore_possibly_undefined()
+                .is_none_or(|attribute_type| {
+                    let truthiness = attribute_type.bool(self.db);
+                    if is_positive {
+                        !truthiness.is_always_false()
+                    } else {
+                        !truthiness.is_always_true()
+                    }
+                })
         });
 
         if narrowed == Type::Union(union) {
@@ -4516,17 +4524,6 @@ fn is_supported_tag_literal(ty: Type) -> bool {
                 | LiteralValueTypeKind::Enum(_)
         )
     )
-}
-
-fn tag_attribute_type<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    attribute_name: &str,
-) -> Option<Type<'db>> {
-    ty.resolve_type_alias(db)
-        .member(db, attribute_name)
-        .place
-        .ignore_possibly_undefined()
 }
 
 // Return true if the given type is a `TypedDict` whose `field_name` field has a supported tag literal


### PR DESCRIPTION
## Summary

Closes astral-sh/ty#4100.

That report wants attribute tagged-union narrowing on a union containing truthiness-guarded intersections (e.g. `A & ~AlwaysFalsy`). It was currently explicit in the attribute-tagged-union narrowing that it only operated on union elements that were nominal instances, but I couldn't find any soundness rationale for this restriction anywhere in the issues or PRs involved in adding this support, and I don't see why it can't apply to attribute access on any type. So this PR narrows tagged unions using the discriminator looked up on each complete union member, rather than limiting narrowing to nominal instances, which of course naturally supports the requested use case of truthiness-narrowed intersections.

## Test plan

- Extend the existing equality mdtest with truthiness-guarded inherited and nested discriminants, one positive intersection, and one read-only structural protocol.
- Extend the existing identity and attribute-truthiness mdtests with one prior-truthiness-guard regression each.