### PR TITLE
[ty] Correct ParamSpec forwarded-argument diagnostic locations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
+++ b/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
@@ -1,9 +1,9 @@
 # `ParamSpec` error locations
 
-When a free `ParamSpec` is available in a parameter before the ones representing it's components
-(`P.args` and `P.kwargs`), ty invokes a sub-call logic where it performs a separate call to the
-function with the arguments that are resolved from the `ParamSpec`. In this case, the diagnostic
-location need to be offset based on the position of the `ParamSpec` components.
+A callable can accept another callable and forward its positional and keyword arguments using a
+`ParamSpec`. These tests check that argument errors identify the callback parameter that rejected
+the argument, or fall back to the forwarding function's `*args` or `**kwargs` when that parameter
+cannot be identified.
 
 ```toml
 [environment]
@@ -31,10 +31,10 @@ error[invalid-argument-type]: Argument to function `foo` is incorrect
 9 | foo(fn1, "a", 2, c="c", unknown=1)
   |          ^^^ Expected `int`, found `Literal["a"]`
 info: Function defined here
- --> src/mdtest_snippet.py:3:5
+ --> src/mdtest_snippet.py:4:5
   |
-3 | def foo[**P, T](fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
-  |     ^^^         ------------------ Parameter declared here
+4 | def fn1(a: int, b: int, c: int) -> None: ...
+  |     ^^^ ------ Parameter declared here
 
 
 error[invalid-argument-type]: Argument to function `foo` is incorrect
@@ -43,10 +43,10 @@ error[invalid-argument-type]: Argument to function `foo` is incorrect
 9 | foo(fn1, "a", 2, c="c", unknown=1)
   |                  ^^^^^ Expected `int`, found `Literal["c"]`
 info: Function defined here
- --> src/mdtest_snippet.py:3:5
+ --> src/mdtest_snippet.py:4:5
   |
-3 | def foo[**P, T](fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs): ...
-  |     ^^^                                            ------------------ Parameter declared here
+4 | def fn1(a: int, b: int, c: int) -> None: ...
+  |     ^^^                 ------ Parameter declared here
 
 
 error[unknown-argument]: Argument `unknown` does not match any known parameter of function `foo`
@@ -163,4 +163,429 @@ foo = Foo()
 # error: [invalid-argument-type]
 # error: [unknown-argument]
 foo.method(fn1, "a", 2, c="c", unknown=1)
+```
+
+## Forwarded keyword arguments
+
+A keyword argument passed to `asyncio.to_thread` should identify the matching parameter on the
+callback, not the `func` parameter on `to_thread`.
+
+```py
+import asyncio
+
+def callback(*, value: int) -> None: ...
+async def run() -> None:
+    await asyncio.to_thread(callback, value="incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+ --> src/mdtest_snippet.py:5:39
+  |
+5 |     await asyncio.to_thread(callback, value="incorrect")  # snapshot: invalid-argument-type
+  |                                       ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:3:5
+  |
+3 | def callback(*, value: int) -> None: ...
+  |     ^^^^^^^^    ---------- Parameter declared here
+```
+
+## Forwarded bound methods
+
+A bound method still includes `self` in its source signature. The diagnostic should skip that
+parameter and identify the argument that actually failed.
+
+```py
+import asyncio
+
+class Handler:
+    def callback(self, *, value: int) -> None: ...
+
+async def run(handler: Handler) -> None:
+    await asyncio.to_thread(handler.callback, value="incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+ --> src/mdtest_snippet.py:7:47
+  |
+7 |     await asyncio.to_thread(handler.callback, value="incorrect")  # snapshot: invalid-argument-type
+  |                                               ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Method defined here
+ --> src/mdtest_snippet.py:4:9
+  |
+4 |     def callback(self, *, value: int) -> None: ...
+  |         ^^^^^^^^          ---------- Parameter declared here
+```
+
+## Callbacks without a source definition
+
+A `Callable` annotation describes the accepted arguments but does not identify the function that
+declared them. In that case, point to the forwarding function's `*args` parameter.
+
+```py
+import asyncio
+from typing import Callable
+
+async def run(callback: Callable[[int], None]) -> None:
+    await asyncio.to_thread(callback, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+ --> src/mdtest_snippet.py:5:39
+  |
+5 |     await asyncio.to_thread(callback, "incorrect")  # snapshot: invalid-argument-type
+  |                                       ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+  --> stdlib/asyncio/threads.pyi:11:11
+   |
+11 | async def to_thread(func: Callable[_P, _R], /, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+   |           ^^^^^^^^^                            -------------- Parameter declared here
+```
+
+## Parameters consumed by Concatenate
+
+`Concatenate` lets a forwarding function provide the first argument itself. The diagnostic still
+needs to account for that argument when locating the callback's remaining parameter.
+
+```py
+from typing import Callable, Concatenate
+
+def wrapper[**P](callback: Callable[Concatenate[int, P], None], *args: P.args, **kwargs: P.kwargs) -> None:
+    callback(0, *args, **kwargs)
+
+def callback(prefix: int, *, value: int) -> None: ...
+
+wrapper(callback, value="incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:8:19
+  |
+8 | wrapper(callback, value="incorrect")  # snapshot: invalid-argument-type
+  |                   ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:6:5
+  |
+6 | def callback(prefix: int, *, value: int) -> None: ...
+  |     ^^^^^^^^                 ---------- Parameter declared here
+```
+
+## Overloaded callbacks
+
+When a callback has multiple overloads, the diagnostic should identify the parameter on the overload
+that accepted the other arguments.
+
+```py
+import asyncio
+from typing import overload
+
+@overload
+def callback(value: int) -> None: ...
+@overload
+def callback(value: str, *, flag: str) -> None: ...
+def callback(value: int | str, *, flag: str | None = None) -> None: ...
+async def run() -> None:
+    await asyncio.to_thread(callback, "value", flag=1)  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+  --> src/mdtest_snippet.py:10:48
+   |
+10 |     await asyncio.to_thread(callback, "value", flag=1)  # snapshot: invalid-argument-type
+   |                                                ^^^^^^ Expected `str`, found `Literal[1]`
+info: Function defined here
+ --> src/mdtest_snippet.py:7:5
+  |
+7 | def callback(value: str, *, flag: str) -> None: ...
+  |     ^^^^^^^^                --------- Parameter declared here
+```
+
+## Overloads selected by Concatenate
+
+The first callback overload accepts a `str` prefix, so it cannot match a forwarding function that
+always supplies an `int`. An error in the remaining arguments should point to the second overload.
+
+```py
+from typing import Callable, Concatenate, overload
+
+def wrapper[**P](callback: Callable[Concatenate[int, P], None], *args: P.args, **kwargs: P.kwargs) -> None:
+    callback(1, *args, **kwargs)
+
+@overload
+def callback(prefix: str, value: str) -> None: ...
+@overload
+def callback(prefix: int, value: int) -> None: ...
+def callback(prefix: str | int, value: str | int) -> None: ...
+
+wrapper(callback, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+  --> src/mdtest_snippet.py:12:19
+   |
+12 | wrapper(callback, "incorrect")  # snapshot: invalid-argument-type
+   |                   ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:9:5
+  |
+9 | def callback(prefix: int, value: int) -> None: ...
+  |     ^^^^^^^^              ---------- Parameter declared here
+```
+
+## Overloads selected by a bound receiver
+
+A generic method can have separate overloads for different receiver types. A method on
+`Receiver[int]` should point to the overload declared for `Receiver[int]`.
+
+```py
+import asyncio
+from typing import overload
+
+class Receiver[T]:
+    value: T
+
+    @overload
+    def method(self: "Receiver[str]", value: str) -> None: ...
+    @overload
+    def method(self: "Receiver[int]", value: int) -> None: ...
+    def method(self, value: str | int) -> None: ...
+
+async def run(receiver: Receiver[int]) -> None:
+    await asyncio.to_thread(receiver.method, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+  --> src/mdtest_snippet.py:14:46
+   |
+14 |     await asyncio.to_thread(receiver.method, "incorrect")  # snapshot: invalid-argument-type
+   |                                              ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Method defined here
+  --> src/mdtest_snippet.py:10:9
+   |
+10 |     def method(self: "Receiver[int]", value: int) -> None: ...
+   |         ^^^^^^                        ---------- Parameter declared here
+```
+
+## Callback annotations with multiple callable alternatives
+
+The callback below matches the second union alternative, which does not consume a leading argument.
+The diagnostic should therefore identify `first`, not `second`.
+
+```py
+from typing import Callable, Concatenate
+
+def wrapper[**P](callback: Callable[Concatenate[int, P], None] | Callable[P, str], *args: P.args, **kwargs: P.kwargs) -> None: ...
+def callback(first: int, second: str) -> str:
+    return second
+
+wrapper(callback, "incorrect", "valid")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:7:19
+  |
+7 | wrapper(callback, "incorrect", "valid")  # snapshot: invalid-argument-type
+  |                   ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+4 | def callback(first: int, second: str) -> str:
+  |     ^^^^^^^^ ---------- Parameter declared here
+```
+
+## Optional callbacks
+
+A union may also contain a value that is not callable. The presence of `None` should not prevent the
+diagnostic from identifying the callback's parameter.
+
+```py
+from typing import Callable
+
+def wrapper[**P](callback: Callable[P, None] | None, *args: P.args, **kwargs: P.kwargs) -> None: ...
+def callback(value: int) -> None: ...
+
+wrapper(callback, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:6:19
+  |
+6 | wrapper(callback, "incorrect")  # snapshot: invalid-argument-type
+  |                   ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+4 | def callback(value: int) -> None: ...
+  |     ^^^^^^^^ ---------- Parameter declared here
+```
+
+## Overloaded forwarding functions
+
+An overloaded forwarding function should retain the note identifying its matching overload as well
+as the note identifying the callback parameter.
+
+```py
+from typing import Callable, overload
+
+@overload
+def wrap[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+@overload
+def wrap(value: int, first: int, second: int) -> None: ...
+def wrap(callback: Callable[..., None] | int, *args: object, **kwargs: object) -> None: ...
+def keyword_callback(*, value: int) -> None: ...
+def positional_callback(*values: int) -> None: ...
+```
+
+A keyword argument belongs to the forwarding function's `**kwargs` parameter.
+
+```py
+wrap(keyword_callback, value="incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrap` is incorrect
+  --> src/mdtest_snippet.py:10:24
+   |
+10 | wrap(keyword_callback, value="incorrect")  # snapshot: invalid-argument-type
+   |                        ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:8:5
+  |
+8 | def keyword_callback(*, value: int) -> None: ...
+  |     ^^^^^^^^^^^^^^^^    ---------- Parameter declared here
+info: Matching overload defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+4 | def wrap[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+  |     ^^^^                                                  ------------------ Parameter declared here
+info: Non-matching overloads for function `wrap`:
+info:   (value: int, first: int, second: int) -> None
+```
+
+A positional argument belongs to `*args`, even when the callback accepts it through `*values`.
+
+```py
+wrap(positional_callback, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrap` is incorrect
+  --> src/mdtest_snippet.py:11:27
+   |
+11 | wrap(positional_callback, "incorrect")  # snapshot: invalid-argument-type
+   |                           ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:9:5
+  |
+9 | def positional_callback(*values: int) -> None: ...
+  |     ^^^^^^^^^^^^^^^^^^^ ------------ Parameter declared here
+info: Matching overload defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+4 | def wrap[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+  |     ^^^^                                   ------------- Parameter declared here
+info: Non-matching overloads for function `wrap`:
+info:   (value: int, first: int, second: int) -> None
+```
+
+## Forwarding through a callable object
+
+The forwarding object's own `self` parameter is not the callback. The diagnostic should point to the
+argument accepted by `callback`.
+
+```py
+from typing import Callable
+
+class Wrapper:
+    def __call__[**P](self, callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+def callback(value: int) -> None: ...
+
+Wrapper()(callback, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to bound method `Wrapper.__call__` is incorrect
+ --> src/mdtest_snippet.py:8:21
+  |
+8 | Wrapper()(callback, "incorrect")  # snapshot: invalid-argument-type
+  |                     ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:6:5
+  |
+6 | def callback(value: int) -> None: ...
+  |     ^^^^^^^^ ---------- Parameter declared here
+```
+
+## Overloads without parameter definitions
+
+Expanding `Unpack[tuple[int]]` can remove the information linking an overload's parameter back to
+its declaration. Until that link is restored, point to the forwarding function's `*args` rather than
+an unrelated overload.
+
+```py
+from typing import Callable, Concatenate, Unpack, overload
+
+def wrapper[**P](callback: Callable[Concatenate[int, P], None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+@overload
+def callback(prefix: str, *values: Unpack[tuple[str]]) -> None: ...
+@overload
+def callback(prefix: int, *values: Unpack[tuple[int]]) -> None: ...
+def callback(prefix: str | int, *values: Unpack[tuple[str | int]]) -> None: ...
+
+wrapper(callback, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+  --> src/mdtest_snippet.py:10:19
+   |
+10 | wrapper(callback, "incorrect")  # snapshot: invalid-argument-type
+   |                   ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:3:5
+  |
+3 | def wrapper[**P](callback: Callable[Concatenate[int, P], None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+  |     ^^^^^^^                                                     ------------- Parameter declared here
+```
+
+## Expanded keyword parameters
+
+`Unpack[Config]` creates separate keyword parameters for `alpha` and `beta`, even though the
+callback declares only `**options`. Without a reliable link to that declaration, point to the
+forwarding function's `**kwargs` parameter.
+
+```py
+import asyncio
+from typing import TypedDict, Unpack
+
+class Config(TypedDict):
+    alpha: int
+    beta: int
+
+def callback(**options: Unpack[Config]) -> None: ...
+async def run() -> None:
+    await asyncio.to_thread(callback, alpha=1, beta="incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+  --> src/mdtest_snippet.py:10:48
+   |
+10 |     await asyncio.to_thread(callback, alpha=1, beta="incorrect")  # snapshot: invalid-argument-type
+   |                                                ^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+  --> stdlib/asyncio/threads.pyi:11:11
+   |
+11 | async def to_thread(func: Callable[_P, _R], /, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+   |           ^^^^^^^^^                                            ------------------- Parameter declared here
 ```

--- a/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
+++ b/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
@@ -167,27 +167,28 @@ foo.method(fn1, "a", 2, c="c", unknown=1)
 
 ## Forwarded keyword arguments
 
-A keyword argument passed to `asyncio.to_thread` should identify the matching parameter on the
-callback, not the `func` parameter on `to_thread`.
+A forwarded keyword argument should identify the matching callback parameter, not the parameter that
+accepts the callback.
 
 ```py
-import asyncio
+from typing import Callable
 
+def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 def callback(*, value: int) -> None: ...
-async def run() -> None:
-    await asyncio.to_thread(callback, value="incorrect")  # snapshot: invalid-argument-type
+
+wrapper(callback, value="incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
- --> src/mdtest_snippet.py:5:39
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:6:19
   |
-5 |     await asyncio.to_thread(callback, value="incorrect")  # snapshot: invalid-argument-type
-  |                                       ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+6 | wrapper(callback, value="incorrect")  # snapshot: invalid-argument-type
+  |                   ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Function defined here
- --> src/mdtest_snippet.py:3:5
+ --> src/mdtest_snippet.py:4:5
   |
-3 | def callback(*, value: int) -> None: ...
+4 | def callback(*, value: int) -> None: ...
   |     ^^^^^^^^    ---------- Parameter declared here
 ```
 
@@ -197,52 +198,55 @@ A bound method still includes `self` in its source signature. The diagnostic sho
 parameter and identify the argument that actually failed.
 
 ```py
-import asyncio
+from typing import Callable
+
+def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 class Handler:
     def callback(self, *, value: int) -> None: ...
 
-async def run(handler: Handler) -> None:
-    await asyncio.to_thread(handler.callback, value="incorrect")  # snapshot: invalid-argument-type
+def run(handler: Handler) -> None:
+    wrapper(handler.callback, value="incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
- --> src/mdtest_snippet.py:7:47
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:9:31
   |
-7 |     await asyncio.to_thread(handler.callback, value="incorrect")  # snapshot: invalid-argument-type
-  |                                               ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+9 |     wrapper(handler.callback, value="incorrect")  # snapshot: invalid-argument-type
+  |                               ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Method defined here
- --> src/mdtest_snippet.py:4:9
+ --> src/mdtest_snippet.py:6:9
   |
-4 |     def callback(self, *, value: int) -> None: ...
+6 |     def callback(self, *, value: int) -> None: ...
   |         ^^^^^^^^          ---------- Parameter declared here
 ```
 
 ## Callbacks without a source definition
 
 A `Callable` annotation describes the accepted arguments but does not identify the function that
-declared them. In that case, point to the forwarding function's `*args` parameter.
+declared them. In that case, point to the forwarding function's `*args` parameter. The expanded
+keyword parameters below cover the corresponding `**kwargs` fallback.
 
 ```py
-import asyncio
 from typing import Callable
 
-async def run(callback: Callable[[int], None]) -> None:
-    await asyncio.to_thread(callback, "incorrect")  # snapshot: invalid-argument-type
+def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+def run(callback: Callable[[int], None]) -> None:
+    wrapper(callback, "incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
- --> src/mdtest_snippet.py:5:39
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:5:23
   |
-5 |     await asyncio.to_thread(callback, "incorrect")  # snapshot: invalid-argument-type
-  |                                       ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+5 |     wrapper(callback, "incorrect")  # snapshot: invalid-argument-type
+  |                       ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Function defined here
-  --> stdlib/asyncio/threads.pyi:11:11
-   |
-11 | async def to_thread(func: Callable[_P, _R], /, *args: _P.args, **kwargs: _P.kwargs) -> _R:
-   |           ^^^^^^^^^                            -------------- Parameter declared here
+ --> src/mdtest_snippet.py:3:5
+  |
+3 | def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+  |     ^^^^^^^                                   ------------- Parameter declared here
 ```
 
 ## Parameters consumed by Concatenate
@@ -280,24 +284,24 @@ When a callback has multiple overloads, the diagnostic should identify the param
 that accepted the other arguments.
 
 ```py
-import asyncio
-from typing import overload
+from typing import Callable, overload
 
+def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 @overload
 def callback(value: int) -> None: ...
 @overload
 def callback(value: str, *, flag: str) -> None: ...
 def callback(value: int | str, *, flag: str | None = None) -> None: ...
-async def run() -> None:
-    await asyncio.to_thread(callback, "value", flag=1)  # snapshot: invalid-argument-type
+
+wrapper(callback, "value", flag=1)  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
-  --> src/mdtest_snippet.py:10:48
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+  --> src/mdtest_snippet.py:10:28
    |
-10 |     await asyncio.to_thread(callback, "value", flag=1)  # snapshot: invalid-argument-type
-   |                                                ^^^^^^ Expected `str`, found `Literal[1]`
+10 | wrapper(callback, "value", flag=1)  # snapshot: invalid-argument-type
+   |                            ^^^^^^ Expected `str`, found `Literal[1]`
 info: Function defined here
  --> src/mdtest_snippet.py:7:5
   |
@@ -344,8 +348,9 @@ A generic method can have separate overloads for different receiver types. A met
 `Receiver[int]` should point to the overload declared for `Receiver[int]`.
 
 ```py
-import asyncio
-from typing import overload
+from typing import Callable, overload
+
+def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 class Receiver[T]:
     value: T
@@ -356,20 +361,20 @@ class Receiver[T]:
     def method(self: "Receiver[int]", value: int) -> None: ...
     def method(self, value: str | int) -> None: ...
 
-async def run(receiver: Receiver[int]) -> None:
-    await asyncio.to_thread(receiver.method, "incorrect")  # snapshot: invalid-argument-type
+def run(receiver: Receiver[int]) -> None:
+    wrapper(receiver.method, "incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
-  --> src/mdtest_snippet.py:14:46
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+  --> src/mdtest_snippet.py:15:30
    |
-14 |     await asyncio.to_thread(receiver.method, "incorrect")  # snapshot: invalid-argument-type
-   |                                              ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+15 |     wrapper(receiver.method, "incorrect")  # snapshot: invalid-argument-type
+   |                              ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Method defined here
-  --> src/mdtest_snippet.py:10:9
+  --> src/mdtest_snippet.py:11:9
    |
-10 |     def method(self: "Receiver[int]", value: int) -> None: ...
+11 |     def method(self: "Receiver[int]", value: int) -> None: ...
    |         ^^^^^^                        ---------- Parameter declared here
 ```
 
@@ -565,27 +570,28 @@ callback declares only `**options`. Without a reliable link to that declaration,
 forwarding function's `**kwargs` parameter.
 
 ```py
-import asyncio
-from typing import TypedDict, Unpack
+from typing import Callable, TypedDict, Unpack
+
+def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 class Config(TypedDict):
     alpha: int
     beta: int
 
 def callback(**options: Unpack[Config]) -> None: ...
-async def run() -> None:
-    await asyncio.to_thread(callback, alpha=1, beta="incorrect")  # snapshot: invalid-argument-type
+
+wrapper(callback, alpha=1, beta="incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
-  --> src/mdtest_snippet.py:10:48
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+  --> src/mdtest_snippet.py:11:28
    |
-10 |     await asyncio.to_thread(callback, alpha=1, beta="incorrect")  # snapshot: invalid-argument-type
-   |                                                ^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+11 | wrapper(callback, alpha=1, beta="incorrect")  # snapshot: invalid-argument-type
+   |                            ^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Function defined here
-  --> stdlib/asyncio/threads.pyi:11:11
-   |
-11 | async def to_thread(func: Callable[_P, _R], /, *args: _P.args, **kwargs: _P.kwargs) -> _R:
-   |           ^^^^^^^^^                                            ------------------- Parameter declared here
+ --> src/mdtest_snippet.py:3:5
+  |
+3 | def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+  |     ^^^^^^^                                                  ------------------ Parameter declared here
 ```

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5208,7 +5208,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         let declared_type =
                             self.signature.parameters()[matched_parameter.index].annotated_type();
                         let argument_type = argument_types.get_for_declared_type(declared_type);
-                        let paramspec_prefix = |candidate: Type<'db>| {
+                        let paramspec_prefix_len = |candidate: Type<'db>| {
                             candidate
                                 .try_upcast_to_callable(self.db)?
                                 .iter()
@@ -5229,10 +5229,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                                 argument_type
                                     .is_assignable_to(self.db, specialized_candidate)
                                     .then_some(*candidate)
-                                    .and_then(paramspec_prefix)
+                                    .and_then(paramspec_prefix_len)
                             })
                         } else {
-                            paramspec_prefix(declared_type)
+                            paramspec_prefix_len(declared_type)
                         }?;
                         let (function, is_bound_method) = match argument_type {
                             Type::FunctionLiteral(function) => (function, false),
@@ -7504,6 +7504,9 @@ pub(crate) struct ForwardedParameterSource<'db> {
 
 impl<'db> ForwardedParameterSource<'db> {
     /// Recovers an overload's original index after specialization filters earlier declarations.
+    ///
+    /// `overload_index` initially refers to the specialized overload list. This method finds the
+    /// corresponding position in the original function, which can differ after filtering.
     fn source_overload_index(self, db: &'db dyn Db, signature: &Signature<'db>) -> Option<usize> {
         let parameter_definition = signature
             .parameters()

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5175,6 +5175,81 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             .collect()
     }
 
+    /// Returns the source callable whose parameters supplied a `ParamSpec` specialization.
+    ///
+    /// Forwarded arguments are checked against the wrapped callable, not the wrapper's
+    /// `Callable[P, R]` parameter. Retaining that callable also lets diagnostics account for bound
+    /// receivers and leading parameters consumed by `Concatenate`.
+    ///
+    /// Return `None` when the callback has no source declaration, so diagnostics can fall back to
+    /// the forwarding function's actual variadic parameter instead of an unrelated parameter.
+    ///
+    /// ```python
+    /// from typing import Callable
+    ///
+    /// def wrapper[**P](fn: Callable[P, None], *args: P.args, **kwargs: P.kwargs): ...
+    /// def target(*, value: int) -> None: ...
+    /// wrapper(target, value="bad")  # The parameter source is `target`.
+    /// ```
+    fn paramspec_parameter_source(
+        &self,
+        paramspec: BoundTypeVarInstance<'db>,
+        overload_index: usize,
+    ) -> Option<ForwardedParameterSource<'db>> {
+        self.enumerate_argument_types()
+            .find_map(|(argument_index, _, argument, argument_types)| {
+                if matches!(argument, Argument::Synthetic) {
+                    return None;
+                }
+
+                self.argument_matches[argument_index]
+                    .iter()
+                    .find_map(|matched_parameter| {
+                        let declared_type =
+                            self.signature.parameters()[matched_parameter.index].annotated_type();
+                        let argument_type = argument_types.get_for_declared_type(declared_type);
+                        let paramspec_prefix = |candidate: Type<'db>| {
+                            candidate
+                                .try_upcast_to_callable(self.db)?
+                                .iter()
+                                .find_map(|callable| {
+                                    callable.signatures(self.db).iter().find_map(|signature| {
+                                        let (prefix, declared_paramspec) =
+                                            signature.parameters().as_paramspec_with_prefix()?;
+                                        (declared_paramspec == paramspec).then_some(prefix.len())
+                                    })
+                                })
+                        };
+                        let prefix_len = if let Type::Union(union) =
+                            declared_type.resolve_type_alias(self.db)
+                        {
+                            union.elements(self.db).iter().find_map(|candidate| {
+                                let specialized_candidate = candidate
+                                    .apply_optional_specialization(self.db, self.specialization());
+                                argument_type
+                                    .is_assignable_to(self.db, specialized_candidate)
+                                    .then_some(*candidate)
+                                    .and_then(paramspec_prefix)
+                            })
+                        } else {
+                            paramspec_prefix(declared_type)
+                        }?;
+                        let (function, is_bound_method) = match argument_type {
+                            Type::FunctionLiteral(function) => (function, false),
+                            Type::BoundMethod(method) => (method.function(self.db), true),
+                            _ => return None,
+                        };
+
+                        Some(ForwardedParameterSource {
+                            function,
+                            is_bound_method,
+                            parameter_index_offset: prefix_len + usize::from(is_bound_method),
+                            overload_index,
+                        })
+                    })
+            })
+    }
+
     fn specialization(&self) -> Option<Specialization<'db>> {
         self.inference
             .map(|inference| inference.specialization(self.db))
@@ -5619,6 +5694,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 expected_ty,
                 provided_ty: argument_type,
                 provenance: matched_parameter.provenance,
+                parameter_source: None,
             });
         }
         // We still update the actual type of the parameter in this binding to match the argument,
