### PR TITLE
[ty] Respect bounds and constraints in generic materializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
@@ -181,6 +181,61 @@ def _(a: type[Unknown], b: type[Any]):
     assert_type(b, type[Unknown])  # fine
 ```
 
+## Equivalent bounded gradual specializations
+
+Checking whether gradual specializations are equivalent must preserve their shape aliases instead of
+replacing the aliases with their static upper bounds. It must also treat defaulted nested generics
+and their explicit `Any` specializations equivalently.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Any, assert_type
+
+from ty_extensions import Unknown, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type AnyShape = tuple[Any, ...]
+type UnknownShape = tuple[Unknown, ...]
+
+class Array[Shape: tuple[int, ...]]:
+    def shape(self) -> Shape:
+        raise NotImplementedError
+
+class InvariantArray[Shape: tuple[int, ...]]:
+    shape: Shape
+
+class Floating[Precision: float = Any]:
+    def precision(self) -> Precision:
+        raise NotImplementedError
+
+class Uniform[Shape: tuple[int, ...], Scalar: Floating[Any] = Floating[Any]]:
+    def scalar(self) -> Scalar:
+        raise NotImplementedError
+
+def equivalent_shapes(
+    aliased: Array[AnyShape],
+    explicit: Array[tuple[Any, ...]],
+    unknown: Array[UnknownShape],
+    invariant: InvariantArray[AnyShape],
+) -> None:
+    assert_type(aliased, Array[tuple[Any, ...]])
+    assert_type(explicit, Array[AnyShape])
+    assert_type(unknown, Array[AnyShape])
+    assert_type(invariant, InvariantArray[tuple[Any, ...]])
+
+def equivalent_defaulted_scalars(value: Uniform[tuple[int], Floating[Any]]) -> None:
+    assert_type(value, Uniform[tuple[int], Floating])
+    assert_type(value, Uniform[tuple[int]])
+
+static_assert(is_equivalent_to(Array[AnyShape], Array[tuple[Any, ...]]))
+static_assert(is_equivalent_to(InvariantArray[AnyShape], InvariantArray[tuple[Any, ...]]))
+static_assert(is_equivalent_to(Uniform[tuple[int], Floating[Any]], Uniform[tuple[int]]))
+```
+
 ## Tuples
 
 Tuple types with the same elements are the same.

--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
@@ -181,61 +181,6 @@ def _(a: type[Unknown], b: type[Any]):
     assert_type(b, type[Unknown])  # fine
 ```
 
-## Equivalent bounded gradual specializations
-
-Checking whether gradual specializations are equivalent must preserve their shape aliases instead of
-replacing the aliases with their static upper bounds. It must also treat defaulted nested generics
-and their explicit `Any` specializations equivalently.
-
-```toml
-[environment]
-python-version = "3.13"
-```
-
-```py
-from typing import Any, assert_type
-
-from ty_extensions import Unknown, static_assert
-from ty_extensions._internal import is_equivalent_to
-
-type AnyShape = tuple[Any, ...]
-type UnknownShape = tuple[Unknown, ...]
-
-class Array[Shape: tuple[int, ...]]:
-    def shape(self) -> Shape:
-        raise NotImplementedError
-
-class InvariantArray[Shape: tuple[int, ...]]:
-    shape: Shape
-
-class Floating[Precision: float = Any]:
-    def precision(self) -> Precision:
-        raise NotImplementedError
-
-class Uniform[Shape: tuple[int, ...], Scalar: Floating[Any] = Floating[Any]]:
-    def scalar(self) -> Scalar:
-        raise NotImplementedError
-
-def equivalent_shapes(
-    aliased: Array[AnyShape],
-    explicit: Array[tuple[Any, ...]],
-    unknown: Array[UnknownShape],
-    invariant: InvariantArray[AnyShape],
-) -> None:
-    assert_type(aliased, Array[tuple[Any, ...]])
-    assert_type(explicit, Array[AnyShape])
-    assert_type(unknown, Array[AnyShape])
-    assert_type(invariant, InvariantArray[tuple[Any, ...]])
-
-def equivalent_defaulted_scalars(value: Uniform[tuple[int], Floating[Any]]) -> None:
-    assert_type(value, Uniform[tuple[int], Floating])
-    assert_type(value, Uniform[tuple[int]])
-
-static_assert(is_equivalent_to(Array[AnyShape], Array[tuple[Any, ...]]))
-static_assert(is_equivalent_to(InvariantArray[AnyShape], InvariantArray[tuple[Any, ...]]))
-static_assert(is_equivalent_to(Uniform[tuple[int], Floating[Any]], Uniform[tuple[int]]))
-```
-
 ## Tuples
 
 Tuple types with the same elements are the same.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -923,18 +923,19 @@ def _(x: object):
         reveal_type(x.y)  # revealed: tuple[A, object]
 ```
 
-A default never restricts which specialization matches at runtime. In particular, a `Never` default
-must not prevent narrowing a bounded generic or recovering its original type argument.
+`isinstance(value, Box)` checks the runtime class, not the type argument used to specialize it.
+Narrowing must therefore preserve the original type argument instead of substituting `Box`'s
+default.
 
 ```py
-from typing import Never, assert_never
+from typing import assert_never
 
-class Box[T: str = Never]:
+class Box[T: str = str]:
     value: T
 
     def __init__(self, value: T) -> None: ...
 
-def box_with_default[T: str = Never](value: Box[T] | T) -> Box[T]:
+def box_with_default[T: str = str](value: Box[T] | T) -> Box[T]:
     if isinstance(value, Box):
         reveal_type(value)  # revealed: Box[T@box_with_default]
         return value
@@ -946,11 +947,11 @@ def box_with_default[T: str = Never](value: Box[T] | T) -> Box[T]:
     assert_never(value)
 ```
 
-A tuple subclass must likewise materialize its declared bound, not its `Never` default. Its
-heterogeneous tuple shape is inherited from the specialized base.
+When `isinstance()` narrows an unknown value to a tuple subclass, its type argument comes from the
+declared upper bound, not the default. Its element types are inherited from the specialized base.
 
 ```py
-class DefaultedTuple[T: int = Never](tuple[T, str]): ...
+class DefaultedTuple[T: int = bool](tuple[T, str]): ...
 
 def narrow_defaulted_tuple(value: object) -> None:
     if isinstance(value, DefaultedTuple):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -625,6 +625,33 @@ def _(x: object):
         reveal_type(x.get())  # revealed: object
 ```
 
+A bounded covariant generic uses its declared upper bound rather than `object`:
+
+```py
+class BoundedCovariant[T: int]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+def _(x: object):
+    if isinstance(x, BoundedCovariant):
+        reveal_type(x)  # revealed: BoundedCovariant[int]
+        reveal_type(x.get())  # revealed: int
+```
+
+Constrained type parameters preserve the materialization of the generic class while making the union
+of valid constraints available when reading a covariant attribute:
+
+```py
+class ConstrainedCovariant[T: (int, str)]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+def _(x: object):
+    if isinstance(x, ConstrainedCovariant):
+        reveal_type(x)  # revealed: Top[ConstrainedCovariant[Unknown]]
+        reveal_type(x.get())  # revealed: int | str
+```
+
 Similarly, contravariant type parameters use their lower bound of `Never`:
 
 ```py
@@ -686,7 +713,7 @@ class InvariantWithAny[T: int]:
 def _(x: object):
     if isinstance(x, InvariantWithAny):
         reveal_type(x)  # revealed: Top[InvariantWithAny[Unknown]]
-        reveal_type(x.a)  # revealed: object
+        reveal_type(x.a)  # revealed: int
         reveal_type(x.b)  # revealed: Any
 ```
 
@@ -773,6 +800,29 @@ class WithAliasDefault[T = A]:
 def _(x: object):
     if isinstance(x, WithAliasDefault):
         reveal_type(x.y)  # revealed: tuple[A, object]
+```
+
+A default never restricts which specialization matches at runtime. In particular, a `Never` default
+must not prevent narrowing a bounded generic or recovering its original type argument.
+
+```py
+from typing import Any, Never
+
+class Unit[T: str = Never]:
+    mapping: dict[T, Any]
+
+    def __init__(self, key: T | None = None) -> None: ...
+
+def unit_with_default[T: str = Never](unit: Unit[T] | T) -> Unit[T]:
+    if isinstance(unit, Unit):
+        reveal_type(unit)  # revealed: Unit[T@unit_with_default]
+        return unit
+
+    if not isinstance(unit, Unit):
+        reveal_type(unit)  # revealed: T@unit_with_default & ~Top[Unit[Unknown]]
+        return Unit[T](unit)
+
+    raise AssertionError("Unreachable")
 ```
 
 ## Narrowing generic `classmethod`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -841,6 +841,51 @@ def excludes_bounded_generic_subclass(
     return cls
 ```
 
+## Narrowing recursively bounded generics
+
+An `isinstance()` check must not recurse indefinitely when a generic bound refers to its own class.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any
+
+class Recursive[T: "Recursive[Any]"]: ...
+
+def narrow(value: object) -> None:
+    if isinstance(value, Recursive):
+        reveal_type(value)  # revealed: Recursive[object]
+```
+
+A self-referential bound must also be safe when its recursion is hidden behind a type alias.
+
+```py
+class AliasedRecursive[T: "RecursiveAlias"]: ...
+
+type RecursiveAlias = AliasedRecursive[Any]
+
+def narrow_alias(value: object) -> None:
+    if isinstance(value, AliasedRecursive):
+        reveal_type(value)  # revealed: AliasedRecursive[object]
+```
+
+The same cycle recovery must handle bounds shared by mutually recursive generic classes.
+
+```py
+class Left[T: "Right[Any]"]: ...
+class Right[U: Left[Any]]: ...
+
+def narrow_mutual(value: object) -> None:
+    if isinstance(value, Left):
+        reveal_type(value)  # revealed: Left[object]
+
+    if isinstance(value, Right):
+        reveal_type(value)  # revealed: Right[object]
+```
+
 ## Narrowing generic defaults in Python 3.13
 
 When a type parameter has a bare `Any` default, narrowing still materializes the substituted

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -638,72 +638,32 @@ def _(x: object):
         reveal_type(x.get())  # revealed: int
 ```
 
-Negative narrowing must exclude every instance of the generic class, including gradual
-specializations. In particular, no impossible generic arm should remain after an `isinstance()`
-check has returned.
+Negative narrowing must exclude every specialization of a bounded generic, including a gradual one.
 
 ```py
-from os import PathLike
-from typing import Any, final
+from typing import Any
 
-@final
-class Image:
-    mode: str
+def excludes_bounded_generic(value: BoundedCovariant[Any] | bool) -> bool:
+    if isinstance(value, BoundedCovariant):
+        reveal_type(value)  # revealed: BoundedCovariant[Any]
+        return False
 
-class Array[Shape: tuple[int, ...], Scalar: int | str]:
-    def shape(self) -> Shape:
-        raise NotImplementedError
+    reveal_type(value)  # revealed: bool
+    return value
+```
 
-    def scalar(self) -> Scalar:
-        raise NotImplementedError
+The same exclusion applies when the generic appears in a tuple of runtime classes.
 
-def excludes_bounded_generic(value: Array[tuple[Any, ...], Any] | Image) -> str:
-    if isinstance(value, Array):
-        reveal_type(value)  # revealed: Array[tuple[Any, ...], Any]
-        return "array"
-
-    reveal_type(value)  # revealed: Image
-    return value.mode
-
+```py
 def excludes_bounded_generic_tuple(
-    value: Array[tuple[Any, ...], Any] | Image | bytes,
-) -> str:
-    if isinstance(value, (Array, bytes)):
-        reveal_type(value)  # revealed: Array[tuple[Any, ...], Any] | bytes
-        return "array or bytes"
+    value: BoundedCovariant[Any] | bool | bytes,
+) -> bool:
+    if isinstance(value, (BoundedCovariant, bytes)):
+        reveal_type(value)  # revealed: BoundedCovariant[Any] | bytes
+        return False
 
-    reveal_type(value)  # revealed: Image
-    return value.mode
-
-class ConstrainedPath[T: (str, bytes)]:
-    def __fspath__(self) -> T:
-        raise NotImplementedError
-
-def excludes_constrained_generic(value: ConstrainedPath[Any] | Image) -> str:
-    if isinstance(value, ConstrainedPath):
-        reveal_type(value)  # revealed: ConstrainedPath[Any]
-        return "path"
-
-    reveal_type(value)  # revealed: Image
-    return value.mode
-
-def excludes_constrained_pathlike(value: PathLike[Any] | Image) -> str:
-    if isinstance(value, PathLike):
-        reveal_type(value)  # revealed: PathLike[Any]
-        return "path"
-
-    reveal_type(value)  # revealed: Image
-    return value.mode
-
-def excludes_bounded_generic_subclass(
-    cls: type[Array[tuple[Any, ...], Any]] | type[Image],
-) -> type[Image]:
-    if issubclass(cls, Array):
-        reveal_type(cls)  # revealed: type[Array[tuple[Any, ...], Any]]
-        return Image
-
-    reveal_type(cls)  # revealed: <class 'Image'>
-    return cls
+    reveal_type(value)  # revealed: bool
+    return value
 ```
 
 Constrained type parameters preserve the materialization of the generic class while making the union
