### PR TITLE
[ty] Index for-statement targets as symbols

### DIFF
--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -341,6 +341,101 @@ def function():
         ");
     }
 
+    #[test]
+    fn document_symbols_for_statement_targets() {
+        let test = cursor_test(
+            "
+for module_target in ():
+    body_target = 1
+else:
+    fallback_target = 2
+
+for [left, *middle, right] in ():
+    pass
+
+class C:
+    for class_target in ():
+        body_field = 1
+
+def function():
+    for local_target in ():
+        pass
+<CURSOR>",
+        );
+
+        assert_snapshot!(test.document_symbols(), @"
+        info[document-symbols]: SymbolInfo
+         --> main.py:2:5
+          |
+        2 | for module_target in ():
+          |     ^^^^^^^^^^^^^
+        info: Variable module_target
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:3:5
+          |
+        3 |     body_target = 1
+          |     ^^^^^^^^^^^
+        info: Variable body_target
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:5:5
+          |
+        5 |     fallback_target = 2
+          |     ^^^^^^^^^^^^^^^
+        info: Variable fallback_target
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:7:6
+          |
+        7 | for [left, *middle, right] in ():
+          |      ^^^^
+        info: Variable left
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:7:13
+          |
+        7 | for [left, *middle, right] in ():
+          |             ^^^^^^
+        info: Variable middle
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:7:21
+          |
+        7 | for [left, *middle, right] in ():
+          |                     ^^^^^
+        info: Variable right
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:10:7
+           |
+        10 | class C:
+           |       ^
+        info: Class C
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:11:9
+           |
+        11 |     for class_target in ():
+           |         ^^^^^^^^^^^^
+        info: Field class_target
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:12:9
+           |
+        12 |         body_field = 1
+           |         ^^^^^^^^^^
+        info: Field body_field
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:14:5
+           |
+        14 | def function():
+           |     ^^^^^^^^
+        info: Function function
+        ");
+    }
+
     impl CursorTest {
         fn document_symbols(&self) -> String {
             let symbols = document_symbols(&self.db, self.cursor.file).to_hierarchical();

--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -263,6 +263,84 @@ class Aliases:
         ");
     }
 
+    #[test]
+    fn document_symbols_with_statement_targets() {
+        let test = cursor_test(
+            "
+from contextlib import nullcontext
+
+with nullcontext() as module_target, nullcontext((1, 2)) as (left, right):
+    body_target = 1
+
+class C:
+    with nullcontext() as class_target:
+        body_field = 1
+
+def function():
+    with nullcontext() as local_target:
+        pass
+<CURSOR>",
+        );
+
+        assert_snapshot!(test.document_symbols(), @"
+        info[document-symbols]: SymbolInfo
+         --> main.py:4:23
+          |
+        4 | with nullcontext() as module_target, nullcontext((1, 2)) as (left, right):
+          |                       ^^^^^^^^^^^^^
+        info: Variable module_target
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:4:62
+          |
+        4 | with nullcontext() as module_target, nullcontext((1, 2)) as (left, right):
+          |                                                              ^^^^
+        info: Variable left
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:4:68
+          |
+        4 | with nullcontext() as module_target, nullcontext((1, 2)) as (left, right):
+          |                                                                    ^^^^^
+        info: Variable right
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:5:5
+          |
+        5 |     body_target = 1
+          |     ^^^^^^^^^^^
+        info: Variable body_target
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:7:7
+          |
+        7 | class C:
+          |       ^
+        info: Class C
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:8:27
+          |
+        8 |     with nullcontext() as class_target:
+          |                           ^^^^^^^^^^^^
+        info: Field class_target
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:9:9
+          |
+        9 |         body_field = 1
+          |         ^^^^^^^^^^
+        info: Field body_field
+
+        info[document-symbols]: SymbolInfo
+          --> main.py:11:5
+           |
+        11 | def function():
+           |     ^^^^^^^^
+        info: Function function
+        ");
+    }
+
     impl CursorTest {
         fn document_symbols(&self) -> String {
             let symbols = document_symbols(&self.db, self.cursor.file).to_hierarchical();

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -1366,6 +1366,10 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
 
                 source_order::walk_stmt(self, stmt);
             }
+            ast::Stmt::For(for_stmt) => {
+                self.add_assignment_target(stmt, &for_stmt.target);
+                source_order::walk_stmt(self, stmt);
+            }
             ast::Stmt::AugAssign(ast::StmtAugAssign {
                 target, op, value, ..
             }) => {
@@ -1600,6 +1604,39 @@ def function():
         left :: Variable
         right :: Variable
         body_target :: Variable
+        C :: Class
+        function :: Function
+        ",
+        );
+    }
+
+    #[test]
+    fn exports_for_statement_targets() {
+        insta::assert_snapshot!(
+            public_test("\
+for module_target in ():
+    body_target = 1
+else:
+    fallback_target = 2
+
+for [left, *middle, right] in ():
+    pass
+
+class C:
+    for class_target in ():
+        body_field = 1
+
+def function():
+    for local_target in ():
+        pass
+").exports(),
+            @"
+        module_target :: Variable
+        body_target :: Variable
+        fallback_target :: Variable
+        left :: Variable
+        middle :: Variable
+        right :: Variable
         C :: Class
         function :: Function
         ",

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -868,6 +868,23 @@ impl<'db> SymbolVisitor<'db> {
         self.add_name_symbol(stmt, name, kind);
     }
 
+    /// Adds symbols introduced by an assignment target.
+    fn add_assignment_target(&mut self, stmt: &ast::Stmt, target: &ast::Expr) {
+        match target {
+            ast::Expr::Name(name) => self.add_assignment(stmt, name),
+            ast::Expr::List(ast::ExprList { elts, .. })
+            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                for element in elts {
+                    self.add_assignment_target(stmt, element);
+                }
+            }
+            ast::Expr::Starred(starred) => {
+                self.add_assignment_target(stmt, &starred.value);
+            }
+            _ => {}
+        }
+    }
+
     /// Adds a symbol introduced via an import `stmt`.
     fn add_import_alias(&mut self, import: AstImport<'_>, alias: &ast::Alias) -> Option<SymbolId> {
         let name = alias.asname.as_ref().unwrap_or(&alias.name);
@@ -1340,6 +1357,15 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                 };
                 self.add_assignment(stmt, name);
             }
+            ast::Stmt::With(with_stmt) => {
+                for item in &with_stmt.items {
+                    if let Some(target) = item.optional_vars.as_deref() {
+                        self.add_assignment_target(stmt, target);
+                    }
+                }
+
+                source_order::walk_stmt(self, stmt);
+            }
             ast::Stmt::AugAssign(ast::StmtAugAssign {
                 target, op, value, ..
             }) => {
@@ -1548,6 +1574,34 @@ def quux():
         X :: Variable
         Foo :: Class
         quux :: Function
+        ",
+        );
+    }
+
+    #[test]
+    fn exports_with_statement_targets() {
+        insta::assert_snapshot!(
+            public_test("\
+from contextlib import nullcontext
+
+with nullcontext() as module_target, nullcontext((1, 2)) as (left, right):
+    body_target = 1
+
+class C:
+    with nullcontext() as class_target:
+        body_field = 1
+
+def function():
+    with nullcontext() as local_target:
+        pass
+").exports(),
+            @"
+        module_target :: Variable
+        left :: Variable
+        right :: Variable
+        body_target :: Variable
+        C :: Class
+        function :: Function
         ",
         );
     }


### PR DESCRIPTION
## Summary

Teach the `SymbolVisitor` to recognize names introduced by `for` statement targets.

This handles:
- synchronous and asynchronous `for` statements, which share the same AST node;
- simple targets;
- tuple and list unpacking targets;
- starred targets;
- module-level targets as variables or constants;
- class-level targets as fields.

Function-local targets remain excluded, consistently with regular assignments. The visitor also continues traversing the loop body and `else` clause.

Addresses the `for x in range(42)` item in astral-sh/ty#1771.

> [!NOTE]
> This is a stacked draft based on #27256. Until that PR merges, GitHub also shows its commit in this PR's diff.

## Test Plan

- `cargo test -p ty_ide`
- `cargo clippy -p ty_ide --all-targets --all-features -- -D warnings`
- `uv run --only-group dev --locked prek run --files crates/ty_ide/src/symbols.rs crates/ty_ide/src/document_symbols.rs`
