### PR TITLE
[ty] Index with-statement targets as symbols

### DIFF
--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -10,7 +10,7 @@ pub fn document_symbols(db: &dyn Db, file: File) -> &FlatSymbols {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::symbols::{HierarchicalSymbols, SymbolId, SymbolInfo};
+    use crate::symbols::{HierarchicalSymbols, SymbolId, SymbolInfo, SymbolKind};
     use crate::tests::{CursorTest, IntoDiagnostic, cursor_test};
     use insta::assert_snapshot;
     use ruff_db::diagnostic::{
@@ -342,157 +342,103 @@ def function():
     }
 
     #[test]
-    fn document_symbols_store_contexts() {
+    fn document_symbols_store_context_targets() {
         let test = cursor_test(
             "
-[left, *middle, right] = (1, 2, 3)
-augmented = 1
-augmented += (augmented_value := 1)
+first, *rest, LAST = values
 
-for loop_target in ():
-    pass
+for loop_left, [loop_right, *loop_rest] in rows:
+    loop_body = 1
 
-(named_target := 1)
-comprehension = [(comprehension_target := value) for value in ()]
-lambda_value = lambda default=(lambda_default := 1): (lambda_local := default)
+with manager() as [with_left, *with_rest], manager() as WITH_CONSTANT:
+    with_body = 1
 
-class C((base_target := object)):
-    [class_left, class_right] = (1, 2)
+captured = (walrus := 1)
 
-@((decorator_target := identity))
-def function(default=(default_target := 1)):
-    [local_left, local_right] = (1, 2)
-    (local_walrus := 1)
+def function():
+    function_local = 1
+    with manager() as function_target:
+        pass
 <CURSOR>",
         );
 
-        assert_snapshot!(test.document_symbols(), @"
-        info[document-symbols]: SymbolInfo
-         --> main.py:2:2
-          |
-        2 | [left, *middle, right] = (1, 2, 3)
-          |  ^^^^
-        info: Variable left
+        let symbols = document_symbols(&test.db, test.cursor.file)
+            .iter()
+            .map(|(_, symbol)| (symbol.name.into_owned(), symbol.kind))
+            .collect::<Vec<_>>();
 
-        info[document-symbols]: SymbolInfo
-         --> main.py:2:9
-          |
-        2 | [left, *middle, right] = (1, 2, 3)
-          |         ^^^^^^
-        info: Variable middle
+        assert_eq!(
+            symbols,
+            [
+                ("first", SymbolKind::Variable),
+                ("rest", SymbolKind::Variable),
+                ("LAST", SymbolKind::Constant),
+                ("loop_left", SymbolKind::Variable),
+                ("loop_right", SymbolKind::Variable),
+                ("loop_rest", SymbolKind::Variable),
+                ("loop_body", SymbolKind::Variable),
+                ("with_left", SymbolKind::Variable),
+                ("with_rest", SymbolKind::Variable),
+                ("WITH_CONSTANT", SymbolKind::Constant),
+                ("with_body", SymbolKind::Variable),
+                ("captured", SymbolKind::Variable),
+                ("walrus", SymbolKind::Variable),
+                ("function", SymbolKind::Function),
+            ]
+            .map(|(name, kind)| (name.to_owned(), kind))
+        );
+    }
 
-        info[document-symbols]: SymbolInfo
-         --> main.py:2:17
-          |
-        2 | [left, *middle, right] = (1, 2, 3)
-          |                 ^^^^^
-        info: Variable right
+    #[test]
+    fn document_symbols_comprehension_and_lambda_scopes() {
+        let test = cursor_test(
+            "
+result = [item for item in values if (leaked := item)]
+generator = (other for other in values)
+lambda_value = lambda: (lambda_local := 1)
+<CURSOR>",
+        );
 
-        info[document-symbols]: SymbolInfo
-         --> main.py:3:1
-          |
-        3 | augmented = 1
-          | ^^^^^^^^^
-        info: Variable augmented
+        let names = document_symbols(&test.db, test.cursor.file)
+            .iter()
+            .map(|(_, symbol)| symbol.name.into_owned())
+            .collect::<Vec<_>>();
 
-        info[document-symbols]: SymbolInfo
-         --> main.py:4:15
-          |
-        4 | augmented += (augmented_value := 1)
-          |               ^^^^^^^^^^^^^^^
-        info: Variable augmented_value
+        assert_eq!(names, ["result", "leaked", "generator", "lambda_value"]);
+    }
 
-        info[document-symbols]: SymbolInfo
-         --> main.py:6:5
-          |
-        6 | for loop_target in ():
-          |     ^^^^^^^^^^^
-        info: Variable loop_target
+    #[test]
+    fn document_symbols_function_and_class_header_bindings() {
+        let test = cursor_test(
+            "
+@(function_decorator := decorate)
+def function(value=(default_value := 1)):
+    function_local = 1
 
-        info[document-symbols]: SymbolInfo
-         --> main.py:9:2
-          |
-        9 | (named_target := 1)
-          |  ^^^^^^^^^^^^
-        info: Variable named_target
+@(class_decorator := decorate)
+class Example((class_base := Base)):
+    class_field = 1
+<CURSOR>",
+        );
 
-        info[document-symbols]: SymbolInfo
-          --> main.py:10:1
-           |
-        10 | comprehension = [(comprehension_target := value) for value in ()]
-           | ^^^^^^^^^^^^^
-        info: Variable comprehension
+        let symbols = document_symbols(&test.db, test.cursor.file)
+            .iter()
+            .map(|(_, symbol)| (symbol.name.into_owned(), symbol.kind))
+            .collect::<Vec<_>>();
 
-        info[document-symbols]: SymbolInfo
-          --> main.py:10:19
-           |
-        10 | comprehension = [(comprehension_target := value) for value in ()]
-           |                   ^^^^^^^^^^^^^^^^^^^^
-        info: Variable comprehension_target
-
-        info[document-symbols]: SymbolInfo
-          --> main.py:11:1
-           |
-        11 | lambda_value = lambda default=(lambda_default := 1): (lambda_local := default)
-           | ^^^^^^^^^^^^
-        info: Variable lambda_value
-
-        info[document-symbols]: SymbolInfo
-          --> main.py:11:32
-           |
-        11 | lambda_value = lambda default=(lambda_default := 1): (lambda_local := default)
-           |                                ^^^^^^^^^^^^^^
-        info: Variable lambda_default
-
-        info[document-symbols]: SymbolInfo
-          --> main.py:13:7
-           |
-        13 | class C((base_target := object)):
-           |       ^
-        info: Class C
-
-        info[document-symbols]: SymbolInfo
-          --> main.py:14:6
-           |
-        14 |     [class_left, class_right] = (1, 2)
-           |      ^^^^^^^^^^
-        info: Field class_left
-
-        info[document-symbols]: SymbolInfo
-          --> main.py:14:18
-           |
-        14 |     [class_left, class_right] = (1, 2)
-           |                  ^^^^^^^^^^^
-        info: Field class_right
-
-        info[document-symbols]: SymbolInfo
-          --> main.py:13:10
-           |
-        13 | class C((base_target := object)):
-           |          ^^^^^^^^^^^
-        info: Variable base_target
-
-        info[document-symbols]: SymbolInfo
-          --> main.py:16:4
-           |
-        16 | @((decorator_target := identity))
-           |    ^^^^^^^^^^^^^^^^
-        info: Variable decorator_target
-
-        info[document-symbols]: SymbolInfo
-          --> main.py:17:5
-           |
-        17 | def function(default=(default_target := 1)):
-           |     ^^^^^^^^
-        info: Function function
-
-        info[document-symbols]: SymbolInfo
-          --> main.py:17:23
-           |
-        17 | def function(default=(default_target := 1)):
-           |                       ^^^^^^^^^^^^^^
-        info: Variable default_target
-        ");
+        assert_eq!(
+            symbols,
+            [
+                ("function_decorator", SymbolKind::Variable),
+                ("function", SymbolKind::Function),
+                ("default_value", SymbolKind::Variable),
+                ("class_decorator", SymbolKind::Variable),
+                ("Example", SymbolKind::Class),
+                ("class_base", SymbolKind::Variable),
+                ("class_field", SymbolKind::Field),
+            ]
+            .map(|(name, kind)| (name.to_owned(), kind))
+        );
     }
 
     impl CursorTest {

--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -263,6 +263,84 @@ class Aliases:
         ");
     }
 
+    #[test]
+    fn document_symbols_with_statement_targets() {
+        let test = cursor_test(
+            "
+from contextlib import nullcontext
+
+with nullcontext() as module_target, nullcontext((1, 2)) as (left, right):
+    body_target = 1
+
+class C:
+    with nullcontext() as class_target:
+        body_field = 1
+
+def function():
+    with nullcontext() as local_target:
+        pass
+<CURSOR>",
+        );
+
+        assert_snapshot!(test.document_symbols(), @"
+        info[document-symbols]: SymbolInfo
+         --> main.py:4:23
+          |
+        4 | with nullcontext() as module_target, nullcontext((1, 2)) as (left, right):
+          |                       ^^^^^^^^^^^^^
+        info: Variable module_target
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:4:62
+          |
+        4 | with nullcontext() as module_target, nullcontext((1, 2)) as (left, right):
+          |                                                              ^^^^
+        info: Variable left
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:4:68
+          |
+        4 | with nullcontext() as module_target, nullcontext((1, 2)) as (left, right):
+          |                                                                    ^^^^^
+        info: Variable right
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:5:5
+          |
+        5 |     body_target = 1
+          |     ^^^^^^^^^^^
+        info: Variable body_target
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:7:7
+          |
+        7 | class C:
+          |       ^
+        info: Class C
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:8:27
+          |
+        8 |     with nullcontext() as class_target:
+          |                           ^^^^^^^^^^^^
+        info: Field class_target
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:9:9
+          |
+        9 |         body_field = 1
+          |         ^^^^^^^^^^
+        info: Field body_field
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:11:5
+           |
+        11 | def function():
+           |     ^^^^^^^^
+        info: Function function
+        ");
+    }
+
     impl CursorTest {
         fn document_symbols(&self) -> String {
             let symbols = document_symbols(&self.db, self.cursor.file).to_hierarchical();

--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -342,6 +342,48 @@ def function():
     }
 
     #[test]
+    fn document_symbols_augmented_assignment_targets() {
+        let test = cursor_test(
+            "
+items = [1]
+items[(index := 0)] += 1
+(obj := factory()).value += 1
+items += (rhs := [1])
+<CURSOR>",
+        );
+
+        assert_snapshot!(test.document_symbols(), @"
+        info[document-symbols]: SymbolInfo
+         --> main.py:2:1
+          |
+        2 | items = [1]
+          | ^^^^^
+        info: Variable items
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:3:8
+          |
+        3 | items[(index := 0)] += 1
+          |        ^^^^^
+        info: Variable index
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:4:2
+          |
+        4 | (obj := factory()).value += 1
+          |  ^^^
+        info: Variable obj
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:5:11
+          |
+        5 | items += (rhs := [1])
+          |           ^^^
+        info: Variable rhs
+        ");
+    }
+
+    #[test]
     fn document_symbols_store_context_targets() {
         let test = cursor_test(
             "

--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -341,6 +341,160 @@ def function():
         ");
     }
 
+    #[test]
+    fn document_symbols_store_contexts() {
+        let test = cursor_test(
+            "
+[left, *middle, right] = (1, 2, 3)
+augmented = 1
+augmented += (augmented_value := 1)
+
+for loop_target in ():
+    pass
+
+(named_target := 1)
+comprehension = [(comprehension_target := value) for value in ()]
+lambda_value = lambda default=(lambda_default := 1): (lambda_local := default)
+
+class C((base_target := object)):
+    [class_left, class_right] = (1, 2)
+
+@((decorator_target := identity))
+def function(default=(default_target := 1)):
+    [local_left, local_right] = (1, 2)
+    (local_walrus := 1)
+<CURSOR>",
+        );
+
+        assert_snapshot!(test.document_symbols(), @"
+        info[document-symbols]: SymbolInfo
+         --> main.py:2:2
+          |
+        2 | [left, *middle, right] = (1, 2, 3)
+          |  ^^^^
+        info: Variable left
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:2:9
+          |
+        2 | [left, *middle, right] = (1, 2, 3)
+          |         ^^^^^^
+        info: Variable middle
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:2:17
+          |
+        2 | [left, *middle, right] = (1, 2, 3)
+          |                 ^^^^^
+        info: Variable right
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:3:1
+          |
+        3 | augmented = 1
+          | ^^^^^^^^^
+        info: Variable augmented
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:4:15
+          |
+        4 | augmented += (augmented_value := 1)
+          |               ^^^^^^^^^^^^^^^
+        info: Variable augmented_value
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:6:5
+          |
+        6 | for loop_target in ():
+          |     ^^^^^^^^^^^
+        info: Variable loop_target
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:9:2
+          |
+        9 | (named_target := 1)
+          |  ^^^^^^^^^^^^
+        info: Variable named_target
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:10:1
+           |
+        10 | comprehension = [(comprehension_target := value) for value in ()]
+           | ^^^^^^^^^^^^^
+        info: Variable comprehension
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:10:19
+           |
+        10 | comprehension = [(comprehension_target := value) for value in ()]
+           |                   ^^^^^^^^^^^^^^^^^^^^
+        info: Variable comprehension_target
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:11:1
+           |
+        11 | lambda_value = lambda default=(lambda_default := 1): (lambda_local := default)
+           | ^^^^^^^^^^^^
+        info: Variable lambda_value
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:11:32
+           |
+        11 | lambda_value = lambda default=(lambda_default := 1): (lambda_local := default)
+           |                                ^^^^^^^^^^^^^^
+        info: Variable lambda_default
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:13:7
+           |
+        13 | class C((base_target := object)):
+           |       ^
+        info: Class C
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:14:6
+           |
+        14 |     [class_left, class_right] = (1, 2)
+           |      ^^^^^^^^^^
+        info: Field class_left
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:14:18
+           |
+        14 |     [class_left, class_right] = (1, 2)
+           |                  ^^^^^^^^^^^
+        info: Field class_right
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:13:10
+           |
+        13 | class C((base_target := object)):
+           |          ^^^^^^^^^^^
+        info: Variable base_target
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:16:4
+           |
+        16 | @((decorator_target := identity))
+           |    ^^^^^^^^^^^^^^^^
+        info: Variable decorator_target
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:17:5
+           |
+        17 | def function(default=(default_target := 1)):
+           |     ^^^^^^^^
+        info: Function function
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:17:23
+           |
+        17 | def function(default=(default_target := 1)):
+           |                       ^^^^^^^^^^^^^^
+        info: Variable default_target
+        ");
+    }
+
     impl CursorTest {
         fn document_symbols(&self) -> String {
             let symbols = document_symbols(&self.db, self.cursor.file).to_hierarchical();

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -700,7 +700,7 @@ struct SymbolVisitor<'db> {
     in_class: bool,
     /// The statement whose expressions are currently being visited.
     current_stmt: Option<&'db ast::Stmt>,
-    /// Whether names in a `Store` context should be ignored.
+    /// Whether store-context names should be excluded from the enclosing scope.
     suppress_store_symbols: bool,
     /// When enabled, the visitor should only try to extract
     /// symbols from a module that we believed form the "exported"
@@ -826,27 +826,10 @@ impl<'db> SymbolVisitor<'db> {
         }
     }
 
-    fn with_current_stmt(
-        &mut self,
-        stmt: &'db ast::Stmt,
-        visit: impl FnOnce(&mut SymbolVisitor<'db>),
-    ) {
-        let previous_stmt = self.current_stmt.replace(stmt);
-        visit(self);
-        self.current_stmt = previous_stmt;
-    }
-
-    fn with_store_symbols_suppressed(&mut self, visit: impl FnOnce(&mut SymbolVisitor<'db>)) {
-        let was_suppressed = self.suppress_store_symbols;
-        self.suppress_store_symbols = true;
-        visit(self);
-        self.suppress_store_symbols = was_suppressed;
-    }
-
-    fn walk_stmt(&mut self, stmt: &'db ast::Stmt) {
-        self.with_current_stmt(stmt, |visitor| {
-            source_order::walk_stmt(visitor, stmt);
-        });
+    fn visit_nonbinding_target(&mut self, target: &'db ast::Expr) {
+        let previous = std::mem::replace(&mut self.suppress_store_symbols, true);
+        self.visit_expr(target);
+        self.suppress_store_symbols = previous;
     }
 
     /// Add a new symbol and return its ID.
@@ -1263,10 +1246,8 @@ impl<'db> SymbolVisitor<'db> {
         // ... otherwise, it's exported!
         true
     }
-}
 
-impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
-    fn visit_stmt(&mut self, stmt: &'db ast::Stmt) {
+    fn visit_stmt_impl(&mut self, stmt: &'db ast::Stmt) {
         match stmt {
             ast::Stmt::FunctionDef(func_def) => {
                 let kind = SymbolKind::function_kind(
@@ -1286,23 +1267,19 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                     imported_from: None,
                 };
 
-                self.with_current_stmt(stmt, |visitor| {
-                    for decorator in &func_def.decorator_list {
-                        visitor.visit_decorator(decorator);
-                    }
-                });
+                for decorator in &func_def.decorator_list {
+                    self.visit_decorator(decorator);
+                }
 
                 let symbol_id = self.add_symbol(symbol);
 
-                self.with_current_stmt(stmt, |visitor| {
-                    if let Some(type_params) = &func_def.type_params {
-                        visitor.visit_type_params(type_params);
-                    }
-                    visitor.visit_parameters(&func_def.parameters);
-                    if let Some(returns) = &func_def.returns {
-                        visitor.visit_annotation(returns);
-                    }
-                });
+                if let Some(type_params) = &func_def.type_params {
+                    self.visit_type_params(type_params);
+                }
+                self.visit_parameters(&func_def.parameters);
+                if let Some(returns) = &func_def.returns {
+                    self.visit_annotation(returns);
+                }
 
                 if self.exports_only {
                     // If global_only, don't walk function bodies
@@ -1333,22 +1310,18 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                     imported_from: None,
                 };
 
-                self.with_current_stmt(stmt, |visitor| {
-                    for decorator in &class_def.decorator_list {
-                        visitor.visit_decorator(decorator);
-                    }
-                });
+                for decorator in &class_def.decorator_list {
+                    self.visit_decorator(decorator);
+                }
 
                 let symbol_id = self.add_symbol(symbol);
 
-                self.with_current_stmt(stmt, |visitor| {
-                    if let Some(type_params) = &class_def.type_params {
-                        visitor.visit_type_params(type_params);
-                    }
-                    if let Some(arguments) = &class_def.arguments {
-                        visitor.visit_arguments(arguments);
-                    }
-                });
+                if let Some(type_params) = &class_def.type_params {
+                    self.visit_type_params(type_params);
+                }
+                if let Some(arguments) = &class_def.arguments {
+                    self.visit_arguments(arguments);
+                }
 
                 if self.exports_only {
                     // If global_only, don't walk class bodies
@@ -1378,52 +1351,78 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
             }
             ast::Stmt::Assign(assign) => {
                 self.add_all_assignment(&assign.targets, Some(&assign.value));
-                self.walk_stmt(stmt);
+                source_order::walk_stmt(self, stmt);
             }
             ast::Stmt::AnnAssign(ann_assign) => {
                 self.add_all_assignment(
                     std::slice::from_ref(&ann_assign.target),
                     ann_assign.value.as_deref(),
                 );
-                self.walk_stmt(stmt);
+                source_order::walk_stmt(self, stmt);
             }
             ast::Stmt::AugAssign(ast::StmtAugAssign {
                 target, op, value, ..
             }) => {
-                if self.exports_only && self.all_origin.is_some() && is_dunder_all(target) {
-                    // Anything other than `+=` is not valid.
-                    if !matches!(op, ast::Operator::Add) || !self.extend_all(value) {
-                        self.all_invalid = true;
-                    }
+                self.visit_nonbinding_target(target);
+                self.visit_expr(value);
+
+                // We don't care about `__all__` unless we're
+                // specifically looking for exported symbols.
+                if !self.exports_only {
+                    return;
                 }
 
-                self.with_current_stmt(stmt, |visitor| {
-                    visitor.with_store_symbols_suppressed(|visitor| {
-                        visitor.visit_expr(target);
-                    });
-                    visitor.visit_operator(op);
-                    visitor.visit_expr(value);
-                });
-            }
-            ast::Stmt::Expr(expr) => {
-                if self.exports_only
-                    && self.all_origin.is_some()
-                    && let Some(ast::ExprCall {
-                        func, arguments, ..
-                    }) = expr.value.as_call_expr()
-                    && let Some(ast::ExprAttribute {
-                        value,
-                        attr,
-                        ctx: ast::ExprContext::Load,
-                        ..
-                    }) = func.as_attribute_expr()
-                    && is_dunder_all(value)
-                    && !self.update_all_by_call_idiom(attr, arguments)
-                {
+                if self.all_origin.is_none() {
+                    // We can't update `__all__` if it doesn't already
+                    // exist.
+                    return;
+                }
+                if !is_dunder_all(target) {
+                    return;
+                }
+                // Anything other than `+=` is not valid.
+                if !matches!(op, ast::Operator::Add) {
+                    self.all_invalid = true;
+                    return;
+                }
+                if !self.extend_all(value) {
                     self.all_invalid = true;
                 }
+            }
+            ast::Stmt::Expr(expr) => {
+                source_order::walk_stmt(self, stmt);
 
-                self.walk_stmt(stmt);
+                // We don't care about `__all__` unless we're
+                // specifically looking for exported symbols.
+                if !self.exports_only {
+                    return;
+                }
+
+                if self.all_origin.is_none() {
+                    // We can't update `__all__` if it doesn't already exist.
+                    return;
+                }
+                let Some(ast::ExprCall {
+                    func, arguments, ..
+                }) = expr.value.as_call_expr()
+                else {
+                    return;
+                };
+                let Some(ast::ExprAttribute {
+                    value,
+                    attr,
+                    ctx: ast::ExprContext::Load,
+                    ..
+                }) = func.as_attribute_expr()
+                else {
+                    return;
+                };
+                if !is_dunder_all(value) {
+                    return;
+                }
+                if !self.update_all_by_call_idiom(attr, arguments) {
+                    self.all_invalid = true;
+                }
             }
             ast::Stmt::Import(import) => {
                 // We ignore any names introduced by imports
@@ -1473,10 +1472,16 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
             // statements. We just assume that all `if` statements are
             // always `True`. This applies to symbols in general but
             // also `__all__`.
-            _ => {
-                self.walk_stmt(stmt);
-            }
+            _ => source_order::walk_stmt(self, stmt),
         }
+    }
+}
+
+impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
+    fn visit_stmt(&mut self, stmt: &'db ast::Stmt) {
+        let previous_stmt = self.current_stmt.replace(stmt);
+        self.visit_stmt_impl(stmt);
+        self.current_stmt = previous_stmt;
     }
 
     fn visit_expr(&mut self, expr: &'db ast::Expr) {
@@ -1492,12 +1497,27 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
             {
                 self.add_assignment(stmt, name);
 
-                if self.exports_only
-                    && !self.in_class
-                    && self.all_origin.is_some()
-                    && name.id == "__all__"
-                    && !is_recognized_all_assignment(stmt, name)
-                {
+                if name.id != "__all__" {
+                    return;
+                }
+
+                // We don't care about `__all__` unless we're
+                // specifically looking for exported symbols.
+                if !self.exports_only {
+                    return;
+                }
+
+                // Class-scoped assignments do not affect the module's exports.
+                if self.in_class {
+                    return;
+                }
+
+                // We can't update `__all__` if it doesn't already exist.
+                if self.all_origin.is_none() {
+                    return;
+                }
+
+                if !is_recognized_all_assignment(stmt, name) {
                     self.all_invalid = true;
                 }
             }
@@ -1516,10 +1536,9 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
     }
 
     fn visit_comprehension(&mut self, comprehension: &'db ast::Comprehension) {
-        self.with_store_symbols_suppressed(|visitor| {
-            visitor.visit_expr(&comprehension.target);
-        });
+        self.visit_nonbinding_target(&comprehension.target);
         self.visit_expr(&comprehension.iter);
+
         for condition in &comprehension.ifs {
             self.visit_expr(condition);
         }
@@ -1543,15 +1562,16 @@ fn is_dunder_all(expr: &ast::Expr) -> bool {
 }
 
 fn is_recognized_all_assignment(stmt: &ast::Stmt, name: &ast::ExprName) -> bool {
-    let target = match stmt {
-        ast::Stmt::Assign(assign) => assign.targets.first(),
-        ast::Stmt::AnnAssign(ann_assign) => Some(&*ann_assign.target),
-        _ => None,
-    };
-
-    target
-        .and_then(ast::Expr::as_name_expr)
-        .is_some_and(|target| std::ptr::eq(target, name))
+    match stmt {
+        ast::Stmt::Assign(assign) => assign
+            .targets
+            .first()
+            .is_some_and(|target| is_dunder_all(target) && target.range() == name.range()),
+        ast::Stmt::AnnAssign(assign) => {
+            is_dunder_all(&assign.target) && assign.target.range() == name.range()
+        }
+        _ => false,
+    }
 }
 
 /// Create and return a string representing a name from the given
@@ -1659,46 +1679,89 @@ def function():
     }
 
     #[test]
-    fn exports_store_contexts() {
-        insta::assert_snapshot!(
-            public_test("\
-[left, *middle, right] = (1, 2, 3)
-augmented = 1
-augmented += (augmented_value := 1)
-
-for loop_target in ():
+    fn exports_store_context_targets() {
+        let test = public_test(
+            "\
+first, *rest, LAST = values
+for loop_left, [loop_right, *loop_rest] in rows:
     pass
+with manager() as [with_left, *with_rest]:
+    pass
+captured = (walrus := 1)
+",
+        );
 
-(named_target := 1)
-comprehension = [(comprehension_target := value) for value in ()]
-lambda_value = lambda default=(lambda_default := 1): (lambda_local := default)
+        assert_eq!(
+            test.exports(),
+            "first :: Variable\n\
+rest :: Variable\n\
+LAST :: Constant\n\
+loop_left :: Variable\n\
+loop_right :: Variable\n\
+loop_rest :: Variable\n\
+with_left :: Variable\n\
+with_rest :: Variable\n\
+captured :: Variable\n\
+walrus :: Variable"
+        );
+    }
 
-class C((base_target := object)):
-    [class_left, class_right] = (1, 2)
+    #[test]
+    fn exports_exclude_comprehension_targets() {
+        let test = public_test(
+            "\
+result = [item for item in values if (leaked := item)]
+generator = (other for other in values)
+lambda_value = lambda: (lambda_local := 1)
+",
+        );
 
-@((decorator_target := identity))
-def function(default=(default_target := 1)):
-    [local_left, local_right] = (1, 2)
-    (local_walrus := 1)
-").exports(),
-            @"
-        left :: Variable
-        middle :: Variable
-        right :: Variable
-        augmented :: Variable
-        augmented_value :: Variable
-        loop_target :: Variable
-        named_target :: Variable
-        comprehension :: Variable
-        comprehension_target :: Variable
-        lambda_value :: Variable
-        lambda_default :: Variable
-        C :: Class
-        base_target :: Variable
-        decorator_target :: Variable
-        function :: Function
-        default_target :: Variable
-        ",
+        assert_eq!(
+            test.exports(),
+            "result :: Variable\n\
+leaked :: Variable\n\
+generator :: Variable\n\
+lambda_value :: Variable"
+        );
+    }
+
+    #[test]
+    fn exports_invalidate_all_rebound_by_with_target() {
+        let test = public_test(
+            "\
+hidden = 1
+visible = 2
+__all__ = ['visible']
+with manager() as __all__:
+    pass
+",
+        );
+
+        assert_eq!(
+            test.exports(),
+            "hidden :: Variable\n\
+visible :: Variable\n\
+__all__ :: Variable"
+        );
+    }
+
+    #[test]
+    fn exports_invalidate_all_rebound_by_named_expression() {
+        let test = public_test(
+            "\
+hidden = 1
+visible = 2
+__all__ = ['visible']
+result = (__all__ := unknown)
+",
+        );
+
+        assert_eq!(
+            test.exports(),
+            "hidden :: Variable\n\
+visible :: Variable\n\
+__all__ :: Variable\n\
+result :: Variable"
         );
     }
 

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -868,6 +868,23 @@ impl<'db> SymbolVisitor<'db> {
         self.add_name_symbol(stmt, name, kind);
     }
 
+    /// Adds symbols introduced by an assignment target.
+    fn add_assignment_target(&mut self, stmt: &ast::Stmt, target: &ast::Expr) {
+        match target {
+            ast::Expr::Name(name) => self.add_assignment(stmt, name),
+            ast::Expr::List(ast::ExprList { elts, .. })
+            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                for element in elts {
+                    self.add_assignment_target(stmt, element);
+                }
+            }
+            ast::Expr::Starred(starred) => {
+                self.add_assignment_target(stmt, &starred.value);
+            }
+            _ => {}
+        }
+    }
+
     /// Adds a symbol introduced via an import `stmt`.
     fn add_import_alias(&mut self, import: AstImport<'_>, alias: &ast::Alias) -> Option<SymbolId> {
         let name = alias.asname.as_ref().unwrap_or(&alias.name);
@@ -1340,6 +1357,15 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                 };
                 self.add_assignment(stmt, name);
             }
+            ast::Stmt::With(with_stmt) => {
+                for item in &with_stmt.items {
+                    if let Some(target) = item.optional_vars.as_deref() {
+                        self.add_assignment_target(stmt, target);
+                    }
+                }
+
+                source_order::walk_stmt(self, stmt);
+            }
             ast::Stmt::AugAssign(ast::StmtAugAssign {
                 target, op, value, ..
             }) => {
@@ -1548,6 +1574,34 @@ def quux():
         X :: Variable
         Foo :: Class
         quux :: Function
+        ",
+        );
+    }
+
+    #[test]
+    fn exports_with_statement_targets() {
+        insta::assert_snapshot!(
+            public_test("\
+from contextlib import nullcontext
+
+with nullcontext() as module_target, nullcontext((1, 2)) as (left, right):
+    body_target = 1
+
+class C:
+    with nullcontext() as class_target:
+        body_field = 1
+
+def function():
+    with nullcontext() as local_target:
+        pass
+").exports(),
+            @"
+        module_target :: Variable
+        left :: Variable
+        right :: Variable
+        body_target :: Variable
+        C :: Class
+        function :: Function
         ",
         );
     }

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -698,6 +698,10 @@ struct SymbolVisitor<'db> {
     /// This is true even when we're inside a function definition
     /// that is inside a class.
     in_class: bool,
+    /// The statement whose expressions are currently being visited.
+    current_stmt: Option<&'db ast::Stmt>,
+    /// Whether names in a `Store` context should be ignored.
+    suppress_store_symbols: bool,
     /// When enabled, the visitor should only try to extract
     /// symbols from a module that we believed form the "exported"
     /// interface for that module. i.e., `__all__` is only respected
@@ -727,6 +731,8 @@ impl<'db> SymbolVisitor<'db> {
             symbol_stack: vec![],
             in_function: false,
             in_class: false,
+            current_stmt: None,
+            suppress_store_symbols: false,
             exports_only: false,
             all_origin: None,
             all_names: FxHashSet::default(),
@@ -820,6 +826,29 @@ impl<'db> SymbolVisitor<'db> {
         }
     }
 
+    fn with_current_stmt(
+        &mut self,
+        stmt: &'db ast::Stmt,
+        visit: impl FnOnce(&mut SymbolVisitor<'db>),
+    ) {
+        let previous_stmt = self.current_stmt.replace(stmt);
+        visit(self);
+        self.current_stmt = previous_stmt;
+    }
+
+    fn with_store_symbols_suppressed(&mut self, visit: impl FnOnce(&mut SymbolVisitor<'db>)) {
+        let was_suppressed = self.suppress_store_symbols;
+        self.suppress_store_symbols = true;
+        visit(self);
+        self.suppress_store_symbols = was_suppressed;
+    }
+
+    fn walk_stmt(&mut self, stmt: &'db ast::Stmt) {
+        self.with_current_stmt(stmt, |visitor| {
+            source_order::walk_stmt(visitor, stmt);
+        });
+    }
+
     /// Add a new symbol and return its ID.
     fn add_symbol(&mut self, mut symbol: SymbolTree) -> SymbolId {
         if let Some(&parent_id) = self.symbol_stack.last() {
@@ -866,23 +895,6 @@ impl<'db> SymbolVisitor<'db> {
             SymbolKind::Variable
         };
         self.add_name_symbol(stmt, name, kind);
-    }
-
-    /// Adds symbols introduced by an assignment target.
-    fn add_assignment_target(&mut self, stmt: &ast::Stmt, target: &ast::Expr) {
-        match target {
-            ast::Expr::Name(name) => self.add_assignment(stmt, name),
-            ast::Expr::List(ast::ExprList { elts, .. })
-            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
-                for element in elts {
-                    self.add_assignment_target(stmt, element);
-                }
-            }
-            ast::Expr::Starred(starred) => {
-                self.add_assignment_target(stmt, &starred.value);
-            }
-            _ => {}
-        }
     }
 
     /// Adds a symbol introduced via an import `stmt`.
@@ -1176,11 +1188,6 @@ impl<'db> SymbolVisitor<'db> {
         self.all_origin = Some(origin);
     }
 
-    fn push_symbol(&mut self, symbol: SymbolTree) {
-        let symbol_id = self.add_symbol(symbol);
-        self.symbol_stack.push(symbol_id);
-    }
-
     fn pop_symbol(&mut self) {
         self.symbol_stack.pop().unwrap();
     }
@@ -1279,19 +1286,36 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                     imported_from: None,
                 };
 
+                self.with_current_stmt(stmt, |visitor| {
+                    for decorator in &func_def.decorator_list {
+                        visitor.visit_decorator(decorator);
+                    }
+                });
+
+                let symbol_id = self.add_symbol(symbol);
+
+                self.with_current_stmt(stmt, |visitor| {
+                    if let Some(type_params) = &func_def.type_params {
+                        visitor.visit_type_params(type_params);
+                    }
+                    visitor.visit_parameters(&func_def.parameters);
+                    if let Some(returns) = &func_def.returns {
+                        visitor.visit_annotation(returns);
+                    }
+                });
+
                 if self.exports_only {
-                    self.add_symbol(symbol);
                     // If global_only, don't walk function bodies
                     return;
                 }
 
-                self.push_symbol(symbol);
+                self.symbol_stack.push(symbol_id);
 
                 // Mark that we're entering a function scope
                 let was_in_function = self.in_function;
                 self.in_function = true;
 
-                source_order::walk_stmt(self, stmt);
+                self.visit_body(&func_def.body);
 
                 // Restore the previous function scope state
                 self.in_function = was_in_function;
@@ -1309,8 +1333,24 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                     imported_from: None,
                 };
 
+                self.with_current_stmt(stmt, |visitor| {
+                    for decorator in &class_def.decorator_list {
+                        visitor.visit_decorator(decorator);
+                    }
+                });
+
+                let symbol_id = self.add_symbol(symbol);
+
+                self.with_current_stmt(stmt, |visitor| {
+                    if let Some(type_params) = &class_def.type_params {
+                        visitor.visit_type_params(type_params);
+                    }
+                    if let Some(arguments) = &class_def.arguments {
+                        visitor.visit_arguments(arguments);
+                    }
+                });
+
                 if self.exports_only {
-                    self.add_symbol(symbol);
                     // If global_only, don't walk class bodies
                     return;
                 }
@@ -1319,8 +1359,8 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                 let was_in_class = self.in_class;
                 self.in_class = true;
 
-                self.push_symbol(symbol);
-                source_order::walk_stmt(self, stmt);
+                self.symbol_stack.push(symbol_id);
+                self.visit_body(&class_def.body);
                 self.pop_symbol();
 
                 // Restore the previous class scope state
@@ -1338,94 +1378,52 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
             }
             ast::Stmt::Assign(assign) => {
                 self.add_all_assignment(&assign.targets, Some(&assign.value));
-
-                for target in &assign.targets {
-                    let ast::Expr::Name(name) = target else {
-                        continue;
-                    };
-                    self.add_assignment(stmt, name);
-                }
+                self.walk_stmt(stmt);
             }
             ast::Stmt::AnnAssign(ann_assign) => {
                 self.add_all_assignment(
                     std::slice::from_ref(&ann_assign.target),
                     ann_assign.value.as_deref(),
                 );
-
-                let ast::Expr::Name(name) = &*ann_assign.target else {
-                    return;
-                };
-                self.add_assignment(stmt, name);
-            }
-            ast::Stmt::With(with_stmt) => {
-                for item in &with_stmt.items {
-                    if let Some(target) = item.optional_vars.as_deref() {
-                        self.add_assignment_target(stmt, target);
-                    }
-                }
-
-                source_order::walk_stmt(self, stmt);
+                self.walk_stmt(stmt);
             }
             ast::Stmt::AugAssign(ast::StmtAugAssign {
                 target, op, value, ..
             }) => {
-                // We don't care about `__all__` unless we're
-                // specifically looking for exported symbols.
-                if !self.exports_only {
-                    return;
+                if self.exports_only && self.all_origin.is_some() && is_dunder_all(target) {
+                    // Anything other than `+=` is not valid.
+                    if !matches!(op, ast::Operator::Add) || !self.extend_all(value) {
+                        self.all_invalid = true;
+                    }
                 }
 
-                if self.all_origin.is_none() {
-                    // We can't update `__all__` if it doesn't already
-                    // exist.
-                    return;
-                }
-                if !is_dunder_all(target) {
-                    return;
-                }
-                // Anything other than `+=` is not valid.
-                if !matches!(op, ast::Operator::Add) {
-                    self.all_invalid = true;
-                    return;
-                }
-                if !self.extend_all(value) {
-                    self.all_invalid = true;
-                }
+                self.with_current_stmt(stmt, |visitor| {
+                    visitor.with_store_symbols_suppressed(|visitor| {
+                        visitor.visit_expr(target);
+                    });
+                    visitor.visit_operator(op);
+                    visitor.visit_expr(value);
+                });
             }
             ast::Stmt::Expr(expr) => {
-                // We don't care about `__all__` unless we're
-                // specifically looking for exported symbols.
-                if !self.exports_only {
-                    return;
-                }
-
-                if self.all_origin.is_none() {
-                    // We can't update `__all__` if it doesn't already exist.
-                    return;
-                }
-                let Some(ast::ExprCall {
-                    func, arguments, ..
-                }) = expr.value.as_call_expr()
-                else {
-                    return;
-                };
-                let Some(ast::ExprAttribute {
-                    value,
-                    attr,
-                    ctx: ast::ExprContext::Load,
-                    ..
-                }) = func.as_attribute_expr()
-                else {
-                    return;
-                };
-                if !is_dunder_all(value) {
-                    return;
-                }
-                if !self.update_all_by_call_idiom(attr, arguments) {
+                if self.exports_only
+                    && self.all_origin.is_some()
+                    && let Some(ast::ExprCall {
+                        func, arguments, ..
+                    }) = expr.value.as_call_expr()
+                    && let Some(ast::ExprAttribute {
+                        value,
+                        attr,
+                        ctx: ast::ExprContext::Load,
+                        ..
+                    }) = func.as_attribute_expr()
+                    && is_dunder_all(value)
+                    && !self.update_all_by_call_idiom(attr, arguments)
+                {
                     self.all_invalid = true;
                 }
 
-                source_order::walk_stmt(self, stmt);
+                self.walk_stmt(stmt);
             }
             ast::Stmt::Import(import) => {
                 // We ignore any names introduced by imports
@@ -1476,14 +1474,56 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
             // always `True`. This applies to symbols in general but
             // also `__all__`.
             _ => {
-                source_order::walk_stmt(self, stmt);
+                self.walk_stmt(stmt);
             }
         }
     }
 
-    // TODO: We might consider handling walrus expressions
-    // here, since they can be used to introduce new names.
-    fn visit_expr(&mut self, _expr: &ast::Expr) {}
+    fn visit_expr(&mut self, expr: &'db ast::Expr) {
+        if self.in_function {
+            return;
+        }
+
+        match expr {
+            ast::Expr::Name(name)
+                if name.ctx.is_store()
+                    && !self.suppress_store_symbols
+                    && let Some(stmt) = self.current_stmt =>
+            {
+                self.add_assignment(stmt, name);
+
+                if self.exports_only
+                    && !self.in_class
+                    && self.all_origin.is_some()
+                    && name.id == "__all__"
+                    && !is_recognized_all_assignment(stmt, name)
+                {
+                    self.all_invalid = true;
+                }
+            }
+            ast::Expr::Lambda(lambda) => {
+                if let Some(parameters) = &lambda.parameters {
+                    self.visit_parameters(parameters);
+                }
+
+                let was_in_function = self.in_function;
+                self.in_function = true;
+                self.visit_expr(&lambda.body);
+                self.in_function = was_in_function;
+            }
+            _ => source_order::walk_expr(self, expr),
+        }
+    }
+
+    fn visit_comprehension(&mut self, comprehension: &'db ast::Comprehension) {
+        self.with_store_symbols_suppressed(|visitor| {
+            visitor.visit_expr(&comprehension.target);
+        });
+        self.visit_expr(&comprehension.iter);
+        for condition in &comprehension.ifs {
+            self.visit_expr(condition);
+        }
+    }
 }
 
 /// Represents where an `__all__` has been defined.
@@ -1500,6 +1540,18 @@ enum DunderAllOrigin {
 /// Checks if the given expression is a name expression for `__all__`.
 fn is_dunder_all(expr: &ast::Expr) -> bool {
     matches!(expr, ast::Expr::Name(ast::ExprName { id, .. }) if id == "__all__")
+}
+
+fn is_recognized_all_assignment(stmt: &ast::Stmt, name: &ast::ExprName) -> bool {
+    let target = match stmt {
+        ast::Stmt::Assign(assign) => assign.targets.first(),
+        ast::Stmt::AnnAssign(ann_assign) => Some(&*ann_assign.target),
+        _ => None,
+    };
+
+    target
+        .and_then(ast::Expr::as_name_expr)
+        .is_some_and(|target| std::ptr::eq(target, name))
 }
 
 /// Create and return a string representing a name from the given
@@ -1602,6 +1654,50 @@ def function():
         body_target :: Variable
         C :: Class
         function :: Function
+        ",
+        );
+    }
+
+    #[test]
+    fn exports_store_contexts() {
+        insta::assert_snapshot!(
+            public_test("\
+[left, *middle, right] = (1, 2, 3)
+augmented = 1
+augmented += (augmented_value := 1)
+
+for loop_target in ():
+    pass
+
+(named_target := 1)
+comprehension = [(comprehension_target := value) for value in ()]
+lambda_value = lambda default=(lambda_default := 1): (lambda_local := default)
+
+class C((base_target := object)):
+    [class_left, class_right] = (1, 2)
+
+@((decorator_target := identity))
+def function(default=(default_target := 1)):
+    [local_left, local_right] = (1, 2)
+    (local_walrus := 1)
+").exports(),
+            @"
+        left :: Variable
+        middle :: Variable
+        right :: Variable
+        augmented :: Variable
+        augmented_value :: Variable
+        loop_target :: Variable
+        named_target :: Variable
+        comprehension :: Variable
+        comprehension_target :: Variable
+        lambda_value :: Variable
+        lambda_default :: Variable
+        C :: Class
+        base_target :: Variable
+        decorator_target :: Variable
+        function :: Function
+        default_target :: Variable
         ",
         );
     }

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -1363,7 +1363,9 @@ impl<'db> SymbolVisitor<'db> {
             ast::Stmt::AugAssign(ast::StmtAugAssign {
                 target, op, value, ..
             }) => {
-                self.visit_nonbinding_target(target);
+                if !target.is_name_expr() {
+                    self.visit_expr(target);
+                }
                 self.visit_expr(value);
 
                 // We don't care about `__all__` unless we're
@@ -1504,11 +1506,6 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                 // We don't care about `__all__` unless we're
                 // specifically looking for exported symbols.
                 if !self.exports_only {
-                    return;
-                }
-
-                // Class-scoped assignments do not affect the module's exports.
-                if self.in_class {
                     return;
                 }
 


### PR DESCRIPTION
## Summary

Teach the `SymbolVisitor` to recognize names introduced by `with ... as` statements.

This handles:
- multiple context managers;
- tuple and list unpacking targets;
- starred targets;
- module-level targets as variables or constants;
- class-level targets as fields.

Function-local targets remain excluded, consistently with regular assignments. The visitor also continues traversing the body of the `with` statement.
Addresses the `with ... as target` item in astral-sh/ty#1771

## Test Plan

- `cargo test -p ty_ide`
- `cargo clippy -p ty_ide --all-targets --all-features -- -D warnings`
- `uv run --only-group dev --locked prek run --files crates/ty_ide/src/symbols.rs crates/ty_ide/src/document_symbols.rs`