@@ -718,6 +678,18 @@ def _(x: object):
     if isinstance(x, ConstrainedCovariant):
         reveal_type(x)  # revealed: Top[ConstrainedCovariant[Unknown]]
         reveal_type(x.get())  # revealed: int | str
+```
+
+Constrained generics must also be excluded by negative narrowing.
+
+```py
+def excludes_constrained_generic(value: ConstrainedCovariant[Any] | bool) -> bool:
+    if isinstance(value, ConstrainedCovariant):
+        reveal_type(value)  # revealed: ConstrainedCovariant[Any]
+        return False
+
+    reveal_type(value)  # revealed: bool
+    return value
 ```
 
 Similarly, contravariant type parameters use their lower bound of `Never`:
@@ -821,6 +793,28 @@ def _(x: Invariant[int] | Covariant[str]):
         reveal_type(x)  # revealed: Covariant[str] & ~Top[Invariant[Unknown]]
 ```
 
+The built-in `tuple` stores its variable-length shape separately from its generic type argument.
+Narrowing must preserve and materialize that shape.
+
+```py
+def narrow_tuple(value: object) -> None:
+    if isinstance(value, tuple):
+        reveal_type(value)  # revealed: tuple[object, ...]
+```
+
+A tuple subclass retains its nominal type and inherits its tuple shape from its specialized base.
+The subclass's own type parameter is still materialized using its declared bound.
+
+```py
+class BoundedTuple[T: int](tuple[T, str]): ...
+
+def narrow_tuple_subclass(value: object) -> None:
+    if isinstance(value, BoundedTuple):
+        reveal_type(value)  # revealed: BoundedTuple[int]
+        reveal_type(value[0])  # revealed: int
+        reveal_type(value[1])  # revealed: str
+```
+
 The behavior of `issubclass()` is similar.
 
 ```py
@@ -831,6 +825,20 @@ def _(x: type[object], y: type[object], z: type[object]):
         reveal_type(y)  # revealed: type[Contravariant[Never]]
     if issubclass(z, Invariant):
         reveal_type(z)  # revealed: type[Top[Invariant[Unknown]]]
+```
+
+Negative `issubclass()` narrowing also excludes every specialization of a bounded generic.
+
+```py
+def excludes_bounded_generic_subclass(
+    cls: type[BoundedCovariant[Any]] | type[bool],
+) -> type[bool]:
+    if issubclass(cls, BoundedCovariant):
+        reveal_type(cls)  # revealed: type[BoundedCovariant[Any]]
+        return bool
+
+    reveal_type(cls)  # revealed: <class 'bool'>
+    return cls
 ```
 
 ## Narrowing generic defaults in Python 3.13
@@ -874,23 +882,50 @@ A default never restricts which specialization matches at runtime. In particular
 must not prevent narrowing a bounded generic or recovering its original type argument.
 
 ```py
-from typing import Any, Never
+from typing import Never, assert_never
 
-class Unit[T: str = Never]:
-    mapping: dict[T, Any]
+class Box[T: str = Never]:
+    value: T
 
-    def __init__(self, key: T | None = None) -> None: ...
+    def __init__(self, value: T) -> None: ...
 
-def unit_with_default[T: str = Never](unit: Unit[T] | T) -> Unit[T]:
-    if isinstance(unit, Unit):
-        reveal_type(unit)  # revealed: Unit[T@unit_with_default]
-        return unit
+def box_with_default[T: str = Never](value: Box[T] | T) -> Box[T]:
+    if isinstance(value, Box):
+        reveal_type(value)  # revealed: Box[T@box_with_default]
+        return value
 
-    if not isinstance(unit, Unit):
-        reveal_type(unit)  # revealed: T@unit_with_default & ~Top[Unit[Unknown]]
-        return Unit[T](unit)
+    if not isinstance(value, Box):
+        reveal_type(value)  # revealed: T@box_with_default & ~Top[Box[Unknown]]
+        return Box[T](value)
 
-    raise AssertionError("Unreachable")
+    assert_never(value)
+```
+
+A tuple subclass must likewise materialize its declared bound, not its `Never` default. Its
+heterogeneous tuple shape is inherited from the specialized base.
+
+```py
+class DefaultedTuple[T: int = Never](tuple[T, str]): ...
+
+def narrow_defaulted_tuple(value: object) -> None:
+    if isinstance(value, DefaultedTuple):
+        reveal_type(value)  # revealed: DefaultedTuple[int]
+        reveal_type(value[0])  # revealed: int
+        reveal_type(value[1])  # revealed: str
+```
+
+Negative narrowing also excludes gradual specializations of the defaulted tuple subclass.
+
+```py
+def excludes_defaulted_tuple(value: DefaultedTuple[Any] | bool) -> bool:
+    if isinstance(value, DefaultedTuple):
+        reveal_type(value)  # revealed: DefaultedTuple[Any]
+        reveal_type(value[0])  # revealed: Any
+        reveal_type(value[1])  # revealed: str
+        return False
+
+    reveal_type(value)  # revealed: bool
+    return value
 ```
 
 ## Narrowing generic `classmethod`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -638,6 +638,74 @@ def _(x: object):
         reveal_type(x.get())  # revealed: int
 ```
 
+Negative narrowing must exclude every instance of the generic class, including gradual
+specializations. In particular, no impossible generic arm should remain after an `isinstance()`
+check has returned.
+
+```py
+from os import PathLike
+from typing import Any, final
+
+@final
+class Image:
+    mode: str
+
+class Array[Shape: tuple[int, ...], Scalar: int | str]:
+    def shape(self) -> Shape:
+        raise NotImplementedError
+
+    def scalar(self) -> Scalar:
+        raise NotImplementedError
+
+def excludes_bounded_generic(value: Array[tuple[Any, ...], Any] | Image) -> str:
+    if isinstance(value, Array):
+        reveal_type(value)  # revealed: Array[tuple[Any, ...], Any]
+        return "array"
+
+    reveal_type(value)  # revealed: Image
+    return value.mode
+
+def excludes_bounded_generic_tuple(
+    value: Array[tuple[Any, ...], Any] | Image | bytes,
+) -> str:
+    if isinstance(value, (Array, bytes)):
+        reveal_type(value)  # revealed: Array[tuple[Any, ...], Any] | bytes
+        return "array or bytes"
+
+    reveal_type(value)  # revealed: Image
+    return value.mode
+
+class ConstrainedPath[T: (str, bytes)]:
+    def __fspath__(self) -> T:
+        raise NotImplementedError
+
+def excludes_constrained_generic(value: ConstrainedPath[Any] | Image) -> str:
+    if isinstance(value, ConstrainedPath):
+        reveal_type(value)  # revealed: ConstrainedPath[Any]
+        return "path"
+
+    reveal_type(value)  # revealed: Image
+    return value.mode
+
+def excludes_constrained_pathlike(value: PathLike[Any] | Image) -> str:
+    if isinstance(value, PathLike):
+        reveal_type(value)  # revealed: PathLike[Any]
+        return "path"
+
+    reveal_type(value)  # revealed: Image
+    return value.mode
+
+def excludes_bounded_generic_subclass(
+    cls: type[Array[tuple[Any, ...], Any]] | type[Image],
+) -> type[Image]:
+    if issubclass(cls, Array):
+        reveal_type(cls)  # revealed: type[Array[tuple[Any, ...], Any]]
+        return Image
+
+    reveal_type(cls)  # revealed: <class 'Image'>
+    return cls
+```
+
 Constrained type parameters preserve the materialization of the generic class while making the union
 of valid constraints available when reading a covariant attribute:
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -112,6 +112,34 @@ def f(x: Covariant[int]):
             assert_never(x)
 ```
 
+## Generic patterns ignore type parameter defaults
+
+A generic class pattern matches every runtime specialization, not only the specialization described
+by its type parameter's default.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Any, Never
+
+class Unit[T: str = Never]:
+    mapping: dict[T, Any]
+
+    def __init__(self, key: T | None = None) -> None: ...
+
+def unit_with_default[T: str = Never](unit: Unit[T] | T) -> Unit[T]:
+    match unit:
+        case Unit():
+            reveal_type(unit)  # revealed: Unit[T@unit_with_default]
+            return unit
+        case key:
+            reveal_type(key)  # revealed: T@unit_with_default & ~Top[Unit[Unknown]]
+            return Unit[T](key)
+```
+
 ## Class patterns with generic `@final` classes
 
 These work the same as non-`@final` classes.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -112,6 +112,29 @@ def f(x: Covariant[int]):
             assert_never(x)
 ```
 
+A class pattern must also preserve and materialize the built-in tuple's variable-length shape.
+
+```py
+def match_tuple(value: object) -> None:
+    match value:
+        case tuple():
+            reveal_type(value)  # revealed: tuple[object, ...]
+```
+
+A tuple-subclass pattern preserves both the subclass's bounded type argument and the inherited
+heterogeneous tuple shape.
+
+```py
+class BoundedTuple[T: int](tuple[T, str]): ...
+
+def match_tuple_subclass(value: object) -> None:
+    match value:
+        case BoundedTuple():
+            reveal_type(value)  # revealed: BoundedTuple[int]
+            reveal_type(value[0])  # revealed: int
+            reveal_type(value[1])  # revealed: str
+```
+
 ## Class patterns with bounded generic classes
 
 A bounded generic class pattern matches every specialization, including gradual specializations, and
@@ -123,27 +146,20 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Any, final
+from typing import Any
 
-@final
-class Image:
-    mode: str
-
-class Array[Shape: tuple[int, ...], Scalar: int | str]:
-    def shape(self) -> Shape:
+class BoundedCovariant[T: int]:
+    def get(self) -> T:
         raise NotImplementedError
 
-    def scalar(self) -> Scalar:
-        raise NotImplementedError
-
-def match_bounded_generic(value: Array[tuple[Any, ...], Any] | Image) -> str:
+def match_bounded_generic(value: BoundedCovariant[Any] | bool) -> bool:
     match value:
