### PR TITLE
[ty] Optimize overloaded constructor receiver binding

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -397,6 +397,20 @@ def partial_mutually_recursive_alias(x: RecursivePartialA) -> bool:  # error: [i
         return True
 ```
 
+## `map` preserves callable inference for an unknown iterable
+
+An unknown iterable must not force an overloaded callable into one synthesized signature. In
+particular, `dict` has distinct constructor overloads for string and bytes pairs, so `map` must
+retain an unknown element type instead of rejecting `dict`.
+
+```py
+from ty_extensions import Unknown
+
+def _(rows: Unknown) -> None:
+    reveal_type(map(dict, rows))  # revealed: map[Unknown]
+    reveal_type(list(map(dict, rows)))  # revealed: list[Unknown]
+```
+
 ## Generic builtins should not overfit upper-bound-only callback constraints
 
 These examples are minimized from ecosystem regressions seen while preserving explicit `Never` and

--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -411,6 +411,39 @@ def _(rows: Unknown) -> None:
     reveal_type(list(map(dict, rows)))  # revealed: list[Unknown]
 ```
 
+## `reversed` preserves ambiguous non-instance constructor inference
+
+`reversed.__new__` returns an iterator rather than an instance of `reversed`. An index-like object
+can satisfy both constructor overloads with different element types, so optimizing
+instance-returning constructors must not change the existing ambiguous-overload result.
+
+```py
+from collections.abc import Iterator
+from typing import Any, Generic, TypeVar, overload
+
+T = TypeVar("T")
+
+class Labels(Generic[T]):
+    def __len__(self) -> int:
+        return 2
+
+    @overload
+    def __getitem__(self, key: int, /) -> T: ...
+    @overload
+    def __getitem__(self, key: slice, /) -> "Labels[T]": ...
+    def __getitem__(self, key: int | slice, /) -> Any:
+        raise NotImplementedError
+
+    def __iter__(self) -> Iterator[int | str]:
+        return iter((1, "label"))
+
+    def __reversed__(self) -> Iterator[int | str]:
+        return iter((1, "label"))
+
+def _(labels: Labels[Any]) -> None:
+    reveal_type(reversed(labels))  # revealed: Unknown
+```
+
 ## Generic builtins should not overfit upper-bound-only callback constraints
 
 These examples are minimized from ecosystem regressions seen while preserving explicit `Never` and

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -374,6 +374,44 @@ class Simple:
 reveal_type(Simple())  # revealed: Simple
 ```
 
+## Overloaded implicit `__new__` receivers
+
+An overloaded constructor can infer `cls` without using that inferred receiver to select an
+overload. Its other arguments must still determine both the selected overload and the constructed
+generic specialization.
+
+```pyi
+from typing import Generic, TypeVar, overload
+from typing_extensions import Self
+
+T = TypeVar("T")
+
+class DTypeLike(Generic[T]):
+    @overload
+    def __new__(cls, value: int) -> DTypeLike[int]: ...
+    @overload
+    def __new__(cls, value: str) -> DTypeLike[str]: ...
+
+reveal_type(DTypeLike(1))  # revealed: DTypeLike[int]
+reveal_type(DTypeLike("value"))  # revealed: DTypeLike[str]
+
+# error: [no-matching-overload]
+reveal_type(DTypeLike(1.0))  # revealed: DTypeLike[T@DTypeLike]
+
+class SelfLike(Generic[T]):
+    @overload
+    def __new__(cls, value: T, /) -> Self: ...
+    @overload
+    def __new__(cls, value: T, /, *, copy: bool) -> Self: ...
+
+reveal_type(SelfLike(1))  # revealed: SelfLike[int]
+reveal_type(SelfLike("value", copy=True))  # revealed: SelfLike[str]
+reveal_type(SelfLike[int](1, copy=False))  # revealed: SelfLike[int]
+
+# error: [invalid-argument-type]
+reveal_type(SelfLike[int]("value"))  # revealed: SelfLike[int]
+```
+
 ## `__new__` defined as a classmethod
 
 Marking it as a classmethod, on the other hand, breaks at runtime.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5378,6 +5378,7 @@ impl<'db> Type<'db> {
             db: &'db dyn Db,
             bindings: Bindings<'db>,
             self_type: Type<'db>,
+            instance_type: Type<'db>,
         ) -> Bindings<'db> {
             bindings.map(|binding| {
                 let mut binding = binding;
@@ -5386,7 +5387,7 @@ impl<'db> Type<'db> {
                 // Note: This intentionally preserves `type.__call__` behavior for `@classmethod __new__`,
                 // which receives an extra implicit `cls` and errors at call sites.
                 binding.bake_bound_type_into_overloads(db);
-                binding.bound_type = Some(self_type);
+                binding.bind_constructor_receiver(db, self_type, instance_type);
                 binding
             })
         }
@@ -5491,13 +5492,17 @@ impl<'db> Type<'db> {
         let (new_bindings, has_any_new) = match new_method.as_ref().map(|method| method.place) {
             Some(place) => match resolve_dunder_new_callable(db, self_type, place) {
                 Some((new_callable, definedness)) => {
-                    let mut bindings =
-                        bind_constructor_new(db, new_callable.bindings(db), self_type)
-                            .into_constructor_bindings(
-                                constructor_instance_ty,
-                                ConstructorCallableKind::New,
-                            )
-                            .with_constructed_instance_type(db, constructor_instance_ty);
+                    let mut bindings = bind_constructor_new(
+                        db,
+                        new_callable.bindings(db),
+                        self_type,
+                        constructor_instance_ty,
+                    )
+                    .into_constructor_bindings(
+                        constructor_instance_ty,
+                        ConstructorCallableKind::New,
+                    )
+                    .with_constructed_instance_type(db, constructor_instance_ty);
                     if definedness == Definedness::PossiblyUndefined {
                         bindings.set_implicit_dunder_new_is_possibly_unbound();
                     }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3193,11 +3193,10 @@ impl<'db> CallableBinding<'db> {
 
     /// Binds an inferred constructor receiver before resolving an overloaded `__new__`.
     ///
-    /// Explicit receiver annotations can constrain overload selection, so mixed or explicitly
-    /// annotated overloads keep their synthetic class argument. Callable arguments can also infer
-    /// the constructed instance's type variables, so their signatures retain the receiver too. A
-    /// single inferred receiver remains synthetic because prebinding it can change constructor
-    /// specialization.
+    /// Prebinding is safe only for overloaded constructors that return the constructed instance.
+    /// Explicit receiver annotations and callable parameters can constrain overload selection, so
+    /// those overloads retain their synthetic class argument. A single inferred receiver also
+    /// remains synthetic because prebinding it can change constructor specialization.
     pub(crate) fn bind_constructor_receiver(
         &mut self,
         db: &'db dyn Db,
@@ -3209,6 +3208,7 @@ impl<'db> CallableBinding<'db> {
                 !overload
                     .signature
                     .has_implicit_positional_receiver_annotation()
+                    || !overload.returns_constructed_instance(db, typing_self_type)
                     || overload
                         .signature
                         .parameters()

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3188,16 +3188,51 @@ impl<'db> CallableBinding<'db> {
             Type::BoundMethod(bound_method) => bound_method.typing_self_type(db),
             _ => bound_self,
         };
+        self.bake_receiver_into_overloads(db, bound_self, typing_self);
+    }
+
+    /// Binds an inferred constructor receiver before resolving an overloaded `__new__`.
+    ///
+    /// Explicit receiver annotations can constrain overload selection, so mixed or explicitly
+    /// annotated overloads keep their synthetic class argument. A single inferred receiver also
+    /// remains synthetic because prebinding it can change constructor specialization.
+    pub(crate) fn bind_constructor_receiver(
+        &mut self,
+        db: &'db dyn Db,
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) {
+        if self.overloads.len() < 2
+            || self.overloads.iter().any(|overload| {
+                !overload
+                    .signature
+                    .has_implicit_positional_receiver_annotation()
+            })
+        {
+            self.bound_type = Some(receiver_type);
+            return;
+        }
+
+        self.bake_receiver_into_overloads(db, receiver_type, typing_self_type);
+    }
+
+    fn bake_receiver_into_overloads(
+        &mut self,
+        db: &'db dyn Db,
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) {
         for overload in &mut self.overloads {
             let removed_receiver = overload
                 .signature
                 .parameters()
                 .get(0)
                 .is_some_and(Parameter::is_positional);
-            overload.signature =
-                overload
-                    .signature
-                    .bind_self_with_receiver(db, Some(bound_self), Some(typing_self));
+            overload.signature = overload.signature.bind_self_with_receiver(
+                db,
+                Some(receiver_type),
+                Some(typing_self_type),
+            );
             overload.return_ty = overload.initial_return_type(db);
             overload.source_parameter_index_offset += usize::from(removed_receiver);
         }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3194,8 +3194,10 @@ impl<'db> CallableBinding<'db> {
     /// Binds an inferred constructor receiver before resolving an overloaded `__new__`.
     ///
     /// Explicit receiver annotations can constrain overload selection, so mixed or explicitly
-    /// annotated overloads keep their synthetic class argument. A single inferred receiver also
-    /// remains synthetic because prebinding it can change constructor specialization.
+    /// annotated overloads keep their synthetic class argument. Callable arguments can also infer
+    /// the constructed instance's type variables, so their signatures retain the receiver too. A
+    /// single inferred receiver remains synthetic because prebinding it can change constructor
+    /// specialization.
     pub(crate) fn bind_constructor_receiver(
         &mut self,
         db: &'db dyn Db,
@@ -3207,6 +3209,12 @@ impl<'db> CallableBinding<'db> {
                 !overload
                     .signature
                     .has_implicit_positional_receiver_annotation()
+                    || overload
+                        .signature
+                        .parameters()
+                        .iter()
+                        .skip(1)
+                        .any(|parameter| matches!(parameter.annotated_type(), Type::Callable(_)))
             })
         {
             self.bound_type = Some(receiver_type);

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -613,6 +613,32 @@ fn constructor_returns_instance<'db>(
 }
 
 impl<'db> Binding<'db> {
+    /// Whether this overload's declared return constructs an instance of `instance_type`.
+    ///
+    /// Constructor receiver binding happens before constructor context is attached, so classify
+    /// self-like type variables using the original receiver annotation.
+    pub(super) fn returns_constructed_instance(
+        &self,
+        db: &'db dyn Db,
+        instance_type: Type<'db>,
+    ) -> bool {
+        let Some(class_literal) = instance_type
+            .as_nominal_instance()
+            .map(|instance| instance.class(db).class_literal(db))
+        else {
+            return false;
+        };
+
+        let return_ty = self.signature.return_ty.resolve_type_alias(db);
+        if let Type::TypeVar(typevar) = return_ty
+            && self.is_self_like_constructor_return_typevar(db, typevar)
+        {
+            return true;
+        }
+
+        constructor_returns_instance(db, class_literal, return_ty)
+    }
+
     /// Is a type variable returned from a constructor method a representation of the self type?
     ///
     /// Handles `typing.Self` annotations and `__new__` methods returning `T` where `self:


### PR DESCRIPTION
## Summary

As an optimization, avoid repeatedly solving synthetic `cls` constraints when selecting among `__new__` overloads whose receivers are all inferred. Instead, reuse the existing receiver-baking machinery while preserving the distinction between the class receiver and the instance used to specialize `Self`. Keep single-overload, explicitly annotated, decorated, and mixed-receiver constructors on the existing semantic path.

## Test plan

Add constructor mdtests for NumPy-like overloaded generic `__new__`, per-overload return specialization, overloaded `Self` returns, explicit generic specialization, invalid arguments, and the existing no-matching-overload diagnostic and revealed type.