@@ -5876,7 +5952,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             };
         let error_argument_indices = error_argument_indices.as_deref();
 
-        // Create Bindings with all overloads and perform full overload resolution
         let callable_binding =
             CallableBinding::from_overloads(self.signature_type, signatures.iter().cloned());
         let bindings = match Bindings::from(callable_binding)
@@ -5897,13 +5972,49 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             .single_element()
             .expect("ParamSpec sub-call should only contain a single CallableBinding");
 
-        let mut extend_errors = |errors: &[BindingError<'db>]| {
-            self.errors.extend(
-                errors
-                    .iter()
-                    .cloned()
-                    .map(|err| err.maybe_remap_argument_indices(error_argument_indices)),
-            );
+        let mut extend_errors = |binding: &Binding<'db>| {
+            let parameter_source = binding
+                .errors
+                .iter()
+                .find(|error| matches!(error, BindingError::InvalidArgumentType { .. }))
+                .and_then(|_| {
+                    self.paramspec_parameter_source(paramspec, binding.source_overload_index())
+                })
+                .and_then(|source| {
+                    let overload_index =
+                        source.source_overload_index(self.db, &binding.signature)?;
+                    Some(ForwardedParameterSource {
+                        overload_index,
+                        ..source
+                    })
+                });
+            let argument_matches = self.argument_matches;
+
+            self.errors
+                .extend(binding.errors.iter().cloned().map(|mut error| {
+                    if let BindingError::InvalidArgumentType {
+                        parameter,
+                        argument_index,
+                        parameter_source: error_parameter_source,
+                        ..
+                    } = &mut error
+                        && error_parameter_source.is_none()
+                    {
+                        if let Some(parameter_source) = parameter_source
+                            && parameter_source.contains_parameter(self.db, parameter.index)
+                        {
+                            *error_parameter_source = Some(parameter_source);
+                        } else if let Some(parameter_index) = argument_index
+                            .and_then(|index| paramspec_arguments?.get(index))
+                            .and_then(|(index, _)| argument_matches[*index].parameters.first())
+                            .map(|parameter| parameter.index)
+                        {
+                            parameter.index = parameter_index;
+                        }
+                    }
+
+                    error.maybe_remap_argument_indices(error_argument_indices)
+                }));
         };
 
         let mut matching_overloads = callable_binding.matching_overloads();
