### PR TITLE
fix(stdlib): treat range as immutable return type for B008

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B006_B008.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B006_B008.py
@@ -203,6 +203,10 @@ def int_okay(value=int("12")):
 def slice_okay(value=slice(1,2)):
     pass
 
+# Allow immutable range()
+def range_okay(value=range(3)):
+    pass
+
 # Allow immutable complex() value
 def complex_okay(value=complex(1,2)):
     pass

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+assertion_line: 85
 ---
 B006 [*] Do not use mutable data structures for argument defaults
   --> B006_B008.py:63:25
@@ -212,111 +213,95 @@ help: Replace with `None`; initialize within function
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:242:20
+   --> B006_B008.py:246:20
     |
-240 | # B006 and B008
-241 | # We should handle arbitrary nesting of these B008.
-242 | def nested_combo(a=[float(3), dt.datetime.now()]):
+244 | # B006 and B008
+245 | # We should handle arbitrary nesting of these B008.
+246 | def nested_combo(a=[float(3), dt.datetime.now()]):
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-243 |     pass
+247 |     pass
     |
 help: Replace with `None`; initialize within function
     |
-241 | # We should handle arbitrary nesting of these B008.
+245 | # We should handle arbitrary nesting of these B008.
     - def nested_combo(a=[float(3), dt.datetime.now()]):
-242 + def nested_combo(a=None):
-243 |     pass
+246 + def nested_combo(a=None):
+247 |     pass
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:279:27
+   --> B006_B008.py:283:27
     |
-278 | def mutable_annotations(
-279 |     a: list[int] | None = [],
+282 | def mutable_annotations(
+283 |     a: list[int] | None = [],
     |                           ^^
-280 |     b: Optional[Dict[int, int]] = {},
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+284 |     b: Optional[Dict[int, int]] = {},
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
 help: Replace with `None`; initialize within function
     |
-278 | def mutable_annotations(
+282 | def mutable_annotations(
     -     a: list[int] | None = [],
-279 +     a: list[int] | None = None,
-280 |     b: Optional[Dict[int, int]] = {},
+283 +     a: list[int] | None = None,
+284 |     b: Optional[Dict[int, int]] = {},
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:280:35
+   --> B006_B008.py:284:35
     |
-278 | def mutable_annotations(
-279 |     a: list[int] | None = [],
-280 |     b: Optional[Dict[int, int]] = {},
+282 | def mutable_annotations(
+283 |     a: list[int] | None = [],
+284 |     b: Optional[Dict[int, int]] = {},
     |                                   ^^
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-282 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+286 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
 help: Replace with `None`; initialize within function
     |
-279 |     a: list[int] | None = [],
+283 |     a: list[int] | None = [],
     -     b: Optional[Dict[int, int]] = {},
-280 +     b: Optional[Dict[int, int]] = None,
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+284 +     b: Optional[Dict[int, int]] = None,
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:281:62
+   --> B006_B008.py:285:62
     |
-279 |     a: list[int] | None = [],
-280 |     b: Optional[Dict[int, int]] = {},
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+283 |     a: list[int] | None = [],
+284 |     b: Optional[Dict[int, int]] = {},
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                              ^^^^^
-282 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-283 | ):
+286 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+287 | ):
     |
 help: Replace with `None`; initialize within function
     |
-280 |     b: Optional[Dict[int, int]] = {},
+284 |     b: Optional[Dict[int, int]] = {},
     -     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-281 +     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
-282 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+285 +     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
+286 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:282:80
+   --> B006_B008.py:286:80
     |
-280 |     b: Optional[Dict[int, int]] = {},
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-282 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+284 |     b: Optional[Dict[int, int]] = {},
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+286 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                                                ^^^^^
-283 | ):
-284 |     pass
+287 | ):
+288 |     pass
     |
 help: Replace with `None`; initialize within function
     |
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     -     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-282 +     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
-283 | ):
-    |
-note: This is an unsafe fix and may change runtime behavior
-
-B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:287:52
-    |
-287 | def single_line_func_wrong(value: dict[str, str] = {}):
-    |                                                    ^^
-288 |     """Docstring"""
-    |
-help: Replace with `None`; initialize within function
-    |
-286 |
-    - def single_line_func_wrong(value: dict[str, str] = {}):
-287 + def single_line_func_wrong(value: dict[str, str] = None):
-288 |     """Docstring"""
+286 +     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
+287 | ):
     |
 note: This is an unsafe fix and may change runtime behavior
 
