### PR TITLE
[ty] Allow mutation of private attributes on frozen Pydantic models

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -1131,7 +1131,7 @@ There are various ways to make a field immutable. A model can be globally frozen
 parameter:
 
 ```py
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 class PersonFrozenName1(BaseModel, frozen=True):
     name: str
@@ -1181,8 +1181,6 @@ derived.value = 2  # error: [invalid-assignment]
 Private attributes on models with `frozen=True` can be mutated:
 
 ```py
-from pydantic import BaseModel, ConfigDict, PrivateAttr
-
 class FrozenPerson(BaseModel):
     model_config = ConfigDict(frozen=True)
 

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -1178,6 +1178,26 @@ derived = Derived(value=1)
 derived.value = 2  # error: [invalid-assignment]
 ```
 
+Private attributes on models with `frozen=True` can be mutated:
+
+```py
+from pydantic import BaseModel, ConfigDict, PrivateAttr
+
+class FrozenPerson(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    _implicit_private: int
+    _private_with_default: int = 1
+    _explicit_private: int = PrivateAttr(default=0)
+
+person = FrozenPerson()
+
+# TODO: These should not error
+person._implicit_private = 2  # error: [invalid-assignment]
+person._private_with_default = 2  # error: [invalid-assignment]
+person._explicit_private = 2  # error: [invalid-assignment]
+```
+
 ## Validation of default values
 
 At runtime, default values are *not* validated against the field type annotation, unless

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -1190,10 +1190,9 @@ class FrozenPerson(BaseModel):
 
 person = FrozenPerson()
 
-# TODO: These should not error
-person._implicit_private = 2  # error: [invalid-assignment]
-person._private_with_default = 2  # error: [invalid-assignment]
-person._explicit_private = 2  # error: [invalid-assignment]
+person._implicit_private = 2
+person._private_with_default = 2
+person._explicit_private = 2
 ```
 
 ## Validation of default values

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2444,9 +2444,8 @@ impl<'db> StaticClassLiteral<'db> {
                     },
                     CodeGeneratorKind::Pydantic(_) => FieldKind::Pydantic {
                         default_ty,
-                        // Pydantic treats underscore-prefixed annotations as private attributes,
-                        // which are instance attributes but never constructor parameters.
-                        init: init && !symbol.name().starts_with('_'),
+                        // Private attributes are instance attributes but never constructor parameters.
+                        init: init && !pydantic::is_private_attribute(symbol.name()),
                         alias,
                         strict,
                     },

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -27,6 +27,11 @@ use crate::types::{
 };
 use crate::{Db, SemanticModel};
 
+/// Pydantic treats underscore-prefixed annotations as private instance attributes.
+pub(in crate::types) fn is_private_attribute(name: &str) -> bool {
+    name.starts_with('_')
+}
+
 /// Metadata that controls Pydantic-specific model synthesis.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub(crate) struct ModelMetadata<'db> {
@@ -487,6 +492,13 @@ pub(in crate::types) fn is_model(db: &dyn Db, class: StaticClassLiteral<'_>) -> 
         .iter_mro(db, None)
         .filter_map(ClassBase::into_class)
         .any(|base| base.is_known(db, KnownClass::PydanticBaseModel))
+}
+
+/// Return whether `ty` is an instance of a Pydantic model.
+pub(in crate::types) fn is_model_instance(db: &dyn Db, ty: Type<'_>) -> bool {
+    ty.nominal_class(db)
+        .and_then(|class| class.static_class_literal(db))
+        .is_some_and(|(class, _)| is_model(db, class))
 }
 
 /// Return whether a field specifier's `default` argument provides a default value.

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -394,6 +394,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             Ok(bindings) => bindings.return_type(db).is_never(),
             Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
         };
+
+        // We could also model this more precisely by synthesizing a `__setattr__`overload set
+        // that only disallows mutation on non-private fields, but for now, we just suppress the
+        // diagnostic here. This is much easier and faster.
         let is_private_pydantic_attribute =
             matches!(member, InstanceAttributeWriteMember::Explicit { .. })
                 && pydantic::is_private_attribute(self.attribute)

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -10,6 +10,7 @@ use crate::types::attribute_write::{
 };
 use crate::types::call::{Bindings, CallArguments, CallDiagnosticOverride, CallError};
 use crate::types::class::FrozenDataclassDispatch;
+use crate::types::dedicated::pydantic;
 use crate::types::diagnostic::{
     INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_ACCESS, UNRESOLVED_ATTRIBUTE, report_bad_dunder_set_call,
     report_invalid_attribute_assignment, report_possibly_missing_attribute,
@@ -393,7 +394,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             Ok(bindings) => bindings.return_type(db).is_never(),
             Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
         };
-        if setattr_returns_never {
+        let is_private_pydantic_attribute =
+            matches!(member, InstanceAttributeWriteMember::Explicit { .. })
+                && pydantic::is_private_attribute(self.attribute)
+                && pydantic::is_model_instance(db, object_ty);
+
+        if setattr_returns_never && !is_private_pydantic_attribute {
             if emit_diagnostics {
                 let is_setattr_synthesized = !matches!(
                     frozen_dataclass_dispatch,


### PR DESCRIPTION
## Summary
Pydantic tracking issue: https://github.com/astral-sh/ty/issues/3959
Related issue here on Pydantic PyCharm plugin: https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/1149

Happy to open a separate issue as well, wasn't sure if it would be preferable to just track in the main thread above.

This is apparently valid at runtime. The closest thing I could find to docs are [here](https://pydantic.dev/docs/validation/dev/concepts/models/#private-model-attributes):

> Attributes whose name has a leading underscore are not treated as fields by Pydantic, and are not included in the model schema. Instead, these are converted into a “private attribute” which is not validated or even set during calls to __init__, model_validate, etc.

Repro: https://github.com/thejchap/pydantic-private-ty

```bash
uv run main.py && uv run ty check

# 1
# error[[invalid-assignment](https://ty.dev/rules#invalid-assignment)]: Property `_a` defined in `A` is read-only
#   --> main.py:10:1
#    |
# 10 | a._a = 1
#    | ^^^^
#    |

# Found 1 diagnostic
```

## Test Plan

Added new TODO test