### PR TITLE
[ty] Index match-pattern bindings as symbols

### DIFF
--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -433,6 +433,88 @@ def function():
     }
 
     #[test]
+    fn document_symbols_match_pattern_bindings() {
+        let test = cursor_test(
+            "
+match subject:
+    case [first, *middle, last] as sequence:
+        body_target = 1
+    case {\"key\": mapping_value, **remaining}:
+        fallback_target = 2
+    case Point(positional, named=keyword):
+        pass
+    case (0 as alternative) | (1 as alternative):
+        pass
+    case _:
+        wildcard_body = 3
+
+match other:
+    case CONSTANT_CAPTURE:
+        pass
+<CURSOR>",
+        );
+
+        let symbols = document_symbols(&test.db, test.program_file(test.cursor.file))
+            .iter()
+            .map(|(_, symbol)| (symbol.name.into_owned(), symbol.kind))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            symbols,
+            [
+                ("first", SymbolKind::Variable),
+                ("middle", SymbolKind::Variable),
+                ("last", SymbolKind::Variable),
+                ("sequence", SymbolKind::Variable),
+                ("body_target", SymbolKind::Variable),
+                ("mapping_value", SymbolKind::Variable),
+                ("remaining", SymbolKind::Variable),
+                ("fallback_target", SymbolKind::Variable),
+                ("positional", SymbolKind::Variable),
+                ("keyword", SymbolKind::Variable),
+                ("alternative", SymbolKind::Variable),
+                ("alternative", SymbolKind::Variable),
+                ("wildcard_body", SymbolKind::Variable),
+                ("CONSTANT_CAPTURE", SymbolKind::Constant),
+            ]
+            .map(|(name, kind)| (name.to_owned(), kind))
+        );
+    }
+
+    #[test]
+    fn document_symbols_match_pattern_scopes() {
+        let test = cursor_test(
+            "
+class C:
+    match subject:
+        case class_capture:
+            body_field = 1
+
+def function():
+    match subject:
+        case local_capture:
+            pass
+<CURSOR>",
+        );
+
+        let symbols = document_symbols(&test.db, test.program_file(test.cursor.file))
+            .iter()
+            .map(|(_, symbol)| (symbol.name.into_owned(), symbol.kind))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            symbols,
+            [
+                ("C", SymbolKind::Class),
+                ("class_capture", SymbolKind::Field),
+                ("body_field", SymbolKind::Field),
+                ("function", SymbolKind::Function),
+            ]
+            .map(|(name, kind)| (name.to_owned(), kind))
+        );
+    }
+
+    #[test]
     fn document_symbols_comprehension_and_lambda_scopes() {
         let test = cursor_test(
             "

--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -482,6 +482,19 @@ match other:
     }
 
     #[test]
+    fn document_symbols_ignore_invalid_pattern_bindings() {
+        let test = cursor_test(
+            "
+match subject:
+    case [*]:
+        pass
+<CURSOR>",
+        );
+
+        assert!(document_symbols(&test.db, test.program_file(test.cursor.file)).is_empty());
+    }
+
+    #[test]
     fn document_symbols_match_pattern_scopes() {
         let test = cursor_test(
             "

--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -495,6 +495,24 @@ match subject:
     }
 
     #[test]
+    fn document_symbols_reports_mapping_pattern_bindings_in_source_order() {
+        let test = cursor_test(
+            "
+match subject:
+    case {\"a\": before, **between, \"b\": after}:
+        pass
+<CURSOR>",
+        );
+
+        let names = document_symbols(&test.db, test.program_file(test.cursor.file))
+            .iter()
+            .map(|(_, symbol)| symbol.name.into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, ["before", "between", "after"]);
+    }
+
+    #[test]
     fn document_symbols_match_pattern_scopes() {
         let test = cursor_test(
             "

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -865,27 +865,53 @@ impl<'db> SymbolVisitor<'db> {
     }
 
     /// Adds a symbol for a name definition.
-    fn add_name_symbol(&mut self, stmt: &ast::Stmt, name: &ast::ExprName, kind: SymbolKind) {
+    fn add_named_symbol(
+        &mut self,
+        stmt: &ast::Stmt,
+        name: &Name,
+        name_range: TextRange,
+        kind: SymbolKind,
+    ) {
         let symbol = SymbolTree {
             parent: None,
-            name: name.id.to_string(),
+            name: name.to_string(),
             kind,
             deprecated: false,
-            name_range: name.range(),
+            name_range,
             full_range: stmt.range(),
             imported_from: None,
         };
         self.add_symbol(symbol);
     }
 
+    fn add_name_symbol(&mut self, stmt: &ast::Stmt, name: &ast::ExprName, kind: SymbolKind) {
+        self.add_named_symbol(stmt, &name.id, name.range(), kind);
+    }
+
     /// Adds a symbol introduced via an assignment.
     fn add_assignment(&mut self, stmt: &ast::Stmt, name: &ast::ExprName) {
+        self.add_assignment_name(stmt, &name.id, name.range());
+    }
+
+    fn add_pattern_binding(&mut self, stmt: &ast::Stmt, name: &ast::Identifier) {
+        if self.in_function || name.id == "_" {
+            return;
+        }
+
+        self.add_assignment_name(stmt, &name.id, name.range());
+
+        if self.exports_only && self.all_origin.is_some() && name.id == "__all__" {
+            self.all_invalid = true;
+        }
+    }
+
+    fn add_assignment_name(&mut self, stmt: &ast::Stmt, name: &Name, name_range: TextRange) {
         // Include assignments only when we're in global or class scope.
         if self.in_function {
             return;
         }
 
-        let kind = if Self::is_constant_name(name.id.as_str()) {
+        let kind = if Self::is_constant_name(name.as_str()) {
             SymbolKind::Constant
         } else if self
             .iter_symbol_stack()
@@ -895,7 +921,7 @@ impl<'db> SymbolVisitor<'db> {
         } else {
             SymbolKind::Variable
         };
-        self.add_name_symbol(stmt, name, kind);
+        self.add_named_symbol(stmt, name, name_range, kind);
     }
 
     /// Adds a symbol introduced via an import `stmt`.
@@ -1575,6 +1601,51 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
             self.visit_expr(condition);
         }
     }
+
+    fn visit_pattern(&mut self, pattern: &'db ast::Pattern) {
+        let Some(stmt) = self.current_stmt else {
+            source_order::walk_pattern(self, pattern);
+            return;
+        };
+
+        match pattern {
+            ast::Pattern::MatchStar(ast::PatternMatchStar {
+                name: Some(name), ..
+            }) => {
+                self.add_pattern_binding(stmt, name);
+                source_order::walk_pattern(self, pattern);
+            }
+            ast::Pattern::MatchAs(ast::PatternMatchAs { name, .. }) => {
+                source_order::walk_pattern(self, pattern);
+                if let Some(name) = name {
+                    self.add_pattern_binding(stmt, name);
+                }
+            }
+            ast::Pattern::MatchMapping(mapping) => {
+                let rest_before_keys = mapping.rest.as_ref().filter(|rest| {
+                    mapping
+                        .keys
+                        .first()
+                        .is_some_and(|key| rest.start() < key.start())
+                });
+                let rest_after_keys = mapping.rest.as_ref().filter(|rest| {
+                    mapping
+                        .keys
+                        .first()
+                        .is_none_or(|key| rest.start() >= key.start())
+                });
+
+                if let Some(rest) = rest_before_keys {
+                    self.add_pattern_binding(stmt, rest);
+                }
+                source_order::walk_pattern(self, pattern);
+                if let Some(rest) = rest_after_keys {
+                    self.add_pattern_binding(stmt, rest);
+                }
+            }
+            _ => source_order::walk_pattern(self, pattern),
+        }
+    }
 }
 
 /// Represents where an `__all__` has been defined.
@@ -1736,6 +1807,67 @@ with_left :: Variable\n\
 with_rest :: Variable\n\
 captured :: Variable\n\
 walrus :: Variable"
+        );
+    }
+
+    #[test]
+    fn exports_match_pattern_bindings() {
+        let test = public_test(
+            "\
+match subject:
+    case [first, *middle, last] as sequence:
+        body_target = 1
+    case {\"key\": mapping_value, **remaining}:
+        fallback_target = 2
+    case Point(positional, named=keyword):
+        pass
+    case (0 as alternative) | (1 as alternative):
+        pass
+    case _:
+        wildcard_body = 3
+
+match other:
+    case CONSTANT_CAPTURE:
+        pass
+",
+        );
+
+        assert_eq!(
+            test.exports(),
+            "first :: Variable\n\
+middle :: Variable\n\
+last :: Variable\n\
+sequence :: Variable\n\
+body_target :: Variable\n\
+mapping_value :: Variable\n\
+remaining :: Variable\n\
+fallback_target :: Variable\n\
+positional :: Variable\n\
+keyword :: Variable\n\
+alternative :: Variable\n\
+wildcard_body :: Variable\n\
+CONSTANT_CAPTURE :: Constant"
+        );
+    }
+
+    #[test]
+    fn exports_invalidate_all_rebound_by_match_pattern() {
+        let test = public_test(
+            "\
+hidden = 1
+visible = 2
+__all__ = ['visible']
+match subject:
+    case __all__:
+        pass
+",
+        );
+
+        assert_eq!(
+            test.exports(),
+            "hidden :: Variable\n\
+visible :: Variable\n\
+__all__ :: Variable"
         );
     }
 

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -715,6 +715,8 @@ struct SymbolVisitor<'db> {
     in_class: bool,
     /// The statement whose expressions are currently being visited.
     current_stmt: Option<&'db ast::Stmt>,
+    /// The binding declared directly by the pattern currently being visited.
+    pattern_binding: Option<&'db ast::Identifier>,
     /// Whether store-context names should be excluded from the enclosing scope.
     suppress_store_symbols: bool,
     /// When enabled, the visitor should only try to extract
@@ -747,6 +749,7 @@ impl<'db> SymbolVisitor<'db> {
             in_function: false,
             in_class: false,
             current_stmt: None,
+            pattern_binding: None,
             suppress_store_symbols: false,
             exports_only: false,
             all_origin: None,
@@ -1603,47 +1606,28 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
     }
 
     fn visit_pattern(&mut self, pattern: &'db ast::Pattern) {
-        let Some(stmt) = self.current_stmt else {
-            source_order::walk_pattern(self, pattern);
-            return;
+        let binding = match pattern {
+            ast::Pattern::MatchStar(pattern) => pattern.name.as_ref(),
+            ast::Pattern::MatchAs(pattern) => pattern.name.as_ref(),
+            ast::Pattern::MatchMapping(pattern) => pattern.rest.as_ref(),
+            _ => None,
         };
 
-        match pattern {
-            ast::Pattern::MatchStar(ast::PatternMatchStar {
-                name: Some(name), ..
-            }) => {
-                self.add_pattern_binding(stmt, name);
-                source_order::walk_pattern(self, pattern);
-            }
-            ast::Pattern::MatchAs(ast::PatternMatchAs { name, .. }) => {
-                source_order::walk_pattern(self, pattern);
-                if let Some(name) = name {
-                    self.add_pattern_binding(stmt, name);
-                }
-            }
-            ast::Pattern::MatchMapping(mapping) => {
-                let rest_before_keys = mapping.rest.as_ref().filter(|rest| {
-                    mapping
-                        .keys
-                        .first()
-                        .is_some_and(|key| rest.start() < key.start())
-                });
-                let rest_after_keys = mapping.rest.as_ref().filter(|rest| {
-                    mapping
-                        .keys
-                        .first()
-                        .is_none_or(|key| rest.start() >= key.start())
-                });
+        let previous_binding = self.pattern_binding;
+        self.pattern_binding = binding;
+        source_order::walk_pattern(self, pattern);
+        self.pattern_binding = previous_binding;
+    }
 
-                if let Some(rest) = rest_before_keys {
-                    self.add_pattern_binding(stmt, rest);
-                }
-                source_order::walk_pattern(self, pattern);
-                if let Some(rest) = rest_after_keys {
-                    self.add_pattern_binding(stmt, rest);
-                }
-            }
-            _ => source_order::walk_pattern(self, pattern),
+    fn visit_identifier(&mut self, identifier: &'db ast::Identifier) {
+        source_order::walk_identifier(self, identifier);
+
+        if let Some(stmt) = self.current_stmt
+            && self
+                .pattern_binding
+                .is_some_and(|binding| std::ptr::eq(binding, identifier))
+        {
+            self.add_pattern_binding(stmt, identifier);
         }
     }
 }
@@ -1847,6 +1831,24 @@ keyword :: Variable\n\
 alternative :: Variable\n\
 wildcard_body :: Variable\n\
 CONSTANT_CAPTURE :: Constant"
+        );
+    }
+
+    #[test]
+    fn exports_reports_mapping_pattern_bindings_in_source_order() {
+        let test = public_test(
+            "\
+match subject:
+    case {\"a\": before, **between, \"b\": after}:
+        pass
+",
+        );
+
+        assert_eq!(
+            test.exports(),
+            "before :: Variable\n\
+between :: Variable\n\
+after :: Variable"
         );
     }
 

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -868,7 +868,7 @@ impl<'db> SymbolVisitor<'db> {
     }
 
     /// Adds a symbol for a name definition.
-    fn add_named_symbol(
+    fn add_name_symbol(
         &mut self,
         stmt: &ast::Stmt,
         name: &Name,
@@ -887,28 +887,20 @@ impl<'db> SymbolVisitor<'db> {
         self.add_symbol(symbol);
     }
 
-    fn add_name_symbol(&mut self, stmt: &ast::Stmt, name: &ast::ExprName, kind: SymbolKind) {
-        self.add_named_symbol(stmt, &name.id, name.range(), kind);
-    }
-
-    /// Adds a symbol introduced via an assignment.
-    fn add_assignment(&mut self, stmt: &ast::Stmt, name: &ast::ExprName) {
-        self.add_assignment_name(stmt, &name.id, name.range());
-    }
-
     fn add_pattern_binding(&mut self, stmt: &ast::Stmt, name: &ast::Identifier) {
         if self.in_function || !name.is_valid() || name.id == "_" {
             return;
         }
 
-        self.add_assignment_name(stmt, &name.id, name.range());
+        self.add_assignment(stmt, &name.id, name.range());
 
         if self.exports_only && self.all_origin.is_some() && name.id == "__all__" {
             self.all_invalid = true;
         }
     }
 
-    fn add_assignment_name(&mut self, stmt: &ast::Stmt, name: &Name, name_range: TextRange) {
+    /// Adds a symbol introduced via an assignment.
+    fn add_assignment(&mut self, stmt: &ast::Stmt, name: &Name, name_range: TextRange) {
         // Include assignments only when we're in global or class scope.
         if self.in_function {
             return;
@@ -924,7 +916,7 @@ impl<'db> SymbolVisitor<'db> {
         } else {
             SymbolKind::Variable
         };
-        self.add_named_symbol(stmt, name, name_range, kind);
+        self.add_name_symbol(stmt, name, name_range, kind);
     }
 
     /// Adds a symbol introduced via an import `stmt`.
@@ -1411,7 +1403,7 @@ impl<'db> SymbolVisitor<'db> {
                 let ast::Expr::Name(name) = &*type_alias.name else {
                     return;
                 };
-                self.add_name_symbol(stmt, name, SymbolKind::Variable);
+                self.add_name_symbol(stmt, &name.id, name.range(), SymbolKind::Variable);
             }
             ast::Stmt::Assign(assign) => {
                 self.add_all_assignment(&assign.targets, Some(&assign.value));
@@ -1561,7 +1553,7 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                     && !self.suppress_store_symbols
                     && let Some(stmt) = self.current_stmt =>
             {
-                self.add_assignment(stmt, name);
+                self.add_assignment(stmt, &name.id, name.range());
 
                 if name.id != "__all__" {
                     return;

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -894,7 +894,7 @@ impl<'db> SymbolVisitor<'db> {
     }
 
     fn add_pattern_binding(&mut self, stmt: &ast::Stmt, name: &ast::Identifier) {
-        if self.in_function || name.id == "_" {
+        if self.in_function || !name.is_valid() || name.id == "_" {
             return;
         }
 


### PR DESCRIPTION
## Summary

Teach the `SymbolVisitor` to recognize names introduced by structural pattern matching.

This handles:
- capture and `as` patterns;
- sequence and starred patterns;
- mapping patterns, including `**rest`;
- positional and keyword class patterns;
- nested patterns and `|` alternatives;
- module-level bindings as variables or constants;
- class-level bindings as fields.

Function-local bindings remain excluded, consistently with regular assignments. Pattern bindings, guards, and case bodies retain source-order traversal.

Addresses the `case bar:` item in astral-sh/ty#1771.

> [!NOTE]
> This draft has been realigned on top of #27256, which now provides the generic Store-context handling. This PR now contains only the match-pattern binding support.

## Test Plan

- `cargo test -p ty_ide`
- `cargo clippy -p ty_ide --all-targets --all-features -- -D warnings`
- `uv run --only-group dev --locked prek run --files crates/ty_ide/src/symbols.rs crates/ty_ide/src/document_symbols.rs`