@@ -5912,7 +6023,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 if let [binding] = callable_binding.overloads() {
                     // This is not an overloaded function, so we can propagate its errors to the
                     // outer bindings.
-                    extend_errors(&binding.errors);
+                    extend_errors(binding);
                 } else {
                     let index = callable_binding
                         .best_failing_overload_index(
@@ -5921,20 +6032,20 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         .unwrap_or(0);
                     // TODO: We should also update the specialization for the `ParamSpec` to reflect
                     // the matching overload here.
-                    extend_errors(&callable_binding.overloads()[index].errors);
+                    extend_errors(&callable_binding.overloads()[index]);
                 }
             }
             (Some((_, binding)), None) => {
                 // TODO: We should also update the specialization for the `ParamSpec` to reflect the
                 // matching overload here.
-                extend_errors(&binding.errors);
+                extend_errors(binding);
             }
             (Some(_), Some(_)) => {
                 if !matches!(
                     callable_binding.overload_call_return_type,
                     Some(OverloadCallReturnType::ArgumentTypeExpansion(_))
                 ) {
-                    extend_errors(&callable_binding.overloads()[0].errors);
+                    extend_errors(&callable_binding.overloads()[0]);
                 }
             }
         }
@@ -7382,6 +7493,66 @@ impl std::fmt::Display for ParameterContexts {
     }
 }
 
