### PR TITLE
[ty] Recover forwarded callable object and constructor sources

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
+++ b/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
@@ -602,26 +602,27 @@ Unlike a plain `Callable` annotation, a callback protocol includes a declaration
 diagnostic should point to the parameter on that method.
 
 ```py
-import asyncio
-from typing import Protocol
+from typing import Callable, Protocol
+
+def wrapper[**P](callback: Callable[P, object], *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 class Callback(Protocol):
     def __call__(self, *, value: int) -> None: ...
 
-async def run(callback: Callback) -> None:
-    await asyncio.to_thread(callback, value="incorrect")  # snapshot: invalid-argument-type
+def run(callback: Callback) -> None:
+    wrapper(callback, value="incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
- --> src/mdtest_snippet.py:8:39
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:9:23
   |
-8 |     await asyncio.to_thread(callback, value="incorrect")  # snapshot: invalid-argument-type
-  |                                       ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+9 |     wrapper(callback, value="incorrect")  # snapshot: invalid-argument-type
+  |                       ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Method defined here
- --> src/mdtest_snippet.py:5:9
+ --> src/mdtest_snippet.py:6:9
   |
-5 |     def __call__(self, *, value: int) -> None: ...
+6 |     def __call__(self, *, value: int) -> None: ...
   |         ^^^^^^^^          ---------- Parameter declared here
 ```
 
@@ -631,53 +632,55 @@ A callable object declares its accepted arguments on `__call__`. Point to that m
 object is passed to a forwarding function.
 
 ```py
-import asyncio
+from typing import Callable
+
+def wrapper[**P](callback: Callable[P, object], *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 class Callback:
     def __call__(self, *, value: int) -> None: ...
 
-async def run() -> None:
-    await asyncio.to_thread(Callback(), value="incorrect")  # snapshot: invalid-argument-type
+wrapper(Callback(), value="incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
- --> src/mdtest_snippet.py:7:41
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:8:21
   |
-7 |     await asyncio.to_thread(Callback(), value="incorrect")  # snapshot: invalid-argument-type
-  |                                         ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+8 | wrapper(Callback(), value="incorrect")  # snapshot: invalid-argument-type
+  |                     ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Method defined here
- --> src/mdtest_snippet.py:4:9
+ --> src/mdtest_snippet.py:6:9
   |
-4 |     def __call__(self, *, value: int) -> None: ...
+6 |     def __call__(self, *, value: int) -> None: ...
   |         ^^^^^^^^          ---------- Parameter declared here
 ```
 
 ## Constructors defined by __init__
 
-Passing a class to `asyncio.to_thread` forwards arguments to its constructor. A class that declares
-`__init__` should identify the matching constructor parameter.
+A class passed as the callback receives the forwarded arguments in its constructor. A class that
+declares `__init__` should identify the matching constructor parameter.
 
 ```py
-import asyncio
+from typing import Callable
+
+def wrapper[**P](callback: Callable[P, object], *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 class Factory:
     def __init__(self, value: int) -> None: ...
 
-async def run() -> None:
-    await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
+wrapper(Factory, "incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
- --> src/mdtest_snippet.py:7:38
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:8:18
   |
-7 |     await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
-  |                                      ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+8 | wrapper(Factory, "incorrect")  # snapshot: invalid-argument-type
+  |                  ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Method defined here
- --> src/mdtest_snippet.py:4:9
+ --> src/mdtest_snippet.py:6:9
   |
-4 |     def __init__(self, value: int) -> None: ...
+6 |     def __init__(self, value: int) -> None: ...
   |         ^^^^^^^^       ---------- Parameter declared here
 ```
 
@@ -687,7 +690,9 @@ A custom metaclass can determine the accepted constructor arguments through its 
 declaration takes precedence over the class's `__init__` method.
 
 ```py
-import asyncio
+from typing import Callable
+
+def wrapper[**P](callback: Callable[P, object], *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 class Meta(type):
     def __call__(cls, value: int) -> object:
@@ -696,20 +701,19 @@ class Meta(type):
 class Factory(metaclass=Meta):
     def __init__(self, value: str) -> None: ...
 
-async def run() -> None:
-    await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
+wrapper(Factory, "incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
-  --> src/mdtest_snippet.py:11:38
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+  --> src/mdtest_snippet.py:12:18
    |
-11 |     await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
-   |                                      ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+12 | wrapper(Factory, "incorrect")  # snapshot: invalid-argument-type
+   |                  ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Method defined here
- --> src/mdtest_snippet.py:4:9
+ --> src/mdtest_snippet.py:6:9
   |
-4 |     def __call__(cls, value: int) -> object:
+6 |     def __call__(cls, value: int) -> object:
   |         ^^^^^^^^      ---------- Parameter declared here
 ```
 
