### PR TITLE
[ty] Recover forwarded functools.partial diagnostic sources

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
+++ b/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
@@ -780,3 +780,59 @@ info: Function defined here
 9 |     def __new__(cls, value: int, flag: int) -> Self: ...
   |         ^^^^^^^                  --------- Parameter declared here
 ```
+
+## Functions wrapped by functools.partial
+
+`functools.partial` supplies the first argument before the callback is passed to `to_thread`. An
+invalid forwarded argument should point to the next parameter on the original function.
+
+```py
+import asyncio
+from functools import partial
+
+def callback(prefix: int, value: int) -> None: ...
+async def run() -> None:
+    await asyncio.to_thread(partial(callback, 1), "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+ --> src/mdtest_snippet.py:6:51
+  |
+6 |     await asyncio.to_thread(partial(callback, 1), "incorrect")  # snapshot: invalid-argument-type
+  |                                                   ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+4 | def callback(prefix: int, value: int) -> None: ...
+  |     ^^^^^^^^              ---------- Parameter declared here
+```
+
+## Bound methods wrapped by functools.partial
+
+When `functools.partial` wraps a bound method, both `self` and the argument supplied by `partial`
+come before the forwarded argument.
+
+```py
+import asyncio
+from functools import partial
+
+class Handler:
+    def callback(self, prefix: int, value: int) -> None: ...
+
+async def run(handler: Handler) -> None:
+    await asyncio.to_thread(partial(handler.callback, 1), "incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+ --> src/mdtest_snippet.py:8:59
+  |
+8 |     await asyncio.to_thread(partial(handler.callback, 1), "incorrect")  # snapshot: invalid-argument-type
+  |                                                           ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Method defined here
+ --> src/mdtest_snippet.py:5:9
+  |
+5 |     def callback(self, prefix: int, value: int) -> None: ...
+  |         ^^^^^^^^                    ---------- Parameter declared here
+```

--- a/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
+++ b/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
@@ -783,28 +783,29 @@ info: Function defined here
 
 ## Functions wrapped by functools.partial
 
-`functools.partial` supplies the first argument before the callback is passed to `to_thread`. An
-invalid forwarded argument should point to the next parameter on the original function.
+`functools.partial` supplies the first argument before the callback is passed to the forwarding
+function. An invalid forwarded argument should point to the next parameter on the original function.
 
 ```py
-import asyncio
 from functools import partial
+from typing import Callable
 
+def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 def callback(prefix: int, value: int) -> None: ...
-async def run() -> None:
-    await asyncio.to_thread(partial(callback, 1), "incorrect")  # snapshot: invalid-argument-type
+
+wrapper(partial(callback, 1), "incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
- --> src/mdtest_snippet.py:6:51
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:7:31
   |
-6 |     await asyncio.to_thread(partial(callback, 1), "incorrect")  # snapshot: invalid-argument-type
-  |                                                   ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+7 | wrapper(partial(callback, 1), "incorrect")  # snapshot: invalid-argument-type
+  |                               ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Function defined here
- --> src/mdtest_snippet.py:4:5
+ --> src/mdtest_snippet.py:5:5
   |
-4 | def callback(prefix: int, value: int) -> None: ...
+5 | def callback(prefix: int, value: int) -> None: ...
   |     ^^^^^^^^              ---------- Parameter declared here
 ```
 
@@ -814,25 +815,27 @@ When `functools.partial` wraps a bound method, both `self` and the argument supp
 come before the forwarded argument.
 
 ```py
-import asyncio
 from functools import partial
+from typing import Callable
+
+def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 
 class Handler:
     def callback(self, prefix: int, value: int) -> None: ...
 
-async def run(handler: Handler) -> None:
-    await asyncio.to_thread(partial(handler.callback, 1), "incorrect")  # snapshot: invalid-argument-type
+def run(handler: Handler) -> None:
+    wrapper(partial(handler.callback, 1), "incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
- --> src/mdtest_snippet.py:8:59
-  |
-8 |     await asyncio.to_thread(partial(handler.callback, 1), "incorrect")  # snapshot: invalid-argument-type
-  |                                                           ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+  --> src/mdtest_snippet.py:10:43
+   |
+10 |     wrapper(partial(handler.callback, 1), "incorrect")  # snapshot: invalid-argument-type
+   |                                           ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Method defined here
- --> src/mdtest_snippet.py:5:9
+ --> src/mdtest_snippet.py:7:9
   |
-5 |     def callback(self, prefix: int, value: int) -> None: ...
+7 |     def callback(self, prefix: int, value: int) -> None: ...
   |         ^^^^^^^^                    ---------- Parameter declared here
 ```

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5185,6 +5185,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     /// the forwarding function's actual variadic parameter instead of an unrelated parameter.
     /// Callable objects and constructors use their existing bindings to preserve the active
     /// constructor stage and any consumed receiver.
+    /// A `functools.partial` also requires accounting for arguments that were supplied before the
+    /// remaining signature was forwarded.
     ///
     /// ```python
     /// from typing import Callable
@@ -5236,19 +5238,49 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         } else {
                             paramspec_prefix_len(declared_type)
                         }?;
-                        let argument_bindings = argument_type.bindings(self.db);
+                        let (source_type, partial_signature) = match argument_type {
+                            Type::KnownInstance(
+                                KnownInstanceType::FunctoolsPartial(partial)
+                                | KnownInstanceType::FunctoolsPartialCall(partial),
+                            ) => (
+                                partial.wrapped(self.db).inner(self.db),
+                                partial
+                                    .partial(self.db)
+                                    .signatures(self.db)
+                                    .overloads
+                                    .get(overload_index),
+                            ),
+                            _ => (argument_type, None),
+                        };
+                        let argument_bindings = source_type.bindings(self.db);
                         let callable = argument_bindings.single_item()?.callable();
                         let (function, is_bound_method) = match callable.signature_type {
                             Type::FunctionLiteral(function) => (function, false),
                             Type::BoundMethod(method) => (method.function(self.db), true),
                             _ => return None,
                         };
-                        let source_parameter_index_offset = callable
+                        let source_binding = callable
                             .overloads()
                             .get(overload_index)
-                            .or_else(|| callable.overloads().first())
+                            .or_else(|| callable.overloads().first());
+                        let source_parameter_index_offset = source_binding
                             .map_or(0, |binding| binding.source_parameter_index_offset)
                             + usize::from(callable.bound_type.is_some());
+                        let source_parameter_index_offset =
+                            partial_signature
+                                .zip(source_binding)
+                                .and_then(|(partial_signature, source_binding)| {
+                                    let definition = partial_signature
+                                        .parameters()
+                                        .iter()
+                                        .find_map(Parameter::definition)?;
+                                    source_binding.signature.parameters().iter().position(
+                                        |parameter| parameter.definition() == Some(definition),
+                                    )
+                                })
+                                .map_or(source_parameter_index_offset, |index| {
+                                    index.max(source_parameter_index_offset)
+                                });
 
                         Some(ForwardedParameterSource {
                             function,


### PR DESCRIPTION
## Summary

Prior to this change, forwarding a `functools.partial` caused us to point at the forwarding function's `*args` parameter instead of the remaining parameter on the original callable:

```py
import asyncio
from functools import partial

def callback(prefix: int, value: int) -> None: ...

async def run() -> None:
    await asyncio.to_thread(partial(callback, 1), "incorrect")
```

We now recover the function or bound method wrapped by `partial` and use its reduced signature to account for arguments that were already supplied.