@@ -326,7 +311,6 @@ B006 [*] Do not use mutable data structures for argument defaults
 291 | def single_line_func_wrong(value: dict[str, str] = {}):
     |                                                    ^^
 292 |     """Docstring"""
-293 |     ...
     |
 help: Replace with `None`; initialize within function
     |
@@ -338,18 +322,19 @@ help: Replace with `None`; initialize within function
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:296:52
+   --> B006_B008.py:295:52
     |
-296 | def single_line_func_wrong(value: dict[str, str] = {}):
+295 | def single_line_func_wrong(value: dict[str, str] = {}):
     |                                                    ^^
-297 |     """Docstring"""; ...
+296 |     """Docstring"""
+297 |     ...
     |
 help: Replace with `None`; initialize within function
     |
-295 |
+294 |
     - def single_line_func_wrong(value: dict[str, str] = {}):
-296 + def single_line_func_wrong(value: dict[str, str] = None):
-297 |     """Docstring"""; ...
+295 + def single_line_func_wrong(value: dict[str, str] = None):
+296 |     """Docstring"""
     |
 note: This is an unsafe fix and may change runtime behavior
 
@@ -358,61 +343,77 @@ B006 [*] Do not use mutable data structures for argument defaults
     |
 300 | def single_line_func_wrong(value: dict[str, str] = {}):
     |                                                    ^^
-301 |     """Docstring"""; \
-302 |         ...
+301 |     """Docstring"""; ...
     |
 help: Replace with `None`; initialize within function
     |
 299 |
     - def single_line_func_wrong(value: dict[str, str] = {}):
 300 + def single_line_func_wrong(value: dict[str, str] = None):
-301 |     """Docstring"""; \
+301 |     """Docstring"""; ...
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:305:52
+   --> B006_B008.py:304:52
     |
-305 |   def single_line_func_wrong(value: dict[str, str] = {
-    |  ____________________________________________________^
-306 | |     # This is a comment
-307 | | }):
-    | |_^
-308 |       """Docstring"""
+304 | def single_line_func_wrong(value: dict[str, str] = {}):
+    |                                                    ^^
+305 |     """Docstring"""; \
+306 |         ...
     |
 help: Replace with `None`; initialize within function
     |
-304 |
+303 |
+    - def single_line_func_wrong(value: dict[str, str] = {}):
+304 + def single_line_func_wrong(value: dict[str, str] = None):
+305 |     """Docstring"""; \
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+B006 [*] Do not use mutable data structures for argument defaults
+   --> B006_B008.py:309:52
+    |
+309 |   def single_line_func_wrong(value: dict[str, str] = {
+    |  ____________________________________________________^
+310 | |     # This is a comment
+311 | | }):
+    | |_^
+312 |       """Docstring"""
+    |
+help: Replace with `None`; initialize within function
+    |
+308 |
     - def single_line_func_wrong(value: dict[str, str] = {
     -     # This is a comment
     - }):
-305 + def single_line_func_wrong(value: dict[str, str] = None):
-306 |     """Docstring"""
+309 + def single_line_func_wrong(value: dict[str, str] = None):
+310 |     """Docstring"""
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 Do not use mutable data structures for argument defaults
-   --> B006_B008.py:311:52
+   --> B006_B008.py:315:52
     |
-311 | def single_line_func_wrong(value: dict[str, str] = {}) \
+315 | def single_line_func_wrong(value: dict[str, str] = {}) \
     |                                                    ^^
-312 |     : \
-313 |     """Docstring"""
+316 |     : \
+317 |     """Docstring"""
     |
 help: Replace with `None`; initialize within function
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:316:52
+   --> B006_B008.py:320:52
     |
-316 | def single_line_func_wrong(value: dict[str, str] = {}):
+320 | def single_line_func_wrong(value: dict[str, str] = {}):
     |                                                    ^^
-317 |     """Docstring without newline"""
+321 |     """Docstring without newline"""
     |
 help: Replace with `None`; initialize within function
     |
-315 |
+319 |
     - def single_line_func_wrong(value: dict[str, str] = {}):
-316 + def single_line_func_wrong(value: dict[str, str] = None):
-317 |     """Docstring without newline"""
+320 + def single_line_func_wrong(value: dict[str, str] = None):
+321 |     """Docstring without newline"""
     |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