@@ -719,27 +723,27 @@ A constructor defined by `__new__` consumes `cls` before checking the forwarded 
 diagnostic should point to `value`, not `cls`.
 
 ```py
-import asyncio
-from typing import Self
+from typing import Callable, Self
+
+def wrapper[**P](callback: Callable[P, object], *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 class Factory:
     def __new__(cls, value: int) -> Self:
         return super().__new__(cls)
 
-async def run() -> None:
-    await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
+wrapper(Factory, "incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
- --> src/mdtest_snippet.py:9:38
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:9:18
   |
-9 |     await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
-  |                                      ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+9 | wrapper(Factory, "incorrect")  # snapshot: invalid-argument-type
+  |                  ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Function defined here
- --> src/mdtest_snippet.py:5:9
+ --> src/mdtest_snippet.py:6:9
   |
-5 |     def __new__(cls, value: int) -> Self:
+6 |     def __new__(cls, value: int) -> Self:
   |         ^^^^^^^      ---------- Parameter declared here
 ```
 
@@ -749,8 +753,9 @@ When `__new__` is overloaded, the diagnostic must both select the matching overl
 its `cls` parameter.
 
 ```py
-import asyncio
-from typing import Self, overload
+from typing import Callable, Self, overload
+
+def wrapper[**P](callback: Callable[P, object], *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 class Factory:
     @overload
@@ -760,19 +765,18 @@ class Factory:
     def __new__(cls, value: str | int, flag: int | None = None) -> Self:
         return super().__new__(cls)
 
-async def run() -> None:
-    await asyncio.to_thread(Factory, 1, "incorrect")  # snapshot: invalid-argument-type
+wrapper(Factory, 1, "incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
-  --> src/mdtest_snippet.py:13:41
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+  --> src/mdtest_snippet.py:13:21
    |
-13 |     await asyncio.to_thread(Factory, 1, "incorrect")  # snapshot: invalid-argument-type
-   |                                         ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+13 | wrapper(Factory, 1, "incorrect")  # snapshot: invalid-argument-type
+   |                     ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Function defined here
- --> src/mdtest_snippet.py:8:9
+ --> src/mdtest_snippet.py:9:9
   |
-8 |     def __new__(cls, value: int, flag: int) -> Self: ...
+9 |     def __new__(cls, value: int, flag: int) -> Self: ...
   |         ^^^^^^^                  --------- Parameter declared here
 ```

