### PR TITLE
[ty] Simplify intersections with bounded covariant generics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -890,7 +890,7 @@ of the first type represent sets of values that are a subset of every possible s
 represented by a materialization of the second type.
 
 ```pyi
-from ty_extensions import Unknown, static_assert
+from ty_extensions import Intersection, Unknown, static_assert
 from ty_extensions._internal import is_subtype_of
 from typing_extensions import Any
 
@@ -913,6 +913,31 @@ static_assert(not is_subtype_of(Covariant[Any], Covariant[int]))
 static_assert(not is_subtype_of(Covariant[int], Covariant[Any]))
 static_assert(is_subtype_of(Covariant[Any], Covariant[object]))
 static_assert(not is_subtype_of(Covariant[object], Covariant[Any]))
+
+class UpperBound: ...
+class Sub(UpperBound): ...
+
+class BoundedCovariant[T: UpperBound]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+static_assert(is_subtype_of(BoundedCovariant[Any], BoundedCovariant[UpperBound]))
+static_assert(is_subtype_of(BoundedCovariant[Intersection[Any, Sub]], BoundedCovariant[Sub]))
+static_assert(not is_subtype_of(BoundedCovariant[Any], BoundedCovariant[Sub]))
+static_assert(not is_subtype_of(BoundedCovariant[Any], BoundedCovariant[Any]))
+
+class BoundedDType[T: UpperBound]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+class BoundedArray[Shape: tuple[int, ...], DType: BoundedDType[Any]]:
+    def shape(self) -> Shape:
+        raise NotImplementedError
+
+    def dtype(self) -> DType:
+        raise NotImplementedError
+
+static_assert(is_subtype_of(BoundedArray[Any, Any], BoundedArray[tuple[int, ...], BoundedDType[Any]]))
 
 class Contravariant[T]:
     def receive(self, input: T): ...

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1556,6 +1556,28 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         *target_type,
                         target_materialization_kind,
                     ),
+                    TypeVarVariance::Covariant
+                        if self.relation.is_subtyping()
+                            && source_type.has_dynamic(db)
+                            && let Some(upper_bound) =
+                                bound_typevar.typevar(db).upper_bound(db) =>
+                    {
+                        let source_type = IntersectionType::from_two_elements(
+                            db,
+                            source_type.materialize(
+                                db,
+                                MaterializationKind::Top,
+                                self.materialization_visitor,
+                            ),
+                            upper_bound,
+                        );
+
+                        if source_type == *target_type {
+                            self.always()
+                        } else {
+                            self.check_type_pair(db, source_type, *target_type)
+                        }
+                    }
                     TypeVarVariance::Covariant => {
                         self.check_type_pair(db, *source_type, *target_type)
                     }


### PR DESCRIPTION
## Summary

Recognize that a gradual specialization of a bounded covariant generic is a subtype of its own upper bound. For example, `Bounded[Any] & ~Bounded[UpperBound]` simplifies to `Never` when `Bounded` is covariant and its type variable has a declared upper bound.

Related to astral-sh/ty#4103.

## Test Plan