@@ -1,31 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+assertion_line: 85
 ---
-B008 Do not perform function call `range` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
-   --> B006_B008.py:102:61
-    |
-101 | # N.B. we're also flagging the function call in the comprehension
-102 | def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
-    |                                                             ^^^^^^^^
-103 |     pass
-    |
-
-B008 Do not perform function call `range` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
-   --> B006_B008.py:106:64
-    |
-106 | def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
-    |                                                                ^^^^^^^^
-107 |     pass
-    |
-
-B008 Do not perform function call `range` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
-   --> B006_B008.py:110:60
-    |
-110 | def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
-    |                                                            ^^^^^^^^
-111 |     pass
-    |
-
 B008 Do not perform function call `time.time` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
    --> B006_B008.py:126:39
     |
@@ -53,39 +29,39 @@ B008 Do not perform function call in argument defaults; instead, perform the cal
     |
 
 B008 Do not perform function call `dt.datetime.now` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
-   --> B006_B008.py:242:31
+   --> B006_B008.py:246:31
     |
-240 | # B006 and B008
-241 | # We should handle arbitrary nesting of these B008.
-242 | def nested_combo(a=[float(3), dt.datetime.now()]):
+244 | # B006 and B008
+245 | # We should handle arbitrary nesting of these B008.
+246 | def nested_combo(a=[float(3), dt.datetime.now()]):
     |                               ^^^^^^^^^^^^^^^^^
-243 |     pass
+247 |     pass
     |
 
 B008 Do not perform function call `map` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
-   --> B006_B008.py:248:22
+   --> B006_B008.py:252:22
     |
-246 | # Don't flag nested B006 since we can't guarantee that
-247 | # it isn't made mutable by the outer operation.
-248 | def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
+250 | # Don't flag nested B006 since we can't guarantee that
+251 | # it isn't made mutable by the outer operation.
+252 | def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-249 |     pass
+253 |     pass
     |
 
 B008 Do not perform function call `random.randint` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
-   --> B006_B008.py:253:19
+   --> B006_B008.py:257:19
     |
-252 | # B008-ception.
-253 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
+256 | # B008-ception.
+257 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-254 |     pass
+258 |     pass
     |
 
 B008 Do not perform function call `dt.datetime.now` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
-   --> B006_B008.py:253:37
+   --> B006_B008.py:257:37
     |
-252 | # B008-ception.
-253 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
+256 | # B008-ception.
+257 | def nested_b008(a=random.randint(0, dt.datetime.now().year)):
     |                                     ^^^^^^^^^^^^^^^^^
-254 |     pass
+258 |     pass
     |

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__preview__B006_B006_B008.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__preview__B006_B006_B008.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+assertion_line: 114
 ---
 B006 [*] Do not use mutable data structures for argument defaults
   --> B006_B008.py:63:25
@@ -212,111 +213,95 @@ help: Replace with `None`; initialize within function
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:242:20
+   --> B006_B008.py:246:20
     |
-240 | # B006 and B008
-241 | # We should handle arbitrary nesting of these B008.
-242 | def nested_combo(a=[float(3), dt.datetime.now()]):
+244 | # B006 and B008
+245 | # We should handle arbitrary nesting of these B008.
+246 | def nested_combo(a=[float(3), dt.datetime.now()]):
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-243 |     pass
+247 |     pass
     |
 help: Replace with `None`; initialize within function
     |
-241 | # We should handle arbitrary nesting of these B008.
+245 | # We should handle arbitrary nesting of these B008.
     - def nested_combo(a=[float(3), dt.datetime.now()]):
-242 + def nested_combo(a=None):
-243 |     pass
+246 + def nested_combo(a=None):
+247 |     pass
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:279:27
+   --> B006_B008.py:283:27
     |
