### PR TITLE
[`pylint`] Add missing fix safety gotchas for `non-augmented-assignment` (`PLR6104`)

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/non_augmented_assignment.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/non_augmented_assignment.rs
@@ -68,6 +68,13 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// foo += [2]
 /// assert (foo, bar) == ([1, 2], [1, 2])
 /// ```
+///
+/// An augmented assignment can also fail where the plain form succeeds. NumPy
+/// writes the result into the target's buffer, so `a *= b` raises where
+/// `a = a * b` would broadcast to a new shape or promote the dtype. The same
+/// applies to `a @= b`, which requires the product to have the target's shape.
+///
+/// The fix replaces the whole statement, so any comments inside it are lost.
 #[derive(ViolationMetadata)]
 #[violation_metadata(preview_since = "v0.3.7")]
 pub(crate) struct NonAugmentedAssignment {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary
Add missing fix safety gotchas for [non-augmented-assignment (PLR6104)](https://docs.astral.sh/ruff/rules/non-augmented-assignment/#non-augmented-assignment-plr6104)

Extracted from https://github.com/astral-sh/ruff/pull/27188

## Test Plan

Look at generated doc
