### PR TITLE
[flake8-bugbear] Flag non-docstring strings in useless-expression (B018)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-bugbear/useless-expression.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-bugbear/useless-expression.md
@@ -1,0 +1,257 @@
+# `useless-expression` (`B018`)
+
+In preview, B018 flags standalone string and f-string literals that are not docstrings or
+attribute docstrings. The sections below cover the string handling.
+
+```toml
+[lint]
+preview = true
+select = ["B018"]
+```
+
+## Docstrings
+
+A string as the first statement of a module, class, or function body is a docstring and is never
+flagged.
+
+```py
+"""Module docstring."""
+
+
+class Foo:
+    """Class docstring."""
+
+    def bar(self):
+        """Method docstring."""
+        return 1
+
+
+def baz():
+    """Function docstring."""
+```
+
+## Attribute docstrings
+
+A string immediately following an assignment, annotated assignment, or type alias at the module,
+class, or `__init__` method level is an attribute docstring and is not flagged. The exemption
+accepts any assignment target and valueless annotations, intentionally broader than PEP 257's
+"simple assignment" to stay conservative.
+
+```py
+x = 1
+"""Docstring for `x`."""
+
+y: int = 2
+"""Docstring for `y`."""
+
+length: int
+"""Docstring for `length`, which has no value yet."""
+
+type Alias = int
+"""Docstring for `Alias`."""
+
+a, b = 1, 2
+"""Docstring for `a` and `b`."""
+
+
+class Foo:
+    attr = 1
+    """Docstring for `attr`."""
+
+    typed: int = 2
+    """Docstring for `typed`."""
+
+    def __init__(self):
+        self.value = 3
+        """Docstring for `value`."""
+        self.typed: int = 4
+        """Docstring for `typed`."""
+        local = 5
+        """Docstring for `local`."""
+```
+
+Comments and blank lines between the assignment and the string don't break the association.
+
+```py
+class Foo:
+    attr = 1
+    # A comment.
+
+    # Another comment.
+    """Still a docstring for `attr`."""
+```
+
+## Strings after assignments in other functions
+
+Outside `__init__`, a string after an assignment is not an attribute docstring and is flagged.
+
+```py
+class Foo:
+    def method(self):
+        self.x = 1
+        "Not an attribute docstring."  # error: [useless-expression]
+```
+
+## Strings in nested blocks
+
+Nested blocks have no docstring concept, so a string as the first statement of such a block is
+flagged.
+
+```py
+if True:
+    "Not a docstring."  # error: [useless-expression]
+
+
+def foo():
+    for _ in range(3):
+        "Not a docstring."  # error: [useless-expression]
+```
+
+However, a string following an assignment inside a nested block is still an attribute docstring if
+the enclosing scope is a module, class, or `__init__` method.
+
+```py
+import sys
+
+if sys.platform == "linux":
+    x = 1
+    """Docstring for `x`."""
+
+
+class Foo:
+    def __init__(self, flag):
+        if flag:
+            self.x = 1
+            """Docstring for `x`."""
+```
+
+## An assignment's docstring expectation doesn't escape its block
+
+Only a string immediately following the assignment, in the same block, is an attribute docstring.
+A string after the enclosing block, or in a sibling `else` clause, is flagged even when the block
+ends with an assignment.
+
+```py
+class Foo:
+    if True:
+        x = 1
+    "Not an attribute docstring."  # error: [useless-expression]
+```
+
+```py
+if True:
+    x = 1
+else:
+    "Not an attribute docstring."  # error: [useless-expression]
+```
+
+## Misplaced module docstrings
+
+A string that follows any non-assignment statement, such as an import, is flagged.
+
+```py
+import sys
+
+"Misplaced module docstring."  # snapshot: useless-expression
+```
+
+```snapshot
+error[B018]: Found useless string statement. Either convert it to a comment or remove it.
+ --> src/mdtest_snippet.py:3:1
+  |
+3 | "Misplaced module docstring."  # snapshot: useless-expression
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+## A second string after the docstring
+
+A string immediately following the real docstring is flagged. PEP 257 calls these "additional
+docstrings", but they are discarded at runtime, and pylint's `pointless-string-statement` flags
+them too.
+
+```py
+"""Module docstring."""
+
+"Second string."  # error: [useless-expression]
+```
+
+## F-strings
+
+An f-string is never a docstring, so it's flagged even in docstring position, unless it has side
+effects.
+
+```py
+def foo():
+    f"Not a docstring."  # error: [useless-expression]
+
+
+def bar():
+    x = 1
+    f"{x} interpolated"  # error: [useless-expression]
+
+
+def baz():
+    f"{print('side effect')}"
+```
+
+## Stable behavior
+
+Without preview, string and f-string statements are skipped entirely.
+
+```toml
+[lint]
+select = ["B018"]
+```
+
+```py
+import sys
+
+"Misplaced module docstring, skipped on stable."
+
+f"Bare f-string, skipped on stable."
+```
+
+## Notebook cells
+
+A string that is the last top-level expression in a notebook cell is the cell's displayed output,
+so it is not flagged, matching B018's existing behavior for other expressions. Strings elsewhere
+in a cell, including a cell-final string nested in a block, are still flagged.
+
+```toml
+[lint]
+preview = true
+select = ["B018"]
+```
+
+`notebook.ipynb`:
+
+```ipynb
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": ["x = 1\n", "print(x)\n", "\"rendered as the cell's output\""]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": ["\"not the cell's output\"  # error: [useless-expression]\n", "print(x)"]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": ["if x:\n", "    \"ends the cell but is nested\"  # error: [useless-expression]"]
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 4
+}
+```

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -53,7 +53,7 @@ use ruff_python_parser::semantic_errors::{
 use ruff_python_parser::typing::{AnnotationKind, ParsedAnnotation, parse_type_annotation};
 use ruff_python_parser::{ParseError, Parsed};
 use ruff_python_semantic::all::{DunderAllDefinition, DunderAllFlags};
-use ruff_python_semantic::analyze::{imports, typing};
+use ruff_python_semantic::analyze::{imports, typing, visibility};
 use ruff_python_semantic::{
     BindingFlags, BindingId, BindingKind, Exceptions, Export, FromImport, GeneratorKind, Globals,
     Import, Module, ModuleKind, ModuleSource, NodeId, ScopeId, ScopeKind, SemanticModel,
@@ -167,7 +167,9 @@ pub(crate) enum ExpectedDocstringKind {
     /// ```
     Function,
 
