### PR TITLE
Bump `gen-lsp-types` to gracefully handle unknown enumeration values in LSP messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "gen-lsp-types"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd635c5206acd03ea024d6b5902539e5c903de3afa220fdb5c94b583af77f4f"
+checksum = "b64887ac3a8083427ae935a7296db876871582cd57eac077564f8bc18fa49116"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ libc = { version = "0.2.153" }
 libcst = { version = "1.8.4", default-features = false }
 log = { version = "0.4.17" }
 lsp-server = { version = "0.10.0" }
-lsp-types = { package = "gen-lsp-types", version = "0.10.0", features = ["url"] }
+lsp-types = { package = "gen-lsp-types", version = "0.11.0", features = ["url"] }
 matchit = { version = "0.9.0" }
 memchr = { version = "2.7.1" }
 mimalloc = { version = "0.1.49", features = ["v2"] }

--- a/crates/ruff_server/src/edit/notebook.rs
+++ b/crates/ruff_server/src/edit/notebook.rs
@@ -63,25 +63,32 @@ impl NotebookDocument {
         let cells = self
             .cells
             .iter()
-            .map(|cell| match cell.kind {
-                NotebookCellKind::Code => ruff_notebook::Cell::Code(ruff_notebook::CodeCell {
-                    execution_count: None,
-                    id: None,
-                    metadata: CellMetadata::default(),
-                    outputs: vec![],
-                    source: ruff_notebook::SourceValue::String(
-                        cell.document.contents().to_string(),
-                    ),
-                }),
+            .filter_map(|cell| match cell.kind {
+                NotebookCellKind::Code => {
+                    Some(ruff_notebook::Cell::Code(ruff_notebook::CodeCell {
+                        execution_count: None,
+                        id: None,
+                        metadata: CellMetadata::default(),
+                        outputs: vec![],
+                        source: ruff_notebook::SourceValue::String(
+                            cell.document.contents().to_string(),
+                        ),
+                    }))
+                }
                 NotebookCellKind::Markup => {
-                    ruff_notebook::Cell::Markdown(ruff_notebook::MarkdownCell {
+                    Some(ruff_notebook::Cell::Markdown(ruff_notebook::MarkdownCell {
                         attachments: None,
                         id: None,
                         metadata: CellMetadata::default(),
                         source: ruff_notebook::SourceValue::String(
                             cell.document.contents().to_string(),
                         ),
-                    })
+                    }))
+                }
+                NotebookCellKind::Custom(_) => {
+                    // Ignore unsupported cell kinds. This arm should never be reached unless a
+                    // client sends a value which is not mentioned/supported in the LSP.
+                    None
                 }
             })
             .collect();

--- a/crates/ty_server/src/document/notebook.rs
+++ b/crates/ty_server/src/document/notebook.rs
@@ -72,7 +72,7 @@ impl NotebookDocument {
         let cells = self
             .cells
             .iter()
-            .map(|cell| {
+            .filter_map(|cell| {
                 let cell_text =
                     if let Ok(document) = index.document(&DocumentKey::from_uri(&cell.uri)) {
                         if let Some(text_document) = document.as_text() {
@@ -89,23 +89,30 @@ impl NotebookDocument {
 
                 let source = ruff_notebook::SourceValue::String(cell_text);
                 match cell.kind {
-                    NotebookCellKind::Code => ruff_notebook::Cell::Code(ruff_notebook::CodeCell {
-                        execution_count: cell
-                            .execution_summary
-                            .as_ref()
-                            .map(|summary| i64::from(summary.execution_order)),
-                        id: None,
-                        metadata: CellMetadata::default(),
-                        outputs: vec![],
-                        source,
-                    }),
+                    NotebookCellKind::Code => {
+                        Some(ruff_notebook::Cell::Code(ruff_notebook::CodeCell {
+                            execution_count: cell
+                                .execution_summary
+                                .as_ref()
+                                .map(|summary| i64::from(summary.execution_order)),
+                            id: None,
+                            metadata: CellMetadata::default(),
+                            outputs: vec![],
+                            source,
+                        }))
+                    }
                     NotebookCellKind::Markup => {
-                        ruff_notebook::Cell::Markdown(ruff_notebook::MarkdownCell {
+                        Some(ruff_notebook::Cell::Markdown(ruff_notebook::MarkdownCell {
                             attachments: None,
                             id: None,
                             metadata: CellMetadata::default(),
                             source,
-                        })
+                        }))
+                    }
+                    NotebookCellKind::Custom(_) => {
+                        // Ignore unsupported cell kinds. This arm should never be reached unless a
+                        // client sends a value which is not mentioned/supported in the LSP.
+                        None
                     }
                 }
             })

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -59,6 +59,8 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
                     path: system_path,
                     kind: DeletedKind::Any,
                 },
+                // Custom file change types are not supported and should be ignored.
+                FileChangeType::Custom(_) => continue,
             };
 
             changes.push(change_event);

--- a/crates/ty_server/tests/e2e/workspace_folders.rs
+++ b/crates/ty_server/tests/e2e/workspace_folders.rs
@@ -759,7 +759,7 @@ fn condensed_full_document_diagnostic_report(report: FullDocumentDiagnosticRepor
                 Some(DiagnosticSeverity::Warning) => "WARNING",
                 Some(DiagnosticSeverity::Information) => "INFORMATION",
                 Some(DiagnosticSeverity::Hint) => "HINT",
-                None => "unknown",
+                Some(DiagnosticSeverity::Custom(_)) | None => "unknown",
             };
             let Message::String(message) = d.message else {
                 panic!(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Bumps gen-lsp-types to v0.11.0, which enables all LSP enumeration types to accept custom values. Fixes https://github.com/astral-sh/ty/issues/4082.

## Test Plan

Tests are kept the same, only changed where necessary due to the library change.