-        case Array():
-            reveal_type(value)  # revealed: Array[tuple[Any, ...], Any]
-            return "array"
-        case image:
-            reveal_type(image)  # revealed: Image
-            return image.mode
+        case BoundedCovariant():
+            reveal_type(value)  # revealed: BoundedCovariant[Any]
+            return False
+        case remaining:
+            reveal_type(remaining)  # revealed: bool
+            return remaining
 ```
 
 ## Generic patterns ignore type parameter defaults
@@ -157,21 +173,52 @@ python-version = "3.13"
 ```
 
 ```py
-from typing import Any, Never
+from typing import Never
 
-class Unit[T: str = Never]:
-    mapping: dict[T, Any]
+class Box[T: str = Never]:
+    value: T
 
-    def __init__(self, key: T | None = None) -> None: ...
+    def __init__(self, value: T) -> None: ...
 
-def unit_with_default[T: str = Never](unit: Unit[T] | T) -> Unit[T]:
-    match unit:
-        case Unit():
-            reveal_type(unit)  # revealed: Unit[T@unit_with_default]
-            return unit
-        case key:
-            reveal_type(key)  # revealed: T@unit_with_default & ~Top[Unit[Unknown]]
-            return Unit[T](key)
+def box_with_default[T: str = Never](value: Box[T] | T) -> Box[T]:
+    match value:
+        case Box():
+            reveal_type(value)  # revealed: Box[T@box_with_default]
+            return value
+        case remaining:
+            reveal_type(remaining)  # revealed: T@box_with_default & ~Top[Box[Unknown]]
+            return Box[T](remaining)
+```
+
+A tuple-subclass pattern also materializes the declared bound rather than the `Never` default, while
+preserving the heterogeneous tuple shape inherited from its base.
+
+```py
+class DefaultedTuple[T: int = Never](tuple[T, str]): ...
+
+def match_defaulted_tuple(value: object) -> None:
+    match value:
+        case DefaultedTuple():
+            reveal_type(value)  # revealed: DefaultedTuple[int]
+            reveal_type(value[0])  # revealed: int
+            reveal_type(value[1])  # revealed: str
+```
+
+The same pattern excludes gradual specializations from the remaining match arms.
+
+```py
+from typing import Any
+
+def excludes_defaulted_tuple(value: DefaultedTuple[Any] | bool) -> bool:
+    match value:
+        case DefaultedTuple():
+            reveal_type(value)  # revealed: DefaultedTuple[Any]
+            reveal_type(value[0])  # revealed: Any
+            reveal_type(value[1])  # revealed: str
+            return False
+        case remaining:
+            reveal_type(remaining)  # revealed: bool
+            return remaining
 ```
 
 ## Class patterns with generic `@final` classes

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -112,6 +112,40 @@ def f(x: Covariant[int]):
             assert_never(x)
 ```
 
+## Class patterns with bounded generic classes
+
+A bounded generic class pattern matches every specialization, including gradual specializations, and
+excludes all of them from later patterns.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, final
+
+@final
+class Image:
+    mode: str
+
+class Array[Shape: tuple[int, ...], Scalar: int | str]:
+    def shape(self) -> Shape:
+        raise NotImplementedError
+
+    def scalar(self) -> Scalar:
+        raise NotImplementedError
+
+def match_bounded_generic(value: Array[tuple[Any, ...], Any] | Image) -> str:
+    match value:
+        case Array():
+            reveal_type(value)  # revealed: Array[tuple[Any, ...], Any]
+            return "array"
+        case image:
+            reveal_type(image)  # revealed: Image
+            return image.mode
+```
+
 ## Generic patterns ignore type parameter defaults
 
 A generic class pattern matches every runtime specialization, not only the specialization described

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -112,56 +112,6 @@ def f(x: Covariant[int]):
             assert_never(x)
 ```
 
-A class pattern must also preserve and materialize the built-in tuple's variable-length shape.
-
-```py
-def match_tuple(value: object) -> None:
-    match value:
-        case tuple():
-            reveal_type(value)  # revealed: tuple[object, ...]
-```
-
-A tuple-subclass pattern preserves both the subclass's bounded type argument and the inherited
-heterogeneous tuple shape.
-
-```py
-class BoundedTuple[T: int](tuple[T, str]): ...
-
-def match_tuple_subclass(value: object) -> None:
-    match value:
-        case BoundedTuple():
-            reveal_type(value)  # revealed: BoundedTuple[int]
-            reveal_type(value[0])  # revealed: int
-            reveal_type(value[1])  # revealed: str
-```
-
-## Class patterns with bounded generic classes
-
-A bounded generic class pattern matches every specialization, including gradual specializations, and
-excludes all of them from later patterns.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from typing import Any
-
-class BoundedCovariant[T: int]:
-    def get(self) -> T:
-        raise NotImplementedError
-
-def match_bounded_generic(value: BoundedCovariant[Any] | bool) -> bool:
-    match value:
-        case BoundedCovariant():
-            reveal_type(value)  # revealed: BoundedCovariant[Any]
-            return False
-        case remaining:
-            reveal_type(remaining)  # revealed: bool
-            return remaining
-```
-
 ## Generic patterns ignore type parameter defaults
 
 A generic class pattern matches every runtime specialization, not only the specialization described
@@ -173,14 +123,14 @@ python-version = "3.13"
 ```
 
 ```py
-from typing import Any, Never
+from typing import Any
 
-class Box[T: str = Never]:
+class Box[T: str = str]:
     value: T
 
     def __init__(self, value: T) -> None: ...
 
-def box_with_default[T: str = Never](value: Box[T] | T) -> Box[T]:
+def box_with_default[T: str = str](value: Box[T] | T) -> Box[T]:
     match value:
         case Box():
             reveal_type(value)  # revealed: Box[T@box_with_default]
@@ -190,11 +140,11 @@ def box_with_default[T: str = Never](value: Box[T] | T) -> Box[T]:
             return Box[T](remaining)
 ```
 
-A tuple-subclass pattern also materializes the declared bound rather than the `Never` default, while
-preserving the heterogeneous tuple shape inherited from its base.
+When a class pattern matches a tuple subclass, its type argument comes from the declared upper
+bound, not the default. Its element types are inherited from the specialized base.
 
 ```py
-class DefaultedTuple[T: int = Never](tuple[T, str]): ...
+class DefaultedTuple[T: int = bool](tuple[T, str]): ...
 
 def match_defaulted_tuple(value: object) -> None:
     match value:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -173,7 +173,7 @@ python-version = "3.13"
 ```
 
 ```py
-from typing import Never
+from typing import Any, Never
 
 class Box[T: str = Never]:
     value: T
@@ -207,8 +207,6 @@ def match_defaulted_tuple(value: object) -> None:
 The same pattern excludes gradual specializations from the remaining match arms.
 
 ```py
-from typing import Any
-
 def excludes_defaulted_tuple(value: DefaultedTuple[Any] | bool) -> bool:
     match value:
         case DefaultedTuple():

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -84,18 +84,18 @@ static_assert(not is_equivalent_to(type, type[Any]))
 static_assert(not is_equivalent_to(type[object], type[Any]))
 ```
 
-## Bounded gradual specializations
+## Equivalent bounded gradual specializations
 
-A bounded generic's gradual type arguments must remain equivalent without being replaced by their
-static upper bounds.
+A bounded generic specialized with a gradual type alias is equivalent to the same generic
+specialized with the expanded alias.
 
 ```toml
 [environment]
 python-version = "3.13"
 ```
 
-A covariant bounded type parameter treats a gradual tuple alias the same as the aliased tuple. The
-alias must not be replaced with the type parameter's static upper bound.
+For a covariant bounded type parameter, this applies to aliases containing either `Any` or
+`Unknown`.
 
 ```py
 from typing import Any
@@ -112,7 +112,6 @@ class BoundedCovariant[T: tuple[int, ...]]:
 
 static_assert(is_equivalent_to(BoundedCovariant[AnyTuple], BoundedCovariant[tuple[Any, ...]]))
 static_assert(is_equivalent_to(BoundedCovariant[UnknownTuple], BoundedCovariant[AnyTuple]))
-static_assert(not is_equivalent_to(BoundedCovariant[AnyTuple], BoundedCovariant[tuple[int, ...]]))
 ```
 
 The same gradual tuple alias remains equivalent when the bounded type parameter is invariant.
@@ -122,10 +121,11 @@ class BoundedInvariant[T: tuple[int, ...]]:
     value: T
 
 static_assert(is_equivalent_to(BoundedInvariant[AnyTuple], BoundedInvariant[tuple[Any, ...]]))
-static_assert(not is_equivalent_to(BoundedInvariant[AnyTuple], BoundedInvariant[tuple[int, ...]]))
 ```
 
-A nested bounded generic remains equivalent whether its gradual default is implicit or explicit.
+`Outer[int, Inner]` is equivalent to `Outer[int, Inner[Any]]` because `Inner` defaults to `Any`.
+`Outer[int]` is equivalent to the same explicit specialization because `Outer` defaults to
+`Inner[Any]`.
 
 ```py
 class Inner[T: int = Any]:
@@ -138,6 +138,40 @@ class Outer[T: int, U: Inner[Any] = Inner[Any]]:
 
 static_assert(is_equivalent_to(Outer[int, Inner[Any]], Outer[int, Inner]))
 static_assert(is_equivalent_to(Outer[int, Inner[Any]], Outer[int]))
+```
+
+## Bounded gradual specializations are distinct from upper bounds
+
+A generic specialized with a gradual type argument is not equivalent to the same generic specialized
+with the type parameter's upper bound.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+For a covariant type parameter:
+
+```py
+from typing import Any
+
+from ty_extensions import static_assert
+from ty_extensions._internal import is_equivalent_to
+
+class BoundedCovariant[T: tuple[int, ...]]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+static_assert(not is_equivalent_to(BoundedCovariant[tuple[Any, ...]], BoundedCovariant[tuple[int, ...]]))
+```
+
+The same distinction applies to an invariant type parameter.
+
+```py
+class BoundedInvariant[T: tuple[int, ...]]:
+    value: T
+
+static_assert(not is_equivalent_to(BoundedInvariant[tuple[Any, ...]], BoundedInvariant[tuple[int, ...]]))
 ```
 
 ## Unions and intersections

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -84,6 +84,62 @@ static_assert(not is_equivalent_to(type, type[Any]))
 static_assert(not is_equivalent_to(type[object], type[Any]))
 ```
 
+## Bounded gradual specializations
+
+A bounded generic's gradual type arguments must remain equivalent without being replaced by their
+static upper bounds.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+A covariant bounded type parameter treats a gradual tuple alias the same as the aliased tuple. The
+alias must not be replaced with the type parameter's static upper bound.
+
+```py
+from typing import Any
+
+from ty_extensions import Unknown, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type AnyTuple = tuple[Any, ...]
+type UnknownTuple = tuple[Unknown, ...]
+
+class BoundedCovariant[T: tuple[int, ...]]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+static_assert(is_equivalent_to(BoundedCovariant[AnyTuple], BoundedCovariant[tuple[Any, ...]]))
+static_assert(is_equivalent_to(BoundedCovariant[UnknownTuple], BoundedCovariant[AnyTuple]))
+static_assert(not is_equivalent_to(BoundedCovariant[AnyTuple], BoundedCovariant[tuple[int, ...]]))
+```
+
+The same gradual tuple alias remains equivalent when the bounded type parameter is invariant.
+
+```py
+class BoundedInvariant[T: tuple[int, ...]]:
+    value: T
+
+static_assert(is_equivalent_to(BoundedInvariant[AnyTuple], BoundedInvariant[tuple[Any, ...]]))
+static_assert(not is_equivalent_to(BoundedInvariant[AnyTuple], BoundedInvariant[tuple[int, ...]]))
+```
+
+A nested bounded generic remains equivalent whether its gradual default is implicit or explicit.
+
+```py
+class Inner[T: int = Any]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class Outer[T: int, U: Inner[Any] = Inner[Any]]:
+    def get(self) -> U:
+        raise NotImplementedError
+
+static_assert(is_equivalent_to(Outer[int, Inner[Any]], Outer[int, Inner]))
+static_assert(is_equivalent_to(Outer[int, Inner[Any]], Outer[int]))
+```
+
 ## Unions and intersections
 
 ```pyi

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1040,8 +1040,7 @@ python-version = "3.12"
 
 ```py
 # error: [invalid-type-arguments]
-class RecursiveSpecialization[T: "RecursiveSpecialization[int]"]:
-    pass
+class RecursiveSpecialization[T: "RecursiveSpecialization[int]"]: ...
 
 # error: [invalid-type-arguments]
 def recursive_specialization(value: RecursiveSpecialization[str]) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -706,6 +706,29 @@ static_assert(is_subtype_of(BoundedCovariant[Any], Top[BoundedCovariant[Any]]))
 static_assert(is_subtype_of(BoundedCovariant[Any], BoundedCovariant[int]))
 ```
 
+A type alias can conceal a gradual argument; the same subtype relationships still apply.
+
+```py
+type AliasedAny = Any
+
+static_assert(is_subtype_of(BoundedCovariant[AliasedAny], Top[BoundedCovariant[AliasedAny]]))
+static_assert(is_subtype_of(BoundedCovariant[AliasedAny], BoundedCovariant[int]))
+```
+
+An alias for a static upper bound remains static. It absorbs a bounded gradual specialization in
+either union order.
+
+```py
+type AliasedInt = int
+
+def aliased_static_bound(
+    gradual_first: BoundedCovariant[Any] | BoundedCovariant[AliasedInt],
+    gradual_last: BoundedCovariant[AliasedInt] | BoundedCovariant[Any],
+) -> None:
+    reveal_type(gradual_first)  # revealed: BoundedCovariant[AliasedInt]
+    reveal_type(gradual_last)  # revealed: BoundedCovariant[AliasedInt]
+```
+
 Contravariance reverses which bound is used by top and bottom materialization.
 
 ```py