-278 | def mutable_annotations(
-279 |     a: list[int] | None = [],
+282 | def mutable_annotations(
+283 |     a: list[int] | None = [],
     |                           ^^
-280 |     b: Optional[Dict[int, int]] = {},
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+284 |     b: Optional[Dict[int, int]] = {},
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
 help: Replace with `None`; initialize within function
     |
-278 | def mutable_annotations(
+282 | def mutable_annotations(
     -     a: list[int] | None = [],
-279 +     a: list[int] | None = None,
-280 |     b: Optional[Dict[int, int]] = {},
+283 +     a: list[int] | None = None,
+284 |     b: Optional[Dict[int, int]] = {},
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:280:35
+   --> B006_B008.py:284:35
     |
-278 | def mutable_annotations(
-279 |     a: list[int] | None = [],
-280 |     b: Optional[Dict[int, int]] = {},
+282 | def mutable_annotations(
+283 |     a: list[int] | None = [],
+284 |     b: Optional[Dict[int, int]] = {},
     |                                   ^^
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-282 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+286 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
 help: Replace with `None`; initialize within function
     |
-279 |     a: list[int] | None = [],
+283 |     a: list[int] | None = [],
     -     b: Optional[Dict[int, int]] = {},
-280 +     b: Optional[Dict[int, int]] = None,
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+284 +     b: Optional[Dict[int, int]] = None,
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:281:62
+   --> B006_B008.py:285:62
     |
-279 |     a: list[int] | None = [],
-280 |     b: Optional[Dict[int, int]] = {},
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+283 |     a: list[int] | None = [],
+284 |     b: Optional[Dict[int, int]] = {},
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                              ^^^^^
-282 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-283 | ):
+286 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+287 | ):
     |
 help: Replace with `None`; initialize within function
     |
-280 |     b: Optional[Dict[int, int]] = {},
+284 |     b: Optional[Dict[int, int]] = {},
     -     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-281 +     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
-282 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+285 +     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
+286 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:282:80
+   --> B006_B008.py:286:80
     |
-280 |     b: Optional[Dict[int, int]] = {},
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-282 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+284 |     b: Optional[Dict[int, int]] = {},
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+286 |     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     |                                                                                ^^^^^
-283 | ):
-284 |     pass
+287 | ):
+288 |     pass
     |
 help: Replace with `None`; initialize within function
     |
-281 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
+285 |     c: Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
     -     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = set(),
-282 +     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
-283 | ):
-    |
-note: This is an unsafe fix and may change runtime behavior
-
-B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:287:52
-    |
-287 | def single_line_func_wrong(value: dict[str, str] = {}):
-    |                                                    ^^
-288 |     """Docstring"""
-    |
-help: Replace with `None`; initialize within function
-    |
-286 |
-    - def single_line_func_wrong(value: dict[str, str] = {}):
-287 + def single_line_func_wrong(value: dict[str, str] = None):
-288 |     """Docstring"""
+286 +     d: typing_extensions.Annotated[Union[Set[str], abc.Sized], "annotation"] = None,
+287 | ):
     |
 note: This is an unsafe fix and may change runtime behavior
 
@@ -326,7 +311,6 @@ B006 [*] Do not use mutable data structures for argument defaults
 291 | def single_line_func_wrong(value: dict[str, str] = {}):
     |                                                    ^^
 292 |     """Docstring"""
-293 |     ...
     |
 help: Replace with `None`; initialize within function
     |
@@ -338,18 +322,19 @@ help: Replace with `None`; initialize within function
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:296:52
+   --> B006_B008.py:295:52
     |
-296 | def single_line_func_wrong(value: dict[str, str] = {}):
+295 | def single_line_func_wrong(value: dict[str, str] = {}):
     |                                                    ^^
-297 |     """Docstring"""; ...
+296 |     """Docstring"""
+297 |     ...
     |
 help: Replace with `None`; initialize within function
     |
-295 |
+294 |
     - def single_line_func_wrong(value: dict[str, str] = {}):
-296 + def single_line_func_wrong(value: dict[str, str] = None):
-297 |     """Docstring"""; ...
+295 + def single_line_func_wrong(value: dict[str, str] = None):
+296 |     """Docstring"""
     |
 note: This is an unsafe fix and may change runtime behavior
 
@@ -358,61 +343,77 @@ B006 [*] Do not use mutable data structures for argument defaults
     |
 300 | def single_line_func_wrong(value: dict[str, str] = {}):
     |                                                    ^^
-301 |     """Docstring"""; \
-302 |         ...
+301 |     """Docstring"""; ...
     |
 help: Replace with `None`; initialize within function
     |
 299 |
     - def single_line_func_wrong(value: dict[str, str] = {}):
 300 + def single_line_func_wrong(value: dict[str, str] = None):
-301 |     """Docstring"""; \
+301 |     """Docstring"""; ...
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:305:52
+   --> B006_B008.py:304:52
     |
