### PR TITLE
[ty] Remove transparent callable decorator workaround

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -225,6 +225,31 @@ class Calculator:
 reveal_type(Calculator().square_then_round(3.14))  # revealed: int
 ```
 
+A callable object with the same signature must not become a method descriptor.
+
+```py
+from typing import assert_type
+
+class CallableReplacement:
+    def __call__(self, owner: "ReplacementExample", value: int, /) -> str:
+        return str(value)
+
+def replace_method(
+    method: Callable[["ReplacementExample", int], str],
+) -> Callable[["ReplacementExample", int], str]:
+    return CallableReplacement()
+
+class ReplacementExample:
+    def original(self, value: int, /) -> str:
+        return str(value)
+
+    replacement = replace_method(original)
+
+example = ReplacementExample()
+assert_type(example.replacement, Callable[[ReplacementExample, int], str])
+example.replacement(example, 1)
+```
+
 ## Use case: Wrappers with explicit receivers
 
 `trio` defines multiple functions that takes in a callable with `Concatenate`-prepended receiver

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1044,8 +1044,7 @@ reveal_type(lazy_frame.collect(background=False))  # revealed: DataFrame
 reveal_type(lazy_frame.collect(background=True))  # revealed: InProcessQuery
 ```
 
-The transparent decorator can be one overload among several. The workaround only inspects the
-overload selected by the decorator call.
+A transparent decorator may be overloaded; the call selects the matching overload.
 
 ```py
 from typing import Any, Callable, overload, reveal_type

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -366,85 +366,6 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     dataclass_field_specifiers: SmallVec<[Type<'db>; NUM_FIELD_SPECIFIERS_INLINE]>,
 }
 
-fn transparent_callable_decorator_result<'db>(
-    db: &'db dyn Db,
-    bindings: &Bindings<'db>,
-    decorated_ty: Type<'db>,
-) -> Option<Type<'db>> {
-    enum TransparentCallableReturn<'db> {
-        TypeVar(BoundTypeVarInstance<'db>),
-        Awaitable(BoundTypeVarInstance<'db>),
-    }
-
-    impl<'db> TransparentCallableReturn<'db> {
-        fn matches(self, db: &'db dyn Db, other: Self) -> bool {
-            match (self, other) {
-                (Self::TypeVar(left), Self::TypeVar(right))
-                | (Self::Awaitable(left), Self::Awaitable(right)) => {
-                    left.is_same_typevar_as(db, right)
-                }
-                _ => false,
-            }
-        }
-    }
-
-    fn callable_paramspec_and_return<'db>(
-        db: &'db dyn Db,
-        ty: Type<'db>,
-    ) -> Option<(BoundTypeVarInstance<'db>, TransparentCallableReturn<'db>)> {
-        let callable = ty.resolve_type_alias(db).as_callable()?;
-        if callable.kind(db) != CallableTypeKind::Regular {
-            return None;
-        }
-        let [signature] = callable.signatures(db).overloads.as_slice() else {
-            return None;
-        };
-        let paramspec = signature.parameters().as_paramspec()?;
-        let return_typevar = if let Some(typevar) = signature.return_ty.as_typevar() {
-            TransparentCallableReturn::TypeVar(typevar)
-        } else {
-            let specialization = signature
-                .return_ty
-                .known_specialization(db, KnownClass::Awaitable)?;
-            let [inner] = specialization.types(db) else {
-                return None;
-            };
-            TransparentCallableReturn::Awaitable(inner.as_typevar()?)
-        };
-        Some((paramspec, return_typevar))
-    }
-
-    if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
-        return None;
-    }
-    let binding = bindings.single_element()?;
-    let (_, overload) = binding.matching_overloads().exactly_one().ok()?;
-    let decorator_signature = &overload.signature;
-    let bound_signature = binding
-        .bound_type
-        .map(|bound_type| decorator_signature.bind_self(db, Some(bound_type)));
-    let decorator_signature = bound_signature.as_ref().unwrap_or(decorator_signature);
-    let [parameter] = decorator_signature.parameters().as_slice() else {
-        return None;
-    };
-
-    let (parameter_callable_paramspec, parameter_callable_return) =
-        callable_paramspec_and_return(db, parameter.annotated_type())?;
-    let (return_callable_paramspec, return_callable_return) =
-        callable_paramspec_and_return(db, decorator_signature.return_ty)?;
-    if !parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
-        || !parameter_callable_return.matches(db, return_callable_return)
-    {
-        return None;
-    }
-
-    match decorated_ty {
-        Type::FunctionLiteral(function) => Some(Type::Callable(function.into_callable_type(db))),
-        Type::Callable(_) => Some(decorated_ty),
-        _ => None,
-    }
-}
-
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// How big a string do we build before bailing?
     ///
@@ -3301,7 +3222,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             .kind()
                             == ScopeKind::Class
                     {
-                        self.apply_desugared_decorator(callable_type, call_expr, ty)
+                        self.apply_desugared_decorator(call_expr, ty)
                     } else {
                         ty
                     };
@@ -4991,14 +4912,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_expression(expression, TypeContext::default())
     }
 
-    /// Preserve the descriptor behavior of a transparent callable decorator when it is written
-    /// as the equivalent assignment form in a class body.
+    /// Preserve method binding when an assignment-form decorator returns an equivalent callable.
     fn apply_desugared_decorator(
         &mut self,
-        decorator_ty: Type<'db>,
         call_expression: &ast::ExprCall,
         return_ty: Type<'db>,
     ) -> Type<'db> {
+        let Type::Callable(returned_callable) = return_ty else {
+            return return_ty;
+        };
+
         let arguments = &call_expression.arguments;
         let [decorated_expression] = &arguments.args[..] else {
             return return_ty;
@@ -5009,13 +4932,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let decorated_ty =
             self.get_or_infer_expression(decorated_expression, TypeContext::default());
-        let call_arguments = CallArguments::positional([decorated_ty]);
-        let Ok(bindings) = decorator_ty.try_call(self.db(), &call_arguments) else {
+        let Some(decorated_callable) = decorated_ty
+            .try_upcast_to_callable(self.db())
+            .and_then(CallableTypes::exactly_one)
+        else {
             return return_ty;
         };
 
-        transparent_callable_decorator_result(self.db(), &bindings, decorated_ty)
-            .unwrap_or(return_ty)
+        if !decorated_callable.is_method_like(self.db())
+            || !return_ty.is_equivalent_to(
+                self.db(),
+                Type::Callable(decorated_callable.into_regular(self.db())),
+            )
+        {
+            return return_ty;
+        }
+
+        Type::Callable(CallableType::new(
+            self.db(),
+            returned_callable.signatures(self.db()),
+            decorated_callable.kind(self.db()),
+            decorated_callable.provenance(self.db()),
+        ))
     }
 
     /// Apply a decorator to a function or class type and return the resulting type.
@@ -5107,23 +5045,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let call_arguments = CallArguments::positional([decorated_ty]);
-        let (return_ty, decorator_bindings) =
-            match decorator_ty.try_call(self.db(), &call_arguments) {
-                Ok(bindings) => (bindings.return_type(self.db()), Some(bindings)),
-                Err(CallError(_, bindings)) => {
-                    bindings.report_diagnostics(&self.context, decorator_node.into());
-                    (bindings.return_type(self.db()), None)
-                }
-            };
-
-        // TODO: Remove this special case once the new constraint solver can preserve
-        // per-overload ParamSpec/return correlations for transparent callable decorators.
-        if let Some(decorator_bindings) = decorator_bindings.as_ref()
-            && let Some(result) =
-                transparent_callable_decorator_result(self.db(), decorator_bindings, decorated_ty)
-        {
-            return result;
-        }
+        let return_ty = match decorator_ty.try_call(self.db(), &call_arguments) {
+            Ok(bindings) => bindings.return_type(self.db()),
+            Err(CallError(_, bindings)) => {
+                bindings.report_diagnostics(&self.context, decorator_node.into());
+                bindings.return_type(self.db())
+            }
+        };
 
         // When a method on a class is decorated with a function that returns a
         // `Callable`, assume that the returned callable is also function-like (or

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -366,6 +366,85 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     dataclass_field_specifiers: SmallVec<[Type<'db>; NUM_FIELD_SPECIFIERS_INLINE]>,
 }
 
+fn transparent_callable_decorator_result<'db>(
+    db: &'db dyn Db,
+    bindings: &Bindings<'db>,
+    decorated_ty: Type<'db>,
+) -> Option<Type<'db>> {
+    enum TransparentCallableReturn<'db> {
+        TypeVar(BoundTypeVarInstance<'db>),
+        Awaitable(BoundTypeVarInstance<'db>),
+    }
+
+    impl<'db> TransparentCallableReturn<'db> {
+        fn matches(self, db: &'db dyn Db, other: Self) -> bool {
+            match (self, other) {
+                (Self::TypeVar(left), Self::TypeVar(right))
+                | (Self::Awaitable(left), Self::Awaitable(right)) => {
+                    left.is_same_typevar_as(db, right)
+                }
+                _ => false,
+            }
+        }
+    }
+
+    fn callable_paramspec_and_return<'db>(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+    ) -> Option<(BoundTypeVarInstance<'db>, TransparentCallableReturn<'db>)> {
+        let callable = ty.resolve_type_alias(db).as_callable()?;
+        if callable.kind(db) != CallableTypeKind::Regular {
+            return None;
+        }
+        let [signature] = callable.signatures(db).overloads.as_slice() else {
+            return None;
+        };
+        let paramspec = signature.parameters().as_paramspec()?;
+        let return_typevar = if let Some(typevar) = signature.return_ty.as_typevar() {
+            TransparentCallableReturn::TypeVar(typevar)
+        } else {
+            let specialization = signature
+                .return_ty
+                .known_specialization(db, KnownClass::Awaitable)?;
+            let [inner] = specialization.types(db) else {
+                return None;
+            };
+            TransparentCallableReturn::Awaitable(inner.as_typevar()?)
+        };
+        Some((paramspec, return_typevar))
+    }
+
+    if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
+        return None;
+    }
+    let binding = bindings.single_element()?;
+    let (_, overload) = binding.matching_overloads().exactly_one().ok()?;
+    let decorator_signature = &overload.signature;
+    let bound_signature = binding
+        .bound_type
+        .map(|bound_type| decorator_signature.bind_self(db, Some(bound_type)));
+    let decorator_signature = bound_signature.as_ref().unwrap_or(decorator_signature);
+    let [parameter] = decorator_signature.parameters().as_slice() else {
+        return None;
+    };
+
+    let (parameter_callable_paramspec, parameter_callable_return) =
+        callable_paramspec_and_return(db, parameter.annotated_type())?;
+    let (return_callable_paramspec, return_callable_return) =
+        callable_paramspec_and_return(db, decorator_signature.return_ty)?;
+    if !parameter_callable_paramspec.is_same_typevar_as(db, return_callable_paramspec)
+        || !parameter_callable_return.matches(db, return_callable_return)
+    {
+        return None;
+    }
+
+    match decorated_ty {
+        Type::FunctionLiteral(function) => Some(Type::Callable(function.into_callable_type(db))),
+        Type::Callable(_) => Some(decorated_ty),
+        _ => None,
+    }
+}
+
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// How big a string do we build before bailing?
     ///
@@ -3222,7 +3301,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             .kind()
                             == ScopeKind::Class
                     {
-                        self.apply_desugared_decorator(call_expr, ty)
+                        self.apply_desugared_decorator(callable_type, call_expr, ty)
                     } else {
                         ty
                     };
@@ -4912,16 +4991,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_expression(expression, TypeContext::default())
     }
 
-    /// Preserve method binding when an assignment-form decorator returns an equivalent callable.
+    /// Preserve the descriptor behavior of a transparent callable decorator when it is written
+    /// as the equivalent assignment form in a class body.
     fn apply_desugared_decorator(
         &mut self,
+        decorator_ty: Type<'db>,
         call_expression: &ast::ExprCall,
         return_ty: Type<'db>,
     ) -> Type<'db> {
-        let Type::Callable(returned_callable) = return_ty else {
-            return return_ty;
-        };
-
         let arguments = &call_expression.arguments;
         let [decorated_expression] = &arguments.args[..] else {
             return return_ty;
@@ -4932,28 +5009,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let decorated_ty =
             self.get_or_infer_expression(decorated_expression, TypeContext::default());
-        let Some(decorated_callable) = decorated_ty
-            .try_upcast_to_callable(self.db())
-            .and_then(CallableTypes::exactly_one)
-        else {
+        let call_arguments = CallArguments::positional([decorated_ty]);
+        let Ok(bindings) = decorator_ty.try_call(self.db(), &call_arguments) else {
             return return_ty;
         };
 
-        if !decorated_callable.is_method_like(self.db())
-            || !return_ty.is_equivalent_to(
-                self.db(),
-                Type::Callable(decorated_callable.into_regular(self.db())),
-            )
-        {
-            return return_ty;
-        }
-
-        Type::Callable(CallableType::new(
-            self.db(),
-            returned_callable.signatures(self.db()),
-            decorated_callable.kind(self.db()),
-            decorated_callable.provenance(self.db()),
-        ))
+        transparent_callable_decorator_result(self.db(), &bindings, decorated_ty)
+            .unwrap_or(return_ty)
     }
 
     /// Apply a decorator to a function or class type and return the resulting type.


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/astral-sh/ty/issues/2278 and https://github.com/astral-sh/ruff/pull/27147.

The decorated-overload changes in #27147 already fix the examples from ty#2278 on `main`. Remove only the now-redundant transparent callable shortcut from normal decorator application and let ordinary decorator-call inference preserve overload behavior.

Keep `apply_desugared_decorator` and `transparent_callable_decorator_result` unchanged for class-body assignments. They still preserve the descriptor behavior required by https://github.com/astral-sh/ty/issues/3961 and distinguish a genuinely transparent `Callable[P, R] -> Callable[P, R]` wrapper from an unrelated callable object with the same signature.

Add an mdtest showing that a same-signature callable-object replacement must not be treated as a bound method. The test fails against the previous signature-equivalence implementation with `type-assertion-failure`, `invalid-argument-type`, and `too-many-positional-arguments`, and passes once the original assignment-form transparency check is restored.

Update the ParamSpec mdtest description so it no longer refers to the removed normal-decorator workaround.

## Test plan

- `env CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG=line-tables-only MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic --status-level fail` (774 passed; 34 skipped).
- `uv run --only-group dev --frozen prek run --files crates/ty_python_semantic/src/types/infer/builder.rs crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md`.
- Verified the new callable-object regression fails before the fix and passes afterward.
- Verified `mdtest::call/callables_as_descriptors.md`, `mdtest::generics/pep695/paramspec.md`, and `mdtest::overloads.md`.