@@ -763,8 +786,8 @@ static_assert(is_equivalent_to(Top[LegacyBoundedContravariant[Any]], LegacyBound
 static_assert(is_equivalent_to(Bottom[LegacyBoundedContravariant[Any]], LegacyBoundedContravariant[int]))
 ```
 
-A legacy invariant type parameter also materializes a readable attribute to its upper or lower
-bound.
+Reading an attribute of a top-materialized legacy invariant generic yields the type parameter's
+upper bound; reading the same attribute from its bottom materialization yields the lower bound.
 
 ```py
 BoundedT = TypeVar("BoundedT", bound=int)
@@ -875,6 +898,17 @@ def constrained_invariant(
     reveal_type(bottom.get)  # revealed: bound method Bottom[ConstrainedInvariant[Any]].get() -> Never
     reveal_type(bottom.put)  # revealed: bound method Bottom[ConstrainedInvariant[Any]].put(value: int | str) -> None
     reveal_type(bottom.value)  # revealed: Never
+```
+
+Direct attribute writes are currently checked against the readable union rather than the safe
+`Never` parameter used for setters.
+
+```py
+def constrained_invariant_writes(top: Top[ConstrainedInvariant[Any]]) -> None:
+    # TODO: Reject these writes; neither value is safe for every specialization.
+    top.value = 1
+    top.value = "value"
+    top.value = 1.5  # error: [invalid-assignment]
 ```
 
 Legacy constrained type variables preserve the same covariant and contravariant subtype

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -681,10 +681,10 @@ def contravariant(top: Top[ContravariantCallable], bottom: Bottom[ContravariantC
     reveal_type(bottom)  # revealed: (GenericContravariant[Never], /) -> None
 ```
 
-## Bounded and constrained generic type parameters
+## Bounded generic type parameters
 
-Materialization respects the declared upper bound of a type parameter. The lower bound remains
-`Never`, and covariance or contravariance determines which bound belongs to each materialization.
+Top materialization of a covariant generic uses the type parameter's declared upper bound. Bottom
+materialization uses its lower bound, `Never`.
 
 ```toml
 [environment]
@@ -693,23 +693,33 @@ python-version = "3.12"
 
 ```py
 from typing import Any, Generic, Never, TypeVar
-from ty_extensions import Bottom, Intersection, Not, Top, static_assert
-from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_equivalent_to, is_subtype_of
 
 class BoundedCovariant[T: int]:
     def get(self) -> T:
         raise NotImplementedError
 
+static_assert(is_equivalent_to(Top[BoundedCovariant[Any]], BoundedCovariant[int]))
+static_assert(is_equivalent_to(Bottom[BoundedCovariant[Any]], BoundedCovariant[Never]))
+static_assert(is_subtype_of(BoundedCovariant[Any], Top[BoundedCovariant[Any]]))
+static_assert(is_subtype_of(BoundedCovariant[Any], BoundedCovariant[int]))
+```
+
+Contravariance reverses which bound is used by top and bottom materialization.
+
+```py
 class BoundedContravariant[T: int]:
     def put(self, value: T) -> None: ...
 
-static_assert(is_equivalent_to(Top[BoundedCovariant[Any]], BoundedCovariant[int]))
-static_assert(is_equivalent_to(Bottom[BoundedCovariant[Any]], BoundedCovariant[Never]))
 static_assert(is_equivalent_to(Top[BoundedContravariant[Any]], BoundedContravariant[Never]))
 static_assert(is_equivalent_to(Bottom[BoundedContravariant[Any]], BoundedContravariant[int]))
-static_assert(is_subtype_of(BoundedCovariant[Any], Top[BoundedCovariant[Any]]))
-static_assert(is_subtype_of(BoundedCovariant[Any], BoundedCovariant[int]))
+```
 
+For an invariant generic, materialize attributes and method parameters according to their own
+variance. An unrelated `Any` attribute must remain gradual.
+
+```py
 class BoundedInvariant[T: int]:
     value: T
     unrelated: Any
@@ -718,21 +728,6 @@ class BoundedInvariant[T: int]:
         raise NotImplementedError
 
     def put(self, value: T) -> None: ...
-
-BoundedT_co = TypeVar("BoundedT_co", bound=int, covariant=True)
-BoundedT_contra = TypeVar("BoundedT_contra", bound=int, contravariant=True)
-BoundedT = TypeVar("BoundedT", bound=int)
-
-class LegacyBoundedCovariant(Generic[BoundedT_co]): ...
-class LegacyBoundedContravariant(Generic[BoundedT_contra]): ...
-
-class LegacyBoundedInvariant(Generic[BoundedT]):
-    value: BoundedT
-
-static_assert(is_equivalent_to(Top[LegacyBoundedCovariant[Any]], LegacyBoundedCovariant[int]))
-static_assert(is_equivalent_to(Bottom[LegacyBoundedCovariant[Any]], LegacyBoundedCovariant[Never]))
-static_assert(is_equivalent_to(Top[LegacyBoundedContravariant[Any]], LegacyBoundedContravariant[Never]))
-static_assert(is_equivalent_to(Bottom[LegacyBoundedContravariant[Any]], LegacyBoundedContravariant[int]))
 
 def bounded_invariant(
     top: Top[BoundedInvariant[Any]],
@@ -747,6 +742,35 @@ def bounded_invariant(
     reveal_type(bottom.get)  # revealed: bound method Bottom[BoundedInvariant[Any]].get() -> Never
     reveal_type(bottom.put)  # revealed: bound method Bottom[BoundedInvariant[Any]].put(value: int) -> None
     reveal_type(bottom.value)  # revealed: Never
+```
+
+Explicitly covariant and contravariant legacy `TypeVar` declarations obey the same bounded
+materialization rules.
+
+```py
+BoundedT_co = TypeVar("BoundedT_co", bound=int, covariant=True)
+
+class LegacyBoundedCovariant(Generic[BoundedT_co]): ...
+
+static_assert(is_equivalent_to(Top[LegacyBoundedCovariant[Any]], LegacyBoundedCovariant[int]))
+static_assert(is_equivalent_to(Bottom[LegacyBoundedCovariant[Any]], LegacyBoundedCovariant[Never]))
+
+BoundedT_contra = TypeVar("BoundedT_contra", bound=int, contravariant=True)
+
+class LegacyBoundedContravariant(Generic[BoundedT_contra]): ...
+
+static_assert(is_equivalent_to(Top[LegacyBoundedContravariant[Any]], LegacyBoundedContravariant[Never]))
+static_assert(is_equivalent_to(Bottom[LegacyBoundedContravariant[Any]], LegacyBoundedContravariant[int]))
+```
+
+A legacy invariant type parameter also materializes a readable attribute to its upper or lower
+bound.
+
+```py
+BoundedT = TypeVar("BoundedT", bound=int)
+
+class LegacyBoundedInvariant(Generic[BoundedT]):
+    value: BoundedT
 
 def legacy_bounded_invariant(
     legacy_top: Top[LegacyBoundedInvariant[Any]],
@@ -756,56 +780,32 @@ def legacy_bounded_invariant(
     reveal_type(legacy_bottom.value)  # revealed: Never
 ```
 
+## Constrained generic type parameters
+
 A constrained type parameter cannot generally be replaced by the union of its constraints: the union
-need not itself be a valid specialization. Preserve the materialization instead.
+need not itself be a valid specialization. Top and bottom materialization must instead retain the
+covariant generic and its valid specializations.
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
+from typing import Any, Generic, Never, TypeVar
+from ty_extensions import Bottom, Intersection, Not, Top, static_assert
+from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+
 class ConstrainedCovariant[T: (int, str)]:
     def get(self) -> T:
         raise NotImplementedError
 
-class ConstrainedContravariant[T: (int, str)]:
-    def put(self, value: T) -> None: ...
-
-class ConstrainedInvariant[T: (int, str)]:
-    value: T
-    unrelated: Any
-
-    def get(self) -> T:
-        raise NotImplementedError
-
-    def put(self, value: T) -> None: ...
-
-ConstrainedT_co = TypeVar("ConstrainedT_co", int, str, covariant=True)
-ConstrainedT_contra = TypeVar("ConstrainedT_contra", int, str, contravariant=True)
-
-class LegacyConstrainedCovariant(Generic[ConstrainedT_co]): ...
-class LegacyConstrainedContravariant(Generic[ConstrainedT_contra]): ...
-
-def constrained(
-    covariant_top: Top[ConstrainedCovariant[Any]],
-    covariant_bottom: Bottom[ConstrainedCovariant[Any]],
-    contravariant_top: Top[ConstrainedContravariant[Any]],
-    contravariant_bottom: Bottom[ConstrainedContravariant[Any]],
+def constrained_covariant(
+    top: Top[ConstrainedCovariant[Any]],
+    bottom: Bottom[ConstrainedCovariant[Any]],
 ) -> None:
-    reveal_type(covariant_top)  # revealed: Top[ConstrainedCovariant[Any]]
-    reveal_type(covariant_bottom)  # revealed: Bottom[ConstrainedCovariant[Any]]
-    reveal_type(contravariant_top)  # revealed: Top[ConstrainedContravariant[Any]]
-    reveal_type(contravariant_bottom)  # revealed: Bottom[ConstrainedContravariant[Any]]
-
-def constrained_invariant(
-    top: Top[ConstrainedInvariant[Any]],
-    bottom: Bottom[ConstrainedInvariant[Any]],
-) -> None:
-    reveal_type(top.value)  # revealed: int | str
-    reveal_type(top.unrelated)  # revealed: Any
-    reveal_type(top.get)  # revealed: bound method Top[ConstrainedInvariant[Any]].get() -> int | str
-    reveal_type(top.put)  # revealed: bound method Top[ConstrainedInvariant[Any]].put(value: Never) -> None
-
-    reveal_type(bottom.unrelated)  # revealed: Any
-    reveal_type(bottom.get)  # revealed: bound method Bottom[ConstrainedInvariant[Any]].get() -> Never
-    reveal_type(bottom.put)  # revealed: bound method Bottom[ConstrainedInvariant[Any]].put(value: int | str) -> None
-    reveal_type(bottom.value)  # revealed: Never
+    reveal_type(top)  # revealed: Top[ConstrainedCovariant[Any]]
+    reveal_type(bottom)  # revealed: Bottom[ConstrainedCovariant[Any]]
 
 static_assert(is_subtype_of(ConstrainedCovariant[int], Top[ConstrainedCovariant[Any]]))
 static_assert(is_subtype_of(ConstrainedCovariant[str], Top[ConstrainedCovariant[Any]]))
@@ -820,6 +820,21 @@ static_assert(not is_equivalent_to(Intersection[ConstrainedCovariant[str], Not[C
 static_assert(is_assignable_to(ConstrainedCovariant[int], Top[ConstrainedCovariant[Any]]))
 static_assert(not is_assignable_to(Top[ConstrainedCovariant[Any]], ConstrainedCovariant[int]))
 static_assert(is_assignable_to(Bottom[ConstrainedCovariant[Any]], ConstrainedCovariant[int]))
+```
+
+Contravariant constrained generics likewise preserve their materializations while reversing the
+relationship between input positions and top or bottom types.
+
+```py
+class ConstrainedContravariant[T: (int, str)]:
+    def put(self, value: T) -> None: ...
+
+def constrained_contravariant(
+    top: Top[ConstrainedContravariant[Any]],
+    bottom: Bottom[ConstrainedContravariant[Any]],
+) -> None:
+    reveal_type(top)  # revealed: Top[ConstrainedContravariant[Any]]
+    reveal_type(bottom)  # revealed: Bottom[ConstrainedContravariant[Any]]
 
 static_assert(is_subtype_of(ConstrainedContravariant[int], Top[ConstrainedContravariant[Any]]))
 static_assert(is_subtype_of(ConstrainedContravariant[str], Top[ConstrainedContravariant[Any]]))
@@ -832,17 +847,68 @@ static_assert(is_subtype_of(Bottom[ConstrainedContravariant[Any]], Top[Constrain
 static_assert(is_assignable_to(ConstrainedContravariant[int], Top[ConstrainedContravariant[Any]]))
 static_assert(not is_assignable_to(Top[ConstrainedContravariant[Any]], ConstrainedContravariant[int]))
 static_assert(is_assignable_to(Bottom[ConstrainedContravariant[Any]], ConstrainedContravariant[int]))
+```
+
+An invariant constrained parameter materializes readable values to the union of valid constraints
+and writable parameters to `Never`. Unrelated gradual attributes remain `Any`.
+
+```py
+class ConstrainedInvariant[T: (int, str)]:
+    value: T
+    unrelated: Any
+
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def put(self, value: T) -> None: ...
+
+def constrained_invariant(
+    top: Top[ConstrainedInvariant[Any]],
+    bottom: Bottom[ConstrainedInvariant[Any]],
+) -> None:
+    reveal_type(top.value)  # revealed: int | str
+    reveal_type(top.unrelated)  # revealed: Any
+    reveal_type(top.get)  # revealed: bound method Top[ConstrainedInvariant[Any]].get() -> int | str
+    reveal_type(top.put)  # revealed: bound method Top[ConstrainedInvariant[Any]].put(value: Never) -> None
+
+    reveal_type(bottom.unrelated)  # revealed: Any
+    reveal_type(bottom.get)  # revealed: bound method Bottom[ConstrainedInvariant[Any]].get() -> Never
+    reveal_type(bottom.put)  # revealed: bound method Bottom[ConstrainedInvariant[Any]].put(value: int | str) -> None
+    reveal_type(bottom.value)  # revealed: Never
+```
+
+Legacy constrained type variables preserve the same covariant and contravariant subtype
+relationships.
+
+```py
+ConstrainedT_co = TypeVar("ConstrainedT_co", int, str, covariant=True)
+
+class LegacyConstrainedCovariant(Generic[ConstrainedT_co]): ...
 
 static_assert(is_subtype_of(LegacyConstrainedCovariant[int], Top[LegacyConstrainedCovariant[Any]]))
 static_assert(is_subtype_of(Bottom[LegacyConstrainedCovariant[Any]], LegacyConstrainedCovariant[str]))
+
+ConstrainedT_contra = TypeVar("ConstrainedT_contra", int, str, contravariant=True)
+
+class LegacyConstrainedContravariant(Generic[ConstrainedT_contra]): ...
+
 static_assert(is_subtype_of(LegacyConstrainedContravariant[int], Top[LegacyConstrainedContravariant[Any]]))
 static_assert(is_subtype_of(Bottom[LegacyConstrainedContravariant[Any]], LegacyConstrainedContravariant[str]))
+```
 
+A partially gradual type argument filters out constraints incompatible with its static `int` arm.
+
+```py
 static_assert(is_equivalent_to(Bottom[ConstrainedCovariant[Any | int]], ConstrainedCovariant[int]))
 static_assert(not is_subtype_of(ConstrainedCovariant[str], Top[ConstrainedCovariant[Any | int]]))
 static_assert(is_equivalent_to(Top[ConstrainedContravariant[Any | int]], ConstrainedContravariant[int]))
 static_assert(not is_subtype_of(Bottom[ConstrainedContravariant[Any | int]], ConstrainedContravariant[str]))
+```
 
+An intersection of `int` and `Any` likewise retains only the compatible `int` constraint for both
+variances.
+
+```py
 type GradualInt = Intersection[int, Any]
 
 static_assert(is_subtype_of(ConstrainedCovariant[int], Top[ConstrainedCovariant[GradualInt]]))
@@ -853,6 +919,22 @@ static_assert(is_subtype_of(ConstrainedContravariant[int], Top[ConstrainedContra
 static_assert(not is_subtype_of(ConstrainedContravariant[str], Top[ConstrainedContravariant[GradualInt]]))
 static_assert(is_subtype_of(Bottom[ConstrainedContravariant[GradualInt]], ConstrainedContravariant[int]))
 static_assert(not is_subtype_of(Bottom[ConstrainedContravariant[GradualInt]], ConstrainedContravariant[str]))
+```
+
+## Gradual generic constraints
+
+When `Any` is itself a constraint, static specializations outside the other constraint must remain
+valid. Reading a top-materialized covariant value produces `object`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_subtype_of
 
 class GradualConstrainedCovariant[T: (int, Any)]:
     def get(self) -> T:
@@ -873,6 +955,22 @@ static_assert(is_subtype_of(GradualConstrainedContravariant[int], Top[GradualCon
 static_assert(is_subtype_of(GradualConstrainedContravariant[str], Top[GradualConstrainedContravariant[Any]]))
 static_assert(is_subtype_of(Bottom[GradualConstrainedContravariant[Any]], GradualConstrainedContravariant[int]))
 static_assert(is_subtype_of(Bottom[GradualConstrainedContravariant[Any]], GradualConstrainedContravariant[str]))
+```
+
+## Overlapping generic constraints
+
+When one valid constraint is a subtype of another, the broader constraint supplies the upper bound
+and the narrower constraint supplies the lower bound.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_equivalent_to
 
 class OverlappingCovariant[T: (int, bool)]:
     def get(self) -> T:
@@ -885,6 +983,24 @@ static_assert(is_equivalent_to(Top[OverlappingCovariant[Any]], OverlappingCovari
 static_assert(is_equivalent_to(Bottom[OverlappingCovariant[Any]], OverlappingCovariant[bool]))
 static_assert(is_equivalent_to(Top[OverlappingContravariant[Any]], OverlappingContravariant[bool]))
 static_assert(is_equivalent_to(Bottom[OverlappingContravariant[Any]], OverlappingContravariant[int]))
+```
+
+## Mixed constrained and unconstrained type parameters
+
+A generic with both constrained and unconstrained parameters materializes each parameter
+independently. Filtering the constrained parameter must not change the unconstrained parameter.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any
+from ty_extensions import Bottom, Intersection, Top, static_assert
+from ty_extensions._internal import is_assignable_to, is_subtype_of
+
+type GradualInt = Intersection[int, Any]
 
 class MixedConstrained[T: (int, str), U]:
     value: T
@@ -913,6 +1029,9 @@ static_assert(not is_assignable_to(Bottom[MixedConstrained[GradualInt, Any]], Mi
 ```
 
 ## Materialization does not force invalid recursive specializations
+
+An invalid self-referential bound must produce the expected diagnostics without forcing recursive
+materialization. Invalid specializations recover as `Unknown`.
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -693,7 +693,7 @@ python-version = "3.12"
 
 ```py
 from typing import Any, Generic, Never, TypeVar
-from ty_extensions import Bottom, Intersection, Top, static_assert
+from ty_extensions import Bottom, Intersection, Not, Top, static_assert
 from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
 
 class BoundedCovariant[T: int]:
@@ -707,6 +707,8 @@ static_assert(is_equivalent_to(Top[BoundedCovariant[Any]], BoundedCovariant[int]
 static_assert(is_equivalent_to(Bottom[BoundedCovariant[Any]], BoundedCovariant[Never]))
 static_assert(is_equivalent_to(Top[BoundedContravariant[Any]], BoundedContravariant[Never]))
 static_assert(is_equivalent_to(Bottom[BoundedContravariant[Any]], BoundedContravariant[int]))
+static_assert(is_subtype_of(BoundedCovariant[Any], Top[BoundedCovariant[Any]]))
+static_assert(is_subtype_of(BoundedCovariant[Any], BoundedCovariant[int]))
 
 class BoundedInvariant[T: int]:
     value: T
@@ -807,11 +809,13 @@ def constrained_invariant(
 
 static_assert(is_subtype_of(ConstrainedCovariant[int], Top[ConstrainedCovariant[Any]]))
 static_assert(is_subtype_of(ConstrainedCovariant[str], Top[ConstrainedCovariant[Any]]))
+static_assert(is_subtype_of(ConstrainedCovariant[Any], Top[ConstrainedCovariant[Any]]))
 static_assert(not is_subtype_of(Top[ConstrainedCovariant[Any]], ConstrainedCovariant[int]))
 static_assert(not is_subtype_of(Top[ConstrainedCovariant[Any]], ConstrainedCovariant[str]))
 static_assert(is_subtype_of(Bottom[ConstrainedCovariant[Any]], ConstrainedCovariant[int]))
 static_assert(is_subtype_of(Bottom[ConstrainedCovariant[Any]], ConstrainedCovariant[str]))
 static_assert(is_subtype_of(Bottom[ConstrainedCovariant[Any]], Top[ConstrainedCovariant[Any]]))
+static_assert(not is_equivalent_to(Intersection[ConstrainedCovariant[str], Not[ConstrainedCovariant[int]]], Never))
 
 static_assert(is_assignable_to(ConstrainedCovariant[int], Top[ConstrainedCovariant[Any]]))
 static_assert(not is_assignable_to(Top[ConstrainedCovariant[Any]], ConstrainedCovariant[int]))

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -681,6 +681,250 @@ def contravariant(top: Top[ContravariantCallable], bottom: Bottom[ContravariantC
     reveal_type(bottom)  # revealed: (GenericContravariant[Never], /) -> None
 ```
 
+## Bounded and constrained generic type parameters
+
+Materialization respects the declared upper bound of a type parameter. The lower bound remains
+`Never`, and covariance or contravariance determines which bound belongs to each materialization.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Any, Generic, Never, TypeVar
+from ty_extensions import Bottom, Intersection, Top, static_assert
+from ty_extensions._internal import is_assignable_to, is_equivalent_to, is_subtype_of
+
+class BoundedCovariant[T: int]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class BoundedContravariant[T: int]:
+    def put(self, value: T) -> None: ...
+
+static_assert(is_equivalent_to(Top[BoundedCovariant[Any]], BoundedCovariant[int]))
+static_assert(is_equivalent_to(Bottom[BoundedCovariant[Any]], BoundedCovariant[Never]))
+static_assert(is_equivalent_to(Top[BoundedContravariant[Any]], BoundedContravariant[Never]))
+static_assert(is_equivalent_to(Bottom[BoundedContravariant[Any]], BoundedContravariant[int]))
+
+class BoundedInvariant[T: int]:
+    value: T
+    unrelated: Any
+
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def put(self, value: T) -> None: ...
+
+BoundedT_co = TypeVar("BoundedT_co", bound=int, covariant=True)
+BoundedT_contra = TypeVar("BoundedT_contra", bound=int, contravariant=True)
+BoundedT = TypeVar("BoundedT", bound=int)
+
+class LegacyBoundedCovariant(Generic[BoundedT_co]): ...
+class LegacyBoundedContravariant(Generic[BoundedT_contra]): ...
+
+class LegacyBoundedInvariant(Generic[BoundedT]):
+    value: BoundedT
+
+static_assert(is_equivalent_to(Top[LegacyBoundedCovariant[Any]], LegacyBoundedCovariant[int]))
+static_assert(is_equivalent_to(Bottom[LegacyBoundedCovariant[Any]], LegacyBoundedCovariant[Never]))
+static_assert(is_equivalent_to(Top[LegacyBoundedContravariant[Any]], LegacyBoundedContravariant[Never]))
+static_assert(is_equivalent_to(Bottom[LegacyBoundedContravariant[Any]], LegacyBoundedContravariant[int]))
+
+def bounded_invariant(
+    top: Top[BoundedInvariant[Any]],
+    bottom: Bottom[BoundedInvariant[Any]],
+) -> None:
+    reveal_type(top.value)  # revealed: int
+    reveal_type(top.unrelated)  # revealed: Any
+    reveal_type(top.get)  # revealed: bound method Top[BoundedInvariant[Any]].get() -> int
+    reveal_type(top.put)  # revealed: bound method Top[BoundedInvariant[Any]].put(value: Never) -> None
+
+    reveal_type(bottom.unrelated)  # revealed: Any
+    reveal_type(bottom.get)  # revealed: bound method Bottom[BoundedInvariant[Any]].get() -> Never
+    reveal_type(bottom.put)  # revealed: bound method Bottom[BoundedInvariant[Any]].put(value: int) -> None
+    reveal_type(bottom.value)  # revealed: Never
+
+def legacy_bounded_invariant(
+    legacy_top: Top[LegacyBoundedInvariant[Any]],
+    legacy_bottom: Bottom[LegacyBoundedInvariant[Any]],
+) -> None:
+    reveal_type(legacy_top.value)  # revealed: int
+    reveal_type(legacy_bottom.value)  # revealed: Never
+```
+
+A constrained type parameter cannot generally be replaced by the union of its constraints: the union
+need not itself be a valid specialization. Preserve the materialization instead.
+
+```py
+class ConstrainedCovariant[T: (int, str)]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class ConstrainedContravariant[T: (int, str)]:
+    def put(self, value: T) -> None: ...
+
+class ConstrainedInvariant[T: (int, str)]:
+    value: T
+    unrelated: Any
+
+    def get(self) -> T:
+        raise NotImplementedError
+
+    def put(self, value: T) -> None: ...
+
+ConstrainedT_co = TypeVar("ConstrainedT_co", int, str, covariant=True)
+ConstrainedT_contra = TypeVar("ConstrainedT_contra", int, str, contravariant=True)
+
+class LegacyConstrainedCovariant(Generic[ConstrainedT_co]): ...
+class LegacyConstrainedContravariant(Generic[ConstrainedT_contra]): ...
+
+def constrained(
+    covariant_top: Top[ConstrainedCovariant[Any]],
+    covariant_bottom: Bottom[ConstrainedCovariant[Any]],
+    contravariant_top: Top[ConstrainedContravariant[Any]],
+    contravariant_bottom: Bottom[ConstrainedContravariant[Any]],
+) -> None:
+    reveal_type(covariant_top)  # revealed: Top[ConstrainedCovariant[Any]]
+    reveal_type(covariant_bottom)  # revealed: Bottom[ConstrainedCovariant[Any]]
+    reveal_type(contravariant_top)  # revealed: Top[ConstrainedContravariant[Any]]
+    reveal_type(contravariant_bottom)  # revealed: Bottom[ConstrainedContravariant[Any]]
+
+def constrained_invariant(
+    top: Top[ConstrainedInvariant[Any]],
+    bottom: Bottom[ConstrainedInvariant[Any]],
+) -> None:
+    reveal_type(top.value)  # revealed: int | str
+    reveal_type(top.unrelated)  # revealed: Any
+    reveal_type(top.get)  # revealed: bound method Top[ConstrainedInvariant[Any]].get() -> int | str
+    reveal_type(top.put)  # revealed: bound method Top[ConstrainedInvariant[Any]].put(value: Never) -> None
+
+    reveal_type(bottom.unrelated)  # revealed: Any
+    reveal_type(bottom.get)  # revealed: bound method Bottom[ConstrainedInvariant[Any]].get() -> Never
+    reveal_type(bottom.put)  # revealed: bound method Bottom[ConstrainedInvariant[Any]].put(value: int | str) -> None
+    reveal_type(bottom.value)  # revealed: Never
+
+static_assert(is_subtype_of(ConstrainedCovariant[int], Top[ConstrainedCovariant[Any]]))
+static_assert(is_subtype_of(ConstrainedCovariant[str], Top[ConstrainedCovariant[Any]]))
+static_assert(not is_subtype_of(Top[ConstrainedCovariant[Any]], ConstrainedCovariant[int]))
+static_assert(not is_subtype_of(Top[ConstrainedCovariant[Any]], ConstrainedCovariant[str]))
+static_assert(is_subtype_of(Bottom[ConstrainedCovariant[Any]], ConstrainedCovariant[int]))
+static_assert(is_subtype_of(Bottom[ConstrainedCovariant[Any]], ConstrainedCovariant[str]))
+static_assert(is_subtype_of(Bottom[ConstrainedCovariant[Any]], Top[ConstrainedCovariant[Any]]))
+
+static_assert(is_assignable_to(ConstrainedCovariant[int], Top[ConstrainedCovariant[Any]]))
+static_assert(not is_assignable_to(Top[ConstrainedCovariant[Any]], ConstrainedCovariant[int]))
+static_assert(is_assignable_to(Bottom[ConstrainedCovariant[Any]], ConstrainedCovariant[int]))
+
+static_assert(is_subtype_of(ConstrainedContravariant[int], Top[ConstrainedContravariant[Any]]))
+static_assert(is_subtype_of(ConstrainedContravariant[str], Top[ConstrainedContravariant[Any]]))
+static_assert(not is_subtype_of(Top[ConstrainedContravariant[Any]], ConstrainedContravariant[int]))
+static_assert(not is_subtype_of(Top[ConstrainedContravariant[Any]], ConstrainedContravariant[str]))
+static_assert(is_subtype_of(Bottom[ConstrainedContravariant[Any]], ConstrainedContravariant[int]))
+static_assert(is_subtype_of(Bottom[ConstrainedContravariant[Any]], ConstrainedContravariant[str]))
+static_assert(is_subtype_of(Bottom[ConstrainedContravariant[Any]], Top[ConstrainedContravariant[Any]]))
+
+static_assert(is_assignable_to(ConstrainedContravariant[int], Top[ConstrainedContravariant[Any]]))
+static_assert(not is_assignable_to(Top[ConstrainedContravariant[Any]], ConstrainedContravariant[int]))
+static_assert(is_assignable_to(Bottom[ConstrainedContravariant[Any]], ConstrainedContravariant[int]))
+
+static_assert(is_subtype_of(LegacyConstrainedCovariant[int], Top[LegacyConstrainedCovariant[Any]]))
+static_assert(is_subtype_of(Bottom[LegacyConstrainedCovariant[Any]], LegacyConstrainedCovariant[str]))
+static_assert(is_subtype_of(LegacyConstrainedContravariant[int], Top[LegacyConstrainedContravariant[Any]]))
+static_assert(is_subtype_of(Bottom[LegacyConstrainedContravariant[Any]], LegacyConstrainedContravariant[str]))
+
+static_assert(is_equivalent_to(Bottom[ConstrainedCovariant[Any | int]], ConstrainedCovariant[int]))
+static_assert(not is_subtype_of(ConstrainedCovariant[str], Top[ConstrainedCovariant[Any | int]]))
+static_assert(is_equivalent_to(Top[ConstrainedContravariant[Any | int]], ConstrainedContravariant[int]))
+static_assert(not is_subtype_of(Bottom[ConstrainedContravariant[Any | int]], ConstrainedContravariant[str]))
+
+type GradualInt = Intersection[int, Any]
+
+static_assert(is_subtype_of(ConstrainedCovariant[int], Top[ConstrainedCovariant[GradualInt]]))
+static_assert(not is_subtype_of(ConstrainedCovariant[str], Top[ConstrainedCovariant[GradualInt]]))
+static_assert(is_subtype_of(Bottom[ConstrainedCovariant[GradualInt]], ConstrainedCovariant[int]))
+static_assert(not is_subtype_of(Bottom[ConstrainedCovariant[GradualInt]], ConstrainedCovariant[str]))
+static_assert(is_subtype_of(ConstrainedContravariant[int], Top[ConstrainedContravariant[GradualInt]]))
+static_assert(not is_subtype_of(ConstrainedContravariant[str], Top[ConstrainedContravariant[GradualInt]]))
+static_assert(is_subtype_of(Bottom[ConstrainedContravariant[GradualInt]], ConstrainedContravariant[int]))
+static_assert(not is_subtype_of(Bottom[ConstrainedContravariant[GradualInt]], ConstrainedContravariant[str]))
+
+class GradualConstrainedCovariant[T: (int, Any)]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class GradualConstrainedContravariant[T: (int, Any)]:
+    def put(self, value: T) -> None: ...
+
+def gradual_constraints(value: Top[GradualConstrainedCovariant[Any]]) -> None:
+    reveal_type(value)  # revealed: Top[GradualConstrainedCovariant[Any]]
+    reveal_type(value.get())  # revealed: object
+
+static_assert(is_subtype_of(GradualConstrainedCovariant[int], Top[GradualConstrainedCovariant[Any]]))
+static_assert(is_subtype_of(GradualConstrainedCovariant[str], Top[GradualConstrainedCovariant[Any]]))
+static_assert(is_subtype_of(Bottom[GradualConstrainedCovariant[Any]], GradualConstrainedCovariant[int]))
+static_assert(is_subtype_of(Bottom[GradualConstrainedCovariant[Any]], GradualConstrainedCovariant[str]))
+static_assert(is_subtype_of(GradualConstrainedContravariant[int], Top[GradualConstrainedContravariant[Any]]))
+static_assert(is_subtype_of(GradualConstrainedContravariant[str], Top[GradualConstrainedContravariant[Any]]))
+static_assert(is_subtype_of(Bottom[GradualConstrainedContravariant[Any]], GradualConstrainedContravariant[int]))
+static_assert(is_subtype_of(Bottom[GradualConstrainedContravariant[Any]], GradualConstrainedContravariant[str]))
+
+class OverlappingCovariant[T: (int, bool)]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class OverlappingContravariant[T: (int, bool)]:
+    def put(self, value: T) -> None: ...
+
+static_assert(is_equivalent_to(Top[OverlappingCovariant[Any]], OverlappingCovariant[int]))
+static_assert(is_equivalent_to(Bottom[OverlappingCovariant[Any]], OverlappingCovariant[bool]))
+static_assert(is_equivalent_to(Top[OverlappingContravariant[Any]], OverlappingContravariant[bool]))
+static_assert(is_equivalent_to(Bottom[OverlappingContravariant[Any]], OverlappingContravariant[int]))
+
+class MixedConstrained[T: (int, str), U]:
+    value: T
+    items: list[U]
+
+def mixed_constrained(
+    top: Top[MixedConstrained[Any, Any]],
+    bottom: Bottom[MixedConstrained[Any, Any]],
+) -> None:
+    reveal_type(top)  # revealed: Top[MixedConstrained[Any, Any]]
+    reveal_type(bottom)  # revealed: Bottom[MixedConstrained[Any, Any]]
+    reveal_type(top.value)  # revealed: int | str
+    reveal_type(top.items)  # revealed: Top[list[Any]]
+    reveal_type(bottom.items)  # revealed: Bottom[list[Any]]
+    reveal_type(bottom.value)  # revealed: Never
+
+static_assert(is_subtype_of(MixedConstrained[int, int], Top[MixedConstrained[Any, Any]]))
+static_assert(is_subtype_of(MixedConstrained[str, int], Top[MixedConstrained[Any, Any]]))
+static_assert(is_subtype_of(Bottom[MixedConstrained[Any, Any]], MixedConstrained[int, int]))
+static_assert(is_subtype_of(Bottom[MixedConstrained[Any, Any]], MixedConstrained[str, int]))
+static_assert(is_subtype_of(MixedConstrained[int, int], Top[MixedConstrained[Any, int]]))
+static_assert(is_assignable_to(MixedConstrained[int, str], Top[MixedConstrained[GradualInt, Any]]))
+static_assert(not is_assignable_to(MixedConstrained[str, str], Top[MixedConstrained[GradualInt, Any]]))
+static_assert(is_assignable_to(Bottom[MixedConstrained[GradualInt, Any]], MixedConstrained[int, int]))
+static_assert(not is_assignable_to(Bottom[MixedConstrained[GradualInt, Any]], MixedConstrained[str, int]))
+```
+
+## Materialization does not force invalid recursive specializations
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+# error: [invalid-type-arguments]
+class RecursiveSpecialization[T: "RecursiveSpecialization[int]"]:
+    pass
+
+# error: [invalid-type-arguments]
+def recursive_specialization(value: RecursiveSpecialization[str]) -> None:
+    reveal_type(value)  # revealed: RecursiveSpecialization[Unknown]
+```
+
 ## Invalid use
 
 `Top[]` and `Bottom[]` are special forms that take a single argument.

--- a/crates/ty_python_semantic/resources/mdtest/union_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/union_types.md
@@ -373,3 +373,43 @@ def _(
     reveal_type(g)  # revealed: Invariant[Any] | Invariant[Any | str]
     reveal_type(h)  # revealed: Invariant[Any | str] | Invariant[Any]
 ```
+
+A type alias does not make a gradual type argument static. Covariant unions simplify the same way
+whether the gradual argument is written directly or hidden behind one or more aliases.
+
+```py
+type GradualAlias = Any | str
+type NestedGradualAlias = GradualAlias
+
+def gradual_aliases(
+    direct_first: Covariant[Any] | Covariant[GradualAlias],
+    direct_last: Covariant[GradualAlias] | Covariant[Any],
+    nested_first: Covariant[Any] | Covariant[NestedGradualAlias],
+    nested_last: Covariant[NestedGradualAlias] | Covariant[Any],
+) -> None:
+    reveal_type(direct_first)  # revealed: Covariant[GradualAlias]
+    reveal_type(direct_last)  # revealed: Covariant[GradualAlias]
+    reveal_type(nested_first)  # revealed: Covariant[NestedGradualAlias]
+    reveal_type(nested_last)  # revealed: Covariant[NestedGradualAlias]
+```
+
+Matching materialization endpoints do not establish that gradual tuple arguments have the same
+shape. A bounded generic must preserve which tuple position contains the gradual element.
+
+```py
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_equivalent_to
+
+type L = tuple[Any, int]
+type R = tuple[int, Any]
+
+class C[T: tuple[int, int]]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+static_assert(is_equivalent_to(Top[C[L]], Top[C[R]]))
+static_assert(is_equivalent_to(Bottom[C[L]], Bottom[C[R]]))
+static_assert(not is_equivalent_to(C[L], C[R]))
+static_assert(not is_equivalent_to(C[L] | C[R], C[L]))
+static_assert(not is_equivalent_to(C[R] | C[L], C[R]))
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -383,7 +383,7 @@ pub(crate) struct VisitSpecialization;
 
 /// How a generic type has been specialized.
 ///
-/// This matters only if there is at least one invariant type parameter.
+/// This matters only if there is at least one invariant or constrained type parameter.
 /// For example, we represent `Top[list[Any]]` as a `GenericAlias` with
 /// `MaterializationKind` set to Top, which we denote as `Top[list[Any]]`.
 /// A type `Top[list[T]]` includes all fully static list types `list[U]` where `U` is
@@ -1579,8 +1579,8 @@ impl<'db> Type<'db> {
     /// More concretely, `T'`, the materialization of `T`, is the type `T` with all occurrences of
     /// the dynamic types (`Any`, `Unknown`, `Todo`) replaced as follows:
     ///
-    /// - In covariant position, it's replaced with `object` (TODO: it should be the `TypeVar`'s upper
-    ///   bound, if any)
+    /// - In covariant position, it's replaced with `object`, or the type variable's upper bound
+    ///   when the dynamic type is a bounded generic argument
     /// - In contravariant position, it's replaced with `Never`
     /// - In invariant position, we replace the object with a special form recording that it's the top
     ///   or bottom materialization.

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -524,13 +524,17 @@ impl<'db> StaticClassLiteral<'db> {
 
     pub(crate) fn top_materialization(self, db: &'db dyn Db) -> ClassType<'db> {
         self.apply_specialization(db, |generic_context| {
-            generic_context
-                .default_specialization(db, self.known(db))
-                .materialize_impl(
-                    db,
-                    MaterializationKind::Top,
-                    &ApplyTypeMappingVisitor::default(),
-                )
+            let specialization = if self.is_tuple(db) {
+                generic_context.default_specialization(db, Some(KnownClass::Tuple))
+            } else {
+                generic_context.unknown_specialization(db)
+            };
+
+            specialization.materialize_impl(
+                db,
+                MaterializationKind::Top,
+                &ApplyTypeMappingVisitor::default(),
+            )
         })
     }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -524,17 +524,13 @@ impl<'db> StaticClassLiteral<'db> {
 
     pub(crate) fn top_materialization(self, db: &'db dyn Db) -> ClassType<'db> {
         self.apply_specialization(db, |generic_context| {
-            let specialization = if self.is_tuple(db) {
-                generic_context.default_specialization(db, Some(KnownClass::Tuple))
-            } else {
-                generic_context.unknown_specialization(db)
-            };
-
-            specialization.materialize_impl(
-                db,
-                MaterializationKind::Top,
-                &ApplyTypeMappingVisitor::default(),
-            )
+            generic_context
+                .unknown_specialization(db, self.known(db))
+                .materialize_impl(
+                    db,
+                    MaterializationKind::Top,
+                    &ApplyTypeMappingVisitor::default(),
+                )
         })
     }
 
@@ -552,7 +548,7 @@ impl<'db> StaticClassLiteral<'db> {
     /// maps each of the class's typevars to `Unknown`.
     pub(crate) fn unknown_specialization(self, db: &'db dyn Db) -> ClassType<'db> {
         self.apply_specialization(db, |generic_context| {
-            generic_context.unknown_specialization(db)
+            generic_context.unknown_specialization(db, self.known(db))
         })
     }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1035,7 +1035,7 @@ pub struct Specialization<'db> {
     /// `Bottom[A[Any]]` is a subtype of all materializations of `A[Any]`, and is represented
     /// with `Some(MaterializationKind::Bottom)`.
     /// The `materialization_kind` field may be non-`None` only if the specialization contains
-    /// dynamic types in invariant positions.
+    /// dynamic types in invariant positions or positions with constrained type variables.
     #[returns(copy)]
     pub(crate) materialization_kind: Option<MaterializationKind>,
 
@@ -1416,26 +1416,46 @@ impl<'db> Specialization<'db> {
         if self.materialization_kind(db).is_some() {
             return self;
         }
-        let mut has_dynamic_invariant_typevar = false;
+        let mut has_unsimplified_dynamic_typevar = false;
         let types = self.map_types(db, |_, bound_typevar, vartype| {
-            match specialization_variance(db, bound_typevar) {
+            let variance = specialization_variance(db, bound_typevar);
+            let top_materialization = vartype.materialize(db, MaterializationKind::Top, visitor);
+            let has_dynamic_type =
+                !visitor.is_equivalent_to_materialization(db, vartype, top_materialization);
+
+            match variance {
                 TypeVarVariance::Bivariant => {
                     // With bivariance, all specializations are subtypes of each other,
                     // so any materialization is acceptable.
-                    vartype.materialize(db, MaterializationKind::Top, visitor)
+                    top_materialization
                 }
-                TypeVarVariance::Covariant => {
-                    vartype.materialize(db, materialization_kind, visitor)
+                TypeVarVariance::Covariant | TypeVarVariance::Contravariant
+                    if has_dynamic_type && bound_typevar.typevar(db).is_constrained(db) =>
+                {
+                    has_unsimplified_dynamic_typevar = true;
+                    vartype
                 }
-                TypeVarVariance::Contravariant => {
-                    vartype.materialize(db, materialization_kind.flip(), visitor)
+                TypeVarVariance::Covariant | TypeVarVariance::Contravariant => {
+                    let effective_materialization_kind = if variance.is_covariant() {
+                        materialization_kind
+                    } else {
+                        materialization_kind.flip()
+                    };
+                    let materialized =
+                        vartype.materialize(db, effective_materialization_kind, visitor);
+
+                    if has_dynamic_type
+                        && effective_materialization_kind == MaterializationKind::Top
+                        && let Some(upper_bound) =
+                            bound_typevar.typevar(db).top_materialized_upper_bound(db)
+                    {
+                        IntersectionType::from_two_elements(db, materialized, upper_bound)
+                    } else {
+                        materialized
+                    }
                 }
                 TypeVarVariance::Invariant => {
-                    let top_materialization =
-                        vartype.materialize(db, MaterializationKind::Top, visitor);
-                    if !visitor.is_equivalent_to_materialization(db, vartype, top_materialization) {
-                        has_dynamic_invariant_typevar = true;
-                    }
+                    has_unsimplified_dynamic_typevar |= has_dynamic_type;
                     vartype
                 }
             }
@@ -1450,11 +1470,8 @@ impl<'db> Specialization<'db> {
                 visitor,
             )
         });
-        let new_materialization_kind = if has_dynamic_invariant_typevar {
-            Some(materialization_kind)
-        } else {
-            None
-        };
+        let new_materialization_kind =
+            has_unsimplified_dynamic_typevar.then_some(materialization_kind);
         // Keep this check in sync with every field that can be transformed above.
         let specialization_unchanged = matches!(&types, Cow::Borrowed(_))
             && tuple_inner == original_tuple_inner
@@ -1542,13 +1559,15 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             db,
             self.constraints,
             |(bound_typevar, source_type, target_type)| {
+                let variance = specialization_variance(db, bound_typevar);
+
                 // Subtyping/assignability of each type in the specialization depends on the variance
                 // of the corresponding typevar:
                 //   - covariant: verify that source_type <: target_type
                 //   - contravariant: verify that target_type <: source_type
                 //   - invariant: verify that source_type <: target_type AND target_type <: source_type
                 //   - bivariant: skip, can't make subtyping/assignability false
-                match specialization_variance(db, bound_typevar) {
+                match variance {
                     TypeVarVariance::Invariant => self.check_relation_in_invariant_position(
                         db,
                         *source_type,
@@ -1556,16 +1575,128 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         *target_type,
                         target_materialization_kind,
                     ),
-                    TypeVarVariance::Covariant => {
-                        self.check_type_pair(db, *source_type, *target_type)
-                    }
-                    TypeVarVariance::Contravariant => {
-                        self.check_type_pair(db, *target_type, *source_type)
+                    TypeVarVariance::Covariant | TypeVarVariance::Contravariant => {
+                        let (
+                            (source_type, source_materialization),
+                            (target_type, target_materialization),
+                        ) = if variance.is_covariant() {
+                            (
+                                (*source_type, source_materialization_kind),
+                                (*target_type, target_materialization_kind),
+                            )
+                        } else {
+                            (
+                                (*target_type, target_materialization_kind),
+                                (*source_type, source_materialization_kind),
+                            )
+                        };
+
+                        self.check_type_pair(
+                            db,
+                            self.materialize_constrained_type_argument(
+                                db,
+                                bound_typevar,
+                                source_type,
+                                variance,
+                                source_materialization,
+                            ),
+                            self.materialize_constrained_type_argument(
+                                db,
+                                bound_typevar,
+                                target_type,
+                                variance,
+                                target_materialization,
+                            ),
+                        )
                     }
                     TypeVarVariance::Bivariant => self.always(),
                 }
             },
         )
+    }
+
+    /// Materializes a constrained covariant or contravariant argument for a relation check.
+    ///
+    /// A constrained type variable can only take one of its declared alternatives. For example,
+    /// replacing `Any` with `int | str` for `class C[T: (int, str)]` would create the invalid
+    /// specialization `C[int | str]`. Preserve the enclosing materialization instead, and combine
+    /// only the constraints reachable within the argument's materialization range.
+    fn materialize_constrained_type_argument(
+        &self,
+        db: &'db dyn Db,
+        bound_typevar: BoundTypeVarInstance<'db>,
+        ty: Type<'db>,
+        variance: TypeVarVariance,
+        materialization: Option<MaterializationKind>,
+    ) -> Type<'db> {
+        let Some(materialization) = materialization else {
+            return ty;
+        };
+
+        // A lazy upper bound may refer back to the enclosing specialization. Check whether this
+        // type variable is constrained before evaluating its bounds or constraints.
+        let typevar = bound_typevar.typevar(db);
+        if !typevar.is_constrained(db) {
+            return ty;
+        }
+
+        let argument_top =
+            ty.materialize(db, MaterializationKind::Top, self.materialization_visitor);
+        if self
+            .materialization_visitor
+            .is_equivalent_to_materialization(db, ty, argument_top)
+        {
+            return ty;
+        }
+        let Some(constraints) = typevar.constraints(db) else {
+            return ty;
+        };
+        let argument_bottom = ty.materialize(
+            db,
+            MaterializationKind::Bottom,
+            self.materialization_visitor,
+        );
+        let effective_materialization = if variance.is_covariant() {
+            materialization
+        } else {
+            materialization.flip()
+        };
+
+        let viable_constraints = constraints.iter().filter_map(|constraint| {
+            let constraint_top =
+                constraint.materialize(db, MaterializationKind::Top, self.materialization_visitor);
+
+            // A viable constraint must overlap the argument's upper materialization and contain
+            // its lower materialization. The upper check matters for `Intersection[int, Any]`,
+            // and the lower check matters for `Any | int`.
+            if argument_top.is_disjoint_from(db, constraint_top)
+                || !argument_bottom.is_subtype_of(db, constraint_top)
+            {
+                return None;
+            }
+
+            Some(match effective_materialization {
+                MaterializationKind::Top => constraint_top,
+                MaterializationKind::Bottom => constraint.materialize(
+                    db,
+                    MaterializationKind::Bottom,
+                    self.materialization_visitor,
+                ),
+            })
+        });
+
+        match effective_materialization {
+            MaterializationKind::Top => IntersectionType::from_two_elements(
+                db,
+                argument_top,
+                UnionType::from_elements(db, viable_constraints),
+            ),
+            MaterializationKind::Bottom => UnionType::from_two_elements(
+                db,
+                argument_bottom,
+                IntersectionType::from_elements(db, viable_constraints),
+            ),
+        }
     }
 
     /// Whether two types encountered in an invariant position

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1616,17 +1616,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ),
                     TypeVarVariance::Covariant | TypeVarVariance::Contravariant => {
                         let (
-                            (source_type, source_materialization),
-                            (target_type, target_materialization),
+                            source_type,
+                            source_materialization,
+                            target_type,
+                            target_materialization,
                         ) = if variance.is_covariant() {
                             (
-                                (*source_type, source_materialization_kind),
-                                (*target_type, target_materialization_kind),
+                                *source_type,
+                                source_materialization_kind,
+                                *target_type,
+                                target_materialization_kind,
                             )
                         } else {
                             (
-                                (*target_type, target_materialization_kind),
-                                (*source_type, source_materialization_kind),
+                                *target_type,
+                                target_materialization_kind.map(MaterializationKind::flip),
+                                *source_type,
+                                source_materialization_kind.map(MaterializationKind::flip),
                             )
                         };
 
@@ -1636,14 +1642,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 db,
                                 bound_typevar,
                                 source_type,
-                                variance,
                                 source_materialization,
                             ),
                             self.materialize_constrained_type_argument(
                                 db,
                                 bound_typevar,
                                 target_type,
-                                variance,
                                 target_materialization,
                             ),
                         )
@@ -1665,7 +1669,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         db: &'db dyn Db,
         bound_typevar: BoundTypeVarInstance<'db>,
         ty: Type<'db>,
-        variance: TypeVarVariance,
         materialization: Option<MaterializationKind>,
     ) -> Type<'db> {
         let Some(materialization) = materialization else {
@@ -1695,11 +1698,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             MaterializationKind::Bottom,
             self.materialization_visitor,
         );
-        let effective_materialization = if variance.is_covariant() {
-            materialization
-        } else {
-            materialization.flip()
-        };
 
         let viable_constraints = constraints.iter().filter_map(|constraint| {
             let constraint_top =
@@ -1714,7 +1712,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 return None;
             }
 
-            Some(match effective_materialization {
+            Some(match materialization {
                 MaterializationKind::Top => constraint_top,
                 MaterializationKind::Bottom => constraint.materialize(
                     db,
@@ -1724,7 +1722,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             })
         });
 
-        match effective_materialization {
+        match materialization {
             MaterializationKind::Top => IntersectionType::from_two_elements(
                 db,
                 argument_top,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1550,12 +1550,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // valid materializations are subtypes. Materialize the entire source so declared bounds
         // and constraints restrict gradual type arguments before comparing each argument. Besides
         // establishing `C[Any] <: Top[C[Any]]`, this ensures an `isinstance(x, C)` check excludes
-        // every specialization of `C` from its false branch.
+        // every specialization of `C` from its false branch. Pure redundancy instead checks
+        // equivalence and must preserve the specialization's full range of materializations.
         if matches!(
             self.relation,
             TypeRelation::Subtyping
                 | TypeRelation::SubtypingAssuming
-                | TypeRelation::Redundancy { .. }
+                | TypeRelation::Redundancy { pure: false }
         ) && source.materialization_kind(db).is_none()
             && source.types(db).iter().any(|ty| ty.has_dynamic(db))
             && target

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -815,9 +815,18 @@ impl<'db> GenericContext<'db> {
         self.specialize(db, types)
     }
 
-    pub(crate) fn unknown_specialization(self, db: &'db dyn Db) -> Specialization<'db> {
-        self.specialize(
+    /// Specializes every type parameter to its unknown form.
+    ///
+    /// The built-in `tuple` also needs an explicit variable-length tuple shape so that
+    /// materialization can preserve its element type.
+    pub(crate) fn unknown_specialization(
+        self,
+        db: &'db dyn Db,
+        known_class: Option<KnownClass>,
+    ) -> Specialization<'db> {
+        Specialization::new(
             db,
+            self,
             self.variables(db)
                 .map(|typevar| match typevar.kind(db) {
                     TypeVarKind::LegacyTypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
@@ -828,7 +837,10 @@ impl<'db> GenericContext<'db> {
                     }
                     _ => Type::unknown(),
                 })
-                .collect::<Vec<_>>(),
+                .collect::<Box<[_]>>(),
+            None,
+            (known_class == Some(KnownClass::Tuple))
+                .then(|| TupleType::homogeneous(db, Type::unknown())),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1558,28 +1558,57 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return self.check_tuple_type_pair(db, source_tuple, target_tuple);
         }
 
-        // A gradual specialization is a subtype of a fully static specialization when all of its
-        // valid materializations are subtypes. Materialize the entire source so declared bounds
-        // and constraints restrict gradual type arguments before comparing each argument. Besides
-        // establishing `C[Any] <: Top[C[Any]]`, this ensures an `isinstance(x, C)` check excludes
-        // every specialization of `C` from its false branch. Pure redundancy instead checks
-        // equivalence and must preserve the specialization's full range of materializations.
+        // A gradual specialization is a subtype of a fully static specialization when all its
+        // valid materializations are subtypes. Materializing the source applies declared bounds
+        // and constraints before comparing arguments. This establishes `C[Any] <: Top[C[Any]]`
+        // and lets negative `isinstance` narrowing exclude every specialization of `C`.
+        //
+        // This transformation is sound for directional subtyping and non-pure redundancy.
+        // Assignability and pure redundancy must retain the source's gradual semantics.
         if matches!(
             self.relation,
             TypeRelation::Subtyping
                 | TypeRelation::SubtypingAssuming
                 | TypeRelation::Redundancy { pure: false }
-        ) && source.materialization_kind(db).is_none()
-            && source.types(db).iter().any(|ty| ty.has_dynamic(db))
+        )
+            // Explicitly materialized sources are already static and cannot advance further.
+            && source.materialization_kind(db).is_none()
+            // Performance only: `source_top != source` below already handles unchanged
+            // arguments. Without expanding aliases, treat them as potentially gradual.
+            && source.types(db).iter().any(|ty| {
+                any_over_type(db, *ty, false, |ty| {
+                    ty.is_dynamic() || matches!(ty, Type::TypeAlias(_))
+                })
+            })
+            // Avoid the `self.always()` type-variable shortcut in
+            // `check_subtyping_in_invariant_position`: it would incorrectly conclude
+            // that `Top[Inv[Any]] <: Inv[T]` for an unresolved `T`.
+            // TODO: remove this once that shortcut is removed.
             && target
                 .types(db)
                 .iter()
                 .all(|ty| !ty.has_typevar_or_typevar_instance(db))
-            && (target.materialization_kind(db).is_some()
-                || target.types(db).iter().all(|ty| !ty.has_dynamic(db)))
+            // Only non-pure redundancy needs a target already equal to its top.
+            // Materializing the source otherwise loses the bottom needed to
+            // simplify `Covariant[Any] | Covariant[Any | str]`. Comparing both
+            // top and bottom is a possible alternative, but it gets more complex
+            // due to the need to preserve Divergent markers. Also the fact that we currently
+            // simplify tuples containing `Never` to `Never` means that for
+            // `class C[T: tuple[int, int]]`, `C[tuple[Any, int]]` and `C[tuple[int, Any]]`
+            // have the same top and bottom but expose `Any` in different tuple positions.
+            // TODO: Try resolving the above issues so we can compare top/bottom subtyping here.
+            && (!matches!(self.relation, TypeRelation::Redundancy { pure: false })
+                || target
+                    == target.materialize_impl(
+                        db,
+                        MaterializationKind::Top,
+                        self.materialization_visitor,
+                    ))
         {
             let source_top =
                 source.materialize_impl(db, MaterializationKind::Top, self.materialization_visitor);
+            // Dynamic arguments can still be unchanged by top materialization; retrying
+            // the same pair would recurse indefinitely.
             if source_top != source {
                 return self.check_specialization_pair(db, source_top, target);
             }
@@ -1662,8 +1691,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ///
     /// A constrained type variable can only take one of its declared alternatives. For example,
     /// replacing `Any` with `int | str` for `class C[T: (int, str)]` would create the invalid
-    /// specialization `C[int | str]`. Preserve the enclosing materialization instead, and combine
-    /// only the constraints reachable within the argument's materialization range.
+    /// specialization `C[int | str]`. The caller preserves the enclosing `Top[C[Any]]`; this
+    /// helper combines the reachable constraints into `int | str` only for the relation check,
+    /// without constructing `C[int | str]`.
     fn materialize_constrained_type_argument(
         &self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1546,6 +1546,32 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return self.check_tuple_type_pair(db, source_tuple, target_tuple);
         }
 
+        // A gradual specialization is a subtype of a fully static specialization when all of its
+        // valid materializations are subtypes. Materialize the entire source so declared bounds
+        // and constraints restrict gradual type arguments before comparing each argument. Besides
+        // establishing `C[Any] <: Top[C[Any]]`, this ensures an `isinstance(x, C)` check excludes
+        // every specialization of `C` from its false branch.
+        if matches!(
+            self.relation,
+            TypeRelation::Subtyping
+                | TypeRelation::SubtypingAssuming
+                | TypeRelation::Redundancy { .. }
+        ) && source.materialization_kind(db).is_none()
+            && source.types(db).iter().any(|ty| ty.has_dynamic(db))
+            && target
+                .types(db)
+                .iter()
+                .all(|ty| !ty.has_typevar_or_typevar_instance(db))
+            && (target.materialization_kind(db).is_some()
+                || target.types(db).iter().all(|ty| !ty.has_dynamic(db)))
+        {
+            let source_top =
+                source.materialize_impl(db, MaterializationKind::Top, self.materialization_visitor);
+            if source_top != source {
+                return self.check_specialization_pair(db, source_top, target);
+            }
+        }
+
         let source_materialization_kind = source.materialization_kind(db);
         let target_materialization_kind = target.materialization_kind(db);
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -241,13 +241,12 @@ impl<'db> TypeVarInstance<'db> {
     /// Returns the static upper bound used when materializing a gradual type argument.
     ///
     /// Constraints are unioned only when materializing an exposed member, where their union is a
-    /// valid conservative upper bound. A bound can also refer to a specialization of the class
-    /// that owns this type variable. Keeping bound materialization in a tracked query lets Salsa
-    /// recover from that recursive dependency instead of repeatedly expanding the same invalid
-    /// specialization.
+    /// valid conservative upper bound. A bound may recursively refer to its own generic class,
+    /// either directly or through other bounds. Such a bound has no finite static top
+    /// materialization, so recover from its cycle without applying an upper bound.
     #[salsa::tracked(
         returns(copy),
-        cycle_initial=|_, _, _| None,
+        cycle_result=|_, _, _| None,
         heap_size=ruff_memory_usage::heap_size
     )]
     pub(super) fn top_materialized_upper_bound(self, db: &'db dyn Db) -> Option<Type<'db>> {

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -15,9 +15,9 @@ use crate::{
     },
     types::{
         ApplySpecialization, ApplyTypeMappingVisitor, CycleDetector, DynamicType, GenericContext,
-        InstanceProjection, KnownClass, KnownInstanceType, MaterializationKind, Parameter,
-        Parameters, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarVariance, UnionBuilder,
-        UnionType, any_over_type, binding_type, definition_expression_type,
+        InstanceProjection, IntersectionType, KnownClass, KnownInstanceType, MaterializationKind,
+        Parameter, Parameters, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarVariance,
+        UnionBuilder, UnionType, any_over_type, binding_type, definition_expression_type,
         tuple::Tuple,
         variance::VarianceInferable,
         visitor::{self, TypeCollector, TypeVisitor, walk_type_with_recursion_guard},
@@ -236,6 +236,35 @@ impl<'db> TypeVarInstance<'db> {
         } else {
             None
         }
+    }
+
+    /// Returns the static upper bound used when materializing a gradual type argument.
+    ///
+    /// Constraints are unioned only when materializing an exposed member, where their union is a
+    /// valid conservative upper bound. A bound can also refer to a specialization of the class
+    /// that owns this type variable. Keeping bound materialization in a tracked query lets Salsa
+    /// recover from that recursive dependency instead of repeatedly expanding the same invalid
+    /// specialization.
+    #[salsa::tracked(
+        returns(copy),
+        cycle_initial=|_, _, _| None,
+        heap_size=ruff_memory_usage::heap_size
+    )]
+    pub(super) fn top_materialized_upper_bound(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        self.bound_or_constraints(db)
+            .map(|bound_or_constraints| bound_or_constraints.as_type(db).top_materialization(db))
+    }
+
+    /// Returns whether this type variable has constraints without evaluating a lazy bound.
+    pub(super) fn is_constrained(self, db: &'db dyn Db) -> bool {
+        matches!(
+            self._bound_or_constraints(db),
+            Some(
+                TypeVarBoundOrConstraintsEvaluation::Eager(TypeVarBoundOrConstraints::Constraints(
+                    _
+                )) | TypeVarBoundOrConstraintsEvaluation::LazyConstraints
+            )
+        )
     }
 
     pub(crate) fn constraints(self, db: &'db dyn Db) -> Option<&'db [Type<'db>]> {
@@ -1164,8 +1193,23 @@ impl<'db> BoundTypeVarInstance<'db> {
                     } else {
                         // Materialization uses a different mapping mode. Reuse of the outer
                         // visitor can incorrectly hit a cache entry from specialization.
-                        let materialization_visitor = ApplyTypeMappingVisitor::default();
-                        mapped.materialize(db, *materialization_kind, &materialization_visitor)
+                        let materialization_visitor = visitor.for_new_materialization_root();
+                        let materialized =
+                            mapped.materialize(db, *materialization_kind, &materialization_visitor);
+
+                        if *materialization_kind == MaterializationKind::Top
+                            && !materialization_visitor.is_equivalent_to_materialization(
+                                db,
+                                mapped,
+                                materialized,
+                            )
+                            && let Some(upper_bound) =
+                                self.typevar(db).top_materialized_upper_bound(db)
+                        {
+                            IntersectionType::from_two_elements(db, materialized, upper_bound)
+                        } else {
+                            materialized
+                        }
                     }
                 })
                 .unwrap_or(Type::TypeVar(self)),


### PR DESCRIPTION
## Summary

Respect declared upper bounds and constraints when materializing generic type arguments across covariance, contravariance, and invariance. Preserve constrained top and bottom materializations during type-relation checks, filter valid alternatives safely, and avoid recursively forcing lazy bounds. Narrow runtime class checks using unknown specializations instead of type-parameter defaults, fixing incorrect `Never`-default narrowing.

Closes astral-sh/ty#1109.

## Test plan

- Add mdtests for PEP 695 and legacy bounded and constrained generics across all variance directions, subtype and assignability relations, overlapping and gradual constraints, and partial unions and intersections.
- Cover invariant attributes, getter and setter polarity, unrelated `Any`, mixed constrained and invariant type arguments, and recursive bounds.
- Cover positive and negative bounded and constrained `isinstance` narrowing, tuple class information, `issubclass`, class-pattern fallthrough, and `Never`-default regressions.
- Cover equivalence for gradual bounded shape aliases, invariant and covariant specializations, and defaulted nested generics.

## Ecosystem

Ecosystem changes are all positive and in line with the intended semantics of this PR.