### PR TITLE
[ty] Preserve forwarded expanded-variadic diagnostic sources

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
+++ b/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
@@ -634,19 +634,19 @@ The same overload identity must survive `functools.partial`, which removes the b
 forwarding the remaining arguments.
 
 ```py
-import asyncio
 from functools import partial
 
-async def run() -> None:
-    await asyncio.to_thread(partial(callback, 1), value="incorrect")  # snapshot: invalid-argument-type
+def forward[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+forward(partial(callback, 1), value="incorrect")  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
-  --> src/mdtest_snippet.py:18:51
+error[invalid-argument-type]: Argument to function `forward` is incorrect
+  --> src/mdtest_snippet.py:18:31
    |
-18 |     await asyncio.to_thread(partial(callback, 1), value="incorrect")  # snapshot: invalid-argument-type
-   |                                                   ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+18 | forward(partial(callback, 1), value="incorrect")  # snapshot: invalid-argument-type
+   |                               ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Function defined here
   --> src/mdtest_snippet.py:10:5
    |
@@ -660,20 +660,20 @@ info: Function defined here
 in the second argument should point to that declaration.
 
 ```py
-import asyncio
-from typing import Unpack
+from typing import Callable, Unpack
 
+def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 def callback(*values: Unpack[tuple[int, str]]) -> None: ...
-async def run() -> None:
-    await asyncio.to_thread(callback, 1, 2)  # snapshot: invalid-argument-type
+
+wrapper(callback, 1, 2)  # snapshot: invalid-argument-type
 ```
 
 ```snapshot
-error[invalid-argument-type]: Argument to function `to_thread` is incorrect
- --> src/mdtest_snippet.py:6:42
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+ --> src/mdtest_snippet.py:6:22
   |
-6 |     await asyncio.to_thread(callback, 1, 2)  # snapshot: invalid-argument-type
-  |                                          ^ Expected `str`, found `Literal[2]`
+6 | wrapper(callback, 1, 2)  # snapshot: invalid-argument-type
+  |                      ^ Expected `str`, found `Literal[2]`
 info: Function defined here
  --> src/mdtest_snippet.py:4:5
   |