+/// The function and source offsets used to locate a forwarded `ParamSpec` parameter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ForwardedParameterSource<'db> {
+    function: FunctionType<'db>,
+    is_bound_method: bool,
+    parameter_index_offset: usize,
+    overload_index: usize,
+}
+
+impl<'db> ForwardedParameterSource<'db> {
+    /// Recovers an overload's original index after specialization filters earlier declarations.
+    fn source_overload_index(self, db: &'db dyn Db, signature: &Signature<'db>) -> Option<usize> {
+        let parameter_definition = signature
+            .parameters()
+            .iter()
+            .find_map(Parameter::definition)?;
+
+        self.function
+            .signature(db)
+            .overloads
+            .iter()
+            .position(|source_signature| {
+                source_signature
+                    .parameters()
+                    .iter()
+                    .any(|parameter| parameter.definition() == Some(parameter_definition))
+            })
+    }
+
+    /// Returns whether the forwarded parameter maps to a specific source parameter.
+    ///
+    /// Out-of-range indices otherwise resolve to the entire signature, which would produce a
+    /// misleading diagnostic annotation.
+    fn contains_parameter(self, db: &'db dyn Db, parameter_index: usize) -> bool {
+        let parameter_index = parameter_index + self.parameter_index_offset;
+        let (overloads, implementation) = self.function.overloads_and_implementation(db);
+        let Some(overload) = overloads
+            .get(self.overload_index)
+            .copied()
+            .or(implementation)
+        else {
+            return false;
+        };
+
+        let (_, parameter_span) = overload.parameter_span(db, Some(parameter_index));
+        let (_, all_parameters_span) = overload.parameter_span(db, None);
+        parameter_span != all_parameters_span
+    }
+
+    /// Locates the matched source overload after restoring omitted receiver and prefix parameters.
+    fn parameter_span(self, db: &'db dyn Db, parameter_index: usize) -> (Span, Span) {
+        let parameter_index = parameter_index + self.parameter_index_offset;
+        let (overloads, _) = self.function.overloads_and_implementation(db);
+        overloads
+            .get(self.overload_index)
+            .map(|overload| overload.parameter_span(db, Some(parameter_index)))
+            .unwrap_or_else(|| self.function.parameter_span(db, Some(parameter_index)))
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum InvalidArgumentTypeProvenance {
     Argument,
@@ -7410,6 +7581,8 @@ pub(crate) enum BindingError<'db> {
         expected_ty: Type<'db>,
         provided_ty: Type<'db>,
         provenance: InvalidArgumentTypeProvenance,
+        /// The callable that actually declared the parameter, when reached through a `ParamSpec`.
+        parameter_source: Option<ForwardedParameterSource<'db>>,
     },
     /// The type of the keyword-variadic argument's key is not `str`.
     InvalidKeyType {
@@ -7687,6 +7860,7 @@ impl<'db> BindingError<'db> {
                 expected_ty,
                 provided_ty,
                 provenance,
+                parameter_source,
             } => {
                 // TODO: Ideally we would not emit diagnostics for `TypedDict` literal arguments
                 // here (see `diagnostic::is_invalid_typed_dict_literal`). However, we may have
@@ -7730,15 +7904,57 @@ impl<'db> BindingError<'db> {
                     provided_ty.assignability_error_context(context.db(), *expected_ty);
                 error_context.attach_to(context.db(), &mut diag);
 
+                if let Some(parameter_source) = parameter_source {
+                    let (name_span, parameter_span) =
+                        parameter_source.parameter_span(context.db(), parameter.index);
+                    let callable_kind = if parameter_source.is_bound_method {
+                        "Method"
+                    } else {
+                        "Function"
+                    };
+                    let mut sub = SubDiagnostic::new(
+                        SubDiagnosticSeverity::Info,
+                        format_args!("{callable_kind} defined here"),
+                    );
+                    sub.annotate(Annotation::primary(name_span));
+                    sub.annotate(
+                        Annotation::secondary(parameter_span).message("Parameter declared here"),
+                    );
+                    diag.sub(sub);
+                }
+
                 if let Some(matching_overload) = matching_overload {
                     if let Some(overload_literal) = matching_overload.get(context.db()) {
                         let mut sub = SubDiagnostic::new(
                             SubDiagnosticSeverity::Info,
                             "Matching overload defined here",
                         );
+                        let parameter_index = if parameter_source.is_some() {
+                            let argument_is_positional = Self::get_argument_node(
+                                node,
+                                argument_index.map(|index| index + context.argument_index_offset),
+                            )
+                            .map_or(parameter.positional, |argument| {
+                                matches!(argument, ArgOrKeyword::Arg(_))
+                            });
+                            overload_literal
+                                .signature(context.db())
+                                .parameters()
+                                .iter()
+                                .position(|candidate| {
+                                    if argument_is_positional {
+                                        candidate.is_variadic()
+                                    } else {
+                                        candidate.is_keyword_variadic()
+                                    }
+                                })
+                                .unwrap_or(parameter.index)
+                        } else {
+                            parameter.index
+                        };
                         let (name_span, parameter_span) = overload_literal.parameter_span(
                             context.db(),
-                            Some(parameter.index + source_parameter_index_offset),
+                            Some(parameter_index + source_parameter_index_offset),
                         );
                         sub.annotate(Annotation::primary(name_span));
                         sub.annotate(
@@ -7770,10 +7986,12 @@ impl<'db> BindingError<'db> {
                             ));
                         }
                     }
-                } else if let Some((name_span, parameter_span)) = callable_ty.parameter_span(
-                    context.db(),
-                    Some(parameter.index + source_parameter_index_offset),
-                ) {
+                } else if parameter_source.is_none()
+                    && let Some((name_span, parameter_span)) = callable_ty.parameter_span(
+                        context.db(),
+                        Some(parameter.index + source_parameter_index_offset),
+                    )
+                {
                     let mut sub = SubDiagnostic::new(
                         SubDiagnosticSeverity::Info,
                         format_args!("{callable_kind} defined here"),


### PR DESCRIPTION
## Summary

Prior to this change, we checked forwarded `ParamSpec` arguments against the callback but reported their parameter locations on the forwarding function. For example, this incorrectly highlighted `asyncio.to_thread`'s `func` parameter instead of the callback's `value` parameter:

```py
import asyncio

def callback(*, value: int) -> None: ...

async def run() -> None:
    await asyncio.to_thread(callback, value="incorrect")
```

We now point to the callback parameter for functions, bound methods, overloads, `Concatenate`, and callable unions. When that parameter cannot be identified reliably, we fall back to the forwarding function's actual `*args` or `**kwargs` parameter rather than highlighting an unrelated parameter or overload.

Closes https://github.com/astral-sh/ty/issues/2198.
