### PR TITLE
[`ruff`] Skip `bytes` patterns unless the target is known to be `bytes` (`RUF055`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF055_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF055_0.py
@@ -103,3 +103,46 @@ re.sub(r'''abc''', "", s)
 # str.split("") raises ValueError while re.split("", s) succeeds
 re.split("", s)
 re.split(r"", s)
+
+
+# A `bytes` pattern requires a target known to be `bytes`: `re` accepts any
+# buffer, but e.g. `b"ab" in memoryview(b"abc")` is False while the `re.search`
+# is truthy (https://github.com/astral-sh/ruff/issues/27024)
+assert re.search(b"ab", memoryview(b"abc"))
+
+
+def bytes_pattern_unknown_target(x):
+    if re.search(b"ab", x):  # no diagnostic: `x` is not known to be `bytes`
+        pass
+    re.split(b"ab", x)  # no diagnostic
+    re.sub(b"ab", b"", x)  # no diagnostic
+
+
+def bytes_pattern_known_bytes(x: bytes):
+    if re.search(b"ab", x):  # this should be replaced with `b"ab" in x`
+        pass
+
+
+def bytes_pattern_known_str(x: str):
+    if re.search(b"ab", x):  # no diagnostic: `x` is `str`, not `bytes`
+        pass
+
+
+class Source:
+    data = b"abc"
+
+
+# this should be replaced with `b"ab" in Source.data`
+if re.search(b"ab", Source.data):
+    pass
+
+
+if re.search(b"ab", b"abc"):  # this should be replaced with `b"ab" in b"abc"`
+    pass
+
+
+# `str` patterns are not restricted: `re` raises `TypeError` for non-`str`
+# targets, so an unknown target type still gets the diagnostic
+def str_pattern_unknown_target(x):
+    if re.search("abc", x):  # this should be replaced with `"abc" in x`
+        pass

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::{
     Arguments, CmpOp, Expr, ExprAttribute, ExprBytesLiteral, ExprCall, ExprCompare, ExprContext,
     ExprStringLiteral, ExprUnaryOp, Identifier, UnaryOp,
 };
-use ruff_python_semantic::analyze::typing::find_binding_value;
+use ruff_python_semantic::analyze::typing::{self, find_binding_value};
 use ruff_python_semantic::{Modules, SemanticModel};
 use ruff_text_size::TextRange;
 
@@ -46,6 +46,12 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 /// For `re.sub`, the `repl` (replacement) argument must also be a string literal,
 /// not a function. For `re.match`, `re.search`, and `re.fullmatch`, the return
 /// value must also be used only for its truth value.
+///
+/// For `bytes` patterns, the `string` argument must also be known to be
+/// `bytes`, either as a literal or as a variable or attribute that can be
+/// inferred to be one. The `re` functions accept any buffer type, such as
+/// `memoryview`, for which the suggested replacements would raise or match
+/// differently.
 ///
 /// ## Fix safety
 ///
@@ -121,6 +127,13 @@ pub(crate) fn unnecessary_regular_expression(checker: &Checker, call: &ExprCall)
     // `str.split("")` raises `ValueError: empty separator` while `re.split("", s)` succeeds,
     // so skip the diagnostic for `re.split` with an empty pattern.
     if matches!(re_func.kind, ReFuncKind::Split) && literal.is_empty() {
+        return;
+    }
+
+    // Only `bytes` patterns need this. Given a `str` pattern, `re` raises `TypeError` for any
+    // non-`str` target, so the rewrite is always operating on a `str`.
+    // See https://github.com/astral-sh/ruff/issues/27024
+    if matches!(literal, Literal::Bytes(_)) && !is_bytes(re_func.string, semantic) {
         return;
     }
 
@@ -359,6 +372,25 @@ impl<'a> ReFunc<'a> {
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         })
+    }
+}
+
+/// Whether `string` is known to be `bytes`.
+///
+/// `re` accepts any object supporting the buffer protocol as the target for a
+/// `bytes` pattern, but the replacement methods and operators are not
+/// equivalent there: `re.search(b"ab", memoryview(b"abc"))` matches, while
+/// `b"ab" in memoryview(b"abc")` is `False`, and `memoryview` has no
+/// `startswith`, `split`, or `replace`.
+fn is_bytes(string: &Expr, semantic: &SemanticModel) -> bool {
+    if let Expr::Name(name) = string {
+        semantic
+            .only_binding(name)
+            .is_some_and(|binding_id| typing::is_bytes(semantic.binding(binding_id), semantic))
+    } else if let Some(binding_id) = semantic.lookup_attribute(string) {
+        typing::is_bytes(semantic.binding(binding_id), semantic)
+    } else {
+        string.is_bytes_literal_expr()
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF055_RUF055_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF055_RUF055_0.py.snap
@@ -257,3 +257,67 @@ help: Replace with `s.replace(r'''abc''', "")`
 100 + s.replace(r'''abc''', "")
 101 |
     |
+
+RUF055 [*] Plain string pattern passed to `re` function
+   --> RUF055_0.py:122:8
+    |
+121 | def bytes_pattern_known_bytes(x: bytes):
+122 |     if re.search(b"ab", x):  # this should be replaced with `b"ab" in x`
+    |        ^^^^^^^^^^^^^^^^^^^
+123 |         pass
+    |
+help: Replace with `b"ab" in x`
+    |
+121 | def bytes_pattern_known_bytes(x: bytes):
+    -     if re.search(b"ab", x):  # this should be replaced with `b"ab" in x`
+122 +     if b"ab" in x:  # this should be replaced with `b"ab" in x`
+123 |         pass
+    |
+
+RUF055 [*] Plain string pattern passed to `re` function
+   --> RUF055_0.py:136:4
+    |
+135 | # this should be replaced with `b"ab" in Source.data`
+136 | if re.search(b"ab", Source.data):
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+137 |     pass
+    |
+help: Replace with `b"ab" in Source.data`
+    |
+135 | # this should be replaced with `b"ab" in Source.data`
+    - if re.search(b"ab", Source.data):
+136 + if b"ab" in Source.data:
+137 |     pass
+    |
+
+RUF055 [*] Plain string pattern passed to `re` function
+   --> RUF055_0.py:140:4
+    |
+140 | if re.search(b"ab", b"abc"):  # this should be replaced with `b"ab" in b"abc"`
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^
+141 |     pass
+    |
+help: Replace with `b"ab" in b"abc"`
+    |
+139 |
+    - if re.search(b"ab", b"abc"):  # this should be replaced with `b"ab" in b"abc"`
+140 + if b"ab" in b"abc":  # this should be replaced with `b"ab" in b"abc"`
+141 |     pass
+    |
+
+RUF055 [*] Plain string pattern passed to `re` function
+   --> RUF055_0.py:147:8
+    |
+145 | # targets, so an unknown target type still gets the diagnostic
+146 | def str_pattern_unknown_target(x):
+147 |     if re.search("abc", x):  # this should be replaced with `"abc" in x`
+    |        ^^^^^^^^^^^^^^^^^^^
+148 |         pass
+    |
+help: Replace with `"abc" in x`
+    |
+146 | def str_pattern_unknown_target(x):
+    -     if re.search("abc", x):  # this should be replaced with `"abc" in x`
+147 +     if "abc" in x:  # this should be replaced with `"abc" in x`
+148 |         pass
+    |


### PR DESCRIPTION
## Summary

Fixes the safe-fix behavior change from #27024: `re.search(b"ab", memoryview(b"abc"))` is truthy, but the suggested safe replacement `b"ab" in memoryview(b"abc")` is `False`. On `memoryview`, the method rewrites (`.startswith`, `.split`, `.replace`) raise `AttributeError`; membership silently flips the result.

Per the direction in the issue and in the close of #27040, the rule now skips `bytes` patterns unless the `string` argument is known to be `bytes` — a bytes literal, or a name/attribute whose binding `analyze::typing::is_bytes` can infer. There's no blocklist of specific buffer types.

`str` patterns are deliberately left alone. `re` raises `TypeError` for any non-`str` target given a `str` pattern (`cannot use a string pattern on a bytes-like object` for buffers), so the memoryview problem can't arise there — and gating them on inferrable types would silently drop the rule's most common hits. On a quick corpus check (five flagged files across bandit, pygments, sympy, torch, google-genai in a real site-packages), all 9 baseline RUF055 hits are `str` patterns, and only one has a target Ruff can infer — an annotated parameter; the rest are subscripts, rebound locals, unannotated parameters, and call results. A both-types gate keeps 1 of 9; the `bytes`-only gate keeps 9 of 9 while still fixing the reported defect.

A few limits worth stating, all shared with the existing `is_string` helper in `missing_maxsplit_arg`: inference is binding-based, so annotations are trusted (a `data: bytes` parameter that's handed a `memoryview` at runtime still gets the fix) and rebinding through `global`/`nonlocal` or `Cls.attr = ...` after the class body isn't tracked; attribute targets resolve for `ClassName.attr` but not `self.attr`. And a target known to be `bytearray` is skipped even though the truthiness rewrites would agree, since the `re.split`/`re.sub` rewrites there change the result type.

Closes #27024

## Test Plan

New `RUF055_0.py` cases: the issue's `memoryview` reproduction and an unknown-type target for `search`/`split`/`sub` (all silent), a known-`str` target for a `bytes` pattern (silent), plus `bytes`-annotated parameter, class-attribute, and bytes-literal targets (all still fire with safe fixes) and an uninferrable `str`-pattern target pinning that `str` patterns stay unrestricted. `cargo nextest run -p ruff_linter` (2807 passed) and `cargo clippy --workspace --all-targets --all-features -- -D warnings` pass locally.
