### PR TITLE
[ty] Respect upper bound in materialization of covariant generics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -619,7 +619,7 @@ a covariant generic, this is equivalent to using the upper bound of the type par
 `object`):
 
 ```py
-from typing import Self
+from typing import Any, Self
 
 class Covariant[T]:
     def get(self) -> T:
@@ -629,6 +629,49 @@ def _(x: object):
     if isinstance(x, Covariant):
         reveal_type(x)  # revealed: Covariant[object]
         reveal_type(x.get())  # revealed: object
+```
+
+For a bounded covariant generic, the narrowed type uses the declared upper bound:
+
+```py
+class UpperBound: ...
+
+class BoundedCovariant[T: UpperBound]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+def _(x: object):
+    if isinstance(x, BoundedCovariant):
+        reveal_type(x)  # revealed: BoundedCovariant[UpperBound]
+        reveal_type(x.get())  # revealed: UpperBound
+
+class Other:
+    def only_on_other(self) -> None: ...
+
+def _(x: BoundedCovariant[Any] | Other):
+    if isinstance(x, BoundedCovariant):
+        return
+
+    reveal_type(x)  # revealed: Other & ~BoundedCovariant[UpperBound]
+    x.only_on_other()
+
+class BoundedDType[T: UpperBound]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class BoundedArray[Shape: tuple[int, ...], DType: BoundedDType[Any]]:
+    def shape(self) -> Shape:
+        raise NotImplementedError
+
+    def dtype(self) -> DType:
+        raise NotImplementedError
+
+def _(x: BoundedArray[Any, Any] | Other):
+    if isinstance(x, BoundedArray):
+        return
+
+    reveal_type(x)  # revealed: Other & ~BoundedArray[tuple[int, ...], BoundedDType[Any]]
+    x.only_on_other()
 ```
 
 Similarly, contravariant type parameters use their lower bound of `Never`:

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -10,7 +10,8 @@ There are two materializations of a type:
 More concretely, `T'`, the materialization of `T`, is the type `T` with all occurrences of `Any` and
 `Unknown` replaced as follows:
 
-- In covariant position, it's replaced with `object`
+- In covariant position, it's replaced with its enclosing type variable's upper bound, or with
+    `object` if the type variable is unbounded
 - In contravariant position, it's replaced with `Never`
 - In invariant position, it's replaced with an unresolved type variable
 
@@ -543,7 +544,7 @@ python-version = "3.12"
 
 ```py
 from typing import Any, Generic, TypeVar, Never
-from ty_extensions import Bottom, Top, static_assert
+from ty_extensions import Bottom, Intersection, Top, static_assert
 from ty_extensions._internal import is_equivalent_to
 
 T = TypeVar("T")
@@ -614,6 +615,39 @@ def covariant(top: Top[CovariantCallable], bottom: Bottom[CovariantCallable]) ->
 def contravariant(top: Top[ContravariantCallable], bottom: Bottom[ContravariantCallable]) -> None:
     reveal_type(top)  # revealed: (GenericContravariant[object], /) -> None
     reveal_type(bottom)  # revealed: (GenericContravariant[Never], /) -> None
+```
+
+The top materialization of a bounded covariant type parameter is its declared upper bound, rather
+than `object`.
+
+```py
+class UpperBound: ...
+
+class BoundedCovariant[T: UpperBound]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+T_bounded_co = TypeVar("T_bounded_co", bound=UpperBound, covariant=True)
+
+class LegacyBoundedCovariant(Generic[T_bounded_co]):
+    def get(self) -> T_bounded_co:
+        raise NotImplementedError
+
+static_assert(is_equivalent_to(Top[BoundedCovariant[Any]], BoundedCovariant[UpperBound]))
+static_assert(is_equivalent_to(Bottom[BoundedCovariant[Any]], BoundedCovariant[Never]))
+
+static_assert(is_equivalent_to(Top[LegacyBoundedCovariant[Any]], LegacyBoundedCovariant[UpperBound]))
+static_assert(is_equivalent_to(Bottom[LegacyBoundedCovariant[Any]], LegacyBoundedCovariant[Never]))
+```
+
+If the materialization of the existing gradual specialization is already narrower than the bound, it
+is retained:
+
+```py
+class Sub(UpperBound): ...
+
+static_assert(is_equivalent_to(Top[BoundedCovariant[Intersection[Any, Sub]]], BoundedCovariant[Sub]))
+static_assert(is_equivalent_to(Top[LegacyBoundedCovariant[Intersection[Any, Sub]]], LegacyBoundedCovariant[Sub]))
 ```
 
 ## Invalid use

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1565,8 +1565,7 @@ impl<'db> Type<'db> {
     /// More concretely, `T'`, the materialization of `T`, is the type `T` with all occurrences of
     /// the dynamic types (`Any`, `Unknown`, `Todo`) replaced as follows:
     ///
-    /// - In covariant position, it's replaced with `object` (TODO: it should be the `TypeVar`'s upper
-    ///   bound, if any)
+    /// - In covariant position, it's replaced with the `TypeVar`'s upper bound, if any, or `object`
     /// - In contravariant position, it's replaced with `Never`
     /// - In invariant position, we replace the object with a special form recording that it's the top
     ///   or bottom materialization.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1418,18 +1418,27 @@ impl<'db> Specialization<'db> {
         }
         let mut has_dynamic_invariant_typevar = false;
         let types = self.map_types(db, |_, bound_typevar, vartype| {
+            let materialize = |materialization_kind| {
+                let materialized = vartype.materialize(db, materialization_kind, visitor);
+
+                if materialization_kind == MaterializationKind::Top
+                    && materialized != vartype
+                    && let Some(upper_bound) = bound_typevar.typevar(db).upper_bound(db)
+                {
+                    IntersectionType::from_two_elements(db, materialized, upper_bound)
+                } else {
+                    materialized
+                }
+            };
+
             match specialization_variance(db, bound_typevar) {
                 TypeVarVariance::Bivariant => {
                     // With bivariance, all specializations are subtypes of each other,
                     // so any materialization is acceptable.
                     vartype.materialize(db, MaterializationKind::Top, visitor)
                 }
-                TypeVarVariance::Covariant => {
-                    vartype.materialize(db, materialization_kind, visitor)
-                }
-                TypeVarVariance::Contravariant => {
-                    vartype.materialize(db, materialization_kind.flip(), visitor)
-                }
+                TypeVarVariance::Covariant => materialize(materialization_kind),
+                TypeVarVariance::Contravariant => materialize(materialization_kind.flip()),
                 TypeVarVariance::Invariant => {
                     let top_materialization =
                         vartype.materialize(db, MaterializationKind::Top, visitor);


### PR DESCRIPTION
## Summary

Respect an explicitly declared upper bound when materializing a covariant generic type variable:

```py
class UpperBound: ...

class Co[T: UpperBound]:
    def get(self) -> T:
        raise NotImplementedError

def _(x: object):
    if isinstance(x, Co):
        reveal_type(x)  # revealed: Co[UpperBound], previously: Co[object]
```

Fixes astral-sh/ty#4103.

Note: Constrained covariant generics might also require some customization here, but I haven't thought about them deeply. Maybe since this affects covariance only, using the union of all constraints is fine?

## Test Plan

New Markdown tests for materialization itself, and for `isinstance` narrowing.