-    /// An attribute-level docstring.
+    /// An attribute-level docstring: a string immediately following an
+    /// assignment, an annotated assignment, or a `type` alias statement, at
+    /// the module, class, or `__init__` method level.
     ///
     /// For example,
     /// ```python
@@ -178,6 +180,10 @@ pub(crate) enum ExpectedDocstringKind {
     /// class Foo:
     ///     b = 1
     ///     """This is the docstring for `Foo.b` class variable."""
+    ///
+    ///     def __init__(self):
+    ///         self.c = 1
+    ///         """This is the docstring for the `c` instance attribute."""
     /// ```
     Attribute,
 }
@@ -1636,19 +1642,28 @@ impl<'a> Visitor<'a> for Checker<'a> {
             _ => visitor::walk_stmt(self, stmt),
         }
 
-        if self.semantic().at_top_level() || self.semantic().current_scope().kind.is_class() {
-            match stmt {
-                Stmt::Assign(ast::StmtAssign { targets, .. }) => {
-                    if let [Expr::Name(_)] = targets.as_slice() {
-                        self.docstring_state =
-                            DocstringState::Expected(ExpectedDocstringKind::Attribute);
-                    }
+        if matches!(
+            stmt,
+            Stmt::Assign(_) | Stmt::AnnAssign(_) | Stmt::TypeAlias(_)
+        ) {
+            // Per PEP 257, attribute docstrings exist at the module, class, and
+            // `__init__` method level. The check is scope-based rather than
+            // top-level-based (an assignment nested in an `if` block can still
+            // carry one), and accepts any assignment target, both intentionally
+            // broader than PEP 257's "simple assignment" to stay conservative.
+            let scope_allows_attribute_docstrings = match &self.semantic.current_scope().kind {
+                ScopeKind::Module | ScopeKind::Class(_) => true,
+                ScopeKind::Function(function_def) => {
+                    visibility::is_init(&function_def.name)
+                        && self
+                            .semantic
+                            .first_non_type_parent_scope(self.semantic.current_scope())
+                            .is_some_and(|scope| scope.kind.is_class())
                 }
-                Stmt::AnnAssign(ast::StmtAnnAssign { target, .. }) if target.is_name_expr() => {
-                    self.docstring_state =
-                        DocstringState::Expected(ExpectedDocstringKind::Attribute);
-                }
-                _ => {}
+                _ => false,
+            };
+            if scope_allows_attribute_docstrings {
+                self.docstring_state = DocstringState::Expected(ExpectedDocstringKind::Attribute);
             }
         }
 
@@ -2394,6 +2409,11 @@ impl<'a> Visitor<'a> for Checker<'a> {
         for stmt in body {
             self.visit_stmt(stmt);
         }
+
+        // Don't let a docstring expectation escape the suite that set it:
+        // without this reset, an assignment at the end of an `if` body would
+        // mark a string after the block as an attribute docstring.
+        self.docstring_state = DocstringState::Other;
     }
 
     fn visit_match_case(&mut self, match_case: &'a MatchCase) {

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -346,3 +346,8 @@ pub const fn is_human_readable_names_enabled(preview: PreviewMode) -> bool {
 pub const fn is_warn_on_unknown_selectors_enabled(preview: PreviewMode) -> bool {
     preview.is_enabled()
 }
+
+// https://github.com/astral-sh/ruff/issues/11292
+pub(crate) const fn is_useless_expression_strings_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -5,6 +5,7 @@ use ruff_text_size::Ranged;
 
 use crate::Violation;
 use crate::checkers::ast::Checker;
+use crate::preview::is_useless_expression_strings_enabled;
 
 use crate::rules::flake8_bugbear::helpers::at_last_top_level_expression_in_cell;
 
@@ -25,6 +26,12 @@ use crate::rules::flake8_bugbear::helpers::at_last_top_level_expression_in_cell;
 /// ```python
 /// foo = 1 + 1
 /// ```
+///
+/// In [preview], this rule also flags string and f-string literals that are
+/// not used as docstrings or [attribute docstrings] (a string immediately
+/// following an assignment at the module, class, or `__init__` level). A
+/// string immediately following the docstring (an "additional docstring" in
+/// [PEP 257]'s terms) is discarded at runtime and is also flagged.
 ///
 /// ## Notebook behavior
 /// For Jupyter Notebooks, this rule is not applied to the last top-level expression in a cell.
@@ -50,6 +57,10 @@ use crate::rules::flake8_bugbear::helpers::at_last_top_level_expression_in_cell;
 /// with errors.ExceptionRaisedContext():
 ///     _ = obj.attribute
 /// ```
+///
+/// [preview]: https://docs.astral.sh/ruff/preview/
+/// [attribute docstrings]: https://peps.python.org/pep-0257/#what-is-a-docstring
+/// [PEP 257]: https://peps.python.org/pep-0257/
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.100")]
 pub(crate) struct UselessExpression {
@@ -67,6 +78,10 @@ impl Violation for UselessExpression {
                 "Found useless attribute access. Either assign it to a variable or remove it."
                     .to_string()
             }
+            Kind::String => {
+                "Found useless string statement. Either convert it to a comment or remove it."
+                    .to_string()
+            }
         }
     }
 }
@@ -78,12 +93,20 @@ pub(crate) fn useless_expression(checker: &Checker, value: &Expr) {
         return;
     }
 
-    // Ignore strings, to avoid false positives with docstrings.
-    if matches!(
-        value,
-        Expr::FString(_) | Expr::StringLiteral(_) | Expr::EllipsisLiteral(_)
-    ) {
+    if value.is_ellipsis_literal_expr() {
         return;
+    }
+
+    if matches!(value, Expr::FString(_) | Expr::StringLiteral(_)) {
+        // In preview, ignore only docstrings and attribute docstrings; any
+        // other standalone string has no effect. On stable, ignore all
+        // strings to avoid false positives with docstrings.
+        if !is_useless_expression_strings_enabled(checker.settings())
+            || checker.semantic().in_pep_257_docstring()
+            || checker.semantic().in_attribute_docstring()
+        {
+            return;
+        }
     }
 
     if checker.source_type.is_ipynb()
@@ -111,16 +134,17 @@ pub(crate) fn useless_expression(checker: &Checker, value: &Expr) {
         return;
     }
 
-    checker.report_diagnostic(
-        UselessExpression {
-            kind: Kind::Expression,
-        },
-        value.range(),
-    );
+    let kind = if matches!(value, Expr::FString(_) | Expr::StringLiteral(_)) {
+        Kind::String
+    } else {
+        Kind::Expression
+    };
+    checker.report_diagnostic(UselessExpression { kind }, value.range());
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 enum Kind {
     Expression,
     Attribute,
+    String,
 }

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -2803,10 +2803,9 @@ bitflags! {
 
         /// The model is in an attribute docstring.
         ///
-        /// An attribute docstring is a string literal immediately following an assignment or an
-        /// annotated assignment statement. The context in which this is valid are:
-        /// 1. At the top level of a module
-        /// 2. At the top level of a class definition i.e., a class attribute
+        /// An attribute docstring is a string literal immediately following an assignment, an
+        /// annotated assignment, or a `type` alias statement, at the module, class, or
+        /// `__init__` method level.
         ///
         /// For example:
         /// ```python
@@ -2817,6 +2816,10 @@ bitflags! {
         /// class Foo:
         ///     b = 1
         ///     """This is an attribute docstring for `Foo.b` class variable"""
+        ///
+        ///     def __init__(self):
+        ///         self.c = 1
+        ///         """This is an attribute docstring for the `c` instance attribute"""
         /// ```
         ///
         /// Unlike other kinds of docstrings as described in [PEP 257], attribute docstrings are


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