-305 |   def single_line_func_wrong(value: dict[str, str] = {
-    |  ____________________________________________________^
-306 | |     # This is a comment
-307 | | }):
-    | |_^
-308 |       """Docstring"""
+304 | def single_line_func_wrong(value: dict[str, str] = {}):
+    |                                                    ^^
+305 |     """Docstring"""; \
+306 |         ...
     |
 help: Replace with `None`; initialize within function
     |
-304 |
+303 |
+    - def single_line_func_wrong(value: dict[str, str] = {}):
+304 + def single_line_func_wrong(value: dict[str, str] = None):
+305 |     """Docstring"""; \
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+B006 [*] Do not use mutable data structures for argument defaults
+   --> B006_B008.py:309:52
+    |
+309 |   def single_line_func_wrong(value: dict[str, str] = {
+    |  ____________________________________________________^
+310 | |     # This is a comment
+311 | | }):
+    | |_^
+312 |       """Docstring"""
+    |
+help: Replace with `None`; initialize within function
+    |
+308 |
     - def single_line_func_wrong(value: dict[str, str] = {
     -     # This is a comment
     - }):
-305 + def single_line_func_wrong(value: dict[str, str] = None):
-306 |     """Docstring"""
+309 + def single_line_func_wrong(value: dict[str, str] = None):
+310 |     """Docstring"""
     |
 note: This is an unsafe fix and may change runtime behavior
 
 B006 Do not use mutable data structures for argument defaults
-   --> B006_B008.py:311:52
+   --> B006_B008.py:315:52
     |
-311 | def single_line_func_wrong(value: dict[str, str] = {}) \
+315 | def single_line_func_wrong(value: dict[str, str] = {}) \
     |                                                    ^^
-312 |     : \
-313 |     """Docstring"""
+316 |     : \
+317 |     """Docstring"""
     |
 help: Replace with `None`; initialize within function
 
 B006 [*] Do not use mutable data structures for argument defaults
-   --> B006_B008.py:316:52
+   --> B006_B008.py:320:52
     |
-316 | def single_line_func_wrong(value: dict[str, str] = {}):
+320 | def single_line_func_wrong(value: dict[str, str] = {}):
     |                                                    ^^
-317 |     """Docstring without newline"""
+321 |     """Docstring without newline"""
     |
 help: Replace with `None`; initialize within function
     |
-315 |
+319 |
     - def single_line_func_wrong(value: dict[str, str] = {}):
-316 + def single_line_func_wrong(value: dict[str, str] = None):
-317 |     """Docstring without newline"""
+320 + def single_line_func_wrong(value: dict[str, str] = None):
+321 |     """Docstring without newline"""
     |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_python_stdlib/src/typing.rs
+++ b/crates/ruff_python_stdlib/src/typing.rs
@@ -324,6 +324,7 @@ pub fn is_immutable_return_type(qualified_name: &[&str]) -> bool {
                     | "float"
                     | "frozenset"
                     | "int"
+                    | "range"
                     | "str"
                     | "tuple"
                     | "slice"


### PR DESCRIPTION
## Summary

Fixes #27245

`B008` (`function-call-in-default-argument`) flagged `range()` in argument defaults even though `range` objects are immutable. Sibling immutable builtins like `slice` and `tuple` were already accepted, so `range` was an omission.

```python
def f(x=range(3)): ...   # B008 before, no diagnostic after
def g(x=slice(3)): ...   # already ok
def h(x=tuple()):  ...   # already ok
```

## Root cause

`range` was missing from the builtin list in `is_immutable_return_type` (`crates/ruff_python_stdlib/src/typing.rs`), even though it is already treated as immutable in `is_immutable_non_generic_type` in the same file — the two helpers were inconsistent.

## Fix

Add `range` to the builtin list in `is_immutable_return_type`, matching the existing treatment of `slice`/`tuple`/`frozenset`. This mirrors #21565 / #21823 ("Accept immutable slice default arguments").

Mutable containers built from `range` (e.g. `[i for i in range(3)]`) are still correctly flagged by `B006`.

## Test

Added a `range_okay` case to the `B006_B008.py` fixture and updated snapshots.

```
$ cargo test -p ruff_linter --lib flake8_bugbear
test result: ok. 75 passed; 0 failed
```

Verified with the built binary:
```
$ ruff check mre.py --isolated --select B008
All checks passed!
```