### PR TITLE
fix(pyupgrade): don't fix UP007 for single-argument Union with a call

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP007_1.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP007_1.py
@@ -153,3 +153,12 @@ if TYPE_CHECKING:
         | Literal["LongLiteralNumberTwo"]
         | Literal["LongLiteralNumberThree"]
     ]
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/27238
+# `Union[tuple(r)]` must not be rewritten to `tuple(r)`: when `r` is a tuple of
+# types, `Union[X]` unpacks `X` into a union, so stripping the `Union[...]`
+# wrapper changes the runtime semantics. No fix should be offered.
+def f(r):
+    ru = Annotated[Union[tuple(r)], Field(default=None)]
+    return ru

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -272,6 +272,15 @@ pub(crate) fn non_pep604_annotation(
                     }
                     _ => {
                         // Single argument.
+                        //
+                        // Don't fix when the argument is a call expression (e.g.
+                        // `Union[tuple(r)]`). `Union[X]` only equals `X` when `X`
+                        // is a type; when `X` is a *tuple* of types, `Union[X]`
+                        // unpacks it into a union, so stripping the `Union[...]`
+                        // wrapper changes the runtime semantics (#27238).
+                        if matches!(slice, Expr::Call(_)) {
+                            return;
+                        }
                         let inner = checker.locator().slice(slice);
                         let replacement = if checker.locator().contains_line_break(slice.range()) {
                             // If the inner expression spans multiple lines, wrap in

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP007_1.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP007_1.py.snap
@@ -335,4 +335,16 @@ help: Convert to `X | Y`
     -         | Literal["LongLiteralNumberThree"]
     -     ]
 153 +         | Literal["LongLiteralNumberThree"])
+154 |
     |
+
+UP007 Use `X | Y` for type annotations
+   --> UP007_1.py:163:20
+    |
+161 | # wrapper changes the runtime semantics. No fix should be offered.
+162 | def f(r):
+163 |     ru = Annotated[Union[tuple(r)], Field(default=None)]
+    |                    ^^^^^^^^^^^^^^^
+164 |     return ru
+    |
+help: Convert to `X | Y`


### PR DESCRIPTION
## Summary

Fixes #27238

UP007 rewrote `Union[tuple(r)]` to `tuple(r)`:

```diff
-ru = Annotated[Union[tuple(r)], Field(default=getattr(schema, "default", None))]
+ru = Annotated[tuple(r), Field(default=getattr(schema, "default", None))]
```

But `Union[X]` only equals `X` when `X` is a **type**. When `X` is a *tuple* of types (as returned by `tuple(r)`), `Union[X]` unpacks it into a union, so stripping the `Union[...]` wrapper changes the runtime semantics and produces an invalid annotation:

```
TypeError: Annotated[t, ...]: t must be a type. Got (typing.Annotated[int, FieldInfo(...)], <class 'NoneType'>, ...)
```

## Fix

Skip the autofix when the single argument to `Union` is a call expression. The diagnostic is still reported; only the fix is suppressed (the call could return either a type or a tuple of types, and we can't tell statically).

## Test

Added a regression case to `UP007_1.py` and updated the snapshot. The new diagnostic is reported **without** a fix:

```
UP007 Use `X | Y` for type annotations
   --> UP007_1.py:163:20
    |
163 |     ru = Annotated[Union[tuple(r)], Field(default=None)]
    |                    ^^^^^^^^^^^^^^^
    |
help: Convert to `X | Y`
```

```
$ cargo test -p ruff_linter -- rules::pyupgrade
test result: ok. 161 passed; 0 failed
```