### PR TITLE
[ty] Preserve inference when filtering constructor overloads

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -991,6 +991,75 @@ reveal_type(SimpleMixed(1))  # revealed: int
 reveal_type(SimpleMixed("foo"))  # revealed: SimpleMixed
 ```
 
+### Overlapping generic `__new__` overloads preserve first-match selection
+
+A synthetic constructor receiver can still contain inferable class type variables, even though each
+overload specializes `cls` differently. Step 5 of the overload evaluation algorithm must preserve
+the overload's inferable variables when checking whether the argument types are covered; otherwise a
+concrete constructor call appears ambiguous. In particular, both overloads below accept `list[int]`,
+but the first one must win. The non-instance return case verifies that this is not specific to
+`Self` or to returning the constructed class.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Self, overload
+
+class MixedSelf[T]:
+    @overload
+    def __new__(cls, value: list[T]) -> Self: ...
+    @overload
+    def __new__(cls, value: T) -> T: ...
+    def __new__(cls, value: object) -> object:
+        return object.__new__(cls)
+
+reveal_type(MixedSelf([1]))  # revealed: MixedSelf[int]
+reveal_type(MixedSelf(1))  # revealed: Literal[1]
+
+class DistinctNonInstanceReturns[T]:
+    @overload
+    def __new__(cls, value: list[T]) -> str: ...
+    @overload
+    def __new__(cls, value: T) -> T: ...
+    def __new__(cls, value: object) -> object:
+        return object.__new__(cls)
+
+reveal_type(DistinctNonInstanceReturns([1]))  # revealed: str
+```
+
+### A gradual constructor receiver participates in overload filtering
+
+The synthetic `cls` argument must participate in overload filtering because it can be the only
+gradual argument. A concrete class specialization selects its matching receiver overload, but an
+`Any` specialization can match receivers with different return types and must remain ambiguous.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Any, overload
+
+class Foo[T]:
+    @overload
+    def __new__(cls: type[Foo[int]]) -> int: ...
+    @overload
+    def __new__(cls: type[Foo[str]]) -> str: ...
+    def __new__(cls) -> object: ...
+
+reveal_type(Foo[int]())  # revealed: int
+reveal_type(Foo[str]())  # revealed: str
+reveal_type(Foo[Any]())  # revealed: Unknown
+```
+
 ### Multiple matching `__new__` overloads
 
 If overload resolution for `__new__` falls back to `Unknown` because the argument is `Any` or

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3992,7 +3992,15 @@ impl<'db> CallableBinding<'db> {
                 }),
             );
 
-            if top_materialized_argument_type.is_assignable_to(db, parameter_types) {
+            if top_materialized_argument_type
+                .when_assignable_to(
+                    db,
+                    parameter_types,
+                    constraints,
+                    self.overloads[*current_index].inferable_typevars,
+                )
+                .is_always_satisfied(db)
+            {
                 filter_remaining_overloads = true;
             }
         }


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#4106.

A concrete call to an overloaded generic constructor should select the first matching overload, unless there is real ambiguity due to gradual arguments. In main, the following instead incorrectly resolves to `Unknown`:

```python
class MixedSelf[T]:
    @overload
    def __new__(cls, value: list[T]) -> Self: ...
    @overload
    def __new__(cls, value: T) -> T: ...

reveal_type(MixedSelf([1]))  # should be MixedSelf[int], but is Unknown in main
```

During step 5 of overload evaluation, the `cls` argument is `type[MixedSelf[T]]`, while the first matching overload has already specialized its receiver to `type[MixedSelf[int]]`. The previous step 5 check accidentally treated `T` as fixed instead of inferable, so it could not recognize that `type[MixedSelf[T]]` is assignable to `type[MixedSelf[int]]`. This caused step 5 to wrongly consider the overloads gradually ambiguous and infer `Unknown`. In this PR, we pass the current overload's inferable type variables into the assignability check to fix this.

The receiver must still participate in overload filtering (Codex's first fix attempt here was to simply exclude it, which is wrong): it can be the only gradual argument. For example:

```python
class Foo[T]:
    @overload
    def __new__(cls: type[Foo[int]]) -> int: ...
    @overload
    def __new__(cls: type[Foo[str]]) -> str: ...

reveal_type(Foo[int]())  # int
reveal_type(Foo[str]())  # str
reveal_type(Foo[Any]())  # Unknown: genuinely ambiguous
```

## Test plan

- Cover the original overlapping `Self`/`T` constructor regression and a non-instance-return variant.
- Cover concrete receiver-specific overload selection for `Foo[int]()` and `Foo[str]()`.
- Cover `Foo[Any]()` as a genuine ambiguity when the synthetic receiver is the only gradual argument.

###

All ecosystem changes are improvements. Bokeh is the only suspicious-looking case, but this is just exposing an existing unsupported metaclass-provides-property-descriptors thing that Bokeh does, so these errors are expected.