--- a/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
+++ b/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
@@ -769,6 +769,43 @@ info: Method defined here
   |         ^^^^^^^^       ---------- Parameter declared here
 ```
 
+## Overloaded constructors defined by __init__
+
+Synthesized constructor signatures should preserve the overload selected by `Concatenate`, even when
+both overloads unpack the same `TypedDict` fields.
+
+```py
+from typing import Callable, Concatenate, TypedDict, Unpack, overload
+
+class Options(TypedDict):
+    value: int
+
+def wrapper[**P, T](callback: Callable[Concatenate[int, P], T], *args: P.args, **kwargs: P.kwargs) -> T:
+    return callback(1, *args, **kwargs)
+
+class Factory:
+    @overload
+    def __init__(self, prefix: str, **options: Unpack[Options]) -> None: ...
+    @overload
+    def __init__(self, prefix: int, **options: Unpack[Options]) -> None: ...
+    def __init__(self, prefix: str | int, **options: Unpack[Options]) -> None: ...
+
+wrapper(Factory, value="incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+  --> src/mdtest_snippet.py:16:18
+   |
+16 | wrapper(Factory, value="incorrect")  # snapshot: invalid-argument-type
+   |                  ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Method defined here
+  --> src/mdtest_snippet.py:13:9
+   |
+13 |     def __init__(self, prefix: int, **options: Unpack[Options]) -> None: ...
+   |         ^^^^^^^^                    -------------------------- Parameter declared here
+```
+
 ## Constructors defined by a metaclass
 
 A custom metaclass can determine the accepted constructor arguments through its own `__call__`. That

--- a/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
+++ b/crates/ty_python_semantic/resources/mdtest/paramspec_subcall_error_location.md
@@ -531,11 +531,11 @@ info: Function defined here
   |     ^^^^^^^^ ---------- Parameter declared here
 ```
 
-## Overloads without parameter definitions
+## Overloads with expanded positional parameters
 
-Expanding `Unpack[tuple[int]]` can remove the information linking an overload's parameter back to
-its declaration. Until that link is restored, point to the forwarding function's `*args` rather than
-an unrelated overload.
+Expanding `Unpack[tuple[int]]` must preserve the link to the callback's `*values` declaration. The
+diagnostic can then identify the matching overload instead of falling back to the forwarding
+function's `*args` parameter.
 
 ```py
 from typing import Callable, Concatenate, Unpack, overload
@@ -557,17 +557,17 @@ error[invalid-argument-type]: Argument to function `wrapper` is incorrect
 10 | wrapper(callback, "incorrect")  # snapshot: invalid-argument-type
    |                   ^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Function defined here
- --> src/mdtest_snippet.py:3:5
+ --> src/mdtest_snippet.py:7:5
   |
-3 | def wrapper[**P](callback: Callable[Concatenate[int, P], None], *args: P.args, **kwargs: P.kwargs) -> None: ...
-  |     ^^^^^^^                                                     ------------- Parameter declared here
+7 | def callback(prefix: int, *values: Unpack[tuple[int]]) -> None: ...
+  |     ^^^^^^^^              --------------------------- Parameter declared here
 ```
 
 ## Expanded keyword parameters
 
 `Unpack[Config]` creates separate keyword parameters for `alpha` and `beta`, even though the
-callback declares only `**options`. Without a reliable link to that declaration, point to the
-forwarding function's `**kwargs` parameter.
+callback declares only `**options`. An error for `beta` should point to that `**options`
+declaration.
 
 ```py
 from typing import Callable, TypedDict, Unpack
@@ -590,10 +590,95 @@ error[invalid-argument-type]: Argument to function `wrapper` is incorrect
 11 | wrapper(callback, alpha=1, beta="incorrect")  # snapshot: invalid-argument-type
    |                            ^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
 info: Function defined here
- --> src/mdtest_snippet.py:3:5
+ --> src/mdtest_snippet.py:9:5
   |
-3 | def wrapper[**P](callback: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
-  |     ^^^^^^^                                                  ------------------ Parameter declared here
+9 | def callback(**options: Unpack[Config]) -> None: ...
+  |     ^^^^^^^^ ------------------------- Parameter declared here
+```
+
+## Overloads with expanded keyword parameters
+
+Both callback overloads unpack the same `TypedDict`, so their expanded parameters refer to the same
+field declarations. The diagnostic should still identify the overload selected by its `int` prefix.
+
+```py
+from typing import Callable, Concatenate, TypedDict, Unpack, overload
+
+class Config(TypedDict):
+    value: int
+
+def wrapper[**P](callback: Callable[Concatenate[int, P], None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+@overload
+def callback(prefix: str, **options: Unpack[Config]) -> None: ...
+@overload
+def callback(prefix: int, **options: Unpack[Config]) -> None: ...
+def callback(prefix: str | int, **options: Unpack[Config]) -> None: ...
+
+wrapper(callback, value="incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `wrapper` is incorrect
+  --> src/mdtest_snippet.py:13:19
+   |
+13 | wrapper(callback, value="incorrect")  # snapshot: invalid-argument-type
+   |                   ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+  --> src/mdtest_snippet.py:10:5
+   |
+10 | def callback(prefix: int, **options: Unpack[Config]) -> None: ...
+   |     ^^^^^^^^              ------------------------- Parameter declared here
+```
+
+The same overload identity must survive `functools.partial`, which removes the bound prefix before
+forwarding the remaining arguments.
+
+```py
+import asyncio
+from functools import partial
+
+async def run() -> None:
+    await asyncio.to_thread(partial(callback, 1), value="incorrect")  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+  --> src/mdtest_snippet.py:18:51
+   |
+18 |     await asyncio.to_thread(partial(callback, 1), value="incorrect")  # snapshot: invalid-argument-type
+   |                                                   ^^^^^^^^^^^^^^^^^ Expected `int`, found `Literal["incorrect"]`
+info: Function defined here
+  --> src/mdtest_snippet.py:10:5
+   |
+10 | def callback(prefix: int, **options: Unpack[Config]) -> None: ...
+   |     ^^^^^^^^              ------------------------- Parameter declared here
+```
+
+## Expanded positional parameters
+
+`Unpack[tuple[int, str]]` creates two positional parameters from one `*values` declaration. An error
+in the second argument should point to that declaration.
+
+```py
+import asyncio
+from typing import Unpack
+
+def callback(*values: Unpack[tuple[int, str]]) -> None: ...
+async def run() -> None:
+    await asyncio.to_thread(callback, 1, 2)  # snapshot: invalid-argument-type
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `to_thread` is incorrect
+ --> src/mdtest_snippet.py:6:42
+  |
+6 |     await asyncio.to_thread(callback, 1, 2)  # snapshot: invalid-argument-type
+  |                                          ^ Expected `str`, found `Literal[2]`
+info: Function defined here
+ --> src/mdtest_snippet.py:4:5
+  |
+4 | def callback(*values: Unpack[tuple[int, str]]) -> None: ...
+  |     ^^^^^^^^ -------------------------------- Parameter declared here
 ```
 
 ## Callback protocols

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -7510,12 +7510,12 @@ pub(crate) struct ParameterContext {
 }
 
 impl ParameterContext {
-    fn new(parameter: &Parameter, signature_parameter_index: usize, positional: bool) -> Self {
+    fn new(parameter: &Parameter, index: usize, positional: bool) -> Self {
         Self {
             name: parameter
                 .display_name()
                 .map(ParameterDisplayName::into_owned),
-            signature_parameter_index,
+            signature_parameter_index: index,
             source_parameter_index: parameter.source_parameter_index(),
             positional,
         }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5259,10 +5259,17 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             Type::BoundMethod(method) => (method.function(self.db), true),
                             _ => return None,
                         };
-                        let source_binding = callable
-                            .overloads()
-                            .get(overload_index)
+                        let source_binding = partial_signature
+                            .and_then(Signature::definition)
+                            .and_then(|definition| {
+                                callable.overloads().iter().find(|binding| {
+                                    binding.signature.definition() == Some(definition)
+                                })
+                            })
+                            .or_else(|| callable.overloads().get(overload_index))
                             .or_else(|| callable.overloads().first());
+                        let overload_index =
+                            source_binding.map_or(overload_index, Binding::source_overload_index);
                         let source_parameter_index_offset = source_binding
                             .map_or(0, |binding| binding.source_parameter_index_offset)
                             + usize::from(callable.bound_type.is_some());
@@ -6043,7 +6050,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         && error_parameter_source.is_none()
                     {
                         if let Some(parameter_source) = parameter_source
-                            && parameter_source.contains_parameter(self.db, parameter.index)
+                            && parameter_source
+                                .source_parameter_index(self.db, parameter)
+                                .is_some()
                         {
                             *error_parameter_source = Some(parameter_source);
                         } else if let Some(parameter_index) = argument_index
@@ -6051,7 +6060,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             .and_then(|(index, _)| argument_matches[*index].parameters.first())
                             .map(|parameter| parameter.index)
                         {
-                            parameter.index = parameter_index;
+                            parameter.signature_parameter_index = parameter_index;
                         }
                     }
 
@@ -7484,7 +7493,12 @@ impl std::fmt::Display for CallableDescription<'_> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ParameterContext {
     name: Option<ParameterDisplayName<Name>>,
-    index: usize,
+
+    /// Position in the current, possibly specialized or expanded signature.
+    signature_parameter_index: usize,
+
+    /// Position of the original source declaration, before any parameter expansion.
+    source_parameter_index: Option<usize>,
 
     /// Was the argument for this parameter passed positionally, and matched to a non-variadic
     /// positional parameter? (If so, we will provide the index in the diagnostic, not just the
@@ -7493,12 +7507,13 @@ pub(crate) struct ParameterContext {
 }
 
 impl ParameterContext {
-    fn new(parameter: &Parameter, index: usize, positional: bool) -> Self {
+    fn new(parameter: &Parameter, signature_parameter_index: usize, positional: bool) -> Self {
         Self {
             name: parameter
                 .display_name()
                 .map(ParameterDisplayName::into_owned),
-            index,
+            signature_parameter_index,
+            source_parameter_index: parameter.source_parameter_index(),
             positional,
         }
     }
@@ -7508,12 +7523,12 @@ impl std::fmt::Display for ParameterContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(name) = &self.name {
             if self.positional {
-                write!(f, "{} (`{name}`)", self.index + 1)
+                write!(f, "{} (`{name}`)", self.signature_parameter_index + 1)
             } else {
                 write!(f, "`{name}`")
             }
         } else {
-            write!(f, "{}", self.index + 1)
+            write!(f, "{}", self.signature_parameter_index + 1)
         }
     }
 }
@@ -7547,52 +7562,91 @@ pub(crate) struct ForwardedParameterSource<'db> {
 impl<'db> ForwardedParameterSource<'db> {
     /// Recovers an overload's original index after specialization filters earlier declarations.
     ///
-    /// `overload_index` initially refers to the specialized overload list. This method finds the
-    /// corresponding position in the original function, which can differ after filtering.
+    /// `overload_index` initially refers to the specialized overload list. Match the overload by
+    /// its function definition when possible, since its position in the original function can
+    /// differ after filtering. In this example, both overloads refer to the same `Config` fields,
+    /// but their function definitions are distinct:
+    ///
+    /// ```python
+    /// @overload
+    /// def callback(prefix: str, **options: Unpack[Config]) -> None: ...
+    /// @overload
+    /// def callback(prefix: int, **options: Unpack[Config]) -> None: ...
+    /// ```
     fn source_overload_index(self, db: &'db dyn Db, signature: &Signature<'db>) -> Option<usize> {
+        let source_signatures = &self.function.signature(db).overloads;
+
+        if let Some(definition) = signature.definition() {
+            return source_signatures
+                .iter()
+                .position(|source_signature| source_signature.definition() == Some(definition));
+        }
+
         let parameter_definition = signature
             .parameters()
             .iter()
             .find_map(Parameter::definition)?;
 
+        let contains_parameter = |source_signature: &Signature<'db>| {
+            source_signature
+                .parameters()
+                .iter()
+                .any(|parameter| parameter.definition() == Some(parameter_definition))
+        };
+
+        if source_signatures
+            .get(self.overload_index)
+            .is_some_and(contains_parameter)
+        {
+            Some(self.overload_index)
+        } else {
+            source_signatures.iter().position(contains_parameter)
+        }
+    }
+
+    /// Locates the source parameter that accepted a forwarded argument.
+    ///
+    /// An unpacked variadic annotation can expand one source declaration into several callable
+    /// parameters. Map each expanded parameter back to its shared `*args` or `**kwargs`
+    /// declaration instead of interpreting its position as a source parameter index. Looking up
+    /// the original position through the cached signature also avoids making the caller depend on
+    /// the callback's entire AST.
+    ///
+    /// ```python
+    /// from typing import Unpack
+    ///
+    /// def callback(*args: Unpack[tuple[int, str]]) -> None: ...
+    /// ```
+    fn source_parameter_index(
+        self,
+        db: &'db dyn Db,
+        parameter: &ParameterContext,
+    ) -> Option<usize> {
+        let parameter_index = parameter
+            .source_parameter_index
+            .unwrap_or(parameter.signature_parameter_index + self.parameter_index_offset);
         self.function
             .signature(db)
             .overloads
+            .get(self.overload_index)?
+            .parameters()
             .iter()
-            .position(|source_signature| {
-                source_signature
-                    .parameters()
-                    .iter()
-                    .any(|parameter| parameter.definition() == Some(parameter_definition))
+            .any(|source_parameter| {
+                source_parameter.source_parameter_index() == Some(parameter_index)
             })
-    }
-
-    /// Returns whether the forwarded parameter maps to a specific source parameter.
-    ///
-    /// Out-of-range indices otherwise resolve to the entire signature, which would produce a
-    /// misleading diagnostic annotation.
-    fn contains_parameter(self, db: &'db dyn Db, parameter_index: usize) -> bool {
-        let parameter_index = parameter_index + self.parameter_index_offset;
-        let (overloads, implementation) = self.function.overloads_and_implementation(db);
-        let Some(overload) = overloads
-            .get(self.overload_index)
-            .copied()
-            .or(implementation)
-        else {
-            return false;
-        };
-
-        let (_, parameter_span) = overload.parameter_span(db, Some(parameter_index));
-        let (_, all_parameters_span) = overload.parameter_span(db, None);
-        parameter_span != all_parameters_span
+            .then_some(parameter_index)
     }
 
     /// Locates the matched source overload after restoring omitted receiver and prefix parameters.
-    fn parameter_span(self, db: &'db dyn Db, parameter_index: usize) -> (Span, Span) {
-        let parameter_index = parameter_index + self.parameter_index_offset;
-        let (overloads, _) = self.function.overloads_and_implementation(db);
+    fn parameter_span(self, db: &'db dyn Db, parameter: &ParameterContext) -> (Span, Span) {
+        let parameter_index = self
+            .source_parameter_index(db, parameter)
+            .unwrap_or(parameter.signature_parameter_index + self.parameter_index_offset);
+        let (overloads, implementation) = self.function.overloads_and_implementation(db);
         overloads
             .get(self.overload_index)
+            .copied()
+            .or(implementation)
             .map(|overload| overload.parameter_span(db, Some(parameter_index)))
             .unwrap_or_else(|| self.function.parameter_span(db, Some(parameter_index)))
     }
@@ -7951,7 +8005,7 @@ impl<'db> BindingError<'db> {
 
                 if let Some(parameter_source) = parameter_source {
                     let (name_span, parameter_span) =
-                        parameter_source.parameter_span(context.db(), parameter.index);
+                        parameter_source.parameter_span(context.db(), parameter);
                     let callable_kind = if parameter_source.is_bound_method {
                         "Method"
                     } else {
@@ -7993,9 +8047,9 @@ impl<'db> BindingError<'db> {
                                         candidate.is_keyword_variadic()
                                     }
                                 })
-                                .unwrap_or(parameter.index)
+                                .unwrap_or(parameter.signature_parameter_index)
                         } else {
-                            parameter.index
+                            parameter.signature_parameter_index
                         };
                         let (name_span, parameter_span) = overload_literal.parameter_span(
                             context.db(),
@@ -8034,7 +8088,7 @@ impl<'db> BindingError<'db> {
                 } else if parameter_source.is_none()
                     && let Some((name_span, parameter_span)) = callable_ty.parameter_span(
                         context.db(),
-                        Some(parameter.index + source_parameter_index_offset),
+                        Some(parameter.signature_parameter_index + source_parameter_index_offset),
                     )
                 {
                     let mut sub = SubDiagnostic::new(
@@ -8135,8 +8189,10 @@ impl<'db> BindingError<'db> {
                     } else {
                         let span = callable_ty.parameter_span(
                             context.db(),
-                            (parameters.0.len() == 1)
-                                .then(|| parameters.0[0].index + source_parameter_index_offset),
+                            (parameters.0.len() == 1).then(|| {
+                                parameters.0[0].signature_parameter_index
+                                    + source_parameter_index_offset
+                            }),
                         );
                         if let Some((_, parameter_span)) = span {
                             let mut sub = SubDiagnostic::new(

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -3128,7 +3128,15 @@ impl<'db> CallableBinding<'db> {
         signature_type: Type<'db>,
         overloads: impl IntoIterator<Item = Signature<'db>>,
     ) -> Self {
-        Self::from_indexed_overloads(signature_type, overloads.into_iter().enumerate())
+        Self::from_indexed_overloads(
+            signature_type,
+            overloads.into_iter().enumerate().map(|(index, signature)| {
+                (
+                    signature.source_overload_index().unwrap_or(index),
+                    signature,
+                )
+            }),
+        )
     }
 
     /// Constructs a callable binding from overloads while preserving each overload's position in
@@ -5242,14 +5250,20 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             Type::KnownInstance(
                                 KnownInstanceType::FunctoolsPartial(partial)
                                 | KnownInstanceType::FunctoolsPartialCall(partial),
-                            ) => (
-                                partial.wrapped(self.db).inner(self.db),
-                                partial
-                                    .partial(self.db)
-                                    .signatures(self.db)
-                                    .overloads
-                                    .get(overload_index),
-                            ),
+                            ) => {
+                                let signatures =
+                                    &partial.partial(self.db).signatures(self.db).overloads;
+                                (
+                                    partial.wrapped(self.db).inner(self.db),
+                                    signatures
+                                        .iter()
+                                        .find(|signature| {
+                                            signature.source_overload_index()
+                                                == Some(overload_index)
+                                        })
+                                        .or_else(|| signatures.get(overload_index)),
+                                )
+                            }
                             _ => (argument_type, None),
                         };
                         let argument_bindings = source_type.bindings(self.db);
@@ -5259,13 +5273,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             Type::BoundMethod(method) => (method.function(self.db), true),
                             _ => return None,
                         };
-                        let source_binding = partial_signature
-                            .and_then(Signature::definition)
-                            .and_then(|definition| {
-                                callable.overloads().iter().find(|binding| {
-                                    binding.signature.definition() == Some(definition)
-                                })
-                            })
+                        let source_binding = callable
+                            .overloads()
+                            .iter()
+                            .find(|binding| binding.source_overload_index() == overload_index)
                             .or_else(|| callable.overloads().get(overload_index))
                             .or_else(|| callable.overloads().first());
                         let overload_index =
@@ -6028,14 +6039,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 .find(|error| matches!(error, BindingError::InvalidArgumentType { .. }))
                 .and_then(|_| {
                     self.paramspec_parameter_source(paramspec, binding.source_overload_index())
-                })
-                .and_then(|source| {
-                    let overload_index =
-                        source.source_overload_index(self.db, &binding.signature)?;
-                    Some(ForwardedParameterSource {
-                        overload_index,
-                        ..source
-                    })
                 });
             let argument_matches = self.argument_matches;
 
@@ -7560,50 +7563,6 @@ pub(crate) struct ForwardedParameterSource<'db> {
 }
 
 impl<'db> ForwardedParameterSource<'db> {
-    /// Recovers an overload's original index after specialization filters earlier declarations.
-    ///
-    /// `overload_index` initially refers to the specialized overload list. Match the overload by
-    /// its function definition when possible, since its position in the original function can
-    /// differ after filtering. In this example, both overloads refer to the same `Config` fields,
-    /// but their function definitions are distinct:
-    ///
-    /// ```python
-    /// @overload
-    /// def callback(prefix: str, **options: Unpack[Config]) -> None: ...
-    /// @overload
-    /// def callback(prefix: int, **options: Unpack[Config]) -> None: ...
-    /// ```
-    fn source_overload_index(self, db: &'db dyn Db, signature: &Signature<'db>) -> Option<usize> {
-        let source_signatures = &self.function.signature(db).overloads;
-
-        if let Some(definition) = signature.definition() {
-            return source_signatures
-                .iter()
-                .position(|source_signature| source_signature.definition() == Some(definition));
-        }
-
-        let parameter_definition = signature
-            .parameters()
-            .iter()
-            .find_map(Parameter::definition)?;
-
-        let contains_parameter = |source_signature: &Signature<'db>| {
-            source_signature
-                .parameters()
-                .iter()
-                .any(|parameter| parameter.definition() == Some(parameter_definition))
-        };
-
-        if source_signatures
-            .get(self.overload_index)
-            .is_some_and(contains_parameter)
-        {
-            Some(self.overload_index)
-        } else {
-            source_signatures.iter().position(contains_parameter)
-        }
-    }
-
     /// Locates the source parameter that accepted a forwarded argument.
     ///
     /// An unpacked variadic annotation can expand one source declaration into several callable

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -742,7 +742,10 @@ impl<'db> CallableTypes<'db> {
         for callable in self.0 {
             for signature in callable.signatures(db) {
                 let signature = signature.clone();
-                let dedup_key = signature.clone().with_definition(None);
+                let dedup_key = signature
+                    .clone()
+                    .with_definition(None)
+                    .with_source_overload_index(None);
                 if seen_overloads.insert(dedup_key) {
                     overloads.push(signature);
                 }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2205,6 +2205,7 @@ impl<'db> ClassType<'db> {
                         return_type,
                     )
                     .with_definition(signature.definition())
+                    .with_source_overload_index(signature.source_overload_index())
                     .bind_self_with_receiver(
                         db,
                         Some(instance_type),

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -909,14 +909,22 @@ impl<'db> FunctionLiteral<'db> {
             return CallableSignature::single(implementation.signature(db));
         }
 
-        CallableSignature::from_overloads(overloads.iter().flat_map(|overload| {
-            // The last overload may still be inferred, so querying its binding would create a cycle.
-            if *overload == self.last_definition {
-                Either::Left(std::iter::once(overload.signature(db)))
-            } else {
-                Either::Right(overload.decorated_signatures(db))
-            }
-        }))
+        CallableSignature::from_overloads(overloads.iter().enumerate().flat_map(
+            |(source_overload_index, overload)| {
+                // The last overload may still be inferred, so querying its binding would create a cycle.
+                if *overload == self.last_definition {
+                    Either::Left(std::iter::once(
+                        overload
+                            .signature(db)
+                            .with_source_overload_index(Some(source_overload_index)),
+                    ))
+                } else {
+                    Either::Right(overload.decorated_signatures(db).map(move |signature| {
+                        signature.with_source_overload_index(Some(source_overload_index))
+                    }))
+                }
+            },
+        ))
     }
 
     /// Typed externally-visible signature of the last overload or implementation of this function.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -243,7 +243,10 @@ impl<'db> CallableSignature<'db> {
                 overload.inference,
                 overload.unspecialized_return_ty,
             );
-            let dedup_key = signature.clone().with_definition(None);
+            let dedup_key = signature
+                .clone()
+                .with_definition(None)
+                .with_source_overload_index(None);
             if seen_overloads.insert(dedup_key) {
                 new_overloads.push(signature);
             }
@@ -325,6 +328,7 @@ impl<'db> CallableSignature<'db> {
                             type_mapping.update_signature_generic_context(db, context)
                         }),
                         definition: self_signature.definition,
+                        source_overload_index: self_signature.source_overload_index,
                         receiver_constraints: self_signature.map_receiver_constraints(
                             db,
                             type_mapping,
@@ -353,6 +357,7 @@ impl<'db> CallableSignature<'db> {
                                 }),
                             ),
                             definition: signature.definition,
+                            source_overload_index: signature.source_overload_index,
                             receiver_constraints: {
                                 let mapped = self_signature.map_receiver_constraints(
                                     db,
@@ -554,6 +559,12 @@ pub struct Signature<'db> {
     /// This is useful for locating and extracting docstring information for the signature.
     pub(crate) definition: Option<Definition<'db>>,
 
+    /// Position of this overload in the original function definition.
+    ///
+    /// Filtering, receiver binding, and partial application can leave a signature at a different
+    /// position in the active overload list. Preserve its source position for call diagnostics.
+    source_overload_index: Option<NonZeroU32>,
+
     /// The constraint introduced by binding an explicitly annotated receiver, if any.
     receiver_constraints: Option<OwnedConstraintSet<'db>>,
 
@@ -694,6 +705,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: None,
             definition: None,
+            source_overload_index: None,
             receiver_constraints: None,
             parameters,
             return_ty,
@@ -708,6 +720,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context,
             definition: None,
+            source_overload_index: None,
             receiver_constraints: None,
             parameters,
             return_ty,
@@ -719,6 +732,7 @@ impl<'db> Signature<'db> {
         Signature {
             generic_context: None,
             definition: None,
+            source_overload_index: None,
             receiver_constraints: None,
             parameters: Parameters::gradual_form(),
             return_ty: signature_type,
@@ -772,6 +786,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context,
             definition: Some(definition),
+            source_overload_index: None,
             receiver_constraints: None,
             parameters,
             return_ty,
@@ -845,6 +860,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: self.generic_context,
             definition: self.definition,
+            source_overload_index: self.source_overload_index,
             receiver_constraints: self.receiver_constraints.clone(),
             parameters,
             return_ty,
@@ -875,6 +891,7 @@ impl<'db> Signature<'db> {
         Some(Self {
             generic_context: self.generic_context,
             definition: self.definition,
+            source_overload_index: self.source_overload_index,
             receiver_constraints: self.receiver_constraints.clone(),
             parameters,
             return_ty,
@@ -893,6 +910,7 @@ impl<'db> Signature<'db> {
                 .generic_context
                 .map(|context| type_mapping.update_signature_generic_context(db, context)),
             definition: self.definition,
+            source_overload_index: self.source_overload_index,
             receiver_constraints: self.map_receiver_constraints(db, type_mapping, tcx, visitor),
             parameters: self
                 .parameters
@@ -1112,6 +1130,7 @@ impl<'db> Signature<'db> {
                 .generic_context
                 .map(|generic_context| generic_context.remove_self(db, binding_context)),
             definition: self.definition,
+            source_overload_index: self.source_overload_index,
             receiver_constraints,
             parameters,
             return_ty,
@@ -1362,6 +1381,7 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: self.generic_context,
             definition: self.definition,
+            source_overload_index: self.source_overload_index,
             receiver_constraints,
             parameters,
             return_ty,
@@ -1736,6 +1756,21 @@ impl<'db> Signature<'db> {
         Self { definition, ..self }
     }
 
+    /// Records this signature's position in its defining function's overload list.
+    pub(crate) fn with_source_overload_index(mut self, index: Option<usize>) -> Self {
+        self.source_overload_index = index
+            .and_then(|index| u32::try_from(index).ok())
+            .and_then(|index| index.checked_add(1))
+            .and_then(NonZeroU32::new);
+        self
+    }
+
+    /// Returns this signature's position in its defining function's overload list.
+    pub(crate) fn source_overload_index(&self) -> Option<usize> {
+        self.source_overload_index
+            .map(|index| index.get() as usize - 1)
+    }
+
     /// Create a new signature with the given parameters.
     pub(crate) fn with_parameters(self, parameters: Parameters<'db>) -> Self {
         Self { parameters, ..self }
@@ -1928,6 +1963,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                     signature.parameters().clone(),
                                     Type::unknown(),
                                 )
+                                .with_source_overload_index(signature.source_overload_index())
                             },
                         )),
                         CallableTypeKind::ParamSpecValue,
@@ -1980,6 +2016,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                         signature.parameters().clone(),
                                         Type::unknown(),
                                     )
+                                    .with_source_overload_index(signature.source_overload_index())
                                 }),
                         ),
                         CallableTypeKind::ParamSpecValue,
@@ -2550,17 +2587,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     if let Some(source_param) = source_params.next() {
                         let lower = Type::Callable(CallableType::new(
                             db,
-                            CallableSignature::single(Signature::new_generic(
-                                source.generic_context,
-                                Parameters::concatenate(
-                                    db,
-                                    std::iter::once(source_param.clone())
-                                        .chain(source_params.cloned())
-                                        .collect(),
-                                    ConcatenateTail::ParamSpec(source_bound_typevar),
-                                ),
-                                Type::unknown(),
-                            )),
+                            CallableSignature::single(
+                                Signature::new_generic(
+                                    source.generic_context,
+                                    Parameters::concatenate(
+                                        db,
+                                        std::iter::once(source_param.clone())
+                                            .chain(source_params.cloned())
+                                            .collect(),
+                                        ConcatenateTail::ParamSpec(source_bound_typevar),
+                                    ),
+                                    Type::unknown(),
+                                )
+                                .with_source_overload_index(source.source_overload_index()),
+                            ),
                             CallableTypeKind::ParamSpecValue,
                             CallableFunctionProvenance::None,
                         ));
@@ -2575,17 +2615,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     } else if let Some(target_param) = target_params.next() {
                         let upper = Type::Callable(CallableType::new(
                             db,
-                            CallableSignature::single(Signature::new_generic(
-                                target.generic_context,
-                                Parameters::concatenate(
-                                    db,
-                                    std::iter::once(target_param.clone())
-                                        .chain(target_params.cloned())
-                                        .collect(),
-                                    ConcatenateTail::ParamSpec(target_bound_typevar),
-                                ),
-                                Type::unknown(),
-                            )),
+                            CallableSignature::single(
+                                Signature::new_generic(
+                                    target.generic_context,
+                                    Parameters::concatenate(
+                                        db,
+                                        std::iter::once(target_param.clone())
+                                            .chain(target_params.cloned())
+                                            .collect(),
+                                        ConcatenateTail::ParamSpec(target_bound_typevar),
+                                    ),
+                                    Type::unknown(),
+                                )
+                                .with_source_overload_index(target.source_overload_index()),
+                            ),
                             CallableTypeKind::ParamSpecValue,
                             CallableFunctionProvenance::None,
                         ));
@@ -2616,11 +2659,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 (None, Some(([], target_bound_typevar))) => {
                     let lower = Type::Callable(CallableType::new(
                         db,
-                        CallableSignature::single(Signature::new_generic(
-                            source.generic_context,
-                            source.parameters.clone(),
-                            Type::unknown(),
-                        )),
+                        CallableSignature::single(
+                            Signature::new_generic(
+                                source.generic_context,
+                                source.parameters.clone(),
+                                Type::unknown(),
+                            )
+                            .with_source_overload_index(source.source_overload_index()),
+                        ),
                         CallableTypeKind::ParamSpecValue,
                         CallableFunctionProvenance::None,
                     ));
@@ -2768,7 +2814,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 source_params,
                                 Type::unknown(),
                             )
-                            .with_definition(source.definition),
+                            .with_source_overload_index(source.source_overload_index()),
                         ),
                         CallableTypeKind::ParamSpecValue,
                         CallableFunctionProvenance::None,
@@ -2789,11 +2835,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 (Some(([], source_bound_typevar)), None) => {
                     let upper = Type::Callable(CallableType::new(
                         db,
-                        CallableSignature::single(Signature::new_generic(
-                            target.generic_context,
-                            target.parameters.clone(),
-                            Type::unknown(),
-                        )),
+                        CallableSignature::single(
+                            Signature::new_generic(
+                                target.generic_context,
+                                target.parameters.clone(),
+                                Type::unknown(),
+                            )
+                            .with_source_overload_index(target.source_overload_index()),
+                        ),
                         CallableTypeKind::ParamSpecValue,
                         CallableFunctionProvenance::None,
                     ));
@@ -2903,11 +2952,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         .with_transformed_parameters(target_params.cloned());
                     let upper = Type::Callable(CallableType::new(
                         db,
-                        CallableSignature::single(Signature::new_generic(
-                            target.generic_context,
-                            target_params,
-                            Type::unknown(),
-                        )),
+                        CallableSignature::single(
+                            Signature::new_generic(
+                                target.generic_context,
+                                target_params,
+                                Type::unknown(),
+                            )
+                            .with_source_overload_index(target.source_overload_index()),
+                        ),
                         CallableTypeKind::ParamSpecValue,
                         CallableFunctionProvenance::None,
                     ));

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -11,6 +11,7 @@
 //! arguments must match _at least one_ overload.
 
 use std::fmt;
+use std::num::NonZeroU32;
 use std::slice::Iter;
 use std::sync::Arc;
 
@@ -2761,11 +2762,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         .with_transformed_parameters(source_params.cloned());
                     let lower = Type::Callable(CallableType::new(
                         db,
-                        CallableSignature::single(Signature::new_generic(
-                            source.generic_context,
-                            source_params,
-                            Type::unknown(),
-                        )),
+                        CallableSignature::single(
+                            Signature::new_generic(
+                                source.generic_context,
+                                source_params,
+                                Type::unknown(),
+                            )
+                            .with_definition(source.definition),
+                        ),
                         CallableTypeKind::ParamSpecValue,
                         CallableFunctionProvenance::None,
                     ));
@@ -3846,14 +3850,16 @@ impl<'db> Parameters<'db> {
                 Parameter::keyword_only(name.clone())
                     .with_annotated_type(field.declared_ty)
                     .with_optional_default_type((!field.is_required()).then_some(Type::unknown()))
-                    .with_definition(field.first_declaration()),
+                    .with_definition(field.first_declaration())
+                    .with_source_parameter_index(parameter.source_parameter_index()),
             );
         }
 
         if let Some(extra_items) = unpacked_typed_dict.openness(db).effective_extra_items() {
             value.push(
                 Parameter::keyword_variadic(kwargs_name)
-                    .with_annotated_type(extra_items.declared_ty),
+                    .with_annotated_type(extra_items.declared_ty)
+                    .with_source_parameter_index(parameter.source_parameter_index()),
             );
         }
     }
@@ -4349,7 +4355,9 @@ impl<'db> Parameters<'db> {
                 .chain(positional_or_keyword)
                 .chain(variadic)
                 .chain(keyword_only)
-                .chain(keywords),
+                .chain(keywords)
+                .enumerate()
+                .map(|(index, parameter)| parameter.with_source_parameter_index(Some(index))),
         )
     }
 
@@ -4458,6 +4466,15 @@ impl<'db> Parameters<'db> {
     }
 
     /// Expands an unpacked `*args` annotation into its logical callable parameters.
+    ///
+    /// Preserve the original `*args` definition and source position on every expanded parameter
+    /// so diagnostics can identify its declaration after specialization or overload filtering.
+    ///
+    /// ```python
+    /// from typing import Unpack
+    ///
+    /// def callback(*args: Unpack[tuple[int, str]]) -> None: ...
+    /// ```
     fn expand_starred_variadic_annotations(&self, db: &'db dyn Db) -> Self {
         if !self
             .data
@@ -4476,37 +4493,36 @@ impl<'db> Parameters<'db> {
                 && let Some(tuple) = parameter.annotated_type().exact_tuple_instance_spec(db)
             {
                 expanded = true;
+                let positional_parameter = |ty| {
+                    Parameter::positional_only(None)
+                        .with_annotated_type(ty)
+                        .with_definition(parameter.definition())
+                        .with_source_parameter_index(parameter.source_parameter_index())
+                };
                 match tuple.as_ref() {
                     Tuple::Fixed(tuple) => {
-                        parameters.extend(
-                            tuple
-                                .iter_all_elements()
-                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
-                        );
+                        parameters.extend(tuple.iter_all_elements().map(positional_parameter));
                     }
                     Tuple::Variable(variable) => {
-                        parameters.extend(
-                            variable
-                                .iter_prefix_elements()
-                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
-                        );
+                        parameters
+                            .extend(variable.iter_prefix_elements().map(positional_parameter));
                         let name = parameter
                             .name()
                             .cloned()
                             .unwrap_or_else(|| Name::new_static("args"));
-                        parameters.push(Parameter::variadic(name).with_annotated_type(
-                            match variable.variable() {
-                                VariableSegment::Homogeneous(element) => element,
-                                VariableSegment::TypeVarTuple(typevartuple) => {
-                                    Type::TypeVar(typevartuple)
-                                }
-                            },
-                        ));
-                        parameters.extend(
-                            variable
-                                .iter_suffix_elements()
-                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
+                        parameters.push(
+                            Parameter::variadic(name)
+                                .with_annotated_type(match variable.variable() {
+                                    VariableSegment::Homogeneous(element) => element,
+                                    VariableSegment::TypeVarTuple(typevartuple) => {
+                                        Type::TypeVar(typevartuple)
+                                    }
+                                })
+                                .with_definition(parameter.definition())
+                                .with_source_parameter_index(parameter.source_parameter_index()),
                         );
+                        parameters
+                            .extend(variable.iter_suffix_elements().map(positional_parameter));
                     }
                 }
             } else {
@@ -4664,6 +4680,13 @@ pub(crate) struct Parameter<'db> {
     /// Syntax-level annotation kind for cases where the annotation has special parameter semantics.
     annotation_kind: ParameterAnnotationKind,
 
+    /// Position of the source parameter that owns this logical parameter.
+    ///
+    /// Expanded tuple and `TypedDict` parameters retain the position of their original `*args` or
+    /// `**kwargs` declaration. Store positions one-based so `None` does not increase the size of
+    /// this struct.
+    source_parameter_index: Option<NonZeroU32>,
+
     kind: ParameterKind<'db>,
 }
 
@@ -4691,6 +4714,7 @@ impl<'db> Parameter<'db> {
             definition: None,
             inferred_annotation: true,
             annotation_kind: ParameterAnnotationKind::Normal,
+            source_parameter_index: None,
             kind: ParameterKind::PositionalOnly {
                 name,
                 default_type: None,
@@ -4704,6 +4728,7 @@ impl<'db> Parameter<'db> {
             definition: None,
             inferred_annotation: true,
             annotation_kind: ParameterAnnotationKind::Normal,
+            source_parameter_index: None,
             kind: ParameterKind::PositionalOrKeyword {
                 name,
                 default_type: None,
@@ -4717,6 +4742,7 @@ impl<'db> Parameter<'db> {
             definition: None,
             inferred_annotation: true,
             annotation_kind: ParameterAnnotationKind::Normal,
+            source_parameter_index: None,
             kind: ParameterKind::Variadic { name },
         }
     }
@@ -4727,6 +4753,7 @@ impl<'db> Parameter<'db> {
             definition: None,
             inferred_annotation: true,
             annotation_kind: ParameterAnnotationKind::Normal,
+            source_parameter_index: None,
             kind: ParameterKind::KeywordOnly {
                 name,
                 default_type: None,
@@ -4740,6 +4767,7 @@ impl<'db> Parameter<'db> {
             definition: None,
             inferred_annotation: true,
             annotation_kind: ParameterAnnotationKind::Normal,
+            source_parameter_index: None,
             kind: ParameterKind::KeywordVariadic { name },
         }
     }
@@ -4783,6 +4811,24 @@ impl<'db> Parameter<'db> {
         self
     }
 
+    /// Records the source position without replacing a synthesized parameter's IDE definition.
+    ///
+    /// A `TypedDict` field can then keep its declaration for navigation while diagnostics refer
+    /// to the enclosing `**kwargs` parameter.
+    fn with_source_parameter_index(mut self, index: Option<usize>) -> Self {
+        self.source_parameter_index = index
+            .and_then(|index| u32::try_from(index).ok())
+            .and_then(|index| index.checked_add(1))
+            .and_then(NonZeroU32::new);
+        self
+    }
+
+    /// Returns the original source parameter's position before variadic expansion.
+    pub(crate) fn source_parameter_index(&self) -> Option<usize> {
+        self.source_parameter_index
+            .map(|index| index.get() as usize - 1)
+    }
+
     fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
@@ -4803,6 +4849,7 @@ impl<'db> Parameter<'db> {
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
             inferred_annotation: self.inferred_annotation,
             annotation_kind: self.annotation_kind,
+            source_parameter_index: self.source_parameter_index,
         }
     }
 
@@ -4818,6 +4865,7 @@ impl<'db> Parameter<'db> {
             definition: self.definition,
             inferred_annotation: self.inferred_annotation,
             annotation_kind: self.annotation_kind,
+            source_parameter_index: self.source_parameter_index,
             kind,
         }
     }
@@ -4833,6 +4881,7 @@ impl<'db> Parameter<'db> {
             definition,
             annotation_kind,
             inferred_annotation,
+            source_parameter_index,
             kind,
         } = self;
 
@@ -4893,6 +4942,7 @@ impl<'db> Parameter<'db> {
             definition: *definition,
             inferred_annotation: *inferred_annotation,
             annotation_kind: *annotation_kind,
+            source_parameter_index: *source_parameter_index,
             kind,
         })
     }
@@ -4938,6 +4988,7 @@ impl<'db> Parameter<'db> {
             definition,
             inferred_annotation,
             annotation_kind,
+            source_parameter_index: None,
             kind,
         }
     }
@@ -5249,6 +5300,7 @@ mod tests {
                 definition: _,
                 annotation_kind,
                 inferred_annotation,
+                source_parameter_index: _,
                 kind,
             } = parameter;
 


### PR DESCRIPTION
## Summary

A callback using `Unpack[Config]` or `Unpack[tuple[...]]` can accept several arguments through a single `**kwargs` or `*args` declaration. Forwarded `ParamSpec` diagnostics currently fall back to the forwarding function because they cannot reliably map those arguments to the callback's source parameter:

```py
import asyncio
from typing import TypedDict, Unpack

class Config(TypedDict):
    alpha: int
    beta: int

def callback(**options: Unpack[Config]) -> None: ...

async def run() -> None:
    await asyncio.to_thread(callback, alpha=1, beta="incorrect")
```

We now preserve parameter definitions while expanding tuple annotations, select the correct overload after `Concatenate` filtering, and map expanded arguments back to the original `*args` or `**kwargs` declaration.