--- a/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
+++ b/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
@@ -595,3 +595,184 @@ info: Function defined here
 3 | def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
   |     ^^^^^^^                                                  ------------------ Parameter declared here
 ```
+
+## Callback protocols
+
+Unlike a plain `Callable` annotation, a callback protocol includes a declaration for `__call__`. The
+diagnostic should point to the parameter on that method.
+
+```py
+import asyncio
+from typing import Protocol
+
+class Callback(Protocol):
+    def __call__(self, *, value: int) -> None: ...
+
+async def run(callback: Callback) -> None:
+    await asyncio.to_thread(callback, value="incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+ --> src/mdtest_snippet.py:8:39
+  |
+8 |     await asyncio.to_thread(callback, value="incorrect")  # snapshot: invalid-argument-type
+  |                                       ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Method defined here
+ --> src/mdtest_snippet.py:5:9
+  |
+5 |     def __call__(self, *, value: int) -> None: ...
+  |         ^^^^^^^^          ---------- Parameter declared here
+```
+
+## Callable objects
+
+A callable object declares its accepted arguments on `__call__`. Point to that method when the
+object is passed to a forwarding function.
+
+```py
+import asyncio
+
+class Callback:
+    def __call__(self, *, value: int) -> None: ...
+
+async def run() -> None:
+    await asyncio.to_thread(Callback(), value="incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+ --> src/mdtest_snippet.py:7:41
+  |
+7 |     await asyncio.to_thread(Callback(), value="incorrect")  # snapshot: invalid-argument-type
+  |                                         ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Method defined here
+ --> src/mdtest_snippet.py:4:9
+  |
+4 |     def __call__(self, *, value: int) -> None: ...
+  |         ^^^^^^^^          ---------- Parameter declared here
+```
+
+## Constructors defined by __init__
+
+Passing a class to `asyncio.to_thread` forwards arguments to its constructor. A class that declares
+`__init__` should identify the matching constructor parameter.
+
+```py
+import asyncio
+
+class Factory:
+    def __init__(self, value: int) -> None: ...
+
+async def run() -> None:
+    await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+ --> src/mdtest_snippet.py:7:38
+  |
+7 |     await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
+  |                                      ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Method defined here
+ --> src/mdtest_snippet.py:4:9
+  |
+4 |     def __init__(self, value: int) -> None: ...
+  |         ^^^^^^^^       ---------- Parameter declared here
+```
+
+## Constructors defined by a metaclass
+
+A custom metaclass can determine the accepted constructor arguments through its own `__call__`. That
+declaration takes precedence over the class's `__init__` method.
+
+```py
+import asyncio
+
+class Meta(type):
+    def __call__(cls, value: int) -> object:
+        return object()
+
+class Factory(metaclass=Meta):
+    def __init__(self, value: str) -> None: ...
+
+async def run() -> None:
+    await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+  --> src/mdtest_snippet.py:11:38
+   |
+11 |     await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
+   |                                      ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Method defined here
+ --> src/mdtest_snippet.py:4:9
+  |
+4 |     def __call__(cls, value: int) -> object:
+  |         ^^^^^^^^      ---------- Parameter declared here
+```
+
+## Constructors defined by __new__
+
+A constructor defined by `__new__` consumes `cls` before checking the forwarded arguments. The
+diagnostic should point to `value`, not `cls`.
+
+```py
+import asyncio
+from typing import Self
+
+class Factory:
+    def __new__(cls, value: int) -> Self:
+        return super().__new__(cls)
+
+async def run() -> None:
+    await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+ --> src/mdtest_snippet.py:9:38
+  |
+9 |     await asyncio.to_thread(Factory, "incorrect")  # snapshot: invalid-argument-type
+  |                                      ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:5:9
+  |
+5 |     def __new__(cls, value: int) -> Self:
+  |         ^^^^^^^      ---------- Parameter declared here
+```
+
+## Overloaded constructors defined by __new__
+
+When `__new__` is overloaded, the diagnostic must both select the matching overload and account for
+its `cls` parameter.
+
+```py
+import asyncio
+from typing import Self, overload
+
+class Factory:
+    @overload
+    def __new__(cls, value: str) -> Self: ...
+    @overload
+    def __new__(cls, value: int, flag: int) -> Self: ...
+    def __new__(cls, value: str | int, flag: int | None = None) -> Self:
+        return super().__new__(cls)
+
+async def run() -> None:
+    await asyncio.to_thread(Factory, 1, "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+  --> src/mdtest_snippet.py:13:41
+   |
+13 |     await asyncio.to_thread(Factory, 1, "incorrect")  # snapshot: invalid-argument-type
+   |                                         ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:8:9
+  |
+8 |     def __new__(cls, value: int, flag: int) -> Self: ...
+  |         ^^^^^^^                  --------- Parameter declared here
+```

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5183,6 +5183,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     ///
     /// Return `None` when the callback has no source declaration, so diagnostics can fall back to
     /// the forwarding function's actual variadic parameter instead of an unrelated parameter.
+    /// Callable objects and constructors use their existing bindings to preserve the active
+    /// constructor stage and any consumed receiver.
     ///
     /// ```python
     /// from typing import Callable
@@ -5234,16 +5236,24 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         } else {
                             paramspec_prefix_len(declared_type)
                         }?;
-                        let (function, is_bound_method) = match argument_type {
+                        let argument_bindings = argument_type.bindings(self.db);
+                        let callable = argument_bindings.single_item()?.callable();
+                        let (function, is_bound_method) = match callable.signature_type {
                             Type::FunctionLiteral(function) => (function, false),
                             Type::BoundMethod(method) => (method.function(self.db), true),
                             _ => return None,
                         };
+                        let source_parameter_index_offset = callable
+                            .overloads()
+                            .get(overload_index)
+                            .or_else(|| callable.overloads().first())
+                            .map_or(0, |binding| binding.source_parameter_index_offset)
+                            + usize::from(callable.bound_type.is_some());
 
                         Some(ForwardedParameterSource {
                             function,
                             is_bound_method,
-                            parameter_index_offset: prefix_len + usize::from(is_bound_method),
+                            parameter_index_offset: prefix_len + source_parameter_index_offset,
                             overload_index,
                         })
                     })


### PR DESCRIPTION
## Summary

When a `ParamSpec` forwarding function receives a callable object, callback protocol, or class, we currently fall back to the forwarding function's `*args` or `**kwargs` parameter even though the underlying callable has a source definition:

```py
import asyncio

class Callback:
    def __call__(self, *, value: int) -> None: ...

class Factory:
    def __init__(self, value: int) -> None: ...

async def run() -> None:
    await asyncio.to_thread(Callback(), value="incorrect")
    await asyncio.to_thread(Factory, "incorrect")
```

We now reuse the existing callable-object and constructor bindings to highlight the appropriate `__call__`, metaclass `__call__`, `__init__`, or `__new__` parameter. This preserves the active constructor stage, the selected overload, and receivers such as `self` and `cls`.
